### PR TITLE
chore(otel): raise exception if exporter unavailable

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -219,7 +219,7 @@ class Tracer:
             except Exception as e:
                 logger.exception("error=<%s> | Failed to configure OTLP exporter", e)
         elif self.otlp_endpoint and self.tracer_provider:
-            logger.warning(OTEL_EXPORTER_MODULE_ERROR)
+            raise ModuleNotFoundError(OTEL_EXPORTER_MODULE_ERROR)
 
         # Set as global tracer provider
         trace_api.set_tracer_provider(self.tracer_provider)


### PR DESCRIPTION
## Description
This is a followup to #232. After speaking with @zastrowm we agreed that it is better to explicitly raise an exception if a customer relies on Strand's internally configured OTEL HTTP exporter. The goal is to avoid a situation where a customer has deployed a Strands agent to production and after #232 their telemetry is no longer being exported. The overall blast radius of this change is minimal as outlined in #232.

## Related Issues


## Documentation PR
Planned for a separate PR. Tracking issue: https://github.com/strands-agents/private-sdk-python-staging/issues/76

## Type of Change
- Followup


## Testing
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
