### PR TITLE
feat: Add Agent State

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -41,6 +41,7 @@ from .conversation_manager import (
     ConversationManager,
     SlidingWindowConversationManager,
 )
+from .state import AgentState
 
 logger = logging.getLogger(__name__)
 
@@ -223,6 +224,7 @@ class Agent:
         *,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        state: Optional[AgentState] = None,
     ):
         """Initialize the Agent with the specified configuration.
 
@@ -259,6 +261,8 @@ class Agent:
                 Defaults to None.
             description: description of what the Agent does
                 Defaults to None.
+            state: stateful information for the agent
+                Defaults to an empty AgentState object.
 
         Raises:
             ValueError: If max_parallel_tools is less than 1.
@@ -319,6 +323,10 @@ class Agent:
         # Initialize tracer instance (no-op if not configured)
         self.tracer = get_tracer()
         self.trace_span: Optional[trace.Span] = None
+
+        # Initialize agent state management
+        self.state = state or AgentState()
+
         self.tool_caller = Agent.ToolCaller(self)
         self.name = name
         self.description = description

--- a/src/strands/agent/state.py
+++ b/src/strands/agent/state.py
@@ -1,0 +1,96 @@
+"""Agent state management."""
+
+import json
+from typing import Any, Dict, Optional
+
+
+class AgentState:
+    """Represents an Agent's stateful information outside of context provided to a model.
+
+    Provides a key-value store for agent state with JSON serialization validation and persistence support.
+    Key features:
+    - JSON serialization validation on assignment
+    - Get/set/delete operations
+    """
+
+    def __init__(self, initial_state: Optional[Dict[str, Dict[str, Any]]] = None):
+        """Initialize AgentState with default and SDK namespaces."""
+        self._state: Dict[str, Dict[str, Any]]
+        if initial_state:
+            self._validate_json_serializable(initial_state)
+            self._state = initial_state.copy()
+        else:
+            self._state = {}
+
+    def set(self, key: str, value: Any) -> None:
+        """Set a value in the state.
+
+        Args:
+            key: The key to store the value under
+            value: The value to store (must be JSON serializable)
+
+        Raises:
+            ValueError: If key is invalid, or if value is not JSON serializable
+        """
+        self._validate_key(key)
+        self._validate_json_serializable(value)
+
+        self._state[key] = value
+
+    def get(self, key: Optional[str] = None) -> Any:
+        """Get a value or entire state.
+
+        Args:
+            key: The key to retrieve (if None, returns entire state object)
+
+        Returns:
+            The stored value, entire state dict, or None if not found
+        """
+        if key is None:
+            return self._state.copy()
+        else:
+            # Return specific key
+            return self._state.get(key)
+
+    def delete(self, key: str) -> None:
+        """Delete a specific key from the state.
+
+        Args:
+            key: The key to delete
+        """
+        self._validate_key(key)
+
+        self._state.pop(key, None)
+
+    def _validate_key(self, key: str) -> None:
+        """Validate that a key is valid.
+
+        Args:
+            key: The key to validate
+
+        Raises:
+            ValueError: If key is invalid
+        """
+        if key is None:
+            raise ValueError("Key cannot be None")
+        if not isinstance(key, str):
+            raise ValueError("Key must be a string")
+        if not key.strip():
+            raise ValueError("Key cannot be empty")
+
+    def _validate_json_serializable(self, value: Any) -> None:
+        """Validate that a value is JSON serializable.
+
+        Args:
+            value: The value to validate
+
+        Raises:
+            ValueError: If value is not JSON serializable
+        """
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"Value is not JSON serializable: {type(value).__name__}. "
+                f"Only JSON-compatible types (str, int, float, bool, list, dict, None) are allowed."
+            ) from e

--- a/tests/strands/agent/test_agent_state.py
+++ b/tests/strands/agent/test_agent_state.py
@@ -1,0 +1,111 @@
+"""Tests for AgentState class."""
+
+import pytest
+
+from strands.agent.state import AgentState
+
+
+def test_set_and_get():
+    """Test basic set and get operations."""
+    state = AgentState()
+    state.set("key", "value")
+    assert state.get("key") == "value"
+
+
+def test_get_nonexistent_key():
+    """Test getting nonexistent key returns None."""
+    state = AgentState()
+    assert state.get("nonexistent") is None
+
+
+def test_get_entire_state():
+    """Test getting entire state when no key specified."""
+    state = AgentState()
+    state.set("key1", "value1")
+    state.set("key2", "value2")
+
+    result = state.get()
+    assert result == {"key1": "value1", "key2": "value2"}
+
+
+def test_initialize_and_get_entire_state():
+    """Test getting entire state when no key specified."""
+    state = AgentState({"key1": "value1", "key2": "value2"})
+
+    result = state.get()
+    assert result == {"key1": "value1", "key2": "value2"}
+
+
+def test_initialize_with_error():
+    with pytest.raises(ValueError, match="not JSON serializable"):
+        AgentState({"object", object()})
+
+
+def test_delete():
+    """Test deleting keys."""
+    state = AgentState()
+    state.set("key1", "value1")
+    state.set("key2", "value2")
+
+    state.delete("key1")
+
+    assert state.get("key1") is None
+    assert state.get("key2") == "value2"
+
+
+def test_delete_nonexistent_key():
+    """Test deleting nonexistent key doesn't raise error."""
+    state = AgentState()
+    state.delete("nonexistent")  # Should not raise
+
+
+def test_json_serializable_values():
+    """Test that only JSON-serializable values are accepted."""
+    state = AgentState()
+
+    # Valid JSON types
+    state.set("string", "test")
+    state.set("int", 42)
+    state.set("bool", True)
+    state.set("list", [1, 2, 3])
+    state.set("dict", {"nested": "value"})
+    state.set("null", None)
+
+    # Invalid JSON types should raise ValueError
+    with pytest.raises(ValueError, match="not JSON serializable"):
+        state.set("function", lambda x: x)
+
+    with pytest.raises(ValueError, match="not JSON serializable"):
+        state.set("object", object())
+
+
+def test_key_validation():
+    """Test key validation for set and delete operations."""
+    state = AgentState()
+
+    # Invalid keys for set
+    with pytest.raises(ValueError, match="Key cannot be None"):
+        state.set(None, "value")
+
+    with pytest.raises(ValueError, match="Key cannot be empty"):
+        state.set("", "value")
+
+    with pytest.raises(ValueError, match="Key must be a string"):
+        state.set(123, "value")
+
+    # Invalid keys for delete
+    with pytest.raises(ValueError, match="Key cannot be None"):
+        state.delete(None)
+
+    with pytest.raises(ValueError, match="Key cannot be empty"):
+        state.delete("")
+
+
+def test_initial_state():
+    """Test initialization with initial state."""
+    initial = {"key1": "value1", "key2": "value2"}
+    state = AgentState(initial_state=initial)
+
+    assert state.get("key1") == "value1"
+    assert state.get("key2") == "value2"
+    assert state.get() == initial

