### PR TITLE
refactor: add kwargs to multiagent interfaces

### DIFF
--- a/src/strands/multiagent/base.py
+++ b/src/strands/multiagent/base.py
@@ -6,7 +6,7 @@ Provides minimal foundation for multi-agent patterns (Swarm, Graph).
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Union
+from typing import Any, Union
 
 from ..agent import AgentResult
 from ..types.content import ContentBlock
@@ -76,11 +76,11 @@ class MultiAgentBase(ABC):
     """
 
     @abstractmethod
-    async def execute_async(self, task: str | list[ContentBlock]) -> MultiAgentResult:
+    async def execute_async(self, task: str | list[ContentBlock], **kwargs: Any) -> MultiAgentResult:
         """Execute task asynchronously."""
         raise NotImplementedError("execute_async not implemented")
 
     @abstractmethod
-    def execute(self, task: str | list[ContentBlock]) -> MultiAgentResult:
+    def execute(self, task: str | list[ContentBlock], **kwargs: Any) -> MultiAgentResult:
         """Execute task synchronously."""
         raise NotImplementedError("execute not implemented")

--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -250,7 +250,7 @@ class Graph(MultiAgentBase):
         self.entry_points = entry_points
         self.state = GraphState()
 
-    def execute(self, task: str | list[ContentBlock]) -> GraphResult:
+    def execute(self, task: str | list[ContentBlock], **kwargs: Any) -> GraphResult:
         """Execute task synchronously."""
 
         def execute() -> GraphResult:
@@ -260,7 +260,7 @@ class Graph(MultiAgentBase):
             future = executor.submit(execute)
             return future.result()
 
-    async def execute_async(self, task: str | list[ContentBlock]) -> GraphResult:
+    async def execute_async(self, task: str | list[ContentBlock], **kwargs: Any) -> GraphResult:
         """Execute the graph asynchronously."""
         logger.debug("task=<%s> | starting graph execution", task)
 


### PR DESCRIPTION
## Description
Add `**kwargs` to `MultiAgentBase`. This will ensure any parameter we add to the abstract functions in the future will be backwards compatible.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Technically breaking change, but this is a new functionality, so it should be fine.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x ] I ran `hatch run prepare`

## Checklist
- [x ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
