### PR TITLE
Update @tool to return an AgentTool that also acts as a function

### DIFF
--- a/src/strands/tools/decorator.py
+++ b/src/strands/tools/decorator.py
@@ -42,10 +42,12 @@ Example:
 
 import functools
 import inspect
-from typing import Any, Callable, Dict, Optional, Type, TypeVar, cast, get_type_hints
+from typing import Any, Callable, Dict, Generic, Optional, ParamSpec, Type, TypeVar, cast, get_type_hints, overload
 
 import docstring_parser
 from pydantic import BaseModel, Field, create_model
+
+from strands.types.tools import AgentTool, ToolResult, ToolSpec, ToolUse
 
 # Type for wrapped function
 T = TypeVar("T", bound=Callable[..., Any])
@@ -124,7 +126,7 @@ class FunctionToolMetadata:
             # Handle case with no parameters
             return create_model(model_name)
 
-    def extract_metadata(self) -> Dict[str, Any]:
+    def extract_metadata(self) -> ToolSpec:
         """Extract metadata from the function to create a tool specification.
 
         This method analyzes the function to create a standardized tool specification that Strands Agent can use to
@@ -155,7 +157,7 @@ class FunctionToolMetadata:
         self._clean_pydantic_schema(input_schema)
 
         # Create tool specification
-        tool_spec = {"name": func_name, "description": description, "inputSchema": {"json": input_schema}}
+        tool_spec: ToolSpec = {"name": func_name, "description": description, "inputSchema": {"json": input_schema}}
 
         return tool_spec
 
@@ -234,7 +236,194 @@ class FunctionToolMetadata:
             raise ValueError(f"Validation failed for input parameters: {error_msg}") from e
 
 
-def tool(func: Optional[Callable[..., Any]] = None, **tool_kwargs: Any) -> Callable[[T], T]:
+P = ParamSpec("P")  # Captures all parameters
+R = TypeVar("R")  # Return type
+
+
+class DecoratedFunctionTool(Generic[P, R], AgentTool):
+    """A Strands Agent tool that wraps a function that was decorated with @tool.
+
+    This class implements the AgentTool interface and provides the bridge between Python functions and the Strands
+    Agent tool system. It handles both direct function calls and tool use invocations, maintaining the function's
+    original behavior while adding tool capabilities.
+
+    The class is generic over the function's parameter types (P) and return type (R) to maintain type safety.
+    """
+
+    _tool_name: str
+    _tool_spec: ToolSpec
+    _metadata: FunctionToolMetadata
+
+    def __init__(
+        self,
+        function: Callable[P, R],
+        tool_name: str,
+        tool_spec: ToolSpec,
+        metadata: FunctionToolMetadata,
+    ):
+        """Initialize the decorated function tool.
+
+        Args:
+            function: The original function being decorated.
+            tool_name: The name to use for the tool (usually the function name).
+            tool_spec: The tool specification containing metadata for Agent integration.
+            metadata: The FunctionToolMetadata object with extracted function information.
+        """
+        super().__init__()
+
+        self._function = function
+        self._tool_spec = tool_spec
+        self._metadata = metadata
+        self._tool_name = tool_name
+
+        functools.update_wrapper(wrapper=self, wrapped=self._function)
+
+    def __get__(self, instance, obj_type=None) -> "DecoratedFunctionTool[P, R]":
+        """Descriptor protocol implementation for proper method binding.
+
+        This method enables the decorated function to work correctly when used as a class method.
+        It binds the instance to the function call when accessed through an instance.
+
+        Args:
+            instance: The instance through which the descriptor is accessed, or None when accessed through the class.
+            obj_type: The class through which the descriptor is accessed.
+
+        Returns:
+            A new DecoratedFunctionTool with the instance bound to the function if accessed through an instance,
+            otherwise returns self.
+        """
+        if instance is not None:
+
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                # insert the instance method
+                args = instance, *args
+                func = self._function
+                return func(*args, **kwargs)
+
+            return DecoratedFunctionTool(
+                function=wrapper, tool_name=self.tool_name, tool_spec=self.tool_spec, metadata=self._metadata
+            )
+        return self
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Call the original function with the provided arguments.
+
+        This method enables the decorated function to be called directly with its original signature,
+        preserving the normal function call behavior.
+
+        Args:
+            *args: Positional arguments to pass to the function.
+            **kwargs: Keyword arguments to pass to the function.
+
+        Returns:
+            The result of the original function call.
+        """
+        return self._function(*args, **kwargs)
+
+    @property
+    def tool_name(self) -> str:
+        """Get the name of the tool.
+
+        Returns:
+            The tool name as a string.
+        """
+        return self._tool_name
+
+    @property
+    def tool_spec(self) -> ToolSpec:
+        """Get the tool specification.
+
+        Returns:
+            The tool specification dictionary containing metadata for Agent integration.
+        """
+        return self._tool_spec
+
+    @property
+    def tool_type(self) -> str:
+        """Get the type of the tool.
+
+        Returns:
+            The string "decorated-function" indicating this is a function-based tool.
+        """
+        return "decorated-function"
+
+    def invoke(self, tool: ToolUse, *args: Any, **kwargs: dict[str, Any]) -> ToolResult:
+        """Invoke the tool with a tool use specification.
+
+        This method handles tool use invocations from a Strands Agent. It validates the input,
+        calls the function, and formats the result according to the expected tool result format.
+
+        Key operations:
+
+        1. Extract tool use ID and input parameters
+        2. Validate input against the function's expected parameters
+        3. Call the function with validated input
+        4. Format the result as a standard tool result
+        5. Handle and format any errors that occur
+
+        Args:
+            tool: The tool use specification from the Agent.
+            *args: Additional positional arguments (not typically used).
+            **kwargs: Additional keyword arguments, may include 'agent' reference.
+
+        Returns:
+            A standardized tool result dictionary with status and content.
+        """
+        # This is a tool use call - process accordingly
+        tool_use = tool
+        tool_use_id = tool_use.get("toolUseId", "unknown")
+        tool_input = tool_use.get("input", {})
+
+        try:
+            # Validate input against the Pydantic model
+            validated_input = self._metadata.validate_input(tool_input)
+
+            # Pass along the agent if provided and expected by the function
+            if "agent" in kwargs and "agent" in self._metadata.signature.parameters:
+                validated_input["agent"] = kwargs.get("agent")
+
+            result = self._function(**validated_input)
+
+            # FORMAT THE RESULT for Strands Agent
+            if isinstance(result, dict) and "status" in result and "content" in result:
+                # Result is already in the expected format, just add toolUseId
+                result["toolUseId"] = tool_use_id
+                return cast(ToolResult, result)
+            else:
+                # Wrap any other return value in the standard format
+                # Always include at least one content item for consistency
+                return {
+                    "toolUseId": tool_use_id,
+                    "status": "success",
+                    "content": [{"text": str(result)}],
+                }
+
+        except ValueError as e:
+            # Special handling for validation errors
+            error_msg = str(e)
+            return {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [{"text": f"Error: {error_msg}"}],
+            }
+        except Exception as e:
+            # Return error result with exception details for any other error
+            error_type = type(e).__name__
+            error_msg = str(e)
+            return {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [{"text": f"Error: {error_type} - {error_msg}"}],
+            }
+
+
+# Handle @decorator
+@overload
+def tool(__func: Callable[P, R]) -> DecoratedFunctionTool[P, R]: ...
+# Handle @decorator()
+@overload
+def tool(**tool_kwargs: Any) -> Callable[[Callable[P, R]], DecoratedFunctionTool[P, R]]: ...
+def tool(func: Optional[Callable[P, R]] = None, **tool_kwargs: Any) -> DecoratedFunctionTool[P, R]:
     """Decorator that transforms a Python function into a Strands tool.
 
     This decorator seamlessly enables a function to be called both as a regular Python function and as a Strands tool.
@@ -282,119 +471,21 @@ def tool(func: Optional[Callable[..., Any]] = None, **tool_kwargs: Any) -> Calla
         ```
     """
 
