### PR TITLE
tools - do not remove $defs

### DIFF
--- a/src/strands/tools/decorator.py
+++ b/src/strands/tools/decorator.py
@@ -195,7 +195,7 @@ class FunctionToolMetadata:
             schema: The Pydantic-generated JSON schema to clean up (modified in place).
         """
         # Remove Pydantic metadata
-        keys_to_remove = ["title", "$defs", "additionalProperties"]
+        keys_to_remove = ["title", "additionalProperties"]
         for key in keys_to_remove:
             if key in schema:
                 del schema[key]

--- a/src/strands/tools/registry.py
+++ b/src/strands/tools/registry.py
@@ -538,6 +538,10 @@ class ToolRegistry:
                 }
                 continue
 
+            # It is expected that type and description are already included in referenced $def.
+            if "$ref" in prop_def:
+                continue
+
             if "type" not in prop_def:
                 prop_def["type"] = "string"
             if "description" not in prop_def:

--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -81,6 +81,11 @@ def _normalize_property(prop_name: str, prop_def: Any) -> Dict[str, Any]:
 
     # Copy existing property, ensuring defaults
     normalized_prop = prop_def.copy()
+
+    # It is expected that type and description are already included in referenced $def.
+    if "$ref" in normalized_prop:
+        return normalized_prop
+
     normalized_prop.setdefault("type", "string")
     normalized_prop.setdefault("description", f"Property {prop_name}")
     return normalized_prop


### PR DESCRIPTION
## Description
The strands tool decorator is removing "$defs" from the generated tool spec, which leads to validation errors or poor quality responses. Take for example the following tool:
```Python
class TimeSpec(pydantic.BaseModel):
    """City name and timezone."""

    city: str = pydantic.Field(description="City name, e.g., New York.")
    timezone: str = pydantic.Field(description="Time zone, e.g., EST.")


@strands.tool
def current_time(spec: TimeSpec) -> str:
    return ...
```

The resulting tool spec is:
```JSON
{
  "name": "current_time",
  "description": "current_time",
  "input_schema": {
    "properties": {
      "spec": {
        "$ref": "#/$defs/TimeSpec",
        "description": "Parameter spec"
      }
    },
    "required": [
      "spec"
    ],
    "type": "object"
  }
}
```

Notice however that the "$ref" remains. I tested this on a few model providers. If I run through bedrock, I encounter the following error:
```txt
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the ConverseStream operation: The model returned the following errors: tools.0.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12 (https://json-schema.org/draft/2020-12). Learn more about tool use at https://docs.anthropic.com/en/docs/tool-use.
```

If I run this through openai, I do not receive a validation error but instead a poor quality response:
```txt
I'm sorry, I can't provide the current time right now. However, you can quickly find the current time in New York by doing a quick web search or by checking the world clock function of your device.
```

This PR removes the filtering of "$defs". My example tool schema then looks as follows:
```json
{
  "name": "current_time",
  "description": "current_time",
  "input_schema": {
    "$defs": {
      "TimeSpec": {
        "description": "City name and timezone.",
        "properties": {
          "city": {
            "description": "City name, e.g., New York.",
            "title": "City",
            "type": "string"
          },
          "timezone": {
            "description": "Time zone, e.g., EST.",
            "title": "Timezone",
            "type": "string"
          }
        },
        "required": [
          "city",
          "timezone"
        ],
        "title": "TimeSpec",
        "type": "object"
      }
    },
    "properties": {
      "spec": {
        "$ref": "#/$defs/TimeSpec",
        "description": "Parameter spec"
      }
    },
    "required": [
      "spec"
    ],
    "type": "object"
  }
}
```

## Related Issues

https://github.com/strands-agents/sdk-python/issues/247

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] I ran `hatch run prepare`
- [x] I also directly invoked each model provider (minus LlamaAPIModel) with my sample tool included in the spec. All successfully called the tool.
  - I don't have a LlamaAPIModel key which is why this one was excluded. However, I did test the llama3.3 model through the OllamaModel provider. 

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
