### PR TITLE
refactor: remove kwargs spread after agent call

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -14,7 +14,7 @@ import logging
 import os
 import random
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, AsyncIterator, Callable, Generator, Mapping, Optional, Type, TypeVar, Union, cast
+from typing import Any, AsyncIterator, Callable, Generator, List, Mapping, Optional, Type, TypeVar, Union, cast
 
 from opentelemetry import trace
 from pydantic import BaseModel
@@ -512,10 +512,10 @@ class Agent:
 
     def _record_tool_execution(
         self,
-        tool: dict[str, Any],
-        tool_result: dict[str, Any],
+        tool: ToolUse,
+        tool_result: ToolResult,
         user_message_override: Optional[str],
-        messages: list[dict[str, Any]],
+        messages: Messages,
     ) -> None:
         """Record a tool execution in the message history.
 

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -97,11 +97,17 @@ class Agent:
                 AttributeError: If no tool with the given name exists or if multiple tools match the given name.
             """
 
-            def caller(user_message_override: Optional[str] = None, **kwargs: Any) -> Any:
+            def caller(
+                user_message_override: Optional[str] = None,
+                record_direct_tool_call: Optional[bool] = None,
+                **kwargs: Any,
+            ) -> Any:
                 """Call a tool directly by name.
 
                 Args:
                     user_message_override: Optional custom message to record instead of default
+                    record_direct_tool_call: Whether to record direct tool calls in message history. Overrides class
+                        attribute if provided.
                     **kwargs: Keyword arguments to pass to the tool.
 
                 Returns:
@@ -131,7 +137,12 @@ class Agent:
                     kwargs=kwargs,
                 )
 
-                if self._agent.record_direct_tool_call:
+                if record_direct_tool_call is not None:
+                    should_record_direct_tool_call = record_direct_tool_call
+                else:
+                    should_record_direct_tool_call = self._agent.record_direct_tool_call
+
+                if should_record_direct_tool_call:
                     # Create a record of this tool execution in the message history
                     self._agent._record_tool_execution(
                         tool_use, tool_result, user_message_override, self._agent.messages

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -31,7 +31,7 @@ from ..tools.watcher import ToolWatcher
 from ..types.content import ContentBlock, Message, Messages
 from ..types.exceptions import ContextWindowOverflowException
 from ..types.models import Model
-from ..types.tools import ToolConfig
+from ..types.tools import ToolConfig, ToolResult, ToolUse
 from ..types.traces import AttributeValue
 from .agent_result import AgentResult
 from .conversation_manager import (
@@ -97,40 +97,12 @@ class Agent:
                 AttributeError: If no tool with the given name exists or if multiple tools match the given name.
             """
 
-            def find_normalized_tool_name() -> Optional[str]:
-                """Lookup the tool represented by name, replacing characters with underscores as necessary."""
-                tool_registry = self._agent.tool_registry.registry
-
-                if tool_registry.get(name, None):
-                    return name
-
-                # If the desired name contains underscores, it might be a placeholder for characters that can't be
-                # represented as python identifiers but are valid as tool names, such as dashes. In that case, find
-                # all tools that can be represented with the normalized name
-                if "_" in name:
-                    filtered_tools = [
-                        tool_name for (tool_name, tool) in tool_registry.items() if tool_name.replace("-", "_") == name
-                    ]
-
-                    # The registry itself defends against similar names, so we can just take the first match
-                    if filtered_tools:
-                        return filtered_tools[0]
-
-                raise AttributeError(f"Tool '{name}' not found")
-
-            def caller(**kwargs: Any) -> Any:
+            def caller(user_message_override: Optional[str] = None, **kwargs: Any) -> Any:
                 """Call a tool directly by name.
 
                 Args:
+                    user_message_override: Optional custom message to record instead of default
                     **kwargs: Keyword arguments to pass to the tool.
-
-                        - user_message_override: Custom message to record instead of default
-                        - tool_execution_handler: Custom handler for tool execution
-                        - event_loop_metrics: Custom metrics collector
-                        - messages: Custom message history to use
-                        - tool_config: Custom tool configuration
-                        - callback_handler: Custom callback handler
-                        - record_direct_tool_call: Whether to record this call in history
 
                 Returns:
                     The result returned by the tool.
@@ -138,44 +110,14 @@ class Agent:
                 Raises:
                     AttributeError: If the tool doesn't exist.
                 """
-                normalized_name = find_normalized_tool_name()
+                normalized_name = self._find_normalized_tool_name(name)
 
                 # Create unique tool ID and set up the tool request
                 tool_id = f"tooluse_{name}_{random.randint(100000000, 999999999)}"
-                tool_use = {
+                tool_use: ToolUse = {
                     "toolUseId": tool_id,
                     "name": normalized_name,
                     "input": kwargs.copy(),
-                }
-
-                # Extract tool execution parameters
-                user_message_override = kwargs.get("user_message_override", None)
-                tool_execution_handler = kwargs.get("tool_execution_handler", self._agent.thread_pool_wrapper)
-                event_loop_metrics = kwargs.get("event_loop_metrics", self._agent.event_loop_metrics)
-                messages = kwargs.get("messages", self._agent.messages)
-                tool_config = kwargs.get("tool_config", self._agent.tool_config)
-                callback_handler = kwargs.get("callback_handler", self._agent.callback_handler)
-                record_direct_tool_call = kwargs.get("record_direct_tool_call", self._agent.record_direct_tool_call)
-
-                # Process tool call
-                handler_kwargs = {
-                    k: v
-                    for k, v in kwargs.items()
-                    if k
-                    not in [
-                        "tool_execution_handler",
-                        "event_loop_metrics",
-                        "messages",
-                        "tool_config",
-                        "callback_handler",
-                        "tool_handler",
-                        "system_prompt",
-                        "model",
-                        "model_id",
-                        "user_message_override",
-                        "agent",
-                        "record_direct_tool_call",
-                    ]
                 }
 
                 # Execute the tool
@@ -183,18 +125,17 @@ class Agent:
                     tool=tool_use,
                     model=self._agent.model,
                     system_prompt=self._agent.system_prompt,
-                    messages=messages,
-                    tool_config=tool_config,
-                    callback_handler=callback_handler,
-                    tool_execution_handler=tool_execution_handler,
-                    event_loop_metrics=event_loop_metrics,
-                    agent=self._agent,
-                    **handler_kwargs,
+                    messages=self._agent.messages,
+                    tool_config=self._agent.tool_config,
+                    callback_handler=self._agent.callback_handler,
+                    kwargs=kwargs,
                 )
 
