### PR TITLE
feat: Add reasoning content for openai model provider

### DIFF
--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -99,6 +99,13 @@ class OpenAIModel(SAOpenAIModel):
             if choice.delta.content:
                 yield {"chunk_type": "content_delta", "data_type": "text", "data": choice.delta.content}
 
+            if choice.delta.reasoning_content:
+                yield {
+                    "chunk_type": "content_delta",
+                    "data_type": "reasoning_content",
+                    "data": choice.delta.reasoning_content,
+                }
+
             for tool_call in choice.delta.tool_calls or []:
                 tool_calls.setdefault(tool_call.index, []).append(tool_call)
 

--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -99,7 +99,7 @@ class OpenAIModel(SAOpenAIModel):
             if choice.delta.content:
                 yield {"chunk_type": "content_delta", "data_type": "text", "data": choice.delta.content}
 
-            if choice.delta.reasoning_content:
+            if hasattr(choice.delta, "reasoning_content") and choice.delta.reasoning_content:
                 yield {
                     "chunk_type": "content_delta",
                     "data_type": "reasoning_content",

--- a/src/strands/types/models/openai.py
+++ b/src/strands/types/models/openai.py
@@ -232,6 +232,9 @@ class OpenAIModel(Model, abc.ABC):
                         "contentBlockDelta": {"delta": {"toolUse": {"input": event["data"].function.arguments or ""}}}
                     }
 
+                if event["data_type"] == "reasoning_content":
+                    return {"contentBlockDelta": {"delta": {"reasoningContent": {"text": event["data"]}}}}
+
                 return {"contentBlockDelta": {"delta": {"text": event["data"]}}}
 
             case "content_stop":


### PR DESCRIPTION
## Description
[Provide a detailed description of the changes in this PR]
Add reasoning content output for OpenAI model provider.
Now agent can output reasoningText when use 'DeepSeek-R1' via OpenAI model provider 
```python
async for event in agent.stream_async(query):
      if 'reasoningText' in event:
          print(event['reasoningText'],end="",flush=True)
      if "data" in event:
          # Only stream text chunks to the client
          print(event['data'],end="",flush=True)
```
## Related Issues
[Link to related issues using #issue-number format]

## Documentation PR
[Link to related associated PR in the agent-docs repo]


## Type of Change
- New feature

## Testing
[How have you tested the change?]
YES
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
