### PR TITLE
fix: handle multiple tool calls in Mistral streaming responses

### DIFF
--- a/tests-integ/test_model_mistral.py
+++ b/tests-integ/test_model_mistral.py
@@ -78,41 +78,32 @@ def weather():
 
 @pytest.mark.skipif("MISTRAL_API_KEY" not in os.environ, reason="MISTRAL_API_KEY environment variable missing")
 def test_agent_invoke(agent):
-    # TODO: https://github.com/strands-agents/sdk-python/issues/374
-    # result = streaming_agent("What is the time and weather in New York?")
-    result = agent("What is the time in New York?")
+    result = agent("What is the time and weather in New York?")
     text = result.message["content"][0]["text"].lower()
 
-    # assert all(string in text for string in ["12:00", "sunny"])
-    assert all(string in text for string in ["12:00"])
+    assert all(string in text for string in ["12:00", "sunny"])
 
 
 @pytest.mark.skipif("MISTRAL_API_KEY" not in os.environ, reason="MISTRAL_API_KEY environment variable missing")
 @pytest.mark.asyncio
 async def test_agent_invoke_async(agent):
-    # TODO: https://github.com/strands-agents/sdk-python/issues/374
-    # result = await streaming_agent.invoke_async("What is the time and weather in New York?")
-    result = await agent.invoke_async("What is the time in New York?")
+    result = await agent.invoke_async("What is the time and weather in New York?")
     text = result.message["content"][0]["text"].lower()
 
-    # assert all(string in text for string in ["12:00", "sunny"])
-    assert all(string in text for string in ["12:00"])
+    assert all(string in text for string in ["12:00", "sunny"])
 
 
 @pytest.mark.skipif("MISTRAL_API_KEY" not in os.environ, reason="MISTRAL_API_KEY environment variable missing")
 @pytest.mark.asyncio
 async def test_agent_stream_async(agent):
-    # TODO: https://github.com/strands-agents/sdk-python/issues/374
-    # stream = streaming_agent.stream_async("What is the time and weather in New York?")
-    stream = agent.stream_async("What is the time in New York?")
+    stream = agent.stream_async("What is the time and weather in New York?")
     async for event in stream:
         _ = event
 
     result = event["result"]
     text = result.message["content"][0]["text"].lower()
 
-    # assert all(string in text for string in ["12:00", "sunny"])
-    assert all(string in text for string in ["12:00"])
+    assert all(string in text for string in ["12:00", "sunny"])
 
 
 @pytest.mark.skipif("MISTRAL_API_KEY" not in os.environ, reason="MISTRAL_API_KEY environment variable missing")


### PR DESCRIPTION
## Description
This PR fixes a bug in the Mistral agentic implementation where only 1 tool call was reported to the agent instead of streaming multiple tool calls. The issue occurred because tool events were being processed immediately as received, but Mistral streams them out of order with all stop events reported together at the end. The fix accumulates tool call deltas and processes them in the correct sequence after stream completion, allowing Mistral to successfully stream multiple tool calls at once.

## Related Issues
https://github.com/strands-agents/sdk-python/issues/374

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

**Note**

- I tested with running `hatch test` and also ran `hatch test tests-integ/test_model_mistral.py`, both passed succesfully.
- However, while running `hatch run test-integ`, it's **failing** even with Mistral. But as the above `hatch test tests-integ/test_model_mistral.py` passed, I have created the PR

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
