### PR TITLE
feat: Add hooks for before/after tool calls + allow hooks to update values

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -13,6 +13,7 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any, AsyncGenerator
 
+from ..experimental.hooks import AfterToolInvocationEvent, BeforeToolInvocationEvent
 from ..telemetry.metrics import Trace
 from ..telemetry.tracer import get_tracer
 from ..tools.executor import run_tools, validate_and_prepare_tools
@@ -271,46 +272,75 @@ def run_tool(agent: "Agent", tool_use: ToolUse, kwargs: dict[str, Any]) -> ToolG
         The final tool result or an error response if the tool fails or is not found.
     """
     logger.debug("tool_use=<%s> | streaming", tool_use)
-    tool_use_id = tool_use["toolUseId"]
     tool_name = tool_use["name"]
 
     # Get the tool info
     tool_info = agent.tool_registry.dynamic_tools.get(tool_name)
     tool_func = tool_info if tool_info is not None else agent.tool_registry.registry.get(tool_name)
 
+    # Add standard arguments to kwargs for Python tools
+    kwargs.update(
+        {
+            "model": agent.model,
+            "system_prompt": agent.system_prompt,
+            "messages": agent.messages,
+            "tool_config": agent.tool_config,
+        }
+    )
+
+    before_event = BeforeToolInvocationEvent(
+        agent=agent,
+        selected_tool=tool_func,
+        tool_use=tool_use,
+        kwargs=kwargs,
+    )
+    agent._hooks.invoke_callbacks(before_event)
+
     try:
+        selected_tool = before_event.selected_tool
+        tool_use = before_event.tool_use
+
         # Check if tool exists
-        if not tool_func:
+        if not selected_tool:
             logger.error(
                 "tool_name=<%s>, available_tools=<%s> | tool not found in registry",
                 tool_name,
                 list(agent.tool_registry.registry.keys()),
             )
             return {
-                "toolUseId": tool_use_id,
+                "toolUseId": str(tool_use.get("toolUseId")),
                 "status": "error",
                 "content": [{"text": f"Unknown tool: {tool_name}"}],
             }
-        # Add standard arguments to kwargs for Python tools
-        kwargs.update(
-            {
-                "model": agent.model,
-                "system_prompt": agent.system_prompt,
-                "messages": agent.messages,
-                "tool_config": agent.tool_config,
-            }
-        )
 
-        result = yield from tool_func.stream(tool_use, **kwargs)
-        return result
+        result = yield from selected_tool.stream(tool_use, **kwargs)
+        after_event = AfterToolInvocationEvent(
+            agent=agent,
+            selected_tool=selected_tool,
+            tool_use=tool_use,
+            kwargs=kwargs,
+            result=result,
+        )
+        agent._hooks.invoke_callbacks(after_event)
+        return after_event.result
 
     except Exception as e:
         logger.exception("tool_name=<%s> | failed to process tool", tool_name)
-        return {
-            "toolUseId": tool_use_id,
+        error_result: ToolResult = {
+            "toolUseId": str(tool_use.get("toolUseId")),
             "status": "error",
             "content": [{"text": f"Error: {str(e)}"}],
         }
+        after_event = AfterToolInvocationEvent(
+            agent=agent,
+            selected_tool=selected_tool,
+            tool_use=tool_use,
+            kwargs=kwargs,
+            result=error_result,
+            exception=e,
+        )
+        agent._hooks.invoke_callbacks(after_event)
+        return after_event.result
 
 
 async def _handle_tool_execution(

--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -314,7 +314,7 @@ def run_tool(agent: "Agent", tool_use: ToolUse, kwargs: dict[str, Any]) -> ToolG
                 logger.debug(
                     "tool_name=<%s>, tool_use_id=<%s> | a hook resulted in a non-existing tool call",
                     tool_name,
-                    tool_use,
+                    str(tool_use.get("toolUseId")),
                 )
 
             result: ToolResult = {

--- a/src/strands/experimental/hooks/__init__.py
+++ b/src/strands/experimental/hooks/__init__.py
@@ -29,13 +29,21 @@ This replaces the older callback_handler approach with a more composable,
 type-safe system that supports multiple subscribers per event type.
 """
 
