### PR TITLE
models - bedrock - remove signaling

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -7,7 +7,6 @@ import asyncio
 import json
 import logging
 import os
-import threading
 from typing import Any, AsyncGenerator, Callable, Iterable, Literal, Optional, Type, TypeVar, Union
 
 import boto3
@@ -335,12 +334,8 @@ class BedrockModel(Model):
             if event is None:
                 return
 
-            signal.wait()
-            signal.clear()
-
         loop = asyncio.get_event_loop()
         queue: asyncio.Queue[Optional[StreamEvent]] = asyncio.Queue()
-        signal = threading.Event()
 
         thread = asyncio.to_thread(self._stream, callback, messages, tool_specs, system_prompt)
         task = asyncio.create_task(thread)
@@ -351,7 +346,6 @@ class BedrockModel(Model):
                 break
 
             yield event
-            signal.set()
 
         await task
 


### PR DESCRIPTION
## Description
The bedrock model provider runs converse stream in a separate thread so as not to block the async event loop. This stream thread pushes events onto a queue for the main thread to read and subsequently yield up to the agent caller. For each new event, the worker thread waits until the main thread signals that it is done yielding. This was an idea taken from the iterative tool implementation that would allow for a form of return of control. The problem however is if the main thread terminates before the stream thread completes, the stream thread can get blocked waiting for a signal.

The fix is to remove signaling. Unlike iterative tool invocation, return of control is not needed for model event streaming. The stream thread can continue queuing events from the model invocation while the main thread reads the events at its leisure. There is no harm in letting the events buffer on the queue. Bedrock is doing this anyway server side.

## Related Issues

Identified during 0.3.0 bug bash.

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Ran `hatch test tests_integ/models/test_model_bedrock.py`
- [x] Also ran the following test script:

```Python
import asyncio

import pydantic
from strands import Agent

class Color(pydantic.BaseModel):
    """Describes a color."""

    name: str


async def func_a():
    print("FUNC_A STARTING")
    agent = Agent(callback_handler=None)
    result = await agent.structured_output_async(Color, "What is the color of the sky?")
    print(f"FUNC_A: {result}")


async def func_b():
    print("FUNC_B STARTING")
    agent = Agent(callback_handler=None)
    result = await agent.structured_output_async(Color, "What is the color of mars?")
    print(f"FUNC_B: {result}")


async def func_c():
    print("FUNC_C STARTING")
    agent = Agent(callback_handler=None)
    result = await agent.structured_output_async(Color, "Please don't call any tools")
    print(f"FUNC_C: {result}")


async def main():
    await asyncio.gather(func_a(), func_b(), func_c())


asyncio.run(main())
```
`func_c` is intentionally setup to raise an exception. If it does so before func_a and func_b complete, the stream threads from the func_a and func_b bedrock model instances will get stuck on the `signal.wait`. Removing signaling fixed the issue. The stream thread is allowed to complete even if the main thread goes down.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