--- a/tests/strands/mocked_model_provider/mocked_model_provider.py
+++ b/tests/strands/mocked_model_provider/mocked_model_provider.py
@@ -1,0 +1,73 @@
+import json
+from typing import Any, Callable, Iterable, Optional, Type, TypeVar
+
+from pydantic import BaseModel
+
+from strands.types.content import Message, Messages
+from strands.types.event_loop import StopReason
+from strands.types.models.model import Model
+from strands.types.streaming import StreamEvent
+from strands.types.tools import ToolSpec
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class MockedModelProvider(Model):
+    """A mock implementation of the Model interface for testing purposes.
+
+    This class simulates a model provider by returning pre-defined agent responses
+    in sequence. It implements the Model interface methods and provides functionality
+    to stream mock responses as events.
+    """
+
+    def __init__(self, agent_responses: Messages):
+        self.agent_responses = agent_responses
+        self.index = 0
+
+    def format_chunk(self, event: Any) -> StreamEvent:
+        return event
+
+    def format_request(
+        self, messages: Messages, tool_specs: Optional[list[ToolSpec]] = None, system_prompt: Optional[str] = None
+    ) -> Any:
+        return None
+
+    def get_config(self) -> Any:
+        pass
+
+    def update_config(self, **model_config: Any) -> None:
+        pass
+
+    def structured_output(
+        self, output_model: Type[T], prompt: Messages, callback_handler: Optional[Callable] = None
+    ) -> T:
+        pass
+
+    def stream(self, request: Any) -> Iterable[Any]:
+        yield from self.map_agent_message_to_events(self.agent_responses[self.index])
+        self.index += 1
+
+    def map_agent_message_to_events(self, agent_message: Message) -> Iterable[dict[str, Any]]:
+        stop_reason: StopReason = "end_turn"
+        yield {"messageStart": {"role": "assistant"}}
+        for content in agent_message["content"]:
+            if "text" in content:
+                yield {"contentBlockStart": {"start": {}}}
+                yield {"contentBlockDelta": {"delta": {"text": content["text"]}}}
+                yield {"contentBlockStop": {}}
+            if "toolUse" in content:
+                stop_reason = "tool_use"
+                yield {
+                    "contentBlockStart": {
+                        "start": {
+                            "toolUse": {
+                                "name": content["toolUse"]["name"],
+                                "toolUseId": content["toolUse"]["toolUseId"],
+                            }
+                        }
+                    }
+                }
+                yield {"contentBlockDelta": {"delta": {"tool_use": {"input": json.dumps(content["toolUse"]["input"])}}}}
+                yield {"contentBlockStop": {}}
+
+        yield {"messageStop": {"stopReason": stop_reason}}

--- a/tests/strands/mocked_model_provider/test_agent_state_updates.py
+++ b/tests/strands/mocked_model_provider/test_agent_state_updates.py
@@ -1,0 +1,29 @@
+from strands.agent.agent import Agent
+from strands.tools.decorator import tool
+from strands.types.content import Messages
+
+from .mocked_model_provider import MockedModelProvider
+
+
+@tool
+def update_state(agent: Agent):
+    agent.state.set("hello", "world")
+
+
+def test_agent_state_update_from_tool():
+    agent_messages: Messages = [
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"name": "update_state", "toolUseId": "123", "input": {}}}],
+        },
+        {"role": "assistant", "content": [{"text": "I invoked a tool!"}]},
+    ]
+    mocked_model_provider = MockedModelProvider(agent_messages)
+
+    agent = Agent(model=mocked_model_provider, tools=[update_state])
+
+    assert agent.state.get("hello") is None
+
+    agent("Invoke Mocked!")
+
+    assert agent.state.get("hello") == "world"


### PR DESCRIPTION
## Description
Created an AgentState class, and added it as an attribute to the Agent class. This represents stateful information, outside of the context provided to a model, that can in the future be persisted and refreshed when persisting an agent.

## Related Issues

<!-- Link to related issues using #issue-number format -->

https://github.com/strands-agents/sdk-python/issues/246

<!-- Link to related associated PR in the agent-docs repo -->

TODO

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
