### PR TITLE
Add permission block to call-tst-lint job

### DIFF
--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   call-test-lint:
     uses: ./.github/workflows/test-lint.yml
+    permissions:
+      contents: read
     with:
       ref: ${{ github.event.release.target_commitish }}
 


### PR DESCRIPTION
## Description
Add permission block to call-tst-lint job

## Related Issues
N/A

## Documentation PR
N/A

## Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation update
- Other (please describe):

Bug fix


## Testing

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