-    def decorator(f: T) -> T:
+    def decorator(f: T) -> "DecoratedFunctionTool[P, R]":
         # Create function tool metadata
         tool_meta = FunctionToolMetadata(f)
         tool_spec = tool_meta.extract_metadata()
-
-        # Update with any additional kwargs
         tool_spec.update(tool_kwargs)
 
-        # Attach TOOL_SPEC directly to the original function (critical for backward compatibility)
-        f.TOOL_SPEC = tool_spec  # type: ignore
+        tool_name = tool_spec.get("name", f.__name__)
 
-        @functools.wraps(f)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            """Tool wrapper.
+        if not isinstance(tool_name, str):
+            raise ValueError(f"Tool name must be a string, got {type(tool_name)}")
 
-            This wrapper handles two different calling patterns:
-
-            1. Normal function calls: `func(arg1, arg2, ...)`
-            2. Tool use calls: `func({"toolUseId": "id", "input": {...}}, agent=agent)`
-            """
-            # Initialize variables to track call type
-            is_method_call = False
-            instance = None
-
-            # DETECT IF THIS IS A METHOD CALL (with 'self' as first argument)
-            # If this is a method call, the first arg would be 'self' (instance)
-            if len(args) > 0 and not isinstance(args[0], dict):
-                try:
-                    # Try to find f in the class of args[0]
-                    if hasattr(args[0], "__class__"):
-                        if hasattr(args[0].__class__, f.__name__):
-                            # This is likely a method call with self as first argument
-                            is_method_call = True
-                            instance = args[0]
-                            args = args[1:]  # Remove self from args
-                except (AttributeError, TypeError):
-                    pass
-
-            # DETECT IF THIS IS A TOOL USE CALL
-            # Check if this is a tool use call (dict with toolUseId or input)
-            if (
-                len(args) > 0
-                and isinstance(args[0], dict)
-                and (not args[0] or "toolUseId" in args[0] or "input" in args[0])
-            ):
-                # This is a tool use call - process accordingly
-                tool_use = args[0]
-                tool_use_id = tool_use.get("toolUseId", "unknown")
-                tool_input = tool_use.get("input", {})
-
-                try:
-                    # Validate input against the Pydantic model
-                    validated_input = tool_meta.validate_input(tool_input)
-
-                    # Pass along the agent if provided and expected by the function
-                    if "agent" in kwargs and "agent" in tool_meta.signature.parameters:
-                        validated_input["agent"] = kwargs.get("agent")
-
-                    # CALL THE ACTUAL FUNCTION based on whether it's a method or not
-                    if is_method_call:
-                        # For methods, pass the instance as 'self'
-                        result = f(instance, **validated_input)
-                    else:
-                        # For standalone functions, just pass the validated inputs
-                        result = f(**validated_input)
-
-                    # FORMAT THE RESULT for Strands Agent
-                    if isinstance(result, dict) and "status" in result and "content" in result:
-                        # Result is already in the expected format, just add toolUseId
-                        result["toolUseId"] = tool_use_id
-                        return result
-                    else:
-                        # Wrap any other return value in the standard format
-                        # Always include at least one content item for consistency
-                        return {
-                            "toolUseId": tool_use_id,
-                            "status": "success",
-                            "content": [{"text": str(result)}],
-                        }
-
-                except ValueError as e:
-                    # Special handling for validation errors
-                    error_msg = str(e)
-                    return {
-                        "toolUseId": tool_use_id,
-                        "status": "error",
-                        "content": [{"text": f"Error: {error_msg}"}],
-                    }
-                except Exception as e:
-                    # Return error result with exception details for any other error
-                    error_type = type(e).__name__
-                    error_msg = str(e)
-                    return {
-                        "toolUseId": tool_use_id,
-                        "status": "error",
-                        "content": [{"text": f"Error: {error_type} - {error_msg}"}],
-                    }
-            else:
-                # NORMAL FUNCTION CALL - pass through to the original function
-                if is_method_call:
-                    # Put instance back as first argument for method calls
-                    return f(instance, *args, **kwargs)
-                else:
-                    # Standard function call
-                    return f(*args, **kwargs)
-
-        # Also attach TOOL_SPEC to wrapper for compatibility
-        wrapper.TOOL_SPEC = tool_spec  # type: ignore
-
-        # Return the wrapper
-        return cast(T, wrapper)
+        return DecoratedFunctionTool(function=f, tool_name=tool_name, tool_spec=tool_spec, metadata=tool_meta)
 
     # Handle both @tool and @tool() syntax
     if func is None:
         return decorator
