### PR TITLE
fix: include agent trace into tool for agent as tools

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -273,7 +273,7 @@ class Tracer:
 
         self._end_span(span, attributes, error)
 
-    def start_tool_call_span(self, tool: ToolUse, parent_span: Optional[Span] = None, **kwargs: Any) -> Optional[Span]:
+    def start_tool_call_span(self, tool: ToolUse, parent_span: Optional[Span] = None, **kwargs: Any) -> Span:
         """Start a new span for a tool call.
 
         Args:


### PR DESCRIPTION
## Description
Include agent trace into tool span when using agent as tool

Trace structure before the change: [link](https://us.cloud.langfuse.com/project/cmbb4s57d01xiad07eex8qvrl/traces/275246a35d032eb2e87465f35917fa64?timestamp=2025-07-23T18:21:33.462Z&display=details)

Trace after the change: [link](https://us.cloud.langfuse.com/project/cmbb4s57d01xiad07eex8qvrl/traces/0bbf6160feacff2949f0e18caebbf9b4?timestamp=2025-07-23T18:26:38.461Z&display=details)

## Related Issues

Will attach it

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
