### PR TITLE
chore!: set Agent property load_tools_from_directory to default to False

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -199,7 +199,7 @@ class Agent:
         ] = _DEFAULT_CALLBACK_HANDLER,
         conversation_manager: Optional[ConversationManager] = None,
         record_direct_tool_call: bool = True,
-        load_tools_from_directory: bool = True,
+        load_tools_from_directory: bool = False,
         trace_attributes: Optional[Mapping[str, AttributeValue]] = None,
         *,
         agent_id: Optional[str] = None,
@@ -235,7 +235,7 @@ class Agent:
             record_direct_tool_call: Whether to record direct tool calls in message history.
                 Defaults to True.
             load_tools_from_directory: Whether to load and automatically reload tools in the `./tools/` directory.
-                Defaults to True.
+                Defaults to False.
             trace_attributes: Custom trace attributes to apply to the agent's trace span.
             agent_id: Optional ID for the agent, useful for multi-agent scenarios.
                 If None, a UUID is generated.

--- a/src/strands/tools/registry.py
+++ b/src/strands/tools/registry.py
@@ -361,7 +361,7 @@ class ToolRegistry:
             logger.exception("tool_name=<%s> | failed to reload tool", tool_name)
             raise
 
-    def initialize_tools(self, load_tools_from_directory: bool = True) -> None:
+    def initialize_tools(self, load_tools_from_directory: bool = False) -> None:
         """Initialize all tools by discovering and loading them dynamically from all tool directories.
 
         Args:

--- a/tests_integ/test_hot_tool_reload_decorator.py
+++ b/tests_integ/test_hot_tool_reload_decorator.py
@@ -30,7 +30,7 @@ def test_hot_reload_decorator():
 
     try:
         # Create an Agent instance without any tools
-        agent = Agent()
+        agent = Agent(load_tools_from_directory=True)
 
         # Create a test tool using @tool decorator
         with open(test_tool_path, "w") as f:
@@ -82,7 +82,7 @@ def test_hot_reload_decorator_update():
 
     try:
         # Create an Agent instance
-        agent = Agent()
+        agent = Agent(load_tools_from_directory=True)
 
         # Create the initial version of the tool
         with open(test_tool_path, "w") as f:


### PR DESCRIPTION
BREAKING CHANGE: load_tools_from_directory will now default to False


Description

This PR updates the Agent property load_tools_from_directory to default to False instead of True.

This is being done to prevent a threat where an Agent has file write access which is then prompt injected to generate a tool which gets used by the Agent on subsequent runs. Auto loading of tools is a useful feature, but one which introduces new risks which may not be obvious to customers. Instead, we will default to False where customers will need to diliberately set the boolean to use the feature.


Related Issues

https://github.com/strands-agents/agent-builder/pull/38


Documentation PR

N/A


Type of Change

Breaking change



Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


* I ran hatch run prepare

Checklist

* I have read the CONTRIBUTING document
* I have added any necessary tests that prove my fix is effective or my feature works
* I have updated the documentation accordingly
* I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
* My changes generate no new warnings
* Any dependent changes have been merged and published


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
