### PR TITLE
fix: Update throttling logic to use exponential back-off

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -136,6 +136,7 @@ def event_loop_cycle(
     metrics: Metrics
 
     # Retry loop for handling throttling exceptions
+    current_delay = INITIAL_DELAY
     for attempt in range(MAX_ATTEMPTS):
         model_id = model.config.get("model_id") if hasattr(model, "config") else None
         model_invoke_span = tracer.start_model_invoke_span(
@@ -168,7 +169,7 @@ def event_loop_cycle(
 
             # Handle throttling errors with exponential backoff
             should_retry, current_delay = handle_throttling_error(
-                e, attempt, MAX_ATTEMPTS, INITIAL_DELAY, MAX_DELAY, callback_handler, kwargs
+                e, attempt, MAX_ATTEMPTS, current_delay, MAX_DELAY, callback_handler, kwargs
             )
             if should_retry:
                 continue


### PR DESCRIPTION
## Description

Previous to this change, `current_delay` was being thrown away and not applied to subsequent retries meaning that we always slept for the same amount of time instead of applying exponential backoff.

Added a test to ensure this going forward.

It looks like this was a bug introduced as part of a previous refactor (a331e63).

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
