### PR TITLE
fix(telemetry): fix agent span start and end when using Agent.stream_async()

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -334,11 +334,11 @@ class Agent:
             # Run the event loop and get the result
             result = self._run_loop(prompt, kwargs)
 
-            self._end_agent_trace_span(span=self.trace_span, response=result)
+            self._end_agent_trace_span(response=result)
 
             return result
         except Exception as e:
-            self._end_agent_trace_span(span=self.trace_span, error=e)
+            self._end_agent_trace_span(error=e)
 
             # Re-raise the exception to preserve original behavior
             raise
@@ -393,9 +393,9 @@ class Agent:
 
             try:
                 result = self._run_loop(prompt, kwargs, supplementary_callback_handler=queuing_callback_handler)
-                self._end_agent_trace_span(span=self.trace_span, response=result)
+                self._end_agent_trace_span(response=result)
             except Exception as e:
-                self._end_agent_trace_span(span=self.trace_span, error=e)
+                self._end_agent_trace_span(error=e)
                 enqueue(e)
             finally:
                 enqueue(_stop_event)
@@ -559,7 +559,6 @@ class Agent:
 
     def _end_agent_trace_span(
         self,
-        span: Optional[trace.Span] = None,
         response: Optional[AgentResult] = None,
         error: Optional[Exception] = None,
     ) -> None:

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -328,27 +328,17 @@ class Agent:
                 - metrics: Performance metrics from the event loop
                 - state: The final state of the event loop
         """
-        model_id = self.model.config.get("model_id") if hasattr(self.model, "config") else None
-
-        self.trace_span = self.tracer.start_agent_span(
-            prompt=prompt,
-            model_id=model_id,
-            tools=self.tool_names,
-            system_prompt=self.system_prompt,
-            custom_trace_attributes=self.trace_attributes,
-        )
+        self._start_agent_trace_span(prompt)
 
         try:
             # Run the event loop and get the result
             result = self._run_loop(prompt, kwargs)
 
-            if self.trace_span:
-                self.tracer.end_agent_span(span=self.trace_span, response=result)
+            self._end_agent_trace_span(span=self.trace_span, response=result)
 
             return result
         except Exception as e:
-            if self.trace_span:
-                self.tracer.end_agent_span(span=self.trace_span, error=e)
+            self._end_agent_trace_span(span=self.trace_span, error=e)
 
             # Re-raise the exception to preserve original behavior
             raise
@@ -383,6 +373,8 @@ class Agent:
                     yield event["data"]
             ```
         """
+        self._start_agent_trace_span(prompt)
+
         _stop_event = uuid4()
 
         queue = asyncio.Queue[Any]()
@@ -400,8 +392,10 @@ class Agent:
             nonlocal kwargs
 
             try:
-                self._run_loop(prompt, kwargs, supplementary_callback_handler=queuing_callback_handler)
-            except BaseException as e:
+                result = self._run_loop(prompt, kwargs, supplementary_callback_handler=queuing_callback_handler)
+                self._end_agent_trace_span(span=self.trace_span, response=result)
+            except Exception as e:
+                self._end_agent_trace_span(span=self.trace_span, error=e)
                 enqueue(e)
             finally:
                 enqueue(_stop_event)
@@ -414,7 +408,7 @@ class Agent:
                 item = await queue.get()
                 if item == _stop_event:
                     break
-                if isinstance(item, BaseException):
+                if isinstance(item, Exception):
                     raise item
                 yield item
         finally:
@@ -546,3 +540,44 @@ class Agent:
         messages.append(tool_use_msg)
         messages.append(tool_result_msg)
         messages.append(assistant_msg)
