### PR TITLE
feat: update structured_output tool name to reduce user confusion

### DIFF
--- a/src/strands/tools/structured_output.py
+++ b/src/strands/tools/structured_output.py
@@ -275,7 +275,7 @@ def convert_pydantic_to_tool_spec(
     Returns:
         ToolSpec: Dict containing the Bedrock tool specification
     """
-    name = model.__name__
+    name = f"{model.__name__}OutputStructurer"
 
     # Get the JSON schema
     input_schema = model.model_json_schema()
@@ -300,7 +300,7 @@ def convert_pydantic_to_tool_spec(
     # Construct the tool specification
     return ToolSpec(
         name=name,
-        description=model_description or f"{name} structured output tool",
+        description=model_description or f"{model.__name__} structured output tool",
         inputSchema={"json": final_schema},
     )
 

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -724,7 +724,7 @@ async def test_structured_output(anthropic_client, model, test_output_model_cls,
                 return_value={
                     "type": "content_block_start",
                     "index": 0,
-                    "content_block": {"type": "tool_use", "id": "123", "name": "TestOutputModel"},
+                    "content_block": {"type": "tool_use", "id": "123", "name": "TestOutputModelOutputStructurer"},
                 }
             ),
         ),

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1084,7 +1084,7 @@ async def test_structured_output(bedrock_client, model, test_output_model_cls, a
     bedrock_client.converse_stream.return_value = {
         "stream": [
             {"messageStart": {"role": "assistant"}},
-            {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "123", "name": "TestOutputModel"}}}},
+            {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "123", "name": "TestOutputModelOutputStructurer"}}}},
             {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"name": "John", "age": 30}'}}}},
             {"contentBlockStop": {}},
             {"messageStop": {"stopReason": "tool_use"}},

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1084,7 +1084,11 @@ async def test_structured_output(bedrock_client, model, test_output_model_cls, a
     bedrock_client.converse_stream.return_value = {
         "stream": [
             {"messageStart": {"role": "assistant"}},
-            {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "123", "name": "TestOutputModelOutputStructurer"}}}},
+            {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": "123", "name": "TestOutputModelOutputStructurer"}}
+                }
+            },
             {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"name": "John", "age": 30}'}}}},
             {"contentBlockStop": {}},
             {"messageStop": {"stopReason": "tool_use"}},

--- a/tests/strands/tools/test_structured_output.py
+++ b/tests/strands/tools/test_structured_output.py
@@ -348,31 +348,31 @@ def test_convert_pydantic_with_refs():
 def test_tool_name_validation():
     """Test that tool names follow proper naming conventions."""
     import re
-    
+
     # Tool names should start with a letter and contain only alphanumeric characters and underscores
-    tool_name_pattern = re.compile(r'^[a-zA-Z][a-zA-Z0-9_]*$')
-    
+    tool_name_pattern = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
+
     # Test with various model names
     class SimpleModel(BaseModel):
         value: str
-    
+
     class Model_With_Underscores(BaseModel):
         value: str
-    
+
     class Model123(BaseModel):
         value: str
-    
+
     # Test all models produce valid tool names
     for model_class in [SimpleModel, Model_With_Underscores, Model123, User, UserWithPlanet]:
         tool_spec = convert_pydantic_to_tool_spec(model_class)
         tool_name = tool_spec["name"]
-        
+
         # Verify the tool name matches the expected pattern
         assert tool_name_pattern.match(tool_name), f"Tool name '{tool_name}' does not match valid pattern"
-        
+
         # Verify the tool name ends with OutputStructurer
         assert tool_name.endswith("OutputStructurer"), f"Tool name '{tool_name}' should end with 'OutputStructurer'"
-        
+
         # Verify the tool name starts with the model name
         expected_prefix = model_class.__name__
         assert tool_name.startswith(expected_prefix), f"Tool name '{tool_name}' should start with '{expected_prefix}'"

--- a/tests/strands/tools/test_structured_output.py
+++ b/tests/strands/tools/test_structured_output.py
@@ -41,7 +41,7 @@ def test_convert_pydantic_to_tool_spec_basic():
     tool_spec = convert_pydantic_to_tool_spec(User)
 
     expected_spec = {
-        "name": "User",
+        "name": "UserOutputStructurer",
         "description": "User model with name and age.",
         "inputSchema": {
             "json": {
@@ -73,7 +73,7 @@ def test_convert_pydantic_to_tool_spec_complex():
     tool_spec = convert_pydantic_to_tool_spec(ListOfUsersWithPlanet)
 
     expected_spec = {
-        "name": "ListOfUsersWithPlanet",
+        "name": "ListOfUsersWithPlanetOutputStructurer",
         "description": "List of users model with planet.",
         "inputSchema": {
             "json": {
@@ -127,7 +127,7 @@ def test_convert_pydantic_to_tool_spec_multiple_same_type():
     tool_spec = convert_pydantic_to_tool_spec(TwoUsersWithPlanet)
 
     expected_spec = {
-        "name": "TwoUsersWithPlanet",
+        "name": "TwoUsersWithPlanetOutputStructurer",
         "description": "Two users model with planet.",
         "inputSchema": {
             "json": {
@@ -286,7 +286,7 @@ def test_convert_pydantic_with_items_refs():
                 "type": "object",
             }
         },
-        "name": "Person",
+        "name": "PersonOutputStructurer",
     }
     assert tool_spec == expected_spec
 
@@ -340,6 +340,39 @@ def test_convert_pydantic_with_refs():
                 "type": "object",
             }
         },
-        "name": "Person",
+        "name": "PersonOutputStructurer",
     }
     assert tool_spec == expected_spec
+
+
+def test_tool_name_validation():
+    """Test that tool names follow proper naming conventions."""
+    import re
+    
+    # Tool names should start with a letter and contain only alphanumeric characters and underscores
+    tool_name_pattern = re.compile(r'^[a-zA-Z][a-zA-Z0-9_]*$')
+    
+    # Test with various model names
+    class SimpleModel(BaseModel):
+        value: str
+    
+    class Model_With_Underscores(BaseModel):
+        value: str
+    
+    class Model123(BaseModel):
+        value: str
+    
+    # Test all models produce valid tool names
+    for model_class in [SimpleModel, Model_With_Underscores, Model123, User, UserWithPlanet]:
+        tool_spec = convert_pydantic_to_tool_spec(model_class)
+        tool_name = tool_spec["name"]
+        
+        # Verify the tool name matches the expected pattern
+        assert tool_name_pattern.match(tool_name), f"Tool name '{tool_name}' does not match valid pattern"
+        
+        # Verify the tool name ends with OutputStructurer
+        assert tool_name.endswith("OutputStructurer"), f"Tool name '{tool_name}' should end with 'OutputStructurer'"
+        
+        # Verify the tool name starts with the model name
+        expected_prefix = model_class.__name__
+        assert tool_name.startswith(expected_prefix), f"Tool name '{tool_name}' should start with '{expected_prefix}'"

--- a/tests/strands/tools/test_structured_output.py
+++ b/tests/strands/tools/test_structured_output.py
@@ -343,36 +343,3 @@ def test_convert_pydantic_with_refs():
         "name": "PersonOutputStructurer",
     }
     assert tool_spec == expected_spec
-
-
-def test_tool_name_validation():
-    """Test that tool names follow proper naming conventions."""
-    import re
-
-    # Tool names should start with a letter and contain only alphanumeric characters and underscores
-    tool_name_pattern = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
-
-    # Test with various model names
-    class SimpleModel(BaseModel):
-        value: str
-
-    class Model_With_Underscores(BaseModel):
-        value: str
-
-    class Model123(BaseModel):
-        value: str
-
-    # Test all models produce valid tool names
-    for model_class in [SimpleModel, Model_With_Underscores, Model123, User, UserWithPlanet]:
-        tool_spec = convert_pydantic_to_tool_spec(model_class)
-        tool_name = tool_spec["name"]
-
-        # Verify the tool name matches the expected pattern
-        assert tool_name_pattern.match(tool_name), f"Tool name '{tool_name}' does not match valid pattern"
-
-        # Verify the tool name ends with OutputStructurer
-        assert tool_name.endswith("OutputStructurer"), f"Tool name '{tool_name}' should end with 'OutputStructurer'"
-
-        # Verify the tool name starts with the model name
-        expected_prefix = model_class.__name__
-        assert tool_name.startswith(expected_prefix), f"Tool name '{tool_name}' should start with '{expected_prefix}'"


### PR DESCRIPTION
## Description

Based on the uploaded file and conversation history, here's the suggested pull request description:

Problem:
Users are experiencing confusion when using structured output functionality. When using:

```python
agent(tools=[...])
agent.structured_output()
```

The tools from the main agent are incrementing normally, but the structured output functionality creates an ephemeral agent that always shows "Tool #1: {model name}" in the output. This is causing confusion since this tool is actually the structured output tool.

For example for a grocery buying agent constructed using

```
class GroceryAgent():
    @tool
     def create_grocery_list(request: str) -> Grocery:
         agent = Agent()
         response = agent(request)
         return agent.structured_output(Grocery, response)

class PurchaseAgent():
    @tool
     def purchase_grocery_list(request: str) -> Purchase:
         agent = Agent()
         response = agent(request)
         return agent.structured_output(Purchase, response)

final_agent = Agent(tools=[GroceryAgent().create_grocery_list, PurchaseAgent().purchase_grocery_list])
final_agent(....)
```

```
Let me help review and schedule your order using the available tools.

Tool #1: create_grocery_list
Let me determine which groceries to buy
Tool #1: Grocery

Tool #2: purchase_grocery_list
I'll purchase the groceries now
Tool #1: Purchase

...
```

Solution:
This PR updates the tool naming convention by appending "OutputStructurer" to the model name (e.g., "GroceryOutputStructurer" instead of just "Grocery"). This change makes it clearer to users which tool is handling the structured output functionality and reduces confusion around tool numbering.

This should result in something slightly more obvious regarding where the tool is coming from like

```
Let me help review and schedule your order using the available tools.

Tool #1: create_grocery_list
Let me determine which groceries to buy
Tool #1: GroceryOutputStructurer

Tool #2: purchase_grocery_list
I'll purchase the groceries now
Tool #1: PurchaseOutputStructurer
```

## Type of Change

Other (please describe): This should not be breaking as the interface has not changed but this change modifies the internal Agent's tool name

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
