### PR TITLE
models - content - documents

### DIFF
--- a/src/strands/types/models/openai.py
+++ b/src/strands/types/models/openai.py
@@ -7,6 +7,7 @@ responses to and from the OpenAI specification.
 """
 
 import abc
+import base64
 import json
 import logging
 import mimetypes
@@ -40,6 +41,17 @@ class OpenAIModel(Model, abc.ABC):
         Returns:
             OpenAI compatible content block.
         """
+        if "document" in content:
+            mime_type = mimetypes.types_map.get(f".{content['document']['format']}", "application/octet-stream")
+            file_data = base64.b64encode(content["document"]["source"]["bytes"]).decode("utf-8")
+            return {
+                "file": {
+                    "file_data": f"data:{mime_type};base64,{file_data}",
+                    "filename": content["document"]["name"],
+                },
+                "type": "file",
+            }
+
         if "image" in content:
             mime_type = mimetypes.types_map.get(f".{content['image']['format']}", "application/octet-stream")
             image_data = content["image"]["source"]["bytes"].decode("utf-8")

--- a/tests/strands/types/models/test_openai.py
+++ b/tests/strands/types/models/test_openai.py
@@ -62,7 +62,24 @@ def system_prompt():
 @pytest.mark.parametrize(
     "content, exp_result",
     [
-        # Case 1: Image
+        # Document
+        (
+            {
+                "document": {
+                    "format": "pdf",
+                    "name": "test doc",
+                    "source": {"bytes": b"document"},
+                },
+            },
+            {
+                "file": {
+                    "file_data": "data:application/pdf;base64,ZG9jdW1lbnQ=",
+                    "filename": "test doc",
+                },
+                "type": "file",
+            },
+        ),
+        # Image
         (
             {
                 "image": {
@@ -79,12 +96,12 @@ def system_prompt():
                 "type": "image_url",
             },
         ),
-        # Case 2: Text
+        # Text
         (
             {"text": "hello"},
             {"type": "text", "text": "hello"},
         ),
-        # Case 3: Other
+        # Other
         (
             {"other": {"a": 1}},
             {


### PR DESCRIPTION
## Description
Add document support to OpenAI and LiteLLM model providers.

## Related Issues
https://github.com/strands-agents/tools/pull/53

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
*  `hatch run test-lint`
* `python ./test_document.py`: Wrote the following test script:

```python
from strands import Agent
from strands.models.litellm import LiteLLMModel

with open("cat.wikipedia.page1.pdf", "rb") as fp:
    doc = fp.read()

agent = Agent(
    messages=[
        {
            "role": "user",
            "content": [
                {
                    "document": {
                        "format": "pdf",
                        "name": "test doc",
                        "source": {
                            "bytes": doc,
                        },
                    },
                },
            ],
        },
    ],
    model=LiteLLMModel(model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0")
)
agent("Can you summarize the provided document?")
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
