### PR TITLE
fix(agent): prevent JSON serialization errors with non-serializable direct tool parameters

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -616,22 +616,10 @@ class Agent:
             user_message_override: Optional custom message to include.
         """
         # Create user message describing the tool call
-
-        # Filter out non-serializable objects to prevent JSON serialization errors
-        serializable_input = {}
-        for key, value in tool["input"].items():
-            try:
-                json.dumps(value)  # Test if serializable
-                serializable_input[key] = value
-            except (TypeError, ValueError):
-                serializable_input[key] = f"<non-serializable: {type(value).__name__}>"
+        input_parameters = json.dumps(tool["input"], default=lambda o: f"<<non-serializable: {type(o).__qualname__}>>")
 
         user_msg_content: list[ContentBlock] = [
-            {
-                "text": (
-                    f"agent.tool.{tool['name']} direct tool call.\nInput parameters: {json.dumps(serializable_input)}\n"
-                )
-            }
+            {"text": (f"agent.tool.{tool['name']} direct tool call.\nInput parameters: {input_parameters}\n")}
         ]
 
         # Add override message if provided

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -157,9 +157,7 @@ class Agent:
 
                 if should_record_direct_tool_call:
                     # Create a record of this tool execution in the message history
-                    self._agent._record_tool_execution(
-                        tool_use, tool_result, user_message_override, self._agent.messages
-                    )
+                    self._agent._record_tool_execution(tool_use, tool_result, user_message_override)
 
                 # Apply window management
                 self._agent.conversation_manager.apply_management(self._agent)
@@ -602,7 +600,6 @@ class Agent:
         tool: ToolUse,
         tool_result: ToolResult,
         user_message_override: Optional[str],
-        messages: Messages,
     ) -> None:
         """Record a tool execution in the message history.
 
@@ -617,11 +614,24 @@ class Agent:
             tool: The tool call information.
             tool_result: The result returned by the tool.
             user_message_override: Optional custom message to include.
