### PR TITLE
Add ensure_ascii=False to json.dumps() calls in telemetry tracer

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -315,7 +315,7 @@ class Tracer:
             "gen_ai.system": "strands-agents",
             "agent.name": agent_name,
             "gen_ai.agent.name": agent_name,
-            "gen_ai.prompt": json.dumps(messages, cls=JSONEncoder),
+            "gen_ai.prompt": json.dumps(messages, ensure_ascii=False, cls=JSONEncoder),
         }
 
         if model_id:
@@ -338,7 +338,7 @@ class Tracer:
             error: Optional exception if the model call failed.
         """
         attributes: Dict[str, AttributeValue] = {
-            "gen_ai.completion": json.dumps(message["content"], cls=JSONEncoder),
+            "gen_ai.completion": json.dumps(message["content"], ensure_ascii=False, cls=JSONEncoder),
             "gen_ai.usage.prompt_tokens": usage["inputTokens"],
             "gen_ai.usage.completion_tokens": usage["outputTokens"],
             "gen_ai.usage.total_tokens": usage["totalTokens"],
@@ -360,10 +360,10 @@ class Tracer:
             The created span, or None if tracing is not enabled.
         """
         attributes: Dict[str, AttributeValue] = {
-            "gen_ai.prompt": json.dumps(tool, cls=JSONEncoder),
+            "gen_ai.prompt": json.dumps(tool, ensure_ascii=False, cls=JSONEncoder),
             "tool.name": tool["name"],
             "tool.id": tool["toolUseId"],
-            "tool.parameters": json.dumps(tool["input"], cls=JSONEncoder),
+            "tool.parameters": json.dumps(tool["input"], ensure_ascii=False, cls=JSONEncoder),
         }
 
         # Add additional kwargs as attributes
@@ -387,7 +387,7 @@ class Tracer:
             status = tool_result.get("status")
             status_str = str(status) if status is not None else ""
 
