### PR TITLE
fix: skip messages with empty content

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -269,6 +269,9 @@ class BedrockModel(Model):
         cleaned_messages = []
 
         for message in messages:
+            if not message["content"]:
+                continue
+
             cleaned_content: list[ContentBlock] = []
 
             for content_block in message["content"]:

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -383,6 +383,25 @@ def test_format_request_tool_specs(model, messages, model_id, tool_spec):
     assert tru_request == exp_request
 
 
+def test_format_request_skip_empty_content(model, model_id, inference_config):
+    messages = [{"role": "user", "content": []}]
+    model.update_config(**inference_config)
+    tru_request = model.format_request(messages)
+    exp_request = {
+        "inferenceConfig": {
+            "maxTokens": inference_config["max_tokens"],
+            "stopSequences": inference_config["stop_sequences"],
+            "temperature": inference_config["temperature"],
+            "topP": inference_config["top_p"],
+        },
+        "modelId": model_id,
+        "messages": [],
+        "system": [],
+    }
+
+    assert tru_request == exp_request
+
+
 def test_format_request_cache(model, messages, model_id, tool_spec, cache_type):
     model.update_config(cache_prompt=cache_type, cache_tools=cache_type)
     tru_request = model.format_request(messages, [tool_spec])


### PR DESCRIPTION
## Description
Skip message with empty content in order to fix validation exception.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/514

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
