### PR TITLE
feat: Update SlidingWindowConversationManager

### DIFF
--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -428,7 +428,7 @@ def test_agent__call__always_sliding_window_conversation_manager_doesnt_infinite
     with pytest.raises(ContextWindowOverflowException):
         agent("Test!")
 
-    assert conversation_manager_spy.reduce_context.call_count == 251
+    assert conversation_manager_spy.reduce_context.call_count > 0
     assert conversation_manager_spy.apply_management.call_count == 1
 
 

--- a/tests/strands/agent/test_conversation_manager.py
+++ b/tests/strands/agent/test_conversation_manager.py
@@ -111,41 +111,7 @@ def conversation_manager(request):
                 {"role": "assistant", "content": [{"text": "Second response"}]},
             ],
         ),
-        # 7 - Message count above max window size - Remove dangling tool uses and tool results
-        (
-            {"window_size": 1},
-            [
-                {"role": "user", "content": [{"text": "First message"}]},
-                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "321", "name": "tool1", "input": {}}}]},
-                {
-                    "role": "user",
-                    "content": [
-                        {"toolResult": {"toolUseId": "123", "content": [{"text": "Hello!"}], "status": "success"}}
-                    ],
-                },
-            ],
-            [
-                {
-                    "role": "user",
-                    "content": [{"text": "\nTool Result Text Content: Hello!\nTool Result Status: success"}],
-                },
-            ],
-        ),
-        # 8 - Message count above max window size - Remove multiple tool use/tool result pairs
-        (
-            {"window_size": 1},
-            [
-                {"role": "user", "content": [{"toolResult": {"toolUseId": "123", "content": [], "status": "success"}}]},
-                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "123", "name": "tool1", "input": {}}}]},
-                {"role": "user", "content": [{"toolResult": {"toolUseId": "456", "content": [], "status": "success"}}]},
-                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "456", "name": "tool1", "input": {}}}]},
-                {"role": "user", "content": [{"toolResult": {"toolUseId": "789", "content": [], "status": "success"}}]},
-            ],
-            [
-                {"role": "user", "content": [{"text": "Tool Result Status: success"}]},
-            ],
-        ),
-        # 9 - Message count above max window size - Preserve tool use/tool result pairs
+        # 7 - Message count above max window size - Preserve tool use/tool result pairs
         (
             {"window_size": 2},
             [
@@ -158,7 +124,7 @@ def conversation_manager(request):
                 {"role": "user", "content": [{"toolResult": {"toolUseId": "456", "content": [], "status": "success"}}]},
             ],
         ),
-        # 10 - Test sliding window behavior - preserve tool use/result pairs across cut boundary
+        # 8 - Test sliding window behavior - preserve tool use/result pairs across cut boundary
         (
             {"window_size": 3},
             [
@@ -173,7 +139,7 @@ def conversation_manager(request):
                 {"role": "assistant", "content": [{"text": "Response after tool use"}]},
             ],
         ),
-        # 11 - Test sliding window with multiple tool pairs that need preservation
+        # 9 - Test sliding window with multiple tool pairs that need preservation
         (
             {"window_size": 4},
             [
@@ -185,7 +151,6 @@ def conversation_manager(request):
                 {"role": "assistant", "content": [{"text": "Final response"}]},
             ],
             [
-                {"role": "user", "content": [{"text": "Tool Result Status: success"}]},
                 {"role": "assistant", "content": [{"toolUse": {"toolUseId": "456", "name": "tool2", "input": {}}}]},
                 {"role": "user", "content": [{"toolResult": {"toolUseId": "456", "content": [], "status": "success"}}]},
                 {"role": "assistant", "content": [{"text": "Final response"}]},
@@ -198,6 +163,20 @@ def test_apply_management(conversation_manager, messages, expected_messages):
     conversation_manager.apply_management(messages)
 
     assert messages == expected_messages
+
+
+def test_sliding_window_conversation_manager_with_untrimmable_history_raises_context_window_overflow_exception():
+    manager = strands.agent.conversation_manager.SlidingWindowConversationManager(1)
+    messages = [
+        {"role": "assistant", "content": [{"toolUse": {"toolUseId": "456", "name": "tool1", "input": {}}}]},
+        {"role": "user", "content": [{"toolResult": {"toolUseId": "789", "content": [], "status": "success"}}]},
+    ]
+    original_messages = messages.copy()
+
+    with pytest.raises(ContextWindowOverflowException):
+        manager.apply_management(messages)
+
+    assert messages == original_messages
 
 
 def test_null_conversation_manager_reduce_context_raises_context_window_overflow_exception():


### PR DESCRIPTION
## Description
Update SlidingWindowConversationManager to take advantage of Bedrocks newly relaxed validation checks. Before, bedrock had strict checks where the oldest message in history needed to be a `user` message with no `toolResult` content blocks. Now the only restriction is that `toolUse` content blocks must be immediately followed by a `toolResult`, and a `toolResult` must have a corresponding `toolUse` immediately before it.

## Related Issues
https://github.com/strands-agents/sdk-python/issues/95

## Documentation PR
N/A

## Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation update
- Other (please describe):

New feature


## Testing

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
