### PR TITLE
feat: add meter

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -308,7 +308,6 @@ class Agent:
         # Initialize tracer instance (no-op if not configured)
         self.tracer = get_tracer()
         self.trace_span: Optional[trace.Span] = None
-
         self.tool_caller = Agent.ToolCaller(self)
 
     @property

--- a/src/strands/telemetry/__init__.py
+++ b/src/strands/telemetry/__init__.py
@@ -3,7 +3,8 @@
 This module provides metrics and tracing functionality.
 """
 
-from .metrics import EventLoopMetrics, Trace, metrics_to_string
+from .config import get_otel_resource
+from .metrics import EventLoopMetrics, MetricsClient, Trace, metrics_to_string
 from .tracer import Tracer, get_tracer
 
 __all__ = [
@@ -12,4 +13,6 @@ __all__ = [
     "metrics_to_string",
     "Tracer",
     "get_tracer",
+    "MetricsClient",
+    "get_otel_resource",
 ]

--- a/src/strands/telemetry/config.py
+++ b/src/strands/telemetry/config.py
@@ -1,0 +1,33 @@
+"""OpenTelemetry configuration and setup utilities for Strands agents.
+
+This module provides centralized configuration and initialization functionality
+for OpenTelemetry components and other telemetry infrastructure shared across Strands applications.
+"""
+
+from importlib.metadata import version
+
+from opentelemetry.sdk.resources import Resource
+
+
+def get_otel_resource() -> Resource:
+    """Create a standard OpenTelemetry resource with service information.
+
+    This function implements a singleton pattern - it will return the same
+    Resource object for the same service_name parameter.
+
+    Args:
+        service_name: Name of the service for OpenTelemetry.
+
+    Returns:
+        Resource object with standard service information.
+    """
+    resource = Resource.create(
+        {
+            "service.name": __name__,
+            "service.version": version("strands-agents"),
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.language": "python",
+        }
+    )
+
+    return resource

--- a/src/strands/telemetry/metrics_constants.py
+++ b/src/strands/telemetry/metrics_constants.py
@@ -1,0 +1,3 @@
+"""Metrics that are emitted in Strands-Agent."""
+
+STRANDS_AGENT_INVOCATION_COUNT = "strands.agent.invocation_count"

--- a/tests/strands/telemetry/test_metrics.py
+++ b/tests/strands/telemetry/test_metrics.py
@@ -1,9 +1,13 @@
 import dataclasses
 import unittest
+from unittest import mock
 
 import pytest
+from opentelemetry.metrics._internal import _ProxyMeter
+from opentelemetry.sdk.metrics import MeterProvider
 
 import strands
+from strands.telemetry import MetricsClient
 from strands.types.streaming import Metrics, Usage
 
 
@@ -115,6 +119,30 @@ def test_trace_end(mock_time, end_time, trace):
     exp_end_time = 1
 
     assert tru_end_time == exp_end_time
+
+
+@pytest.fixture
+def mock_get_meter_provider():
+    with mock.patch("strands.telemetry.metrics.metrics_api.get_meter_provider") as mock_get_meter_provider:
+        meter_provider_mock = mock.MagicMock(spec=MeterProvider)
+        mock_get_meter_provider.return_value = meter_provider_mock
+
+        mock_meter = mock.MagicMock()
+        meter_provider_mock.get_meter.return_value = mock_meter
+
+        yield mock_get_meter_provider
+
+
+@pytest.fixture
+def mock_sdk_meter_provider():
+    with mock.patch("strands.telemetry.metrics.metrics_sdk.MeterProvider") as mock_meter_provider:
+        yield mock_meter_provider
+
+
+@pytest.fixture
+def mock_resource():
+    with mock.patch("opentelemetry.sdk.resources.Resource") as mock_resource:
+        yield mock_resource
 
 
 def test_trace_add_child(child_trace, trace):
@@ -379,3 +407,31 @@ def test_metrics_to_string(trace, child_trace, tool_metrics, exp_str, event_loop
     tru_str = strands.telemetry.metrics.metrics_to_string(event_loop_metrics)
 
     assert tru_str == exp_str
+
+
+def test_setup_meter_if_meter_provider_is_set(
+    mock_get_meter_provider,
+    mock_resource,
+):
+    """Test global meter_provider and meter are used"""
+    mock_resource_instance = mock.MagicMock()
+    mock_resource.create.return_value = mock_resource_instance
+
+    metrics_client = MetricsClient()
+
+    mock_get_meter_provider.assert_called()
+    mock_get_meter_provider.return_value.get_meter.assert_called()
+
+    assert metrics_client is not None
+
+
+def test_use_ProxyMeter_if_no_global_meter_provider():
+    """Return _ProxyMeter"""
+    # Reset the singleton instance
+    strands.telemetry.metrics.MetricsClient._instance = None
+
+    # Create a new instance which should use the real _ProxyMeter
+    metrics_client = MetricsClient()
+
+    # Verify it's using a _ProxyMeter
+    assert isinstance(metrics_client.meter, _ProxyMeter)

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -73,7 +73,9 @@ def mock_console_exporter():
 
 @pytest.fixture
 def mock_resource():
-    with mock.patch("strands.telemetry.tracer.Resource") as mock_resource:
+    with mock.patch("strands.telemetry.tracer.get_otel_resource") as mock_resource:
+        mock_resource_instance = mock.MagicMock()
+        mock_resource.return_value = mock_resource_instance
         yield mock_resource
 
 
@@ -175,14 +177,12 @@ def test_initialize_tracer_with_console(
 ):
     """Test initializing the tracer with console exporter."""
     mock_is_initialized.return_value = False
-    mock_resource_instance = mock.MagicMock()
-    mock_resource.create.return_value = mock_resource_instance
 
     # Initialize Tracer
     Tracer(enable_console_export=True)
 
     # Verify the tracer provider was created with correct resource
-    mock_tracer_provider.assert_called_once_with(resource=mock_resource_instance)
+    mock_tracer_provider.assert_called_once_with(resource=mock_resource.return_value)
 
     # Verify console exporter was added
     mock_console_exporter.assert_called_once()
@@ -198,9 +198,6 @@ def test_initialize_tracer_with_otlp(
     """Test initializing the tracer with OTLP exporter."""
     mock_is_initialized.return_value = False
 
-    mock_resource_instance = mock.MagicMock()
-    mock_resource.create.return_value = mock_resource_instance
-
     # Initialize Tracer
     with (
         mock.patch("strands.telemetry.tracer.HAS_OTEL_EXPORTER_MODULE", True),
@@ -209,7 +206,7 @@ def test_initialize_tracer_with_otlp(
         Tracer(otlp_endpoint="http://test-endpoint")
 
     # Verify the tracer provider was created with correct resource
-    mock_tracer_provider.assert_called_once_with(resource=mock_resource_instance)
+    mock_tracer_provider.assert_called_once_with(resource=mock_resource.return_value)
 
     # Verify OTLP exporter was added with correct endpoint
     mock_otlp_exporter.assert_called_once()
@@ -508,8 +505,6 @@ def test_initialize_tracer_with_invalid_otlp_endpoint(
     """Test initializing the tracer with an invalid OTLP endpoint."""
     mock_is_initialized.return_value = False
 
-    mock_resource_instance = mock.MagicMock()
-    mock_resource.create.return_value = mock_resource_instance
     mock_otlp_exporter.side_effect = Exception("Connection error")
 
     # This should not raise an exception, but should log an error
@@ -522,7 +517,7 @@ def test_initialize_tracer_with_invalid_otlp_endpoint(
         Tracer(otlp_endpoint="http://invalid-endpoint")
 
     # Verify the tracer provider was created with correct resource
-    mock_tracer_provider.assert_called_once_with(resource=mock_resource_instance)
+    mock_tracer_provider.assert_called_once_with(resource=mock_resource.return_value)
 
     # Verify OTLP exporter was attempted
     mock_otlp_exporter.assert_called_once()
@@ -537,9 +532,6 @@ def test_initialize_tracer_with_missing_module(
     """Test initializing the tracer when the OTLP exporter module is missing."""
     mock_is_initialized.return_value = False
 
-    mock_resource_instance = mock.MagicMock()
-    mock_resource.create.return_value = mock_resource_instance
-
     # Initialize Tracer with OTLP endpoint but missing module
     with (
         mock.patch("strands.telemetry.tracer.HAS_OTEL_EXPORTER_MODULE", False),
@@ -552,13 +544,13 @@ def test_initialize_tracer_with_missing_module(
     assert "otel http exporting is currently DISABLED" in str(excinfo.value)
 
     # Verify the tracer provider was created with correct resource
-    mock_tracer_provider.assert_called_once_with(resource=mock_resource_instance)
+    mock_tracer_provider.assert_called_once_with(resource=mock_resource.return_value)
 
     # Verify set_tracer_provider was not called since an exception was raised
     mock_set_tracer_provider.assert_not_called()
 
 
-def test_initialize_tracer_with_custom_tracer_provider(mock_get_tracer_provider, mock_resource):
+def test_initialize_tracer_with_custom_tracer_provider(mock_is_initialized, mock_get_tracer_provider, mock_resource):
     """Test initializing the tracer with NoOpTracerProvider."""
     mock_is_initialized.return_value = True
     tracer = Tracer(otlp_endpoint="http://invalid-endpoint")


### PR DESCRIPTION
## Description
Initiated OTEL Meter in Strands in order to send metrics.

Note:
User has to setup global meter_provider for strands to use them directly (will update the documentation).

## Documentation PR
Will update the documentation along with the traces.

## Type of Change
- New feature


## Testing
- Added unit tests

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`

- Tested manually with and without global OTEL Meter setup:
```
# Set up the resource
resource = Resource.create({ResourceAttributes.SERVICE_NAME: "strands-otel-test", "environment": "test"})

# Set up metrics with console exporter
console_metric_reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
metrics_provider = MeterProvider(resource=resource, metric_readers=[console_metric_reader])
metrics.set_meter_provider(metrics_provider)
```
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
