### PR TITLE
Remove redundant permissions block

### DIFF
--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -57,8 +57,6 @@ jobs:
 
   deploy:
     name: Upload release to PyPI
-    permissions:
-      contents: read
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Remove redundant permission block

## Related Issues
N/A

## Documentation PR
N/A

## Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation update
- Other (please describe):

Bug fix


## Testing
Tested in my personal fork: https://github.com/Unshure/sdk-python/actions/runs/15431050036

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
