### PR TITLE
fix: enable parallel execution in graph workflow

### DIFF
--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -338,13 +338,18 @@ class Graph(MultiAgentBase):
             current_batch = ready_nodes.copy()
             ready_nodes.clear()
 
-            # Execute current batch of ready nodes
-            for node in current_batch:
-                if node not in self.state.completed_nodes:
-                    await self._execute_node(node)
+            # Execute current batch of ready nodes concurrently
+            tasks = [
+                asyncio.create_task(self._execute_node(node))
+                for node in current_batch
+                if node not in self.state.completed_nodes
+            ]
 
-                    # Find newly ready nodes after this execution
-                    ready_nodes.extend(self._find_newly_ready_nodes())
+            if tasks:
+                await asyncio.gather(*tasks)
+
+            # Find newly ready nodes after batch execution
+            ready_nodes.extend(self._find_newly_ready_nodes())
 
     def _find_newly_ready_nodes(self) -> list["GraphNode"]:
         """Find nodes that became ready after the last execution."""

--- a/tests_integ/test_multiagent_graph.py
+++ b/tests_integ/test_multiagent_graph.py
@@ -131,7 +131,10 @@ async def test_graph_execution_with_string(math_agent, summary_agent, validation
 
     # Verify execution order - extract node_ids from GraphNode objects
     execution_order_ids = [node.node_id for node in result.execution_order]
-    assert execution_order_ids == ["computation_subgraph", "secondary_math", "validator", "primary_summary"]
+    # With parallel execution, secondary_math and validator can complete in any order
+    assert execution_order_ids[0] == "computation_subgraph"  # First
+    assert execution_order_ids[3] == "primary_summary"  # Last
+    assert set(execution_order_ids[1:3]) == {"secondary_math", "validator"}  # Middle two in any order
 
     # Verify specific nodes completed
     assert "computation_subgraph" in result.results


### PR DESCRIPTION
## Description
This PR fixes a performance bottleneck in the graph workflow by implementing parallel execution for independent agents. Previously, the researcher, analyst, and writer agents were executing sequentially, causing unnecessary delays. This change uses `asyncio.gather()` to run these three agents concurrently, while maintaining the dependency order where the synthesizer runs after all agents complete.

Tested timeline:
```
21:10:34 ──── Writer starts (25s duration)
21:10:59 ──── Analyst starts (10s duration) ──── completes 21:11:09
21:11:09 ──── Researcher starts (33s duration) ──── completes 21:11:42
21:11:42 ──── Synthesizer starts (waits for all dependencies)

```
**Performance Impact:**
- Eliminates sequential execution bottleneck
- Significantly reduces total execution time
- Maintains correct dependency order (synthesizer waits for all agents)

## Related Issues
<!-- If there's no existing issue, you can leave this blank or create one first -->

## Documentation PR
<!-- Leave blank if no documentation changes needed -->

## Type of Change
Bug fix

## Testing
How have you tested the change?

- [x] Tested with trace analysis showing parallel execution vs sequential
- [x] Verified agents execute concurrently using OpenTelemetry spans
- [x] Confirmed synthesizer still runs after all agents complete
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
