### PR TITLE
feat(multi-agent): allow passing invocation states to sub-agents as tools

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -414,7 +414,7 @@ class AnthropicModel(Model):
         stop_reason, messages, _, _ = event["stop"]
 
         if stop_reason != "tool_use":
-            raise ValueError(f"Model returned stop_reason: {stop_reason} instead of \"tool_use\".")
+            raise ValueError(f'Model returned stop_reason: {stop_reason} instead of "tool_use".')
 
         content = messages["content"]
         output_response: dict[str, Any] | None = None

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -631,7 +631,7 @@ class BedrockModel(Model):
         stop_reason, messages, _, _ = event["stop"]
 
         if stop_reason != "tool_use":
-            raise ValueError(f"Model returned stop_reason: {stop_reason} instead of \"tool_use\".")
+            raise ValueError(f'Model returned stop_reason: {stop_reason} instead of "tool_use".')
 
         content = messages["content"]
         output_response: dict[str, Any] | None = None


### PR DESCRIPTION
## Description
Allow passing invocation states to sub-agents as tools.

Example usage

```
from strands import Agent
from strands.tools import tool

@tool
def teacher(query: str, **kwargs):
    hidden_number = kwargs.get("hidden_number")
    agent = kwargs.get("agent")
    print(f"Getting query from {agent.name}")

    teacher_agent = Agent(name="teacher", system_prompt=f"You're a math teacher help with math problems. You have got an hidden number {hidden_number} and you must use it in the calculation")
    
    return teacher_agent(query)


coordinator = Agent(name="coordinator", system_prompt="You're a coordinator, always pass your query to teacher agent", tools=[teacher])
invocation_state = {"hidden_number": 3}
response = coordinator("times 2", **invocation_state)
```


## Related Issues
#579 

## Documentation PR

Not created yet. 

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
