### PR TITLE
docs: add hot reloading documentation for load_tools_from_directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ agent = Agent(tools=[word_count])
 response = agent("How many words are in this sentence?")
 ```
 
+**Hot Reloading from Directory:**
+Enable automatic tool loading and reloading from the `./tools/` directory:
+
+```python
+from strands import Agent
+
+# Agent will watch ./tools/ directory for changes
+agent = Agent(load_tools_from_directory=True)
+response = agent("Use any tools you find in the tools directory")
+```
+
 ### MCP Support
 
 Seamlessly integrate Model Context Protocol (MCP) servers:


### PR DESCRIPTION
## Summary
This PR adds documentation for the hot reloading functionality that enables automatic tool loading and reloading from the `./tools/` directory.

## Changes
- Added **Hot Reloading from Directory** section to README.md
- Documents the `Agent(load_tools_from_directory=True)` parameter
- Includes practical code example for developers
- Improves discoverability of this useful development feature

## Context
The hot reloading functionality was already implemented via the `load_tools_from_directory=True` parameter in the Agent constructor, but wasn't featured in the README. This capability significantly improves developer experience by enabling:

- ✨ Automatic tool discovery from `./tools/` directory
- 🔄 Hot reloading when tools are modified 
- 🚀 Faster development iteration without agent restarts

## Testing
- [x] Documentation builds correctly
- [x] Code examples are valid Python syntax
- [x] Pre-commit hooks pass

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change