### PR TITLE
fix(multiagent): remove a2a module from strands.multiagent __init__.py as it is an optional dependency

### DIFF
--- a/src/strands/multiagent/__init__.py
+++ b/src/strands/multiagent/__init__.py
@@ -8,12 +8,10 @@ Submodules:
          standardized communication between agents.
 """
 
-from . import a2a
 from .base import MultiAgentBase, MultiAgentResult
 from .graph import GraphBuilder, GraphResult
 
 __all__ = [
-    "a2a",
     "GraphBuilder",
     "GraphResult",
     "MultiAgentBase",


### PR DESCRIPTION
## Description
remove a2a module from strands.multiagent __init__.py as it is an optional dependency

without this fix, importing anything from `strands.multiagent` module requires the a2a optional dependencies

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`
- [X] Ran `hatch run test-integ`
- [X] Installed `strands-agents` in a fresh venv, tested with `from strands.multiagent import GraphBuilder` in a standalone script. Previously it failed requiring the a2a dependencies, now it works fine

## Checklist
- [X] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
