### PR TITLE
Rename StartRequestEvent & EndRequestEvent events

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -21,11 +21,11 @@ from pydantic import BaseModel
 
 from ..event_loop.event_loop import event_loop_cycle, run_tool
 from ..experimental.hooks import (
-    AgentInitializedEvent,
     AfterInvocationEvent,
+    AgentInitializedEvent,
+    BeforeInvocationEvent,
     HookRegistry,
     MessageAddedEvent,
-    BeforeInvocationEvent,
 )
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from ..models.bedrock import BedrockModel

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -22,10 +22,10 @@ from pydantic import BaseModel
 from ..event_loop.event_loop import event_loop_cycle, run_tool
 from ..experimental.hooks import (
     AgentInitializedEvent,
-    EndRequestEvent,
+    AfterInvocationEvent,
     HookRegistry,
     MessageAddedEvent,
-    StartRequestEvent,
+    BeforeInvocationEvent,
 )
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from ..models.bedrock import BedrockModel
@@ -422,7 +422,7 @@ class Agent:
         Raises:
             ValueError: If no conversation history or prompt is provided.
         """
-        self._hooks.invoke_callbacks(StartRequestEvent(agent=self))
+        self._hooks.invoke_callbacks(BeforeInvocationEvent(agent=self))
 
         try:
             if not self.messages and not prompt:
@@ -440,7 +440,7 @@ class Agent:
             return event["output"]
 
         finally:
-            self._hooks.invoke_callbacks(EndRequestEvent(agent=self))
+            self._hooks.invoke_callbacks(AfterInvocationEvent(agent=self))
 
     async def stream_async(self, prompt: Union[str, list[ContentBlock]], **kwargs: Any) -> AsyncIterator[Any]:
         """Process a natural language prompt and yield events as an async iterator.
@@ -506,7 +506,7 @@ class Agent:
         Yields:
             Events from the event loop cycle.
         """
-        self._hooks.invoke_callbacks(StartRequestEvent(agent=self))
+        self._hooks.invoke_callbacks(BeforeInvocationEvent(agent=self))
 
         try:
             yield {"callback": {"init_event_loop": True, **kwargs}}
@@ -520,7 +520,7 @@ class Agent:
 
         finally:
             self.conversation_manager.apply_management(self)
-            self._hooks.invoke_callbacks(EndRequestEvent(agent=self))
+            self._hooks.invoke_callbacks(AfterInvocationEvent(agent=self))
 
     async def _execute_event_loop_cycle(self, kwargs: dict[str, Any]) -> AsyncGenerator[dict[str, Any], None]:
         """Execute the event loop cycle with retry logic for context window limits.

--- a/src/strands/experimental/hooks/__init__.py
+++ b/src/strands/experimental/hooks/__init__.py
@@ -30,14 +30,14 @@ type-safe system that supports multiple subscribers per event type.
 """
 
 from .events import (
+    AfterInvocationEvent,
     AfterModelInvocationEvent,
     AfterToolInvocationEvent,
     AgentInitializedEvent,
+    BeforeInvocationEvent,
     BeforeModelInvocationEvent,
     BeforeToolInvocationEvent,
-    AfterInvocationEvent,
     MessageAddedEvent,
-    BeforeInvocationEvent,
 )
 from .registry import HookCallback, HookEvent, HookProvider, HookRegistry, get_registry
 

--- a/src/strands/experimental/hooks/__init__.py
+++ b/src/strands/experimental/hooks/__init__.py
@@ -35,16 +35,16 @@ from .events import (
     AgentInitializedEvent,
     BeforeModelInvocationEvent,
     BeforeToolInvocationEvent,
-    EndRequestEvent,
+    AfterInvocationEvent,
     MessageAddedEvent,
-    StartRequestEvent,
+    BeforeInvocationEvent,
 )
 from .registry import HookCallback, HookEvent, HookProvider, HookRegistry, get_registry
 
 __all__ = [
     "AgentInitializedEvent",
-    "StartRequestEvent",
-    "EndRequestEvent",
+    "BeforeInvocationEvent",
+    "AfterInvocationEvent",
     "BeforeModelInvocationEvent",
     "AfterModelInvocationEvent",
     "BeforeToolInvocationEvent",

--- a/src/strands/experimental/hooks/events.py
+++ b/src/strands/experimental/hooks/events.py
@@ -25,10 +25,10 @@ class AgentInitializedEvent(HookEvent):
 
 
 @dataclass
-class StartRequestEvent(HookEvent):
+class BeforeInvocationEvent(HookEvent):
     """Event triggered at the beginning of a new agent request.
 
-    This event is fired when the agent begins processing a new user request,
+    This event is fired before the agent begins processing a new user request,
     before any model inference or tool execution occurs. Hook providers can
     use this event to perform request-level setup, logging, or validation.
 
@@ -42,7 +42,7 @@ class StartRequestEvent(HookEvent):
 
 
 @dataclass
