### PR TITLE
chore: allow custom agent name

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -55,6 +55,7 @@ class _DefaultCallbackHandlerSentinel:
 
 
 _DEFAULT_CALLBACK_HANDLER = _DefaultCallbackHandlerSentinel()
+_DEFAULT_AGENT_NAME = "Strands Agents"
 
 
 class Agent:
@@ -311,7 +312,7 @@ class Agent:
             self.state = AgentState()
 
         self.tool_caller = Agent.ToolCaller(self)
-        self.name = name
+        self.name = name or _DEFAULT_AGENT_NAME
         self.description = description
 
         self._hooks = HookRegistry()
@@ -647,6 +648,7 @@ class Agent:
 
         self.trace_span = self.tracer.start_agent_span(
             prompt=prompt,
+            agent_name=self.name,
             model_id=model_id,
             tools=self.tool_names,
             system_prompt=self.system_prompt,

--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -406,7 +406,7 @@ class Tracer:
     def start_agent_span(
         self,
         prompt: str,
-        agent_name: str = "Strands Agent",
+        agent_name: str,
         model_id: Optional[str] = None,
         tools: Optional[list] = None,
         custom_trace_attributes: Optional[Mapping[str, AttributeValue]] = None,

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -1231,6 +1231,7 @@ def test_agent_call_creates_and_ends_span_on_success(mock_get_tracer, mock_model
     # Verify span was created
     mock_tracer.start_agent_span.assert_called_once_with(
         prompt="test prompt",
+        agent_name="Strands Agents",
         model_id=unittest.mock.ANY,
         tools=agent.tool_names,
         system_prompt=agent.system_prompt,
@@ -1264,6 +1265,7 @@ async def test_agent_stream_async_creates_and_ends_span_on_success(mock_get_trac
     # Verify span was created
     mock_tracer.start_agent_span.assert_called_once_with(
         prompt="test prompt",
+        agent_name="Strands Agents",
         model_id=unittest.mock.ANY,
         tools=agent.tool_names,
         system_prompt=agent.system_prompt,
@@ -1301,6 +1303,7 @@ def test_agent_call_creates_and_ends_span_on_exception(mock_get_tracer, mock_mod
     # Verify span was created
     mock_tracer.start_agent_span.assert_called_once_with(
         prompt="test prompt",
+        agent_name="Strands Agents",
         model_id=unittest.mock.ANY,
         tools=agent.tool_names,
         system_prompt=agent.system_prompt,
@@ -1336,6 +1339,7 @@ async def test_agent_stream_async_creates_and_ends_span_on_exception(mock_get_tr
     # Verify span was created
     mock_tracer.start_agent_span.assert_called_once_with(
         prompt="test prompt",
+        agent_name="Strands Agents",
         model_id=unittest.mock.ANY,
         tools=agent.tool_names,
         system_prompt=agent.system_prompt,


### PR DESCRIPTION
## Description
Allow customer to set agent name

## Related Issues
https://github.com/strands-agents/sdk-python/issues/277

## Documentation PR

No need to update

## Type of Change

New feature with small changes

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
