### PR TITLE
models - anthropic - document - plain text

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -97,13 +97,16 @@ class AnthropicModel(Model):
             Anthropic formatted content block.
         """
         if "document" in content:
+            mime_type = mimetypes.types_map.get(f".{content['document']['format']}", "application/octet-stream")
             return {
                 "source": {
-                    "data": base64.b64encode(content["document"]["source"]["bytes"]).decode("utf-8"),
-                    "media_type": mimetypes.types_map.get(
-                        f".{content['document']['format']}", "application/octet-stream"
+                    "data": (
+                        content["document"]["source"]["bytes"].decode("utf-8")
+                        if mime_type == "text/plain"
+                        else base64.b64encode(content["document"]["source"]["bytes"]).decode("utf-8")
                     ),
-                    "type": "base64",
+                    "media_type": mime_type,
+                    "type": "text" if mime_type == "text/plain" else "base64",
                 },
                 "title": content["document"]["name"],
                 "type": "document",

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -102,19 +102,46 @@ def test_format_request_with_system_prompt(model, messages, model_id, max_tokens
     assert tru_request == exp_request
 
 
-def test_format_request_with_document(model, model_id, max_tokens):
+@pytest.mark.parametrize(
+    ("content", "formatted_content"),
+    [
+        # PDF
+        (
+            {
+                "document": {"format": "pdf", "name": "test doc", "source": {"bytes": b"pdf"}},
+            },
+            {
+                "source": {
+                    "data": "cGRm",
+                    "media_type": "application/pdf",
+                    "type": "base64",
+                },
+                "title": "test doc",
+                "type": "document",
+            },
+        ),
+        # Plain text
+        (
+            {
+                "document": {"format": "txt", "name": "test doc", "source": {"bytes": b"txt"}},
+            },
+            {
+                "source": {
+                    "data": "txt",
+                    "media_type": "text/plain",
+                    "type": "text",
+                },
+                "title": "test doc",
+                "type": "document",
+            },
+        ),
+    ],
+)
+def test_format_request_with_document(content, formatted_content, model, model_id, max_tokens):
     messages = [
         {
             "role": "user",
-            "content": [
-                {
-                    "document": {
-                        "format": "pdf",
-                        "name": "test-doc",
-                        "source": {"bytes": b"base64encodeddoc"},
-                    },
-                },
-            ],
+            "content": [content],
         },
     ]
 
@@ -124,17 +151,7 @@ def test_format_request_with_document(model, model_id, max_tokens):
         "messages": [
             {
                 "role": "user",
-                "content": [
-                    {
-                        "source": {
-                            "data": "YmFzZTY0ZW5jb2RlZGRvYw==",
-                            "media_type": "application/pdf",
-                            "type": "base64",
-                        },
-                        "title": "test-doc",
-                        "type": "document",
-                    },
-                ],
+                "content": [formatted_content],
             },
         ],
         "model": model_id,


### PR DESCRIPTION
## Description
Our Anthropic model provider passes along all document content in the same manner. However, we need special handling for plain text documents ([docs](https://docs.anthropic.com/en/api/messages#plain-text)). This PR adds the fix.

## Related Issues
https://github.com/strands-agents/tools/pull/53

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
* `hatch run test-lint`
* `python test_doc.py`: Ran the following test script:

```python
from strands import Agent
from strands.models.anthropic import AnthropicModel

with open("cat.wikipedia.page1.txt", "rb") as fp:
    doc = fp.read()

agent = Agent(
    messages=[
        {
            "role": "user",
            "content": [
                {
                    "document": {
                        "format": "txt",
                        "name": "test doc",
                        "source": {
                            "bytes": doc,
                        },
                    },
                },
            ],
        },
    ],
    model=AnthropicModel(client_args={"api_key": "***"}, model_id="claude-3-5-sonnet-latest", max_tokens=8000)
)
agent("Can you summarize the provided document?")
```


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