-from .events import AgentInitializedEvent, EndRequestEvent, StartRequestEvent
+from .events import (
+    AfterToolInvocationEvent,
+    AgentInitializedEvent,
+    BeforeToolInvocationEvent,
+    EndRequestEvent,
+    StartRequestEvent,
+)
 from .registry import HookCallback, HookEvent, HookProvider, HookRegistry
 
 __all__ = [
     "AgentInitializedEvent",
     "StartRequestEvent",
     "EndRequestEvent",
+    "BeforeToolInvocationEvent",
+    "AfterToolInvocationEvent",
     "HookEvent",
     "HookProvider",
     "HookCallback",

--- a/src/strands/experimental/hooks/registry.py
+++ b/src/strands/experimental/hooks/registry.py
@@ -8,7 +8,7 @@ via hook provider objects.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Generator, Generic, Protocol, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Generator, Generic, Protocol, Type, TypeVar
 
 if TYPE_CHECKING:
     from ...agent import Agent
@@ -33,9 +33,6 @@ class HookEvent:
             invoke callbacks in reverse order (e.g., cleanup/teardown events).
         """
         return False
-
-    ### Code below is infrastructure for disallowing updates to properties ###
-    ### that aren't expected to be updated from hook callbacks.            ###
 
     def _can_write(self, name: str) -> bool:
         """Check if the given property can be written to.
@@ -69,11 +66,11 @@ class HookEvent:
         raise AttributeError(f"Property {name} is not writable")
 
 
-T = TypeVar("T", bound=Callable)
 TEvent = TypeVar("TEvent", bound=HookEvent, contravariant=True)
+"""Generic for adding callback handlers - contravariant to allow adding handlers which take in base classes."""
 
-# Non-contravariant generic for when invoking events
 TInvokeEvent = TypeVar("TInvokeEvent", bound=HookEvent)
+"""Generic for invoking events - non-contravariant to enable returning events."""
 
 
 class HookProvider(Protocol):

--- a/tests/fixtures/mock_hook_provider.py
+++ b/tests/fixtures/mock_hook_provider.py
@@ -1,5 +1,4 @@
-from collections import deque
-from typing import Type
+from typing import Iterator, Tuple, Type
 
 from strands.experimental.hooks import HookEvent, HookProvider, HookRegistry
 
@@ -9,8 +8,8 @@ class MockHookProvider(HookProvider):
         self.events_received = []
         self.events_types = event_types
 
-    def get_events(self) -> deque[HookEvent]:
-        return deque(self.events_received)
+    def get_events(self) -> Tuple[int, Iterator[HookEvent]]:
+        return len(self.events_received), iter(self.events_received)
 
     def register_hooks(self, registry: HookRegistry) -> None:
         for event_type in self.events_types:

--- a/tests/fixtures/mock_hook_provider.py
+++ b/tests/fixtures/mock_hook_provider.py
@@ -14,7 +14,7 @@ class MockHookProvider(HookProvider):
 
     def register_hooks(self, registry: HookRegistry) -> None:
         for event_type in self.events_types:
-            registry.add_callback(event_type, self._add_event)
+            registry.add_callback(event_type, self.add_event)
 
-    def _add_event(self, event: HookEvent) -> None:
+    def add_event(self, event: HookEvent) -> None:
         self.events_received.append(event)

--- a/tests/strands/agent/test_agent_hooks.py
+++ b/tests/strands/agent/test_agent_hooks.py
@@ -93,21 +93,21 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, tool_use):
 
     agent("test message")
 
-    events = hook_provider.get_events()
+    length, events = hook_provider.get_events()
 
