### PR TITLE
chore/update metrics

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -88,11 +88,11 @@ def event_loop_cycle(
     kwargs["event_loop_cycle_id"] = uuid.uuid4()
 
     event_loop_metrics: EventLoopMetrics = kwargs.get("event_loop_metrics", EventLoopMetrics())
-
     # Initialize state and get cycle trace
     if "request_state" not in kwargs:
         kwargs["request_state"] = {}
-    cycle_start_time, cycle_trace = event_loop_metrics.start_cycle()
+    attributes = {"event_loop_cycle_id": str(kwargs.get("event_loop_cycle_id"))}
+    cycle_start_time, cycle_trace = event_loop_metrics.start_cycle(attributes=attributes)
     kwargs["event_loop_cycle_trace"] = cycle_trace
 
     callback_handler(start=True)
@@ -211,7 +211,7 @@ def event_loop_cycle(
             )
 
         # End the cycle and return results
-        event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
+        event_loop_metrics.end_cycle(cycle_start_time, cycle_trace, attributes)
         if cycle_span:
             tracer.end_event_loop_cycle_span(
                 span=cycle_span,
@@ -344,7 +344,6 @@ def _handle_tool_execution(
 
     if not tool_uses:
         return stop_reason, message, event_loop_metrics, kwargs["request_state"]
-
     tool_handler_process = partial(
         tool_handler.process,
         messages=messages,

--- a/src/strands/telemetry/metrics_constants.py
+++ b/src/strands/telemetry/metrics_constants.py
@@ -1,3 +1,15 @@
-"""Metrics that are emitted in Strands-Agent."""
+"""Metrics that are emitted in Strands-Agents."""
 
-STRANDS_AGENT_INVOCATION_COUNT = "strands.agent.invocation_count"
+STRANDS_EVENT_LOOP_CYCLE_COUNT = "strands.event_loop.cycle_count"
+STRANDS_EVENT_LOOP_START_CYCLE = "strands.event_loop.start_cycle"
+STRANDS_EVENT_LOOP_END_CYCLE = "strands.event_loop.end_cycle"
+STRANDS_TOOL_CALL_COUNT = "strands.tool.call_count"
+STRANDS_TOOL_SUCCESS_COUNT = "strands.tool.success_count"
+STRANDS_TOOL_ERROR_COUNT = "strands.tool.error_count"
+
+# Histograms
+STRANDS_EVENT_LOOP_LATENCY = "strands.event_loop.latency"
+STRANDS_TOOL_DURATION = "strands.tool.duration"
+STRANDS_EVENT_LOOP_CYCLE_DURATION = "strands.event_loop.cycle_duration"
+STRANDS_EVENT_LOOP_INPUT_TOKENS = "strands.event_loop.input.tokens"
+STRANDS_EVENT_LOOP_OUTPUT_TOKENS = "strands.event_loop.output.tokens"

--- a/tests/strands/tools/test_executor.py
+++ b/tests/strands/tools/test_executor.py
@@ -44,6 +44,12 @@ def tool_uses(request, tool_use):
 
 
 @pytest.fixture
+def mock_metrics_client():
+    with unittest.mock.patch("strands.telemetry.MetricsClient") as mock_metrics_client:
+        yield mock_metrics_client
+
+
+@pytest.fixture
 def event_loop_metrics():
     return strands.telemetry.metrics.EventLoopMetrics()
 
@@ -303,6 +309,7 @@ def test_run_tools_creates_and_ends_span_on_success(
     mock_get_tracer,
     tool_handler,
     tool_uses,
+    mock_metrics_client,
     event_loop_metrics,
     request_state,
     invalid_tool_use_ids,


### PR DESCRIPTION
## Description
Start emitting metrics in Strands to the collector if configured.

## Documentation PR

Will add them once the exporter work is finished

## Type of Change
Other (please describe):

Emit strands metrics

## Testing
- [x] I ran `hatch run prepare`
- [x] Unit tests
- [x] Manually setup meter and view metrics in console:
```
# Set up the resource
resource = Resource.create({ResourceAttributes.SERVICE_NAME: "strands-otel-test", "environment": "test"})

# Set up metrics with console exporter

```
from opentelemetry import metrics
from opentelemetry.sdk.resources import Resource
from opentelemetry.sdk.metrics import MeterProvider
from opentelemetry.sdk.metrics.export import ConsoleMetricExporter, PeriodicExportingMetricReader

console_metric_reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
metrics_provider = MeterProvider(resource=resource, metric_readers=[console_metric_reader])
metrics.set_meter_provider(metrics_provider)

agent = Agent(tools=[calculator])
result = agent("what is 16*16?")
``` 

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
