### PR TITLE
a2a streaming

### DIFF
--- a/src/strands/multiagent/a2a/executor.py
+++ b/src/strands/multiagent/a2a/executor.py
@@ -128,8 +128,7 @@ class StrandsA2AExecutor(AgentExecutor):
         logger.debug("Streaming event: %s", event)
         if "data" in event:
             # process data chunks from agent
-            text_content = event["data"]
-            if text_content:
+            if text_content := event["data"]:
                 await updater.update_status(
                     TaskState.working,
                     new_agent_text_message(
@@ -160,8 +159,7 @@ class StrandsA2AExecutor(AgentExecutor):
                 if isinstance(content, list):
                     for block in content:
                         if isinstance(block, dict) and "text" in block:
-                            text_content = block["text"]
-                            if text_content:
+                            if text_content := block["text"]:
                                 final_content += text_content
                 elif isinstance(content, str):
                     final_content = content

--- a/src/strands/multiagent/a2a/executor.py
+++ b/src/strands/multiagent/a2a/executor.py
@@ -104,7 +104,7 @@ class StrandsA2AExecutor(AgentExecutor):
             context: The A2A request context, containing the user's input and other metadata.
             updater: The task updater for managing task state and sending the final result.
         """
-        logger.info("Executing request in non-streaming mode")
+        logger.info("Executing request in synchronous mode")
         user_input = context.get_user_input()
         try:
             await updater.update_status(TaskState.working)
@@ -179,7 +179,7 @@ class StrandsA2AExecutor(AgentExecutor):
         always raises an UnsupportedOperationError.
 
         Args:
-            context: The A2A request context for.
+            context: The A2A request context.
             event_queue: The A2A event queue.
 
         Raises:

--- a/src/strands/multiagent/a2a/server.py
+++ b/src/strands/multiagent/a2a/server.py
@@ -33,6 +33,8 @@ class A2AServer:
         port: int = 9000,
         version: str = "0.0.1",
         skills: list[AgentSkill] | None = None,
+        # AgentCapabilities
+        streaming: bool = False,
     ):
         """Initialize an A2A-compatible agent from a Strands agent.
 
@@ -44,6 +46,7 @@ class A2AServer:
             port: The port to bind the A2A server to. Defaults to 9000.
             version: The version of the agent. Defaults to "0.0.1".
             skills: The list of capabilities or functions the agent can perform.
+            streaming: Whether the agent supports streaming capabilities. Defaults to False.
         """
         self.host = host
         self.port = port
@@ -52,10 +55,9 @@ class A2AServer:
         self.strands_agent = agent
         self.name = self.strands_agent.name
         self.description = self.strands_agent.description
-        # TODO: enable configurable capabilities and request handler
-        self.capabilities = AgentCapabilities()
+        self.capabilities = AgentCapabilities(streaming=streaming)
         self.request_handler = DefaultRequestHandler(
-            agent_executor=StrandsA2AExecutor(self.strands_agent),
+            agent_executor=StrandsA2AExecutor(self.strands_agent, self.capabilities),
             task_store=InMemoryTaskStore(),
         )
         self._agent_skills = skills

--- a/src/strands/multiagent/a2a/server.py
+++ b/src/strands/multiagent/a2a/server.py
@@ -33,8 +33,6 @@ class A2AServer:
         port: int = 9000,
         version: str = "0.0.1",
         skills: list[AgentSkill] | None = None,
-        # AgentCapabilities
-        streaming: bool = False,
     ):
         """Initialize an A2A-compatible agent from a Strands agent.
 
@@ -46,7 +44,6 @@ class A2AServer:
             port: The port to bind the A2A server to. Defaults to 9000.
             version: The version of the agent. Defaults to "0.0.1".
             skills: The list of capabilities or functions the agent can perform.
-            streaming: Whether the agent supports streaming capabilities. Defaults to False.
         """
         self.host = host
         self.port = port
@@ -55,9 +52,9 @@ class A2AServer:
         self.strands_agent = agent
         self.name = self.strands_agent.name
         self.description = self.strands_agent.description
-        self.capabilities = AgentCapabilities(streaming=streaming)
+        self.capabilities = AgentCapabilities(streaming=True)
         self.request_handler = DefaultRequestHandler(
-            agent_executor=StrandsA2AExecutor(self.strands_agent, self.capabilities),
+            agent_executor=StrandsA2AExecutor(self.strands_agent),
             task_store=InMemoryTaskStore(),
         )
         self._agent_skills = skills

--- a/tests/multiagent/a2a/conftest.py
+++ b/tests/multiagent/a2a/conftest.py
@@ -22,6 +22,10 @@ def mock_strands_agent():
     mock_result.message = {"content": [{"text": "Test response"}]}
     agent.return_value = mock_result
 
+    # Setup async methods
+    agent.invoke_async = AsyncMock(return_value=mock_result)
+    agent.stream_async = AsyncMock(return_value=iter([]))
+
     # Setup mock tool registry
     mock_tool_registry = MagicMock()
     mock_tool_registry.get_all_tools_config.return_value = {}

--- a/tests/multiagent/a2a/test_executor.py
+++ b/tests/multiagent/a2a/test_executor.py
@@ -1,9 +1,9 @@
 """Tests for the StrandsA2AExecutor class."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from a2a.types import UnsupportedOperationError
+from a2a.types import AgentCapabilities, UnsupportedOperationError
 from a2a.utils.errors import ServerError
 
 from strands.agent.agent_result import AgentResult as SAAgentResult
@@ -12,107 +12,424 @@ from strands.multiagent.a2a.executor import StrandsA2AExecutor
 
 def test_executor_initialization(mock_strands_agent):
     """Test that StrandsA2AExecutor initializes correctly."""
-    executor = StrandsA2AExecutor(mock_strands_agent)
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
 
     assert executor.agent == mock_strands_agent
+    assert executor.capabilities == capabilities
+
+
+def test_executor_initialization_with_streaming(mock_strands_agent):
+    """Test that StrandsA2AExecutor initializes correctly with streaming enabled."""
+    capabilities = AgentCapabilities(streaming=True)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    assert executor.agent == mock_strands_agent
+    assert executor.capabilities.streaming is True
 
 
 @pytest.mark.asyncio
-async def test_execute_with_text_response(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute processes text responses correctly."""
+async def test_execute_sync_mode_with_text_response(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute processes text responses correctly in sync mode."""
     # Setup mock agent response
     mock_result = MagicMock(spec=SAAgentResult)
     mock_result.message = {"content": [{"text": "Test response"}]}
-    mock_strands_agent.return_value = mock_result
+    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
 
-    # Create executor and call execute
-    executor = StrandsA2AExecutor(mock_strands_agent)
+    # Create executor with sync capabilities
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
     await executor.execute(mock_request_context, mock_event_queue)
 
     # Verify agent was called with correct input
-    mock_strands_agent.assert_called_once_with("Test input")
+    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
 
-    # Verify event was enqueued
-    mock_event_queue.enqueue_event.assert_called_once()
-    args, _ = mock_event_queue.enqueue_event.call_args
-    event = args[0]
-    assert event.parts[0].root.text == "Test response"
+    # Verify event was enqueued for task completion
+    mock_event_queue.enqueue_event.assert_called()
 
 
 @pytest.mark.asyncio
-async def test_execute_with_multiple_text_blocks(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute processes multiple text blocks correctly."""
+async def test_execute_sync_mode_with_multiple_text_blocks(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute processes multiple text blocks correctly in sync mode."""
     # Setup mock agent response with multiple text blocks
     mock_result = MagicMock(spec=SAAgentResult)
     mock_result.message = {"content": [{"text": "First response"}, {"text": "Second response"}]}
-    mock_strands_agent.return_value = mock_result
+    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
 
-    # Create executor and call execute
-    executor = StrandsA2AExecutor(mock_strands_agent)
+    # Create executor with sync capabilities
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
     await executor.execute(mock_request_context, mock_event_queue)
 
     # Verify agent was called with correct input
-    mock_strands_agent.assert_called_once_with("Test input")
+    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
 
     # Verify events were enqueued
-    assert mock_event_queue.enqueue_event.call_count == 2
-
-    # Check first event
-    args1, _ = mock_event_queue.enqueue_event.call_args_list[0]
-    event1 = args1[0]
-    assert event1.parts[0].root.text == "First response"
-
-    # Check second event
-    args2, _ = mock_event_queue.enqueue_event.call_args_list[1]
-    event2 = args2[0]
-    assert event2.parts[0].root.text == "Second response"
+    mock_event_queue.enqueue_event.assert_called()
 
 
 @pytest.mark.asyncio
-async def test_execute_with_empty_response(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute handles empty responses correctly."""
+async def test_execute_sync_mode_with_string_content(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute handles string content correctly in sync mode."""
+    # Setup mock agent response with string content
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.message = {"content": "Simple string response"}
+    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
+
+    # Create executor with sync capabilities
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    # Verify agent was called with correct input
+    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
+
+    # Verify events were enqueued
+    mock_event_queue.enqueue_event.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_sync_mode_with_empty_response(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute handles empty responses correctly in sync mode."""
     # Setup mock agent response with empty content
     mock_result = MagicMock(spec=SAAgentResult)
     mock_result.message = {"content": []}
-    mock_strands_agent.return_value = mock_result
+    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
 
-    # Create executor and call execute
-    executor = StrandsA2AExecutor(mock_strands_agent)
+    # Create executor with sync capabilities
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
     await executor.execute(mock_request_context, mock_event_queue)
 
     # Verify agent was called with correct input
-    mock_strands_agent.assert_called_once_with("Test input")
+    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
 
-    # Verify no events were enqueued
-    mock_event_queue.enqueue_event.assert_not_called()
+    # Verify completion event was still enqueued
+    mock_event_queue.enqueue_event.assert_called()
 
 
 @pytest.mark.asyncio
-async def test_execute_with_no_message(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute handles responses with no message correctly."""
+async def test_execute_sync_mode_with_no_message(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute handles responses with no message correctly in sync mode."""
     # Setup mock agent response with no message
     mock_result = MagicMock(spec=SAAgentResult)
     mock_result.message = None
-    mock_strands_agent.return_value = mock_result
+    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
 
-    # Create executor and call execute
-    executor = StrandsA2AExecutor(mock_strands_agent)
+    # Create executor with sync capabilities
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
     await executor.execute(mock_request_context, mock_event_queue)
 
     # Verify agent was called with correct input
-    mock_strands_agent.assert_called_once_with("Test input")
+    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
 
-    # Verify no events were enqueued
-    mock_event_queue.enqueue_event.assert_not_called()
+    # Verify completion event was still enqueued
+    mock_event_queue.enqueue_event.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_streaming_mode_with_data_events(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute processes streaming data events correctly."""
+
+    # Setup mock streaming response
+    async def mock_stream():
+        yield {"data": "Streaming chunk 1"}
+        yield {"data": "Streaming chunk 2"}
+        yield {"result": None}
+
+    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream())
+
+    # Create executor with streaming capabilities
+    capabilities = AgentCapabilities(streaming=True)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    # Verify agent was called with correct input
+    mock_strands_agent.stream_async.assert_called_once_with("Test input")
+
+    # Verify events were enqueued
+    mock_event_queue.enqueue_event.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_streaming_mode_with_result_event(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute processes streaming result events correctly."""
+    # Setup mock streaming response with result
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.message = {"content": [{"text": "Final result"}]}
+
+    async def mock_stream():
+        yield {"data": "Streaming chunk"}
+        yield {"result": mock_result}
+
+    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream())
+
+    # Create executor with streaming capabilities
+    capabilities = AgentCapabilities(streaming=True)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    # Verify agent was called with correct input
+    mock_strands_agent.stream_async.assert_called_once_with("Test input")
+
+    # Verify events were enqueued
+    mock_event_queue.enqueue_event.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_streaming_mode_with_empty_data(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute handles empty streaming data correctly."""
+
+    # Setup mock streaming response with empty data
+    async def mock_stream():
+        yield {"data": ""}
+        yield {"data": None}
+        yield {"result": None}
+
+    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream())
+
+    # Create executor with streaming capabilities
+    capabilities = AgentCapabilities(streaming=True)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    # Verify agent was called with correct input
+    mock_strands_agent.stream_async.assert_called_once_with("Test input")
+
+    # Verify events were enqueued
+    mock_event_queue.enqueue_event.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_streaming_mode_with_unexpected_event(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute handles unexpected streaming events correctly."""
+
+    # Setup mock streaming response with unexpected event
+    async def mock_stream():
+        yield {"data": "Valid chunk"}
+        yield {"unexpected": "event"}
+        yield {"result": None}
+
+    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream())
+
+    # Create executor with streaming capabilities
+    capabilities = AgentCapabilities(streaming=True)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    # Verify agent was called with correct input
+    mock_strands_agent.stream_async.assert_called_once_with("Test input")
+
+    # Should still complete successfully despite unexpected event
+    mock_event_queue.enqueue_event.assert_called()
+
+
+@pytest.mark.asyncio
+@patch("strands.multiagent.a2a.executor.new_task")
+async def test_execute_creates_task_when_none_exists(
+    mock_new_task, mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """Test that execute creates a task when none exists in the context."""
+    # Setup mock agent response
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.message = {"content": [{"text": "Test response"}]}
+    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
+
+    # Setup mock task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_new_task.return_value = mock_task
+
+    # Create executor with sync capabilities
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # No current task in context
+    mock_request_context.current_task = None
+
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    # Verify agent was called
+    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
+
+    # Verify task creation and completion events were enqueued
+    assert mock_event_queue.enqueue_event.call_count >= 1
+    mock_new_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_sync_mode_handles_agent_exception(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute handles agent exceptions correctly in sync mode."""
+    # Setup mock agent to raise exception
+    mock_strands_agent.invoke_async = AsyncMock(side_effect=Exception("Agent error"))
+
+    # Create executor with sync capabilities
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
+    with pytest.raises(ServerError):
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    # Verify agent was called
+    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
+
+
+@pytest.mark.asyncio
+async def test_execute_streaming_mode_handles_agent_exception(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """Test that execute handles agent exceptions correctly in streaming mode."""
+    # Setup mock agent to raise exception
+    mock_strands_agent.stream_async = MagicMock(side_effect=Exception("Agent error"))
+
+    # Create executor with streaming capabilities
+    capabilities = AgentCapabilities(streaming=True)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
+    with pytest.raises(ServerError):
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    # Verify agent was called
+    mock_strands_agent.stream_async.assert_called_once_with("Test input")
 
 
 @pytest.mark.asyncio
 async def test_cancel_raises_unsupported_operation_error(mock_strands_agent, mock_request_context, mock_event_queue):
     """Test that cancel raises UnsupportedOperationError."""
-    executor = StrandsA2AExecutor(mock_strands_agent)
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
 
     with pytest.raises(ServerError) as excinfo:
         await executor.cancel(mock_request_context, mock_event_queue)
 
     # Verify the error is a ServerError containing an UnsupportedOperationError
     assert isinstance(excinfo.value.error, UnsupportedOperationError)
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_result_with_none_result(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that _handle_agent_result handles None result correctly."""
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
+    # Mock TaskUpdater
+    mock_updater = MagicMock()
+    mock_updater.complete = AsyncMock()
+
+    # Call _handle_agent_result with None
+    await executor._handle_agent_result(None, mock_updater)
+
+    # Verify completion was called
+    mock_updater.complete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_result_with_result_but_no_message(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """Test that _handle_agent_result handles result with no message correctly."""
+    capabilities = AgentCapabilities(streaming=False)
+    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+
+    # Mock the task creation
+    mock_task = MagicMock()
+    mock_task.id = "test-task-id"
+    mock_task.contextId = "test-context-id"
+    mock_request_context.current_task = mock_task
+
+    # Mock TaskUpdater
+    mock_updater = MagicMock()
+    mock_updater.complete = AsyncMock()
+
+    # Create result with no message
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.message = None
+
+    # Call _handle_agent_result
+    await executor._handle_agent_result(mock_result, mock_updater)
+
+    # Verify completion was called
+    mock_updater.complete.assert_called_once()

--- a/tests/multiagent/a2a/test_executor.py
+++ b/tests/multiagent/a2a/test_executor.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from a2a.types import AgentCapabilities, UnsupportedOperationError
+from a2a.types import UnsupportedOperationError
 from a2a.utils.errors import ServerError
 
 from strands.agent.agent_result import AgentResult as SAAgentResult
@@ -12,172 +12,26 @@ from strands.multiagent.a2a.executor import StrandsA2AExecutor
 
 def test_executor_initialization(mock_strands_agent):
     """Test that StrandsA2AExecutor initializes correctly."""
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    executor = StrandsA2AExecutor(mock_strands_agent)
 
     assert executor.agent == mock_strands_agent
-    assert executor.capabilities == capabilities
-
-
-def test_executor_initialization_with_streaming(mock_strands_agent):
-    """Test that StrandsA2AExecutor initializes correctly with streaming enabled."""
-    capabilities = AgentCapabilities(streaming=True)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
-
-    assert executor.agent == mock_strands_agent
-    assert executor.capabilities.streaming is True
-
-
-@pytest.mark.asyncio
-async def test_execute_sync_mode_with_text_response(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute processes text responses correctly in sync mode."""
-    # Setup mock agent response
-    mock_result = MagicMock(spec=SAAgentResult)
-    mock_result.message = {"content": [{"text": "Test response"}]}
-    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
-
-    # Create executor with sync capabilities
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
-
-    # Mock the task creation
-    mock_task = MagicMock()
-    mock_task.id = "test-task-id"
-    mock_task.contextId = "test-context-id"
-    mock_request_context.current_task = mock_task
-
-    await executor.execute(mock_request_context, mock_event_queue)
-
-    # Verify agent was called with correct input
-    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
-
-    # Verify event was enqueued for task completion
-    mock_event_queue.enqueue_event.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_execute_sync_mode_with_multiple_text_blocks(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute processes multiple text blocks correctly in sync mode."""
-    # Setup mock agent response with multiple text blocks
-    mock_result = MagicMock(spec=SAAgentResult)
-    mock_result.message = {"content": [{"text": "First response"}, {"text": "Second response"}]}
-    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
-
-    # Create executor with sync capabilities
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
-
-    # Mock the task creation
-    mock_task = MagicMock()
-    mock_task.id = "test-task-id"
-    mock_task.contextId = "test-context-id"
-    mock_request_context.current_task = mock_task
-
-    await executor.execute(mock_request_context, mock_event_queue)
-
-    # Verify agent was called with correct input
-    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
-
-    # Verify events were enqueued
-    mock_event_queue.enqueue_event.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_execute_sync_mode_with_string_content(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute handles string content correctly in sync mode."""
-    # Setup mock agent response with string content
-    mock_result = MagicMock(spec=SAAgentResult)
-    mock_result.message = {"content": "Simple string response"}
-    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
-
-    # Create executor with sync capabilities
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
-
-    # Mock the task creation
-    mock_task = MagicMock()
-    mock_task.id = "test-task-id"
-    mock_task.contextId = "test-context-id"
-    mock_request_context.current_task = mock_task
-
-    await executor.execute(mock_request_context, mock_event_queue)
-
-    # Verify agent was called with correct input
-    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
-
-    # Verify events were enqueued
-    mock_event_queue.enqueue_event.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_execute_sync_mode_with_empty_response(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute handles empty responses correctly in sync mode."""
-    # Setup mock agent response with empty content
-    mock_result = MagicMock(spec=SAAgentResult)
-    mock_result.message = {"content": []}
-    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
-
-    # Create executor with sync capabilities
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
-
-    # Mock the task creation
-    mock_task = MagicMock()
-    mock_task.id = "test-task-id"
-    mock_task.contextId = "test-context-id"
-    mock_request_context.current_task = mock_task
-
-    await executor.execute(mock_request_context, mock_event_queue)
-
-    # Verify agent was called with correct input
-    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
-
-    # Verify completion event was still enqueued
-    mock_event_queue.enqueue_event.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_execute_sync_mode_with_no_message(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute handles responses with no message correctly in sync mode."""
-    # Setup mock agent response with no message
-    mock_result = MagicMock(spec=SAAgentResult)
-    mock_result.message = None
-    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
-
-    # Create executor with sync capabilities
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
-
-    # Mock the task creation
-    mock_task = MagicMock()
-    mock_task.id = "test-task-id"
-    mock_task.contextId = "test-context-id"
-    mock_request_context.current_task = mock_task
-
-    await executor.execute(mock_request_context, mock_event_queue)
-
-    # Verify agent was called with correct input
-    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
-
-    # Verify completion event was still enqueued
-    mock_event_queue.enqueue_event.assert_called()
 
 
 @pytest.mark.asyncio
 async def test_execute_streaming_mode_with_data_events(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute processes streaming data events correctly."""
+    """Test that execute processes data events correctly in streaming mode."""
 
-    # Setup mock streaming response
-    async def mock_stream():
-        yield {"data": "Streaming chunk 1"}
-        yield {"data": "Streaming chunk 2"}
-        yield {"result": None}
+    async def mock_stream(user_input):
+        """Mock streaming function that yields data events."""
+        yield {"data": "First chunk"}
+        yield {"data": "Second chunk"}
+        yield {"result": MagicMock(spec=SAAgentResult)}
 
-    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream())
+    # Setup mock agent streaming
+    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream("Test input"))
 
-    # Create executor with streaming capabilities
-    capabilities = AgentCapabilities(streaming=True)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    # Create executor
+    executor = StrandsA2AExecutor(mock_strands_agent)
 
     # Mock the task creation
     mock_task = MagicMock()
@@ -196,20 +50,17 @@ async def test_execute_streaming_mode_with_data_events(mock_strands_agent, mock_
 
 @pytest.mark.asyncio
 async def test_execute_streaming_mode_with_result_event(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute processes streaming result events correctly."""
-    # Setup mock streaming response with result
-    mock_result = MagicMock(spec=SAAgentResult)
-    mock_result.message = {"content": [{"text": "Final result"}]}
+    """Test that execute processes result events correctly in streaming mode."""
 
-    async def mock_stream():
-        yield {"data": "Streaming chunk"}
-        yield {"result": mock_result}
+    async def mock_stream(user_input):
+        """Mock streaming function that yields only result event."""
+        yield {"result": MagicMock(spec=SAAgentResult)}
 
-    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream())
+    # Setup mock agent streaming
+    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream("Test input"))
 
-    # Create executor with streaming capabilities
-    capabilities = AgentCapabilities(streaming=True)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    # Create executor
+    executor = StrandsA2AExecutor(mock_strands_agent)
 
     # Mock the task creation
     mock_task = MagicMock()
@@ -228,19 +79,18 @@ async def test_execute_streaming_mode_with_result_event(mock_strands_agent, mock
 
 @pytest.mark.asyncio
 async def test_execute_streaming_mode_with_empty_data(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute handles empty streaming data correctly."""
+    """Test that execute handles empty data events correctly in streaming mode."""
 
-    # Setup mock streaming response with empty data
-    async def mock_stream():
+    async def mock_stream(user_input):
+        """Mock streaming function that yields empty data."""
         yield {"data": ""}
-        yield {"data": None}
-        yield {"result": None}
+        yield {"result": MagicMock(spec=SAAgentResult)}
 
-    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream())
+    # Setup mock agent streaming
+    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream("Test input"))
 
-    # Create executor with streaming capabilities
-    capabilities = AgentCapabilities(streaming=True)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    # Create executor
+    executor = StrandsA2AExecutor(mock_strands_agent)
 
     # Mock the task creation
     mock_task = MagicMock()
@@ -259,19 +109,18 @@ async def test_execute_streaming_mode_with_empty_data(mock_strands_agent, mock_r
 
 @pytest.mark.asyncio
 async def test_execute_streaming_mode_with_unexpected_event(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute handles unexpected streaming events correctly."""
+    """Test that execute handles unexpected events correctly in streaming mode."""
 
-    # Setup mock streaming response with unexpected event
-    async def mock_stream():
-        yield {"data": "Valid chunk"}
+    async def mock_stream(user_input):
+        """Mock streaming function that yields unexpected event."""
         yield {"unexpected": "event"}
-        yield {"result": None}
+        yield {"result": MagicMock(spec=SAAgentResult)}
 
-    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream())
+    # Setup mock agent streaming
+    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream("Test input"))
 
-    # Create executor with streaming capabilities
-    capabilities = AgentCapabilities(streaming=True)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    # Create executor
+    executor = StrandsA2AExecutor(mock_strands_agent)
 
     # Mock the task creation
     mock_task = MagicMock()
@@ -284,38 +133,32 @@ async def test_execute_streaming_mode_with_unexpected_event(mock_strands_agent, 
     # Verify agent was called with correct input
     mock_strands_agent.stream_async.assert_called_once_with("Test input")
 
-    # Should still complete successfully despite unexpected event
+    # Verify events were enqueued
     mock_event_queue.enqueue_event.assert_called()
 
 
 @pytest.mark.asyncio
-@patch("strands.multiagent.a2a.executor.new_task")
-async def test_execute_creates_task_when_none_exists(
-    mock_new_task, mock_strands_agent, mock_request_context, mock_event_queue
-):
-    """Test that execute creates a task when none exists in the context."""
-    # Setup mock agent response
-    mock_result = MagicMock(spec=SAAgentResult)
-    mock_result.message = {"content": [{"text": "Test response"}]}
-    mock_strands_agent.invoke_async = AsyncMock(return_value=mock_result)
+async def test_execute_creates_task_when_none_exists(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Test that execute creates a new task when none exists."""
 
-    # Setup mock task creation
-    mock_task = MagicMock()
-    mock_task.id = "test-task-id"
-    mock_task.contextId = "test-context-id"
-    mock_new_task.return_value = mock_task
+    async def mock_stream(user_input):
+        """Mock streaming function that yields data events."""
+        yield {"data": "Test chunk"}
+        yield {"result": MagicMock(spec=SAAgentResult)}
 
-    # Create executor with sync capabilities
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    # Setup mock agent streaming
+    mock_strands_agent.stream_async = MagicMock(return_value=mock_stream("Test input"))
 
-    # No current task in context
+    # Create executor
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    # Mock no existing task
     mock_request_context.current_task = None
 
-    await executor.execute(mock_request_context, mock_event_queue)
+    with patch("strands.multiagent.a2a.executor.new_task") as mock_new_task:
+        mock_new_task.return_value = MagicMock(id="new-task-id", contextId="new-context-id")
 
-    # Verify agent was called
-    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
+        await executor.execute(mock_request_context, mock_event_queue)
 
     # Verify task creation and completion events were enqueued
     assert mock_event_queue.enqueue_event.call_count >= 1
@@ -323,39 +166,16 @@ async def test_execute_creates_task_when_none_exists(
 
 
 @pytest.mark.asyncio
-async def test_execute_sync_mode_handles_agent_exception(mock_strands_agent, mock_request_context, mock_event_queue):
-    """Test that execute handles agent exceptions correctly in sync mode."""
-    # Setup mock agent to raise exception
-    mock_strands_agent.invoke_async = AsyncMock(side_effect=Exception("Agent error"))
-
-    # Create executor with sync capabilities
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
-
-    # Mock the task creation
-    mock_task = MagicMock()
-    mock_task.id = "test-task-id"
-    mock_task.contextId = "test-context-id"
-    mock_request_context.current_task = mock_task
-
-    with pytest.raises(ServerError):
-        await executor.execute(mock_request_context, mock_event_queue)
-
-    # Verify agent was called
-    mock_strands_agent.invoke_async.assert_called_once_with("Test input")
-
-
-@pytest.mark.asyncio
 async def test_execute_streaming_mode_handles_agent_exception(
     mock_strands_agent, mock_request_context, mock_event_queue
 ):
     """Test that execute handles agent exceptions correctly in streaming mode."""
-    # Setup mock agent to raise exception
+
+    # Setup mock agent to raise exception when stream_async is called
     mock_strands_agent.stream_async = MagicMock(side_effect=Exception("Agent error"))
 
-    # Create executor with streaming capabilities
-    capabilities = AgentCapabilities(streaming=True)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    # Create executor
+    executor = StrandsA2AExecutor(mock_strands_agent)
 
     # Mock the task creation
     mock_task = MagicMock()
@@ -373,8 +193,7 @@ async def test_execute_streaming_mode_handles_agent_exception(
 @pytest.mark.asyncio
 async def test_cancel_raises_unsupported_operation_error(mock_strands_agent, mock_request_context, mock_event_queue):
     """Test that cancel raises UnsupportedOperationError."""
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    executor = StrandsA2AExecutor(mock_strands_agent)
 
     with pytest.raises(ServerError) as excinfo:
         await executor.cancel(mock_request_context, mock_event_queue)
@@ -386,8 +205,7 @@ async def test_cancel_raises_unsupported_operation_error(mock_strands_agent, moc
 @pytest.mark.asyncio
 async def test_handle_agent_result_with_none_result(mock_strands_agent, mock_request_context, mock_event_queue):
     """Test that _handle_agent_result handles None result correctly."""
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    executor = StrandsA2AExecutor(mock_strands_agent)
 
     # Mock the task creation
     mock_task = MagicMock()
@@ -398,6 +216,7 @@ async def test_handle_agent_result_with_none_result(mock_strands_agent, mock_req
     # Mock TaskUpdater
     mock_updater = MagicMock()
     mock_updater.complete = AsyncMock()
+    mock_updater.add_artifact = AsyncMock()
 
     # Call _handle_agent_result with None
     await executor._handle_agent_result(None, mock_updater)
@@ -411,8 +230,7 @@ async def test_handle_agent_result_with_result_but_no_message(
     mock_strands_agent, mock_request_context, mock_event_queue
 ):
     """Test that _handle_agent_result handles result with no message correctly."""
-    capabilities = AgentCapabilities(streaming=False)
-    executor = StrandsA2AExecutor(mock_strands_agent, capabilities)
+    executor = StrandsA2AExecutor(mock_strands_agent)
 
     # Mock the task creation
     mock_task = MagicMock()
@@ -423,6 +241,7 @@ async def test_handle_agent_result_with_result_but_no_message(
     # Mock TaskUpdater
     mock_updater = MagicMock()
     mock_updater.complete = AsyncMock()
+    mock_updater.add_artifact = AsyncMock()
 
     # Create result with no message
     mock_result = MagicMock(spec=SAAgentResult)

--- a/tests/multiagent/a2a/test_server.py
+++ b/tests/multiagent/a2a/test_server.py
@@ -44,27 +44,14 @@ def test_a2a_agent_initialization_with_custom_values(mock_strands_agent):
     assert a2a_agent.port == 8080
     assert a2a_agent.http_url == "http://127.0.0.1:8080/"
     assert a2a_agent.version == "1.0.0"
-    assert a2a_agent.capabilities.streaming is False
-
-
-def test_a2a_agent_initialization_with_streaming_enabled(mock_strands_agent):
-    """Test that A2AAgent initializes correctly with streaming enabled."""
-    a2a_agent = A2AServer(
-        mock_strands_agent,
-        streaming=True,
-    )
-
     assert a2a_agent.capabilities.streaming is True
 
 
-def test_a2a_agent_initialization_with_streaming_disabled(mock_strands_agent):
-    """Test that A2AAgent initializes correctly with streaming disabled."""
-    a2a_agent = A2AServer(
-        mock_strands_agent,
-        streaming=False,
-    )
+def test_a2a_agent_initialization_with_streaming_always_enabled(mock_strands_agent):
+    """Test that A2AAgent always initializes with streaming enabled."""
+    a2a_agent = A2AServer(mock_strands_agent)
 
-    assert a2a_agent.capabilities.streaming is False
+    assert a2a_agent.capabilities.streaming is True
 
 
 def test_a2a_agent_initialization_with_custom_skills(mock_strands_agent):
@@ -492,23 +479,14 @@ def test_serve_with_custom_kwargs(mock_run, mock_strands_agent):
     assert kwargs["reload"] is True
 
 
-def test_executor_created_with_correct_capabilities(mock_strands_agent):
-    """Test that the executor is created with the correct capabilities."""
+def test_executor_created_correctly(mock_strands_agent):
+    """Test that the executor is created correctly."""
     from strands.multiagent.a2a.executor import StrandsA2AExecutor
 
-    # Test with streaming enabled
-    a2a_agent = A2AServer(mock_strands_agent, streaming=True)
+    a2a_agent = A2AServer(mock_strands_agent)
 
     assert isinstance(a2a_agent.request_handler.agent_executor, StrandsA2AExecutor)
-    assert a2a_agent.request_handler.agent_executor.capabilities.streaming is True
     assert a2a_agent.request_handler.agent_executor.agent == mock_strands_agent
-
-    # Test with streaming disabled
-    a2a_agent_no_streaming = A2AServer(mock_strands_agent, streaming=False)
-
-    assert isinstance(a2a_agent_no_streaming.request_handler.agent_executor, StrandsA2AExecutor)
-    assert a2a_agent_no_streaming.request_handler.agent_executor.capabilities.streaming is False
-    assert a2a_agent_no_streaming.request_handler.agent_executor.agent == mock_strands_agent
 
 
 @patch("uvicorn.run", side_effect=KeyboardInterrupt)

--- a/tests/multiagent/a2a/test_server.py
+++ b/tests/multiagent/a2a/test_server.py
@@ -44,6 +44,27 @@ def test_a2a_agent_initialization_with_custom_values(mock_strands_agent):
     assert a2a_agent.port == 8080
     assert a2a_agent.http_url == "http://127.0.0.1:8080/"
     assert a2a_agent.version == "1.0.0"
+    assert a2a_agent.capabilities.streaming is False
+
+
+def test_a2a_agent_initialization_with_streaming_enabled(mock_strands_agent):
+    """Test that A2AAgent initializes correctly with streaming enabled."""
+    a2a_agent = A2AServer(
+        mock_strands_agent,
+        streaming=True,
+    )
+
+    assert a2a_agent.capabilities.streaming is True
+
+
+def test_a2a_agent_initialization_with_streaming_disabled(mock_strands_agent):
+    """Test that A2AAgent initializes correctly with streaming disabled."""
+    a2a_agent = A2AServer(
+        mock_strands_agent,
+        streaming=False,
+    )
+
+    assert a2a_agent.capabilities.streaming is False
 
 
 def test_a2a_agent_initialization_with_custom_skills(mock_strands_agent):
@@ -469,6 +490,25 @@ def test_serve_with_custom_kwargs(mock_run, mock_strands_agent):
     _, kwargs = mock_run.call_args
     assert kwargs["log_level"] == "debug"
     assert kwargs["reload"] is True
+
+
+def test_executor_created_with_correct_capabilities(mock_strands_agent):
+    """Test that the executor is created with the correct capabilities."""
+    from strands.multiagent.a2a.executor import StrandsA2AExecutor
+
+    # Test with streaming enabled
+    a2a_agent = A2AServer(mock_strands_agent, streaming=True)
+
+    assert isinstance(a2a_agent.request_handler.agent_executor, StrandsA2AExecutor)
+    assert a2a_agent.request_handler.agent_executor.capabilities.streaming is True
+    assert a2a_agent.request_handler.agent_executor.agent == mock_strands_agent
+
+    # Test with streaming disabled
+    a2a_agent_no_streaming = A2AServer(mock_strands_agent, streaming=False)
+
+    assert isinstance(a2a_agent_no_streaming.request_handler.agent_executor, StrandsA2AExecutor)
+    assert a2a_agent_no_streaming.request_handler.agent_executor.capabilities.streaming is False
+    assert a2a_agent_no_streaming.request_handler.agent_executor.agent == mock_strands_agent
 
 
 @patch("uvicorn.run", side_effect=KeyboardInterrupt)


### PR DESCRIPTION
## Description
- Implemented streaming support for `A2AServer`.
	- Clients can now use the `A2AServer` in streaming and non-streaming mode. The underlying executor supports both modes of execution and uses the `stream_async` and `invoke_async` functions accordingly.
- The `A2AServer` also supports [Tasks](https://a2aproject.github.io/A2A/v0.2.5/topics/streaming-and-async/) where the request status is incrementally updated via the `Task` interface. This works gracefully in either streaming or synchronous mode. In streaming mode updates are sent via `SSE`, in sync mode an `A2A` response payload is returned with the task once it is complete.

## Related Issues

- https://github.com/strands-agents/private-sdk-python-staging/issues/97
- https://github.com/strands-agents/private-sdk-python-staging/issues/95

## Documentation PR

- N/A coming soon

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

### Sample Code

`A2A server with in sync or streaming mode`
```python
import logging
import sys

from strands import Agent
from strands.multiagent.a2a import A2AServer

logging.basicConfig(
    level=logging.DEBUG,
    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
    handlers=[logging.StreamHandler(sys.stdout)],
    force=True,
)

# Log that we're starting
logging.info("Starting A2A server with root logger")

strands_agent = Agent(
    model="us.anthropic.claude-3-haiku-20240307-v1:0",
    name="Hello World Agent",
    description="Just a hello world agent",
    callback_handler=None
)

# uncomment to enable streaming
# strands_a2a_agent = A2AServer(agent=strands_agent, streaming=True)

# sync enabled
strands_a2a_agent = A2AServer(agent=strands_agent)

strands_a2a_agent.serve()
```

`A2A client script in sync mode`
```python
import asyncio
import json
import logging
from typing import Any
from uuid import uuid4

import httpx
from a2a.client import A2ACardResolver, A2AClient
from a2a.types import (
    AgentCard,
    MessageSendParams,
    SendMessageRequest,
    SendStreamingMessageRequest,
)

logging.basicConfig(level=logging.INFO)
logger = logging.getLogger(__name__)
PUBLIC_AGENT_CARD_PATH = "/.well-known/agent.json"
BASE_URL = "http://localhost:9000"


async def main() -> None:
    async with httpx.AsyncClient() as httpx_client:
        # Initialize A2ACardResolver
        resolver = A2ACardResolver(
            httpx_client=httpx_client,
            base_url=BASE_URL,
        )

        # Fetch Public Agent Card and Initialize Client
        agent_card: AgentCard | None = None

        try:
            logger.info("Attempting to fetch public agent card from: {} {}", BASE_URL, PUBLIC_AGENT_CARD_PATH)
            agent_card = await resolver.get_agent_card()  # Fetches from default public path
            logger.info("Successfully fetched public agent card:")
            logger.info(agent_card.model_dump_json(indent=2, exclude_none=True))
        except Exception as e:
            logger.exception("Critical error fetching public agent card")
            raise RuntimeError("Failed to fetch the public agent card. Cannot continue.") from e

        client = A2AClient(httpx_client=httpx_client, agent_card=agent_card)
        logger.info("A2AClient initialized.")

        send_message_payload: dict[str, Any] = {
            "message": {
                "role": "user",
                "parts": [{"kind": "text", "text": "how much is 10 USD in INR?"}],
                "messageId": uuid4().hex,
            },
        }
        request = SendMessageRequest(id=str(uuid4()), params=MessageSendParams(**send_message_payload))
        response = await client.send_message(request)
		print(response)

asyncio.run(main())
```

Sample output
```json
... <omitted previous streamed events> ...
{
  "id": "dceae647-c661-4203-a99b-1ce2b28f8804",
  "jsonrpc": "2.0",
  "result": {
    "contextId": "0f99d6c9-2792-4277-a00f-ef07c4ab6b27",
    "final": false,
    "kind": "status-update",
    "status": {
      "message": {
        "contextId": "0f99d6c9-2792-4277-a00f-ef07c4ab6b27",
        "kind": "message",
        "messageId": "d10e403e-d103-449f-9a4e-e2e02a7585c0",
        "parts": [
          {
            "kind": "text",
            "text": " conversions."
          }
        ],
        "role": "agent",
        "taskId": "48d715cf-c11e-4c03-90da-22be14bc6e05"
      },
      "state": "working",
      "timestamp": "2025-07-07T15:48:36.118118+00:00"
    },
    "taskId": "48d715cf-c11e-4c03-90da-22be14bc6e05"
  }
}
{
  "id": "dceae647-c661-4203-a99b-1ce2b28f8804",
  "jsonrpc": "2.0",
  "result": {
    "artifact": {
      "artifactId": "9823991a-ae14-41e5-a3bb-d51b3a2d35dc",
      "name": "agent_response",
      "parts": [
        {
          "kind": "text",
          "text": "As of the current exchange rate, 10 USD (United States Dollars) is approximately equivalent to 821.50 INR (Indian Rupees).\n\nThe exact conversion rate can vary slightly depending on the source and the time of the conversion, but the current approximate conversion rate is:\n\n1 USD \u2248 82.15 INR\n\nTherefore, 10 USD \u2248 10 \u00d7 82.15 INR \u2248 821.50 INR.\n\nIt's worth noting that exchange rates can fluctuate over time, so the exact conversion value may change. It's always a good idea to check the current exchange rate when making currency conversions."
        }
      ]
    },
    "contextId": "0f99d6c9-2792-4277-a00f-ef07c4ab6b27",
    "kind": "artifact-update",
    "taskId": "48d715cf-c11e-4c03-90da-22be14bc6e05"
  }
}
{
  "id": "dceae647-c661-4203-a99b-1ce2b28f8804",
  "jsonrpc": "2.0",
  "result": {
    "contextId": "0f99d6c9-2792-4277-a00f-ef07c4ab6b27",
    "final": true,
    "kind": "status-update",
    "status": {
      "state": "completed",
      "timestamp": "2025-07-07T15:48:36.173200+00:00"
    },
    "taskId": "48d715cf-c11e-4c03-90da-22be14bc6e05"
  }
}

```

`A2A client script in streaming mode` 
> Modify the script above and replace the sync request with the following streaming request

```python

request = SendStreamingMessageRequest(id=str(uuid4()), params=MessageSendParams(**send_message_payload))
async for event in client.send_message_streaming(request):
    print(json.dumps(event.model_dump(mode="json", exclude_none=True), indent=2))
```

Sample output
```json
{
  "id": "2af88a6a-82a7-41a7-95b7-f8817da38bc9",
  "jsonrpc": "2.0",
  "result": {
    "artifacts": [
      {
        "artifactId": "db6f9fbf-afb4-4e97-a782-28c659d5b6e2",
        "name": "agent_response",
        "parts": [
          {
            "kind": "text",
            "text": "Okay, let me re-check the current exchange rate and provide you with the updated conversion of 10 USD to INR.\n\nAs of today's exchange rate, 10 USD is equivalent to approximately 830 INR.\n\nThe current exchange rate is approximately 1 USD = 83 INR.\n\nSo, to calculate 10 USD in INR:\n10 USD x 83 INR/USD = 830 INR\n\nTherefore, 10 USD is equal to approximately 830 Indian Rupees (INR) at the current exchange rate.\n\nPlease note that currency exchange rates fluctuate regularly, so it's always a good idea to check the latest rate when making currency conversions."
          }
        ]
      }
    ],
    "contextId": "e8d7ef9e-ccb9-4224-bbb0-aa21585d6803",
    "history": [
      {
        "contextId": "e8d7ef9e-ccb9-4224-bbb0-aa21585d6803",
        "kind": "message",
        "messageId": "6306e0b7dc3d41af8c5d1dbef56bc0ad",
        "parts": [
          {
            "kind": "text",
            "text": "how much is 10 USD in INR?"
          }
        ],
        "role": "user",
        "taskId": "ce2e498b-365f-48c3-9b32-1a52c71cce65"
      }
    ],
    "id": "ce2e498b-365f-48c3-9b32-1a52c71cce65",
    "kind": "task",
    "status": {
      "state": "completed",
      "timestamp": "2025-07-07T15:46:44.430558+00:00"
    }
  }
}
```


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
