### PR TITLE
feat: Store conversation manager in session

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -588,6 +588,11 @@ class Agent:
         except ContextWindowOverflowException as e:
             # Try reducing the context size and retrying
             self.conversation_manager.reduce_context(self, e=e)
+
+            # Sync agent after reduce_context to keep conversation_manager_state up to date in the session
+            if self._session_manager:
+                self._session_manager.sync_agent(self)
+
             events = self._execute_event_loop_cycle(invocation_state)
             async for event in events:
                 yield event

--- a/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
+++ b/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
@@ -6,35 +6,11 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     from ...agent.agent import Agent
 
-from ...types.content import Message, Messages
+from ...types.content import Messages
 from ...types.exceptions import ContextWindowOverflowException
 from .conversation_manager import ConversationManager
 
 logger = logging.getLogger(__name__)
-
-
-def is_user_message(message: Message) -> bool:
-    """Check if a message is from a user.
-
-    Args:
-        message: The message object to check.
-
-    Returns:
-        True if the message has the user role, False otherwise.
-    """
-    return message["role"] == "user"
-
-
-def is_assistant_message(message: Message) -> bool:
-    """Check if a message is from an assistant.
-
-    Args:
-        message: The message object to check.
-
-    Returns:
-        True if the message has the assistant role, False otherwise.
-    """
-    return message["role"] == "assistant"
 
 
 class SlidingWindowConversationManager(ConversationManager):
@@ -52,6 +28,7 @@ class SlidingWindowConversationManager(ConversationManager):
                 Defaults to 40 messages.
             should_truncate_results: Truncate tool results when a message is too large for the model's context window
         """
+        super().__init__()
         self.window_size = window_size
         self.should_truncate_results = should_truncate_results
 
@@ -128,6 +105,9 @@ class SlidingWindowConversationManager(ConversationManager):
         else:
             # If we didn't find a valid trim_index, then we throw
             raise ContextWindowOverflowException("Unable to trim conversation context!") from e
+
+        # trim_index represents the number of messages being removed from the agents messages array
+        self.removed_message_count += trim_index
 
         # Overwrite message history
         messages[:] = messages[trim_index:]

--- a/src/strands/session/file_session_manager.py
+++ b/src/strands/session/file_session_manager.py
@@ -30,8 +30,8 @@ class FileSessionManager(RepositorySessionManager, SessionRepository):
             └── agent_<agent_id>/
                 ├── agent.json          # Agent metadata
                 └── messages/
-                    ├── message_<created_timestamp>_<id1>.json
-                    └── message_<created_timestamp>_<id2>.json
+                    ├── message_<id1>.json
+                    └── message_<id2>.json
 
     """
 

--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -31,8 +31,8 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             └── agent_<agent_id>/
                 ├── agent.json          # Agent metadata
                 └── messages/
