### PR TITLE
Fix(Tool): Class method with @tool decorator is also accepted as a valid Tool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__*
 *.bak
 .vscode
 dist
+.idea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,10 @@ ignore_missing_imports = false
 module = "litellm"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "strands.telemetry.tracer"
+warn_unused_ignores = false
+
 [tool.ruff]
 line-length = 120
 include = ["examples/**/*.py", "src/**/*.py", "tests/**/*.py", "tests-integ/**/*.py"]

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -108,9 +108,7 @@ class Agent:
                 # all tools that can be represented with the normalized name
                 if "_" in name:
                     filtered_tools = [
-                        tool_name
-                        for (tool_name, tool) in tool_registry.items()
-                        if tool_name.replace("-", "_") == name
+                        tool_name for (tool_name, tool) in tool_registry.items() if tool_name.replace("-", "_") == name
                     ]
 
                     if len(filtered_tools) > 1:

--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -3,6 +3,7 @@
 This module provides tracing capabilities using OpenTelemetry,
 enabling trace data to be sent to OTLP endpoints.
 """
+# mypy: disable-error-code="unused-ignore"
 
 import json
 import logging

--- a/src/strands/tools/registry.py
+++ b/src/strands/tools/registry.py
@@ -92,8 +92,8 @@ class ToolRegistry:
                     if not function_tools:
                         logger.warning("tool_name=<%s>, module_path=<%s> | invalid agent tool", tool_name, module_path)
 
-            # Case 5: Function decorated with @tool
-            elif inspect.isfunction(tool) and hasattr(tool, "TOOL_SPEC"):
+            # Case 5: Function or Method decorated with @tool
+            elif (inspect.isfunction(tool) or inspect.ismethod(tool)) and hasattr(tool, "TOOL_SPEC"):
                 try:
                     function_tool = FunctionTool(tool)
                     logger.debug("tool_name=<%s> | registering function tool", function_tool.tool_name)


### PR DESCRIPTION
## Description
# Problem
When using a class method decorated with @tool and passing it as a tool to an Agent instance, the system raises an "unrecognized tool specification" error. This occurs because bound methods (class methods accessed through an instance) are not properly recognized by the Agent's tool handling mechanism.

# Solution
This PR fixes the issue by improving the tool registration process to properly handle bound methods. The implementation now correctly identifies and processes class methods that have been decorated with @tool when they're passed as instance methods.

# Changes
Enhanced tool registration to recognize bound methods
Added proper handling for class methods decorated with @tool
Ensured compatibility with both standalone functions and class methods

# Testing
Verified that the following pattern now works correctly:

```
class MyClass:
    @tool
    def my_tool_method(self, query: str):
        # method implementation
        return result

instance = MyClass()
agent = Agent(tools=[instance.my_tool_method])
```
This change maintains backward compatibility while extending support for object-oriented usage patterns.

## Related Issues
#199 
[Link to related issues using #issue-number format]

## Documentation PR
Not needed.
[Link to related associated PR in the agent-docs repo]

## Type of Change
- Bug fix


## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
