### PR TITLE
Fix: Update mistral tests to avoid shared agents

### DIFF
--- a/tests_integ/models/test_model_mistral.py
+++ b/tests_integ/models/test_model_mistral.py
@@ -12,7 +12,7 @@ from tests_integ.models import providers
 pytestmark = providers.mistral.mark
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def streaming_model():
     return MistralModel(
         model_id="mistral-medium-latest",
@@ -24,7 +24,7 @@ def streaming_model():
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def non_streaming_model():
     return MistralModel(
         model_id="mistral-medium-latest",
@@ -36,12 +36,12 @@ def non_streaming_model():
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def system_prompt():
     return "You are an AI assistant that provides helpful and accurate information."
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def tools():
     @strands.tool
     def tool_time() -> str:
@@ -54,12 +54,12 @@ def tools():
     return [tool_time, tool_weather]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def streaming_agent(streaming_model, tools):
     return Agent(model=streaming_model, tools=tools)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def non_streaming_agent(non_streaming_model, tools):
     return Agent(model=non_streaming_model, tools=tools)
 
@@ -69,7 +69,7 @@ def agent(request):
     return request.getfixturevalue(request.param)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def weather():
     class Weather(BaseModel):
         """Extracts the time and weather from the user's message with the exact strings."""


### PR DESCRIPTION

## Description

We can't reuse the same agent instance when running in parallel and these were failing locally.  Now they are not.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
