### PR TITLE
fix: update direct tool call references

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -6,7 +6,7 @@ models and tools in the SDK.
 The Agent interface supports two complementary interaction patterns:
 
 1. Natural language for conversation: `agent("Analyze this data")`
-2. Method-style for direct tool access: `agent.tool_name(param1="value")`
+2. Method-style for direct tool access: `agent.tool.tool_name(param1="value")`
 """
 
 import asyncio
@@ -515,7 +515,7 @@ class Agent:
         """
         # Create user message describing the tool call
         user_msg_content = [
-            {"text": (f"agent.{tool['name']} direct tool call\nInput parameters: {json.dumps(tool['input'])}\n")}
+            {"text": (f"agent.tool.{tool['name']} direct tool call.\nInput parameters: {json.dumps(tool['input'])}\n")}
         ]
 
         # Add override message if provided

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -566,7 +566,7 @@ def test_agent_tool_user_message_override(agent):
             },
             {
                 "text": (
-                    "agent.tool_decorated direct tool call\n"
+                    "agent.tool.tool_decorated direct tool call.\n"
                     "Input parameters: "
                     '{"random_string": "abcdEfghI123", "user_message_override": "test override"}\n'
                 ),


### PR DESCRIPTION
This PR updates references to direct tool calls to use the new format `agent.tool.tool_name` instead of the old `agent.tool_name`.

Fixes: https://github.com/strands-agents/sdk-python/issues/42.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.