### PR TITLE
Expand additional $refs for structured_output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "opentelemetry-api>=1.30.0,<2.0.0",
     "opentelemetry-sdk>=1.30.0,<2.0.0",
     "opentelemetry-instrumentation-threading>=0.51b0,<1.00b0",
+    "notebook>=7.4.4",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "opentelemetry-api>=1.30.0,<2.0.0",
     "opentelemetry-sdk>=1.30.0,<2.0.0",
     "opentelemetry-instrumentation-threading>=0.51b0,<1.00b0",
-    "notebook>=7.4.4",
 ]
 
 [project.urls]

--- a/src/strands/tools/structured_output.py
+++ b/src/strands/tools/structured_output.py
@@ -54,7 +54,9 @@ def _flatten_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
 
                 # Process each nested property
                 for nested_prop_name, nested_prop_value in prop_value["properties"].items():
-                    processed_prop["properties"][nested_prop_name] = nested_prop_value
+                    is_required = "required" in prop_value and nested_prop_name in prop_value["required"]
+                    sub_property = _process_property(nested_prop_value, schema.get("$defs", {}), is_required)
+                    processed_prop["properties"][nested_prop_name] = sub_property
 
                 # Copy required fields if present
                 if "required" in prop_value:
@@ -136,6 +138,10 @@ def _process_property(
             # Copy description if available in the property
             if "description" in prop:
                 result["description"] = prop["description"]
+
+            # Need to process item refs as well (#337)
+            if "items" in result:
+                result["items"] = _process_property(result["items"], defs)
 
             return result
 

--- a/tests/strands/tools/test_structured_output.py
+++ b/tests/strands/tools/test_structured_output.py
@@ -1,4 +1,3 @@
-import json
 from typing import Literal, Optional
 
 import pytest
@@ -243,9 +242,53 @@ def test_convert_pydantic_with_items_refs():
         list_of_item_or_nullable: list[Optional[Address]]
 
     tool_spec = convert_pydantic_to_tool_spec(Person)
-    raw_json = json.dumps(tool_spec, indent=2)
 
-    assert "$ref" not in raw_json
+    expected_spec = {
+        "description": "Complete person information.",
+        "inputSchema": {
+            "json": {
+                "description": "Complete person information.",
+                "properties": {
+                    "list_of_item_or_nullable": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "properties": {"postal_code": {"type": ["string", "null"]}},
+                                    "title": "Address",
+                                    "type": "object",
+                                },
+                                {"type": "null"},
+                            ]
+                        },
+                        "title": "List Of Item Or Nullable",
+                        "type": "array",
+                    },
+                    "list_of_items": {
+                        "items": {
+                            "properties": {"postal_code": {"type": ["string", "null"]}},
+                            "title": "Address",
+                            "type": "object",
+                        },
+                        "title": "List Of Items",
+                        "type": "array",
+                    },
+                    "list_of_items_nullable": {
+                        "items": {
+                            "properties": {"postal_code": {"type": ["string", "null"]}},
+                            "title": "Address",
+                            "type": "object",
+                        },
+                        "type": ["array", "null"],
+                    },
+                },
+                "required": ["list_of_items", "list_of_item_or_nullable"],
+                "title": "Person",
+                "type": "object",
+            }
+        },
+        "name": "Person",
+    }
+    assert tool_spec == expected_spec
 
 
 def test_convert_pydantic_with_refs():
@@ -266,6 +309,37 @@ def test_convert_pydantic_with_refs():
         contact: Contact = Field(description="Contact methods")
 
     tool_spec = convert_pydantic_to_tool_spec(Person)
-    raw_json = json.dumps(tool_spec, indent=2)
 
-    assert "$ref" not in raw_json
+    expected_spec = {
+        "description": "Complete person information.",
+        "inputSchema": {
+            "json": {
+                "description": "Complete person information.",
+                "properties": {
+                    "contact": {
+                        "description": "Contact methods",
+                        "properties": {
+                            "address": {
+                                "properties": {
+                                    "city": {"title": "City", "type": "string"},
+                                    "country": {"title": "Country", "type": "string"},
+                                    "postal_code": {"type": ["string", "null"]},
+                                    "street": {"title": "Street", "type": "string"},
+                                },
+                                "required": ["street", "city", "country"],
+                                "title": "Address",
+                                "type": "object",
+                            }
+                        },
+                        "required": ["address"],
+                        "type": "object",
+                    }
+                },
+                "required": ["contact"],
+                "title": "Person",
+                "type": "object",
+            }
+        },
+        "name": "Person",
+    }
+    assert tool_spec == expected_spec


### PR DESCRIPTION


## Description

Previously lists of items that were optional were not correctly expanding $refs. Derived classes also weren't having their $refs expanded as the subclass already had a "properties" object which bypassed $ref expansion

## Related Issues

Fixes #337 

Created a follow-up issue to remove this ref expansion altogether: #438

## Documentation PR

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
