### PR TITLE
feat: Add tool result caching

### DIFF
--- a/src/strands/tools/cache.py
+++ b/src/strands/tools/cache.py
@@ -1,0 +1,133 @@
+"""Tool result caching implementation."""
+
+import hashlib
+import json
+import logging
+import threading
+import time
+from typing import Any, Dict, Optional, Tuple
+
+from ..types.tools import ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+class ToolResultCache:
+    """Cache for tool execution results.
+
+    This class provides caching functionality for tool execution results to avoid
+    redundant tool executions with the same parameters.
+    """
+
+    def __init__(self, max_size: int = 100, ttl_seconds: int = 300):
+        """Initialize the tool result cache.
+
+        Args:
+            max_size: Maximum number of entries to store in the cache.
+            ttl_seconds: Time-to-live for cache entries in seconds.
+        """
+        self.cache: Dict[str, Tuple[ToolResult, float]] = {}
+        self.max_size = max_size
+        self.ttl_seconds = ttl_seconds
+        self.hits = 0
+        self.misses = 0
+        self.lock = threading.RLock()
+
+    def get(self, tool_name: str, tool_input: Dict[str, Any]) -> Optional[ToolResult]:
+        """Get a cached tool result.
+
+        Args:
+            tool_name: Name of the tool.
+            tool_input: Input parameters for the tool.
+
+        Returns:
+            The cached tool result, or None if not found or expired.
+        """
+        with self.lock:
+            key = self._make_key(tool_name, tool_input)
+            if key in self.cache:
+                result, timestamp = self.cache[key]
+                # Check TTL
+                if time.time() - timestamp <= self.ttl_seconds:
+                    self.hits += 1
+                    logger.debug("tool_name=<%s> | cache hit", tool_name)
+                    return result
+                else:
+                    del self.cache[key]
+                    logger.debug("tool_name=<%s> | cache entry expired", tool_name)
+
+            self.misses += 1
+            return None
+
+    def set(self, tool_name: str, tool_input: Dict[str, Any], result: ToolResult) -> None:
+        """Store a tool result in the cache.
+
+        Args:
+            tool_name: Name of the tool.
+            tool_input: Input parameters for the tool.
+            result: The tool execution result to cache.
+        """
+        with self.lock:
+            key = self._make_key(tool_name, tool_input)
+
+            # Check the size of cache
+            if len(self.cache) >= self.max_size:
+                self._evict_cache()
+
+            self.cache[key] = (result.copy(), time.time())
+            logger.debug("tool_name=<%s> | cached result", tool_name)
+
+    def _make_key(self, tool_name: str, tool_input: Dict[str, Any]) -> str:
+        """Generate a cache key from tool name and input parameters.
+
+        Args:
+            tool_name: Name of the tool.
+            tool_input: Input parameters for the tool.
+
+        Returns:
+            A unique cache key.
+        """
+        input_str = json.dumps(tool_input, sort_keys=True)
+        return f"{tool_name}:{hashlib.md5(input_str.encode()).hexdigest()}"
+
+    def _evict_cache(self) -> None:
+        """Evict the oldest entry from the cache when it reaches max size."""
+        if not self.cache:
+            return
+
+        # LRU
+        oldest_key = None
+        oldest_time = float("inf")
+
+        for key, (_, timestamp) in self.cache.items():
+            if timestamp < oldest_time:
+                oldest_time = timestamp
+                oldest_key = key
+
+        if oldest_key:
+            del self.cache[oldest_key]
+            logger.debug("cache_key=<%s> | evicted from cache", oldest_key)
+
+    def clear(self) -> None:
+        """Clear all entries from the cache."""
+        with self.lock:
+            self.cache.clear()
+            logger.debug("cleared tool result cache")
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get cache statistics.
+
+        Returns:
+            Dictionary with cache statistics.
+        """
+        with self.lock:
+            total = self.hits + self.misses
+            hit_ratio = self.hits / total if total > 0 else 0
+            return {
+                "hits": self.hits,
+                "misses": self.misses,
+                "size": len(self.cache),
+                "max_size": self.max_size,
+                "hit_ratio": hit_ratio,
+                "ttl_seconds": self.ttl_seconds,
+            }

--- a/tests/strands/handlers/test_tool_handler_cache.py
+++ b/tests/strands/handlers/test_tool_handler_cache.py
@@ -1,0 +1,227 @@
+import unittest.mock
+
+import pytest
+
+from strands import Agent
+from strands.handlers.tool_handler import AgentToolHandler
+from strands.tools.registry import ToolRegistry
+
+
+@pytest.fixture
+def tool_registry():
+    """Fixture providing a tool registry"""
+    return ToolRegistry()
+
+
+@pytest.fixture
+def tool_handler(tool_registry):
+    """Fixture providing a tool handler"""
+    return AgentToolHandler(tool_registry=tool_registry)
+
+
+@pytest.fixture
+def mock_tool():
+    """Fixture providing a mock tool"""
+    mock = unittest.mock.Mock()
+    mock.tool_name = "mock_tool"
+    mock.invoke.return_value = {"toolUseId": "test_id", "status": "success", "content": [{"text": "Test result"}]}
+    return mock
+
+
+@pytest.fixture
+def agent_with_cache():
+    """Fixture providing an Agent instance with caching enabled"""
+    agent = Agent(enable_tool_cache=True, tool_cache_size=10, tool_cache_ttl=60)
+    return agent
+
+
+def test_tool_handler_process_with_cache(tool_handler, tool_registry, mock_tool, agent_with_cache):
+    """Test that tool handler utilizes the cache"""
+    # Register mock tool in the registry
+    tool_registry.registry["mock_tool"] = mock_tool
+
+    # Tool use request
+    tool_use = {"toolUseId": "test_id", "name": "mock_tool", "input": {"param": "value"}}
+
+    # First call - cache miss
+    result1 = tool_handler.process(
+        tool=tool_use,
+        model=unittest.mock.Mock(),
+        system_prompt="Test prompt",
+        messages=[],
+        tool_config={},
+        callback_handler=unittest.mock.Mock(),
+        agent=agent_with_cache,
+    )
+
+    # Verify mock tool's invoke method was called
+    mock_tool.invoke.assert_called_once()
+    mock_tool.invoke.reset_mock()
+
+    # Second call - cache hit
+    result2 = tool_handler.process(
+        tool=tool_use,
+        model=unittest.mock.Mock(),
+        system_prompt="Test prompt",
+        messages=[],
+        tool_config={},
+        callback_handler=unittest.mock.Mock(),
+        agent=agent_with_cache,
+    )
+
+    # Verify mock tool's invoke method was not called (result from cache)
+    mock_tool.invoke.assert_not_called()
+
+    # Verify results are the same
+    assert result1 == result2
+
+    # Verify cache statistics
+    stats = agent_with_cache.get_tool_cache_stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+
+
+def test_tool_handler_process_with_cacheable_tools(tool_handler, tool_registry, mock_tool):
+    """Test that cacheable tools list works correctly"""
+    # Register mock tools in the registry
+    tool_registry.registry["mock_tool"] = mock_tool
+    tool_registry.registry["other_tool"] = unittest.mock.Mock()
+
+    # Create agent with cacheable tools list
+    agent = Agent(
+        enable_tool_cache=True,
+        cacheable_tools=["mock_tool"],
+    )
+
+    # mock_tool call
+    tool_use1 = {"toolUseId": "test_id1", "name": "mock_tool", "input": {"param": "value"}}
+
+    # other_tool call
+    tool_use2 = {"toolUseId": "test_id2", "name": "other_tool", "input": {"param": "value"}}
+
+    # mock_tool call - should be cached
+    tool_handler.process(
+        tool=tool_use1,
+        model=unittest.mock.Mock(),
+        system_prompt="Test prompt",
+        messages=[],
+        tool_config={},
+        callback_handler=unittest.mock.Mock(),
+        agent=agent,
+    )
+
+    # other_tool call - should not be cached
+    tool_handler.process(
+        tool=tool_use2,
+        model=unittest.mock.Mock(),
+        system_prompt="Test prompt",
+        messages=[],
+        tool_config={},
+        callback_handler=unittest.mock.Mock(),
+        agent=agent,
+    )
+
+    # Verify cache statistics
+    stats = agent.get_tool_cache_stats()
+    assert stats["size"] == 1  # Only mock_tool should be cached
+
+
+def test_tool_handler_process_with_uncacheable_tools(tool_handler, tool_registry, mock_tool):
+    """Test that uncacheable tools list works correctly"""
+    # Register mock tools in the registry
+    tool_registry.registry["mock_tool"] = mock_tool
+
+    # Create and configure other_tool mock
+    other_tool = unittest.mock.Mock()
+    other_tool.tool_name = "other_tool"
+    other_tool.invoke.return_value = {
+        "toolUseId": "test_id2",
+        "status": "success",
+        "content": [{"text": "Other tool result"}],
+    }
+    tool_registry.registry["other_tool"] = other_tool
+
+    # Create agent with uncacheable tools list
+    agent = Agent(
+        enable_tool_cache=True,
+        uncacheable_tools=["mock_tool"],  # Only mock_tool is uncacheable
+    )
+
+    # mock_tool call
+    tool_use1 = {"toolUseId": "test_id1", "name": "mock_tool", "input": {"param": "value"}}
+
+    # other_tool call
+    tool_use2 = {"toolUseId": "test_id2", "name": "other_tool", "input": {"param": "value"}}
+
+    # mock_tool call - should not be cached
+    tool_handler.process(
+        tool=tool_use1,
+        model=unittest.mock.Mock(),
+        system_prompt="Test prompt",
+        messages=[],
+        tool_config={},
+        callback_handler=unittest.mock.Mock(),
+        agent=agent,
+    )
+
+    # other_tool call - should be cached
+    tool_handler.process(
+        tool=tool_use2,
+        model=unittest.mock.Mock(),
+        system_prompt="Test prompt",
+        messages=[],
+        tool_config={},
+        callback_handler=unittest.mock.Mock(),
+        agent=agent,
+    )
+
+    # Verify cache statistics
+    stats = agent.get_tool_cache_stats()
+    assert stats["size"] == 1  # Only other_tool should be cached
+
+
+def test_tool_handler_process_error_not_cached(tool_handler, tool_registry, mock_tool, agent_with_cache):
+    """Test that error results are not cached"""
+    # Register mock tool in the registry
+    tool_registry.registry["mock_tool"] = mock_tool
+
+    # Configure mock tool to return an error result
+    error_result = {"toolUseId": "test_id", "status": "error", "content": [{"text": "Error result"}]}
+    mock_tool.invoke.return_value = error_result
+
+    # Tool use request
+    tool_use = {"toolUseId": "test_id", "name": "mock_tool", "input": {"param": "value"}}
+
+    # First call - should invoke the tool and get an error result
+    result1 = tool_handler.process(
+        tool=tool_use,
+        model=unittest.mock.Mock(),
+        system_prompt="Test prompt",
+        messages=[],
+        tool_config={},
+        callback_handler=unittest.mock.Mock(),
+        agent=agent_with_cache,
+    )
+
+    # Verify the result is an error
+    assert result1["status"] == "error"
+
+    # Reset the mock to track the next call
+    mock_tool.invoke.reset_mock()
+
+    # Second call with the same parameters - should invoke the tool again
+    result2 = tool_handler.process(
+        tool=tool_use,
+        model=unittest.mock.Mock(),
+        system_prompt="Test prompt",
+        messages=[],
+        tool_config={},
+        callback_handler=unittest.mock.Mock(),
+        agent=agent_with_cache,
+    )
+
+    # Verify the tool was invoked again
+    mock_tool.invoke.assert_called_once()
+
+    # Verify the results are the same
+    assert result1 == result2

--- a/tests/strands/tools/test_cache.py
+++ b/tests/strands/tools/test_cache.py
@@ -1,0 +1,178 @@
+import threading
+import time
+
+import pytest
+
+from strands.tools.cache import ToolResultCache
+
+
+@pytest.fixture
+def cache():
+    """Fixture providing a basic cache instance"""
+    return ToolResultCache(max_size=3, ttl_seconds=1)
+
+
+@pytest.fixture
+def tool_result():
+    """Fixture providing a test tool result"""
+    return {"toolUseId": "test_id", "status": "success", "content": [{"text": "Test result"}]}
+
+
+def test_cache_get_set(cache, tool_result):
+    """Test basic get/set operations"""
+    # Should return None when cache is empty
+    assert cache.get("test_tool", {"param": "value"}) is None
+
+    # Set a value in the cache
+    cache.set("test_tool", {"param": "value"}, tool_result)
+
+    # Get the value from cache
+    cached_result = cache.get("test_tool", {"param": "value"})
+    assert cached_result == tool_result
+
+    # Should be cache miss for different parameters
+    assert cache.get("test_tool", {"param": "different"}) is None
+    assert cache.get("different_tool", {"param": "value"}) is None
+
+
+def test_cache_ttl(cache, tool_result):
+    """Test TTL (time-to-live) functionality"""
+    # Set a value in the cache
+    cache.set("test_tool", {"param": "value"}, tool_result)
+
+    # Value should be retrievable before TTL expires
+    assert cache.get("test_tool", {"param": "value"}) == tool_result
+
+    # Wait for TTL to expire (1 second + a bit more)
+    time.sleep(1.1)
+
+    # Value should not be retrievable after TTL expires (returns None)
+    assert cache.get("test_tool", {"param": "value"}) is None
+
+
+def test_cache_max_size(cache, tool_result):
+    """Test maximum size limit"""
+    # Add items to cache up to maximum size (3)
+    cache.set("tool1", {"param": "1"}, tool_result)
+    cache.set("tool2", {"param": "2"}, tool_result)
+    cache.set("tool3", {"param": "3"}, tool_result)
+
+    # All items should be cache hits
+    assert cache.get("tool1", {"param": "1"}) == tool_result
+    assert cache.get("tool2", {"param": "2"}) == tool_result
+    assert cache.get("tool3", {"param": "3"}) == tool_result
+
+    # Adding a 4th item should evict the oldest item (tool1)
+    cache.set("tool4", {"param": "4"}, tool_result)
+
+    # tool1 should be evicted from cache
+    assert cache.get("tool1", {"param": "1"}) is None
+
+    # Other items should still be in cache
+    assert cache.get("tool2", {"param": "2"}) == tool_result
+    assert cache.get("tool3", {"param": "3"}) == tool_result
+    assert cache.get("tool4", {"param": "4"}) == tool_result
+
+
+def test_cache_clear(cache, tool_result):
+    """Test cache clear functionality"""
+    # Set some values in the cache
+    cache.set("tool1", {"param": "1"}, tool_result)
+    cache.set("tool2", {"param": "2"}, tool_result)
+
+    # Clear the cache
+    cache.clear()
+
+    # All items should be removed from cache
+    assert cache.get("tool1", {"param": "1"}) is None
+    assert cache.get("tool2", {"param": "2"}) is None
+
+
+def test_cache_stats(cache, tool_result):
+    """Test cache statistics"""
+    # Initially, hits and misses should be 0
+    stats = cache.get_stats()
+    assert stats["hits"] == 0
+    assert stats["misses"] == 0
+    assert stats["size"] == 0
+
+    # Cache miss should be recorded
+    cache.get("tool1", {"param": "1"})
+    stats = cache.get_stats()
+    assert stats["misses"] == 1
+
+    # Set a value in the cache
+    cache.set("tool1", {"param": "1"}, tool_result)
+
+    # Cache hit should be recorded
+    cache.get("tool1", {"param": "1"})
+    stats = cache.get_stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["size"] == 1
+    assert stats["hit_ratio"] == 0.5  # 1 hit / (1 hit + 1 miss)
+
+
+def test_cache_thread_safety():
+    """Test thread safety"""
+    cache = ToolResultCache(max_size=100, ttl_seconds=10)
+    tool_result = {"toolUseId": "test_id", "status": "success", "content": [{"text": "Test result"}]}
+
+    # Access cache concurrently from multiple threads
+    def worker(worker_id: int):
+        for i in range(50):
+            # Alternate between read and write operations
+            if i % 2 == 0:
+                cache.set(f"tool{worker_id}", {"param": str(i)}, tool_result)
+            else:
+                cache.get(f"tool{worker_id}", {"param": str(i - 1)})
+
+    # Create and run 10 threads
+    threads = []
+    for i in range(10):
+        t = threading.Thread(target=worker, args=(i,))
+        threads.append(t)
+        t.start()
+
+    # Wait for all threads to complete
+    for t in threads:
+        t.join()
+
+    # Test passes if no exceptions were raised
+    # Additionally, verify cache size is correct
+    stats = cache.get_stats()
+    assert 0 <= stats["size"] <= 100  # Should not exceed max size
+
+
+def test_cache_key_generation(cache, tool_result):
+    """Test edge cases for cache key generation"""
+    # Verify that different parameter order generates the same key
+    cache.set("tool", {"a": 1, "b": 2}, tool_result)
+    assert cache.get("tool", {"b": 2, "a": 1}) == tool_result
+
+    # Test numeric values separately - don't expect 1 and 1.0 to be equivalent
+    # since JSON serialization treats them differently
+    cache.set("tool", {"num": 1}, tool_result)
+    assert cache.get("tool", {"num": 1}) == tool_result
+
+    cache.set("tool", {"num": 1.0}, tool_result)
+    assert cache.get("tool", {"num": 1.0}) == tool_result
+
+    # Verify that nested parameters are handled correctly
+    cache.set("tool", {"nested": {"a": 1, "b": 2}}, tool_result)
+    assert cache.get("tool", {"nested": {"b": 2, "a": 1}}) == tool_result
+
+
+def test_cache_with_different_tool_results(cache):
+    """Test caching different tool results"""
+    result1 = {"toolUseId": "id1", "status": "success", "content": [{"text": "Result 1"}]}
+
+    result2 = {"toolUseId": "id2", "status": "success", "content": [{"text": "Result 2"}]}
+
+    # Cache different results for different tools
+    cache.set("tool1", {"param": "value"}, result1)
+    cache.set("tool2", {"param": "value"}, result2)
+
+    # Verify correct results are retrieved
+    assert cache.get("tool1", {"param": "value"}) == result1
+    assert cache.get("tool2", {"param": "value"}) == result2


### PR DESCRIPTION
## Description
This PR introduces a tool result caching mechanism to the Strands Agent framework, allowing agents to store and reuse tool execution results for identical inputs. This improves performance and reduces unnecessary API calls or expensive computations.

## Related Issues
resolve #158 

## Documentation PR
`N/A`

## Type of Change
- New feature

## Testing
- [x] `hatch fmt --linter`
- [x] `hatch fmt --formatter`
- [x] `hatch test --all`
- [x] Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