-                    ├── message_<created_timestamp>_<id1>.json
-                    └── message_<created_timestamp>_<id2>.json
+                    ├── message_<id1>.json
+                    └── message_<id2>.json
 
     """
 
@@ -77,7 +77,7 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
 
     def _get_session_path(self, session_id: str) -> str:
         """Get session S3 prefix."""
-        return f"{self.prefix}{SESSION_PREFIX}{session_id}/"
+        return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
 
     def _get_agent_path(self, session_id: str, agent_id: str) -> str:
         """Get agent S3 prefix."""

--- a/src/strands/types/session.py
+++ b/src/strands/types/session.py
@@ -106,6 +106,7 @@ class SessionAgent:
 
     agent_id: str
     state: Dict[str, Any]
+    conversation_manager_state: Dict[str, Any]
     created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
@@ -116,6 +117,7 @@ class SessionAgent:
             raise ValueError("agent_id needs to be defined.")
         return cls(
             agent_id=agent.agent_id,
+            conversation_manager_state=agent.conversation_manager.get_state(),
             state=agent.state.get(),
         )
 

--- a/tests/fixtures/mock_session_repository.py
+++ b/tests/fixtures/mock_session_repository.py
@@ -1,5 +1,6 @@
 from strands.session.session_repository import SessionRepository
 from strands.types.exceptions import SessionException
+from strands.types.session import SessionAgent, SessionMessage
 
 
 class MockedSessionRepository(SessionRepository):
@@ -11,7 +12,7 @@ class MockedSessionRepository(SessionRepository):
         self.agents = {}
         self.messages = {}
 
-    def create_session(self, session):
+    def create_session(self, session) -> None:
         """Create a session."""
         session_id = session.session_id
         if session_id in self.sessions:
@@ -19,13 +20,12 @@ class MockedSessionRepository(SessionRepository):
         self.sessions[session_id] = session
         self.agents[session_id] = {}
         self.messages[session_id] = {}
-        return session
 
-    def read_session(self, session_id):
+    def read_session(self, session_id) -> SessionAgent:
         """Read a session."""
         return self.sessions.get(session_id)
 
-    def create_agent(self, session_id, session_agent):
+    def create_agent(self, session_id, session_agent) -> None:
         """Create an agent."""
         agent_id = session_agent.agent_id
         if session_id not in self.sessions:
@@ -36,13 +36,13 @@ class MockedSessionRepository(SessionRepository):
         self.messages.setdefault(session_id, {}).setdefault(agent_id, {})
         return session_agent
 
-    def read_agent(self, session_id, agent_id):
+    def read_agent(self, session_id, agent_id) -> SessionAgent:
         """Read an agent."""
         if session_id not in self.sessions:
             return None
         return self.agents.get(session_id, {}).get(agent_id)
 
-    def update_agent(self, session_id, session_agent):
+    def update_agent(self, session_id, session_agent) -> None:
         """Update an agent."""
         agent_id = session_agent.agent_id
         if session_id not in self.sessions:
@@ -51,7 +51,7 @@ class MockedSessionRepository(SessionRepository):
             raise SessionException(f"Agent {agent_id} does not exist in session {session_id}")
         self.agents[session_id][agent_id] = session_agent
 
-    def create_message(self, session_id, agent_id, session_message):
+    def create_message(self, session_id, agent_id, session_message) -> None:
         """Create a message."""
         message_id = session_message.message_id
         if session_id not in self.sessions:
@@ -62,7 +62,7 @@ class MockedSessionRepository(SessionRepository):
             raise SessionException(f"Message {message_id} already exists in agent {agent_id} in session {session_id}")
         self.messages.setdefault(session_id, {}).setdefault(agent_id, {})[message_id] = session_message
 
-    def read_message(self, session_id, agent_id, message_id):
+    def read_message(self, session_id, agent_id, message_id) -> SessionMessage:
         """Read a message."""
         if session_id not in self.sessions:
             return None
@@ -70,7 +70,7 @@ class MockedSessionRepository(SessionRepository):
             return None
         return self.messages.get(session_id, {}).get(agent_id, {}).get(message_id)
 
-    def update_message(self, session_id, agent_id, session_message):
+    def update_message(self, session_id, agent_id, session_message) -> None:
         """Update a message."""
 
         message_id = session_message.message_id
@@ -82,7 +82,7 @@ class MockedSessionRepository(SessionRepository):
             raise SessionException(f"Message {message_id} does not exist in session {session_id}")
         self.messages[session_id][agent_id][message_id] = session_message
 
-    def list_messages(self, session_id, agent_id, limit=None, offset=0):
+    def list_messages(self, session_id, agent_id, limit=None, offset=0) -> list[SessionMessage]:
         """List messages."""
         if session_id not in self.sessions:
             return []

--- a/tests/strands/agent/test_conversation_manager.py
+++ b/tests/strands/agent/test_conversation_manager.py
@@ -1,24 +1,9 @@
 import pytest
 
-import strands
 from strands.agent.agent import Agent
+from strands.agent.conversation_manager.null_conversation_manager import NullConversationManager
+from strands.agent.conversation_manager.sliding_window_conversation_manager import SlidingWindowConversationManager
 from strands.types.exceptions import ContextWindowOverflowException
-
-
-@pytest.mark.parametrize(("role", "exp_result"), [("user", True), ("assistant", False)])
-def test_is_user_message(role, exp_result):
-    from strands.agent.conversation_manager.sliding_window_conversation_manager import is_user_message
-
-    tru_result = is_user_message({"role": role})
-    assert tru_result == exp_result
-
-
-@pytest.mark.parametrize(("role", "exp_result"), [("user", False), ("assistant", True)])
-def test_is_assistant_message(role, exp_result):
-    from strands.agent.conversation_manager.sliding_window_conversation_manager import is_assistant_message
-
-    tru_result = is_assistant_message({"role": role})
-    assert tru_result == exp_result
 
 
 @pytest.fixture
@@ -30,7 +15,7 @@ def conversation_manager(request):
     if hasattr(request, "param"):
         params.update(request.param)
 
-    return strands.agent.conversation_manager.SlidingWindowConversationManager(**params)
+    return SlidingWindowConversationManager(**params)
 
 
 @pytest.mark.parametrize(
@@ -171,7 +156,7 @@ def test_apply_management(conversation_manager, messages, expected_messages):
 
 
 def test_sliding_window_conversation_manager_with_untrimmable_history_raises_context_window_overflow_exception():
-    manager = strands.agent.conversation_manager.SlidingWindowConversationManager(1, False)
+    manager = SlidingWindowConversationManager(1, False)
     messages = [
         {"role": "assistant", "content": [{"toolUse": {"toolUseId": "456", "name": "tool1", "input": {}}}]},
         {"role": "user", "content": [{"toolResult": {"toolUseId": "789", "content": [], "status": "success"}}]},
@@ -186,7 +171,7 @@ def test_sliding_window_conversation_manager_with_untrimmable_history_raises_con
 
 
 def test_sliding_window_conversation_manager_with_tool_results_truncated():
-    manager = strands.agent.conversation_manager.SlidingWindowConversationManager(1)
+    manager = SlidingWindowConversationManager(1)
     messages = [
         {"role": "assistant", "content": [{"toolUse": {"toolUseId": "456", "name": "tool1", "input": {}}}]},
         {
@@ -221,7 +206,7 @@ def test_sliding_window_conversation_manager_with_tool_results_truncated():
 
 def test_null_conversation_manager_reduce_context_raises_context_window_overflow_exception():
     """Test that NullConversationManager doesn't modify messages."""
