### PR TITLE
feat: Add Boto session config to Bedrock model

### DIFF
--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -96,8 +96,29 @@ def test__init__with_custom_region(bedrock_client):
     custom_region = "us-east-1"
 
     with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:
-        _ = BedrockModel(region_name=custom_region)
+        _ = BedrockModel(boto_session_config={"region_name": custom_region})
         mock_session_cls.assert_called_once_with(region_name=custom_region)
+
+
+def test__init__with_profile_name(bedrock_client):
+    """Test that BedrockModel uses the provided profile name."""
+    _ = bedrock_client
+    profile_name = "test-profile"
+
+    with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:
+        _ = BedrockModel(boto_session_config={"profile_name": profile_name})
+        mock_session_cls.assert_called_once_with(profile_name=profile_name, region_name=unittest.mock.ANY)
+
+
+def test__init__with_profile_and_region(bedrock_client):
+    """Test that BedrockModel uses both profile name and region when provided."""
+    _ = bedrock_client
+    profile_name = "test-profile"
+    custom_region = "eu-central-1"
+
+    with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:
+        _ = BedrockModel(boto_session_config={"profile_name": profile_name, "region_name": custom_region})
+        mock_session_cls.assert_called_once_with(profile_name=profile_name, region_name=custom_region)
 
 
 def test__init__with_environment_variable_region(bedrock_client):
@@ -110,10 +131,12 @@ def test__init__with_environment_variable_region(bedrock_client):
         mock_session_cls.assert_called_once_with(region_name="eu-west-1")
 
 
-def test__init__with_region_and_session_raises_value_error():
-    """Test that BedrockModel raises ValueError when both region and session are provided."""
+def test__init__with_session_and_config_raises_value_error():
+    """Test that BedrockModel raises ValueError when both boto_session and boto_session_config are provided."""
     with pytest.raises(ValueError):
-        _ = BedrockModel(region_name="us-east-1", boto_session=boto3.Session(region_name="us-east-1"))
+        _ = BedrockModel(
+            boto_session=boto3.Session(region_name="us-east-1"), boto_session_config={"region_name": "us-east-1"}
+        )
 
 
 def test__init__model_config(bedrock_client):


### PR DESCRIPTION
## Description
The goal of this PR is to allow easier credential handling through configurations. It allows users to set different inference credential profiles for agents. More specifically, for my use case, I am interested in providing inference credential profiles for Strands CLI

This PR enhances the `BedrockModel` class to support more flexible boto3 session configuration options. It introduces a new `BotoSessionConfig` TypedDict that allows users to configure both `region_name` and `profile_name` parameters for AWS credentials, making it easier to work with multiple AWS accounts or profiles.

The main changes include:
1. Added a `BotoSessionConfig` TypedDict to define valid boto3 Session configuration options
2. Replaced the `region_name` parameter with the more flexible `boto_session_config` parameter
3. Updated the session initialization logic to properly handle profile credentials
4. Added comprehensive unit tests for the new functionality

## Related Issues
No specific issue - enhancement to improve flexibility

## Documentation PR
N/A

## Type of Change
> **Breaking Change** 

- This CR removes `region_name` into `BotoSessionConfig`
  - I am also okay with leaving `region_name` for now, but I think session configuration object is more scalable for other use cases sessions provide.

## Testing
- Added new unit tests for profile_name and combined region/profile configuration
- Updated existing tests to use the new configuration pattern
- Verified all tests pass with `pytest tests/strands/models/test_bedrock.py -v`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
  - [x] I've updated inline docs 
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published [N/A]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice