### PR TITLE
feat(a2a): support mounts for containerized deployments

### DIFF
--- a/src/strands/multiagent/a2a/server.py
+++ b/src/strands/multiagent/a2a/server.py
@@ -6,6 +6,7 @@ allowing it to be used in A2A-compatible systems.
 
 import logging
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 import uvicorn
 from a2a.server.apps import A2AFastAPIApplication, A2AStarletteApplication
@@ -31,6 +32,7 @@ class A2AServer:
         # AgentCard
         host: str = "0.0.0.0",
         port: int = 9000,
+        http_url: str | None = None,
         version: str = "0.0.1",
         skills: list[AgentSkill] | None = None,
     ):
@@ -40,13 +42,27 @@ class A2AServer:
             agent: The Strands Agent to wrap with A2A compatibility.
             host: The hostname or IP address to bind the A2A server to. Defaults to "0.0.0.0".
             port: The port to bind the A2A server to. Defaults to 9000.
+            http_url: The public HTTP URL where this agent will be accessible. If provided,
+                this overrides the generated URL from host/port and enables automatic
+                path-based mounting for load balancer scenarios.
+                Example: "http://my-alb.amazonaws.com/agent1"
             version: The version of the agent. Defaults to "0.0.1".
             skills: The list of capabilities or functions the agent can perform.
         """
         self.host = host
         self.port = port
-        self.http_url = f"http://{self.host}:{self.port}/"
         self.version = version
+
+        if http_url:
+            # Parse the provided URL to extract components for mounting
+            self.public_base_url, self.mount_path = self._parse_public_url(http_url)
+            self.http_url = http_url.rstrip("/") + "/"
+        else:
+            # Fall back to constructing the URL from host and port
+            self.public_base_url = f"http://{host}:{port}"
+            self.http_url = f"{self.public_base_url}/"
+            self.mount_path = ""
+
         self.strands_agent = agent
         self.name = self.strands_agent.name
         self.description = self.strands_agent.description
@@ -57,6 +73,25 @@ class A2AServer:
         )
         self._agent_skills = skills
         logger.info("Strands' integration with A2A is experimental. Be aware of frequent breaking changes.")
+
+    def _parse_public_url(self, url: str) -> tuple[str, str]:
+        """Parse the public URL into base URL and mount path components.
+
+        Args:
+            url: The full public URL (e.g., "http://my-alb.amazonaws.com/agent1")
+
+        Returns:
+            tuple: (base_url, mount_path) where base_url is the scheme+netloc
+                  and mount_path is the path component
+
+        Example:
+            _parse_public_url("http://my-alb.amazonaws.com/agent1")
+            Returns: ("http://my-alb.amazonaws.com", "/agent1")
+        """
+        parsed = urlparse(url.rstrip("/"))
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+        mount_path = parsed.path if parsed.path != "/" else ""
+        return base_url, mount_path
 
     @property
     def public_agent_card(self) -> AgentCard:
@@ -119,24 +154,42 @@ class A2AServer:
     def to_starlette_app(self) -> Starlette:
         """Create a Starlette application for serving this agent via HTTP.
 
-        This method creates a Starlette application that can be used to serve
-        the agent via HTTP using the A2A protocol.
+        Automatically handles path-based mounting if a mount path was derived
+        from the http_url parameter.
 
         Returns:
             Starlette: A Starlette application configured to serve this agent.
         """
-        return A2AStarletteApplication(agent_card=self.public_agent_card, http_handler=self.request_handler).build()
+        a2a_app = A2AStarletteApplication(agent_card=self.public_agent_card, http_handler=self.request_handler).build()
+
+        if self.mount_path:
+            # Create parent app and mount the A2A app at the specified path
+            parent_app = Starlette()
+            parent_app.mount(self.mount_path, a2a_app)
+            logger.info("Mounting A2A server at path: %s", self.mount_path)
+            return parent_app
+
+        return a2a_app
 
     def to_fastapi_app(self) -> FastAPI:
         """Create a FastAPI application for serving this agent via HTTP.
 
