### PR TITLE
Fix: strip reasoningContent from messages before sending to Bedrock to avoid ValidationException

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -7,7 +7,17 @@ import asyncio
 import json
 import logging
 import os
-from typing import Any, AsyncGenerator, Callable, Iterable, Literal, Optional, Type, TypeVar, Union
+from typing import (
+    Any,
+    AsyncGenerator,
+    Callable,
+    Iterable,
+    Literal,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import boto3
 from botocore.config import Config as BotocoreConfig
@@ -131,11 +141,18 @@ class BedrockModel(Model):
             else:
                 new_user_agent = "strands-agents"
 
-            client_config = boto_client_config.merge(BotocoreConfig(user_agent_extra=new_user_agent))
+            client_config = boto_client_config.merge(
+                BotocoreConfig(user_agent_extra=new_user_agent)
+            )
         else:
             client_config = BotocoreConfig(user_agent_extra="strands-agents")
 
-        resolved_region = region_name or session.region_name or os.environ.get("AWS_REGION") or DEFAULT_BEDROCK_REGION
+        resolved_region = (
+            region_name
+            or session.region_name
+            or os.environ.get("AWS_REGION")
+            or DEFAULT_BEDROCK_REGION
+        )
 
         self.client = session.client(
             service_name="bedrock-runtime",
@@ -143,7 +160,9 @@ class BedrockModel(Model):
             region_name=resolved_region,
         )
 
-        logger.debug("region=<%s> | bedrock client created", self.client.meta.region_name)
+        logger.debug(
+            "region=<%s> | bedrock client created", self.client.meta.region_name
+        )
 
     @override
     def update_config(self, **model_config: Unpack[BedrockConfig]) -> None:  # type: ignore
@@ -184,7 +203,11 @@ class BedrockModel(Model):
             "messages": self._format_bedrock_messages(messages),
             "system": [
                 *([{"text": system_prompt}] if system_prompt else []),
-                *([{"cachePoint": {"type": self.config["cache_prompt"]}}] if self.config.get("cache_prompt") else []),
+                *(
+                    [{"cachePoint": {"type": self.config["cache_prompt"]}}]
+                    if self.config.get("cache_prompt")
+                    else []
+                ),
             ],
             **(
                 {
@@ -204,12 +227,20 @@ class BedrockModel(Model):
                 else {}
             ),
             **(
-                {"additionalModelRequestFields": self.config["additional_request_fields"]}
+                {
+                    "additionalModelRequestFields": self.config[
+                        "additional_request_fields"
+                    ]
+                }
                 if self.config.get("additional_request_fields")
                 else {}
             ),
             **(
-                {"additionalModelResponseFieldPaths": self.config["additional_response_field_paths"]}
+                {
+                    "additionalModelResponseFieldPaths": self.config[
+                        "additional_response_field_paths"
+                    ]
+                }
                 if self.config.get("additional_response_field_paths")
                 else {}
             ),
@@ -220,13 +251,18 @@ class BedrockModel(Model):
                         "guardrailVersion": self.config["guardrail_version"],
                         "trace": self.config.get("guardrail_trace", "enabled"),
                         **(
-                            {"streamProcessingMode": self.config.get("guardrail_stream_processing_mode")}
+                            {
+                                "streamProcessingMode": self.config.get(
+                                    "guardrail_stream_processing_mode"
+                                )
+                            }
                             if self.config.get("guardrail_stream_processing_mode")
                             else {}
                         ),
                     }
                 }
-                if self.config.get("guardrail_id") and self.config.get("guardrail_version")
+                if self.config.get("guardrail_id")
+                and self.config.get("guardrail_version")
                 else {}
             ),
             "inferenceConfig": {
@@ -241,7 +277,8 @@ class BedrockModel(Model):
             },
             **(
                 self.config["additional_args"]
-                if "additional_args" in self.config and self.config["additional_args"] is not None
+                if "additional_args" in self.config
+                and self.config["additional_args"] is not None
                 else {}
             ),
         }
