### PR TITLE
chore: updated scope name, enable setting up meter

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -81,14 +81,9 @@ class Tracer:
 
     def __init__(
         self,
-        service_name: str = "strands-agents",
-    ):
-        """Initialize the tracer.
-
-        Args:
-            service_name: Name of the service for OpenTelemetry.
-        """
-        self.service_name = service_name
+    ) -> None:
+        """Initialize the tracer."""
+        self.service_name = __name__
         self.tracer_provider: Optional[trace_api.TracerProvider] = None
         self.tracer: Optional[trace_api.Tracer] = None
 
@@ -505,9 +500,7 @@ class Tracer:
 _tracer_instance = None
 
 
-def get_tracer(
-    service_name: str = "strands-agents",
-) -> Tracer:
+def get_tracer() -> Tracer:
     """Get or create the global tracer.
 
     Args:
@@ -519,9 +512,7 @@ def get_tracer(
     global _tracer_instance
 
     if not _tracer_instance:
-        _tracer_instance = Tracer(
-            service_name=service_name,
-        )
+        _tracer_instance = Tracer()
 
     return _tracer_instance
 

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -52,7 +52,7 @@ def test_init_default():
     """Test initializing the Tracer with default parameters."""
     tracer = Tracer()
 
-    assert tracer.service_name == "strands-agents"
+    assert tracer.service_name == "strands.telemetry.tracer"
     assert tracer.tracer_provider is not None
     assert tracer.tracer is not None
 
@@ -345,17 +345,6 @@ def test_get_tracer_new_endpoint():
         tracer2 = get_tracer()
 
         assert tracer1 is tracer2
-
-
-def test_get_tracer_parameters():
-    """Test that get_tracer passes parameters correctly."""
-    # Reset the singleton first
-    with mock.patch("strands.telemetry.tracer._tracer_instance", None):
-        tracer = get_tracer(
-            service_name="test-service",
-        )
-
-        assert tracer.service_name == "test-service"
 
 
 def test_initialize_tracer_with_custom_tracer_provider(mock_get_tracer_provider):


### PR DESCRIPTION
## Description
- Disallow users to setup scope name, which ends up service_name not required.
  - scope name will become `strands.telemetry.tracer` which is valid 
- Enable users to set up meter
  - In python, there's no way to `add` metrics_exporters after the meter_provider is created. Users would either setup the meter by themselves, or call setup_meter with choices of console/otlp metrics exporters.

## Documentation PR

[link](https://github.com/strands-agents/docs/pull/119)

## Type of Change
Other (please describe):
 - Updates

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
