### PR TITLE
fix: Merge strands-agents user agent into existing botocore config

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -112,7 +112,21 @@ class BedrockModel(Model):
         session = boto_session or boto3.Session(
             region_name=region_name or os.getenv("AWS_REGION") or "us-west-2",
         )
-        client_config = boto_client_config or BotocoreConfig(user_agent_extra="strands-agents")
+
+        # Add strands-agents to the request user agent
+        if boto_client_config:
+            existing_user_agent = getattr(boto_client_config, "user_agent_extra", None)
+
+            # Append 'strands-agents' to existing user_agent_extra or set it if not present
+            if existing_user_agent:
+                new_user_agent = f"{existing_user_agent} strands-agents"
+            else:
+                new_user_agent = "strands-agents"
+
+            client_config = boto_client_config.merge(BotocoreConfig(user_agent_extra=new_user_agent))
+        else:
+            client_config = BotocoreConfig(user_agent_extra="strands-agents")
+
         self.client = session.client(
             service_name="bedrock-runtime",
             config=client_config,


### PR DESCRIPTION
Previously if the caller provided a botocore Config, we did not set the user agent to strands-agents. However, it turns out it's fairly common to provide a Config to set retries.  This change adds to the caller's user agent if present, and otherwise sets it to user agent.  The botocore Config merge method ensures that we don't lose any of the caller's Config settings.
