### PR TITLE
fix: Unify dependencies in groups & add test to catch future revisions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ all = [
     "sphinx-autodoc-typehints>=1.12.0,<2.0.0",
 
     # litellm
-    "litellm>=1.72.6,<1.73.0",
+    "litellm>=1.73.1,<2.0.0",
 
     # llama
     "llama-api-client>=0.1.0,<1.0.0",

--- a/tests/strands/test_pyproject.py
+++ b/tests/strands/test_pyproject.py
@@ -1,0 +1,48 @@
+"""Tests for project configuration consistency."""
+
+from pathlib import Path
+
+import tomllib
+
+
+def test_optional_dependencies_version_consistency():
+    """Test that duplicate dependencies across groups have consistent version specifiers."""
+    pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
+
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+
+    optional_deps = data["project"]["optional-dependencies"]
+
+    # Collect all dependencies and their version specifiers with group info
+    dep_specs: dict[str, tuple[str, str]] = {}
+
+    for group_name, deps in optional_deps.items():
+        for dep in deps:
+            # Extract package name before any version specifier
+            name = dep
+            for op in [">=", "==", ">", "<", "~=", "!="]:
+                if op in name:
+                    name = name.split(op)[0].strip()
+                    break
+
+            # Remove extras like [sql] from name
+            if "[" in name:
+                name = name.split("[")[0].strip()
+
+            # Extract version specifier (everything after package name)
+            version_spec = dep[len(name) :].strip()
+            # Remove extras from version spec if present
+            if version_spec.startswith("["):
+                bracket_end = version_spec.find("]")
+                if bracket_end != -1:
+                    version_spec = version_spec[bracket_end + 1 :].strip()
+
+            if name in dep_specs:
+                (previous_spec, first_group) = dep_specs[name]
+                assert previous_spec == version_spec, (
+                    f"Version specifier mismatch for {name}: '{dep_specs[name]}'"
+                    f" in [{first_group}] vs '{version_spec}' in [{group_name}]"
+                )
+            else:
+                dep_specs[name] = (version_spec, group_name)


### PR DESCRIPTION

## Description

We recently updated our litellm dependency, but only in the litellm optional dependency, not the [all] group, so fix that + add a test to catch future regressions


## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