@@ -278,7 +315,9 @@ class BedrockModel(Model):
 
                     # Keep only the required fields for Bedrock
                     cleaned_tool_result = ToolResult(
-                        content=tool_result["content"], toolUseId=tool_result["toolUseId"], status=tool_result["status"]
+                        content=tool_result["content"],
+                        toolUseId=tool_result["toolUseId"],
+                        status=tool_result["status"],
                     )
 
                     cleaned_block: ContentBlock = {"toolResult": cleaned_tool_result}
@@ -288,7 +327,9 @@ class BedrockModel(Model):
                     cleaned_content.append(content_block)
 
             # Create new message with cleaned content
-            cleaned_message: Message = Message(content=cleaned_content, role=message["role"])
+            cleaned_message: Message = Message(
+                content=cleaned_content, role=message["role"]
+            )
             cleaned_messages.append(cleaned_message)
 
         return cleaned_messages
@@ -306,11 +347,17 @@ class BedrockModel(Model):
         output_assessments = guardrail_data.get("outputAssessments", {})
 
         # Check input assessments
-        if any(self._find_detected_and_blocked_policy(assessment) for assessment in input_assessment.values()):
+        if any(
+            self._find_detected_and_blocked_policy(assessment)
+            for assessment in input_assessment.values()
+        ):
             return True
 
         # Check output assessments
-        if any(self._find_detected_and_blocked_policy(assessment) for assessment in output_assessments.values()):
+        if any(
+            self._find_detected_and_blocked_policy(assessment)
+            for assessment in output_assessments.values()
+        ):
             return True
 
         return False
@@ -341,7 +388,8 @@ class BedrockModel(Model):
                 {
                     "redactContent": {
                         "redactAssistantContentMessage": self.config.get(
-                            "guardrail_redact_output_message", "[Assistant output redacted.]"
+                            "guardrail_redact_output_message",
+                            "[Assistant output redacted.]",
                         )
                     }
                 }
@@ -384,7 +432,9 @@ class BedrockModel(Model):
         loop = asyncio.get_event_loop()
         queue: asyncio.Queue[Optional[StreamEvent]] = asyncio.Queue()
 
-        thread = asyncio.to_thread(self._stream, callback, messages, tool_specs, system_prompt)
+        thread = asyncio.to_thread(
+            self._stream, callback, messages, tool_specs, system_prompt
+        )
         task = asyncio.create_task(thread)
 
         while True:
@@ -395,6 +445,18 @@ class BedrockModel(Model):
             yield event
 
         await task
