### PR TITLE
feat: allow users to use custom agent name

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -56,6 +56,7 @@ class _DefaultCallbackHandlerSentinel:
 
 
 _DEFAULT_CALLBACK_HANDLER = _DefaultCallbackHandlerSentinel()
+_DEFAULT_AGENT_NAME = "Strands Agents"
 
 
 class Agent:
@@ -631,8 +632,12 @@ class Agent:
         """
         model_id = self.model.config.get("model_id") if hasattr(self.model, "config") else None
 
+        # Use custom agent name if provided
+        agent_name = self.name if self.name else _DEFAULT_AGENT_NAME
+
         self.trace_span = self.tracer.start_agent_span(
             prompt=prompt,
+            agent_name=agent_name,
             model_id=model_id,
             tools=self.tool_names,
             system_prompt=self.system_prompt,

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -1050,6 +1050,24 @@ def test_agent_init_initializes_tracer(mock_get_tracer):
     assert agent.trace_span is None
 
 
+def test_agent_trace_span_uses_custom_name():
+    """Test that trace span uses custom name when provided."""
+    custom_name = "Custom Agent Name"
+    agent = Agent(name=custom_name)
+
+    # Mock the tracer to verify the name is passed correctly
+    mock_tracer = unittest.mock.Mock()
+    agent.tracer = mock_tracer
+
+    # Call the method that uses the name
+    agent._start_agent_trace_span("test prompt")
+
+    # Verify the custom name was used
+    mock_tracer.start_agent_span.assert_called_once()
+    args, kwargs = mock_tracer.start_agent_span.call_args
+    assert kwargs["agent_name"] == custom_name
+
+
 @unittest.mock.patch("strands.agent.agent.get_tracer")
 def test_agent_call_creates_and_ends_span_on_success(mock_get_tracer, mock_model):
     """Test that __call__ creates and ends a span when the call succeeds."""
@@ -1074,6 +1092,7 @@ def test_agent_call_creates_and_ends_span_on_success(mock_get_tracer, mock_model
     # Verify span was created
     mock_tracer.start_agent_span.assert_called_once_with(
         prompt="test prompt",
+        agent_name="Strands Agents",
         model_id=unittest.mock.ANY,
         tools=agent.tool_names,
         system_prompt=agent.system_prompt,
@@ -1116,6 +1135,7 @@ async def test_agent_stream_async_creates_and_ends_span_on_success(mock_get_trac
     # Verify span was created
     mock_tracer.start_agent_span.assert_called_once_with(
         prompt="test prompt",
+        agent_name="Strands Agents",
         model_id=unittest.mock.ANY,
         tools=agent.tool_names,
         system_prompt=agent.system_prompt,
@@ -1153,6 +1173,7 @@ def test_agent_call_creates_and_ends_span_on_exception(mock_get_tracer, mock_mod
     # Verify span was created
     mock_tracer.start_agent_span.assert_called_once_with(
         prompt="test prompt",
+        agent_name="Strands Agents",
         model_id=unittest.mock.ANY,
         tools=agent.tool_names,
         system_prompt=agent.system_prompt,
@@ -1189,6 +1210,7 @@ async def test_agent_stream_async_creates_and_ends_span_on_exception(mock_get_tr
     # Verify span was created
     mock_tracer.start_agent_span.assert_called_once_with(
         prompt="test prompt",
+        agent_name="Strands Agents",
         model_id=unittest.mock.ANY,
         tools=agent.tool_names,
         system_prompt=agent.system_prompt,


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
Traces are all named "Strands Agents", which confuses users when viewing the data in platforms like Langfuse. 

## Related Issues

<!-- Link to related issues using #issue-number format -->
resolve #277 

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
