### PR TITLE
feat: Add non-streaming support to BedrockModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ bedrock_model = BedrockModel(
 agent = Agent(model=bedrock_model)
 agent("Tell me about Agentic AI")
 
+# Bedrock with non-streaming mode
+bedrock_model = BedrockModel(
+  model_id="us.amazon.nova-pro-v1:0",
+  streaming=False
+)
+agent = Agent(model=bedrock_model)
+agent("Tell me about Agentic AI")
+
 # Ollama
 ollama_model = OllamaModel(
   host="http://localhost:11434",
@@ -140,6 +148,24 @@ Built-in providers:
  - [Ollama](https://strandsagents.com/latest/user-guide/concepts/model-providers/ollama/)
 
 Custom providers can be implemented using [Custom Providers](https://strandsagents.com/latest/user-guide/concepts/model-providers/custom_model_provider/)
+
+### Streaming Support
+
+The Bedrock model provider supports both streaming and non-streaming modes. By default, streaming is enabled. To disable streaming:
+
+```python
+from strands import Agent
+from strands.models import BedrockModel
+
+# Disable streaming
+bedrock_model = BedrockModel(
+    model_id="us.amazon.nova-pro-v1:0",
+    streaming=False
+)
+agent = Agent(model=bedrock_model)
+```
+
+Note that not all Bedrock models support streaming. If you're using a model that doesn't support streaming, you should set `streaming=False`.
 
 ### Example tools
 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,7 @@ from strands.models.llamaapi import LlamaAPIModel
 bedrock_model = BedrockModel(
   model_id="us.amazon.nova-pro-v1:0",
   temperature=0.3,
-)
-agent = Agent(model=bedrock_model)
-agent("Tell me about Agentic AI")
-
-# Bedrock with non-streaming mode
-bedrock_model = BedrockModel(
-  model_id="us.amazon.nova-pro-v1:0",
-  streaming=False
+  streaming=True, # Enable/disable streaming
 )
 agent = Agent(model=bedrock_model)
 agent("Tell me about Agentic AI")
@@ -148,24 +141,6 @@ Built-in providers:
  - [Ollama](https://strandsagents.com/latest/user-guide/concepts/model-providers/ollama/)
 
 Custom providers can be implemented using [Custom Providers](https://strandsagents.com/latest/user-guide/concepts/model-providers/custom_model_provider/)
-
-### Streaming Support
-
-The Bedrock model provider supports both streaming and non-streaming modes. By default, streaming is enabled. To disable streaming:
-
-```python
-from strands import Agent
-from strands.models import BedrockModel
-
-# Disable streaming
-bedrock_model = BedrockModel(
-    model_id="us.amazon.nova-pro-v1:0",
-    streaming=False
-)
-agent = Agent(model=bedrock_model)
-```
-
-Note that not all Bedrock models support streaming. If you're using a model that doesn't support streaming, you should set `streaming=False`.
 
 ### Example tools
 

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -3,13 +3,14 @@
 - Docs: https://aws.amazon.com/bedrock/
 """
 
+import json
 import logging
 import os
 from typing import Any, Iterable, Literal, Optional, cast
 
 import boto3
 from botocore.config import Config as BotocoreConfig
-from botocore.exceptions import ClientError, EventStreamError
+from botocore.exceptions import ClientError
 from typing_extensions import TypedDict, Unpack, override
 
 from ..types.content import Messages
@@ -61,6 +62,7 @@ class BedrockModel(Model):
             max_tokens: Maximum number of tokens to generate in the response
             model_id: The Bedrock model ID (e.g., "us.anthropic.claude-3-7-sonnet-20250219-v1:0")
             stop_sequences: List of sequences that will stop generation when encountered
+            streaming: Flag to enable/disable streaming. Defaults to True.
             temperature: Controls randomness in generation (higher = more random)
             top_p: Controls diversity via nucleus sampling (alternative to temperature)
         """
@@ -81,6 +83,7 @@ class BedrockModel(Model):
         max_tokens: Optional[int]
         model_id: str
         stop_sequences: Optional[list[str]]
+        streaming: Optional[bool]
         temperature: Optional[float]
         top_p: Optional[float]
 
@@ -232,11 +235,68 @@ class BedrockModel(Model):
         """
         return cast(StreamEvent, event)
 
+    def _has_blocked_guardrail(self, guardrail_data: dict[str, Any]) -> bool:
+        """Check if guardrail data contains any blocked policies.
+
+        Args:
+            guardrail_data: Guardrail data from trace information.
+
+        Returns:
+            True if any blocked guardrail is detected, False otherwise.
+        """
+        input_assessment = guardrail_data.get("inputAssessment", {})
+        output_assessments = guardrail_data.get("outputAssessments", {})
+
+        # Check input assessments
+        if any(self._find_detected_and_blocked_policy(assessment) for assessment in input_assessment.values()):
+            return True
+
+        # Check output assessments
+        if any(self._find_detected_and_blocked_policy(assessment) for assessment in output_assessments.values()):
+            return True
+
+        return False
+
+    def _generate_redaction_events(self) -> list[dict[str, Any]]:
+        """Generate redaction events based on configuration.
+
+        Returns:
+            List of redaction events to yield.
+        """
+        events = []
+
+        if self.config.get("guardrail_redact_input", True):
+            logger.debug("Redacting user input due to guardrail.")
+            events.append(
+                {
+                    "redactContent": {
+                        "redactUserContentMessage": self.config.get(
+                            "guardrail_redact_input_message", "[User input redacted.]"
+                        )
+                    }
+                }
+            )
+
+        if self.config.get("guardrail_redact_output", False):
+            logger.debug("Redacting assistant output due to guardrail.")
+            events.append(
+                {
+                    "redactContent": {
+                        "redactAssistantContentMessage": self.config.get(
+                            "guardrail_redact_output_message", "[Assistant output redacted.]"
+                        )
+                    }
+                }
+            )
+
+        return events
+
     @override
     def stream(self, request: dict[str, Any]) -> Iterable[dict[str, Any]]:
-        """Send the request to the Bedrock model and get the streaming response.
+        """Send the request to the Bedrock model and get the response.
 
-        This method calls the Bedrock converse_stream API and returns the stream of response events.
+        This method calls either the Bedrock converse_stream API or the converse API
+        based on the streaming parameter in the configuration.
 
         Args:
             request: The formatted request to send to the Bedrock model
@@ -246,63 +306,132 @@ class BedrockModel(Model):
 
         Raises:
             ContextWindowOverflowException: If the input exceeds the model's context window.
-            EventStreamError: For all other Bedrock API errors.
+            ModelThrottledException: If the model service is throttling requests.
         """
+        streaming = self.config.get("streaming", True)
+
         try:
-            response = self.client.converse_stream(**request)
-            for chunk in response["stream"]:
-                if self.config.get("guardrail_redact_input", True) or self.config.get("guardrail_redact_output", False):
+            if streaming:
+                # Streaming implementation
+                response = self.client.converse_stream(**request)
+                for chunk in response["stream"]:
                     if (
                         "metadata" in chunk
                         and "trace" in chunk["metadata"]
                         and "guardrail" in chunk["metadata"]["trace"]
                     ):
-                        inputAssessment = chunk["metadata"]["trace"]["guardrail"].get("inputAssessment", {})
-                        outputAssessments = chunk["metadata"]["trace"]["guardrail"].get("outputAssessments", {})
+                        guardrail_data = chunk["metadata"]["trace"]["guardrail"]
+                        if self._has_blocked_guardrail(guardrail_data):
+                            yield from self._generate_redaction_events()
+                    yield chunk
+            else:
+                # Non-streaming implementation
+                response = self.client.converse(**request)
 
-                        # Check if an input or output guardrail was triggered
-                        if any(
-                            self._find_detected_and_blocked_policy(assessment)
-                            for assessment in inputAssessment.values()
-                        ) or any(
-                            self._find_detected_and_blocked_policy(assessment)
-                            for assessment in outputAssessments.values()
-                        ):
-                            if self.config.get("guardrail_redact_input", True):
-                                logger.debug("Found blocked input guardrail. Redacting input.")
-                                yield {
-                                    "redactContent": {
-                                        "redactUserContentMessage": self.config.get(
-                                            "guardrail_redact_input_message", "[User input redacted.]"
-                                        )
-                                    }
-                                }
-                            if self.config.get("guardrail_redact_output", False):
-                                logger.debug("Found blocked output guardrail. Redacting output.")
-                                yield {
-                                    "redactContent": {
-                                        "redactAssistantContentMessage": self.config.get(
-                                            "guardrail_redact_output_message", "[Assistant output redacted.]"
-                                        )
-                                    }
-                                }
+                # Convert and yield from the response
+                yield from self._convert_non_streaming_to_streaming(response)
 
-                yield chunk
-        except EventStreamError as e:
-            # Handle throttling that occurs mid-stream?
-            if "ThrottlingException" in str(e) and "ConverseStream" in str(e):
-                raise ModelThrottledException(str(e)) from e
+                # Check for guardrail triggers after yielding any events (same as streaming path)
+                if (
+                    "trace" in response
+                    and "guardrail" in response["trace"]
+                    and self._has_blocked_guardrail(response["trace"]["guardrail"])
+                ):
+                    yield from self._generate_redaction_events()
 
-            if any(overflow_message in str(e) for overflow_message in BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES):
+        except ClientError as e:
+            error_message = str(e)
+
+            # Handle throttling error
+            if "ThrottlingException" in error_message:
+                raise ModelThrottledException(error_message) from e
+
+            # Handle context window overflow
+            if any(overflow_message in error_message for overflow_message in BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES):
                 logger.warning("bedrock threw context window overflow error")
                 raise ContextWindowOverflowException(e) from e
-            raise e
-        except ClientError as e:
-            # Handle throttling that occurs at the beginning of the call
-            if e.response["Error"]["Code"] == "ThrottlingException":
-                raise ModelThrottledException(str(e)) from e
 
-            raise
+            # Otherwise raise the error
+            raise e
+
+    def _convert_non_streaming_to_streaming(self, response: dict[str, Any]) -> Iterable[dict[str, Any]]:
+        """Convert a non-streaming response to the streaming format.
+
+        Args:
+            response: The non-streaming response from the Bedrock model.
+
+        Returns:
+            An iterable of response events in the streaming format.
+        """
+        # Yield messageStart event
+        yield {"messageStart": {"role": response["output"]["message"]["role"]}}
+
+        # Process content blocks
+        for content in response["output"]["message"]["content"]:
+            # Yield contentBlockStart event if needed
+            if "toolUse" in content:
+                yield {
+                    "contentBlockStart": {
+                        "start": {
+                            "toolUse": {
+                                "toolUseId": content["toolUse"]["toolUseId"],
+                                "name": content["toolUse"]["name"],
+                            }
+                        },
+                    }
+                }
+
+                # For tool use, we need to yield the input as a delta
+                input_value = json.dumps(content["toolUse"]["input"])
+
+                yield {"contentBlockDelta": {"delta": {"toolUse": {"input": input_value}}}}
+            elif "text" in content:
+                # Then yield the text as a delta
+                yield {
+                    "contentBlockDelta": {
+                        "delta": {"text": content["text"]},
+                    }
+                }
+            elif "reasoningContent" in content:
+                # Then yield the reasoning content as a delta
+                yield {
+                    "contentBlockDelta": {
+                        "delta": {"reasoningContent": {"text": content["reasoningContent"]["reasoningText"]["text"]}}
+                    }
+                }
+
+                if "signature" in content["reasoningContent"]["reasoningText"]:
+                    yield {
+                        "contentBlockDelta": {
+                            "delta": {
+                                "reasoningContent": {
+                                    "signature": content["reasoningContent"]["reasoningText"]["signature"]
+                                }
+                            }
+                        }
+                    }
+
+            # Yield contentBlockStop event
+            yield {"contentBlockStop": {}}
+
+        # Yield messageStop event
+        yield {
+            "messageStop": {
+                "stopReason": response["stopReason"],
+                "additionalModelResponseFields": response.get("additionalModelResponseFields"),
+            }
+        }
+
+        # Yield metadata event
+        if "usage" in response or "metrics" in response or "trace" in response:
+            metadata = {"metadata": {}}
+            if "usage" in response:
+                metadata["metadata"]["usage"] = response["usage"]
+            if "metrics" in response:
+                metadata["metadata"]["metrics"] = response["metrics"]
+            if "trace" in response:
+                metadata["metadata"]["trace"] = response["trace"]
+            yield metadata
 
     def _find_detected_and_blocked_policy(self, input: Any) -> bool:
         """Recursively checks if the assessment contains a detected and blocked guardrail.

--- a/src/strands/types/streaming.py
+++ b/src/strands/types/streaming.py
@@ -157,7 +157,7 @@ class ModelStreamErrorEvent(ExceptionEvent):
     originalStatusCode: int
 
 
-class RedactContentEvent(TypedDict):
+class RedactContentEvent(TypedDict, total=False):
     """Event for redacting content.
 
     Attributes:

--- a/tests-integ/test_model_bedrock.py
+++ b/tests-integ/test_model_bedrock.py
@@ -1,0 +1,116 @@
+import pytest
+
+import strands
+from strands import Agent
+from strands.models import BedrockModel
+
+
+@pytest.fixture
+def system_prompt():
+    return "You are an AI assistant that uses & instead of ."
+
+
+@pytest.fixture
+def streaming_model():
+    return BedrockModel(
+        model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        streaming=True,
+    )
+
+
+@pytest.fixture
+def non_streaming_model():
+    return BedrockModel(
+        model_id="us.meta.llama3-2-90b-instruct-v1:0",
+        streaming=False,
+    )
+
+
+@pytest.fixture
+def streaming_agent(streaming_model, system_prompt):
+    return Agent(model=streaming_model, system_prompt=system_prompt)
+
+
+@pytest.fixture
+def non_streaming_agent(non_streaming_model, system_prompt):
+    return Agent(model=non_streaming_model, system_prompt=system_prompt)
+
+
+def test_streaming_agent(streaming_agent):
+    """Test agent with streaming model."""
+    result = streaming_agent("Hello!")
+
+    assert len(str(result)) > 0
+
+
+def test_non_streaming_agent(non_streaming_agent):
+    """Test agent with non-streaming model."""
+    result = non_streaming_agent("Hello!")
+
+    assert len(str(result)) > 0
+
+
+def test_streaming_model_events(streaming_model):
+    """Test streaming model events."""
+    messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+
+    # Call converse and collect events
+    events = list(streaming_model.converse(messages))
+
+    # Verify basic structure of events
+    assert any("messageStart" in event for event in events)
+    assert any("contentBlockDelta" in event for event in events)
+    assert any("messageStop" in event for event in events)
+
+
+def test_non_streaming_model_events(non_streaming_model):
+    """Test non-streaming model events."""
+    messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+
+    # Call converse and collect events
+    events = list(non_streaming_model.converse(messages))
+
+    # Verify basic structure of events
+    assert any("messageStart" in event for event in events)
+    assert any("contentBlockDelta" in event for event in events)
+    assert any("messageStop" in event for event in events)
+
+
+def test_tool_use_streaming(streaming_model):
+    """Test tool use with streaming model."""
+
+    @strands.tool
+    def calculator(expression: str) -> float:
+        """Calculate the result of a mathematical expression."""
+        return eval(expression)
+
+    agent = Agent(model=streaming_model, tools=[calculator])
+    result = agent("What is 123 + 456?")
+
+    # Print the full message content for debugging
+    print("\nFull message content:")
+    import json
+
+    print(json.dumps(result.message["content"], indent=2))
+
+    # The test is passing as long as the agent successfully uses the tool
+    # We can see in the logs that the calculator tool is being invoked
+    # But the final message might not contain the toolUse block
+    assert True  # Tool use was observed in logs
+
+
+def test_tool_use_non_streaming(non_streaming_model):
+    """Test tool use with non-streaming model."""
+
+    @strands.tool
+    def calculator(expression: str) -> float:
+        """Calculate the result of a mathematical expression."""
+        return eval(expression)
+
+    agent = Agent(model=non_streaming_model, tools=[calculator])
+    agent("What is 123 + 456?")
+
+    # The test is passing as long as the agent successfully uses the tool
+    # We can see in the logs that the calculator tool is being invoked
+    # But the final message might not contain the toolUse block
+    assert True  # Tool use was observed in logs

--- a/tests-integ/test_model_bedrock.py
+++ b/tests-integ/test_model_bedrock.py
@@ -28,12 +28,12 @@ def non_streaming_model():
 
 @pytest.fixture
 def streaming_agent(streaming_model, system_prompt):
-    return Agent(model=streaming_model, system_prompt=system_prompt)
+    return Agent(model=streaming_model, system_prompt=system_prompt, load_tools_from_directory=False)
 
 
 @pytest.fixture
 def non_streaming_agent(non_streaming_model, system_prompt):
-    return Agent(model=non_streaming_model, system_prompt=system_prompt)
+    return Agent(model=non_streaming_model, system_prompt=system_prompt, load_tools_from_directory=False)
 
 
 def test_streaming_agent(streaming_agent):
@@ -79,12 +79,17 @@ def test_non_streaming_model_events(non_streaming_model):
 def test_tool_use_streaming(streaming_model):
     """Test tool use with streaming model."""
 
+    tool_was_called = False
+
     @strands.tool
     def calculator(expression: str) -> float:
         """Calculate the result of a mathematical expression."""
+
+        nonlocal tool_was_called
+        tool_was_called = True
         return eval(expression)
 
-    agent = Agent(model=streaming_model, tools=[calculator])
+    agent = Agent(model=streaming_model, tools=[calculator], load_tools_from_directory=False)
     result = agent("What is 123 + 456?")
 
     # Print the full message content for debugging
@@ -93,24 +98,23 @@ def test_tool_use_streaming(streaming_model):
 
     print(json.dumps(result.message["content"], indent=2))
 
-    # The test is passing as long as the agent successfully uses the tool
-    # We can see in the logs that the calculator tool is being invoked
-    # But the final message might not contain the toolUse block
-    assert True  # Tool use was observed in logs
+    assert tool_was_called
 
 
 def test_tool_use_non_streaming(non_streaming_model):
     """Test tool use with non-streaming model."""
 
+    tool_was_called = False
+
     @strands.tool
     def calculator(expression: str) -> float:
         """Calculate the result of a mathematical expression."""
+
+        nonlocal tool_was_called
+        tool_was_called = True
         return eval(expression)
 
-    agent = Agent(model=non_streaming_model, tools=[calculator])
+    agent = Agent(model=non_streaming_model, tools=[calculator], load_tools_from_directory=False)
     agent("What is 123 + 456?")
 
-    # The test is passing as long as the agent successfully uses the tool
-    # We can see in the logs that the calculator tool is being invoked
-    # But the final message might not contain the toolUse block
-    assert True  # Tool use was observed in logs
+    assert tool_was_called

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -305,9 +305,9 @@ def test_stream(bedrock_client, model):
 
 
 def test_stream_throttling_exception_from_event_stream_error(bedrock_client, model):
-    error_message = "ThrottlingException - Rate exceeded"
+    error_message = "Rate exceeded"
     bedrock_client.converse_stream.side_effect = EventStreamError(
-        {"Error": {"Message": error_message}}, "ConverseStream"
+        {"Error": {"Message": error_message, "Code": "ThrottlingException"}}, "ConverseStream"
     )
 
     request = {"a": 1}


### PR DESCRIPTION
## Description
Add support for non-streaming bedrock models

## Related Issues
https://github.com/strands-agents/sdk-python/issues/32

## Documentation PR
https://github.com/strands-agents/docs/pull/65

## Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation update
- Other (please describe):

New feature


## Testing

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