-    manager = strands.agent.conversation_manager.NullConversationManager()
+    manager = NullConversationManager()
     messages = [
         {"role": "user", "content": [{"text": "Hello"}]},
         {"role": "assistant", "content": [{"text": "Hi there"}]},
@@ -239,7 +224,7 @@ def test_null_conversation_manager_reduce_context_raises_context_window_overflow
 
 def test_null_conversation_manager_reduce_context_with_exception_raises_same_exception():
     """Test that NullConversationManager doesn't modify messages."""
-    manager = strands.agent.conversation_manager.NullConversationManager()
+    manager = NullConversationManager()
     messages = [
         {"role": "user", "content": [{"text": "Hello"}]},
         {"role": "assistant", "content": [{"text": "Hi there"}]},
@@ -253,3 +238,11 @@ def test_null_conversation_manager_reduce_context_with_exception_raises_same_exc
         manager.reduce_context(messages, RuntimeError("test"))
 
     assert messages == original_messages
+
+
+def test_null_conversation_does_not_restore_with_incorrect_state():
+    """Test that NullConversationManager doesn't modify messages."""
+    manager = NullConversationManager()
+
+    with pytest.raises(ValueError):
+        manager.restore_from_session({})

--- a/tests/strands/agent/test_summarizing_conversation_manager.py
+++ b/tests/strands/agent/test_summarizing_conversation_manager.py
@@ -1,14 +1,13 @@
-from typing import TYPE_CHECKING, cast
+from typing import cast
 from unittest.mock import Mock, patch
 
 import pytest
 
+from strands.agent.agent import Agent
 from strands.agent.conversation_manager.summarizing_conversation_manager import SummarizingConversationManager
 from strands.types.content import Messages
 from strands.types.exceptions import ContextWindowOverflowException
-
-if TYPE_CHECKING:
-    from strands.agent.agent import Agent
+from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 
 class MockAgent:
@@ -564,3 +563,48 @@ def test_reduce_context_adjustment_returns_zero():
     # The adjustment method will return 0, which should trigger line 122-123
     with pytest.raises(ContextWindowOverflowException, match="insufficient messages for summarization"):
         manager.reduce_context(mock_agent)
+
+
+def test_summarizing_conversation_manager_properly_records_removed_message_count():
+    mock_model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "Summary"}]},
+            {"role": "assistant", "content": [{"text": "Summary"}]},
+        ]
+    )
+
+    simple_messages: Messages = [
+        {"role": "user", "content": [{"text": "Message 1"}]},
+        {"role": "assistant", "content": [{"text": "Response 1"}]},
+        {"role": "user", "content": [{"text": "Message 2"}]},
+        {"role": "assistant", "content": [{"text": "Response 1"}]},
+        {"role": "user", "content": [{"text": "Message 3"}]},
+        {"role": "assistant", "content": [{"text": "Response 3"}]},
+        {"role": "user", "content": [{"text": "Message 4"}]},
+        {"role": "assistant", "content": [{"text": "Response 4"}]},
+    ]
+    agent = Agent(model=mock_model, messages=simple_messages)
+    manager = SummarizingConversationManager(summary_ratio=0.5, preserve_recent_messages=1)
+
+    assert manager._summary_message is None
+    assert manager.removed_message_count == 0
+
+    manager.reduce_context(agent)
+    # Assert the oldest message is the sumamry message
+    assert manager._summary_message["content"][0]["text"] == "Summary"
+    # There are 8 messages in the agent messages array, since half will be summarized,
+    # 4 will remain plus 1 summary message = 5
+    assert (len(agent.messages)) == 5
+    # Half of the messages were summarized and removed: 8/2 = 4
+    assert manager.removed_message_count == 4
+
+    manager.reduce_context(agent)
+    assert manager._summary_message["content"][0]["text"] == "Summary"
+    # After the first summary, 5 messages remain. Summarizing again will lead to:
+    # 5 - (int(5/2)) (messages to be sumamrized) + 1 (new summary message) = 5 - 2 + 1 = 4
+    assert (len(agent.messages)) == 4
+    # Half of the messages were summarized and removed: int(5/2) = 2
+    # However, one of the messages that was summarized was the previous summary message,
+    # so we dont count this toward the total:
+    # 4 (Previously removed messages) + 2 (removed messages) - 1 (Previous summary message) = 5
+    assert manager.removed_message_count == 5

