### PR TITLE
docs(multiagent): Update A2AServer docstrings

### DIFF
--- a/src/strands/multiagent/a2a/server.py
+++ b/src/strands/multiagent/a2a/server.py
@@ -34,12 +34,10 @@ class A2AServer:
         version: str = "0.0.1",
         skills: list[AgentSkill] | None = None,
     ):
-        """Initialize an A2A-compatible agent from a Strands agent.
+        """Initialize an A2A-compatible server from a Strands agent.
 
         Args:
             agent: The Strands Agent to wrap with A2A compatibility.
-            name: The name of the agent, used in the AgentCard.
-            description: A description of the agent's capabilities, used in the AgentCard.
             host: The hostname or IP address to bind the A2A server to. Defaults to "0.0.0.0".
             port: The port to bind the A2A server to. Defaults to 9000.
             version: The version of the agent. Defaults to "0.0.1".


### PR DESCRIPTION
## Description
Updated `A2AServer` __init__ docstrings to reflect changes to class name and parameters
- Changed 'A2A-compatible agent' to 'A2A-compatible server'
- Removed 'name' and 'description'

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
