### PR TITLE
Add Model Invocation Hooks

### DIFF
--- a/src/strands/experimental/hooks/__init__.py
+++ b/src/strands/experimental/hooks/__init__.py
@@ -30,8 +30,10 @@ type-safe system that supports multiple subscribers per event type.
 """
 
 from .events import (
+    AfterModelInvocationEvent,
     AfterToolInvocationEvent,
     AgentInitializedEvent,
+    BeforeModelInvocationEvent,
     BeforeToolInvocationEvent,
     EndRequestEvent,
     MessageAddedEvent,
@@ -43,6 +45,8 @@ __all__ = [
     "AgentInitializedEvent",
     "StartRequestEvent",
     "EndRequestEvent",
+    "BeforeModelInvocationEvent",
+    "AfterModelInvocationEvent",
     "BeforeToolInvocationEvent",
     "AfterToolInvocationEvent",
     "MessageAddedEvent",

--- a/src/strands/experimental/hooks/rules.md
+++ b/src/strands/experimental/hooks/rules.md
@@ -1,0 +1,20 @@
+# Hook System Rules
+
+## Terminology
+
+- **Paired events**: Events that denote the beginning and end of an operation
+- **Hook callback**: A function that receives a strongly-typed event argument and performs some action in response
+
+## Naming Conventions
+
+- All hook events have a suffix of `Event`
+- Paired events follow the naming convention of `Before{Item}Event` and `After{Item}Event`
+
+## Paired Events
+
+- The final event in a pair returns `True` for `should_reverse_callbacks`
+- For every `Before` event there is a corresponding `After` event, even if an exception occurs
+
+## Writable Properties
+
+For events with writable properties, those values are re-read after invoking the hook callbacks and used in subsequent processing. For example, `BeforeToolInvocationEvent.selected_tool` is writable - after invoking the callback for `BeforeToolInvocationEvent`, the `selected_tool` takes effect for the tool call.

--- a/tests/strands/agent/test_agent_hooks.py
+++ b/tests/strands/agent/test_agent_hooks.py
@@ -6,8 +6,10 @@ from pydantic import BaseModel
 import strands
 from strands import Agent
 from strands.experimental.hooks import (
+    AfterModelInvocationEvent,
     AfterToolInvocationEvent,
     AgentInitializedEvent,
+    BeforeModelInvocationEvent,
     BeforeToolInvocationEvent,
     EndRequestEvent,
     MessageAddedEvent,
@@ -29,6 +31,8 @@ def hook_provider():
             EndRequestEvent,
             AfterToolInvocationEvent,
             BeforeToolInvocationEvent,
+            BeforeModelInvocationEvent,
+            AfterModelInvocationEvent,
             MessageAddedEvent,
         ]
     )
@@ -85,6 +89,11 @@ def agent(
 
 
 @pytest.fixture
+def tools_config(agent):
+    return agent.tool_config["tools"]
+
+
+@pytest.fixture
 def user():
     class User(BaseModel):
         name: str
@@ -131,20 +140,33 @@ def test_agent_tool_call(agent, hook_provider, agent_tool):
     assert len(agent.messages) == 4
 
 
-def test_agent__call__hooks(agent, hook_provider, agent_tool, tool_use):
+def test_agent__call__hooks(agent, hook_provider, agent_tool, mock_model, tool_use):
     """Verify that the correct hook events are emitted as part of __call__."""
 
     agent("test message")
 
     length, events = hook_provider.get_events()
 
-    assert length == 8
+    assert length == 12
 
     assert next(events) == StartRequestEvent(agent=agent)
     assert next(events) == MessageAddedEvent(
         agent=agent,
         message=agent.messages[0],
     )
+    assert next(events) == BeforeModelInvocationEvent(agent=agent)
+    assert next(events) == AfterModelInvocationEvent(
+        agent=agent,
+        stop_response=AfterModelInvocationEvent.ModelStopResponse(
+            message={
+                "content": [{"toolUse": tool_use}],
+                "role": "assistant",
+            },
+            stop_reason="tool_use",
+        ),
+        exception=None,
+    )
+
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[1])
     assert next(events) == BeforeToolInvocationEvent(
         agent=agent, selected_tool=agent_tool, tool_use=tool_use, kwargs=ANY
@@ -157,14 +179,24 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, tool_use):
         result={"content": [{"text": "!loot a dekovni I"}], "status": "success", "toolUseId": "123"},
     )
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[2])
+    assert next(events) == BeforeModelInvocationEvent(agent=agent)
+    assert next(events) == AfterModelInvocationEvent(
+        agent=agent,
+        stop_response=AfterModelInvocationEvent.ModelStopResponse(
+            message=mock_model.agent_responses[1],
+            stop_reason="end_turn",
+        ),
+        exception=None,
+    )
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[3])
+
     assert next(events) == EndRequestEvent(agent=agent)
 
     assert len(agent.messages) == 4
 
 
 @pytest.mark.asyncio
-async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, tool_use):
+async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, mock_model, tool_use, agenerator):
     """Verify that the correct hook events are emitted as part of stream_async."""
     iterator = agent.stream_async("test message")
     await anext(iterator)
@@ -176,13 +208,26 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, tool_u
 
     length, events = hook_provider.get_events()
 
-    assert length == 8
+    assert length == 12
 
     assert next(events) == StartRequestEvent(agent=agent)
     assert next(events) == MessageAddedEvent(
         agent=agent,
         message=agent.messages[0],
     )
+    assert next(events) == BeforeModelInvocationEvent(agent=agent)
+    assert next(events) == AfterModelInvocationEvent(
+        agent=agent,
+        stop_response=AfterModelInvocationEvent.ModelStopResponse(
+            message={
+                "content": [{"toolUse": tool_use}],
+                "role": "assistant",
+            },
+            stop_reason="tool_use",
+        ),
+        exception=None,
+    )
+
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[1])
     assert next(events) == BeforeToolInvocationEvent(
         agent=agent, selected_tool=agent_tool, tool_use=tool_use, kwargs=ANY
@@ -195,7 +240,17 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, tool_u
         result={"content": [{"text": "!loot a dekovni I"}], "status": "success", "toolUseId": "123"},
     )
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[2])
+    assert next(events) == BeforeModelInvocationEvent(agent=agent)
+    assert next(events) == AfterModelInvocationEvent(
+        agent=agent,
+        stop_response=AfterModelInvocationEvent.ModelStopResponse(
+            message=mock_model.agent_responses[1],
+            stop_reason="end_turn",
+        ),
+        exception=None,
+    )
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[3])
+
     assert next(events) == EndRequestEvent(agent=agent)
 
     assert len(agent.messages) == 4


### PR DESCRIPTION
## Description

This PR introduces new hook events that allow subscribers to monitor and interact with model invocations during agent execution.  Each call to the model from the event loop will fire these events, even if we're going to retry the request.  In the future I think we could expand the `AfterModelInvocationEvent` to reimplemenet retries and allow customers to specify how the request is retried, but that will require further design.

**Changes:**

- Added `BeforeModelInvocationEvent` and `AfterModelInvocationEvent` to the experimental hooks system
- The `AfterModelInvocationEvent` includes model response data and stop reason information
- Initially I had tool specifications included on the events and modifable in the BeforeEvent.  I decided against this after initial implementation to refine the API design
  - #386 is a closed PR that demonstrates what this looks like
- Note that structured_output calls are not included in these events - because it doesn't have a `stop_data` it didn't make sense to combine the event.  I'm still considering how best to include structured_output calls
- I also simplify the exception logic for the event_loop - condensing all exception handling into a single `except` block.

**Feedback wanted**:

- Naming of the `stop_data` field and dataclass

## Related Issues

#231

## Documentation PR

Todo

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
