### PR TITLE
models - litellm - capture usage

### DIFF
--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -334,6 +334,8 @@ class LiteLLMModel(Model):
 
         yield {"chunk_type": "message_stop", "data": choice.finish_reason}
 
+        # Skip remaining events as we don't have use for anything except the final usage payload
         for event in response:
-            if hasattr(event, "usage"):
-                yield {"chunk_type": "metadata", "data": event.usage}
+            _ = event
+
+        yield {"chunk_type": "metadata", "data": event.usage}

--- a/tests/strands/models/test_litellm.py
+++ b/tests/strands/models/test_litellm.py
@@ -545,12 +545,14 @@ def test_stream(litellm_client, model):
 
 def test_stream_empty(litellm_client, model):
     mock_delta = unittest.mock.Mock(content=None, tool_calls=None)
+    mock_usage = unittest.mock.Mock(prompt_tokens=0, completion_tokens=0, total_tokens=0)
 
     mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta)])
     mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="stop")])
-    mock_event_3 = unittest.mock.Mock(spec=[])
+    mock_event_3 = unittest.mock.Mock()
+    mock_event_4 = unittest.mock.Mock(usage=mock_usage)
 
-    litellm_client.chat.completions.create.return_value = iter([mock_event_1, mock_event_2, mock_event_3])
+    litellm_client.chat.completions.create.return_value = iter([mock_event_1, mock_event_2, mock_event_3, mock_event_4])
 
     request = {"model": "m1", "messages": [{"role": "user", "content": []}]}
     response = model.stream(request)
@@ -561,6 +563,7 @@ def test_stream_empty(litellm_client, model):
         {"chunk_type": "content_start", "data_type": "text"},
         {"chunk_type": "content_stop", "data_type": "text"},
         {"chunk_type": "message_stop", "data": "stop"},
+        {"chunk_type": "metadata", "data": mock_usage},
     ]
 
     assert tru_events == exp_events


### PR DESCRIPTION
## Description
Certain models executed under LiteLLM will return additional payloads inbetween the `finish_reason` message and the `usage` message. Here is an example of an inbetween payload:
```txt
ModelResponseStream(id='chatcmpl-3cdd4223-9c65-4ce0-9456-0a41d4a70b86', created=1747836095, model='gpt-4.1-mini-2025-04-14', object='chat.completion.chunk', system_fingerprint='fp_c8225066ea', choices=[StreamingChoices(finish_reason=None, index=0, delta=Delta(provider_specific_fields=None, content=None, role=None, function_call=None, tool_calls=None, audio=None), logprobs=None)], provider_specific_fields=None, stream_options={'include_usage': True})
```
We don't have any use for these inbetween messages and so for now, we will skip over them so we can get to the final usage message for reporting.

## Related Issues
https://github.com/strands-agents/sdk-python/issues/47

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`: Relying on existing unit tests and integration tests. They still cover these changes.
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
