### PR TITLE
fix(bedrock): use the AWS_REGION environment variable for the Bedrock model provider region if set and boto_session is not passed

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -4,6 +4,7 @@
 """
 
 import logging
+import os
 from typing import Any, Iterable, Literal, Optional, cast
 
 import boto3
@@ -96,7 +97,8 @@ class BedrockModel(Model):
         Args:
             boto_session: Boto Session to use when calling the Bedrock Model.
             boto_client_config: Configuration to use when creating the Bedrock-Runtime Boto Client.
-            region_name: AWS region to use for the Bedrock service. Defaults to "us-west-2".
+            region_name: AWS region to use for the Bedrock service.
+                Defaults to the AWS_REGION environment variable if set, or "us-west-2" if not set.
             **model_config: Configuration options for the Bedrock model.
         """
         if region_name and boto_session:
@@ -108,7 +110,7 @@ class BedrockModel(Model):
         logger.debug("config=<%s> | initializing", self.config)
 
         session = boto_session or boto3.Session(
-            region_name=region_name or "us-west-2",
+            region_name=region_name or os.getenv("AWS_REGION") or "us-west-2",
         )
         client_config = boto_client_config or BotocoreConfig(user_agent_extra="strands-agents")
         self.client = session.client(

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1,3 +1,4 @@
+import os
 import unittest.mock
 
 import boto3
@@ -97,6 +98,16 @@ def test__init__with_custom_region(bedrock_client):
     with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:
         _ = BedrockModel(region_name=custom_region)
         mock_session_cls.assert_called_once_with(region_name=custom_region)
+
+
+def test__init__with_environment_variable_region(bedrock_client):
+    """Test that BedrockModel uses the provided region."""
+    _ = bedrock_client
+    os.environ["AWS_REGION"] = "eu-west-1"
+
+    with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:
+        _ = BedrockModel()
+        mock_session_cls.assert_called_once_with(region_name="eu-west-1")
 
 
 def test__init__with_region_and_session_raises_value_error():


### PR DESCRIPTION
## Description
Use the `AWS_REGION` environment variable for the Bedrock model provider region if set and boto_session is not passed.

## Related Issues
https://github.com/strands-agents/sdk-python/issues/38

## Documentation PR
https://github.com/strands-agents/docs/pull/15

## Type of Change
- Bug fix

## Testing
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* `hatch run test-integ`
* Manually tested by:
  1. Setting `AWS_REGION` to `us-west-1`, got an error as expected because Bedrock is not available in us-west-1: `botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the ConverseStream operation: Your account is not authorized to invoke this API operation.`
  2. Unset `AWS_REGION`, fell back to `us-west-2` and succeeded as expected

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