+
+    def _strip_reasoning_content_from_message(self, message: dict) -> dict:
+        # Deep copy the message to avoid mutating original
+        import copy
+
+        msg_copy = copy.deepcopy(message)
+
+        content = msg_copy.get("content", [])
+        # Filter out any content blocks with reasoningContent
+        filtered_content = [c for c in content if "reasoningContent" not in c]
+        msg_copy["content"] = filtered_content
+        return msg_copy
 
     def _stream(
         self,
@@ -418,8 +480,14 @@ class BedrockModel(Model):
             ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: If the model service is throttling requests.
         """
-        logger.debug("formatting request")
-        request = self.format_request(messages, tool_specs, system_prompt)
+        logger.debug("stripping reasoning content from messages")
+        cleaned_messages = [
+            self._strip_reasoning_content_from_message(m) for m in messages
+        ]
+
+        logger.debug("formatting request with cleaned messages")
+        request = self.format_request(cleaned_messages, tool_specs, system_prompt)
+
         logger.debug("request=<%s>", request)
 
         logger.debug("invoking model")
@@ -461,7 +529,10 @@ class BedrockModel(Model):
             if e.response["Error"]["Code"] == "ThrottlingException":
                 raise ModelThrottledException(error_message) from e
 
-            if any(overflow_message in error_message for overflow_message in BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES):
+            if any(
+                overflow_message in error_message
+                for overflow_message in BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES
+            ):
                 logger.warning("bedrock threw context window overflow error")
                 raise ContextWindowOverflowException(e) from e
 
@@ -497,7 +568,9 @@ class BedrockModel(Model):
             callback()
             logger.debug("finished streaming response from model")
 
-    def _convert_non_streaming_to_streaming(self, response: dict[str, Any]) -> Iterable[StreamEvent]:
+    def _convert_non_streaming_to_streaming(
+        self, response: dict[str, Any]
+    ) -> Iterable[StreamEvent]:
         """Convert a non-streaming response to the streaming format.
 
         Args:
@@ -527,7 +600,9 @@ class BedrockModel(Model):
                 # For tool use, we need to yield the input as a delta
                 input_value = json.dumps(content["toolUse"]["input"])
 
-                yield {"contentBlockDelta": {"delta": {"toolUse": {"input": input_value}}}}
+                yield {
+                    "contentBlockDelta": {"delta": {"toolUse": {"input": input_value}}}
+                }
             elif "text" in content:
                 # Then yield the text as a delta
                 yield {
@@ -539,7 +614,13 @@ class BedrockModel(Model):
                 # Then yield the reasoning content as a delta
                 yield {
                     "contentBlockDelta": {
-                        "delta": {"reasoningContent": {"text": content["reasoningContent"]["reasoningText"]["text"]}}
+                        "delta": {
+                            "reasoningContent": {
+                                "text": content["reasoningContent"]["reasoningText"][
+                                    "text"
+                                ]
+                            }
+                        }
                     }
                 }
 
@@ -548,7 +629,9 @@ class BedrockModel(Model):
                         "contentBlockDelta": {
                             "delta": {
                                 "reasoningContent": {
-                                    "signature": content["reasoningContent"]["reasoningText"]["signature"]
+                                    "signature": content["reasoningContent"][
+                                        "reasoningText"
+                                    ]["signature"]
                                 }
                             }
                         }
@@ -561,7 +644,9 @@ class BedrockModel(Model):
         yield {
             "messageStop": {
                 "stopReason": response["stopReason"],
-                "additionalModelResponseFields": response.get("additionalModelResponseFields"),
+                "additionalModelResponseFields": response.get(
+                    "additionalModelResponseFields"
+                ),
             }
         }
 
@@ -589,7 +674,11 @@ class BedrockModel(Model):
         # Check if input is a dictionary
         if isinstance(input, dict):
             # Check if current dictionary has action: BLOCKED and detected: true
-            if input.get("action") == "BLOCKED" and input.get("detected") and isinstance(input.get("detected"), bool):
+            if (
+                input.get("action") == "BLOCKED"
+                and input.get("detected")
+                and isinstance(input.get("detected"), bool)
+            ):
                 return True
 
             # Recursively check all values in the dictionary
@@ -609,7 +698,11 @@ class BedrockModel(Model):
 
     @override
     async def structured_output(
-        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None, **kwargs: Any
+        self,
+        output_model: Type[T],
+        prompt: Messages,
+        system_prompt: Optional[str] = None,
+        **kwargs: Any,
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
@@ -624,14 +717,21 @@ class BedrockModel(Model):
         """
         tool_spec = convert_pydantic_to_tool_spec(output_model)
 
-        response = self.stream(messages=prompt, tool_specs=[tool_spec], system_prompt=system_prompt, **kwargs)
+        response = self.stream(
+            messages=prompt,
+            tool_specs=[tool_spec],
+            system_prompt=system_prompt,
+            **kwargs,
+        )
         async for event in streaming.process_stream(response):
             yield event
 
         stop_reason, messages, _, _ = event["stop"]
 
         if stop_reason != "tool_use":
-            raise ValueError(f'Model returned stop_reason: {stop_reason} instead of "tool_use".')
+            raise ValueError(
+                f'Model returned stop_reason: {stop_reason} instead of "tool_use".'
+            )
 
         content = messages["content"]
         output_response: dict[str, Any] | None = None
@@ -644,6 +744,8 @@ class BedrockModel(Model):
                 continue
 
         if output_response is None:
-            raise ValueError("No valid tool use or tool use input was found in the Bedrock response.")
+            raise ValueError(
+                "No valid tool use or tool use input was found in the Bedrock response."
+            )
 
         yield {"output": output_model(**output_response)}


### PR DESCRIPTION
Fix: strip reasoningContent from messages before sending to Bedrock to avoid ValidationException

## Description
<!-- Provide a detailed description of the changes in this PR -->

This is a PR in a response to bug I found #651 which updates the Bedrock model class in the Strands Agents SDK to strip reasoning content before calling the converse_stream operation to avoid the validation exception.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

I locally installed my version of the lib with changes I made and tested it on my code which I was getting the error for and it started working with no ValidationException error.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