-        This method creates a FastAPI application that can be used to serve
-        the agent via HTTP using the A2A protocol.
+        Automatically handles path-based mounting if a mount path was derived
+        from the http_url parameter.
 
         Returns:
             FastAPI: A FastAPI application configured to serve this agent.
         """
-        return A2AFastAPIApplication(agent_card=self.public_agent_card, http_handler=self.request_handler).build()
+        a2a_app = A2AFastAPIApplication(agent_card=self.public_agent_card, http_handler=self.request_handler).build()
+
+        if self.mount_path:
+            # Create parent app and mount the A2A app at the specified path
+            parent_app = FastAPI()
+            parent_app.mount(self.mount_path, a2a_app)
+            logger.info("Mounting A2A server at path: %s", self.mount_path)
+            return parent_app
+
+        return a2a_app
 
     def serve(
         self,

--- a/src/strands/multiagent/a2a/server.py
+++ b/src/strands/multiagent/a2a/server.py
@@ -33,6 +33,7 @@ class A2AServer:
         host: str = "0.0.0.0",
         port: int = 9000,
         http_url: str | None = None,
+        serve_at_root: bool = False,
         version: str = "0.0.1",
         skills: list[AgentSkill] | None = None,
     ):
@@ -46,6 +47,9 @@ class A2AServer:
                 this overrides the generated URL from host/port and enables automatic
                 path-based mounting for load balancer scenarios.
                 Example: "http://my-alb.amazonaws.com/agent1"
+            serve_at_root: If True, forces the server to serve at root path regardless of
+                http_url path component. Use this when your load balancer strips path prefixes.
+                Defaults to False.
             version: The version of the agent. Defaults to "0.0.1".
             skills: The list of capabilities or functions the agent can perform.
         """
@@ -57,6 +61,10 @@ class A2AServer:
             # Parse the provided URL to extract components for mounting
             self.public_base_url, self.mount_path = self._parse_public_url(http_url)
             self.http_url = http_url.rstrip("/") + "/"
+
+            # Override mount path if serve_at_root is requested
+            if serve_at_root:
+                self.mount_path = ""
         else:
             # Fall back to constructing the URL from host and port
             self.public_base_url = f"http://{host}:{port}"

--- a/src/strands/session/repository_session_manager.py
+++ b/src/strands/session/repository_session_manager.py
@@ -133,9 +133,7 @@ class RepositorySessionManager(SessionManager):
             agent.state = AgentState(session_agent.state)
 
             # Restore the conversation manager to its previous state, and get the optional prepend messages
-            prepend_messages = agent.conversation_manager.restore_from_session(
-                session_agent.conversation_manager_state
-            )
+            prepend_messages = agent.conversation_manager.restore_from_session(session_agent.conversation_manager_state)
 
             if prepend_messages is None:
                 prepend_messages = []

--- a/tests/strands/multiagent/a2a/test_server.py
+++ b/tests/strands/multiagent/a2a/test_server.py
@@ -509,3 +509,193 @@ def test_serve_handles_general_exception(mock_run, mock_strands_agent, caplog):
 
     assert "Strands A2A server encountered exception" in caplog.text
     assert "Strands A2A server has shutdown" in caplog.text