-    assert len(events) == 4
-    assert events.popleft() == StartRequestEvent(agent=agent)
-    assert events.popleft() == BeforeToolInvocationEvent(
+    assert length == 4
+    assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == BeforeToolInvocationEvent(
         agent=agent, selected_tool=agent_tool, tool_use=tool_use, kwargs=ANY
     )
-    assert events.popleft() == AfterToolInvocationEvent(
+    assert next(events) == AfterToolInvocationEvent(
         agent=agent,
         selected_tool=agent_tool,
         tool_use=tool_use,
         kwargs=ANY,
         result={"content": [{"text": "!loot a dekovni I"}], "status": "success", "toolUseId": "123"},
     )
-    assert events.popleft() == EndRequestEvent(agent=agent)
+    assert next(events) == EndRequestEvent(agent=agent)
 
 
 @pytest.mark.asyncio
@@ -121,21 +121,22 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, tool_u
     async for _ in iterator:
         pass
 
-    events = hook_provider.get_events()
+    length, events = hook_provider.get_events()
 
-    assert len(events) == 4
-    assert events.popleft() == StartRequestEvent(agent=agent)
-    assert events.popleft() == BeforeToolInvocationEvent(
+    assert length == 4
+
+    assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == BeforeToolInvocationEvent(
         agent=agent, selected_tool=agent_tool, tool_use=tool_use, kwargs=ANY
     )
-    assert events.popleft() == AfterToolInvocationEvent(
+    assert next(events) == AfterToolInvocationEvent(
         agent=agent,
         selected_tool=agent_tool,
         tool_use=tool_use,
         kwargs=ANY,
         result={"content": [{"text": "!loot a dekovni I"}], "status": "success", "toolUseId": "123"},
     )
-    assert events.popleft() == EndRequestEvent(agent=agent)
+    assert next(events) == EndRequestEvent(agent=agent)
 
 
 def test_agent_structured_output_hooks(agent, hook_provider, user, agenerator):

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -1,15 +1,17 @@
 import concurrent
 import unittest.mock
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
 import strands
 import strands.telemetry
 from strands.event_loop.event_loop import run_tool
+from strands.experimental.hooks import AfterToolInvocationEvent, BeforeToolInvocationEvent, HookRegistry
 from strands.telemetry.metrics import EventLoopMetrics
 from strands.tools.registry import ToolRegistry
 from strands.types.exceptions import ContextWindowOverflowException, EventLoopException, ModelThrottledException
+from tests.fixtures.mock_hook_provider import MockHookProvider
 
 
 @pytest.fixture
@@ -61,6 +63,28 @@ def tool(tool_registry):
 
 
 @pytest.fixture
+def tool_times_2(tool_registry):
+    @strands.tools.tool
+    def multiply_by_2(x: int) -> int:
+        return x * 2
+
+    tool_registry.register_tool(multiply_by_2)
+
+    return multiply_by_2
+
+
+@pytest.fixture
+def tool_times_5(tool_registry):
+    @strands.tools.tool
+    def multiply_by_5(x: int) -> int:
+        return x * 5
+
+    tool_registry.register_tool(multiply_by_5)
+
+    return multiply_by_5
+
+
+@pytest.fixture
 def tool_stream(tool):
     return [
         {
@@ -80,7 +104,19 @@ def tool_stream(tool):
 
 
 @pytest.fixture
-def agent(model, system_prompt, messages, tool_config, tool_registry, thread_pool):
+def hook_registry():
+    return HookRegistry()
+
+
+@pytest.fixture
+def hook_provider(hook_registry):
+    provider = MockHookProvider(event_types=[BeforeToolInvocationEvent, AfterToolInvocationEvent])
+    hook_registry.add_hook(provider)
+    return provider
+
+
+@pytest.fixture
+def agent(model, system_prompt, messages, tool_config, tool_registry, thread_pool, hook_registry):
     mock = unittest.mock.Mock(name="agent")
     mock.config.cache_points = []
     mock.model = model
@@ -90,6 +126,7 @@ def agent(model, system_prompt, messages, tool_config, tool_registry, thread_poo
     mock.tool_registry = tool_registry
     mock.thread_pool = thread_pool
     mock.event_loop_metrics = EventLoopMetrics()
+    mock._hooks = hook_registry
 
     return mock
 
@@ -755,3 +792,119 @@ def test_run_tool_missing_tool(agent, generate):
     }
 
     assert tru_events == exp_events and tru_result == exp_result
+
+
+def test_run_tool_hooks(agent, generate, hook_provider, tool_times_2):
+    """Test that the correct hooks are emitted."""
+
+    process = run_tool(
+        agent=agent,
+        tool_use={"toolUseId": "test", "name": tool_times_2.tool_name, "input": {"x": 5}},
+        kwargs={},
+    )
+
+    _, result = generate(process)
+
+    assert len(hook_provider.events_received) == 2
+
+    assert hook_provider.events_received[0] == BeforeToolInvocationEvent(
+        agent=agent,
+        selected_tool=tool_times_2,
+        tool_use={"input": {"x": 5}, "name": "multiply_by_2", "toolUseId": "test"},
+        kwargs=ANY,
+    )
+
+    assert hook_provider.events_received[1] == AfterToolInvocationEvent(
+        agent=agent,
+        selected_tool=tool_times_2,
+        exception=None,
+        tool_use={"toolUseId": "test", "name": tool_times_2.tool_name, "input": {"x": 5}},
+        result={"toolUseId": "test", "status": "success", "content": [{"text": "10"}]},
+        kwargs=ANY,
+    )
+
+
+def test_run_tool_hook_after_tool_invocation_on_exception(agent, tool_registry, generate, hook_provider):
+    """Test that AfterToolInvocation hook is invoked even when tool throws exception."""
+    error = ValueError("Tool failed")
+
+    failing_tool = MagicMock()
+    failing_tool.tool_name = "failing_tool"
+
+    failing_tool.stream.side_effect = error
+
+    tool_registry.register_tool(failing_tool)
+
+    process = run_tool(
+        agent=agent,
+        tool_use={"toolUseId": "test", "name": "failing_tool", "input": {"x": 5}},
+        kwargs={},
+    )
+
+    _, result = generate(process)
+
+    assert hook_provider.events_received[1] == AfterToolInvocationEvent(
+        agent=agent,
+        selected_tool=failing_tool,
+        tool_use={"input": {"x": 5}, "name": "failing_tool", "toolUseId": "test"},
+        kwargs=ANY,
+        result={"content": [{"text": "Error: Tool failed"}], "status": "error", "toolUseId": "test"},
+        exception=error,
+    )
+
+
+def test_run_tool_hook_before_tool_invocation_updates(agent, tool_times_5, generate, hook_registry, hook_provider):
+    """Test that modifying properties on BeforeToolInvocation takes effect."""
+
+    updated_tool_use = {"toolUseId": "modified", "name": "replacement_tool", "input": {"x": 3}}
+
+    def modify_hook(event: BeforeToolInvocationEvent):
+        # Modify selected_tool to use replacement_tool
+        event.selected_tool = tool_times_5
+        # Modify tool_use to change toolUseId
+        event.tool_use = updated_tool_use
+
+    hook_registry.add_callback(BeforeToolInvocationEvent, modify_hook)
+
+    process = run_tool(
+        agent=agent,
+        tool_use={"toolUseId": "original", "name": "original_tool", "input": {"x": 1}},
+        kwargs={},
+    )
+
+    _, result = generate(process)
+
+    # Should use replacement_tool (5 * 3 = 15) instead of original_tool (1 * 2 = 2)
+    assert result == {"toolUseId": "modified", "status": "success", "content": [{"text": "15"}]}
+
+    assert hook_provider.events_received[1] == AfterToolInvocationEvent(
+        agent=agent,
+        selected_tool=tool_times_5,
+        tool_use=updated_tool_use,
+        kwargs=ANY,
+        result={"content": [{"text": "15"}], "status": "success", "toolUseId": "modified"},
+        exception=None,
+    )
+
+
+def test_run_tool_hook_after_tool_invocation_updates(agent, tool_times_2, generate, hook_registry):
+    """Test that modifying properties on AfterToolInvocation takes effect."""
+
+    updated_result = {"toolUseId": "modified", "status": "success", "content": [{"text": "modified_result"}]}
+
+    def modify_hook(event: AfterToolInvocationEvent):
+        # Modify result to change the output
+        event.result = updated_result
+
+    hook_registry.add_callback(AfterToolInvocationEvent, modify_hook)
+
+    process = run_tool(
+        agent=agent,
+        tool_use={"toolUseId": "test", "name": tool_times_2.tool_name, "input": {"x": 5}},
+        kwargs={},
+    )
+
+    _, result = generate(process)
+
+    # Should return modified result instead of original (5 * 2 = 10)
+    assert result == updated_result

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -1008,6 +1008,6 @@ def test_run_tool_hook_update_result_with_missing_tool(agent, generate, tool_reg
         call(
             "tool_name=<%s>, tool_use_id=<%s> | a hook resulted in a non-existing tool call",
             "test_quota",
-            {"toolUseId": "test", "name": "test_quota", "input": {"x": 5}},
+            "test",
         ),
     ]

--- a/tests/strands/experimental/hooks/test_events.py
+++ b/tests/strands/experimental/hooks/test_events.py
@@ -1,0 +1,124 @@
+from unittest.mock import Mock
+
+import pytest
+
+from strands.experimental.hooks.events import (
+    AfterToolInvocationEvent,
+    AgentInitializedEvent,
+    BeforeToolInvocationEvent,
+    EndRequestEvent,
+    StartRequestEvent,
+)
+from strands.types.tools import ToolResult, ToolUse
+
+
+@pytest.fixture
+def agent():
+    return Mock()
+
+
+@pytest.fixture
+def tool():
+    tool = Mock()
+    tool.tool_name = "test_tool"
+    return tool
+
+
+@pytest.fixture
+def tool_use():
+    return ToolUse(name="test_tool", toolUseId="123", input={"param": "value"})
+
+
+@pytest.fixture
+def tool_kwargs():
+    return {"param": "value"}
+
+
+@pytest.fixture
+def tool_result():
+    return ToolResult(content=[{"text": "result"}], status="success", toolUseId="123")
+
+
+@pytest.fixture
+def initialized_event(agent):
+    return AgentInitializedEvent(agent=agent)
+
+
+@pytest.fixture
+def start_request_event(agent):
+    return StartRequestEvent(agent=agent)
+
+
+@pytest.fixture
+def end_request_event(agent):
+    return EndRequestEvent(agent=agent)
+
+
+@pytest.fixture
+def before_tool_event(agent, tool, tool_use, tool_kwargs):
+    return BeforeToolInvocationEvent(
+        agent=agent,
+        selected_tool=tool,
+        tool_use=tool_use,
+        kwargs=tool_kwargs,
+    )
+
+
+@pytest.fixture
+def after_tool_event(agent, tool, tool_use, tool_kwargs, tool_result):
+    return AfterToolInvocationEvent(
+        agent=agent,
+        selected_tool=tool,
+        tool_use=tool_use,
+        kwargs=tool_kwargs,
+        result=tool_result,
+    )
+
+
+def test_event_should_reverse_callbacks(
+    initialized_event,
+    start_request_event,
+    end_request_event,
+    before_tool_event,
+    after_tool_event,
+):
+    # note that we ignore E712 (explicit booleans) for consistency/readability purposes
+
+    assert initialized_event.should_reverse_callbacks == False  # noqa: E712
+
+    assert start_request_event.should_reverse_callbacks == False  # noqa: E712
+    assert end_request_event.should_reverse_callbacks == True  # noqa: E712
+
+    assert before_tool_event.should_reverse_callbacks == False  # noqa: E712
+    assert after_tool_event.should_reverse_callbacks == True  # noqa: E712
+
+
+def test_before_tool_invocation_event_can_write_properties(before_tool_event):
+    new_tool_use = ToolUse(name="new_tool", toolUseId="456", input={})
+    before_tool_event.selected_tool = None  # Should not raise
+    before_tool_event.tool_use = new_tool_use  # Should not raise
+
+
+def test_before_tool_invocation_event_cannot_write_properties(before_tool_event):
+    with pytest.raises(AttributeError, match="Property agent is not writable"):
+        before_tool_event.agent = Mock()
+    with pytest.raises(AttributeError, match="Property kwargs is not writable"):
+        before_tool_event.kwargs = {}
+
+
+def test_after_tool_invocation_event_can_write_properties(after_tool_event):
+    new_result = ToolResult(content=[{"text": "new result"}], status="success", toolUseId="456")
+    after_tool_event.result = new_result  # Should not raise
+
+
+def test_after_tool_invocation_event_cannot_write_properties(after_tool_event):
+    with pytest.raises(AttributeError, match="Property agent is not writable"):
+        after_tool_event.agent = Mock()
+    with pytest.raises(AttributeError, match="Property selected_tool is not writable"):
+        after_tool_event.selected_tool = None
+    with pytest.raises(AttributeError, match="Property tool_use is not writable"):
+        after_tool_event.tool_use = ToolUse(name="new", toolUseId="456", input={})
+    with pytest.raises(AttributeError, match="Property kwargs is not writable"):
+        after_tool_event.kwargs = {}
+    with pytest.raises(AttributeError, match="Property exception is not writable"):
+        after_tool_event.exception = Exception("test")


### PR DESCRIPTION
## Description

### Add Tool Call Hooks with Value Modification Support

This PR adds two new hook events that fire before and after tool execution, allowing hooks to inspect and modify tool calls and their results. The hook system has been enhanced to support selective property updates on event objects.

**New Hook Events**

- `BeforeToolInvocation` : Fires before a tool is executed, allowing modification of the selected tool and parameters
- `AfterToolInvocation`: Fires after tool execution completes, allowing modification of the result

**Enhanced Hook Registry**

The base `HookEvent` class now includes a property write protection system. Event classes can override `_can_write()` to specify which properties hooks are allowed to modify. This prevents accidental modification of read-only properties while enabling controlled updates where needed.

### Usage Examples

**Tool Replacement**

```python
def replace_calculator(event: BeforeToolInvocation):
    if event.tool_use["name"] == "calculator":
        event.selected_tool = my_custom_calculator

registry.add_callback(BeforeToolInvocation, replace_calculator)
```

**Result Modification**

Allow intercepting tools and preventing their usage:

```python
class ToolLimiter(HookProvider):
    def register_hooks(self, registry: "HookRegistry") -> None:
        registry.add_callback(BeforeToolInvocationEvent, self.before_tool_call)
        registry.add_callback(AfterToolInvocationEvent, self.after_tool_call)

    def before_tool_call(self, event: BeforeToolInvocationEvent):
        if event.tool_use.get("name") == "test_quota":
            event.selected_tool = None

    def after_tool_call(self, event: AfterToolInvocationEvent):
        if event.tool_use.get("name") == "test_quota":
            event.result = {
                "status": "error",
                "toolUseId": "test",
                "content": [{"text": "This tool has been used too many times!"}],
            }

...
agent._hooks.add_hook(ToolLimiter())
```

**Tool Monitoring**

```python
class ToolLogger(HookProvider):
    def register_hooks(self, registry):
        registry.add_callback(BeforeToolInvocationEvent, self.log_start)
        registry.add_callback(AfterToolInvocationEvent, self.log_end)
    
    def log_start(self, event):
        logger.info(f"Starting tool: {event.tool_use['name']}")
    
    def log_end(self, event):
        logger.info(f"Tool finished: {event.result['status']}")
```


## Related Issues

#231

## Documentation PR

N/A for now.  Will soon begin PR to document hooks experimentally.

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
