### PR TITLE
Add hooks for when new messages are appended to the agent's messages

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -14,6 +14,7 @@ import uuid
 from typing import TYPE_CHECKING, Any, AsyncGenerator, cast
 
 from ..experimental.hooks import AfterToolInvocationEvent, BeforeToolInvocationEvent
+from ..experimental.hooks.events import MessageAddedEvent
 from ..experimental.hooks.registry import get_registry
 from ..telemetry.metrics import Trace
 from ..telemetry.tracer import get_tracer
@@ -166,6 +167,7 @@ async def event_loop_cycle(agent: "Agent", kwargs: dict[str, Any]) -> AsyncGener
 
         # Add the response message to the conversation
         agent.messages.append(message)
+        get_registry(agent).invoke_callbacks(MessageAddedEvent(agent=agent, message=message))
         yield {"callback": {"message": message}}
 
         # Update metrics
@@ -431,6 +433,7 @@ async def _handle_tool_execution(
     }
 
     agent.messages.append(tool_result_message)
+    get_registry(agent).invoke_callbacks(MessageAddedEvent(agent=agent, message=tool_result_message))
     yield {"callback": {"message": tool_result_message}}
 
     if cycle_span:

--- a/src/strands/experimental/hooks/__init__.py
+++ b/src/strands/experimental/hooks/__init__.py
@@ -34,9 +34,10 @@ from .events import (
     AgentInitializedEvent,
     BeforeToolInvocationEvent,
     EndRequestEvent,
+    MessageAddedEvent,
     StartRequestEvent,
 )
-from .registry import HookCallback, HookEvent, HookProvider, HookRegistry
+from .registry import HookCallback, HookEvent, HookProvider, HookRegistry, get_registry
 
 __all__ = [
     "AgentInitializedEvent",
@@ -44,8 +45,10 @@ __all__ = [
     "EndRequestEvent",
     "BeforeToolInvocationEvent",
     "AfterToolInvocationEvent",
+    "MessageAddedEvent",
     "HookEvent",
     "HookProvider",
     "HookCallback",
     "HookRegistry",
+    "get_registry",
 ]

--- a/src/strands/experimental/hooks/events.py
+++ b/src/strands/experimental/hooks/events.py
@@ -6,6 +6,7 @@ This module defines the events that are emitted as Agents run through the lifecy
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from ...types.content import Message
 from ...types.tools import AgentTool, ToolResult, ToolUse
 from .registry import HookEvent
 
@@ -118,3 +119,22 @@ class AfterToolInvocationEvent(HookEvent):
     def should_reverse_callbacks(self) -> bool:
         """True to invoke callbacks in reverse order."""
         return True
+
+
+@dataclass
+class MessageAddedEvent(HookEvent):
+    """Event triggered when a message is added to the agent's conversation.
+
+    This event is fired whenever the agent adds a new message to its internal
+    message history, including user messages, assistant responses, and tool
+    results. Hook providers can use this event for logging, monitoring, or
+    implementing custom message processing logic.
+
+    Note: This event is only triggered for messages added by the framework
+    itself, not for messages manually added by tools or external code.
+
+    Attributes:
+        message: The message that was added to the conversation history.
+    """
+
+    message: Message

--- a/tests/strands/agent/test_agent_hooks.py
+++ b/tests/strands/agent/test_agent_hooks.py
@@ -10,9 +10,12 @@ from strands.experimental.hooks import (
     AgentInitializedEvent,
     BeforeToolInvocationEvent,
     EndRequestEvent,
+    MessageAddedEvent,
     StartRequestEvent,
+    get_registry,
 )
 from strands.types.content import Messages
+from strands.types.tools import ToolResult, ToolUse
 from tests.fixtures.mock_hook_provider import MockHookProvider
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
@@ -20,7 +23,14 @@ from tests.fixtures.mocked_model_provider import MockedModelProvider
 @pytest.fixture
 def hook_provider():
     return MockHookProvider(
-        [AgentInitializedEvent, StartRequestEvent, EndRequestEvent, AfterToolInvocationEvent, BeforeToolInvocationEvent]
+        [
+            AgentInitializedEvent,
+            StartRequestEvent,
+            EndRequestEvent,
+            AfterToolInvocationEvent,
+            BeforeToolInvocationEvent,
+            MessageAddedEvent,
+        ]
     )
 
 
@@ -63,8 +73,13 @@ def agent(
         tools=[agent_tool],
     )
 
-    # for now, hooks are private
-    agent._hooks.add_hook(hook_provider)
+    hooks = get_registry(agent)
+    hooks.add_hook(hook_provider)
+
+    def assert_message_is_last_message_added(event: MessageAddedEvent):
+        assert event.agent.messages[-1] == event.message
+
+    hooks.add_callback(MessageAddedEvent, assert_message_is_last_message_added)
 
     return agent
 
@@ -88,6 +103,34 @@ def test_agent__init__hooks(mock_invoke_callbacks):
     assert mock_invoke_callbacks.call_args == call(AgentInitializedEvent(agent=agent))
 
 
+def test_agent_tool_call(agent, hook_provider, agent_tool):
+    agent.tool.tool_decorated(random_string="a string")
+
+    length, events = hook_provider.get_events()
+
+    tool_use: ToolUse = {"input": {"random_string": "a string"}, "name": "tool_decorated", "toolUseId": ANY}
+    result: ToolResult = {"content": [{"text": "gnirts a"}], "status": "success", "toolUseId": ANY}
+
+    assert length == 6
+
+    assert next(events) == BeforeToolInvocationEvent(
+        agent=agent, selected_tool=agent_tool, tool_use=tool_use, kwargs=ANY
+    )
+    assert next(events) == AfterToolInvocationEvent(
+        agent=agent,
+        selected_tool=agent_tool,
+        tool_use=tool_use,
+        kwargs=ANY,
+        result=result,
+    )
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[0])
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[1])
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[2])
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[3])
+
+    assert len(agent.messages) == 4
+
+
 def test_agent__call__hooks(agent, hook_provider, agent_tool, tool_use):
     """Verify that the correct hook events are emitted as part of __call__."""
 
