### PR TITLE
Add VPC endpoint support to BedrockModel class - Add optional endpoin…

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -115,7 +115,6 @@ class BedrockModel(Model):
                 Defaults to the AWS_REGION environment variable if set, or "us-west-2" if not set.
             endpoint_url: Custom endpoint URL for VPC endpoints (PrivateLink)
             **model_config: Configuration options for the Bedrock model.
-                Use endpoint_url for VPC endpoint connectivity.
         """
         if region_name and boto_session:
             raise ValueError("Cannot specify both `region_name` and `boto_session`.")

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -75,7 +75,6 @@ class BedrockModel(Model):
             streaming: Flag to enable/disable streaming. Defaults to True.
             temperature: Controls randomness in generation (higher = more random)
             top_p: Controls diversity via nucleus sampling (alternative to temperature)
-            endpoint_url: Custom endpoint URL for VPC endpoints (PrivateLink)
         """
 
         additional_args: Optional[dict[str, Any]]
@@ -97,7 +96,6 @@ class BedrockModel(Model):
         streaming: Optional[bool]
         temperature: Optional[float]
         top_p: Optional[float]
-        endpoint_url: Optional[str]  #Adding Endpoint URL
 
     def __init__(
         self,
@@ -105,6 +103,7 @@ class BedrockModel(Model):
         boto_session: Optional[boto3.Session] = None,
         boto_client_config: Optional[BotocoreConfig] = None,
         region_name: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
         **model_config: Unpack[BedrockConfig],
     ):
         """Initialize provider instance.
@@ -114,6 +113,7 @@ class BedrockModel(Model):
             boto_client_config: Configuration to use when creating the Bedrock-Runtime Boto Client.
             region_name: AWS region to use for the Bedrock service.
                 Defaults to the AWS_REGION environment variable if set, or "us-west-2" if not set.
+            endpoint_url: Custom endpoint URL for VPC endpoints (PrivateLink)
             **model_config: Configuration options for the Bedrock model.
                 Use endpoint_url for VPC endpoint connectivity.
         """
@@ -146,7 +146,7 @@ class BedrockModel(Model):
         self.client = session.client(
             service_name="bedrock-runtime",
             config=client_config,
-            endpoint_url=self.config.get("endpoint_url"),
+            endpoint_url=endpoint_url,
             region_name=resolved_region,
         )
 

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -75,6 +75,7 @@ class BedrockModel(Model):
             streaming: Flag to enable/disable streaming. Defaults to True.
             temperature: Controls randomness in generation (higher = more random)
             top_p: Controls diversity via nucleus sampling (alternative to temperature)
+            endpoint_url: Custom endpoint URL for VPC endpoints (PrivateLink)
         """
 
         additional_args: Optional[dict[str, Any]]
@@ -96,6 +97,7 @@ class BedrockModel(Model):
         streaming: Optional[bool]
         temperature: Optional[float]
         top_p: Optional[float]
+        endpoint_url: Optional[str]  #Adding Endpoint URL
 
     def __init__(
         self,
@@ -113,6 +115,7 @@ class BedrockModel(Model):
             region_name: AWS region to use for the Bedrock service.
                 Defaults to the AWS_REGION environment variable if set, or "us-west-2" if not set.
             **model_config: Configuration options for the Bedrock model.
+                Use endpoint_url for VPC endpoint connectivity.
         """
         if region_name and boto_session:
             raise ValueError("Cannot specify both `region_name` and `boto_session`.")
@@ -143,6 +146,7 @@ class BedrockModel(Model):
         self.client = session.client(
             service_name="bedrock-runtime",
             config=client_config,
+            endpoint_url=self.config.get("endpoint_url"),
             region_name=resolved_region,
         )
 

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -164,28 +164,38 @@ def test__init__region_precedence(mock_client_method, session_cls):
 
         # specifying a region always wins out
         BedrockModel(region_name="us-specified-1")
-        mock_client_method.assert_called_with(region_name="us-specified-1", config=ANY, service_name=ANY, endpoint_url=None)
+        mock_client_method.assert_called_with(
+            region_name="us-specified-1", config=ANY, service_name=ANY, endpoint_url=None
+        )
 
         # other-wise uses the session's
         BedrockModel()
-        mock_client_method.assert_called_with(region_name="us-session-1", config=ANY, service_name=ANY, endpoint_url=None)
+        mock_client_method.assert_called_with(
+            region_name="us-session-1", config=ANY, service_name=ANY, endpoint_url=None
+        )
 
         # environment variable next
         session_cls.return_value.region_name = None
         BedrockModel()
-        mock_client_method.assert_called_with(region_name="us-environment-1", config=ANY, service_name=ANY, endpoint_url=None)
+        mock_client_method.assert_called_with(
+            region_name="us-environment-1", config=ANY, service_name=ANY, endpoint_url=None
+        )
 
         mock_os_environ.pop("AWS_REGION")
         session_cls.return_value.region_name = None  # No session region
         BedrockModel()
-        mock_client_method.assert_called_with(region_name=DEFAULT_BEDROCK_REGION, config=ANY, service_name=ANY, endpoint_url=None)
+        mock_client_method.assert_called_with(
+            region_name=DEFAULT_BEDROCK_REGION, config=ANY, service_name=ANY, endpoint_url=None
+        )
 
 
 def test__init__with_endpoint_url(mock_client_method):
     """Test that BedrockModel uses the provided endpoint_url for VPC endpoints."""
     custom_endpoint = "https://vpce-12345-abcde.bedrock-runtime.us-west-2.vpce.amazonaws.com"
     BedrockModel(endpoint_url=custom_endpoint)
