### PR TITLE
fix: Added hyphen to allowed characters in tool name validation

### DIFF
--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -47,7 +47,7 @@ def validate_tool_use_name(tool: ToolUse) -> None:
         raise InvalidToolUseNameException(message)
 
     tool_name = tool["name"]
-    tool_name_pattern = r"^[a-zA-Z][a-zA-Z0-9_]*$"
+    tool_name_pattern = r"^[a-zA-Z][a-zA-Z0-9_\-]*$"
     tool_name_max_length = 64
     valid_name_pattern = bool(re.match(tool_name_pattern, tool_name))
     tool_name_len = len(tool_name)

--- a/tests/strands/tools/test_tools.py
+++ b/tests/strands/tools/test_tools.py
@@ -18,6 +18,10 @@ def test_validate_tool_use_name_valid():
     # Should not raise an exception
     validate_tool_use_name(tool)
 
+    tool = {"name": "valid-name", "toolUseId": "123"}
+    # Should not raise an exception
+    validate_tool_use_name(tool)
+
 
 def test_validate_tool_use_name_missing():
     tool = {"toolUseId": "123"}


### PR DESCRIPTION
## Description
Added hyphen to allowed characters in tool name validation, to support tavily search mcp server with tool names as "tavily-search" and "tavily-extract"

## Related Issues
https://github.com/strands-agents/sdk-python/issues/54

## Documentation PR
[Link to related associated PR in the agent-docs repo]

## Type of Change
- Bug fix

## Testing
yes

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
