### PR TITLE
fix: add inference profile to litellm test and remove ownership check…

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,13 +26,7 @@ jobs:
               return
             }
             
-            const isOwner = pr.author_association === 'OWNER'
-            if (isOwner) {
-              core.info('PR author is an OWNER')
-              return
-            }
-
-            core.setFailed('Pull Request must either have label approved-for-integ-test or be created by an owner')
+            core.setFailed('Pull Request must either have label approved-for-integ-test')
       - name: Configure Credentials 
         uses: aws-actions/configure-aws-credentials@v4
         with: 

--- a/tests-integ/test_model_litellm.py
+++ b/tests-integ/test_model_litellm.py
@@ -7,7 +7,7 @@ from strands.models.litellm import LiteLLMModel
 
 @pytest.fixture
 def model():
-    return LiteLLMModel(model_id="bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0")
+    return LiteLLMModel(model_id="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
Follow up to #201 .

It seems there were two bugs.

One was that the the inference profile seems to need to be added. Unclear why this worked locally earlier, but that is not important.

The other is that for the enterprise organization it seems that the ownership check is not needed. For now, we will simply require the `approved for integ test label` We can attempt to optimize if the collaborators find this provides too much friction.




## Related Issues
 #201 

## Type of Change
- Bug fix

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

Tested tests-integ/test_model_litellm.py
```
========================================================================= 1 passed, 54 warnings in 13.73s ==========================================================================

```


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
