### PR TITLE
deps(a2a): upgrade a2a with db support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ otel = [
     "opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0",
 ]
 a2a = [
-    "a2a-sdk>=0.2.6",
+    "a2a-sdk[sql]>=0.2.11",
     "uvicorn>=0.34.2",
     "httpx>=0.28.1",
     "fastapi>=0.115.12",


### PR DESCRIPTION
## Description
Google recently updated the A2A SDK with DB support and this is a non-optional dependency. https://github.com/a2aproject/a2a-python/pull/259. 

When using A2A without this dependency the following error message is show: 

```
E   ImportError: DatabaseTaskStore requires SQLAlchemy and a database driver. Install with one of: 'pip install a2a-sdk[postgresql]', 'pip install a2a-sdk[mysql]', 'pip install a2a-sdk[sqlite]', or 'pip install a2a-sdk[sql]'
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Dependency bump

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
