### PR TITLE
docs: update contributing guide to manage python env with hatch shell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,16 @@ This project uses [hatchling](https://hatch.pypa.io/latest/build/#hatchling) as 
 
 ### Setting Up Your Development Environment
 
-1. Install development dependencies:
+1. Entering virtual environment using `hatch` (recommended), then launch your IDE in the new shell.
+   ```bash
+   hatch shell dev
+   ```
+
+   Alternatively, install development dependencies in a manually created virtual environment:
    ```bash
    pip install -e ".[dev]" && pip install -e ".[litellm]
    ```
+
 
 2. Set up pre-commit hooks:
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,11 @@ extra-args = [
     "-vv",
 ]
 
+[tool.hatch.envs.dev]
+dev-mode = true
+features = ["dev", "docs", "anthropic", "litellm", "llamaapi", "ollama"]
+
+
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.13", "3.12", "3.11", "3.10"]

--- a/src/strands/handlers/tool_handler.py
+++ b/src/strands/handlers/tool_handler.py
@@ -46,6 +46,7 @@ class AgentToolHandler(ToolHandler):
     def process(
         self,
         tool: Any,
+        *,
         model: Model,
         system_prompt: Optional[str],
         messages: List[Any],


### PR DESCRIPTION
## Description
Since the project is already using `hatch` as the build backend, it would be a more consistent development experience to also manage the python virtual environments using `hatch shell`.

I added a new env named `dev` so that contributor can use `hatch shell dev` to enter this virtual environment. It includes every optional features.



## Type of Change
- Other (please describe): contributing guide


## Testing
[How have you tested the change?]

yes

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