-            messages: The message history to append to.
         """
         # Create user message describing the tool call
+
+        # Filter out non-serializable objects to prevent JSON serialization errors
+        serializable_input = {}
+        for key, value in tool["input"].items():
+            try:
+                json.dumps(value)  # Test if serializable
+                serializable_input[key] = value
+            except (TypeError, ValueError):
+                serializable_input[key] = f"<non-serializable: {type(value).__name__}>"
+
         user_msg_content: list[ContentBlock] = [
-            {"text": (f"agent.tool.{tool['name']} direct tool call.\nInput parameters: {json.dumps(tool['input'])}\n")}
+            {
+                "text": (
+                    f"agent.tool.{tool['name']} direct tool call.\nInput parameters: {json.dumps(serializable_input)}\n"
+                )
+            }
         ]
 
         # Add override message if provided
@@ -643,7 +653,7 @@ class Agent:
         }
         assistant_msg: Message = {
             "role": "assistant",
-            "content": [{"text": f"agent.{tool['name']} was called"}],
+            "content": [{"text": f"agent.tool.{tool['name']} was called."}],
         }
 
         # Add to message history

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -1576,3 +1576,184 @@ def test_agent_with_session_and_conversation_manager():
     assert agent.messages == agent_2.messages
     # Asser the conversation manager was initialized properly
     assert agent.conversation_manager.removed_message_count == agent_2.conversation_manager.removed_message_count
+
+
+def test_agent_tool_non_serializable_parameter_filtering(agent, mock_randint):
+    """Test that non-serializable objects in tool parameters are properly filtered during tool call recording."""
+    mock_randint.return_value = 42
+
+    # Create a non-serializable object (Agent instance)
+    another_agent = Agent()
+
+    # This should not crash even though we're passing non-serializable objects
+    result = agent.tool.tool_decorated(
+        random_string="test_value",
+        non_serializable_agent=another_agent,  # This would previously cause JSON serialization error
+        user_message_override="Testing non-serializable parameter filtering",
+    )
+
+    # Verify the tool executed successfully
+    expected_result = {
+        "content": [{"text": "test_value"}],
+        "status": "success",
+        "toolUseId": "tooluse_tool_decorated_42",
+    }
+    assert result == expected_result
+
+    # The key test: this should not crash during execution
+    # Check that we have messages recorded (exact count may vary)
+    assert len(agent.messages) > 0
+
+    # Check user message with filtered parameters - this is the main test for the bug fix
+    user_message = agent.messages[0]
+    assert user_message["role"] == "user"
+    assert len(user_message["content"]) == 2
+
+    # Check override message
+    assert user_message["content"][0]["text"] == "Testing non-serializable parameter filtering\n"
+
+    # Check tool call description with filtered parameters - this is where JSON serialization would fail
+    tool_call_text = user_message["content"][1]["text"]
+    assert "agent.tool.tool_decorated direct tool call." in tool_call_text
+    assert '"random_string": "test_value"' in tool_call_text
+    assert '"non_serializable_agent": "<non-serializable: Agent>"' in tool_call_text
+
+
+def test_agent_tool_multiple_non_serializable_types(agent, mock_randint):
+    """Test filtering of various non-serializable object types."""
+    mock_randint.return_value = 123
+
+    # Create various non-serializable objects
+    class CustomClass:
+        def __init__(self, value):
+            self.value = value
+
+    non_serializable_objects = {
+        "agent": Agent(),
+        "custom_object": CustomClass("test"),
+        "function": lambda x: x,
+        "set_object": {1, 2, 3},
+        "complex_number": 3 + 4j,
+        "serializable_string": "this_should_remain",
+        "serializable_number": 42,
+        "serializable_list": [1, 2, 3],
+        "serializable_dict": {"key": "value"},
+    }
+
+    # This should not crash
+    result = agent.tool.tool_decorated(random_string="test_filtering", **non_serializable_objects)
+
+    # Verify tool executed successfully
+    expected_result = {
+        "content": [{"text": "test_filtering"}],
+        "status": "success",
+        "toolUseId": "tooluse_tool_decorated_123",
+    }
+    assert result == expected_result
+
+    # Check the recorded message for proper parameter filtering
+    assert len(agent.messages) > 0
+    user_message = agent.messages[0]
+    tool_call_text = user_message["content"][0]["text"]
+
+    # Verify serializable objects remain unchanged
+    assert '"serializable_string": "this_should_remain"' in tool_call_text
+    assert '"serializable_number": 42' in tool_call_text
+    assert '"serializable_list": [1, 2, 3]' in tool_call_text
+    assert '"serializable_dict": {"key": "value"}' in tool_call_text
+
+    # Verify non-serializable objects are replaced with descriptive strings
+    assert '"agent": "<non-serializable: Agent>"' in tool_call_text
+    assert '"custom_object": "<non-serializable: CustomClass>"' in tool_call_text
+    assert '"function": "<non-serializable: function>"' in tool_call_text
+    assert '"set_object": "<non-serializable: set>"' in tool_call_text
+    assert '"complex_number": "<non-serializable: complex>"' in tool_call_text
+
+
+def test_agent_tool_serialization_edge_cases(agent, mock_randint):
+    """Test edge cases in parameter serialization filtering."""
+    mock_randint.return_value = 999
+
+    # Test with None values, empty containers, and nested structures
+    edge_case_params = {
+        "none_value": None,
+        "empty_list": [],
+        "empty_dict": {},
+        "nested_list_with_non_serializable": [1, 2, Agent()],  # This should be filtered out
+        "nested_dict_serializable": {"nested": {"key": "value"}},  # This should remain
+    }
+
+    result = agent.tool.tool_decorated(random_string="edge_cases", **edge_case_params)
+
+    # Verify successful execution
+    expected_result = {
+        "content": [{"text": "edge_cases"}],
+        "status": "success",
+        "toolUseId": "tooluse_tool_decorated_999",
+    }
+    assert result == expected_result
+
+    # Check parameter filtering in recorded message
+    assert len(agent.messages) > 0
+    user_message = agent.messages[0]
+    tool_call_text = user_message["content"][0]["text"]
+
+    # Verify serializable values remain
+    assert '"none_value": null' in tool_call_text
+    assert '"empty_list": []' in tool_call_text
+    assert '"empty_dict": {}' in tool_call_text
+    assert '"nested_dict_serializable": {"nested": {"key": "value"}}' in tool_call_text
+
+    # Verify non-serializable nested structure is replaced
+    assert '"nested_list_with_non_serializable": "<non-serializable: list>"' in tool_call_text
+
+
+def test_agent_tool_no_non_serializable_parameters(agent, mock_randint):
+    """Test that normal tool calls with only serializable parameters work unchanged."""
+    mock_randint.return_value = 555
+
+    # Call with only serializable parameters
+    result = agent.tool.tool_decorated(random_string="normal_call", user_message_override="Normal tool call test")
+
+    # Verify successful execution
+    expected_result = {
+        "content": [{"text": "normal_call"}],
+        "status": "success",
+        "toolUseId": "tooluse_tool_decorated_555",
+    }
+    assert result == expected_result
+
+    # Check message recording works normally
+    assert len(agent.messages) > 0
+    user_message = agent.messages[0]
+    tool_call_text = user_message["content"][1]["text"]
+
+    # Verify normal parameter serialization (no filtering needed)
+    assert "agent.tool.tool_decorated direct tool call." in tool_call_text
+    assert '"random_string": "normal_call"' in tool_call_text
+    # Should not contain any "<non-serializable:" strings
+    assert "<non-serializable:" not in tool_call_text
+
+
+def test_agent_tool_record_direct_tool_call_disabled_with_non_serializable(agent, mock_randint):
+    """Test that when record_direct_tool_call is disabled, non-serializable parameters don't cause issues."""
+    mock_randint.return_value = 777
+
+    # Disable tool call recording
+    agent.record_direct_tool_call = False
+
+    # This should work fine even with non-serializable parameters since recording is disabled
+    result = agent.tool.tool_decorated(
+        random_string="no_recording", non_serializable_agent=Agent(), user_message_override="This shouldn't be recorded"
+    )
+
+    # Verify successful execution
+    expected_result = {
+        "content": [{"text": "no_recording"}],
+        "status": "success",
+        "toolUseId": "tooluse_tool_decorated_777",
+    }
+    assert result == expected_result
+
+    # Verify no messages were recorded
+    assert len(agent.messages) == 0

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -1616,7 +1616,7 @@ def test_agent_tool_non_serializable_parameter_filtering(agent, mock_randint):
     tool_call_text = user_message["content"][1]["text"]
     assert "agent.tool.tool_decorated direct tool call." in tool_call_text
     assert '"random_string": "test_value"' in tool_call_text
