### PR TITLE
test: set OTEL_ env vars correctly for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,8 @@ def moto_env(monkeypatch):
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
     monkeypatch.setenv("AWS_SECURITY_TOKEN", "test")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
 
 
 @pytest.fixture

--- a/tests/strands/tools/test_executor.py
+++ b/tests/strands/tools/test_executor.py
@@ -1,12 +1,18 @@
 import concurrent
 import functools
 import unittest.mock
+import uuid
 
 import pytest
 
 import strands
 import strands.telemetry
 from strands.types.content import Message
+
+
+@pytest.fixture(autouse=True)
+def moto_autouse(moto_env):
+    _ = moto_env
 
 
 @pytest.fixture
@@ -52,10 +58,10 @@ def invalid_tool_use_ids(request):
     return request.param if hasattr(request, "param") else []
 
 
-@unittest.mock.patch.object(strands.telemetry.metrics, "uuid4", return_value="trace1")
 @pytest.fixture
 def cycle_trace():
-    return strands.telemetry.metrics.Trace(name="test trace", raw_name="raw_name")
+    with unittest.mock.patch.object(uuid, "uuid4", return_value="trace1"):
+        return strands.telemetry.metrics.Trace(name="test trace", raw_name="raw_name")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
Fixes scenario where tests fail when `OTEL_` environment variables are set in the environment where tests are ran.

## Related Issues
N/A

## Documentation PR
N/A

## Type of Change
- Bug fix
- Tests fix

## Testing
* `hatch fmt`
* `hatch run test-lint`
* `hatch test`
* `hatch run test-integ`


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
