### PR TITLE
fix(telemetry): replace TypeErrors with <replaced> string placeholder

### DIFF
--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -369,7 +369,7 @@ def test_end_agent_span(mock_span):
 
     tracer.end_agent_span(mock_span, mock_response)
 
-    mock_span.set_attribute.assert_any_call("gen_ai.completion", "Agent response")
+    mock_span.set_attribute.assert_any_call("gen_ai.completion", '"<replaced>"')
     mock_span.set_attribute.assert_any_call("gen_ai.usage.prompt_tokens", 50)
     mock_span.set_attribute.assert_any_call("gen_ai.usage.completion_tokens", 100)
     mock_span.set_attribute.assert_any_call("gen_ai.usage.total_tokens", 150)


### PR DESCRIPTION
## Description
replace TypeErrors with <replaced> string placeholder

example traces: https://us.cloud.langfuse.com/project/cmaoqkqd901afad07ui6ndt1v/traces/d26b646ce8ab591b23d0656a70d178c4?timestamp=2025-05-16T17%3A27%3A03.220Z&display=details&observation=d1cec81248985b08

## Type of Change
- Bug fix

## Testing
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* `hatch run test-integ`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
