### PR TITLE
Increasing Coverage Message Processor : From 79% to 94%

### DIFF
--- a/tests/strands/event_loop/test_message_processor.py
+++ b/tests/strands/event_loop/test_message_processor.py
@@ -1,0 +1,128 @@
+import copy
+
+import pytest
+
+from strands.event_loop import message_processor
+
+
+@pytest.mark.parametrize(
+    "messages,expected,expected_messages",
+    [
+        # Orphaned toolUse with empty input, no toolResult
+        (
+            [
+                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "1", "input": {}, "name": "foo"}}]},
+                {"role": "user", "content": [{"toolResult": {"toolUseId": "2"}}]},
+            ],
+            True,
+            [
+                {"role": "assistant", "content": [{"text": "[Attempted to use foo, but operation was canceled]"}]},
+                {"role": "user", "content": [{"toolResult": {"toolUseId": "2"}}]},
+            ],
+        ),
+        # toolUse with input, has matching toolResult
+        (
+            [
+                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "1", "input": {"a": 1}, "name": "foo"}}]},
+                {"role": "user", "content": [{"toolResult": {"toolUseId": "1"}}]},
+            ],
+            False,
+            [
+                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "1", "input": {"a": 1}, "name": "foo"}}]},
+                {"role": "user", "content": [{"toolResult": {"toolUseId": "1"}}]},
+            ],
+        ),
+        # No messages
+        (
+            [],
+            False,
+            [],
+        ),
+    ],
+)
+def test_clean_orphaned_empty_tool_uses(messages, expected, expected_messages):
+    test_messages = copy.deepcopy(messages)
+    result = message_processor.clean_orphaned_empty_tool_uses(test_messages)
+    assert result == expected
+    assert test_messages == expected_messages
+
+
+@pytest.mark.parametrize(
+    "messages,expected_idx",
+    [
+        (
+            [
+                {"role": "user", "content": [{"text": "hi"}]},
+                {"role": "user", "content": [{"toolResult": {"toolUseId": "1"}}]},
+                {"role": "assistant", "content": [{"text": "ok"}]},
+            ],
+            1,
+        ),
+        (
+            [
+                {"role": "user", "content": [{"text": "hi"}]},
+                {"role": "assistant", "content": [{"text": "ok"}]},
+            ],
+            None,
+        ),
+        (
+            [],
+            None,
+        ),
+    ],
+)
+def test_find_last_message_with_tool_results(messages, expected_idx):
+    idx = message_processor.find_last_message_with_tool_results(messages)
+    assert idx == expected_idx
+
+
+@pytest.mark.parametrize(
+    "messages,msg_idx,expected_changed,expected_content",
+    [
+        (
+            [
+                {
+                    "role": "user",
+                    "content": [{"toolResult": {"toolUseId": "1", "status": "ok", "content": [{"text": "big"}]}}],
+                }
+            ],
+            0,
+            True,
+            [
+                {
+                    "toolResult": {
+                        "toolUseId": "1",
+                        "status": "error",
+                        "content": [{"text": "The tool result was too large!"}],
+                    }
+                }
+            ],
+        ),
+        (
+            [{"role": "user", "content": [{"text": "no tool result"}]}],
+            0,
+            False,
+            [{"text": "no tool result"}],
+        ),
+        (
+            [],
+            0,
+            False,
+            [],
+        ),
+        (
+            [{"role": "user", "content": [{"toolResult": {"toolUseId": "1"}}]}],
+            2,
+            False,
+            [{"toolResult": {"toolUseId": "1"}}],
+        ),
+    ],
+)
+def test_truncate_tool_results(messages, msg_idx, expected_changed, expected_content):
+    test_messages = copy.deepcopy(messages)
+    changed = message_processor.truncate_tool_results(test_messages, msg_idx)
+    assert changed == expected_changed
+    if 0 <= msg_idx < len(test_messages):
+        assert test_messages[msg_idx]["content"] == expected_content
+    else:
+        assert test_messages == messages


### PR DESCRIPTION

![phoenix_logo_small](https://github.com/user-attachments/assets/a276c8b1-57d2-4733-a8fc-24a9a218126e)

## Description
🧪 Test Suite Overview for message_processor

This test module provides coverage for key utility functions in message_processor.py under strands.event_loop, specifically validating behavior related to message sanitization and correction in tool use scenarios. The tests are structured with pytest and include parameterized inputs for robustness.

✅ test_clean_orphaned_empty_tool_uses

Tests the function clean_orphaned_empty_tool_uses, which removes or replaces toolUse messages that:
	•	Have empty input
	•	Do not have a matching toolResult

This ensures the message history doesn’t contain stale or incomplete tool use entries. The test checks both whether the cleanup happened and what the cleaned messages look like.

🔍 test_find_last_message_with_tool_results

Validates find_last_message_with_tool_results, which scans a message list to find the last occurrence of a toolResult. This is useful for indexing or pruning based on tool result placement.

✂️ test_truncate_tool_results

Covers truncate_tool_results, which modifies a specific message to mark its toolResult as errored (e.g., when the result is too large). The function updates the content and returns a flag indicating whether the modification occurred.

Each test ensures:
	•	Correct handling of edge cases (empty inputs, invalid indexes)
	•	No side effects on input data (using deepcopy)
	•	Expected message transformations or detection logic

## Type of Change
- Adding test coverage

Before
<img width="989" alt="image" src="https://github.com/user-attachments/assets/0bb19d8a-75a5-401a-a0da-aa12ef2b3806" /> 

After
<img width="1094" alt="image" src="https://github.com/user-attachments/assets/08e5223b-bf32-49a4-8ff8-508360f496ba" />



[Choose one of the above types of changes]


## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [X] I have read the CONTRIBUTING document
- [X ] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


