### PR TITLE
multiagent - use invoke_async instead of stream_async

### DIFF
--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -19,11 +19,11 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Callable, Tuple, cast
+from typing import Any, Callable, Tuple
 
 from opentelemetry import trace as trace_api
 
-from ..agent import Agent, AgentResult
+from ..agent import Agent
 from ..telemetry import get_tracer
 from ..types.content import ContentBlock
 from ..types.event_loop import Metrics, Usage
@@ -379,15 +379,7 @@ class Graph(MultiAgentBase):
                 )
 
             elif isinstance(node.executor, Agent):
-                agent_response: AgentResult | None = (
-                    None  # Initialize with None to handle case where no result is yielded
-                )
-                async for event in node.executor.stream_async(node_input):
-                    if "result" in event:
-                        agent_response = cast(AgentResult, event["result"])
-
-                if not agent_response:
-                    raise ValueError(f"Node '{node.node_id}' did not return a result")
+                agent_response = await node.executor.invoke_async(node_input)
 
                 # Extract metrics from agent response
                 usage = Usage(inputTokens=0, outputTokens=0, totalTokens=0)

--- a/src/strands/multiagent/swarm.py
+++ b/src/strands/multiagent/swarm.py
@@ -19,7 +19,7 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Callable, Tuple, cast
+from typing import Any, Callable, Tuple
 
 from ..agent import Agent, AgentResult
 from ..agent.state import AgentState
@@ -601,12 +601,7 @@ class Swarm(MultiAgentBase):
             # Execute node
             result = None
             node.reset_executor_state()
-            async for event in node.executor.stream_async(node_input):
-                if "result" in event:
-                    result = cast(AgentResult, event["result"])
-
-            if not result:
-                raise ValueError(f"Node '{node_name}' did not return a result")
+            result = await node.executor.invoke_async(node_input)
 
             execution_time = round((time.time() - start_time) * 1000)
 


### PR DESCRIPTION
## Description
In our multiagent logic, just making a switch to `agent.invoke_async` from `agent.stream_async` in the spots we don't use the yielded events.

## Related Issues

No issue, just a quality of life update.

## Documentation PR

Internal only change.

## Type of Change

Other (please describe): Code improvement.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I ran `hatch test tests_integ/test_multiagent_swarm.py` and `hatch test tests_integ/test_multiagent_graph.py`.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