+
     return decorator(func)

--- a/tests/strands/tools/test_decorator.py
+++ b/tests/strands/tools/test_decorator.py
@@ -1,11 +1,13 @@
 """
 Tests for the function-based tool decorator pattern.
 """
+# mypy: ignore-errors
 
 from typing import Any, Dict, Optional, Union
 from unittest.mock import MagicMock
 
 from strands.tools.decorator import tool
+from strands.types.tools import ToolUse
 
 
 def test_basic_tool_creation():
@@ -22,8 +24,8 @@ def test_basic_tool_creation():
         return f"Result: {param1} {param2}"
 
     # Check TOOL_SPEC was generated correctly
-    assert hasattr(test_tool, "TOOL_SPEC")
-    spec = test_tool.TOOL_SPEC
+    assert test_tool.tool_spec is not None
+    spec = test_tool.tool_spec
 
     # Check basic spec properties
     assert spec["name"] == "test_tool"
@@ -49,10 +51,21 @@ Args:
 
     # Test actual usage
     tool_use = {"toolUseId": "test-id", "input": {"param1": "hello", "param2": 42}}
-    result = test_tool(tool_use)
+    result = test_tool.invoke(tool_use)
     assert result["toolUseId"] == "test-id"
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "Result: hello 42"
+
+    # Make sure these are set properly
+    assert test_tool.__wrapped__ is not None
+    assert test_tool.__doc__ == (
+        "Test tool function.\n"
+        "\n"
+        "        Args:\n"
+        "            param1: First parameter\n"
+        "            param2: Second parameter\n"
+        "        "
+    )
 
 
 def test_tool_with_custom_name_description():
