### PR TITLE
fix: correcting incorrect docstring in tracer.py - non-existing argument documented

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -582,7 +582,6 @@ def get_tracer(
         otlp_endpoint: OTLP endpoint URL for sending traces.
         otlp_headers: Headers to include with OTLP requests.
         enable_console_export: Whether to also export traces to console.
-        tracer_provider: Optional existing TracerProvider to use instead of creating a new one.
 
     Returns:
         The global tracer instance.


### PR DESCRIPTION
## Description

The docstring of get_tracer() in tracer.py mentions a fifth argument that does not exist. This PR removes the incorrect line describing this "trace_provider": see commit diff.

## Related Issues

N/A

## Documentation PR

The above can also be considered as a doc chamge

## Type of Change

Documentation update


## Testing

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