+
+
+# Tests for http_url parameter and path mounting functionality
+
+
+def test_initialization_with_http_url_no_path(mock_strands_agent):
+    """Test initialization with http_url containing no path."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(
+        mock_strands_agent, host="0.0.0.0", port=8080, http_url="http://my-alb.amazonaws.com", skills=[]
+    )
+
+    assert a2a_agent.host == "0.0.0.0"
+    assert a2a_agent.port == 8080
+    assert a2a_agent.http_url == "http://my-alb.amazonaws.com/"
+    assert a2a_agent.public_base_url == "http://my-alb.amazonaws.com"
+    assert a2a_agent.mount_path == ""
+
+
+def test_initialization_with_http_url_with_path(mock_strands_agent):
+    """Test initialization with http_url containing a path for mounting."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(
+        mock_strands_agent, host="0.0.0.0", port=8080, http_url="http://my-alb.amazonaws.com/agent1", skills=[]
+    )
+
+    assert a2a_agent.host == "0.0.0.0"
+    assert a2a_agent.port == 8080
+    assert a2a_agent.http_url == "http://my-alb.amazonaws.com/agent1/"
+    assert a2a_agent.public_base_url == "http://my-alb.amazonaws.com"
+    assert a2a_agent.mount_path == "/agent1"
+
+
+def test_initialization_with_https_url(mock_strands_agent):
+    """Test initialization with HTTPS URL."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="https://my-alb.amazonaws.com/secure-agent", skills=[])
+
+    assert a2a_agent.http_url == "https://my-alb.amazonaws.com/secure-agent/"
+    assert a2a_agent.public_base_url == "https://my-alb.amazonaws.com"
+    assert a2a_agent.mount_path == "/secure-agent"
+
+
+def test_initialization_with_http_url_with_port(mock_strands_agent):
+    """Test initialization with http_url containing explicit port."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="http://my-server.com:8080/api/agent", skills=[])
+
+    assert a2a_agent.http_url == "http://my-server.com:8080/api/agent/"
+    assert a2a_agent.public_base_url == "http://my-server.com:8080"
+    assert a2a_agent.mount_path == "/api/agent"
+
+
+def test_parse_public_url_method(mock_strands_agent):
+    """Test the _parse_public_url method directly."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+    a2a_agent = A2AServer(mock_strands_agent, skills=[])
+
+    # Test various URL formats
+    base_url, mount_path = a2a_agent._parse_public_url("http://example.com/path")
+    assert base_url == "http://example.com"
+    assert mount_path == "/path"
+
+    base_url, mount_path = a2a_agent._parse_public_url("https://example.com:443/deep/path")
+    assert base_url == "https://example.com:443"
+    assert mount_path == "/deep/path"
+
+    base_url, mount_path = a2a_agent._parse_public_url("http://example.com/")
+    assert base_url == "http://example.com"
+    assert mount_path == ""
+
+    base_url, mount_path = a2a_agent._parse_public_url("http://example.com")
+    assert base_url == "http://example.com"
+    assert mount_path == ""
+
+
+def test_public_agent_card_with_http_url(mock_strands_agent):
+    """Test that public_agent_card uses the http_url when provided."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="https://my-alb.amazonaws.com/agent1", skills=[])
+
+    card = a2a_agent.public_agent_card
+
+    assert isinstance(card, AgentCard)
+    assert card.url == "https://my-alb.amazonaws.com/agent1/"
+    assert card.name == "Test Agent"
+    assert card.description == "A test agent for unit testing"
+
+
+def test_to_starlette_app_with_mounting(mock_strands_agent):
+    """Test that to_starlette_app creates mounted app when mount_path exists."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="http://example.com/agent1", skills=[])
+
+    app = a2a_agent.to_starlette_app()
+
+    assert isinstance(app, Starlette)
+    # The returned app should be the parent app with the A2A app mounted
+    # We can't easily inspect the mounting, but we can verify it's a Starlette app
+
+
+def test_to_starlette_app_without_mounting(mock_strands_agent):
+    """Test that to_starlette_app creates regular app when no mount_path."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="http://example.com", skills=[])
+
+    app = a2a_agent.to_starlette_app()
+
+    assert isinstance(app, Starlette)
+
+
+def test_to_fastapi_app_with_mounting(mock_strands_agent):
+    """Test that to_fastapi_app creates mounted app when mount_path exists."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="http://example.com/agent1", skills=[])
+
+    app = a2a_agent.to_fastapi_app()
+
+    assert isinstance(app, FastAPI)
+
+
+def test_to_fastapi_app_without_mounting(mock_strands_agent):
+    """Test that to_fastapi_app creates regular app when no mount_path."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="http://example.com", skills=[])
+
+    app = a2a_agent.to_fastapi_app()
+
+    assert isinstance(app, FastAPI)
+
+
+def test_backwards_compatibility_without_http_url(mock_strands_agent):
+    """Test that the old behavior is preserved when http_url is not provided."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, host="localhost", port=9000, skills=[])
+
+    # Should behave exactly like before
+    assert a2a_agent.host == "localhost"
+    assert a2a_agent.port == 9000
+    assert a2a_agent.http_url == "http://localhost:9000/"
+    assert a2a_agent.public_base_url == "http://localhost:9000"
+    assert a2a_agent.mount_path == ""
+
+    # Agent card should use the traditional URL
+    card = a2a_agent.public_agent_card
+    assert card.url == "http://localhost:9000/"
+
+
+def test_mount_path_logging(mock_strands_agent, caplog):
+    """Test that mounting logs the correct message."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="http://example.com/test-agent", skills=[])
+
+    # Test Starlette app mounting logs
+    caplog.clear()
+    a2a_agent.to_starlette_app()
+    assert "Mounting A2A server at path: /test-agent" in caplog.text
+
+    # Test FastAPI app mounting logs
+    caplog.clear()
+    a2a_agent.to_fastapi_app()
+    assert "Mounting A2A server at path: /test-agent" in caplog.text
+
+
+def test_http_url_trailing_slash_handling(mock_strands_agent):
+    """Test that trailing slashes in http_url are handled correctly."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    # Test with trailing slash
+    a2a_agent1 = A2AServer(mock_strands_agent, http_url="http://example.com/agent1/", skills=[])
+
+    # Test without trailing slash
+    a2a_agent2 = A2AServer(mock_strands_agent, http_url="http://example.com/agent1", skills=[])
+
+    # Both should result in the same normalized URL
+    assert a2a_agent1.http_url == "http://example.com/agent1/"
+    assert a2a_agent2.http_url == "http://example.com/agent1/"
+    assert a2a_agent1.mount_path == "/agent1"
+    assert a2a_agent2.mount_path == "/agent1"

--- a/tests/strands/multiagent/a2a/test_server.py
+++ b/tests/strands/multiagent/a2a/test_server.py
@@ -511,9 +511,6 @@ def test_serve_handles_general_exception(mock_run, mock_strands_agent, caplog):
     assert "Strands A2A server has shutdown" in caplog.text
 
 
-# Tests for http_url parameter and path mounting functionality
-
-
 def test_initialization_with_http_url_no_path(mock_strands_agent):
     """Test initialization with http_url containing no path."""
     mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
@@ -612,8 +609,6 @@ def test_to_starlette_app_with_mounting(mock_strands_agent):
     app = a2a_agent.to_starlette_app()
 
     assert isinstance(app, Starlette)
-    # The returned app should be the parent app with the A2A app mounted
-    # We can't easily inspect the mounting, but we can verify it's a Starlette app
 
 
 def test_to_starlette_app_without_mounting(mock_strands_agent):


### PR DESCRIPTION
Description

This PR adds native support for configurable public URLs and automatic path-based mounting to the `A2AServer` class, enabling seamless deployment in containerized environments and behind load balancers with path-based routing.

### Key Changes

**1. New `http_url` Parameter**
- Added `http_url: str | None = None` parameter to `A2AServer` constructor
- When provided, overrides the auto-generated URL from `host:port` for public agent card URLs
- Maintains separate concerns: `host`/`port` for internal binding, `http_url` for external access

**2. Automatic Path-Based Mounting** 
- When `http_url` contains a path component, the server automatically mounts the A2A application at that path
- Uses framework-native Starlette/FastAPI mounting capabilities (no middleware required)
- Handles URL parsing and normalization automatically

**3. Escape Hatch for Path-Stripping Load Balancers**
- Added `serve_at_root: bool = False` parameter as an escape hatch for edge cases
- When `True`, forces the server to serve at root path regardless of `http_url` path component
- Solves scenarios where load balancers strip path prefixes before forwarding to containers
- Maintains correct public URLs in agent cards while serving internally at root

**4. Enhanced URL Handling**
- Added `_parse_public_url()` method to extract base URL and mount path from provided URLs
- Proper URL normalization with trailing slash handling
- Intelligent mounting behavior with explicit override capability

**5. Framework Integration**
- Updated both `to_starlette_app()` and `to_fastapi_app()` methods to handle mounting
- Maintains backwards compatibility - existing code works unchanged

### Use Cases Solved

- **Container Deployments**: Internal binding (`0.0.0.0:8080`) vs external URL (`https://my-alb.amazonaws.com`)
- **Load Balancer Scenarios**: Public URLs that don't match internal configuration  
- **Path-Based Routing**: Multiple agents behind same ALB with different path prefixes
- **Path-Preserving ALBs**: Load balancer forwards full path to container (default behavior)
- **Path-Stripping ALBs**: Load balancer strips path prefix before forwarding (use `serve_at_root=True`)

## Related Issues

Addresses two GitHub feature requests:
- https://github.com/strands-agents/sdk-python/issues/382
- https://github.com/strands-agents/sdk-python/issues/383

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->
Will publish a followup PR for docs.

## Type of Change

New feature

## Testing

- unit tests
- manual testing

How have you tested the change? Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works (13 new tests)
- [x] I have updated the documentation accordingly (comprehensive inline docs + example script)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

**Examples of New Functionality:**

```python
# Most ALB scenarios (path preservation)
A2AServer(agent, http_url="http://my-alb.com/agent1")
# → Mounts at /agent1, serves /agent1/.well-known/agent.json

# Path-stripping ALBs 
A2AServer(agent, http_url="http://my-alb.com/agent1", serve_at_root=True)
# → Serves at root, but agent card shows http://my-alb.com/agent1/

# Local dev (unchanged)
A2AServer(agent, host="localhost", port=9000)
# → Serves at root on http://localhost:9000/
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.