### PR TITLE
models - bedrock - daemon thread

### DIFF
--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1197,7 +1197,6 @@ async def test_stream_logging(bedrock_client, model, messages, caplog, alist):
     assert "formatting request" in log_text
     assert "request=<" in log_text
     assert "invoking model" in log_text
-    assert "got response from model" in log_text
     assert "finished streaming response from model" in log_text
 
 


### PR DESCRIPTION
## Description
Running Bedrock model provider in a daemon thread so that it terminates immediately with the main thread if the main thread goes down. This is particularly useful for `agent-builder` which has special controls around keyboard interrupts. 

## Related Issues

https://github.com/strands-agents/sdk-python/issues/560


## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] `hatch run test-integ`
- [x] `strands`: Ran a local version of `agent-builder` that I am updating with non-blocking threads. Ran against this updated version of the Bedrock model provider and pressed `ctrl-c`. The CLI now exits immediately as before.
- [x] `python test_threading`: Wrote the following script for testing `ctrl-c` response directly
```Python
import asyncio
from strands import Agent

async def main():
    agent = Agent()
    await agent.invoke_async("What is 2+2? Please think through the answer")

asyncio.run(main())
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
