### PR TITLE
Use region from boto3 session when possible

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -142,7 +142,7 @@ class BedrockModel(Model):
             region_name=resolved_region,
         )
 
-        logger.debug("region=<%s> | bedrock client created", resolved_region)
+        logger.debug("region=<%s> | bedrock client created", self.client.meta.region_name)
 
     @override
     def update_config(self, **model_config: Unpack[BedrockConfig]) -> None:  # type: ignore

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -134,11 +134,15 @@ class BedrockModel(Model):
         else:
             client_config = BotocoreConfig(user_agent_extra="strands-agents")
 
+        resolved_region = region_name or session.region_name or os.environ.get("AWS_REGION") or DEFAULT_BEDROCK_REGION
+
         self.client = session.client(
             service_name="bedrock-runtime",
             config=client_config,
-            region_name=region_name or session.region_name or os.environ.get("AWS_REGION") or DEFAULT_BEDROCK_REGION,
+            region_name=resolved_region,
         )
+
+        logger.debug("region=<%s> | bedrock client created", resolved_region)
 
     @override
     def update_config(self, **model_config: Unpack[BedrockConfig]) -> None:  # type: ignore

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -25,6 +25,7 @@ from ..types.tools import ToolSpec
 logger = logging.getLogger(__name__)
 
 DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+DEFAULT_BEDROCK_REGION = "us-west-2"
 
 BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
     "Input is too long for requested model",
@@ -117,18 +118,7 @@ class BedrockModel(Model):
 
         logger.debug("config=<%s> | initializing", self.config)
 
-        region_for_boto = region_name or os.getenv("AWS_REGION")
-        if region_for_boto is None:
-            region_for_boto = "us-west-2"
-            logger.warning("defaulted to us-west-2 because no region was specified")
-            logger.warning(
-                "issue=<%s> | this behavior will change in an upcoming release",
-                "https://github.com/strands-agents/sdk-python/issues/238",
-            )
-
-        session = boto_session or boto3.Session(
-            region_name=region_for_boto,
-        )
+        session = boto_session or boto3.Session()
 
         # Add strands-agents to the request user agent
         if boto_client_config:
@@ -147,6 +137,7 @@ class BedrockModel(Model):
         self.client = session.client(
             service_name="bedrock-runtime",
             config=client_config,
+            region_name=region_name or session.region_name or os.environ.get("AWS_REGION") or DEFAULT_BEDROCK_REGION,
         )
 
     @override


### PR DESCRIPTION
## Description

Only use a default region if the session doesn't provide one or if the AWS_REGION environment variable is not set. Previously we were using us-west-2 even if the session could load it from the environment (either variables or profiles).  No we only specify a region if the session doesn't provide one

Fixes #238 

## Related Issues

#238 

## Documentation PR

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

I tested creating an agent:
  - With a profile region set (boto3 default behavior)
  - With an environment variable AWS_REGION specified (our custom behavior)
  -  With an environment variable AWS_DEFAULT_REGION specified (boto3 default behavior)
  -  Explicitly passing a region
  - Using the default (us-west-2)

All cases used the region as expected

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
