### PR TITLE
refactor: Update conversation manager interface

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -165,7 +165,7 @@ class Agent:
                     self._agent._record_tool_execution(tool_use, tool_result, user_message_override, messages)
 
                 # Apply window management
-                self._agent.conversation_manager.apply_management(self._agent.messages)
+                self._agent.conversation_manager.apply_management(self._agent)
 
                 return tool_result
 
@@ -439,7 +439,7 @@ class Agent:
             return self._execute_event_loop_cycle(invocation_callback_handler, kwargs)
 
         finally:
-            self.conversation_manager.apply_management(self.messages)
+            self.conversation_manager.apply_management(self)
 
     def _execute_event_loop_cycle(self, callback_handler: Callable, kwargs: dict[str, Any]) -> AgentResult:
         """Execute the event loop cycle with retry logic for context window limits.
@@ -483,7 +483,7 @@ class Agent:
         except ContextWindowOverflowException as e:
             # Try reducing the context size and retrying
 
-            self.conversation_manager.reduce_context(messages, e=e)
+            self.conversation_manager.reduce_context(self, e=e)
             return self._execute_event_loop_cycle(callback_handler_override, kwargs)
 
     def _record_tool_execution(

--- a/src/strands/agent/conversation_manager/conversation_manager.py
+++ b/src/strands/agent/conversation_manager/conversation_manager.py
@@ -1,9 +1,10 @@
 """Abstract interface for conversation history management."""
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from ...types.content import Messages
+if TYPE_CHECKING:
+    from ...agent.agent import Agent
 
 
 class ConversationManager(ABC):
@@ -19,22 +20,22 @@ class ConversationManager(ABC):
 
     @abstractmethod
     # pragma: no cover
-    def apply_management(self, messages: Messages) -> None:
-        """Applies management strategy to the provided list of messages.
+    def apply_management(self, agent: "Agent") -> None:
+        """Applies management strategy to the provided agent.
 
         Processes the conversation history to maintain appropriate size by modifying the messages list in-place.
         Implementations should handle message pruning, summarization, or other size management techniques to keep the
         conversation context within desired bounds.
 
         Args:
-            messages: The conversation history to manage.
+            agent: The agent whose conversation history will be manage.
                 This list is modified in-place.
         """
         pass
 
     @abstractmethod
     # pragma: no cover
-    def reduce_context(self, messages: Messages, e: Optional[Exception] = None) -> None:
+    def reduce_context(self, agent: "Agent", e: Optional[Exception] = None) -> None:
         """Called when the model's context window is exceeded.
 
         This method should implement the specific strategy for reducing the window size when a context overflow occurs.
@@ -48,7 +49,7 @@ class ConversationManager(ABC):
         - Maintaining critical conversation markers
 
         Args:
-            messages: The conversation history to reduce.
+            agent: The agent whose conversation history will be reduced.
                 This list is modified in-place.
             e: The exception that triggered the context reduction, if any.
         """

--- a/src/strands/agent/conversation_manager/null_conversation_manager.py
+++ b/src/strands/agent/conversation_manager/null_conversation_manager.py
@@ -1,8 +1,10 @@
 """Null implementation of conversation management."""
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from ...types.content import Messages
+if TYPE_CHECKING:
+    from ...agent.agent import Agent
+
 from ...types.exceptions import ContextWindowOverflowException
 from .conversation_manager import ConversationManager
 
@@ -17,19 +19,19 @@ class NullConversationManager(ConversationManager):
     - Situations where the full conversation history should be preserved
     """
 
-    def apply_management(self, messages: Messages) -> None:
+    def apply_management(self, _agent: "Agent") -> None:
         """Does nothing to the conversation history.
 
         Args:
-            messages: The conversation history that will remain unmodified.
+            agent: The agent whose conversation history will remain unmodified.
         """
         pass
 
-    def reduce_context(self, messages: Messages, e: Optional[Exception] = None) -> None:
+    def reduce_context(self, _agent: "Agent", e: Optional[Exception] = None) -> None:
         """Does not reduce context and raises an exception.
 
         Args:
-            messages: The conversation history that will remain unmodified.
+            agent: The agent whose conversation history will remain unmodified.
             e: The exception that triggered the context reduction, if any.
 
         Raises:

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -318,7 +318,7 @@ def test_agent__call__(
     )
 
     callback_handler.assert_called()
-    conversation_manager_spy.apply_management.assert_called_with(agent.messages)
+    conversation_manager_spy.apply_management.assert_called_with(agent)
 
 
 def test_agent__call__passes_kwargs(mock_model, system_prompt, callback_handler, agent, tool, mock_event_loop_cycle):
@@ -583,7 +583,7 @@ def test_agent_tool(mock_randint, agent):
     }
 
     assert tru_result == exp_result
-    conversation_manager_spy.apply_management.assert_called_with(agent.messages)
+    conversation_manager_spy.apply_management.assert_called_with(agent)
 
 
 def test_agent_tool_user_message_override(agent):

--- a/tests/strands/agent/test_conversation_manager.py
+++ b/tests/strands/agent/test_conversation_manager.py
@@ -1,6 +1,7 @@
 import pytest
 
 import strands
+from strands.agent.agent import Agent
 from strands.types.exceptions import ContextWindowOverflowException
 
 
@@ -160,7 +161,8 @@ def conversation_manager(request):
     indirect=["conversation_manager"],
 )
 def test_apply_management(conversation_manager, messages, expected_messages):
-    conversation_manager.apply_management(messages)
+    test_agent = Agent(messages=messages)
+    conversation_manager.apply_management(test_agent)
 
     assert messages == expected_messages
 
@@ -172,9 +174,10 @@ def test_sliding_window_conversation_manager_with_untrimmable_history_raises_con
         {"role": "user", "content": [{"toolResult": {"toolUseId": "789", "content": [], "status": "success"}}]},
     ]
     original_messages = messages.copy()
+    test_agent = Agent(messages=messages)
 
     with pytest.raises(ContextWindowOverflowException):
-        manager.apply_management(messages)
+        manager.apply_management(test_agent)
 
     assert messages == original_messages
 
@@ -187,8 +190,9 @@ def test_null_conversation_manager_reduce_context_raises_context_window_overflow
         {"role": "assistant", "content": [{"text": "Hi there"}]},
     ]
     original_messages = messages.copy()
+    test_agent = Agent(messages=messages)
 
-    manager.apply_management(messages)
+    manager.apply_management(test_agent)
 
     with pytest.raises(ContextWindowOverflowException):
         manager.reduce_context(messages)
@@ -204,8 +208,9 @@ def test_null_conversation_manager_reduce_context_with_exception_raises_same_exc
         {"role": "assistant", "content": [{"text": "Hi there"}]},
     ]
     original_messages = messages.copy()
+    test_agent = Agent(messages=messages)
 
-    manager.apply_management(messages)
+    manager.apply_management(test_agent)
 
     with pytest.raises(RuntimeError):
         manager.reduce_context(messages, RuntimeError("test"))


### PR DESCRIPTION
## Description
Refactor the ConversationManager so that it can take in an `Agent` instead of a list of messages. This is to simplify the interface, and better support the new SummarizationConversationManager implementation: https://github.com/strands-agents/sdk-python/pull/112

## Related Issues
https://github.com/strands-agents/sdk-python/issues/90

## Documentation PR
No changes needed

## Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation update
- Other (please describe):

Breaking change


## Testing

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
