### PR TITLE
fix: add-threading-instrumentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "watchdog>=6.0.0,<7.0.0",
     "opentelemetry-api>=1.30.0,<2.0.0",
     "opentelemetry-sdk>=1.30.0,<2.0.0",
+    "opentelemetry-instrumentation-threading>=0.51b0,<1.00b0",
 ]
 
 [project.urls]

--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, timezone
 from typing import Any, Dict, Mapping, Optional
 
 import opentelemetry.trace as trace_api
+from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 from opentelemetry.trace import Span, StatusCode
 
 from ..agent.agent_result import AgentResult
@@ -89,6 +90,7 @@ class Tracer:
 
         self.tracer_provider = trace_api.get_tracer_provider()
         self.tracer = self.tracer_provider.get_tracer(self.service_name)
+        ThreadingInstrumentor().instrument()
 
     def _start_span(
         self,


### PR DESCRIPTION
## Description
We recently updated the agent calls with threading, this causes opentelemery fails to propagate context and result in creating multiple traceIds instead of one.


Adding `opentelemetry-instrumentation-threading > ThreadingInstrumentor` to allow context propagation between threads. And the package itself [is pretty light](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/333fc5dcb4613f88c939db5b9807ba8f0f466f54/instrumentation/opentelemetry-instrumentation-threading/pyproject.toml) so we can include them while installing the sdk-python.

## Related Issues

NA

## Documentation PR

NA

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Manually test the changes

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
