### PR TITLE
litellm - set 1.73.1 as minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs = [
     "sphinx-autodoc-typehints>=1.12.0,<2.0.0",
 ]
 litellm = [
-    "litellm>=1.72.6,<1.73.0",
+    "litellm>=1.73.1,<2.0.0",
 ]
 llamaapi = [
     "llama-api-client>=0.1.0,<1.0.0",


### PR DESCRIPTION
## Description
Follow up on https://github.com/strands-agents/sdk-python/issues/271. LiteLLM version 1.73.0 had a bug that removed tool names from model responses. This has since been fixed in version 1.73.1.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/271

## Documentation PR

N/A

## Type of Change

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Ran `hatch test tests_integ/models/test_model_litellm.py`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
