### PR TITLE
fix: Allow tool names that start with numbers

### DIFF
--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -48,7 +48,7 @@ def validate_tool_use_name(tool: ToolUse) -> None:
         raise InvalidToolUseNameException(message)
 
     tool_name = tool["name"]
-    tool_name_pattern = r"^[a-zA-Z][a-zA-Z0-9_\-]*$"
+    tool_name_pattern = r"^[a-zA-Z0-9_\-]{1,}$"
     tool_name_max_length = 64
     valid_name_pattern = bool(re.match(tool_name_pattern, tool_name))
     tool_name_len = len(tool_name)

--- a/tests/strands/tools/test_tools.py
+++ b/tests/strands/tools/test_tools.py
@@ -59,6 +59,10 @@ def test_validate_tool_use_name_valid():
     # Should not raise an exception
     validate_tool_use_name(tool2)
 
+    tool3 = {"name": "34234_numbers", "toolUseId": "123"}
+    # Should not raise an exception
+    validate_tool_use_name(tool3)
+
 
 def test_validate_tool_use_name_missing():
     tool = {"toolUseId": "123"}
@@ -67,7 +71,7 @@ def test_validate_tool_use_name_missing():
 
 
 def test_validate_tool_use_name_invalid_pattern():
-    tool = {"name": "123_invalid", "toolUseId": "123"}
+    tool = {"name": "+123_invalid", "toolUseId": "123"}
     with pytest.raises(InvalidToolUseNameException, match="invalid tool name pattern"):
         validate_tool_use_name(tool)
 
@@ -414,7 +418,7 @@ def test_validate_tool_use_with_valid_input():
         # Name - Invalid characters
         (
             {
-                "name": "1-invalid",
+                "name": "+1-invalid",
                 "toolUseId": "123",
                 "input": {},
             },
@@ -428,6 +432,15 @@ def test_validate_tool_use_with_valid_input():
                 "input": {},
             },
             strands.tools.InvalidToolUseNameException,
+        ),
+        # Name - Empty
+        (
+                {
+                    "name": "",
+                    "toolUseId": "123",
+                    "input": {},
+                },
+                strands.tools.InvalidToolUseNameException,
         ),
     ],
 )

--- a/tests/strands/tools/test_tools.py
+++ b/tests/strands/tools/test_tools.py
@@ -435,12 +435,12 @@ def test_validate_tool_use_with_valid_input():
         ),
         # Name - Empty
         (
-                {
-                    "name": "",
-                    "toolUseId": "123",
-                    "input": {},
-                },
-                strands.tools.InvalidToolUseNameException,
+            {
+                "name": "",
+                "toolUseId": "123",
+                "input": {},
+            },
+            strands.tools.InvalidToolUseNameException,
         ),
     ],
 )


### PR DESCRIPTION

## Description

Some MCP servers return tool names that have numeric identifiers that start with a number; open up our regex to allow those names.

This will not allow direct method invocations of those tools, but we can revisit the need for that in the future if it become a concern.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change


Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

Ran the following conformance tests and it passed in all except llama (I have no key to test) and ollama (I'm currently ulling the model):

```python
def test_numeric_tool_names_allowed_underscore(model):
    @tool(name="_13")
    def numeric_tool():
        return "19"

    agent = Agent(model, tools=[numeric_tool])
    agent("Invoke the 13 tool and tell me what the return value is.  output only the return value")

def test_numeric_tool_names_allowed_numeric(model):
    @tool(name="13")
    def numeric_tool():
        return "19"

    agent = Agent(model, tools=[numeric_tool])
    agent("Invoke the 13 tool and tell me what the return value is.  output only the return value")
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
