### PR TITLE
added list_prompts, get_prompt methods

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -156,6 +156,52 @@ class MCPClient:
         mcp_tools = [MCPAgentTool(tool, self) for tool in list_tools_response.tools]
         self._log_debug_with_thread("successfully adapted %d MCP tools", len(mcp_tools))
         return mcp_tools
+    
+    def list_prompts_sync(self) -> ListPromptsResult:
+        """Synchronously retrieves the list of available prompts from the MCP server.
+
+        This method calls the asynchronous list_prompts method on the MCP session
+        and adapts the returned prompts to the AgentTool interface.
+
+        Returns:
+            ListPromptsResult: A list of available prompts
+        """
+        self._log_debug_with_thread("listing MCP prompts synchronously")
+        if not self._is_session_active():
+            raise MCPClientInitializationError("the client session is not running")
+
+        async def _list_prompts_async() -> ListPromptsResult:
+            return await self._background_thread_session.list_prompts()
+
+        list_prompts_response: ListPromptsResult = self._invoke_on_background_thread(_list_prompts_async())
+        self._log_debug_with_thread("received %d prompts from MCP server:")
+        for prompt in list_prompts_response.prompts:
+            self._log_debug_with_thread(prompt.name)
+
+        return list_prompts_response
+    
+    def get_prompt_sync(self, prompt_id: str, args: dict[Any, Any]) -> GetPromptResult:
+        """Synchronously retrieves a prompt from the MCP server.
+
+        Args:
+            prompt_id: The ID of the prompt to retrieve
+            args: Optional arguments to pass to the prompt
+
+        Returns:
+            GetPromptResult: The prompt response from the MCP server
+        """
+        self._log_debug_with_thread("getting MCP prompt synchronously")
+        if not self._is_session_active():
+            raise MCPClientInitializationError("the client session is not running")
+        
+        async def _get_prompt_async():
+            return await self._background_thread_session.get_prompt(
+                prompt_id, arguments=args
+            )
+        get_prompt_response: GetPromptResult = self._invoke_on_background_thread(_get_prompt_async())
+        self._log_debug_with_thread("received prompt from MCP server:", get_prompt_response)
+
+        return get_prompt_response
 
     def call_tool_sync(
         self,


### PR DESCRIPTION
## Description
This PR introduces two new methods to the `MCPClient` class: `list_prompts_sync` and `get_prompt_sync`.

-   `list_prompts_sync`: This method synchronously retrieves a list of available prompts from the MCP server. It calls the asynchronous `list_prompts` method on the underlying MCP session and returns the `ListPromptsResult`.
-   `get_prompt_sync`: This method synchronously retrieves a specific prompt by its ID from the MCP server, along with any specified arguments. It calls the asynchronous `get_prompt` method on the MCP session and returns the `GetPromptResult`.

These additions enhance the `MCPClient`'s capabilities to interact with MCP-based prompt services.

### How to use:

**Listing available prompts:**
```python
# Assuming mcp_client is an initialized MCPClient instance
prompts_result = mcp_client.list_prompts_sync()
for prompt in prompts_result.prompts:
    print(f"Prompt Name: {prompt.name}")
    print(f"Prompt Arguments: {prompt.arguments}")
    # print(f"Prompt Description: {prompt.description}") # If available
```

**Getting a specific prompt:**
```python
# Assuming mcp_client is an initialized MCPClient instance
prompt_id_to_get = "sum-two-numbers" # Example prompt ID
arguments_for_prompt = {
    "a": "123",
    "b": "456"
}
prompt_response = mcp_client.get_prompt_sync(prompt_id_to_get, arguments_for_prompt)
if prompt_response.messages:
    print(f"Prompt Content: {prompt_response.messages[0].content.text}")
```


## Related Issues
N/A

## Documentation PR
N/A

## Type of Change
- New feature

## Testing

- [x] `hatch fmt --linter`
- [x] `hatch fmt --formatter`
- [x] `hatch test --all`
- [x] Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