-    mock_client_method.assert_called_with(region_name=DEFAULT_BEDROCK_REGION, config=ANY, service_name=ANY, endpoint_url=custom_endpoint)
+    mock_client_method.assert_called_with(
+        region_name=DEFAULT_BEDROCK_REGION, config=ANY, service_name=ANY, endpoint_url=custom_endpoint
+    )
 
 
 def test__init__with_region_and_session_raises_value_error():

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -129,7 +129,7 @@ def test__init__with_default_region(session_cls, mock_client_method):
     with unittest.mock.patch.object(os, "environ", {}):
         BedrockModel()
         session_cls.return_value.client.assert_called_with(
-            region_name=DEFAULT_BEDROCK_REGION, config=ANY, service_name=ANY
+            region_name=DEFAULT_BEDROCK_REGION, config=ANY, service_name=ANY, endpoint_url=None
         )
 
 
@@ -139,14 +139,14 @@ def test__init__with_session_region(session_cls, mock_client_method):
 
     BedrockModel()
 
-    mock_client_method.assert_called_with(region_name="eu-blah-1", config=ANY, service_name=ANY)
+    mock_client_method.assert_called_with(region_name="eu-blah-1", config=ANY, service_name=ANY, endpoint_url=None)
 
 
 def test__init__with_custom_region(mock_client_method):
     """Test that BedrockModel uses the provided region."""
     custom_region = "us-east-1"
     BedrockModel(region_name=custom_region)
-    mock_client_method.assert_called_with(region_name=custom_region, config=ANY, service_name=ANY)
+    mock_client_method.assert_called_with(region_name=custom_region, config=ANY, service_name=ANY, endpoint_url=None)
 
 
 def test__init__with_default_environment_variable_region(mock_client_method):
@@ -154,7 +154,7 @@ def test__init__with_default_environment_variable_region(mock_client_method):
     with unittest.mock.patch.object(os, "environ", {"AWS_REGION": "eu-west-2"}):
         BedrockModel()
 
-    mock_client_method.assert_called_with(region_name="eu-west-2", config=ANY, service_name=ANY)
+    mock_client_method.assert_called_with(region_name="eu-west-2", config=ANY, service_name=ANY, endpoint_url=None)
 
 
 def test__init__region_precedence(mock_client_method, session_cls):
@@ -164,21 +164,28 @@ def test__init__region_precedence(mock_client_method, session_cls):
 
         # specifying a region always wins out
         BedrockModel(region_name="us-specified-1")
-        mock_client_method.assert_called_with(region_name="us-specified-1", config=ANY, service_name=ANY)
+        mock_client_method.assert_called_with(region_name="us-specified-1", config=ANY, service_name=ANY, endpoint_url=None)
 
         # other-wise uses the session's
         BedrockModel()
-        mock_client_method.assert_called_with(region_name="us-session-1", config=ANY, service_name=ANY)
+        mock_client_method.assert_called_with(region_name="us-session-1", config=ANY, service_name=ANY, endpoint_url=None)
 
         # environment variable next
         session_cls.return_value.region_name = None
         BedrockModel()
-        mock_client_method.assert_called_with(region_name="us-environment-1", config=ANY, service_name=ANY)
+        mock_client_method.assert_called_with(region_name="us-environment-1", config=ANY, service_name=ANY, endpoint_url=None)
 
         mock_os_environ.pop("AWS_REGION")
         session_cls.return_value.region_name = None  # No session region
         BedrockModel()
-        mock_client_method.assert_called_with(region_name=DEFAULT_BEDROCK_REGION, config=ANY, service_name=ANY)
+        mock_client_method.assert_called_with(region_name=DEFAULT_BEDROCK_REGION, config=ANY, service_name=ANY, endpoint_url=None)
+
+
+def test__init__with_endpoint_url(mock_client_method):
+    """Test that BedrockModel uses the provided endpoint_url for VPC endpoints."""
+    custom_endpoint = "https://vpce-12345-abcde.bedrock-runtime.us-west-2.vpce.amazonaws.com"
+    BedrockModel(endpoint_url=custom_endpoint)
+    mock_client_method.assert_called_with(region_name=DEFAULT_BEDROCK_REGION, config=ANY, service_name=ANY, endpoint_url=custom_endpoint)
 
 
 def test__init__with_region_and_session_raises_value_error():


### PR DESCRIPTION
## Description
Adds support for custom endpoint URLs in the BedrockModel class to enable connectivity through AWS VPC endpoints (PrivateLink). This feature allows users to specify a custom endpoint URL for organizations that require all Bedrock traffic to flow through VPC endpoints for security and compliance reasons.

### Changes Made:
- Add optional `endpoint_url` parameter to BedrockModel constructor
- Pass endpoint_url to boto3 client for VPC endpoint connectivity  
- Update BedrockConfig TypedDict to include endpoint_url field
- Update constructor docstring to document VPC endpoint usage
- Maintains backward compatibility with existing code

### Usage Example:
```python
from strands.models import BedrockModel

# Using VPC endpoint
model = BedrockModel(
    model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
    endpoint_url="https://vpce-1234567-abcd.bedrock-runtime.us-west-2.vpce.amazonaws.com",
    region_name="us-west-2"
)
```

## Related Issues
Resolves: Issue #496 
## Documentation PR
<!-- No documentation PR needed as this is a simple parameter addition -->

## Type of Change
New feature

## Testing
How have you tested the change?
- [x] Verified backward compatibility - existing code continues to work unchanged
- [x] Tested VPC endpoint parameter acceptance and storage in config
- [x] Confirmed endpoint_url is properly passed to boto3 client
- [x] Validated BedrockConfig TypedDict includes new parameter
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (docstring updates)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.