-            tool_result_content_json = json.dumps(tool_result.get("content"), cls=JSONEncoder)
+            tool_result_content_json = json.dumps(tool_result.get("content"), ensure_ascii=False, cls=JSONEncoder)
             attributes.update(
                 {
                     "tool.result": tool_result_content_json,
@@ -420,7 +420,7 @@ class Tracer:
         parent_span = parent_span if parent_span else event_loop_kwargs.get("event_loop_parent_span")
 
         attributes: Dict[str, AttributeValue] = {
-            "gen_ai.prompt": json.dumps(messages, cls=JSONEncoder),
+            "gen_ai.prompt": json.dumps(messages, ensure_ascii=False, cls=JSONEncoder),
             "event_loop.cycle_id": event_loop_cycle_id,
         }
 
@@ -449,11 +449,11 @@ class Tracer:
             error: Optional exception if the cycle failed.
         """
         attributes: Dict[str, AttributeValue] = {
-            "gen_ai.completion": json.dumps(message["content"], cls=JSONEncoder),
+            "gen_ai.completion": json.dumps(message["content"], ensure_ascii=False, cls=JSONEncoder),
         }
 
         if tool_result_message:
-            attributes["tool.result"] = json.dumps(tool_result_message["content"], cls=JSONEncoder)
+            attributes["tool.result"] = json.dumps(tool_result_message["content"], ensure_ascii=False, cls=JSONEncoder)
 
         self._end_span(span, attributes, error)
 
@@ -490,7 +490,7 @@ class Tracer:
             attributes["gen_ai.request.model"] = model_id
 
         if tools:
-            tools_json = json.dumps(tools, cls=JSONEncoder)
+            tools_json = json.dumps(tools, ensure_ascii=False, cls=JSONEncoder)
             attributes["agent.tools"] = tools_json
             attributes["gen_ai.agent.tools"] = tools_json
 

--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -315,7 +315,7 @@ class Tracer:
             "gen_ai.system": "strands-agents",
             "agent.name": agent_name,
             "gen_ai.agent.name": agent_name,
-            "gen_ai.prompt": json.dumps(messages, ensure_ascii=False, cls=JSONEncoder),
+            "gen_ai.prompt": serialize(messages),
         }
 
         if model_id:
@@ -338,7 +338,7 @@ class Tracer:
             error: Optional exception if the model call failed.
         """
         attributes: Dict[str, AttributeValue] = {
-            "gen_ai.completion": json.dumps(message["content"], ensure_ascii=False, cls=JSONEncoder),
+            "gen_ai.completion": serialize(message["content"]),
             "gen_ai.usage.prompt_tokens": usage["inputTokens"],
             "gen_ai.usage.completion_tokens": usage["outputTokens"],
             "gen_ai.usage.total_tokens": usage["totalTokens"],
@@ -360,10 +360,10 @@ class Tracer:
             The created span, or None if tracing is not enabled.
         """
         attributes: Dict[str, AttributeValue] = {
-            "gen_ai.prompt": json.dumps(tool, ensure_ascii=False, cls=JSONEncoder),
+            "gen_ai.prompt": serialize(tool),
             "tool.name": tool["name"],
             "tool.id": tool["toolUseId"],
-            "tool.parameters": json.dumps(tool["input"], ensure_ascii=False, cls=JSONEncoder),
+            "tool.parameters": serialize(tool["input"]),
         }
 
         # Add additional kwargs as attributes
@@ -387,7 +387,7 @@ class Tracer:
             status = tool_result.get("status")
             status_str = str(status) if status is not None else ""
 
-            tool_result_content_json = json.dumps(tool_result.get("content"), ensure_ascii=False, cls=JSONEncoder)
+            tool_result_content_json = serialize(tool_result.get("content"))
             attributes.update(
                 {
                     "tool.result": tool_result_content_json,
@@ -420,7 +420,7 @@ class Tracer:
         parent_span = parent_span if parent_span else event_loop_kwargs.get("event_loop_parent_span")
 
         attributes: Dict[str, AttributeValue] = {
-            "gen_ai.prompt": json.dumps(messages, ensure_ascii=False, cls=JSONEncoder),
+            "gen_ai.prompt": serialize(messages),
             "event_loop.cycle_id": event_loop_cycle_id,
         }
 
@@ -449,11 +449,11 @@ class Tracer:
             error: Optional exception if the cycle failed.
         """
         attributes: Dict[str, AttributeValue] = {
-            "gen_ai.completion": json.dumps(message["content"], ensure_ascii=False, cls=JSONEncoder),
+            "gen_ai.completion": serialize(message["content"]),
         }
 
         if tool_result_message:
-            attributes["tool.result"] = json.dumps(tool_result_message["content"], ensure_ascii=False, cls=JSONEncoder)
+            attributes["tool.result"] = serialize(tool_result_message["content"])
 
         self._end_span(span, attributes, error)
 
@@ -490,7 +490,7 @@ class Tracer:
             attributes["gen_ai.request.model"] = model_id
 
         if tools:
-            tools_json = json.dumps(tools, ensure_ascii=False, cls=JSONEncoder)
+            tools_json = serialize(tools)
             attributes["agent.tools"] = tools_json
             attributes["gen_ai.agent.tools"] = tools_json
 
@@ -571,3 +571,15 @@ def get_tracer(
         )
 
     return _tracer_instance
+
+
+def serialize(obj: Any) -> str:
+    """Serialize an object to JSON with consistent settings.
+
+    Args:
+        obj: The object to serialize
+
+    Returns:
+        JSON string representation of the object
+    """
+    return json.dumps(obj, ensure_ascii=False, cls=JSONEncoder)

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -639,7 +639,6 @@ def test_json_encoder_value_error():
 
 def test_serialize_non_ascii_characters():
     """Test that non-ASCII characters are preserved in JSON serialization."""
-    from strands.telemetry.tracer import serialize
 
     # Test with Japanese text
     japanese_text = "こんにちは世界"

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 from opentelemetry.trace import StatusCode  # type: ignore
 
-from strands.telemetry.tracer import JSONEncoder, Tracer, get_tracer
+from strands.telemetry.tracer import JSONEncoder, Tracer, get_tracer, serialize
 from strands.types.streaming import Usage
 
 
@@ -635,3 +635,50 @@ def test_json_encoder_value_error():
     # Test just the value
     result = json.loads(encoder.encode(huge_number))
     assert result == "<replaced>"
+
+
+def test_serialize_non_ascii_characters():
+    """Test that non-ASCII characters are preserved in JSON serialization."""
+    from strands.telemetry.tracer import serialize
+
+    # Test with Japanese text
+    japanese_text = "こんにちは世界"
+    result = serialize({"text": japanese_text})
+    assert japanese_text in result
+    assert "\\u" not in result
+
+    # Test with emoji
+    emoji_text = "Hello 🌍"
+    result = serialize({"text": emoji_text})
+    assert emoji_text in result
+    assert "\\u" not in result
+
+    # Test with Chinese characters
+    chinese_text = "你好，世界"
+    result = serialize({"text": chinese_text})
+    assert chinese_text in result
+    assert "\\u" not in result
+
+    # Test with mixed content
+    mixed_text = {"ja": "こんにちは", "emoji": "😊", "zh": "你好", "en": "hello"}
+    result = serialize(mixed_text)
+    assert "こんにちは" in result
+    assert "😊" in result
+    assert "你好" in result
+    assert "\\u" not in result
+
+
+def test_serialize_vs_json_dumps():
+    """Test that serialize behaves differently from default json.dumps for non-ASCII characters."""
+
+    # Test with Japanese text
+    japanese_text = "こんにちは世界"
+
+    # Default json.dumps should escape non-ASCII characters
+    default_result = json.dumps({"text": japanese_text})
+    assert "\\u" in default_result
+
+    # Our serialize function should preserve non-ASCII characters
+    custom_result = serialize({"text": japanese_text})
+    assert japanese_text in custom_result
+    assert "\\u" not in custom_result


### PR DESCRIPTION
## Description
This PR adds ensure_ascii=False parameter to all json.dumps() calls in the telemetry tracer module. This change ensures proper handling of non-ASCII characters (such as Japanese, Chinese, or emoji) in telemetry data by preventing them from being escaped as \uXXXX sequences in JSON output. The modification improves readability of logs and telemetry data when working with international content.

## Related Issues
No specific issue ticket, addressing as part of internationalization improvements.

## Documentation PR
N/A - This is an internal implementation change that doesn't require documentation updates.

## Type of Change
- Bug fix

## Testing
• [x] hatch fmt --linter
• [x] hatch fmt --formatter
• [x] hatch test --all
* [x] Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [-] I have updated the documentation accordingly
- [-] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
