### PR TITLE
Don't re-run workflows on un/approvals

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -3,7 +3,7 @@ name: Pull Request and Push Action
 on:
   pull_request:  # Safer than pull_request_target for untrusted code
     branches: [ main ]
-    types: [opened, synchronize, reopened, ready_for_review, review_requested, review_request_removed]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [ main ]  # Also run on direct pushes to main
 concurrency:


### PR DESCRIPTION


## Description

These were necessary when we had conditional running but we switched to needing to approve all workflows for non-maintainers, so we no longer need these.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
