### PR TITLE
fix: only set signature in message if signature was provided by the model

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -194,16 +194,18 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
         state["text"] = ""
 
     elif reasoning_text:
-        content.append(
-            {
-                "reasoningContent": {
-                    "reasoningText": {
-                        "text": state["reasoningText"],
-                        "signature": state["signature"],
-                    }
+        content_block: ContentBlock = {
+            "reasoningContent": {
+                "reasoningText": {
+                    "text": state["reasoningText"],
                 }
             }
-        )
+        }
+
+        if "signature" in state:
+            content_block["reasoningContent"]["reasoningText"]["signature"] = state["signature"]
+
+        content.append(content_block)
         state["reasoningText"] = ""
 
     return state
@@ -263,7 +265,6 @@ async def process_stream(chunks: AsyncIterable[StreamEvent]) -> AsyncGenerator[d
         "text": "",
         "current_tool_use": {},
         "reasoningText": "",
-        "signature": "",
     }
     state["content"] = state["message"]["content"]
 

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -216,6 +216,21 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, state, exp_up
                 "signature": "123",
             },
         ),
+        # Reasoning without signature
+        (
+            {
+                "content": [],
+                "current_tool_use": {},
+                "text": "",
+                "reasoningText": "test",
+            },
+            {
+                "content": [{"reasoningContent": {"reasoningText": {"text": "test"}}}],
+                "current_tool_use": {},
+                "text": "",
+                "reasoningText": "",
+            },
+        ),
         # Empty
         (
             {


### PR DESCRIPTION
## Description
I am testing Strands against the new gpt-oss model in Bedrock, and getting this error on the second turn:

```
strands.types.exceptions.EventLoopException: An error occurred (ValidationException) when calling the Converse operation:
This model doesn't support the reasoningContent.reasoningText.signature field. Remove reasoningContent.reasoningText.signature and try again.
```

When I look at the request, Strands is setting the signature to an empty string.

## Type of Change

Bug fix

## Testing

I tested with gpt-oss and Sonnet 4, and added a unit test.

```
Agent(
        system_prompt=NAMING_SYSTEM_PROMPT,
        tools=tools,
        model=BedrockModel(model_id="openai.gpt-oss-20b-1:0", streaming=False),
)

and

Agent(
        system_prompt=NAMING_SYSTEM_PROMPT,
        tools=tools,
        model=BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
                           additional_request_fields={
                               "anthropic_beta": ["interleaved-thinking-2025-05-14"],
                               "thinking": {"type": "enabled", "budget_tokens": 8000},
                           }),
)

```


- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
