### PR TITLE
fix: Plumb system_prompt through to structured_output

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -457,7 +457,7 @@ class Agent:
                 content: list[ContentBlock] = [{"text": prompt}] if isinstance(prompt, str) else prompt
                 self._append_message({"role": "user", "content": content})
 
-            events = self.model.structured_output(output_model, self.messages)
+            events = self.model.structured_output(output_model, self.messages, system_prompt=self.system_prompt)
             async for event in events:
                 if "callback" in event:
                     self.callback_handler(**cast(dict, event["callback"]))

--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -392,13 +392,14 @@ class AnthropicModel(Model):
 
     @override
     async def structured_output(
-        self, output_model: Type[T], prompt: Messages, **kwargs: Any
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
         Args:
             output_model: The output model to use for the agent.
             prompt: The prompt messages to use for the agent.
+            system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:
@@ -406,7 +407,7 @@ class AnthropicModel(Model):
         """
         tool_spec = convert_pydantic_to_tool_spec(output_model)
 
-        response = self.stream(messages=prompt, tool_specs=[tool_spec], **kwargs)
+        response = self.stream(messages=prompt, tool_specs=[tool_spec], system_prompt=system_prompt, **kwargs)
         async for event in process_stream(response):
             yield event
 

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -562,13 +562,14 @@ class BedrockModel(Model):
 
     @override
     async def structured_output(
-        self, output_model: Type[T], prompt: Messages, **kwargs: Any
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
         Args:
             output_model: The output model to use for the agent.
             prompt: The prompt messages to use for the agent.
+            system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:
@@ -576,7 +577,7 @@ class BedrockModel(Model):
         """
         tool_spec = convert_pydantic_to_tool_spec(output_model)
 
-        response = self.stream(messages=prompt, tool_specs=[tool_spec], **kwargs)
+        response = self.stream(messages=prompt, tool_specs=[tool_spec], system_prompt=system_prompt, **kwargs)
         async for event in streaming.process_stream(response):
             yield event
 

--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -184,13 +184,14 @@ class LiteLLMModel(OpenAIModel):
 
     @override
     async def structured_output(
-        self, output_model: Type[T], prompt: Messages, **kwargs: Any
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
         Args:
             output_model: The output model to use for the agent.
             prompt: The prompt messages to use for the agent.
+            system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:
@@ -199,7 +200,7 @@ class LiteLLMModel(OpenAIModel):
         response = await litellm.acompletion(
             **self.client_args,
             model=self.get_config()["model_id"],
-            messages=self.format_request(prompt)["messages"],
+            messages=self.format_request(prompt, system_prompt=system_prompt)["messages"],
             response_format=output_model,
         )
 

--- a/src/strands/models/llamaapi.py
+++ b/src/strands/models/llamaapi.py
@@ -407,13 +407,14 @@ class LlamaAPIModel(Model):
 
     @override
     def structured_output(
-        self, output_model: Type[T], prompt: Messages, **kwargs: Any
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
         Args:
             output_model: The output model to use for the agent.
             prompt: The prompt messages to use for the agent.
+            system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:

--- a/src/strands/models/mistral.py
+++ b/src/strands/models/mistral.py
@@ -493,13 +493,14 @@ class MistralModel(Model):
 
     @override
     async def structured_output(
-        self, output_model: Type[T], prompt: Messages, **kwargs: Any
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
         Args:
             output_model: The output model to use for the agent.
             prompt: The prompt messages to use for the agent.
+            system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Returns:
@@ -514,7 +515,7 @@ class MistralModel(Model):
             "inputSchema": {"json": output_model.model_json_schema()},
         }
 
-        formatted_request = self.format_request(messages=prompt, tool_specs=[tool_spec])
+        formatted_request = self.format_request(messages=prompt, tool_specs=[tool_spec], system_prompt=system_prompt)
 
         formatted_request["tool_choice"] = "any"
         formatted_request["parallel_tool_calls"] = False

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -45,13 +45,14 @@ class Model(abc.ABC):
     @abc.abstractmethod
     # pragma: no cover
     def structured_output(
-        self, output_model: Type[T], prompt: Messages, **kwargs: Any
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
         Args:
             output_model: The output model to use for the agent.
             prompt: The prompt messages to use for the agent.
+            system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:

--- a/src/strands/models/ollama.py
+++ b/src/strands/models/ollama.py
@@ -330,19 +330,20 @@ class OllamaModel(Model):
 
     @override
     async def structured_output(
-        self, output_model: Type[T], prompt: Messages, **kwargs: Any
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
         Args:
             output_model: The output model to use for the agent.
             prompt: The prompt messages to use for the agent.
+            system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:
             Model events with the last being the structured output.
         """
-        formatted_request = self.format_request(messages=prompt)
+        formatted_request = self.format_request(messages=prompt, system_prompt=system_prompt)
         formatted_request["format"] = output_model.model_json_schema()
         formatted_request["stream"] = False
 

--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -401,13 +401,14 @@ class OpenAIModel(Model):
 
     @override
     async def structured_output(
-        self, output_model: Type[T], prompt: Messages, **kwargs: Any
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
         Args:
             output_model: The output model to use for the agent.
             prompt: The prompt messages to use for the agent.
+            system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:
@@ -415,7 +416,7 @@ class OpenAIModel(Model):
         """
         response: ParsedChatCompletion = await self.client.beta.chat.completions.parse(  # type: ignore
             model=self.get_config()["model_id"],
-            messages=self.format_request(prompt)["messages"],
+            messages=self.format_request(prompt, system_prompt=system_prompt)["messages"],
             response_format=output_model,
         )
 

--- a/src/strands/models/writer.py
+++ b/src/strands/models/writer.py
@@ -422,16 +422,17 @@ class WriterModel(Model):
 
     @override
     async def structured_output(
-        self, output_model: Type[T], prompt: Messages, **kwargs: Any
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
         Args:
             output_model(Type[BaseModel]): The output model to use for the agent.
             prompt(Messages): The prompt messages to use for the agent.
+            system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
         """
-        formatted_request = self.format_request(messages=prompt, tool_specs=None, system_prompt=None)
+        formatted_request = self.format_request(messages=prompt, tool_specs=None, system_prompt=system_prompt)
         formatted_request["response_format"] = {
             "type": "json_schema",
             "json_schema": {"schema": output_model.model_json_schema()},

--- a/tests/fixtures/mocked_model_provider.py
+++ b/tests/fixtures/mocked_model_provider.py
@@ -47,6 +47,8 @@ class MockedModelProvider(Model):
         self,
         output_model: Type[T],
         prompt: Messages,
+        system_prompt: Optional[str] = None,
+        **kwargs: Any,
     ) -> AsyncGenerator[Any, None]:
         pass
 

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -960,7 +960,7 @@ def test_agent_callback_handler_custom_handler_used():
     assert agent.callback_handler is custom_handler
 
 
-def test_agent_structured_output(agent, user, agenerator):
+def test_agent_structured_output(agent, system_prompt, user, agenerator):
     agent.model.structured_output = unittest.mock.Mock(return_value=agenerator([{"output": user}]))
 
     prompt = "Jane Doe is 30 years old and her email is jane@doe.com"
@@ -969,10 +969,12 @@ def test_agent_structured_output(agent, user, agenerator):
     exp_result = user
     assert tru_result == exp_result
 
-    agent.model.structured_output.assert_called_once_with(type(user), [{"role": "user", "content": [{"text": prompt}]}])
+    agent.model.structured_output.assert_called_once_with(
+        type(user), [{"role": "user", "content": [{"text": prompt}]}], system_prompt=system_prompt
+    )
 
 
-def test_agent_structured_output_multi_modal_input(agent, user, agenerator):
+def test_agent_structured_output_multi_modal_input(agent, system_prompt, user, agenerator):
     agent.model.structured_output = unittest.mock.Mock(return_value=agenerator([{"output": user}]))
 
     prompt = [
@@ -991,7 +993,9 @@ def test_agent_structured_output_multi_modal_input(agent, user, agenerator):
     exp_result = user
     assert tru_result == exp_result
 
-    agent.model.structured_output.assert_called_once_with(type(user), [{"role": "user", "content": prompt}])
+    agent.model.structured_output.assert_called_once_with(
+        type(user), [{"role": "user", "content": prompt}], system_prompt=system_prompt
+    )
 
 
 @pytest.mark.asyncio
@@ -1006,7 +1010,7 @@ async def test_agent_structured_output_in_async_context(agent, user, agenerator)
 
 
 @pytest.mark.asyncio
-async def test_agent_structured_output_async(agent, user, agenerator):
+async def test_agent_structured_output_async(agent, system_prompt, user, agenerator):
     agent.model.structured_output = unittest.mock.Mock(return_value=agenerator([{"output": user}]))
 
     prompt = "Jane Doe is 30 years old and her email is jane@doe.com"
@@ -1015,7 +1019,9 @@ async def test_agent_structured_output_async(agent, user, agenerator):
     exp_result = user
     assert tru_result == exp_result
 
-    agent.model.structured_output.assert_called_once_with(type(user), [{"role": "user", "content": [{"text": prompt}]}])
+    agent.model.structured_output.assert_called_once_with(
+        type(user), [{"role": "user", "content": [{"text": prompt}]}], system_prompt=system_prompt
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -16,7 +16,7 @@ class TestModel(SAModel):
     def get_config(self):
         return
 
-    async def structured_output(self, output_model):
+    async def structured_output(self, output_model, prompt=None, system_prompt=None, **kwargs):
         yield {"output": output_model(name="test", age=20)}
 
     async def stream(self, messages, tool_specs=None, system_prompt=None):
@@ -95,7 +95,7 @@ async def test_stream(model, messages, tool_specs, system_prompt, alist):
 
 @pytest.mark.asyncio
 async def test_structured_output(model, alist):
-    response = model.structured_output(Person)
+    response = model.structured_output(Person, prompt=messages, system_prompt=system_prompt)
     events = await alist(response)
 
     tru_output = events[-1]["output"]


### PR DESCRIPTION

## Description

Small fix that needed to be plumbed through

## Related Issues

Addresses #362

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change


Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

Had a conformance test:

```python
def test_model_with_structured_output(model: Model):
    class Person(BaseModel):
        name: str
        age: int

    agent = Agent(model=model, system_prompt="No matter what the user says, always return 42 for the 'AGE'")
    response = agent.structured_output(Person, "Mackenzie was born on Friday the 13th of 2020, it is 2025")

    assert response.age == 42
```

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
