### PR TITLE
fix: Emit warning that default region behavior will be changing

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -112,8 +112,17 @@ class BedrockModel(Model):
 
         logger.debug("config=<%s> | initializing", self.config)
 
+        region_for_boto = region_name or os.getenv("AWS_REGION")
+        if region_for_boto is None:
+            region_for_boto = "us-west-2"
+            logger.warning("defaulted to us-west-2 because no region was specified")
+            logger.warning(
+                "issue=<%s> | this behavior will change in an upcoming release",
+                "https://github.com/strands-agents/sdk-python/issues/238",
+            )
+
         session = boto_session or boto3.Session(
-            region_name=region_name or os.getenv("AWS_REGION") or "us-west-2",
+            region_name=region_for_boto,
         )
 
         # Add strands-agents to the request user agent

--- a/src/strands/types/models/openai.py
+++ b/src/strands/types/models/openai.py
@@ -62,7 +62,7 @@ class OpenAIModel(Model, abc.ABC):
                 base64.b64decode(image_bytes, validate=True)
                 logger.warning(
                     "issue=<%s> | base64 encoded images will not be accepted in a future version",
-                    "https://github.com/strands-agents/sdk-python/issues/252"
+                    "https://github.com/strands-agents/sdk-python/issues/252",
                 )
             except ValueError:
                 image_bytes = base64.b64encode(image_bytes)

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -91,6 +91,23 @@ def test__init__default_model_id(bedrock_client):
     assert tru_model_id == exp_model_id
 
 
+def test__init__with_default_region(bedrock_client):
+    """Test that BedrockModel uses the provided region."""
+    _ = bedrock_client
+    default_region = "us-west-2"
+
+    with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:
+        with unittest.mock.patch("strands.models.bedrock.logger.warning") as mock_warning:
+            _ = BedrockModel()
+            mock_session_cls.assert_called_once_with(region_name=default_region)
+            # Assert that warning logs are emitted
+            mock_warning.assert_any_call("defaulted to us-west-2 because no region was specified")
+            mock_warning.assert_any_call(
+                "issue=<%s> | this behavior will change in an upcoming release",
+                "https://github.com/strands-agents/sdk-python/issues/238",
+            )
+
+
 def test__init__with_custom_region(bedrock_client):
     """Test that BedrockModel uses the provided region."""
     _ = bedrock_client


### PR DESCRIPTION

## Description

In preparation for #238, emit a warning the behavior of the default region will be changing in an upcoming release

## Related Issues

#238

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