@@ -62,7 +75,8 @@ def test_tool_with_custom_name_description():
     def test_tool(param: str) -> str:
         return f"Result: {param}"
 
-    spec = test_tool.TOOL_SPEC
+    spec = test_tool.tool_spec
+
     assert spec["name"] == "custom_name"
     assert spec["description"] == "Custom description"
 
@@ -82,7 +96,7 @@ def test_tool_with_optional_params():
             return f"Result: {required}"
         return f"Result: {required} {optional}"
 
-    spec = test_tool.TOOL_SPEC
+    spec = test_tool.tool_spec
     schema = spec["inputSchema"]["json"]
 
     # Only required should be in required list
@@ -92,14 +106,14 @@ def test_tool_with_optional_params():
     # Test with only required param
     tool_use = {"toolUseId": "test-id", "input": {"required": "hello"}}
 
-    result = test_tool(tool_use)
+    result = test_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "Result: hello"
 
     # Test with both params
     tool_use = {"toolUseId": "test-id", "input": {"required": "hello", "optional": 42}}
 
-    result = test_tool(tool_use)
+    result = test_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "Result: hello 42"
 
@@ -117,7 +131,7 @@ def test_tool_error_handling():
     # Test with missing required param
     tool_use = {"toolUseId": "test-id", "input": {}}
 
