### PR TITLE
feat(bedrock): support uploads directly from S3

### DIFF
--- a/src/strands/types/media.py
+++ b/src/strands/types/media.py
@@ -13,14 +13,33 @@ DocumentFormat = Literal["pdf", "csv", "doc", "docx", "xls", "xlsx", "html", "tx
 """Supported document formats."""
 
 
-class DocumentSource(TypedDict):
+class S3Location(TypedDict, total=False):
+    """Contains the S3 location information for a document.
+
+    Attributes:
+        bucket: The S3 bucket name.
+        key: The S3 object key.
+
+    Note:
+        Both bucket and key are required for a valid S3 location,
+        but they are marked as optional in the type definition to allow
+        for runtime validation in the code.
+    """
+
+    bucket: str
+    key: str
+
+
+class DocumentSource(TypedDict, total=False):
     """Contains the content of a document.
 
     Attributes:
         bytes: The binary content of the document.
+        s3Location: The S3 location of the document (for Bedrock Nova models).
     """
 
     bytes: bytes
+    s3Location: S3Location
 
 
 class DocumentContent(TypedDict):
@@ -29,7 +48,7 @@ class DocumentContent(TypedDict):
     Attributes:
         format: The format of the document (e.g., "pdf", "txt").
         name: The name of the document.
-        source: The source containing the document's binary content.
+        source: The source containing the document's binary content or S3 location.
     """
 
     format: Literal["pdf", "csv", "doc", "docx", "xls", "xlsx", "html", "txt", "md"]


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
This PR makes Strands Agents possible to include documentation directly from S3 when using Nova.

## Related Issues

<!-- Link to related issues using #issue-number format -->
resolve strands-agents/tools#172 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->
`N/A`

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
