### PR TITLE
fix(structured_output): do not modify conversation_history when prompt is passed

### DIFF
--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -984,10 +984,17 @@ def test_agent_structured_output(agent, system_prompt, user, agenerator):
 
     prompt = "Jane Doe is 30 years old and her email is jane@doe.com"
 
+    # Store initial message count
+    initial_message_count = len(agent.messages)
+
     tru_result = agent.structured_output(type(user), prompt)
     exp_result = user
     assert tru_result == exp_result
 
+    # Verify conversation history is not polluted
+    assert len(agent.messages) == initial_message_count
+
+    # Verify the model was called with temporary messages array
     agent.model.structured_output.assert_called_once_with(
         type(user), [{"role": "user", "content": [{"text": prompt}]}], system_prompt=system_prompt
     )
@@ -1008,10 +1015,17 @@ def test_agent_structured_output_multi_modal_input(agent, system_prompt, user, a
         },
     ]
 
+    # Store initial message count
+    initial_message_count = len(agent.messages)
+
     tru_result = agent.structured_output(type(user), prompt)
     exp_result = user
     assert tru_result == exp_result
 
+    # Verify conversation history is not polluted
+    assert len(agent.messages) == initial_message_count
+
+    # Verify the model was called with temporary messages array
     agent.model.structured_output.assert_called_once_with(
         type(user), [{"role": "user", "content": prompt}], system_prompt=system_prompt
     )
@@ -1023,9 +1037,40 @@ async def test_agent_structured_output_in_async_context(agent, user, agenerator)
 
     prompt = "Jane Doe is 30 years old and her email is jane@doe.com"
 
+    # Store initial message count
+    initial_message_count = len(agent.messages)
+
     tru_result = await agent.structured_output_async(type(user), prompt)
     exp_result = user
     assert tru_result == exp_result
+
+    # Verify conversation history is not polluted
+    assert len(agent.messages) == initial_message_count
+
+
+def test_agent_structured_output_without_prompt(agent, system_prompt, user, agenerator):
+    """Test that structured_output works with existing conversation history and no new prompt."""
+    agent.model.structured_output = unittest.mock.Mock(return_value=agenerator([{"output": user}]))
+
+    # Add some existing messages to the agent
+    existing_messages = [
+        {"role": "user", "content": [{"text": "Jane Doe is 30 years old"}]},
+        {"role": "assistant", "content": [{"text": "I understand."}]},
+    ]
+    agent.messages.extend(existing_messages)
+
+    initial_message_count = len(agent.messages)
+
+    tru_result = agent.structured_output(type(user))  # No prompt provided
+    exp_result = user
+    assert tru_result == exp_result
+
+    # Verify conversation history is unchanged
+    assert len(agent.messages) == initial_message_count
+    assert agent.messages == existing_messages
+
+    # Verify the model was called with existing messages only
+    agent.model.structured_output.assert_called_once_with(type(user), existing_messages, system_prompt=system_prompt)
 
 
 @pytest.mark.asyncio
@@ -1034,10 +1079,17 @@ async def test_agent_structured_output_async(agent, system_prompt, user, agenera
 
     prompt = "Jane Doe is 30 years old and her email is jane@doe.com"
 
+    # Store initial message count
+    initial_message_count = len(agent.messages)
+
     tru_result = agent.structured_output(type(user), prompt)
     exp_result = user
     assert tru_result == exp_result
 
+    # Verify conversation history is not polluted
+    assert len(agent.messages) == initial_message_count
+
+    # Verify the model was called with temporary messages array
     agent.model.structured_output.assert_called_once_with(
         type(user), [{"role": "user", "content": [{"text": prompt}]}], system_prompt=system_prompt
     )

--- a/tests/strands/agent/test_agent_hooks.py
+++ b/tests/strands/agent/test_agent_hooks.py
@@ -267,13 +267,12 @@ def test_agent_structured_output_hooks(agent, hook_provider, user, agenerator):
 
     length, events = hook_provider.get_events()
 
-    assert length == 3
+    assert length == 2
 
     assert next(events) == BeforeInvocationEvent(agent=agent)
-    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[0])
     assert next(events) == AfterInvocationEvent(agent=agent)
 
-    assert len(agent.messages) == 1
+    assert len(agent.messages) == 0  # no new messages added
 
 
 @pytest.mark.asyncio
@@ -285,10 +284,9 @@ async def test_agent_structured_async_output_hooks(agent, hook_provider, user, a
 
     length, events = hook_provider.get_events()
 
-    assert length == 3
+    assert length == 2
 
     assert next(events) == BeforeInvocationEvent(agent=agent)
-    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[0])
     assert next(events) == AfterInvocationEvent(agent=agent)
 
-    assert len(agent.messages) == 1
+    assert len(agent.messages) == 0  # no new messages added


### PR DESCRIPTION
## Description

A customer brought up the following concern regarding using structured_output on an agent.
```
If I use the alternate method, first go through one agent loop using result = agent(user_message)  and then agent.structured_output(<pydantic model>, result) , then there are 2 problems -
Won’t passing the result again as a “prompt” pollute the context window?
{ignore problem 2}
```

Adding the prompt to the conversation history seems like a bug. We are indicating that we want a particular message structured, but we never add the result to the conversation history. 

So, we can either not append or we can add the result of the structuring after it is complete. I am biased towards the former. This is because structured output is not an action taken by the agent. Rather, it is more similar to a utility function for the user to format the result of an agent invocation. The structuring of the output is not itself an invocation in the same sense - especially since it is making a model request with only a single, non-user defined, tool.



## Documentation PR

No documentation updates needed after inspecting https://strandsagents.com/latest/documentation/docs/user-guide/concepts/agents/structured-output/

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
