### PR TITLE
style(callback_handler): fix docstring for PrintingCallbackHandler.__call__

### DIFF
--- a/src/strands/handlers/callback_handler.py
+++ b/src/strands/handlers/callback_handler.py
@@ -17,10 +17,10 @@ class PrintingCallbackHandler:
 
         Args:
             **kwargs: Callback event data including:
-            - reasoningText (Optional[str]): Reasoning text to print if provided.
-            - data (str): Text content to stream.
-            - complete (bool): Whether this is the final chunk of a response.
-            - current_tool_use (dict): Information about the current tool being used.
+                - reasoningText (Optional[str]): Reasoning text to print if provided.
+                - data (str): Text content to stream.
+                - complete (bool): Whether this is the final chunk of a response.
+                - current_tool_use (dict): Information about the current tool being used.
         """
         reasoningText = kwargs.get("reasoningText", False)
         data = kwargs.get("data", "")


### PR DESCRIPTION
## Description
fix docstring for PrintingCallbackHandler.__call__

resolves:
```
WARNING -  griffe: /Users/arron/.env/lib/python3.13/site-packages/strands/handlers/callback_handler.py:20: Parameter '-' does not appear in the function signature
WARNING -  griffe: /Users/arron/.env/lib/python3.13/site-packages/strands/handlers/callback_handler.py:21: Parameter '-' does not appear in the function signature
WARNING -  griffe: /Users/arron/.env/lib/python3.13/site-packages/strands/handlers/callback_handler.py:22: Parameter '-' does not appear in the function signature
WARNING -  griffe: /Users/arron/.env/lib/python3.13/site-packages/strands/handlers/callback_handler.py:23: Parameter '-' does not appear in the function signature
```

## Type of Change
- Documentation update

## Testing
* `hatch fmt`
* `hatch run test-lint`
* `hatch test --all`
* Ran `mkdocs serve -a 0.0.0.0:8000` in the strands-agents/docs repository and verified that the griffe warning disappeared


## Checklist
- [X] I have read the CONTRIBUTING document
- [-] I have added tests that prove my fix is effective or my feature works
- [-] I have updated the documentation accordingly
- [-] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
