### PR TITLE
fix: ignore mypy error from latest OpenTelemetrySDK update

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -13,7 +13,9 @@ from typing import Any, Dict, Mapping, Optional
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource
+
+# See see https://github.com/open-telemetry/opentelemetry-python/issues/4615 for the type ignore
+from opentelemetry.sdk.resources import Resource  # type: ignore[attr-defined]
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor
 from opentelemetry.trace import StatusCode


### PR DESCRIPTION
See open-telemetry/opentelemetry-python#4615 but it looks like an OpenTelemetrySDK update caused type errors
