### PR TITLE
fix: session manager tracks all agent last message

### DIFF
--- a/src/strands/session/session_repository.py
+++ b/src/strands/session/session_repository.py
@@ -34,7 +34,7 @@ class SessionRepository(ABC):
         """Create a new Message for the Agent."""
 
     @abstractmethod
-    def read_message(self, session_id: str, agent_id: str, message_id: str) -> Optional[SessionMessage]:
+    def read_message(self, session_id: str, agent_id: str, message_id: int) -> Optional[SessionMessage]:
         """Read a Message."""
 
     @abstractmethod

--- a/tests/strands/session/test_file_session_manager.py
+++ b/tests/strands/session/test_file_session_manager.py
@@ -44,11 +44,12 @@ def sample_agent():
 @pytest.fixture
 def sample_message():
     """Create sample message for testing."""
-    return SessionMessage(
+    return SessionMessage.from_message(
         message={
             "role": "user",
             "content": [ContentBlock(text="Hello world")],
-        }
+        },
+        index=0,
     )
 
 
@@ -189,7 +190,7 @@ class TestFileSessionManagerMessageOperations:
 
         # Verify message file
         message_path = file_manager._get_message_path(
-            sample_session.session_id, sample_agent.agent_id, sample_message.message_id, sample_message.created_at
+            sample_session.session_id, sample_agent.agent_id, sample_message.message_id
         )
         assert os.path.exists(message_path)
 
@@ -206,7 +207,7 @@ class TestFileSessionManagerMessageOperations:
         file_manager.create_message(sample_session.session_id, sample_agent.agent_id, sample_message)
 
         # Create multiple messages when reading
-        sample_message.message_id = sample_message.message_id + "_2"
+        sample_message.message_id = sample_message.message_id + 1
         file_manager.create_message(sample_session.session_id, sample_agent.agent_id, sample_message)
 
         # Read message
@@ -244,7 +245,8 @@ class TestFileSessionManagerMessageOperations:
                 message={
                     "role": "user",
                     "content": [ContentBlock(text=f"Message {i}")],
-                }
+                },
+                message_id=i,
             )
             messages.append(message)
             file_manager.create_message(sample_session.session_id, sample_agent.agent_id, message)
@@ -266,7 +268,8 @@ class TestFileSessionManagerMessageOperations:
                 message={
                     "role": "user",
                     "content": [ContentBlock(text=f"Message {i}")],
-                }
+                },
+                message_id=i,
             )
             file_manager.create_message(sample_session.session_id, sample_agent.agent_id, message)
 
@@ -287,7 +290,8 @@ class TestFileSessionManagerMessageOperations:
                 message={
                     "role": "user",
                     "content": [ContentBlock(text=f"Message {i}")],
-                }
+                },
+                message_id=i,
             )
             file_manager.create_message(sample_session.session_id, sample_agent.agent_id, message)
 

--- a/tests/strands/session/test_repository_session_manager.py
+++ b/tests/strands/session/test_repository_session_manager.py
@@ -97,7 +97,8 @@ def test_initialize_restores_existing_agent(session_manager, agent):
         message={
             "role": "user",
             "content": [ContentBlock(text="Hello")],
-        }
+        },
+        message_id=0,
     )
     session_manager.session_repository.create_message("test-session", "existing-agent", message)
 
@@ -111,17 +112,10 @@ def test_initialize_restores_existing_agent(session_manager, agent):
     assert agent.messages[0]["content"][0]["text"] == "Hello"
 
 
-def test_append_message(session_manager, agent):
+def test_append_message(session_manager):
     """Test appending a message to an agent's session."""
     # Set agent ID
-    agent.agent_id = "test-agent"
-
-    # Create agent in repository
-    session_agent = SessionAgent(
-        agent_id="test-agent",
-        state={},
-    )
-    session_manager.session_repository.create_agent("test-session", session_agent)
+    agent = Agent(agent_id="test-agent", session_manager=session_manager)
 
     # Create message
     message = {"role": "user", "content": [{"type": "text", "text": "Hello"}]}

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -60,11 +60,12 @@ def sample_agent():
 @pytest.fixture
 def sample_message():
     """Create sample message for testing."""
