### PR TITLE
Switch readme to use light logo for better display in github dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <div>
     <a href="https://strandsagents.com">
-      <img src="https://strandsagents.com/latest/assets/logo-auto.svg" alt="Strands Agents" width="55px" height="105px">
+      <img src="https://strandsagents.com/latest/assets/logo-light.svg" alt="Strands Agents" width="55px" height="105px">
     </a>
   </div>
 


### PR DESCRIPTION
## Description

Update logo so that in dark mode the other strand is available

*Before*

<img width="1938" height="550" alt="image" src="https://github.com/user-attachments/assets/0af0146d-9707-464d-a2be-ee84b9cfff4b" />

*After*

<img width="1096" height="454" alt="image" src="https://github.com/user-attachments/assets/e70df2b6-9535-4c7b-a0dd-ae295bc3a646" />

*After light mode*

<img width="1012" height="371" alt="image" src="https://github.com/user-attachments/assets/0ff5835e-76dc-4fb3-8714-400ac38f39b4" />


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
