### PR TITLE
refactor: Remove _remove_dangling_messages from SlidingWindowConversationManager

### DIFF
--- a/tests/strands/agent/test_conversation_manager.py
+++ b/tests/strands/agent/test_conversation_manager.py
@@ -58,21 +58,21 @@ def conversation_manager(request):
                 {"role": "user", "content": [{"toolResult": {"toolUseId": "123", "content": [], "status": "success"}}]},
             ],
         ),
-        # 2 - Remove dangling user message with no tool result
+        # 2 - Keep user message
         (
             {"window_size": 2},
             [
                 {"role": "user", "content": [{"text": "Hello"}]},
             ],
-            [],
+            [{"role": "user", "content": [{"text": "Hello"}]}],
         ),
-        # 3 - Remove dangling assistant message with tool use
+        # 3 - Keep dangling assistant message with tool use
         (
             {"window_size": 3},
             [
                 {"role": "assistant", "content": [{"toolUse": {"toolUseId": "123", "name": "tool1", "input": {}}}]},
             ],
-            [],
+            [{"role": "assistant", "content": [{"toolUse": {"toolUseId": "123", "name": "tool1", "input": {}}}]}],
         ),
         # 4 - Remove dangling assistant message with tool use - User tool result remains
         (
@@ -83,6 +83,7 @@ def conversation_manager(request):
             ],
             [
                 {"role": "user", "content": [{"toolResult": {"toolUseId": "123", "content": [], "status": "success"}}]},
+                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "123", "name": "tool1", "input": {}}}]},
             ],
         ),
         # 5 - Remove dangling assistant message with tool use and user message without tool result
@@ -95,8 +96,9 @@ def conversation_manager(request):
                 {"role": "assistant", "content": [{"toolUse": {"toolUseId": "123", "name": "tool1", "input": {}}}]},
             ],
             [
-                {"role": "user", "content": [{"text": "First"}]},
                 {"role": "assistant", "content": [{"text": "First response"}]},
+                {"role": "user", "content": [{"text": "Use a tool"}]},
+                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "123", "name": "tool1", "input": {}}}]},
             ],
         ),
         # 6 - Message count above max window size - Basic drop


### PR DESCRIPTION
### Breaking Change!!

## Description
Remove `_remove_dangling_messages` from SlidingWindowConversationManager.

### Retain previous behavior
For users who want to keep the behavior that the sdk provided before this change, you can add the following logic after your agent call:

```python
agent.(<Your input here>)
if len(agent.messages) > 0 and agent.messages[-1]["role"] == "assistant":
    if any("toolUse" in content for content in agent.messages[-1]["content"]):
        agent.messages.pop()
```

We believe this currently only happens if the event-loop is interrupted by client applications and thus believe that clients should handle this case outside of the loop. 

In the future, we expect dangling tool_use messages to be a valid use-case where agents can resume from and thus we're removing this logic before we got 1.0

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Breaking change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
