### PR TITLE
fix: Remove leftover print statement from sagemaker model provider

### DIFF
--- a/src/strands/models/sagemaker.py
+++ b/src/strands/models/sagemaker.py
@@ -274,8 +274,6 @@ class SageMakerAIModel(OpenAIModel):
         if self.endpoint_config.get("additional_args"):
             request.update(self.endpoint_config["additional_args"].__dict__)
 
-        print(json.dumps(request["Body"], indent=2))
-
         return request
 
     @override


### PR DESCRIPTION
## Description
Remove debug print statement that was leftover during development. 

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
