### PR TITLE
fix: Remove finish_reason check from structured_output in LiteLLMModel

### DIFF
--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -209,17 +209,15 @@ class LiteLLMModel(OpenAIModel):
         if len(response.choices) > 1:
             raise ValueError("Multiple choices found in the response.")
 
-        # Find the first choice with tool_calls
         for choice in response.choices:
-            if choice.finish_reason == "tool_calls":
-                try:
-                    # Parse the tool call content as JSON
-                    tool_call_data = json.loads(choice.message.content)
-                    # Instantiate the output model with the parsed data
-                    yield {"output": output_model(**tool_call_data)}
-                    return
-                except (json.JSONDecodeError, TypeError, ValueError) as e:
-                    raise ValueError(f"Failed to parse or load content into model: {e}") from e
+            try:
+                # Parse the message content as JSON
+                output_data = json.loads(choice.message.content)
+                # Instantiate the output model with the parsed data
+                yield {"output": output_model(**output_data)}
+                return
+            except (json.JSONDecodeError, TypeError, ValueError) as e:
+                raise ValueError(f"Failed to parse or load content into model: {e}") from e
 
-        # If no tool_calls found, raise an error
-        raise ValueError("No tool_calls found in response")
+        # If no choices found, raise an error
+        raise ValueError("No choices found in response")


### PR DESCRIPTION
## Description

Using LiteLLM, I have access to a variety of models. When I run `agent.structured_output`, some models like `gemini-2.5-flash`, `gpt-4o` return a perfectly formatted output that satisfies `output_model` but with a `finish_reason` different from `tool_calls`. 

In my opinion, checking the `finish_reason` isn’t useful when we're only interested in the content itself.

## Type of Change
Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