-                if record_direct_tool_call:
+                if self._agent.record_direct_tool_call:
                     # Create a record of this tool execution in the message history
-                    self._agent._record_tool_execution(tool_use, tool_result, user_message_override, messages)
+                    self._agent._record_tool_execution(
+                        tool_use, tool_result, user_message_override, self._agent.messages
+                    )
 
                 # Apply window management
                 self._agent.conversation_manager.apply_management(self._agent)
@@ -202,6 +143,27 @@ class Agent:
                 return tool_result
 
             return caller
+
+        def _find_normalized_tool_name(self, name: str) -> str:
+            """Lookup the tool represented by name, replacing characters with underscores as necessary."""
+            tool_registry = self._agent.tool_registry.registry
+
+            if tool_registry.get(name, None):
+                return name
+
+            # If the desired name contains underscores, it might be a placeholder for characters that can't be
+            # represented as python identifiers but are valid as tool names, such as dashes. In that case, find
+            # all tools that can be represented with the normalized name
+            if "_" in name:
+                filtered_tools = [
+                    tool_name for (tool_name, tool) in tool_registry.items() if tool_name.replace("-", "_") == name
+                ]
+
+                # The registry itself defends against similar names, so we can just take the first match
+                if filtered_tools:
+                    return filtered_tools[0]
+
+            raise AttributeError(f"Tool '{name}' not found")
 
     def __init__(
         self,
@@ -371,7 +333,7 @@ class Agent:
 
         Args:
             prompt: The natural language prompt from the user.
-            **kwargs: Additional parameters to pass to the event loop.
+            **kwargs: Additional parameters to pass through the event loop.
 
         Returns:
             Result object containing:
@@ -514,37 +476,28 @@ class Agent:
         Yields:
             Events of the loop cycle.
         """
-        # Extract parameters with fallbacks to instance values
-        system_prompt = kwargs.pop("system_prompt", self.system_prompt)
-        model = kwargs.pop("model", self.model)
-        tool_execution_handler = kwargs.pop("tool_execution_handler", self.thread_pool_wrapper)
-        event_loop_metrics = kwargs.pop("event_loop_metrics", self.event_loop_metrics)
-        callback_handler_override = kwargs.pop("callback_handler", callback_handler)
-        tool_handler = kwargs.pop("tool_handler", self.tool_handler)
-        messages = kwargs.pop("messages", self.messages)
-        tool_config = kwargs.pop("tool_config", self.tool_config)
-        kwargs.pop("agent", None)  # Remove agent to avoid conflicts
+        # Add `Agent` to kwargs to keep backwards-compatibility
+        kwargs["agent"] = self
 
         try:
             # Execute the main event loop cycle
             yield from event_loop_cycle(
-                model=model,
-                system_prompt=system_prompt,
-                messages=messages,  # will be modified by event_loop_cycle
-                tool_config=tool_config,
-                callback_handler=callback_handler_override,
-                tool_handler=tool_handler,
-                tool_execution_handler=tool_execution_handler,
-                event_loop_metrics=event_loop_metrics,
-                agent=self,
+                model=self.model,
+                system_prompt=self.system_prompt,
+                messages=self.messages,  # will be modified by event_loop_cycle
+                tool_config=self.tool_config,
+                callback_handler=callback_handler,
+                tool_handler=self.tool_handler,
+                tool_execution_handler=self.thread_pool_wrapper,
+                event_loop_metrics=self.event_loop_metrics,
                 event_loop_parent_span=self.trace_span,
-                **kwargs,
+                kwargs=kwargs,
             )
 
         except ContextWindowOverflowException as e:
             # Try reducing the context size and retrying
             self.conversation_manager.reduce_context(self, e=e)
-            yield from self._execute_event_loop_cycle(callback_handler_override, kwargs)
+            yield from self._execute_event_loop_cycle(callback_handler, kwargs)
 
     def _record_tool_execution(
         self,
@@ -569,7 +522,7 @@ class Agent:
             messages: The message history to append to.
         """
         # Create user message describing the tool call
-        user_msg_content = [
+        user_msg_content: List[ContentBlock] = [
             {"text": (f"agent.tool.{tool['name']} direct tool call.\nInput parameters: {json.dumps(tool['input'])}\n")}
         ]
 
@@ -578,19 +531,19 @@ class Agent:
             user_msg_content.insert(0, {"text": f"{user_message_override}\n"})
 
         # Create the message sequence
-        user_msg = {
+        user_msg: Message = {
             "role": "user",
             "content": user_msg_content,
         }
-        tool_use_msg = {
+        tool_use_msg: Message = {
             "role": "assistant",
             "content": [{"toolUse": tool}],
         }
-        tool_result_msg = {
+        tool_result_msg: Message = {
             "role": "user",
             "content": [{"toolResult": tool_result}],
         }
-        assistant_msg = {
+        assistant_msg: Message = {
             "role": "assistant",
             "content": [{"text": f"agent.{tool['name']} was called"}],
         }

--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -14,6 +14,8 @@ import uuid
 from functools import partial
 from typing import Any, Callable, Generator, Optional, cast
 
+from opentelemetry import trace
+
 from ..telemetry.metrics import EventLoopMetrics, Trace
 from ..telemetry.tracer import get_tracer
 from ..tools.executor import run_tools, validate_and_prepare_tools
@@ -40,8 +42,10 @@ def event_loop_cycle(
     tool_config: Optional[ToolConfig],
     callback_handler: Callable[..., Any],
     tool_handler: Optional[ToolHandler],
-    tool_execution_handler: Optional[ParallelToolExecutorInterface] = None,
-    **kwargs: Any,
+    tool_execution_handler: Optional[ParallelToolExecutorInterface],
+    event_loop_metrics: EventLoopMetrics,
+    event_loop_parent_span: Optional[trace.Span],
+    kwargs: dict[str, Any],
 ) -> Generator[dict[str, Any], None, None]:
     """Execute a single cycle of the event loop.
 
@@ -64,13 +68,13 @@ def event_loop_cycle(
         callback_handler: Callback for processing events as they happen.
         tool_handler: Handler for executing tools.
         tool_execution_handler: Optional handler for parallel tool execution.
-        **kwargs: Additional arguments including:
+        event_loop_metrics: Metrics tracking object for the event loop.
+        event_loop_parent_span: Span for the parent of this event loop.
+        kwargs: Additional arguments including:
 
-            - event_loop_metrics: Metrics tracking object
             - request_state: State maintained across cycles
             - event_loop_cycle_id: Unique ID for this cycle
             - event_loop_cycle_span: Current tracing Span for this cycle
-            - event_loop_parent_span: Parent tracing Span for this cycle
 
     Yields:
         Model and tool invocation events. The last event is a tuple containing:
@@ -87,7 +91,6 @@ def event_loop_cycle(
     # Initialize cycle state
     kwargs["event_loop_cycle_id"] = uuid.uuid4()
 
-    event_loop_metrics: EventLoopMetrics = kwargs.get("event_loop_metrics", EventLoopMetrics())
     # Initialize state and get cycle trace
     if "request_state" not in kwargs:
         kwargs["request_state"] = {}
@@ -100,9 +103,8 @@ def event_loop_cycle(
 
     # Create tracer span for this event loop cycle
     tracer = get_tracer()
-    parent_span = kwargs.get("event_loop_parent_span")
     cycle_span = tracer.start_event_loop_cycle_span(
-        event_loop_kwargs=kwargs, parent_span=parent_span, messages=messages
+        event_loop_kwargs=kwargs, parent_span=event_loop_parent_span, messages=messages
     )
     kwargs["event_loop_cycle_span"] = cycle_span
 
@@ -213,6 +215,7 @@ def event_loop_cycle(
                 callback_handler,
                 tool_execution_handler,
                 event_loop_metrics,
+                event_loop_parent_span,
                 cycle_trace,
                 cycle_span,
                 cycle_start_time,
@@ -251,23 +254,33 @@ def event_loop_cycle(
 
 
 def recurse_event_loop(
-    **kwargs: Any,
+    model: Model,
+    system_prompt: Optional[str],
+    messages: Messages,
+    tool_config: Optional[ToolConfig],
+    callback_handler: Callable[..., Any],
+    tool_handler: Optional[ToolHandler],
+    tool_execution_handler: Optional[ParallelToolExecutorInterface],
+    event_loop_metrics: EventLoopMetrics,
+    event_loop_parent_span: Optional[trace.Span],
+    kwargs: dict[str, Any],
 ) -> Generator[dict[str, Any], None, None]:
     """Make a recursive call to event_loop_cycle with the current state.
 
     This function is used when the event loop needs to continue processing after tool execution.
 
     Args:
-        **kwargs: Arguments to pass to event_loop_cycle, including:
+        model: Provider for running model inference
+        system_prompt: System prompt instructions for the model
+        messages: Conversation history messages
+        tool_config: Configuration for available tools
+        callback_handler: Callback for processing events as they happen
+        tool_handler: Handler for tool execution
+        tool_execution_handler: Optional handler for parallel tool execution.
+        event_loop_metrics: Metrics tracking object for the event loop.
+        event_loop_parent_span: Span for the parent of this event loop.
+        kwargs: Arguments to pass through event_loop_cycle
 
-            - model: Provider for running model inference
-            - system_prompt: System prompt instructions for the model
-            - messages: Conversation history messages
-            - tool_config: Configuration for available tools
-            - callback_handler: Callback for processing events as they happen
-            - tool_handler: Handler for tool execution
-            - event_loop_cycle_trace: Trace for the current cycle
-            - event_loop_metrics: Metrics tracking object
 
     Yields:
         Results from event_loop_cycle where the last result contains:
@@ -284,7 +297,18 @@ def recurse_event_loop(
     cycle_trace.add_child(recursive_trace)
 
     yield {"callback": {"start": True}}
-    yield from event_loop_cycle(**kwargs)
+    yield from event_loop_cycle(
+        model=model,
+        system_prompt=system_prompt,
+        messages=messages,
+        tool_config=tool_config,
+        callback_handler=callback_handler,
+        tool_handler=tool_handler,
+        tool_execution_handler=tool_execution_handler,
+        event_loop_metrics=event_loop_metrics,
+        event_loop_parent_span=event_loop_parent_span,
+        kwargs=kwargs,
+    )
 
     recursive_trace.end()
 
@@ -300,6 +324,7 @@ def _handle_tool_execution(
     callback_handler: Callable[..., Any],
     tool_execution_handler: Optional[ParallelToolExecutorInterface],
     event_loop_metrics: EventLoopMetrics,
+    event_loop_parent_span: Optional[trace.Span],
     cycle_trace: Trace,
     cycle_span: Any,
     cycle_start_time: float,
@@ -323,6 +348,7 @@ def _handle_tool_execution(
         callback_handler (Callable[..., Any]): Callback for processing events as they happen.
         tool_execution_handler (Optional[ParallelToolExecutorInterface]): Optional handler for parallel tool execution.
         event_loop_metrics (EventLoopMetrics): Metrics tracking object for the event loop.
+        event_loop_parent_span (Any): Span for the parent of this event loop.
         cycle_trace (Trace): Trace object for the current event loop cycle.
         cycle_span (Any): Span object for tracing the cycle (type may vary).
         cycle_start_time (float): Start time of the current cycle.
@@ -344,12 +370,12 @@ def _handle_tool_execution(
 
     tool_handler_process = partial(
         tool_handler.process,
-        messages=messages,
         model=model,
         system_prompt=system_prompt,
+        messages=messages,
         tool_config=tool_config,
         callback_handler=callback_handler,
-        **kwargs,
+        kwargs=kwargs,
     )
 
     run_tools(
@@ -365,7 +391,6 @@ def _handle_tool_execution(
     )
 
     # Store parent cycle ID for the next cycle
-    kwargs["event_loop_metrics"] = event_loop_metrics
     kwargs["event_loop_parent_cycle_id"] = kwargs["event_loop_cycle_id"]
 
     tool_result_message: Message = {
@@ -392,5 +417,8 @@ def _handle_tool_execution(
         tool_config=tool_config,
         callback_handler=callback_handler,
         tool_handler=tool_handler,
-        **kwargs,
+        tool_execution_handler=tool_execution_handler,
+        event_loop_metrics=event_loop_metrics,
+        event_loop_parent_span=event_loop_parent_span,
+        kwargs=kwargs,
     )

--- a/src/strands/handlers/tool_handler.py
+++ b/src/strands/handlers/tool_handler.py
@@ -1,11 +1,12 @@
 """This module provides handlers for managing tool invocations."""
 
 import logging
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from ..tools.registry import ToolRegistry
+from ..types.content import Messages
 from ..types.models import Model
-from ..types.tools import ToolConfig, ToolHandler, ToolResult, ToolUse
+from ..types.tools import ToolConfig, ToolHandler, ToolUse
 
 logger = logging.getLogger(__name__)
 
@@ -25,34 +26,16 @@ class AgentToolHandler(ToolHandler):
         """
         self.tool_registry = tool_registry
 
-    def preprocess(
-        self,
-        tool: ToolUse,
-        tool_config: ToolConfig,
-        **kwargs: Any,
-    ) -> Optional[ToolResult]:
-        """Preprocess a tool before invocation (not implemented).
-
-        Args:
-            tool: The tool use object to preprocess.
-            tool_config: Configuration for the tool.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            Result of preprocessing, if any.
-        """
-        pass
-
     def process(
         self,
-        tool: Any,
+        tool: ToolUse,
         *,
         model: Model,
         system_prompt: Optional[str],
-        messages: List[Any],
-        tool_config: Any,
+        messages: Messages,
+        tool_config: ToolConfig,
         callback_handler: Any,
-        **kwargs: Any,
+        kwargs: dict[str, Any],
     ) -> Any:
         """Process a tool invocation.
 
@@ -65,7 +48,7 @@ class AgentToolHandler(ToolHandler):
             messages: The conversation history.
             tool_config: Configuration for the tool.
             callback_handler: Callback for processing events as they happen.
-            **kwargs: Additional keyword arguments passed to the tool.
+            kwargs: Additional keyword arguments passed to the tool.
 
         Returns:
             The result of the tool invocation, or an error response if the tool fails or is not found.

--- a/src/strands/types/tools.py
+++ b/src/strands/types/tools.py
@@ -241,37 +241,16 @@ class ToolHandler(ABC):
     """Abstract base class for handling tool execution within the agent framework."""
 
     @abstractmethod
-    # pragma: no cover
-    def preprocess(
-        self,
-        tool: ToolUse,
-        tool_config: ToolConfig,
-        **kwargs: Any,
-    ) -> Optional[ToolResult]:
-        """Preprocess a tool use request before execution.
-
-        Args:
-            tool: The tool use request to preprocess.
-            tool_config: The tool configuration for the current session.
-            **kwargs: Additional context-specific arguments.
-
-        Returns:
-            A preprocessed tool result object.
-        """
-        ...
-
-    @abstractmethod
-    # pragma: no cover
     def process(
         self,
         tool: ToolUse,
         *,
-        messages: "Messages",
         model: "Model",
         system_prompt: Optional[str],
+        messages: "Messages",
         tool_config: ToolConfig,
         callback_handler: Any,
-        **kwargs: Any,
+        kwargs: dict[str, Any],
     ) -> ToolResult:
         """Process a tool use request and execute the tool.
 
@@ -282,7 +261,7 @@ class ToolHandler(ABC):
             system_prompt: The system prompt for the conversation.
             tool_config: The tool configuration for the current session.
             callback_handler: Callback for processing events as they happen.
-            **kwargs: Additional context-specific arguments.
+            kwargs: Additional context-specific arguments.
 
         Returns:
             The result of the tool execution.

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -346,18 +346,18 @@ def test_agent__call__passes_kwargs(mock_model, system_prompt, callback_handler,
     override_messages = [{"role": "user", "content": [{"text": "override msg"}]}]
     override_tool_config = {"test": "config"}
 
-    def check_kwargs(some_value, **kwargs):
-        assert some_value == "a_value"
-        assert kwargs is not None
-        assert kwargs["system_prompt"] == override_system_prompt
-        assert kwargs["model"] == override_model
-        assert kwargs["tool_execution_handler"] == override_tool_execution_handler
-        assert kwargs["event_loop_metrics"] == override_event_loop_metrics
-        assert kwargs["callback_handler"] == override_callback_handler
-        assert kwargs["tool_handler"] == override_tool_handler
-        assert kwargs["messages"] == override_messages
-        assert kwargs["tool_config"] == override_tool_config
-        assert kwargs["agent"] == agent
+    def check_kwargs(**kwargs):
+        kwargs_kwargs = kwargs["kwargs"]
+        assert kwargs_kwargs["some_value"] == "a_value"
+        assert kwargs_kwargs["system_prompt"] == override_system_prompt
+        assert kwargs_kwargs["model"] == override_model
+        assert kwargs_kwargs["tool_execution_handler"] == override_tool_execution_handler
+        assert kwargs_kwargs["event_loop_metrics"] == override_event_loop_metrics
+        assert kwargs_kwargs["callback_handler"] == override_callback_handler
+        assert kwargs_kwargs["tool_handler"] == override_tool_handler
+        assert kwargs_kwargs["messages"] == override_messages
+        assert kwargs_kwargs["tool_config"] == override_tool_config
+        assert kwargs_kwargs["agent"] == agent
 
         # Return expected values from event_loop_cycle
         yield {"stop": ("stop", {"role": "assistant", "content": [{"text": "Response"}]}, {}, {})}
@@ -632,8 +632,6 @@ def test_agent__call__callback(mock_model, agent, callback_handler):
                 event_loop_cycle_id=unittest.mock.ANY,
                 event_loop_cycle_span=unittest.mock.ANY,
                 event_loop_cycle_trace=unittest.mock.ANY,
-                event_loop_metrics=unittest.mock.ANY,
-                event_loop_parent_span=unittest.mock.ANY,
                 request_state={},
             ),
             unittest.mock.call(event={"contentBlockStop": {}}),
@@ -645,8 +643,6 @@ def test_agent__call__callback(mock_model, agent, callback_handler):
                 event_loop_cycle_id=unittest.mock.ANY,
                 event_loop_cycle_span=unittest.mock.ANY,
                 event_loop_cycle_trace=unittest.mock.ANY,
-                event_loop_metrics=unittest.mock.ANY,
-                event_loop_parent_span=unittest.mock.ANY,
                 reasoning=True,
                 reasoningText="value",
                 request_state={},
@@ -658,8 +654,6 @@ def test_agent__call__callback(mock_model, agent, callback_handler):
                 event_loop_cycle_id=unittest.mock.ANY,
                 event_loop_cycle_span=unittest.mock.ANY,
                 event_loop_cycle_trace=unittest.mock.ANY,
-                event_loop_metrics=unittest.mock.ANY,
-                event_loop_parent_span=unittest.mock.ANY,
                 reasoning=True,
                 reasoning_signature="value",
                 request_state={},
@@ -674,8 +668,6 @@ def test_agent__call__callback(mock_model, agent, callback_handler):
                 event_loop_cycle_id=unittest.mock.ANY,
                 event_loop_cycle_span=unittest.mock.ANY,
                 event_loop_cycle_trace=unittest.mock.ANY,
-                event_loop_metrics=unittest.mock.ANY,
-                event_loop_parent_span=unittest.mock.ANY,
                 request_state={},
             ),
             unittest.mock.call(event={"contentBlockStop": {}}),
@@ -725,9 +717,7 @@ def test_agent_tool_user_message_override(agent):
             },
             {
                 "text": (
-                    "agent.tool.tool_decorated direct tool call.\n"
-                    "Input parameters: "
-                    '{"random_string": "abcdEfghI123", "user_message_override": "test override"}\n'
+                    'agent.tool.tool_decorated direct tool call.\nInput parameters: {"random_string": "abcdEfghI123"}\n'
                 ),
             },
         ],
@@ -738,9 +728,8 @@ def test_agent_tool_user_message_override(agent):
 
 
 def test_agent_tool_do_not_record_tool(agent):
-    agent.tool.tool_decorated(
-        random_string="abcdEfghI123", user_message_override="test override", record_direct_tool_call=False
-    )
+    agent.record_direct_tool_call = False
+    agent.tool.tool_decorated(random_string="abcdEfghI123", user_message_override="test override")
 
     tru_messages = agent.messages
     exp_messages = []
@@ -795,9 +784,7 @@ def test_agent_tool_no_parameter_conflict(agent, tool_registry, mock_randint):
         messages=unittest.mock.ANY,
         tool_config=unittest.mock.ANY,
         callback_handler=unittest.mock.ANY,
-        tool_execution_handler=unittest.mock.ANY,
-        event_loop_metrics=unittest.mock.ANY,
-        agent=agent,
+        kwargs={"system_prompt": "tool prompt"},
     )
 
 
@@ -956,9 +943,9 @@ async def test_stream_async_passes_kwargs(agent, mock_model, mock_event_loop_cyc
         ],
     ]
 
-    def check_kwargs(some_value, **kwargs):
-        assert some_value == "a_value"
-        assert kwargs is not None
+    def check_kwargs(**kwargs):
+        kwargs_kwargs = kwargs["kwargs"]
+        assert kwargs_kwargs["some_value"] == "a_value"
         # Return expected values from event_loop_cycle
         yield {"stop": ("stop", {"role": "assistant", "content": [{"text": "Response"}]}, {}, {})}
 

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -737,6 +737,18 @@ def test_agent_tool_do_not_record_tool(agent):
     assert tru_messages == exp_messages
 
 
+def test_agent_tool_do_not_record_tool_with_method_override(agent):
+    agent.record_direct_tool_call = True
+    agent.tool.tool_decorated(
+        random_string="abcdEfghI123", user_message_override="test override", record_direct_tool_call=False
+    )
+
+    tru_messages = agent.messages
+    exp_messages = []
+
+    assert tru_messages == exp_messages
+
+
 def test_agent_tool_tool_does_not_exist(agent):
     with pytest.raises(AttributeError):
         agent.tool.does_not_exist()

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -7,6 +7,7 @@ import pytest
 import strands
 import strands.telemetry
 from strands.handlers.tool_handler import AgentToolHandler
+from strands.telemetry.metrics import EventLoopMetrics
 from strands.tools.registry import ToolRegistry
 from strands.types.exceptions import ContextWindowOverflowException, EventLoopException, ModelThrottledException
 
@@ -20,11 +21,6 @@ def mock_time():
 @pytest.fixture
 def model():
     return unittest.mock.Mock()
-
-
-@pytest.fixture
-def model_id():
-    return "m1"
 
 
 @pytest.fixture
@@ -112,7 +108,6 @@ def mock_tracer():
 
 def test_event_loop_cycle_text_response(
     model,
-    model_id,
     system_prompt,
     messages,
     tool_config,
@@ -127,13 +122,15 @@ def test_event_loop_cycle_text_response(
 
     stream = strands.event_loop.event_loop.event_loop_cycle(
         model=model,
-        model_id=model_id,
         system_prompt=system_prompt,
         messages=messages,
         tool_config=tool_config,
         callback_handler=callback_handler,
         tool_handler=tool_handler,
         tool_execution_handler=tool_execution_handler,
+        event_loop_metrics=EventLoopMetrics(),
+        event_loop_parent_span=None,
+        kwargs={},
     )
     event = list(stream)[-1]
     tru_stop_reason, tru_message, _, tru_request_state = event["stop"]
@@ -148,7 +145,6 @@ def test_event_loop_cycle_text_response(
 def test_event_loop_cycle_text_response_throttling(
     mock_time,
     model,
-    model_id,
     system_prompt,
     messages,
     tool_config,
@@ -166,13 +162,15 @@ def test_event_loop_cycle_text_response_throttling(
 
     stream = strands.event_loop.event_loop.event_loop_cycle(
         model=model,
-        model_id=model_id,
         system_prompt=system_prompt,
         messages=messages,
         tool_config=tool_config,
         callback_handler=callback_handler,
         tool_handler=tool_handler,
         tool_execution_handler=tool_execution_handler,
+        event_loop_metrics=EventLoopMetrics(),
+        event_loop_parent_span=None,
+        kwargs={},
     )
     event = list(stream)[-1]
     tru_stop_reason, tru_message, _, tru_request_state = event["stop"]
@@ -189,7 +187,6 @@ def test_event_loop_cycle_text_response_throttling(
 def test_event_loop_cycle_exponential_backoff(
     mock_time,
     model,
-    model_id,
     system_prompt,
     messages,
     tool_config,
@@ -211,13 +208,15 @@ def test_event_loop_cycle_exponential_backoff(
 
     stream = strands.event_loop.event_loop.event_loop_cycle(
         model=model,
-        model_id=model_id,
         system_prompt=system_prompt,
         messages=messages,
         tool_config=tool_config,
         callback_handler=callback_handler,
         tool_handler=tool_handler,
         tool_execution_handler=tool_execution_handler,
+        event_loop_metrics=EventLoopMetrics(),
+        event_loop_parent_span=None,
+        kwargs={},
     )
     event = list(stream)[-1]
     tru_stop_reason, tru_message, _, tru_request_state = event["stop"]
@@ -236,7 +235,6 @@ def test_event_loop_cycle_exponential_backoff(
 def test_event_loop_cycle_text_response_throttling_exceeded(
     mock_time,
     model,
-    model_id,
     system_prompt,
     messages,
     tool_config,
@@ -256,13 +254,15 @@ def test_event_loop_cycle_text_response_throttling_exceeded(
     with pytest.raises(ModelThrottledException):
         stream = strands.event_loop.event_loop.event_loop_cycle(
             model=model,
-            model_id=model_id,
             system_prompt=system_prompt,
             messages=messages,
             tool_config=tool_config,
             callback_handler=callback_handler,
             tool_handler=tool_handler,
             tool_execution_handler=tool_execution_handler,
+            event_loop_metrics=EventLoopMetrics(),
+            event_loop_parent_span=None,
+            kwargs={},
         )
         list(stream)
 
@@ -279,7 +279,6 @@ def test_event_loop_cycle_text_response_throttling_exceeded(
 
 def test_event_loop_cycle_text_response_error(
     model,
-    model_id,
     system_prompt,
     messages,
     tool_config,
@@ -292,13 +291,15 @@ def test_event_loop_cycle_text_response_error(
     with pytest.raises(RuntimeError):
         stream = strands.event_loop.event_loop.event_loop_cycle(
             model=model,
-            model_id=model_id,
             system_prompt=system_prompt,
             messages=messages,
             tool_config=tool_config,
             callback_handler=callback_handler,
             tool_handler=tool_handler,
             tool_execution_handler=tool_execution_handler,
+            event_loop_metrics=EventLoopMetrics(),
+            event_loop_parent_span=None,
+            kwargs={},
         )
         list(stream)
 
@@ -323,13 +324,15 @@ def test_event_loop_cycle_tool_result(
 
     stream = strands.event_loop.event_loop.event_loop_cycle(
         model=model,
-        model_id=model_id,
         system_prompt=system_prompt,
         messages=messages,
         tool_config=tool_config,
         callback_handler=callback_handler,
         tool_handler=tool_handler,
         tool_execution_handler=tool_execution_handler,
+        event_loop_metrics=EventLoopMetrics(),
+        event_loop_parent_span=None,
+        kwargs={},
     )
     event = list(stream)[-1]
     tru_stop_reason, tru_message, _, tru_request_state = event["stop"]
@@ -395,6 +398,9 @@ def test_event_loop_cycle_tool_result_error(
             callback_handler=callback_handler,
             tool_handler=tool_handler,
             tool_execution_handler=tool_execution_handler,
+            event_loop_metrics=EventLoopMetrics(),
+            event_loop_parent_span=None,
+            kwargs={},
         )
         list(stream)
 
@@ -419,6 +425,9 @@ def test_event_loop_cycle_tool_result_no_tool_handler(
             callback_handler=callback_handler,
             tool_handler=None,
             tool_execution_handler=tool_execution_handler,
+            event_loop_metrics=EventLoopMetrics(),
+            event_loop_parent_span=None,
+            kwargs={},
         )
         list(stream)
 
@@ -443,6 +452,9 @@ def test_event_loop_cycle_tool_result_no_tool_config(
             callback_handler=callback_handler,
             tool_handler=tool_handler,
             tool_execution_handler=tool_execution_handler,
+            event_loop_metrics=EventLoopMetrics(),
+            event_loop_parent_span=None,
+            kwargs={},
         )
         list(stream)
 
@@ -482,7 +494,9 @@ def test_event_loop_cycle_stop(
         callback_handler=callback_handler,
         tool_handler=tool_handler,
         tool_execution_handler=tool_execution_handler,
-        request_state={"stop_event_loop": True},
+        event_loop_metrics=EventLoopMetrics(),
+        event_loop_parent_span=None,
+        kwargs={"request_state": {"stop_event_loop": True}},
     )
     event = list(stream)[-1]
     tru_stop_reason, tru_message, _, tru_request_state = event["stop"]
@@ -523,13 +537,15 @@ def test_cycle_exception(
     with pytest.raises(EventLoopException):
         stream = strands.event_loop.event_loop.event_loop_cycle(
             model=model,
-            model_id=model_id,
             system_prompt=system_prompt,
             messages=messages,
             tool_config=tool_config,
             callback_handler=callback_handler,
             tool_handler=tool_handler,
             tool_execution_handler=tool_execution_handler,
+            event_loop_metrics=EventLoopMetrics(),
+            event_loop_parent_span=None,
+            kwargs={},
         )
         for event in stream:
             tru_stop_event = event
@@ -541,7 +557,6 @@ def test_cycle_exception(
 def test_event_loop_cycle_creates_spans(
     mock_get_tracer,
     model,
-    model_id,
     system_prompt,
     messages,
     tool_config,
@@ -565,13 +580,15 @@ def test_event_loop_cycle_creates_spans(
     # Call event_loop_cycle
     stream = strands.event_loop.event_loop.event_loop_cycle(
         model=model,
-        model_id=model_id,
         system_prompt=system_prompt,
         messages=messages,
         tool_config=tool_config,
         callback_handler=callback_handler,
         tool_handler=tool_handler,
         tool_execution_handler=tool_execution_handler,
+        event_loop_metrics=EventLoopMetrics(),
+        event_loop_parent_span=None,
+        kwargs={},
     )
     list(stream)
 
@@ -587,7 +604,6 @@ def test_event_loop_cycle_creates_spans(
 def test_event_loop_tracing_with_model_error(
     mock_get_tracer,
     model,
-    model_id,
     system_prompt,
     messages,
     tool_config,
@@ -610,13 +626,15 @@ def test_event_loop_tracing_with_model_error(
     with pytest.raises(ContextWindowOverflowException):
         stream = strands.event_loop.event_loop.event_loop_cycle(
             model=model,
-            model_id=model_id,
             system_prompt=system_prompt,
             messages=messages,
             tool_config=tool_config,
             callback_handler=callback_handler,
             tool_handler=tool_handler,
             tool_execution_handler=tool_execution_handler,
+            event_loop_metrics=EventLoopMetrics(),
+            event_loop_parent_span=None,
+            kwargs={},
         )
         list(stream)
 
@@ -656,13 +674,15 @@ def test_event_loop_tracing_with_tool_execution(
     # Call event_loop_cycle which should execute a tool
     stream = strands.event_loop.event_loop.event_loop_cycle(
         model=model,
-        model_id=model_id,
         system_prompt=system_prompt,
         messages=messages,
         tool_config=tool_config,
         callback_handler=callback_handler,
         tool_handler=tool_handler,
         tool_execution_handler=tool_execution_handler,
+        event_loop_metrics=EventLoopMetrics(),
+        event_loop_parent_span=None,
+        kwargs={},
     )
     list(stream)
 
@@ -676,7 +696,6 @@ def test_event_loop_tracing_with_tool_execution(
 def test_event_loop_tracing_with_throttling_exception(
     mock_get_tracer,
     model,
-    model_id,
     system_prompt,
     messages,
     tool_config,
@@ -705,13 +724,15 @@ def test_event_loop_tracing_with_throttling_exception(
     with patch("strands.event_loop.event_loop.time.sleep"):
         stream = strands.event_loop.event_loop.event_loop_cycle(
             model=model,
-            model_id=model_id,
             system_prompt=system_prompt,
             messages=messages,
             tool_config=tool_config,
             callback_handler=callback_handler,
             tool_handler=tool_handler,
             tool_execution_handler=tool_execution_handler,
+            event_loop_metrics=EventLoopMetrics(),
+            event_loop_parent_span=None,
+            kwargs={},
         )
         list(stream)
 
@@ -726,7 +747,6 @@ def test_event_loop_tracing_with_throttling_exception(
 def test_event_loop_cycle_with_parent_span(
     mock_get_tracer,
     model,
-    model_id,
     system_prompt,
     messages,
     tool_config,
@@ -749,14 +769,15 @@ def test_event_loop_cycle_with_parent_span(
     # Call event_loop_cycle with a parent span
     stream = strands.event_loop.event_loop.event_loop_cycle(
         model=model,
-        model_id=model_id,
         system_prompt=system_prompt,
         messages=messages,
         tool_config=tool_config,
         callback_handler=callback_handler,
         tool_handler=tool_handler,
         tool_execution_handler=tool_execution_handler,
+        event_loop_metrics=EventLoopMetrics(),
         event_loop_parent_span=parent_span,
+        kwargs={},
     )
     list(stream)
 
@@ -770,13 +791,15 @@ def test_request_state_initialization():
     # Call without providing request_state
     stream = strands.event_loop.event_loop.event_loop_cycle(
         model=MagicMock(),
-        model_id=MagicMock(),
         system_prompt=MagicMock(),
         messages=MagicMock(),
         tool_config=MagicMock(),
         callback_handler=MagicMock(),
         tool_handler=MagicMock(),
         tool_execution_handler=MagicMock(),
+        event_loop_metrics=EventLoopMetrics(),
+        event_loop_parent_span=None,
+        kwargs={},
     )
     event = list(stream)[-1]
     _, _, _, tru_request_state = event["stop"]
@@ -788,13 +811,15 @@ def test_request_state_initialization():
     initial_request_state = {"key": "value"}
     stream = strands.event_loop.event_loop.event_loop_cycle(
         model=MagicMock(),
-        model_id=MagicMock(),
         system_prompt=MagicMock(),
         messages=MagicMock(),
         tool_config=MagicMock(),
         callback_handler=MagicMock(),
         tool_handler=MagicMock(),
-        request_state=initial_request_state,
+        tool_execution_handler=MagicMock(),
+        event_loop_metrics=EventLoopMetrics(),
+        event_loop_parent_span=None,
+        kwargs={"request_state": initial_request_state},
     )
     event = list(stream)[-1]
     _, _, _, tru_request_state = event["stop"]
@@ -827,20 +852,21 @@ def test_prepare_next_cycle_in_tool_execution(model, tool_stream):
         # Call event_loop_cycle which should execute a tool and then call recurse_event_loop
         stream = strands.event_loop.event_loop.event_loop_cycle(
             model=model,
-            model_id=MagicMock(),
             system_prompt=MagicMock(),
             messages=MagicMock(),
             tool_config=MagicMock(),
             callback_handler=MagicMock(),
             tool_handler=MagicMock(),
             tool_execution_handler=MagicMock(),
+            event_loop_metrics=EventLoopMetrics(),
+            event_loop_parent_span=None,
+            kwargs={},
         )
         list(stream)
 
         assert mock_recurse.called
 
         # Verify required properties are present
-        recursive_kwargs = mock_recurse.call_args[1]
-        assert "event_loop_metrics" in recursive_kwargs
-        assert "event_loop_parent_cycle_id" in recursive_kwargs
-        assert recursive_kwargs["event_loop_parent_cycle_id"] == recursive_kwargs["event_loop_cycle_id"]
+        recursive_args = mock_recurse.call_args[1]
+        assert "event_loop_parent_cycle_id" in recursive_args["kwargs"]
+        assert recursive_args["kwargs"]["event_loop_parent_cycle_id"] == recursive_args["kwargs"]["event_loop_cycle_id"]

--- a/tests/strands/handlers/test_tool_handler.py
+++ b/tests/strands/handlers/test_tool_handler.py
@@ -40,10 +40,6 @@ def tool_use_error(tool_registry):
     return {"toolUseId": "error", "name": "error", "input": {}}
 
 
-def test_preprocess(tool_handler, tool_use_identity):
-    tool_handler.preprocess(tool_use_identity, tool_config={})
-
-
 def test_process(tool_handler, tool_use_identity):
     tru_result = tool_handler.process(
         tool_use_identity,
@@ -52,6 +48,7 @@ def test_process(tool_handler, tool_use_identity):
         messages=[],
         tool_config={},
         callback_handler=unittest.mock.Mock(),
+        kwargs={},
     )
     exp_result = {"toolUseId": "identity", "status": "success", "content": [{"text": "1"}]}
 
@@ -66,6 +63,7 @@ def test_process_missing_tool(tool_handler):
         messages=[],
         tool_config={},
         callback_handler=unittest.mock.Mock(),
+        kwargs={},
     )
     exp_result = {
         "toolUseId": "missing",


### PR DESCRIPTION
## Description
This refactors how kwargs are handled within the Agent class. Instead of allowing certain override parameters to be passed in via kwargs, we instead rely on the agent's attributes. After invoking an agent, or using a direct tool call, the kwargs are passed around as a dict instead of being spread.

## Related Issues

N/A

## Documentation PR

TODO if there are any docs changes needed

## Type of Change

Breaking change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