@@ -95,8 +138,14 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, tool_use):
 
     length, events = hook_provider.get_events()
 
-    assert length == 4
+    assert length == 8
+
     assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == MessageAddedEvent(
+        agent=agent,
+        message=agent.messages[0],
+    )
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[1])
     assert next(events) == BeforeToolInvocationEvent(
         agent=agent, selected_tool=agent_tool, tool_use=tool_use, kwargs=ANY
     )
@@ -107,7 +156,11 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, tool_use):
         kwargs=ANY,
         result={"content": [{"text": "!loot a dekovni I"}], "status": "success", "toolUseId": "123"},
     )
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[2])
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[3])
     assert next(events) == EndRequestEvent(agent=agent)
+
+    assert len(agent.messages) == 4
 
 
 @pytest.mark.asyncio
@@ -123,9 +176,14 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, tool_u
 
     length, events = hook_provider.get_events()
 
-    assert length == 4
+    assert length == 8
 
     assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == MessageAddedEvent(
+        agent=agent,
+        message=agent.messages[0],
+    )
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[1])
     assert next(events) == BeforeToolInvocationEvent(
         agent=agent, selected_tool=agent_tool, tool_use=tool_use, kwargs=ANY
     )
@@ -136,7 +194,11 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, tool_u
         kwargs=ANY,
         result={"content": [{"text": "!loot a dekovni I"}], "status": "success", "toolUseId": "123"},
     )
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[2])
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[3])
     assert next(events) == EndRequestEvent(agent=agent)
+
+    assert len(agent.messages) == 4
 
 
 def test_agent_structured_output_hooks(agent, hook_provider, user, agenerator):
@@ -145,7 +207,15 @@ def test_agent_structured_output_hooks(agent, hook_provider, user, agenerator):
     agent.model.structured_output = Mock(return_value=agenerator([{"output": user}]))
     agent.structured_output(type(user), "example prompt")
 
-    assert hook_provider.events_received == [StartRequestEvent(agent=agent), EndRequestEvent(agent=agent)]
+    length, events = hook_provider.get_events()
+
+    assert length == 3
+
+    assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[0])
+    assert next(events) == EndRequestEvent(agent=agent)
+
+    assert len(agent.messages) == 1
 
 
 @pytest.mark.asyncio
@@ -155,4 +225,12 @@ async def test_agent_structured_async_output_hooks(agent, hook_provider, user, a
     agent.model.structured_output = Mock(return_value=agenerator([{"output": user}]))
     await agent.structured_output_async(type(user), "example prompt")
 
-    assert hook_provider.events_received == [StartRequestEvent(agent=agent), EndRequestEvent(agent=agent)]
+    length, events = hook_provider.get_events()
+
+    assert length == 3
+
+    assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[0])
+    assert next(events) == EndRequestEvent(agent=agent)
+
+    assert len(agent.messages) == 1


### PR DESCRIPTION


## Description

Add a hook for whenever new messages are appended to the agent's messages

This unblocks session management use-cases

## Related Issues

#231

## Documentation PR

N/A for now

## Type of Change


New feature
## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