+
+    def _start_agent_trace_span(self, prompt: str) -> None:
+        """Starts a trace span for the agent.
+
+        Args:
+            prompt: The natural language prompt from the user.
+        """
+        model_id = self.model.config.get("model_id") if hasattr(self.model, "config") else None
+
+        self.trace_span = self.tracer.start_agent_span(
+            prompt=prompt,
+            model_id=model_id,
+            tools=self.tool_names,
+            system_prompt=self.system_prompt,
+            custom_trace_attributes=self.trace_attributes,
+        )
+
+    def _end_agent_trace_span(
+        self,
+        span: Optional[trace.Span] = None,
+        response: Optional[AgentResult] = None,
+        error: Optional[Exception] = None,
+    ) -> None:
+        """Ends a trace span for the agent.
+
+        Args:
+            span: The span to end.
+            response: Response to record as a trace attribute.
+            error: Error to record as a trace attribute.
+        """
+        if self.trace_span:
+            trace_attributes: Dict[str, Any] = {
+                "span": self.trace_span,
+            }
+
+            if response:
+                trace_attributes["response"] = response
+            if error:
+                trace_attributes["error"] = error
+
+            self.tracer.end_agent_span(**trace_attributes)

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -9,7 +9,8 @@ from time import sleep
 import pytest
 
 import strands
-from strands.agent.agent import Agent
+from strands import Agent
+from strands.agent import AgentResult
 from strands.agent.conversation_manager.null_conversation_manager import NullConversationManager
 from strands.agent.conversation_manager.sliding_window_conversation_manager import SlidingWindowConversationManager
 from strands.handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
@@ -687,8 +688,6 @@ def test_agent_with_callback_handler_none_uses_null_handler():
 
 @pytest.mark.asyncio
 async def test_stream_async_returns_all_events(mock_event_loop_cycle):
-    mock_event_loop_cycle.side_effect = ValueError("Test exception")
-
     agent = Agent()
 
     # Define the side effect to simulate callback handler being called multiple times
