### PR TITLE
fix: Add linting rule to enforce unused parameter rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ select = [
   "G", # logging format
   "I", # isort
   "LOG", # logging
+  "ARG", # flake8-unused-arguments
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -399,7 +399,7 @@ def _handle_tool_execution(
         handler=tool_handler_process,
         tool_uses=tool_uses,
         event_loop_metrics=event_loop_metrics,
-        request_state=cast(Any, kwargs["request_state"]),
+        _request_state=cast(Any, kwargs["request_state"]),
         invalid_tool_use_ids=invalid_tool_use_ids,
         tool_results=tool_results,
         cycle_trace=cycle_trace,

--- a/src/strands/tools/executor.py
+++ b/src/strands/tools/executor.py
@@ -21,7 +21,7 @@ def run_tools(
     handler: Callable[[ToolUse], ToolResult],
     tool_uses: List[ToolUse],
     event_loop_metrics: EventLoopMetrics,
-    request_state: Any,
+    _request_state: Any,
     invalid_tool_use_ids: List[str],
     tool_results: List[ToolResult],
     cycle_trace: Trace,

--- a/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/src/strands/tools/mcp/mcp_agent_tool.py
@@ -73,7 +73,7 @@ class MCPAgentTool(AgentTool):
         """
         return "python"
 
-    def invoke(self, tool: ToolUse, *args: Any, **kwargs: dict[str, Any]) -> ToolResult:
+    def invoke(self, tool: ToolUse, *_args: Any, **_kwargs: dict[str, Any]) -> ToolResult:
         """Invoke the MCP tool.
 
         This method delegates the tool invocation to the MCP server connection,

--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -108,7 +108,7 @@ class MCPClient:
         return self
 
     def stop(
-        self, exc_type: Optional[BaseException], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+        self, _exc_type: Optional[BaseException], _exc_val: Optional[BaseException], _exc_tb: Optional[TracebackType]
     ) -> None:
         """Signals the background thread to stop and waits for it to complete, ensuring proper cleanup of all resources.
 

--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -207,7 +207,7 @@ class FunctionTool(AgentTool):
         """
         return True
 
-    def invoke(self, tool: ToolUse, *args: Any, **kwargs: Any) -> ToolResult:
+    def invoke(self, tool: ToolUse, *_args: Any, **kwargs: Any) -> ToolResult:
         """Execute the function with the given tool use request.
 
         Args:

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -991,7 +991,7 @@ async def test_agent_stream_async_creates_and_ends_span_on_success(mock_get_trac
     mock_get_tracer.return_value = mock_tracer
 
     # Define the side effect to simulate callback handler being called multiple times
-    def call_callback_handler(*args, **kwargs):
+    def call_callback_handler(*_args, **kwargs):
         # Extract the callback handler from kwargs
         callback_handler = kwargs.get("callback_handler")
         # Call the callback handler with different data values

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -119,6 +119,7 @@ def test__init__with_region_and_session_raises_value_error():
 
 def test__init__default_user_agent(bedrock_client):
     """Set user agent when no boto_client_config is provided."""
+    _ = bedrock_client
     with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:
         mock_session = mock_session_cls.return_value
         _ = BedrockModel()
@@ -133,6 +134,7 @@ def test__init__default_user_agent(bedrock_client):
 
 def test__init__with_custom_boto_client_config_no_user_agent(bedrock_client):
     """Set user agent when boto_client_config is provided without user_agent_extra."""
+    _ = bedrock_client
     custom_config = BotocoreConfig(read_timeout=900)
 
     with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:
@@ -150,6 +152,7 @@ def test__init__with_custom_boto_client_config_no_user_agent(bedrock_client):
 
 def test__init__with_custom_boto_client_config_with_user_agent(bedrock_client):
     """Append to existing user agent when boto_client_config is provided with user_agent_extra."""
+    _ = bedrock_client
     custom_config = BotocoreConfig(user_agent_extra="existing-agent", read_timeout=900)
 
     with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -726,8 +726,8 @@ def test_serialize_vs_json_dumps():
     assert japanese_text in custom_result
     assert "\\u" not in custom_result
 
-
-def test_init_with_no_env_or_param(clean_env):  # noqa: ARG001
+@pytest.mark.usefixtures("clean_env")
+def test_init_with_no_env_or_param():
     """Test initializing with neither environment variable nor constructor parameter."""
     tracer = Tracer()
     assert tracer.otlp_endpoint is None
@@ -739,8 +739,8 @@ def test_init_with_no_env_or_param(clean_env):  # noqa: ARG001
     tracer = Tracer(enable_console_export=True)
     assert tracer.enable_console_export is True
 
-
-def test_constructor_params_with_otlp_env(env_with_otlp):  # noqa: ARG001
+@pytest.mark.usefixtures("env_with_otlp")
+def test_constructor_params_with_otlp_env():
     """Test constructor parameters precedence over OTLP environment variable."""
     # Constructor parameter should take precedence
     tracer = Tracer(otlp_endpoint="http://constructor-endpoint")
@@ -750,8 +750,8 @@ def test_constructor_params_with_otlp_env(env_with_otlp):  # noqa: ARG001
     tracer = Tracer()
     assert tracer.otlp_endpoint == "http://env-endpoint"
 
-
-def test_constructor_params_with_console_env(env_with_console):  # noqa: ARG001
+@pytest.mark.usefixtures("env_with_console")
+def test_constructor_params_with_console_env():
     """Test constructor parameters precedence over console environment variable."""
     # Constructor parameter should take precedence
     tracer = Tracer(enable_console_export=False)
@@ -761,8 +761,8 @@ def test_constructor_params_with_console_env(env_with_console):  # noqa: ARG001
     tracer = Tracer()
     assert tracer.enable_console_export is True
 
-
-def test_fallback_to_env_vars(env_with_both):  # noqa: ARG001
+@pytest.mark.usefixtures("env_with_both")
+def test_fallback_to_env_vars():
     """Test fallback to environment variables when no constructor parameters."""
     tracer = Tracer()
     assert tracer.otlp_endpoint == "http://env-endpoint"

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -727,7 +727,7 @@ def test_serialize_vs_json_dumps():
     assert "\\u" not in custom_result
 
 
-def test_init_with_no_env_or_param(clean_env):
+def test_init_with_no_env_or_param(clean_env):  # noqa: ARG001
     """Test initializing with neither environment variable nor constructor parameter."""
     tracer = Tracer()
     assert tracer.otlp_endpoint is None
@@ -740,7 +740,7 @@ def test_init_with_no_env_or_param(clean_env):
     assert tracer.enable_console_export is True
 
 
-def test_constructor_params_with_otlp_env(env_with_otlp):
+def test_constructor_params_with_otlp_env(env_with_otlp):  # noqa: ARG001
     """Test constructor parameters precedence over OTLP environment variable."""
     # Constructor parameter should take precedence
     tracer = Tracer(otlp_endpoint="http://constructor-endpoint")
@@ -751,7 +751,7 @@ def test_constructor_params_with_otlp_env(env_with_otlp):
     assert tracer.otlp_endpoint == "http://env-endpoint"
 
 
-def test_constructor_params_with_console_env(env_with_console):
+def test_constructor_params_with_console_env(env_with_console):  # noqa: ARG001
     """Test constructor parameters precedence over console environment variable."""
     # Constructor parameter should take precedence
     tracer = Tracer(enable_console_export=False)
@@ -762,7 +762,7 @@ def test_constructor_params_with_console_env(env_with_console):
     assert tracer.enable_console_export is True
 
 
-def test_fallback_to_env_vars(env_with_both):
+def test_fallback_to_env_vars(env_with_both):  # noqa: ARG001
     """Test fallback to environment variables when no constructor parameters."""
     tracer = Tracer()
     assert tracer.otlp_endpoint == "http://env-endpoint"

--- a/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -40,7 +40,7 @@ def test_tool_type(mcp_agent_tool):
     assert mcp_agent_tool.tool_type == "python"
 
 
-def test_tool_spec_with_description(mcp_agent_tool, mock_mcp_tool):
+def test_tool_spec_with_description(mcp_agent_tool):
     tool_spec = mcp_agent_tool.tool_spec
 
     assert tool_spec["name"] == "test_tool"

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -42,7 +42,7 @@ def mock_session():
 
 
 @pytest.fixture
-def mcp_client(mock_transport, mock_session):
+def mcp_client(mock_transport):
     with MCPClient(mock_transport["transport_callable"]) as client:
         yield client
 

--- a/tests/strands/tools/test_decorator.py
+++ b/tests/strands/tools/test_decorator.py
@@ -144,7 +144,7 @@ def test_type_handling():
         bool_param: bool,
     ) -> str:
         """Test basic types."""
-        return "Success"
+        return f"Successfully used parameters: {str_param}, {int_param}, {float_param}, {bool_param}"
 
     spec = test_tool.TOOL_SPEC
     schema = spec["inputSchema"]["json"]
@@ -570,7 +570,7 @@ def test_detailed_validation_errors():
             int_param: Integer parameter
             bool_param: Boolean parameter
         """
-        return "Valid"
+        return f"Valid parameters: String argument{str_param}, Int arguemnt {int_param}, Bool argument {bool_param}"
 
     # Test wrong type for int
     tool_use = {

--- a/tests/strands/tools/test_executor.py
+++ b/tests/strands/tools/test_executor.py
@@ -1,7 +1,6 @@
 import concurrent
 import functools
 import unittest.mock
-import uuid
 
 import pytest
 

--- a/tests/strands/tools/test_executor.py
+++ b/tests/strands/tools/test_executor.py
@@ -59,9 +59,9 @@ def invalid_tool_use_ids(request):
 
 
 @pytest.fixture
-def cycle_trace():
-    with unittest.mock.patch.object(uuid, "uuid4", return_value="trace1"):
-        return strands.telemetry.metrics.Trace(name="test trace", raw_name="raw_name")
+def cycle_trace(mocker):
+    mocker.patch.object(strands.telemetry.metrics, "id", return_value="trace1")
+    return strands.telemetry.metrics.Trace(name="test trace", raw_name="raw_name")
 
 
 @pytest.fixture
@@ -395,7 +395,6 @@ def test_run_tools_creates_and_ends_span_on_failure(
 @unittest.mock.patch("strands.tools.executor.get_tracer")
 def test_run_tools_handles_exception_in_tool_execution(
     mock_get_tracer,
-    tool_handler,
     tool_uses,
     event_loop_metrics,
     request_state,


### PR DESCRIPTION
## Description
Added a linting rule `ARG` that checks for unused parameters in functions and class methods.
Documentation reference : https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg

## Related Issues
#128

## Type of Change
- Bug fix

[Choose one of the above types of changes]


## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
