### PR TITLE
models - openai - argument none

### DIFF
--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -18,6 +18,7 @@ class Client(Protocol):
     """Protocol defining the OpenAI-compatible interface for the underlying provider client."""
 
     @property
+    # pragma: no cover
     def chat(self) -> Any:
         """Chat completions interface."""
         ...

--- a/src/strands/types/models/openai.py
+++ b/src/strands/types/models/openai.py
@@ -206,7 +206,9 @@ class OpenAIModel(Model, abc.ABC):
 
             case "content_delta":
                 if event["data_type"] == "tool":
-                    return {"contentBlockDelta": {"delta": {"toolUse": {"input": event["data"].function.arguments}}}}
+                    return {
+                        "contentBlockDelta": {"delta": {"toolUse": {"input": event["data"].function.arguments or ""}}}
+                    }
 
                 return {"contentBlockDelta": {"delta": {"text": event["data"]}}}
 

--- a/tests/strands/types/models/test_openai.py
+++ b/tests/strands/types/models/test_openai.py
@@ -246,12 +246,12 @@ def test_format_request(model, messages, tool_specs, system_prompt):
 @pytest.mark.parametrize(
     ("event", "exp_chunk"),
     [
-        # Case 1: Message start
+        # Message start
         (
             {"chunk_type": "message_start"},
             {"messageStart": {"role": "assistant"}},
         ),
-        # Case 2: Content Start - Tool Use
+        # Content Start - Tool Use
         (
             {
                 "chunk_type": "content_start",
@@ -260,12 +260,12 @@ def test_format_request(model, messages, tool_specs, system_prompt):
             },
             {"contentBlockStart": {"start": {"toolUse": {"name": "calculator", "toolUseId": "c1"}}}},
         ),
-        # Case 3: Content Start - Text
+        # Content Start - Text
         (
             {"chunk_type": "content_start", "data_type": "text"},
             {"contentBlockStart": {"start": {}}},
         ),
-        # Case 4: Content Delta - Tool Use
+        # Content Delta - Tool Use
         (
             {
                 "chunk_type": "content_delta",
@@ -274,32 +274,41 @@ def test_format_request(model, messages, tool_specs, system_prompt):
             },
             {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"expression": "2+2"}'}}}},
         ),
-        # Case 5: Content Delta - Text
+        # Content Delta - Tool Use - None
+        (
+            {
+                "chunk_type": "content_delta",
+                "data_type": "tool",
+                "data": unittest.mock.Mock(function=unittest.mock.Mock(arguments=None)),
+            },
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": ""}}}},
+        ),
+        # Content Delta - Text
         (
             {"chunk_type": "content_delta", "data_type": "text", "data": "hello"},
             {"contentBlockDelta": {"delta": {"text": "hello"}}},
         ),
-        # Case 6: Content Stop
+        # Content Stop
         (
             {"chunk_type": "content_stop"},
             {"contentBlockStop": {}},
         ),
-        # Case 7: Message Stop - Tool Use
+        # Message Stop - Tool Use
         (
             {"chunk_type": "message_stop", "data": "tool_calls"},
             {"messageStop": {"stopReason": "tool_use"}},
         ),
-        # Case 8: Message Stop - Max Tokens
+        # Message Stop - Max Tokens
         (
             {"chunk_type": "message_stop", "data": "length"},
             {"messageStop": {"stopReason": "max_tokens"}},
         ),
-        # Case 9: Message Stop - End Turn
+        # Message Stop - End Turn
         (
             {"chunk_type": "message_stop", "data": "stop"},
             {"messageStop": {"stopReason": "end_turn"}},
         ),
-        # Case 10: Metadata
+        # Metadata
         (
             {
                 "chunk_type": "metadata",


### PR DESCRIPTION
## Description
Handling an edge case where some models executed through the OpenAI model provider return `None` arguments with the start tool call chunk. The following is an example tool call start chunk from a Qwen model:
```txt
ChatCompletionChunk(..., tool_calls=[ChoiceDeltaToolCall(index=0, id='chatcmpl-tool-d01e322b370a4bdd9af5bdea0afda466', function=ChoiceDeltaToolCallFunction(arguments=None, name='calculator'), type='function')]), ...)
```
We have now seen cases where this is `None`, `''`, and `'{...'`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
