### PR TITLE
agent tool - remove invoke

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -265,7 +265,7 @@ def run_tool(agent: "Agent", tool_use: ToolUse, kwargs: dict[str, Any]) -> ToolG
         kwargs: Additional keyword arguments passed to the tool.
 
     Yields:
-        Events of the tool invocation.
+        Events of the tool stream.
 
     Returns:
         The final tool result or an error response if the tool fails or is not found.

--- a/src/strands/handlers/__init__.py
+++ b/src/strands/handlers/__init__.py
@@ -2,7 +2,6 @@
 
 Examples include:
 
-- Processing tool invocations
 - Displaying events from the event stream
 """
 

--- a/src/strands/tools/decorator.py
+++ b/src/strands/tools/decorator.py
@@ -342,21 +342,6 @@ class DecoratedFunctionTool(AgentTool, Generic[P, R]):
         Returns:
             The result of the original function call.
         """
-        if (
-            len(args) > 0
-            and isinstance(args[0], dict)
-            and (not args[0] or "toolUseId" in args[0] or "input" in args[0])
-        ):
-            # This block is only for backwards compatability so we cast as any for now
-            logger.warning(
-                "issue=<%s> | "
-                "passing tool use into a function instead of using .invoke will be removed in a future release",
-                "https://github.com/strands-agents/sdk-python/pull/258",
-            )
-            tool_use = cast(Any, args[0])
-
-            return cast(R, self.invoke(tool_use, **kwargs))
-
         return self._tool_func(*args, **kwargs)
 
     @property

--- a/src/strands/types/tools.py
+++ b/src/strands/types/tools.py
@@ -6,7 +6,7 @@ These types are modeled after the Bedrock API.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Generator, Literal, Protocol, Union, cast
+from typing import Any, Callable, Generator, Literal, Protocol, Union
 
 from typing_extensions import TypedDict
 
@@ -172,7 +172,7 @@ class AgentTool(ABC):
     """Abstract base class for all SDK tools.
 
     This class defines the interface that all tool implementations must follow. Each tool must provide its name,
-    specification, and implement an invoke method that executes the tool's functionality.
+    specification, and implement a stream method that executes the tool's functionality.
     """
 
     _is_dynamic: bool
@@ -213,25 +213,6 @@ class AgentTool(ABC):
             False by default.
         """
         return False
-
-    def invoke(self, tool_use: ToolUse, *args: Any, **kwargs: dict[str, Any]) -> ToolResult:
-        """Execute the tool's functionality with the given tool use request.
-
-        Args:
-            tool_use: The tool use request containing tool ID and parameters.
-            *args: Positional arguments to pass to the tool.
-            **kwargs: Keyword arguments to pass to the tool.
-
-        Returns:
-            The result of the tool execution.
-        """
-        events = self.stream(tool_use, *args, **kwargs)
-
-        try:
-            while True:
-                next(events)
-        except StopIteration as stop:
-            return cast(ToolResult, stop.value)
 
     @abstractmethod
     # pragma: no cover

--- a/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -57,18 +57,6 @@ def test_tool_spec_without_description(mock_mcp_tool, mock_mcp_client):
     assert tool_spec["description"] == "Tool which performs test_tool"
 
 
-def test_invoke(mcp_agent_tool, mock_mcp_client):
-    tool_use = {"toolUseId": "test-123", "name": "test_tool", "input": {"param": "value"}}
-
-    tru_result = mcp_agent_tool.invoke(tool_use)
-    exp_result = mock_mcp_client.call_tool_sync.return_value
-    assert tru_result == exp_result
-
-    mock_mcp_client.call_tool_sync.assert_called_once_with(
-        tool_use_id="test-123", name="test_tool", arguments={"param": "value"}
-    )
-
-
 def test_stream(mcp_agent_tool, mock_mcp_client, generate):
     tool_use = {"toolUseId": "test-123", "name": "test_tool", "input": {"param": "value"}}
 

--- a/tests/strands/tools/test_tools.py
+++ b/tests/strands/tools/test_tools.py
@@ -488,14 +488,6 @@ def test_get_display_properties(identity_tool):
     assert tru_properties == exp_properties
 
 
-@pytest.mark.parametrize("identity_tool", ["identity_invoke", "identity_stream"], indirect=True)
-def test_invoke(identity_tool):
-    tru_result = identity_tool.invoke({"tool_use": 1}, a=2)
-    exp_result = ({"tool_use": 1}, 2)
-
-    assert tru_result == exp_result
-
-
 @pytest.mark.parametrize(
     ("identity_tool", "exp_events"),
     [


### PR DESCRIPTION
## Description
For tool invocations, the agent class operates on `AgentTool` instances. Currently, an `AgentTool` can implement both an `invoke` and `stream` method. For consistency of pattern, we are only going to support the `stream` method going forward. This will match more closely to the model providers where we can stream events of the invocation.

Note, Python decorated and module based tools still support calling non-generator functions in their `stream` methods. In these cases, we just return the tool result and yield no events from `stream`.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/83

## Documentation PR

Will follow up on documentation for customers that want to derive their own `AgentTool` classes. This will fold into https://github.com/strands-agents/docs/issues/110.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
