### PR TITLE
Automate deployment to PYPI

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -1,0 +1,17 @@
+name: Pull Request and Push Action
+
+on:
+  pull_request:  # Safer than pull_request_target for untrusted code
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review, review_requested, review_request_removed]
+  push:
+    branches: [ main ]  # Also run on direct pushes to main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call-test-lint:
+    uses: ./.github/workflows/test-lint.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -6,8 +6,15 @@ on:
       - published
 
 jobs:
+  call-test-lint:
+    uses: ./.github/workflows/test-lint.yml
+    with:
+      ref: ${{ github.event.release.target_commitish }}
+
   build:
     name: Build distribution 📦
+    needs:
+      - call-test-lint
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +31,17 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install hatch twine
+
+    - name: Validate version
+      run: |
+        version=$(hatch version)
+        if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Valid version format"
+            exit 0
+        else
+            echo "Invalid version format"
+            exit 1
+        fi
 
     - name: Build
       run: |
@@ -44,8 +62,8 @@ jobs:
     # environment is used by PyPI Trusted Publisher and is strongly encouraged
     # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/strands-agents
+      name: pypi
+      url: https://pypi.org/p/strands-agents
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
@@ -56,8 +74,5 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-
-    - name: Publish distribution 📦 to TestPyPI
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -1,14 +1,11 @@
 name: Test and Lint
 
 on:
-  pull_request:  # Safer than pull_request_target for untrusted code
-    branches: [ main ]
-    types: [opened, synchronize, reopened, ready_for_review, review_requested, review_request_removed]
-  push:
-    branches: [ main ]  # Also run on direct pushes to main
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
 
 jobs:
   unit-test:
@@ -56,7 +53,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}  # Explicitly define which commit to check out
+          ref: ${{ inputs.ref }}  # Explicitly define which commit to check out
           persist-credentials: false  # Don't persist credentials for subsequent actions
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -78,7 +75,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Set up Python

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__*
 .ruff_cache
 *.bak
 .vscode
+dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "strands-agents"
-version = "0.1.5"
+dynamic = ["version"]
 description = "A model-driven approach to building AI agents in just a few lines of code"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -78,6 +78,10 @@ ollama = [
 openai = [
     "openai>=1.68.0,<2.0.0",
 ]
+
+[tool.hatch.version]
+# Tells Hatch to use your version control system (git) to determine the version.
+source = "vcs"
 
 [tool.hatch.envs.hatch-static-analysis]
 features = ["anthropic", "litellm", "llamaapi", "ollama", "openai"]


### PR DESCRIPTION
## Description
This pr adds a github action to deploy the latest version of strands-agents to PYPI when a github release is created. This implements the following features:
- dynamic version checking based on tag
- Refactor testing workflow to be reusable, and run it before the release deployment process
- Build and deploy to PYPI

## Related Issues
N/A

## Documentation PR
N/A

## Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation update
- Other (please describe):

New feature


## Testing
Ive tested this on my fork repo. You can see the testing results here: https://github.com/Unshure/sdk-python/actions/runs/15332480959


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
