### PR TITLE
fix: Update PR Integration Test Workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,7 +51,7 @@ jobs:
          role-to-assume: ${{ secrets.STRANDS_INTEG_TEST_ROLE }}
          aws-region: us-east-1
          mask-aws-account-id: true
-      - name: Checkout base branch
+      - name: Checkout head commit
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }} # Pull the commit from the forked repo

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,7 +2,7 @@ name: Secure Integration test
 
 on:
   pull_request_target:
-    types: [opened, synchronize, labeled, unlabled, reopened]
+    branches: main
   
 jobs:
   authorization-check:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,28 +5,46 @@ on:
     types: [opened, synchronize, labeled, unlabled, reopened]
   
 jobs:
+  authorization-check:
+    permissions: read-all
+    runs-on: ubuntu-latest
+    outputs: 
+      approval-env: ${{ steps.collab-check.outputs.result }}
+    steps:
+      - name: Collaborator Check
+        uses: actions/github-script@v7
+        id: collab-check
+        with:
+          result-encoding: string
+          script: | 
+            try {
+              const permissionResponse = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.payload.pull_request.user.login,
+              });
+              const permission = permissionResponse.data.permission;
+              const hasWriteAccess = ['write', 'admin'].includes(permission);
+              if (!hasWriteAccess) {
+                console.log(`User ${context.payload.pull_request.user.login} does not have write access to the repository (permission: ${permission})`);
+                return "manual-approval"
+              } else {
+                console.log(`Verifed ${context.payload.pull_request.user.login} has write access. Auto Approving PR Checks.`)
+                return "auto-approve"
+              }             
+            } catch (error) {
+              console.log(`${context.payload.pull_request.user.login} does not have write access. Requiring Manual Approval to run PR Checks.`)
+              return "manual-approval"
+            }
   check-access-and-checkout:
     runs-on: ubuntu-latest
+    needs: authorization-check
+    environment: ${{ needs.authorization-check.outputs.approval-env }}
     permissions:
       id-token: write
       pull-requests: read
       contents: read
     steps:
-      - name: Check PR labels and author
-        id: check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            
-            const labels = pr.labels.map(label => label.name);
-            const hasLabel = labels.includes('approved-for-integ-test')
-            if (hasLabel) {
-              core.info('PR contains label approved-for-integ-test')
-              return
-            }
-            
-            core.setFailed('Pull Request must either have label approved-for-integ-test')
       - name: Configure Credentials 
         uses: aws-actions/configure-aws-credentials@v4
         with: 
@@ -36,7 +54,7 @@ jobs:
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }} # Pull the commit from the forked repo
+          ref: ${{ github.event.pull_request.head.sha }} # Pull the commit from the forked repo
           persist-credentials: false  # Don't persist credentials for subsequent actions
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Description

This pull request adds a secure check to ensure that the integration tests require approval if the PR creator does not have write access. If the creator has write access or higher, then it will run without approval.

Based on discussion with @Unshure 

## Related Issues
N/A
## Documentation PR
N/A

## Type of Change
- Bug fix

## Testing

Tested in my fork to confirm the permission check works: https://github.com/AdnaneKhan/sdk-python/actions/runs/15708340706/job/44259494661

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
