### PR TITLE
models - ollama - async

### DIFF
--- a/src/strands/models/ollama.py
+++ b/src/strands/models/ollama.py
@@ -7,7 +7,7 @@ import json
 import logging
 from typing import Any, AsyncGenerator, Optional, Type, TypeVar, Union, cast
 
-from ollama import Client as OllamaClient
+import ollama
 from pydantic import BaseModel
 from typing_extensions import TypedDict, Unpack, override
 
@@ -74,7 +74,7 @@ class OllamaModel(Model):
 
         ollama_client_args = ollama_client_args if ollama_client_args is not None else {}
 
-        self.client = OllamaClient(host, **ollama_client_args)
+        self.client = ollama.AsyncClient(host, **ollama_client_args)
 
     @override
     def update_config(self, **model_config: Unpack[OllamaConfig]) -> None:  # type: ignore
@@ -296,12 +296,12 @@ class OllamaModel(Model):
         """
         tool_requested = False
 
-        response = self.client.chat(**request)
+        response = await self.client.chat(**request)
 
         yield {"chunk_type": "message_start"}
         yield {"chunk_type": "content_start", "data_type": "text"}
 
-        for event in response:
+        async for event in response:
             for tool_call in event.message.tool_calls or []:
                 yield {"chunk_type": "content_start", "data_type": "tool", "data": tool_call}
                 yield {"chunk_type": "content_delta", "data_type": "tool", "data": tool_call}
@@ -330,7 +330,7 @@ class OllamaModel(Model):
         formatted_request = self.format_request(messages=prompt)
         formatted_request["format"] = output_model.model_json_schema()
         formatted_request["stream"] = False
-        response = self.client.chat(**formatted_request)
+        response = await self.client.chat(**formatted_request)
 
         try:
             content = response.message.content.strip()

--- a/tests-integ/test_model_ollama.py
+++ b/tests-integ/test_model_ollama.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 from pydantic import BaseModel
 
+import strands
 from strands import Agent
 from strands.models.ollama import OllamaModel
 
@@ -13,35 +14,80 @@ def is_server_available() -> bool:
         return False
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def model():
     return OllamaModel(host="http://localhost:11434", model_id="llama3.3:70b")
 
 
-@pytest.fixture
-def agent(model):
-    return Agent(model=model)
+@pytest.fixture(scope="module")
+def tools():
+    @strands.tool
+    def tool_time() -> str:
+        return "12:00"
+
+    @strands.tool
+    def tool_weather() -> str:
+        return "sunny"
+
+    return [tool_time, tool_weather]
 
 
-@pytest.mark.skipif(not is_server_available(), reason="Local Ollama endpoint not available at localhost:11434")
-def test_agent(agent):
-    result = agent("Say 'hello world' with no other text")
-    assert isinstance(result.message["content"][0]["text"], str)
+@pytest.fixture(scope="module")
+def agent(model, tools):
+    return Agent(model=model, tools=tools)
 
 
-@pytest.mark.skipif(not is_server_available(), reason="Local Ollama endpoint not available at localhost:11434")
-def test_structured_output(agent):
+@pytest.fixture(scope="module")
+def weather():
     class Weather(BaseModel):
-        """Extract the time and weather.
-
-        Time format: HH:MM
-        Weather: sunny, cloudy, rainy, etc.
-        """
+        """Extracts the time and weather from the user's message with the exact strings."""
 
         time: str
         weather: str
 
-    result = agent.structured_output(Weather, "The time is 12:00 and the weather is sunny")
-    assert isinstance(result, Weather)
-    assert result.time == "12:00"
-    assert result.weather == "sunny"
+    return Weather(time="12:00", weather="sunny")
+
+
+@pytest.mark.skipif(not is_server_available(), reason="Local Ollama endpoint not available at localhost:11434")
+def test_agent_invoke(agent):
+    result = agent("What is the time and weather in New York?")
+    text = result.message["content"][0]["text"].lower()
+
+    assert all(string in text for string in ["12:00", "sunny"])
+
+
+@pytest.mark.skipif(not is_server_available(), reason="Local Ollama endpoint not available at localhost:11434")
+@pytest.mark.asyncio
+async def test_agent_invoke_async(agent):
+    result = await agent.invoke_async("What is the time and weather in New York?")
+    text = result.message["content"][0]["text"].lower()
+
+    assert all(string in text for string in ["12:00", "sunny"])
+
+
+@pytest.mark.skipif(not is_server_available(), reason="Local Ollama endpoint not available at localhost:11434")
+@pytest.mark.asyncio
+async def test_agent_stream_async(agent):
+    stream = agent.stream_async("What is the time and weather in New York?")
+    async for event in stream:
+        _ = event
+
+    result = event["result"]
+    text = result.message["content"][0]["text"].lower()
+
+    assert all(string in text for string in ["12:00", "sunny"])
+
+
+@pytest.mark.skipif(not is_server_available(), reason="Local Ollama endpoint not available at localhost:11434")
+def test_agent_structured_output(agent, weather):
+    tru_weather = agent.structured_output(type(weather), "The time is 12:00 and the weather is sunny")
+    exp_weather = weather
+    assert tru_weather == exp_weather
+
+
+@pytest.mark.skipif(not is_server_available(), reason="Local Ollama endpoint not available at localhost:11434")
+@pytest.mark.asyncio
+async def test_agent_structured_output_async(agent, weather):
+    tru_weather = await agent.structured_output_async(type(weather), "The time is 12:00 and the weather is sunny")
+    exp_weather = weather
+    assert tru_weather == exp_weather