--- a/tests/strands/session/test_file_session_manager.py
+++ b/tests/strands/session/test_file_session_manager.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from strands.agent.conversation_manager.null_conversation_manager import NullConversationManager
 from strands.session.file_session_manager import FileSessionManager
 from strands.types.content import ContentBlock
 from strands.types.exceptions import SessionException
@@ -36,8 +37,7 @@ def sample_session():
 def sample_agent():
     """Create sample agent for testing."""
     return SessionAgent(
-        agent_id="test-agent",
-        state={"key": "value"},
+        agent_id="test-agent", state={"key": "value"}, conversation_manager_state=NullConversationManager().get_state()
     )
 
 

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -8,6 +8,7 @@ from botocore.config import Config as BotocoreConfig
 from botocore.exceptions import ClientError
 from moto import mock_aws
 
+from strands.agent.conversation_manager.null_conversation_manager import NullConversationManager
 from strands.session.s3_session_manager import S3SessionManager
 from strands.types.content import ContentBlock
 from strands.types.exceptions import SessionException
@@ -54,6 +55,7 @@ def sample_agent():
     return SessionAgent(
         agent_id="test-agent-456",
         state={"key": "value"},
+        conversation_manager_state=NullConversationManager().get_state(),
     )
 
 

--- a/tests/strands/types/test_session.py
+++ b/tests/strands/types/test_session.py
@@ -1,6 +1,7 @@
 import json
 from uuid import uuid4
 
+from strands.agent.conversation_manager.null_conversation_manager import NullConversationManager
 from strands.types.session import (
     Session,
     SessionAgent,
@@ -20,7 +21,9 @@ def test_session_json_serializable():
 
 
 def test_agent_json_serializable():
-    agent = SessionAgent(agent_id=str(uuid4()), state={"foo": "bar"})
+    agent = SessionAgent(
+        agent_id=str(uuid4()), state={"foo": "bar"}, conversation_manager_state=NullConversationManager().get_state()
+    )
     # json dumps will fail if its not json serializable
     agent_json_string = json.dumps(agent.to_dict())
     loaded_agent = SessionAgent.from_dict(json.loads(agent_json_string))

--- a/tests_integ/test_session.py
+++ b/tests_integ/test_session.py
@@ -8,6 +8,7 @@ import pytest
 from botocore.client import ClientError
 
 from strands import Agent
+from strands.agent.conversation_manager.sliding_window_conversation_manager import SlidingWindowConversationManager
 from strands.session.file_session_manager import FileSessionManager
 from strands.session.s3_session_manager import S3SessionManager
 
@@ -49,6 +50,36 @@ def test_agent_with_file_session(temp_dir):
         assert len(agent_2.messages) == 2
         agent_2("Hello!")
         assert len(agent_2.messages) == 4
+        assert len(session_manager_2.list_messages(test_session_id, agent_2.agent_id)) == 4
+    finally:
+        # Delete the session
+        session_manager.delete_session(test_session_id)
+        assert session_manager.read_session(test_session_id) is None
+
+
+def test_agent_with_file_session_and_conversation_manager(temp_dir):
+    # Set up the session manager and add an agent
+    test_session_id = str(uuid4())
+    # Create a session
+    session_manager = FileSessionManager(session_id=test_session_id, storage_dir=temp_dir)
+    try:
+        agent = Agent(
+            session_manager=session_manager, conversation_manager=SlidingWindowConversationManager(window_size=1)
+        )
+        agent("Hello!")
+        assert len(session_manager.list_messages(test_session_id, agent.agent_id)) == 2
+        # Conversation Manager reduced messages
+        assert len(agent.messages) == 1
+
+        # After agent is persisted and run, restore the agent and run it again
+        session_manager_2 = FileSessionManager(session_id=test_session_id, storage_dir=temp_dir)
+        agent_2 = Agent(
+            session_manager=session_manager_2, conversation_manager=SlidingWindowConversationManager(window_size=1)
+        )
+        assert len(agent_2.messages) == 1
+        assert agent_2.conversation_manager.removed_message_count == 1
+        agent_2("Hello!")
+        assert len(agent_2.messages) == 1
         assert len(session_manager_2.list_messages(test_session_id, agent_2.agent_id)) == 4
     finally:
         # Delete the session


### PR DESCRIPTION
## Description
Store conversation manager state as a part of the session

## Related Issues

N/A

## Documentation PR

https://github.com/strands-agents/docs/pull/146

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