-    result = test_tool(tool_use)
+    result = test_tool.invoke(tool_use)
     assert result["status"] == "error"
     assert "validation error for test_tooltool\nrequired\n" in result["content"][0]["text"].lower(), (
         "Validation error should indicate which argument is missing"
@@ -126,7 +140,7 @@ def test_tool_error_handling():
     # Test with exception in tool function
     tool_use = {"toolUseId": "test-id", "input": {"required": "error"}}
 
-    result = test_tool(tool_use)
+    result = test_tool.invoke(tool_use)
     assert result["status"] == "error"
     assert "test error" in result["content"][0]["text"].lower(), (
         "Runtime error should contain the original error message"
@@ -146,7 +160,7 @@ def test_type_handling():
         """Test basic types."""
         return "Success"
 
-    spec = test_tool.TOOL_SPEC
+    spec = test_tool.tool_spec
     schema = spec["inputSchema"]["json"]
     props = schema["properties"]
 
@@ -170,11 +184,11 @@ def test_agent_parameter_passing():
     tool_use = {"toolUseId": "test-id", "input": {"param": "test"}}
 
     # Test without agent
-    result = test_tool(tool_use)
+    result = test_tool.invoke(tool_use)
     assert result["content"][0]["text"] == "Param: test"
 
     # Test with agent
-    result = test_tool(tool_use, agent=mock_agent)
+    result = test_tool.invoke(tool_use, agent=mock_agent)
     assert "Agent:" in result["content"][0]["text"]
     assert "test" in result["content"][0]["text"]
 
@@ -201,19 +215,19 @@ def test_tool_decorator_with_different_return_values():
         pass
 
     # Test the dict return - should preserve dict format but add toolUseId
-    tool_use = {"toolUseId": "test-id", "input": {"param": "test"}}
-    result = dict_return_tool(tool_use)
+    tool_use: ToolUse = {"toolUseId": "test-id", "input": {"param": "test"}}
+    result = dict_return_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "Result: test"
     assert result["toolUseId"] == "test-id"
 
     # Test the string return - should wrap in standard format
-    result = string_return_tool(tool_use)
+    result = string_return_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "Result: test"
 
     # Test None return - should still create valid ToolResult with "None" text
-    result = none_return_tool(tool_use)
+    result = none_return_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "None"
 
@@ -238,8 +252,7 @@ def test_class_method_handling():
     instance = TestClass("Test")
 
     # Check that tool spec exists and doesn't include self
-    assert hasattr(instance.test_method, "TOOL_SPEC")
-    spec = instance.test_method.TOOL_SPEC
+    spec = instance.test_method.tool_spec
     assert "param" in spec["inputSchema"]["json"]["properties"]
     assert "self" not in spec["inputSchema"]["json"]["properties"]
 
@@ -249,7 +262,7 @@ def test_class_method_handling():
 
     # Test tool-style call
     tool_use = {"toolUseId": "test-id", "input": {"param": "tool-value"}}
-    result = instance.test_method(tool_use)
+    result = instance.test_method.invoke(tool_use)
     assert "Test: tool-value" in result["content"][0]["text"]
 
 
@@ -268,7 +281,7 @@ def test_default_parameter_handling():
         return f"{required} {optional} {number}"
 
     # Check schema has correct required fields
-    spec = tool_with_defaults.TOOL_SPEC
+    spec = tool_with_defaults.tool_spec
     schema = spec["inputSchema"]["json"]
     assert "required" in schema["required"]
     assert "optional" not in schema["required"]
@@ -276,12 +289,12 @@ def test_default_parameter_handling():
 
     # Call with just required parameter
     tool_use = {"toolUseId": "test-id", "input": {"required": "hello"}}
-    result = tool_with_defaults(tool_use)
+    result = tool_with_defaults.invoke(tool_use)
     assert result["content"][0]["text"] == "hello default 42"
 
     # Call with some but not all optional parameters
     tool_use = {"toolUseId": "test-id", "input": {"required": "hello", "number": 100}}
-    result = tool_with_defaults(tool_use)
+    result = tool_with_defaults.invoke(tool_use)
     assert result["content"][0]["text"] == "hello default 100"
 
 
@@ -294,12 +307,12 @@ def test_empty_tool_use_handling():
         return f"Got: {required}"
 
     # Test with completely empty tool use
-    result = test_tool({})
+    result = test_tool.invoke({})
     assert result["status"] == "error"
     assert "unknown" in result["toolUseId"]
 
     # Test with missing input
-    result = test_tool({"toolUseId": "test-id"})
+    result = test_tool.invoke({"toolUseId": "test-id"})
     assert result["status"] == "error"
     assert "test-id" in result["toolUseId"]
 
@@ -323,7 +336,7 @@ def test_traditional_function_call():
 
     # Call through tool interface
     tool_use = {"toolUseId": "test-id", "input": {"a": 2, "b": 3}}
-    result = add_numbers(tool_use)
+    result = add_numbers.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "5"
 
@@ -343,7 +356,7 @@ def test_multiple_default_parameters():
         return f"{required_param}, {optional_str}, {optional_int}, {optional_bool}, {optional_float}"
 
     # Check the tool spec
-    spec = multi_default_tool.TOOL_SPEC
+    spec = multi_default_tool.tool_spec
     schema = spec["inputSchema"]["json"]
 
     # Verify that only required_param is in the required list
@@ -356,7 +369,7 @@ def test_multiple_default_parameters():
 
     # Test calling with only required parameter
     tool_use = {"toolUseId": "test-id", "input": {"required_param": "hello"}}
-    result = multi_default_tool(tool_use)
+    result = multi_default_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert "hello, default_str, 42, True, 3.14" in result["content"][0]["text"]
 
@@ -365,7 +378,7 @@ def test_multiple_default_parameters():
         "toolUseId": "test-id",
         "input": {"required_param": "hello", "optional_int": 100, "optional_float": 2.718},
     }
-    result = multi_default_tool(tool_use)
+    result = multi_default_tool.invoke(tool_use)
     assert "hello, default_str, 100, True, 2.718" in result["content"][0]["text"]
 
 
@@ -389,7 +402,7 @@ def test_return_type_validation():
 
     # Test with return that matches declared type
     tool_use = {"toolUseId": "test-id", "input": {"param": "valid"}}
-    result = int_return_tool(tool_use)
+    result = int_return_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "42"
 
@@ -397,13 +410,13 @@ def test_return_type_validation():
     # Note: This should still work because Python doesn't enforce return types at runtime
     # but the function will return a string instead of an int
     tool_use = {"toolUseId": "test-id", "input": {"param": "invalid_type"}}
-    result = int_return_tool(tool_use)
+    result = int_return_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "not an int"
 
     # Test with None return from a non-None return type
     tool_use = {"toolUseId": "test-id", "input": {"param": "none"}}
-    result = int_return_tool(tool_use)
+    result = int_return_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "None"
 
@@ -424,17 +437,17 @@ def test_return_type_validation():
 
     # Test with each possible return type in the Union
     tool_use = {"toolUseId": "test-id", "input": {"param": "dict"}}
-    result = union_return_tool(tool_use)
+    result = union_return_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert "{'key': 'value'}" in result["content"][0]["text"] or '{"key": "value"}' in result["content"][0]["text"]
 
     tool_use = {"toolUseId": "test-id", "input": {"param": "str"}}
-    result = union_return_tool(tool_use)
+    result = union_return_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "string result"
 
     tool_use = {"toolUseId": "test-id", "input": {"param": "none"}}
-    result = union_return_tool(tool_use)
+    result = union_return_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "None"
 
@@ -448,14 +461,14 @@ def test_tool_with_no_parameters():
         return "Success - no parameters needed"
 
     # Check schema is still valid even with no parameters
-    spec = no_params_tool.TOOL_SPEC
+    spec = no_params_tool.tool_spec
     schema = spec["inputSchema"]["json"]
     assert schema["type"] == "object"
     assert "properties" in schema
 
     # Test tool use call
     tool_use = {"toolUseId": "test-id", "input": {}}
-    result = no_params_tool(tool_use)
+    result = no_params_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "Success - no parameters needed"
 
@@ -481,7 +494,7 @@ def test_complex_parameter_types():
 
     # Call via tool use
     tool_use = {"toolUseId": "test-id", "input": {"config": nested_dict}}
-    result = complex_type_tool(tool_use)
+    result = complex_type_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert "Got config with 3 keys" in result["content"][0]["text"]
 
@@ -508,7 +521,7 @@ def test_custom_tool_result_handling():
 
     # Test via tool use
     tool_use = {"toolUseId": "custom-id", "input": {"param": "test"}}
-    result = custom_result_tool(tool_use)
+    result = custom_result_tool.invoke(tool_use)
 
     # The wrapper should preserve our format and just add the toolUseId
     assert result["status"] == "success"
@@ -543,7 +556,7 @@ def test_docstring_parsing():
         """
         return f"{param1} {param2}"
 
-    spec = documented_tool.TOOL_SPEC
+    spec = documented_tool.tool_spec
 
     # Check description captures both summary and details
     assert "This is the summary line" in spec["description"]
@@ -581,7 +594,7 @@ def test_detailed_validation_errors():
             "bool_param": True,
         },
     }
-    result = validation_tool(tool_use)
+    result = validation_tool.invoke(tool_use)
     assert result["status"] == "error"
     assert "int_param" in result["content"][0]["text"]
 
@@ -594,7 +607,7 @@ def test_detailed_validation_errors():
             "bool_param": True,
         },
     }
-    result = validation_tool(tool_use)
+    result = validation_tool.invoke(tool_use)
     assert result["status"] == "error"
     assert "int_param" in result["content"][0]["text"]
 
@@ -615,20 +628,20 @@ def test_tool_complex_validation_edge_cases():
 
     # Test with None value
     tool_use = {"toolUseId": "test-id", "input": {"param": None}}
-    result = edge_case_tool(tool_use)
+    result = edge_case_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "None"
 
     # Test with empty dict
     tool_use = {"toolUseId": "test-id", "input": {"param": {}}}
-    result = edge_case_tool(tool_use)
+    result = edge_case_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert result["content"][0]["text"] == "{}"
 
     # Test with a complex nested dictionary
     nested_dict = {"key1": {"nested": [1, 2, 3]}, "key2": None}
     tool_use = {"toolUseId": "test-id", "input": {"param": nested_dict}}
-    result = edge_case_tool(tool_use)
+    result = edge_case_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert "key1" in result["content"][0]["text"]
     assert "nested" in result["content"][0]["text"]
@@ -675,7 +688,7 @@ def test_tool_method_detection_errors():
     assert instance.test_method("test") == "Method Got: test"
 
     # Test direct function call
-    direct_result = instance.test_method({"toolUseId": "test-id", "input": {"param": "direct"}})
+    direct_result = instance.test_method.invoke({"toolUseId": "test-id", "input": {"param": "direct"}})
     assert direct_result["status"] == "success"
     assert direct_result["content"][0]["text"] == "Method Got: direct"
 
@@ -695,7 +708,7 @@ def test_tool_method_detection_errors():
     assert result == "Standalone: param1, param2"
 
     # And that it works with tool use call too
-    tool_use_result = standalone_tool({"toolUseId": "test-id", "input": {"p1": "value1"}})
+    tool_use_result = standalone_tool.invoke({"toolUseId": "test-id", "input": {"p1": "value1"}})
     assert tool_use_result["status"] == "success"
     assert tool_use_result["content"][0]["text"] == "Standalone: value1, default"
 
@@ -724,7 +737,7 @@ def test_tool_general_exception_handling():
     error_types = ["value_error", "type_error", "attribute_error", "key_error"]
     for error_type in error_types:
         tool_use = {"toolUseId": "test-id", "input": {"param": error_type}}
-        result = failing_tool(tool_use)
+        result = failing_tool.invoke(tool_use)
         assert result["status"] == "error"
 
         error_message = result["content"][0]["text"]
@@ -756,25 +769,25 @@ def test_tool_with_complex_anyof_schema():
 
     # Test with a list
     tool_use = {"toolUseId": "test-id", "input": {"union_param": [1, 2, 3]}}
-    result = complex_schema_tool(tool_use)
+    result = complex_schema_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert "list: [1, 2, 3]" in result["content"][0]["text"]
 
     # Test with a dict
     tool_use = {"toolUseId": "test-id", "input": {"union_param": {"key": "value"}}}
-    result = complex_schema_tool(tool_use)
+    result = complex_schema_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert "dict:" in result["content"][0]["text"]
     assert "key" in result["content"][0]["text"]
 
     # Test with a string
     tool_use = {"toolUseId": "test-id", "input": {"union_param": "test_string"}}
-    result = complex_schema_tool(tool_use)
+    result = complex_schema_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert "str: test_string" in result["content"][0]["text"]
 
     # Test with None
     tool_use = {"toolUseId": "test-id", "input": {"union_param": None}}
-    result = complex_schema_tool(tool_use)
+    result = complex_schema_tool.invoke(tool_use)
     assert result["status"] == "success"
     assert "NoneType: None" in result["content"][0]["text"]


### PR DESCRIPTION
## Description

Right now when you decorate a function you get back another function that mimics the behavior of a python module. Going forward, we're discussing adding helper/utility methods for AgentTool and in anticipatation of those changes return an AgentTool implementation that also acts like the original function.


## Related Issues

N/A

## Documentation PR

n/A

## Type of Change

Refactor

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