-    assert '"non_serializable_agent": "<non-serializable: Agent>"' in tool_call_text
+    assert '"non_serializable_agent": "<<non-serializable: Agent>>"' in tool_call_text
 
 
 def test_agent_tool_multiple_non_serializable_types(agent, mock_randint):
@@ -1663,11 +1663,14 @@ def test_agent_tool_multiple_non_serializable_types(agent, mock_randint):
     assert '"serializable_dict": {"key": "value"}' in tool_call_text
 
     # Verify non-serializable objects are replaced with descriptive strings
-    assert '"agent": "<non-serializable: Agent>"' in tool_call_text
-    assert '"custom_object": "<non-serializable: CustomClass>"' in tool_call_text
-    assert '"function": "<non-serializable: function>"' in tool_call_text
-    assert '"set_object": "<non-serializable: set>"' in tool_call_text
-    assert '"complex_number": "<non-serializable: complex>"' in tool_call_text
+    assert '"agent": "<<non-serializable: Agent>>"' in tool_call_text
+    assert (
+        '"custom_object": "<<non-serializable: test_agent_tool_multiple_non_serializable_types.<locals>.CustomClass>>"'
+        in tool_call_text
+    )
+    assert '"function": "<<non-serializable: function>>"' in tool_call_text
+    assert '"set_object": "<<non-serializable: set>>"' in tool_call_text
+    assert '"complex_number": "<<non-serializable: complex>>"' in tool_call_text
 
 
 def test_agent_tool_serialization_edge_cases(agent, mock_randint):
