### PR TITLE
fixing various typos in markdowns and scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ To send us a pull request, please:
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on.
+Looking at the existing issues is a great way to find something to contribute to.
 
 You can check:
 - Our known bugs list in [Bug Reports](../../issues?q=is%3Aissue%20state%3Aopen%20label%3Abug) for issues that need fixing

--- a/src/strands/agent/conversation_manager/conversation_manager.py
+++ b/src/strands/agent/conversation_manager/conversation_manager.py
@@ -22,7 +22,7 @@ class ConversationManager(ABC):
     def apply_management(self, messages: Messages) -> None:
         """Applies management strategy to the provided list of messages.
 
-        Processes the conversation history to maintain appropriate size by modifying the messages list in-place.
+        Processes the conversation history to maintain appropriate size by modifying the message list in-place.
         Implementations should handle message pruning, summarization, or other size management techniques to keep the
         conversation context within desired bounds.
 

--- a/src/strands/agent/conversation_manager/conversation_manager.py
+++ b/src/strands/agent/conversation_manager/conversation_manager.py
@@ -22,7 +22,7 @@ class ConversationManager(ABC):
     def apply_management(self, messages: Messages) -> None:
         """Applies management strategy to the provided list of messages.
 
-        Processes the conversation history to maintain appropriate size by modifying the message list in-place.
+        Processes the conversation history to maintain appropriate size by modifying the messages list in-place.
         Implementations should handle message pruning, summarization, or other size management techniques to keep the
         conversation context within desired bounds.
 

--- a/src/strands/event_loop/error_handler.py
+++ b/src/strands/event_loop/error_handler.py
@@ -74,7 +74,7 @@ def handle_input_too_long_error(
     """Handle 'Input is too long' errors by truncating tool results.
 
     When a context window overflow exception occurs (input too long for the model), this function attempts to recover
-    by finding and truncating the most recent tool results in the conversation history. If trunction is successful, the
+    by finding and truncating the most recent tool results in the conversation history. If truncation is successful, the
     function will make a call to the event loop.
 
     Args:

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -132,7 +132,7 @@ class BedrockModel(Model):
         """Get the current Bedrock Model configuration.
 
         Returns:
-            The Bedrok model configuration.
+            The Bedrock model configuration.
         """
         return self.config
 

--- a/src/strands/types/guardrails.py
+++ b/src/strands/types/guardrails.py
@@ -16,7 +16,7 @@ class GuardrailConfig(TypedDict, total=False):
     Attributes:
         guardrailIdentifier: Unique identifier for the guardrail.
         guardrailVersion: Version of the guardrail to apply.
-        streamProcessingMode: Procesing mode.
+        streamProcessingMode: Processing mode.
         trace: The trace behavior for the guardrail.
     """
 
@@ -219,7 +219,7 @@ class GuardrailAssessment(TypedDict):
         contentPolicy: The content policy.
         contextualGroundingPolicy: The contextual grounding policy used for the guardrail assessment.
         sensitiveInformationPolicy: The sensitive information policy.
-        topicPolic: The topic policy.
+        topicPolicy: The topic policy.
         wordPolicy: The word policy.
     """
 

--- a/src/strands/types/media.py
+++ b/src/strands/types/media.py
@@ -68,7 +68,7 @@ VideoFormat = Literal["flv", "mkv", "mov", "mpeg", "mpg", "mp4", "three_gp", "we
 
 
 class VideoSource(TypedDict):
-    """Contains the content of a vidoe.
+    """Contains the content of a video.
 
     Attributes:
         bytes: The binary content of the video.


### PR DESCRIPTION
## Description

Fixing various typos in markdowns and scripts. See commit diffs for details.

## Related Issues

## Documentation PR

Fixing some typos in code comments and markdowns

## Type of Change

- Documentation update


## Testing
[How have you tested the change?]

* `hatch fmt --linter`

## Checklist
- [X] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