-class EndRequestEvent(HookEvent):
+class AfterInvocationEvent(HookEvent):
     """Event triggered at the end of an agent request.
 
     This event is fired after the agent has completed processing a request,

--- a/tests/strands/agent/test_agent_hooks.py
+++ b/tests/strands/agent/test_agent_hooks.py
@@ -6,14 +6,14 @@ from pydantic import BaseModel
 import strands
 from strands import Agent
 from strands.experimental.hooks import (
+    AfterInvocationEvent,
     AfterModelInvocationEvent,
     AfterToolInvocationEvent,
     AgentInitializedEvent,
+    BeforeInvocationEvent,
     BeforeModelInvocationEvent,
     BeforeToolInvocationEvent,
-    AfterInvocationEvent,
     MessageAddedEvent,
-    BeforeInvocationEvent,
     get_registry,
 )
 from strands.types.content import Messages

--- a/tests/strands/agent/test_agent_hooks.py
+++ b/tests/strands/agent/test_agent_hooks.py
@@ -11,9 +11,9 @@ from strands.experimental.hooks import (
     AgentInitializedEvent,
     BeforeModelInvocationEvent,
     BeforeToolInvocationEvent,
-    EndRequestEvent,
+    AfterInvocationEvent,
     MessageAddedEvent,
-    StartRequestEvent,
+    BeforeInvocationEvent,
     get_registry,
 )
 from strands.types.content import Messages
@@ -27,8 +27,8 @@ def hook_provider():
     return MockHookProvider(
         [
             AgentInitializedEvent,
-            StartRequestEvent,
-            EndRequestEvent,
+            BeforeInvocationEvent,
+            AfterInvocationEvent,
             AfterToolInvocationEvent,
             BeforeToolInvocationEvent,
             BeforeModelInvocationEvent,
@@ -149,7 +149,7 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, mock_model, tool_u
 
     assert length == 12
 
-    assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == BeforeInvocationEvent(agent=agent)
     assert next(events) == MessageAddedEvent(
         agent=agent,
         message=agent.messages[0],
@@ -190,7 +190,7 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, mock_model, tool_u
     )
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[3])
 
-    assert next(events) == EndRequestEvent(agent=agent)
+    assert next(events) == AfterInvocationEvent(agent=agent)
 
     assert len(agent.messages) == 4
 
@@ -200,7 +200,7 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, mock_m
     """Verify that the correct hook events are emitted as part of stream_async."""
     iterator = agent.stream_async("test message")
     await anext(iterator)
-    assert hook_provider.events_received == [StartRequestEvent(agent=agent)]
+    assert hook_provider.events_received == [BeforeInvocationEvent(agent=agent)]
 
     # iterate the rest
     async for _ in iterator:
@@ -210,7 +210,7 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, mock_m
 
     assert length == 12
 
-    assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == BeforeInvocationEvent(agent=agent)
     assert next(events) == MessageAddedEvent(
         agent=agent,
         message=agent.messages[0],
@@ -251,7 +251,7 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, mock_m
     )
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[3])
 
-    assert next(events) == EndRequestEvent(agent=agent)
+    assert next(events) == AfterInvocationEvent(agent=agent)
 
     assert len(agent.messages) == 4
 
@@ -266,9 +266,9 @@ def test_agent_structured_output_hooks(agent, hook_provider, user, agenerator):
 
     assert length == 3
 
-    assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == BeforeInvocationEvent(agent=agent)
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[0])
-    assert next(events) == EndRequestEvent(agent=agent)
+    assert next(events) == AfterInvocationEvent(agent=agent)
 
     assert len(agent.messages) == 1
 
@@ -284,8 +284,8 @@ async def test_agent_structured_async_output_hooks(agent, hook_provider, user, a
 
     assert length == 3
 
-    assert next(events) == StartRequestEvent(agent=agent)
+    assert next(events) == BeforeInvocationEvent(agent=agent)
     assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[0])
-    assert next(events) == EndRequestEvent(agent=agent)
+    assert next(events) == AfterInvocationEvent(agent=agent)
 
     assert len(agent.messages) == 1

--- a/tests/strands/experimental/hooks/test_events.py
+++ b/tests/strands/experimental/hooks/test_events.py
@@ -6,9 +6,9 @@ from strands.experimental.hooks import (
     AfterToolInvocationEvent,
     AgentInitializedEvent,
     BeforeToolInvocationEvent,
-    EndRequestEvent,
+    AfterInvocationEvent,
     MessageAddedEvent,
-    StartRequestEvent,
+    BeforeInvocationEvent,
 )
 from strands.types.tools import ToolResult, ToolUse
 
@@ -47,7 +47,7 @@ def initialized_event(agent):
 
 @pytest.fixture
 def start_request_event(agent):
-    return StartRequestEvent(agent=agent)
+    return BeforeInvocationEvent(agent=agent)
 
 
 @pytest.fixture
@@ -57,7 +57,7 @@ def messaged_added_event(agent):
 
 @pytest.fixture
 def end_request_event(agent):
-    return EndRequestEvent(agent=agent)
+    return AfterInvocationEvent(agent=agent)
 
 
 @pytest.fixture

--- a/tests/strands/experimental/hooks/test_events.py
+++ b/tests/strands/experimental/hooks/test_events.py
@@ -3,12 +3,12 @@ from unittest.mock import Mock
 import pytest
 
 from strands.experimental.hooks import (
+    AfterInvocationEvent,
     AfterToolInvocationEvent,
     AgentInitializedEvent,
-    BeforeToolInvocationEvent,
-    AfterInvocationEvent,
-    MessageAddedEvent,
     BeforeInvocationEvent,
+    BeforeToolInvocationEvent,
+    MessageAddedEvent,
 )
 from strands.types.tools import ToolResult, ToolUse
 


### PR DESCRIPTION
## Description

To conform to our rules that Indicate that Start/After is the preferred terminology + changing to invocation which should be more clear.

## Related Issues

#231

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Refactor

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
