### PR TITLE
actions: fix docs dispatch

### DIFF
--- a/.github/workflows/dispatch-docs.yml
+++ b/.github/workflows/dispatch-docs.yml
@@ -12,5 +12,3 @@ jobs:
     steps:
       - name: Dispatch
         run: gh api repos/${{ github.repository_owner }}/docs/dispatches -F event_type=sdk-push
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Description
No longer require PAT_TOKEN now that repos are public. This will fix our broken dispatches ([example](https://github.com/strands-agents/sdk-python/actions/runs/15077141783/job/42387020832)).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing
* `gh api repos/strands-agents/docs/dispatches -F event_type=sdk-push`: Ran locally ([results](https://github.com/strands-agents/docs/actions/runs/15077135838)).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