@@ -952,6 +951,52 @@ def test_agent_call_creates_and_ends_span_on_success(mock_get_tracer, mock_model
     mock_tracer.end_agent_span.assert_called_once_with(span=mock_span, response=result)
 
 
+@pytest.mark.asyncio
+@unittest.mock.patch("strands.agent.agent.get_tracer")
+async def test_agent_stream_async_creates_and_ends_span_on_success(mock_get_tracer, mock_event_loop_cycle):
+    """Test that stream_async creates and ends a span when the call succeeds."""
+    # Setup mock tracer and span
+    mock_tracer = unittest.mock.MagicMock()
+    mock_span = unittest.mock.MagicMock()
+    mock_tracer.start_agent_span.return_value = mock_span
+    mock_get_tracer.return_value = mock_tracer
+
+    # Define the side effect to simulate callback handler being called multiple times
+    def call_callback_handler(*args, **kwargs):
+        # Extract the callback handler from kwargs
+        callback_handler = kwargs.get("callback_handler")
+        # Call the callback handler with different data values
+        callback_handler(data="First chunk")
+        callback_handler(data="Second chunk")
+        callback_handler(data="Final chunk", complete=True)
+        # Return expected values from event_loop_cycle
+        return "stop", {"role": "assistant", "content": [{"text": "Agent Response"}]}, {}, {}
+
+    mock_event_loop_cycle.side_effect = call_callback_handler
+
+    # Create agent and make a call
+    agent = Agent(model=mock_model)
+    iterator = agent.stream_async("test prompt")
+    async for _event in iterator:
+        pass  # NoOp
+
+    # Verify span was created
+    mock_tracer.start_agent_span.assert_called_once_with(
+        prompt="test prompt",
+        model_id=unittest.mock.ANY,
+        tools=agent.tool_names,
+        system_prompt=agent.system_prompt,
+        custom_trace_attributes=agent.trace_attributes,
+    )
+
+    expected_response = AgentResult(
+        stop_reason="stop", message={"role": "assistant", "content": [{"text": "Agent Response"}]}, metrics={}, state={}
+    )
+
+    # Verify span was ended with the result
+    mock_tracer.end_agent_span.assert_called_once_with(span=mock_span, response=expected_response)
+
+
 @unittest.mock.patch("strands.agent.agent.get_tracer")
 def test_agent_call_creates_and_ends_span_on_exception(mock_get_tracer, mock_model):
     """Test that __call__ creates and ends a span when an exception occurs."""
@@ -971,6 +1016,42 @@ def test_agent_call_creates_and_ends_span_on_exception(mock_get_tracer, mock_mod
     # Call the agent and catch the exception
     with pytest.raises(ValueError):
         agent("test prompt")
+
+    # Verify span was created
+    mock_tracer.start_agent_span.assert_called_once_with(
+        prompt="test prompt",
+        model_id=unittest.mock.ANY,
+        tools=agent.tool_names,
+        system_prompt=agent.system_prompt,
+        custom_trace_attributes=agent.trace_attributes,
+    )
+
+    # Verify span was ended with the exception
+    mock_tracer.end_agent_span.assert_called_once_with(span=mock_span, error=test_exception)
+
+
+@pytest.mark.asyncio
+@unittest.mock.patch("strands.agent.agent.get_tracer")
+async def test_agent_stream_async_creates_and_ends_span_on_exception(mock_get_tracer, mock_model):
+    """Test that stream_async creates and ends a span when the call succeeds."""
+    # Setup mock tracer and span
+    mock_tracer = unittest.mock.MagicMock()
+    mock_span = unittest.mock.MagicMock()
+    mock_tracer.start_agent_span.return_value = mock_span
+    mock_get_tracer.return_value = mock_tracer
+
+    # Define the side effect to simulate callback handler raising an Exception
+    test_exception = ValueError("Test exception")
+    mock_model.mock_converse.side_effect = test_exception
+
+    # Create agent and make a call
+    agent = Agent(model=mock_model)
+
+    # Call the agent and catch the exception
+    with pytest.raises(ValueError):
+        iterator = agent.stream_async("test prompt")
+        async for _event in iterator:
+            pass  # NoOp
 
     # Verify span was created
     mock_tracer.start_agent_span.assert_called_once_with(


### PR DESCRIPTION
## Description
Fix agent span start and end when using Agent.stream_async()

## Related Issues
https://github.com/strands-agents/sdk-python/issues/118

## Documentation PR
N/A

## Type of Change
- Bug fix

## Testing
* `hatch fmt`
* `hatch run test-lint`
* `hatch test --all`
* `hatch run test-integ`
* Verified manually with a test script (trace: https://us.cloud.langfuse.com/project/cmaoqkqd901afad07ui6ndt1v/traces/274b27477f1192d0134307ddd3539743?timestamp=2025-05-26T16%3A31%3A17.773Z&display=details):
```python
#!/usr/bin/env python

import asyncio
import logging
import os
from strands import Agent, tool
from strands_tools import calculator, http_request, image_reader

logging.getLogger("strands.telemetry.tracer").setLevel(logging.DEBUG)
logging.basicConfig(
    format="%(levelname)s | %(name)s | %(message)s",
    handlers=[logging.StreamHandler()]
)

os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://us.cloud.langfuse.com/api/public/otel"
os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = "Authorization=Basic <REDACTED>"

agent = Agent(
    system_prompt="You are a helpful assistant that provides concise responses.",
    tools=[http_request, calculator, image_reader],
    trace_attributes={
        "session.id": "abc-1234",
        "user.id": "user-email-example@domain.com",
        "langfuse.tags": [
            "Agent-SDK",
            "Okatank-Project",
            "Observability-Tags",
        ]
    },
    callback_handler=None,
)

async def process_streaming_response():
    agent_stream = agent.stream_async("\u30d5\u30a9\u30fc Describe the image at /Users/arron/strands-samples/01-getting-started/00-first-agent/images/architecture.png")
    async for event in agent_stream:
        print(event)

# Run the agent
asyncio.run(process_streaming_response())
```

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [-] I have updated the documentation accordingly
- [-] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
