### PR TITLE
Remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @strands-agents/contributors will be requested for
-# review when someone opens a pull request.
-*       @strands-agents/maintainers


### PR DESCRIPTION
## Description

Remove codeowners to avoid the code owners from being added to every PR.  We can re-add once we have fine-grained owners but right now we're getting more notifications than we need.

This is not required for PR approvers, since only [members who have write or greater can approver PRs](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role):

<img width="749" alt="screenshot_962" src="https://github.com/user-attachments/assets/c528b479-429b-4f83-8328-5feb509e0fc6" />

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

- Other (please describe): Repo maintenance 

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

## Checklist
- [X] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
