### PR TITLE
refactor(a2a): configurable host and port and remove excessive logging

### DIFF
--- a/src/strands/multiagent/a2a/executor.py
+++ b/src/strands/multiagent/a2a/executor.py
@@ -111,8 +111,6 @@ class StrandsA2AExecutor(AgentExecutor):
                 )
         elif "result" in event:
             await self._handle_agent_result(event["result"], updater)
-        else:
-            logger.warning("Unexpected streaming event: %s", event)
 
     async def _handle_agent_result(self, result: SAAgentResult | None, updater: TaskUpdater) -> None:
         """Handle the final result from the Strands Agent.

--- a/src/strands/multiagent/a2a/server.py
+++ b/src/strands/multiagent/a2a/server.py
@@ -138,7 +138,14 @@ class A2AServer:
         """
         return A2AFastAPIApplication(agent_card=self.public_agent_card, http_handler=self.request_handler).build()
 
-    def serve(self, app_type: Literal["fastapi", "starlette"] = "starlette", **kwargs: Any) -> None:
+    def serve(
+        self,
+        app_type: Literal["fastapi", "starlette"] = "starlette",
+        *,
+        host: str | None = None,
+        port: int | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Start the A2A server with the specified application type.
 
         This method starts an HTTP server that exposes the agent via the A2A protocol.
@@ -148,14 +155,16 @@ class A2AServer:
         Args:
             app_type: The type of application to serve, either "fastapi" or "starlette".
                 Defaults to "starlette".
+            host: The host address to bind the server to. Defaults to "0.0.0.0".
+            port: The port number to bind the server to. Defaults to 9000.
             **kwargs: Additional keyword arguments to pass to uvicorn.run.
         """
         try:
             logger.info("Starting Strands A2A server...")
             if app_type == "fastapi":
-                uvicorn.run(self.to_fastapi_app(), host=self.host, port=self.port, **kwargs)
+                uvicorn.run(self.to_fastapi_app(), host=host or self.host, port=port or self.port, **kwargs)
             else:
-                uvicorn.run(self.to_starlette_app(), host=self.host, port=self.port, **kwargs)
+                uvicorn.run(self.to_starlette_app(), host=host or self.host, port=port or self.port, **kwargs)
         except KeyboardInterrupt:
             logger.warning("Strands A2A server shutdown requested (KeyboardInterrupt).")
         except Exception:


### PR DESCRIPTION
## Description
Changes

1. allow host and port to be overridden in serve function
2. remove excessive logging in executor

## Related Issues


## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
