### PR TITLE
fix: set user-agent for Bedrock API calls

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -110,9 +110,10 @@ class BedrockModel(Model):
         session = boto_session or boto3.Session(
             region_name=region_name or "us-west-2",
         )
+        client_config = boto_client_config or BotocoreConfig(user_agent_extra="strands-agents")
         self.client = session.client(
             service_name="bedrock-runtime",
-            config=boto_client_config,
+            config=client_config,
         )
 
     @override


### PR DESCRIPTION
This change adds "strands-agents" to the user agent for API calls to Bedrock. The user-agent shows up in CloudTrail logs, enabling users to understand where Bedrock calls are coming from.

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
