### PR TITLE
models - mistral - init client on every request

### DIFF
--- a/tests/strands/models/test_mistral.py
+++ b/tests/strands/models/test_mistral.py
@@ -11,7 +11,9 @@ from strands.types.exceptions import ModelThrottledException
 @pytest.fixture
 def mistral_client():
     with unittest.mock.patch.object(strands.models.mistral.mistralai, "Mistral") as mock_client_cls:
-        yield mock_client_cls.return_value
+        mock_client = unittest.mock.AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        yield mock_client
 
 
 @pytest.fixture
@@ -25,9 +27,7 @@ def max_tokens():
 
 
 @pytest.fixture
-def model(mistral_client, model_id, max_tokens):
-    _ = mistral_client
-
+def model(model_id, max_tokens):
     return MistralModel(model_id=model_id, max_tokens=max_tokens)
 
 


### PR DESCRIPTION
## Description
The Mistral async client has an issue where making multiple requests with separate `asyncio.run()` calls causes the second request to fail with "Event loop is closed" error. The reason is that the client uses httpx internally, which maintains a connection pool that persists beyond individual event loops. This means connections created in the first event loop remain in the pool after that loop closes, and when the second `asyncio.run()` creates a new event loop, httpx tries to reuse those existing pooled connections that are still tied to the first event loop instead of the new event loop, thus causing a failure.

This is a problem for Strands as `Agent.__call__` runs `asyncio.run()` on every invocation. Consequently, doing something like the following with the MistralModel provider will fail:

```Python
from strands import Agent
from strands.models.mistral import MistralModel

model = MistralModel(api_key="****", model_id="mistral-medium-latest")
agent = Agent(model=model)

agent("Hello")
agent("Hello again")  # Event loop is closed encountered
```

The fix is to establish a new Mistral client connection on every call to `stream`. This fits with the pattern documented in both the Mistral [docs](https://github.com/mistralai/client-python?tab=readme-ov-file#create-chat-completions) and the httpx [docs](https://www.python-httpx.org/async/).

## Related Issues

https://github.com/strands-agents/sdk-python/issues/431

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Ran `hatch test tests_integ/models/test_model_mistral.py`
- [x] Ran the following test script:
```Python
import gc
from strands import Agent
from strands.models.mistral import MistralModel

model = MistralModel(api_key="****", model_id="mistral-medium-latest")

for _ in range(10):
    agent = Agent(model=model)
    agent("what is 2+2")

    gc.collect()
```


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
