### PR TITLE
Remove agent.tool_config and update usages to use tool_specs

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -31,7 +31,7 @@ from ..tools.watcher import ToolWatcher
 from ..types.content import ContentBlock, Message, Messages
 from ..types.exceptions import ContextWindowOverflowException
 from ..types.models import Model
-from ..types.tools import ToolConfig, ToolResult, ToolUse
+from ..types.tools import ToolResult, ToolUse
 from ..types.traces import AttributeValue
 from .agent_result import AgentResult
 from .conversation_manager import (
@@ -334,15 +334,6 @@ class Agent:
         """
         all_tools = self.tool_registry.get_all_tools_config()
         return list(all_tools.keys())
-
-    @property
-    def tool_config(self) -> ToolConfig:
-        """Get the tool configuration for this agent.
-
-        Returns:
-            The complete tool configuration.
-        """
-        return self.tool_registry.initialize_tool_config()
 
     def __del__(self) -> None:
         """Clean up resources when Agent is garbage collected.

--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -19,7 +19,7 @@ from ..types.streaming import (
     StreamEvent,
     Usage,
 )
-from ..types.tools import ToolConfig, ToolUse
+from ..types.tools import ToolSpec, ToolUse
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +304,7 @@ async def stream_messages(
     model: Model,
     system_prompt: Optional[str],
     messages: Messages,
-    tool_config: Optional[ToolConfig],
+    tool_specs: list[ToolSpec],
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Streams messages to the model and processes the response.
 
@@ -312,7 +312,7 @@ async def stream_messages(
         model: Model provider.
         system_prompt: The system prompt to send.
         messages: List of messages to send.
-        tool_config: Configuration for the tools to use.
+        tool_specs: The list of tool specs.
 
     Returns:
         The reason for stopping, the final message, and the usage metrics
@@ -320,8 +320,7 @@ async def stream_messages(
     logger.debug("model=<%s> | streaming messages", model)
 
     messages = remove_blank_messages_content_text(messages)
-    tool_specs = [tool["toolSpec"] for tool in tool_config.get("tools", [])] or None if tool_config else None
 
-    chunks = model.converse(messages, tool_specs, system_prompt)
+    chunks = model.converse(messages, tool_specs if tool_specs else None, system_prompt)
     async for event in process_stream(chunks, messages):
         yield event

--- a/src/strands/tools/registry.py
+++ b/src/strands/tools/registry.py
@@ -17,7 +17,7 @@ from typing_extensions import TypedDict, cast
 
 from strands.tools.decorator import DecoratedFunctionTool
 
-from ..types.tools import AgentTool, Tool, ToolChoice, ToolChoiceAuto, ToolConfig, ToolSpec
+from ..types.tools import AgentTool, ToolSpec
 from .tools import PythonAgentTool, normalize_schema, normalize_tool_spec
 
 logger = logging.getLogger(__name__)
@@ -472,20 +472,15 @@ class ToolRegistry:
             for tool_name, error in tool_import_errors.items():
                 logger.debug("tool_name=<%s> | import error | %s", tool_name, error)
 
-    def initialize_tool_config(self) -> ToolConfig:
-        """Initialize tool configuration from tool handler with optional filtering.
+    def get_all_tool_specs(self) -> list[ToolSpec]:
+        """Get all the tool specs for all tools in this registry..
 
         Returns:
-            Tool config.
+            A list of ToolSpecs.
         """
         all_tools = self.get_all_tools_config()
-
-        tools: List[Tool] = [{"toolSpec": tool_spec} for tool_spec in all_tools.values()]
-
-        return ToolConfig(
-            tools=tools,
-            toolChoice=cast(ToolChoice, {"auto": ToolChoiceAuto()}),
-        )
+        tools: List[ToolSpec] = [tool_spec for tool_spec in all_tools.values()]
+        return tools
 
     def validate_tool_spec(self, tool_spec: ToolSpec) -> None:
         """Validate tool specification against required schema.

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -180,7 +180,7 @@ def test_agent__init__tool_loader_format(tool_decorated, tool_module, tool_impor
 
     agent = Agent(tools=[tool_decorated, tool_module, tool_imported])
 
-    tru_tool_names = sorted(tool_spec["toolSpec"]["name"] for tool_spec in agent.tool_config["tools"])
+    tru_tool_names = sorted(tool_spec["name"] for tool_spec in agent.tool_registry.get_all_tool_specs())
     exp_tool_names = ["tool_decorated", "tool_imported", "tool_module"]
 
     assert tru_tool_names == exp_tool_names
@@ -191,7 +191,7 @@ def test_agent__init__tool_loader_dict(tool_module, tool_registry):
 
     agent = Agent(tools=[{"name": "tool_module", "path": tool_module}])
 
-    tru_tool_names = sorted(tool_spec["toolSpec"]["name"] for tool_spec in agent.tool_config["tools"])
+    tru_tool_names = sorted(tool_spec["name"] for tool_spec in agent.tool_registry.get_all_tool_specs())
     exp_tool_names = ["tool_module"]
 
     assert tru_tool_names == exp_tool_names

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -36,11 +36,6 @@ def messages():
 
 
 @pytest.fixture
-def tool_config():
-    return {"tools": [{"toolSpec": {"name": "tool_for_testing"}}], "toolChoice": {"auto": {}}}
-
-
-@pytest.fixture
 def tool_registry():
     return ToolRegistry()
 
@@ -116,13 +111,12 @@ def hook_provider(hook_registry):
 
 
 @pytest.fixture
-def agent(model, system_prompt, messages, tool_config, tool_registry, thread_pool, hook_registry):
+def agent(model, system_prompt, messages, tool_registry, thread_pool, hook_registry):
     mock = unittest.mock.Mock(name="agent")
     mock.config.cache_points = []
     mock.model = model
     mock.system_prompt = system_prompt
     mock.messages = messages
-    mock.tool_config = tool_config
     mock.tool_registry = tool_registry
     mock.thread_pool = thread_pool
     mock.event_loop_metrics = EventLoopMetrics()
@@ -298,6 +292,7 @@ async def test_event_loop_cycle_tool_result(
     system_prompt,
     messages,
     tool_stream,
+    tool_registry,
     agenerator,
     alist,
 ):
@@ -353,7 +348,7 @@ async def test_event_loop_cycle_tool_result(
             },
             {"role": "assistant", "content": [{"text": "test text"}]},
         ],
-        [{"name": "tool_for_testing"}],
+        tool_registry.get_all_tool_specs(),
         "p1",
     )
 

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -549,7 +549,7 @@ async def test_stream_messages(agenerator, alist):
         mock_model,
         system_prompt="test prompt",
         messages=[{"role": "assistant", "content": [{"text": "a"}, {"text": " \n"}]}],
-        tool_config=None,
+        tool_specs=None,
     )
 
     tru_events = await alist(stream)

--- a/tests/strands/tools/test_registry.py
+++ b/tests/strands/tools/test_registry.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import strands
 from strands.tools import PythonAgentTool
 from strands.tools.decorator import DecoratedFunctionTool, tool
 from strands.tools.registry import ToolRegistry
@@ -44,6 +45,23 @@ def test_register_tool_with_similar_name_raises():
         str(err.value) == "Tool name 'tool_like_this' already exists as 'tool-like-this'. "
         "Cannot add a duplicate tool which differs by a '-' or '_'"
     )
+
+
+def test_get_all_tool_specs_returns_right_tool_specs():
+    tool_1 = strands.tool(lambda a: a, name="tool_1")
+    tool_2 = strands.tool(lambda b: b, name="tool_2")
+
+    tool_registry = ToolRegistry()
+
+    tool_registry.register_tool(tool_1)
+    tool_registry.register_tool(tool_2)
+
+    tool_specs = tool_registry.get_all_tool_specs()
+
+    assert tool_specs == [
+        tool_1.tool_spec,
+        tool_2.tool_spec,
+    ]
 
 
 def test_scan_module_for_tools():


### PR DESCRIPTION
## Description

Agent.tool_config is a configuration object which serves as a wrapper to tool_specs and nothing else.  We actually don't use the toolChoice at all anywhere, and the `Tool` wrapper also was a container that served no purpose as everywhere we used the tools, we wanted the ToolSpec anyways.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Breaking change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
