### PR TITLE
models - openai - do not accept b64 images

### DIFF
--- a/src/strands/types/models/openai.py
+++ b/src/strands/types/models/openai.py
@@ -34,32 +34,6 @@ class OpenAIModel(Model, abc.ABC):
 
     config: dict[str, Any]
 
-    @staticmethod
-    def b64encode(data: bytes) -> bytes:
-        """Base64 encode the provided data.
-
-        If the data is already base64 encoded, we do nothing.
-        Note, this is a temporary method used to provide a warning to users who pass in base64 encoded data. In future
-        versions, images and documents will be base64 encoded on behalf of customers for consistency with the other
-        providers and general convenience.
-
-        Args:
-            data: Data to encode.
-
-        Returns:
-            Base64 encoded data.
-        """
-        try:
-            base64.b64decode(data, validate=True)
-            logger.warning(
-                "issue=<%s> | base64 encoded images and documents will not be accepted in future versions",
-                "https://github.com/strands-agents/sdk-python/issues/252",
-            )
-        except ValueError:
-            data = base64.b64encode(data)
-
-        return data
-
     @classmethod
     def format_request_message_content(cls, content: ContentBlock) -> dict[str, Any]:
         """Format an OpenAI compatible content block.
@@ -86,7 +60,7 @@ class OpenAIModel(Model, abc.ABC):
 
         if "image" in content:
             mime_type = mimetypes.types_map.get(f".{content['image']['format']}", "application/octet-stream")
-            image_data = OpenAIModel.b64encode(content["image"]["source"]["bytes"]).decode("utf-8")
+            image_data = base64.b64encode(content["image"]["source"]["bytes"]).decode("utf-8")
 
             return {
                 "image_url": {

--- a/tests/strands/types/models/test_openai.py
+++ b/tests/strands/types/models/test_openai.py
@@ -1,4 +1,3 @@
-import base64
 import unittest.mock
 
 import pytest
@@ -85,23 +84,6 @@ def system_prompt():
                 "image": {
                     "format": "jpg",
                     "source": {"bytes": b"image"},
-                },
-            },
-            {
-                "image_url": {
-                    "detail": "auto",
-                    "format": "image/jpeg",
-                    "url": "data:image/jpeg;base64,aW1hZ2U=",
-                },
-                "type": "image_url",
-            },
-        ),
-        # Image - base64 encoded
-        (
-            {
-                "image": {
-                    "format": "jpg",
-                    "source": {"bytes": base64.b64encode(b"image")},
                 },
             },
             {
@@ -367,15 +349,3 @@ def test_format_chunk_unknown_type(model):
 
     with pytest.raises(RuntimeError, match="chunk_type=<unknown> | unknown type"):
         model.format_chunk(event)
-
-
-@pytest.mark.parametrize(
-    ("data", "exp_result"),
-    [
-        (b"image", b"aW1hZ2U="),
-        (b"aW1hZ2U=", b"aW1hZ2U="),
-    ],
-)
-def test_b64encode(data, exp_result):
-    tru_result = SAOpenAIModel.b64encode(data)
-    assert tru_result == exp_result


### PR DESCRIPTION
## Description
Following up on https://github.com/strands-agents/sdk-python/pull/251 to stop accepting base64 encoded images in the OpenAI model provider. For more details, see https://github.com/strands-agents/sdk-python/issues/252.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/252

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change: This is intentional and was preceded by a log warning to users.
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
