### PR TITLE
feat: redact content from a message in a session

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -407,7 +407,7 @@ class AnthropicModel(Model):
         tool_spec = convert_pydantic_to_tool_spec(output_model)
 
         response = self.stream(messages=prompt, tool_specs=[tool_spec], **kwargs)
-        async for event in process_stream(response, prompt):
+        async for event in process_stream(response):
             yield event
 
         stop_reason, messages, _, _ = event["stop"]

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -577,7 +577,7 @@ class BedrockModel(Model):
         tool_spec = convert_pydantic_to_tool_spec(output_model)
 
         response = self.stream(messages=prompt, tool_specs=[tool_spec], **kwargs)
-        async for event in streaming.process_stream(response, prompt):
+        async for event in streaming.process_stream(response):
             yield event
 
         stop_reason, messages, _, _ = event["stop"]

--- a/src/strands/session/session_manager.py
+++ b/src/strands/session/session_manager.py
@@ -27,6 +27,15 @@ class SessionManager(HookProvider, ABC):
         registry.add_callback(MessageAddedEvent, lambda event: self.sync_agent(event.agent))
 
     @abstractmethod
+    def redact_latest_message(self, redact_message: Message, agent: "Agent") -> None:
+        """Redact the message most recently appended to the agent in the session.
+
+        Args:
+            redact_message: New message to use that contains the redact content
+            agent: Agent to apply the message redaction to
+        """
+
+    @abstractmethod
     def append_message(self, message: Message, agent: "Agent") -> None:
         """Append a message to the agent's session.
 

--- a/tests/fixtures/mocked_model_provider.py
+++ b/tests/fixtures/mocked_model_provider.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, AsyncGenerator, Iterable, Optional, Type, TypeVar
+from typing import Any, AsyncGenerator, Iterable, Optional, Type, TypedDict, TypeVar, Union
 
 from pydantic import BaseModel
 
@@ -12,6 +12,11 @@ from strands.types.tools import ToolSpec
 T = TypeVar("T", bound=BaseModel)
 
 
+class RedactionMessage(TypedDict):
+    redactedUserContent: str
+    redactedAssistantContent: str
+
+
 class MockedModelProvider(Model):
     """A mock implementation of the Model interface for testing purposes.
 
@@ -20,7 +25,7 @@ class MockedModelProvider(Model):
     to stream mock responses as events.
     """
 
-    def __init__(self, agent_responses: Messages):
+    def __init__(self, agent_responses: list[Union[Message, RedactionMessage]]):
         self.agent_responses = agent_responses
         self.index = 0
 
@@ -54,27 +59,36 @@ class MockedModelProvider(Model):
 
         self.index += 1
 
-    def map_agent_message_to_events(self, agent_message: Message) -> Iterable[dict[str, Any]]:
+    def map_agent_message_to_events(self, agent_message: Union[Message, RedactionMessage]) -> Iterable[dict[str, Any]]:
         stop_reason: StopReason = "end_turn"
         yield {"messageStart": {"role": "assistant"}}
-        for content in agent_message["content"]:
-            if "text" in content:
-                yield {"contentBlockStart": {"start": {}}}
-                yield {"contentBlockDelta": {"delta": {"text": content["text"]}}}
-                yield {"contentBlockStop": {}}
-            if "toolUse" in content:
-                stop_reason = "tool_use"
-                yield {
-                    "contentBlockStart": {
-                        "start": {
-                            "toolUse": {
-                                "name": content["toolUse"]["name"],
-                                "toolUseId": content["toolUse"]["toolUseId"],
+        if agent_message.get("redactedAssistantContent"):
+            yield {"redactContent": {"redactUserContentMessage": agent_message["redactedUserContent"]}}
+            yield {"contentBlockStart": {"start": {}}}
+            yield {"contentBlockDelta": {"delta": {"text": agent_message["redactedAssistantContent"]}}}
+            yield {"contentBlockStop": {}}
+            stop_reason = "guardrail_intervened"
+        else:
+            for content in agent_message["content"]:
+                if "text" in content:
+                    yield {"contentBlockStart": {"start": {}}}
+                    yield {"contentBlockDelta": {"delta": {"text": content["text"]}}}
+                    yield {"contentBlockStop": {}}
+                if "toolUse" in content:
+                    stop_reason = "tool_use"
+                    yield {
+                        "contentBlockStart": {
+                            "start": {
+                                "toolUse": {
+                                    "name": content["toolUse"]["name"],
+                                    "toolUseId": content["toolUse"]["toolUseId"],
+                                }
                             }
                         }
                     }
-                }
-                yield {"contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(content["toolUse"]["input"])}}}}
-                yield {"contentBlockStop": {}}
+                    yield {
+                        "contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(content["toolUse"]["input"])}}}
+                    }
+                    yield {"contentBlockStop": {}}
 
         yield {"messageStop": {"stopReason": stop_reason}}

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -528,8 +528,7 @@ def test_extract_usage_metrics():
 )
 @pytest.mark.asyncio
 async def test_process_stream(response, exp_events, agenerator, alist):
-    messages = [{"role": "user", "content": [{"text": "Some input!"}]}]
-    stream = strands.event_loop.streaming.process_stream(agenerator(response), messages)
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
 
     tru_events = await alist(stream)
     assert tru_events == exp_events

--- a/tests_integ/test_session.py
+++ b/tests_integ/test_session.py
@@ -11,12 +11,7 @@ from strands import Agent
 from strands.session.file_session_manager import FileSessionManager
 from strands.session.s3_session_manager import S3SessionManager
 
-
-@pytest.fixture
-def yellow_img(pytestconfig):
-    path = pytestconfig.rootdir / "tests_integ/yellow.png"
-    with open(path, "rb") as fp:
-        return fp.read()
+# yellow_img imported from conftest
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
Redact messages in the Session manager if a guardrail is triggered

- I moved the user input redaction logic out of the event loop streaming class, and instead include it in the Agent class as this is meant to alter a previously appended message in the agent.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
