### PR TITLE
fix: Remove status field from toolResult for non-claude 3 models in Bedrock model provider

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -276,10 +276,19 @@ class BedrockModel(Model):
                     # Create a new content block with only the cleaned toolResult
                     tool_result: ToolResult = content_block["toolResult"]
 
-                    # Keep only the required fields for Bedrock
-                    cleaned_tool_result = ToolResult(
-                        content=tool_result["content"], toolUseId=tool_result["toolUseId"], status=tool_result["status"]
-                    )
+                    model_id = self.config.get("model_id")
+                    if "claude-3" in model_id:
+                        # Keep the status field for Claude models
+                        cleaned_tool_result = ToolResult(
+                            content=tool_result["content"],
+                            toolUseId=tool_result["toolUseId"],
+                            status=tool_result["status"],
+                        )
+                    else:
+                        # For non-Claude models, use ToolResult without status
+                        cleaned_tool_result = ToolResult(
+                            toolUseId=tool_result["toolUseId"], content=tool_result["content"]
+                        )
 
                     cleaned_block: ContentBlock = {"toolResult": cleaned_tool_result}
                     cleaned_content.append(cleaned_block)

--- a/src/strands/types/tools.py
+++ b/src/strands/types/tools.py
@@ -7,7 +7,7 @@ These types are modeled after the Bedrock API.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Literal, Protocol, Union
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Literal, Optional, Protocol, Union
 
 from typing_extensions import TypedDict
 
@@ -91,7 +91,7 @@ class ToolResult(TypedDict):
     """
 
     content: list[ToolResultContent]
-    status: ToolResultStatus
+    status: Optional[ToolResultStatus]
     toolUseId: str
 
 


### PR DESCRIPTION
## Description
Removed the `status` field from the `toolResult` block for non claude-3 models in the Bedrock Model provider. This change is motivated by the linked issue. Furthermore, this change is supported by the bedrock documentation where it explicitly states that the `status` field is only supported in [claude 3 models](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html). 


## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/554

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

Script used to test:

```
from strands import Agent
from strands.models import BedrockModel
from strands_tools import calculator

## change the model-id to any foundation model enabled in your AWS Account
model = BedrockModel(
    model_id="us.anthropic.claude-opus-4-20250514-v1:0", #Or us.writer.palmyra-x4-v1:0
    temperature=0.3,
    streaming=False,
    region_name="us-west-2"
)

agent = Agent(
    model=model,
    tools=[calculator],
    system_prompt="You are an enterprise assistant that helps automate business workflows.",
)

response = agent("tell me what is square root of 64 times 2")
```
- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