@@ -1705,7 +1708,7 @@ def test_agent_tool_serialization_edge_cases(agent, mock_randint):
     assert '"nested_dict_serializable": {"nested": {"key": "value"}}' in tool_call_text
 
     # Verify non-serializable nested structure is replaced
-    assert '"nested_list_with_non_serializable": "<non-serializable: list>"' in tool_call_text
+    assert '"nested_list_with_non_serializable": [1, 2, "<<non-serializable: Agent>>"]' in tool_call_text
 
 
 def test_agent_tool_no_non_serializable_parameters(agent, mock_randint):
@@ -1731,8 +1734,8 @@ def test_agent_tool_no_non_serializable_parameters(agent, mock_randint):
     # Verify normal parameter serialization (no filtering needed)
     assert "agent.tool.tool_decorated direct tool call." in tool_call_text
     assert '"random_string": "normal_call"' in tool_call_text
-    # Should not contain any "<non-serializable:" strings
-    assert "<non-serializable:" not in tool_call_text
+    # Should not contain any "<<non-serializable:" strings
+    assert "<<non-serializable:" not in tool_call_text
 
 
 def test_agent_tool_record_direct_tool_call_disabled_with_non_serializable(agent, mock_randint):


### PR DESCRIPTION
## Description

This PR fixes a critical issue where passing non-serializable objects as tool parameters would cause JSON serialization errors during tool call recording, leading to crashes when agents tried to record their tool usage.

### The Problem
When agents passed complex objects like Agent instances, custom classes, functions, or other non-JSON-serializable objects as tool parameters, the `_record_tool_execution()` method would fail with cryptic JSON serialization errors, breaking the entire tool execution flow.

### The Solution
- **Smart Parameter Filtering**: Added logic to test each parameter with `json.dumps()` before recording
- **Graceful Degradation**: Replace non-serializable objects with descriptive strings like `<non-serializable: TypeName>`
- **Maintain Functionality**: Tool execution continues normally while providing clear indicators in the recorded history
- **Clean Implementation**: No breaking changes to existing functionality

### Key Changes
- Add parameter filtering in `_record_tool_execution()` to handle non-serializable objects
- Remove unused `messages` parameter from method signature
- Fix message format consistency (`agent.tool.{name}` vs `agent.{name}`)
- Comprehensive test coverage for edge cases and regression prevention

## Related Issues

Closes #350

## Documentation PR

No documentation changes needed - this is an internal bug fix that maintains existing API.

## Type of Change

Bug fix

## Testing

Comprehensive test suite added covering:

- [x] Single non-serializable objects (Agent instances)
- [x] Multiple types of non-serializable objects (custom classes, functions, sets, complex numbers)
- [x] Edge cases with nested structures and None values
- [x] Normal serializable parameters (regression testing)
- [x] Disabled recording scenarios
- [x] I ran `hatch run prepare` - all pre-commit hooks passed

### Test Results
All existing tests pass, and 5 new test functions added:
- `test_agent_tool_non_serializable_parameter_filtering`
- `test_agent_tool_multiple_non_serializable_types`
- `test_agent_tool_serialization_edge_cases`
- `test_agent_tool_no_non_serializable_parameters`
- `test_agent_tool_record_direct_tool_call_disabled_with_non_serializable`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (none needed for internal bug fix)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (none required)

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.