### PR TITLE
fix: Fix event loop starvation in Agent.stream_async() by yielding control

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -505,6 +505,7 @@ class Agent:
                 if "callback" in event:
                     callback_handler(**event["callback"])
                     yield event["callback"]
+                    await asyncio.sleep(0)  # Yield control
 
             result = AgentResult(*event["stop"])
             callback_handler(result=result)


### PR DESCRIPTION
## Description

Fixes event loop starvation in `Agent.stream_async()` that prevents real-time streaming in async environments.

**Problem:** When using `stream_async()` in WebSocket applications or other async environments, events would buffer and only be delivered after the entire stream completed, rather than streaming in real-time. This occurred because the async iterator wasn't properly yielding control to the event loop between events.

**Impact:** Enables true real-time streaming without requiring workarounds in consuming code. WebSocket messages and other async operations can now be processed immediately as events are generated.

## Related Issues

Fixes event loop blocking that prevents real-time streaming in async environments such as WebSocket applications.

## Documentation PR

N/A - This is an internal implementation fix that doesn't change the public API.

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Verified streaming works properly in WebSocket environments (Django Channels)
- [x] Confirmed the fix resolves event loop starvation without requiring consumer-side workarounds

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.