### PR TITLE
fix: add system_prompt to structured_output_span before adding input_messages

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -470,15 +470,15 @@ class Agent:
                         "gen_ai.operation.name": "execute_structured_output",
                     }
                 )
-                for message in temp_messages:
-                    structured_output_span.add_event(
-                        f"gen_ai.{message['role']}.message",
-                        attributes={"role": message["role"], "content": serialize(message["content"])},
-                    )
                 if self.system_prompt:
                     structured_output_span.add_event(
                         "gen_ai.system.message",
                         attributes={"role": "system", "content": serialize([{"text": self.system_prompt}])},
+                    )
+                for message in temp_messages:
+                    structured_output_span.add_event(
+                        f"gen_ai.{message['role']}.message",
+                        attributes={"role": message["role"], "content": serialize(message["content"])},
                     )
                 events = self.model.structured_output(output_model, temp_messages, system_prompt=self.system_prompt)
                 async for event in events:


### PR DESCRIPTION
## Description
This PR fixes the order of system_prompt and input_messages in `structured_output_span` .

The system_prompt should added before input_message, and align with the order of what sent to model_provider, inside of `model.structured_output`.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/692

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
