### PR TITLE
tools - parallel execution - sleep

### DIFF
--- a/src/strands/tools/executor.py
+++ b/src/strands/tools/executor.py
@@ -102,6 +102,8 @@ def run_tools(
                 yield event
                 worker_events[worker_id].set()
 
+            time.sleep(0.001)
+
         tool_results.extend([worker.result() for worker in workers])
 
     else:


### PR DESCRIPTION
## Description
Tool invocation is being reworked to support streaming of events that the agent can pass to the callback handler on behalf of the user. As part of this reworking, we updated the parallel tool execution logic to utilize a queue for sharing events with the main thread. There is some busy waiting however in the main thread that is slowing down overall tool execution. Adding a sleep to combat this. Will explore other options as well. This is just an immediate fix.

From simple experiments with the use_aws tool, invocation dropped from an average of 30 seconds to 5 seconds.

## Related Issues
https://github.com/strands-agents/sdk-python/issues/356

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
