### PR TITLE
Change max_tokens type to int to match Anthropic API

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -55,7 +55,7 @@ class AnthropicModel(Model):
                 For a complete list of supported parameters, see https://docs.anthropic.com/en/api/messages.
         """
 
-        max_tokens: Required[str]
+        max_tokens: Required[int]
         model_id: Required[str]
         params: Optional[dict[str, Any]]
 


### PR DESCRIPTION
Using a string as suggested by the type annotation causes the Anthropic API call to fail:
```
anthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'max_tokens: Input should be a valid integer'}}
```

## Description
Just a quick type change.

## Documentation PR
Documentation actually looks right, just the type annotation is incorrect.

## Type of Change
Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
