### PR TITLE
Lower OpenTelemetry minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ dependencies = [
     "pydantic>=2.0.0,<3.0.0",
     "typing-extensions>=4.13.2,<5.0.0",
     "watchdog>=6.0.0,<7.0.0",
-    "opentelemetry-api>=1.33.0,<2.0.0",
-    "opentelemetry-sdk>=1.33.0,<2.0.0",
-    "opentelemetry-exporter-otlp-proto-http>=1.33.0,<2.0.0",
+    "opentelemetry-api>=1.30.0,<2.0.0",
+    "opentelemetry-sdk>=1.30.0,<2.0.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION


## Description

This fixes https://github.com/strands-agents/sdk-python/issues/88

Because we used the latest open-telemetry version if someone has a lower version required (as in the issue above) then it makes it difficult to install the SDK 

Looking at the release notes for the library at https://github.com/open-telemetry/opentelemetry-python/releases this seems like a safe change.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/88


## Type of Change
Bug fix


## Testing


* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
