### PR TITLE
feat: support redactedContent in reasoningContent streamed events

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -182,6 +182,7 @@ def handle_content_block_stop(state: Dict[str, Any]) -> Dict[str, Any]:
     current_tool_use = state["current_tool_use"]
     text = state["text"]
     reasoning_text = state["reasoningText"]
+    redacted_content = state["redactedContent"]
 
     if current_tool_use:
         if "input" not in current_tool_use:
@@ -219,8 +220,8 @@ def handle_content_block_stop(state: Dict[str, Any]) -> Dict[str, Any]:
             }
         )
         state["reasoningText"] = ""
-    elif "redactedContent" in state and state["redactedContent"]:
-        content.append({"reasoningContent": {"redactedContent": state["redactedContent"]}})
+    elif redacted_content:
+        content.append({"reasoningContent": {"redactedContent": redacted_content}})
         state["redactedContent"] = b""
 
     return state

--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -152,6 +152,18 @@ def handle_content_block_delta(
                 reasoning=True,
                 **kwargs,
             )
+            
+        elif "redactedContent" in delta_content["reasoningContent"]:
+            if "redactedContent" not in state:
+                state["redactedContent"] = b""
+
+            state["redactedContent"] += delta_content["reasoningContent"]["redactedContent"]
+            callback_handler(
+                redactedContent=delta_content["reasoningContent"]["redactedContent"],
+                delta=delta_content,
+                reasoning=True,
+                **kwargs,
+            )
 
     return state
 
@@ -207,6 +219,16 @@ def handle_content_block_stop(state: Dict[str, Any]) -> Dict[str, Any]:
             }
         )
         state["reasoningText"] = ""
+        state["signature"] = ""
+    elif "redactedContent" in state and state["redactedContent"]:
+        content.append(
+            {
+                "reasoningContent": {
+                    "redactedContent": state["redactedContent"]
+                }
+            }
+        )
+        state["redactedContent"] = b""
 
     return state
 
@@ -279,6 +301,7 @@ def process_stream(
         "current_tool_use": {},
         "reasoningText": "",
         "signature": "",
+        "redactedContent": b"",
     }
     state["content"] = state["message"]["content"]
 

--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -152,7 +152,7 @@ def handle_content_block_delta(
                 reasoning=True,
                 **kwargs,
             )
-            
+
         elif "redactedContent" in delta_content["reasoningContent"]:
             if "redactedContent" not in state:
                 state["redactedContent"] = b""
@@ -219,15 +219,8 @@ def handle_content_block_stop(state: Dict[str, Any]) -> Dict[str, Any]:
             }
         )
         state["reasoningText"] = ""
-        state["signature"] = ""
     elif "redactedContent" in state and state["redactedContent"]:
-        content.append(
-            {
-                "reasoningContent": {
-                    "redactedContent": state["redactedContent"]
-                }
-            }
-        )
+        content.append({"reasoningContent": {"redactedContent": state["redactedContent"]}})
         state["redactedContent"] = b""
 
     return state

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -134,16 +134,16 @@ def test_handle_content_block_start(chunk: ContentBlockStartEvent, exp_tool_use)
         ),
         # Reasoning - redactedContent - New
         (
-            {"delta": {"reasoningContent": {"redactedContent": b"encrypted"}}},
+            {"delta": {"reasoningContent": {"redactedContent": b"encoded"}}},
             {},
-            {"redactedContent": b"encrypted"},
-            {"redactedContent": b"encrypted", "reasoning": True},
+            {"redactedContent": b"encoded"},
+            {"redactedContent": b"encoded", "reasoning": True},
         ),
         # Reasoning - redactedContent - Existing
         (
             {"delta": {"reasoningContent": {"redactedContent": b"data"}}},
-            {"redactedContent": b"encrypted_"},
-            {"redactedContent": b"encrypted_data"},
+            {"redactedContent": b"encoded_"},
+            {"redactedContent": b"encoded_data"},
             {"redactedContent": b"data", "reasoning": True},
         ),
         # Reasoning - Empty
@@ -189,12 +189,14 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, state, exp_up
                 "current_tool_use": {"toolUseId": "123", "name": "test", "input": '{"key": "value"}'},
                 "text": "",
                 "reasoningText": "",
+                "redactedContent": b"",
             },
             {
                 "content": [{"toolUse": {"toolUseId": "123", "name": "test", "input": {"key": "value"}}}],
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
+                "redactedContent": b"",
             },
         ),
         # Tool Use - Missing input
@@ -204,12 +206,14 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, state, exp_up
                 "current_tool_use": {"toolUseId": "123", "name": "test"},
                 "text": "",
                 "reasoningText": "",
+                "redactedContent": b"",
             },
             {
                 "content": [{"toolUse": {"toolUseId": "123", "name": "test", "input": {}}}],
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
+                "redactedContent": b"",
             },
         ),
         # Text
@@ -219,12 +223,14 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, state, exp_up
                 "current_tool_use": {},
                 "text": "test",
                 "reasoningText": "",
+                "redactedContent": b"",
             },
             {
                 "content": [{"text": "test"}],
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
+                "redactedContent": b"",
             },
         ),
         # Reasoning
@@ -235,6 +241,7 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, state, exp_up
                 "text": "",
                 "reasoningText": "test",
                 "signature": "123",
+                "redactedContent": b"",
             },
             {
                 "content": [{"reasoningContent": {"reasoningText": {"text": "test", "signature": "123"}}}],
@@ -242,6 +249,7 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, state, exp_up
                 "text": "",
                 "reasoningText": "",
                 "signature": "123",
+                "redactedContent": b"",
             },
         ),
         # redactedContent
@@ -251,10 +259,10 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, state, exp_up
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
-                "redactedContent": b"encrypted_data",
+                "redactedContent": b"encoded_data",
             },
             {
-                "content": [{"reasoningContent": {"redactedContent": b"encrypted_data"}}],
+                "content": [{"reasoningContent": {"redactedContent": b"encoded_data"}}],
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
@@ -268,12 +276,14 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, state, exp_up
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
+                "redactedContent": b"",
             },
             {
                 "content": [],
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
+                "redactedContent": b"",
             },
         ),
     ],
@@ -393,7 +403,7 @@ def test_extract_usage_metrics():
                     "contentBlockStart": {"start": {}},
                 },
                 {
-                    "contentBlockDelta": {"delta": {"reasoningContent": {"redactedContent": b"encrypted_data"}}},
+                    "contentBlockDelta": {"delta": {"reasoningContent": {"redactedContent": b"encoded_data"}}},
                 },
                 {"contentBlockStop": {}},
                 {
@@ -409,7 +419,7 @@ def test_extract_usage_metrics():
             "end_turn",
             {
                 "role": "assistant",
-                "content": [{"reasoningContent": {"redactedContent": b"encrypted_data"}}],
+                "content": [{"reasoningContent": {"redactedContent": b"encoded_data"}}],
             },
             {"inputTokens": 1, "outputTokens": 1, "totalTokens": 1},
             {"latencyMs": 1},


### PR DESCRIPTION
## Description
Added support for the redactedContent field in ReasoningContentBlock from AWS Bedrock API. 

## Related Issues
Closes #99 


## Type of Change
- New feature


## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