--- a/tests/strands/models/test_ollama.py
+++ b/tests/strands/models/test_ollama.py
@@ -11,7 +11,7 @@ from strands.types.content import Messages
 
 @pytest.fixture
 def ollama_client():
-    with unittest.mock.patch.object(strands.models.ollama, "OllamaClient") as mock_client_cls:
+    with unittest.mock.patch.object(strands.models.ollama.ollama, "AsyncClient") as mock_client_cls:
         yield mock_client_cls.return_value
 
 
@@ -416,13 +416,13 @@ def test_format_chunk_other(model):
 
 
 @pytest.mark.asyncio
-async def test_stream(ollama_client, model, alist):
+async def test_stream(ollama_client, model, agenerator, alist):
     mock_event = unittest.mock.Mock()
     mock_event.message.tool_calls = None
     mock_event.message.content = "Hello"
     mock_event.done_reason = "stop"
 
-    ollama_client.chat.return_value = [mock_event]
+    ollama_client.chat = unittest.mock.AsyncMock(return_value=agenerator([mock_event]))
 
     request = {"model": "m1", "messages": [{"role": "user", "content": "Hello"}]}
     response = model.stream(request)
@@ -442,14 +442,14 @@ async def test_stream(ollama_client, model, alist):
 
 
 @pytest.mark.asyncio
-async def test_stream_with_tool_calls(ollama_client, model, alist):
+async def test_stream_with_tool_calls(ollama_client, model, agenerator, alist):
     mock_event = unittest.mock.Mock()
     mock_tool_call = unittest.mock.Mock()
     mock_event.message.tool_calls = [mock_tool_call]
     mock_event.message.content = "I'll calculate that for you"
     mock_event.done_reason = "stop"
 
-    ollama_client.chat.return_value = [mock_event]
+    ollama_client.chat = unittest.mock.AsyncMock(return_value=agenerator([mock_event]))
 
     request = {"model": "m1", "messages": [{"role": "user", "content": "Calculate 2+2"}]}
     response = model.stream(request)
@@ -478,7 +478,7 @@ async def test_structured_output(ollama_client, model, test_output_model_cls, al
     mock_response = unittest.mock.Mock()
     mock_response.message.content = '{"name": "John", "age": 30}'
 
-    ollama_client.chat.return_value = mock_response
+    ollama_client.chat = unittest.mock.AsyncMock(return_value=mock_response)
 
     stream = model.structured_output(test_output_model_cls, messages)
     events = await alist(stream)


### PR DESCRIPTION
## Description
Use the `ollama.AsyncClient`.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/83

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Wrote new integ tests.
- [x] Ran the following test script:

```Python
model = OllamaModel(host="http://localhost:11434", model_id="mistral-nemo")
agent = Agent(model=model, callback_handler=None)

prompt = "What is 2+2? Think through the steps."


async def func_a():
    result = await agent.invoke_async(prompt)
    print(f"FUNC_A: {result.message}")


async def func_b():
    result = await agent.invoke_async(prompt)
    print(f"FUNC_B: {result.message}")


async def func_c():
    result = await agent.invoke_async(prompt)
    print(f"FUNC_C: {result.message}")


async def func_d():
    result = await agent.invoke_async(prompt)
    print(f"FUNC_D: {result.message}")


async def main():
    await asyncio.gather(func_a(), func_b(), func_c(), func_d())


asyncio.run(main())
```

Using the sync Ollama Python client, every function ran sequentially and the total run time averaged 1m 30s. Using the Async Python client, every function ran concurrently and the total run time averaged 40s.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