-    return SessionMessage(
+    return SessionMessage.from_message(
         message={
             "role": "user",
             "content": [ContentBlock(text="test_message")],
-        }
+        },
+        index=0,
     )
 
 
@@ -219,9 +220,7 @@ def test_create_message(s3_manager, sample_session, sample_agent, sample_message
     s3_manager.create_message(sample_session.session_id, sample_agent.agent_id, sample_message)
 
     # Verify S3 object created
-    key = s3_manager._get_message_path(
-        sample_session.session_id, sample_agent.agent_id, sample_message.message_id, sample_message.created_at
-    )
+    key = s3_manager._get_message_path(sample_session.session_id, sample_agent.agent_id, sample_message.message_id)
     response = s3_manager.client.get_object(Bucket=s3_manager.bucket, Key=key)
     data = json.loads(response["Body"].read().decode("utf-8"))
 
@@ -268,7 +267,8 @@ def test_list_messages_all(s3_manager, sample_session, sample_agent):
             {
                 "role": "user",
                 "content": [ContentBlock(text=f"Message {i}")],
-            }
+            },
+            i,
         )
         messages.append(message)
         s3_manager.create_message(sample_session.session_id, sample_agent.agent_id, message)
@@ -286,12 +286,13 @@ def test_list_messages_with_pagination(s3_manager, sample_session, sample_agent)
     s3_manager.create_agent(sample_session.session_id, sample_agent)
 
     # Create multiple messages
-    for _ in range(10):
-        message = SessionMessage(
+    for index in range(10):
+        message = SessionMessage.from_message(
             message={
                 "role": "user",
                 "content": [ContentBlock(text="test_message")],
-            }
+            },
+            index=index,
         )
         s3_manager.create_message(sample_session.session_id, sample_agent.agent_id, message)
 

--- a/tests/strands/types/test_session.py
+++ b/tests/strands/types/test_session.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import asdict
 from uuid import uuid4
 
 from strands.types.session import (
@@ -15,7 +14,7 @@ from strands.types.session import (
 def test_session_json_serializable():
     session = Session(session_id=str(uuid4()), session_type=SessionType.AGENT)
     # json dumps will fail if its not json serializable
-    session_json_string = json.dumps(asdict(session))
+    session_json_string = json.dumps(session.to_dict())
     loaded_session = Session.from_dict(json.loads(session_json_string))
     assert loaded_session is not None
 
@@ -23,15 +22,15 @@ def test_session_json_serializable():
 def test_agent_json_serializable():
     agent = SessionAgent(agent_id=str(uuid4()), state={"foo": "bar"})
     # json dumps will fail if its not json serializable
-    agent_json_string = json.dumps(asdict(agent))
+    agent_json_string = json.dumps(agent.to_dict())
     loaded_agent = SessionAgent.from_dict(json.loads(agent_json_string))
     assert loaded_agent is not None
 
 
 def test_message_json_serializable():
-    message = SessionMessage(message={"role": "user", "content": [{"text": "Hello!"}]})
+    message = SessionMessage(message={"role": "user", "content": [{"text": "Hello!"}]}, message_id=0)
     # json dumps will fail if its not json serializable
-    message_json_string = json.dumps(asdict(message))
+    message_json_string = json.dumps(message.to_dict())
     loaded_message = SessionMessage.from_dict(json.loads(message_json_string))
     assert loaded_message is not None
 
@@ -75,10 +74,10 @@ def test_session_message_with_bytes():
     }
 
     # Create a SessionMessage
-    session_message = SessionMessage.from_message(message)
+    session_message = SessionMessage.from_message(message, 0)
 
     # Verify it's JSON serializable
-    message_json_string = json.dumps(asdict(session_message))
+    message_json_string = json.dumps(session_message.to_dict())
 
     # Load it back
     loaded_message = SessionMessage.from_dict(json.loads(message_json_string))


### PR DESCRIPTION
## Description
- Fix session manager to track the last message for every agent
- Change how messages are stored. use index instead of created_at time when naming the file

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
