### PR TITLE
Add EmbeddedResource support to mcp

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -23,6 +23,7 @@ from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import GetPromptResult, ListPromptsResult
 from mcp.types import ImageContent as MCPImageContent
 from mcp.types import TextContent as MCPTextContent
+from mcp.types import EmbeddedResource as MCPEmbeddedResource  # <-- minimal add
 
 from ...types import PaginatedList
 from ...types.exceptions import MCPClientInitializationError
@@ -410,6 +411,80 @@ class MCPClient:
                     "source": {"bytes": base64.b64decode(content.data)},
                 }
             }
+        # If EmbeddedResource
+        elif isinstance(content, MCPEmbeddedResource):
+            self._log_debug_with_thread("mapping MCP embedded resource content")
+            res = getattr(content, "resource", None)
+            if res is None:
+                self._log_debug_with_thread("embedded resource has no 'resource' field - dropping")
+                return None
+
+            # Support both pydantic model and dict access
+            def _get(attr: str) -> Any:
+                if hasattr(res, attr):
+                    return getattr(res, attr)
+                if isinstance(res, dict):
+                    return res.get(attr)
+                return None
+
+            text_val = _get("text")
+            if text_val:
+                return {"text": text_val}
+
+            blob_val = _get("blob")
+            mime_type = _get("mimeType")
+
+            if blob_val is not None:
+                # blob is a base64 string in current mcp schema
+                raw_bytes: Optional[bytes]
+                try:
+                    if isinstance(blob_val, (bytes, bytearray)):
+                        raw_bytes = bytes(blob_val)
+                    elif isinstance(blob_val, str):
+                        raw_bytes = base64.b64decode(blob_val)
+                    else:
+                        raw_bytes = None
+                except Exception:
+                    raw_bytes = None
+
+                if raw_bytes is None:
+                    self._log_debug_with_thread("embedded resource blob could not be decoded - dropping")
+                    return None
+
+                def _is_textual(mt: Optional[str]) -> bool:
+                    if not mt:
+                        return False
+                    if mt.startswith("text/"):
+                        return True
+                    textual = (
+                        "application/json",
+                        "application/xml",
+                        "application/javascript",
+                        "application/x-yaml",
+                        "application/yaml",
+                        "application/xhtml+xml",
+                    )
+                    if mt in textual or mt.endswith("+json") or mt.endswith("+xml"):
+                        return True
+                    return False
+
+                if _is_textual(mime_type):
+                    try:
+                        return {"text": raw_bytes.decode("utf-8", errors="replace")}
+                    except Exception:
+                        pass
+
+                if mime_type in MIME_TO_FORMAT:
+                    return {
+                        "image": {
+                            "format": MIME_TO_FORMAT[mime_type],
+                            "source": {"bytes": raw_bytes},
+                        }
+                    }
+
+                self._log_debug_with_thread("embedded resource blob with non-textual/unknown mimeType - dropping")
+                return None
+        # -------------------------------------------------
         else:
             self._log_debug_with_thread("unhandled content type: %s - dropping content", content.__class__.__name__)
             return None

--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -484,7 +484,15 @@ class MCPClient:
 
                 self._log_debug_with_thread("embedded resource blob with non-textual/unknown mimeType - dropping")
                 return None
-        # -------------------------------------------------
+            
+            # Handle URI-only resources
+            uri = _get("uri")
+            if uri:
+                return {"text": f"[embedded resource] {uri} ({mime_type or 'unknown mime'})"}
+
+            # Make sure we return in all paths
+            self._log_debug_with_thread("embedded resource had no usable text/blob/uri; dropping")
+            return None
         else:
             self._log_debug_with_thread("unhandled content type: %s - dropping content", content.__class__.__name__)
             return None

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -1,4 +1,5 @@
 import time
+import base64
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -466,3 +467,52 @@ def test_get_prompt_sync_session_not_active():
 
     with pytest.raises(MCPClientInitializationError, match="client session is not running"):
         client.get_prompt_sync("test_prompt_id", {})
+
+
+def test_call_tool_sync_embedded_nested_text(mock_transport, mock_session):
+    """EmbeddedResource.resource (uri + text) should map to plain text content."""
+    er = {
+        "type": "resource",  # required literal
+        "resource": {
+            "uri": "mcp://resource/embedded-text-1",
+            "text": "inner text",
+            "mimeType": "text/plain",
+        },
+    }
+    mock_session.call_tool.return_value = MCPCallToolResult(isError=False, content=[er])
+
+    from strands.tools.mcp import MCPClient
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(tool_use_id="er-text", name="get_file_contents", arguments={})
+
+        mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None)
+        assert result["status"] == "success"
+        assert len(result["content"]) == 1
+        assert result["content"][0]["text"] == "inner text"
+
+
+def test_call_tool_sync_embedded_nested_base64_textual_mime(mock_transport, mock_session):
+    """EmbeddedResource.resource (uri + blob with textual MIME) should decode to text."""
+    import base64
+    from mcp.types import CallToolResult as MCPCallToolResult
+    payload = base64.b64encode(b'{"k":"v"}').decode()
+
+    er = {
+        "type": "resource",
+        "resource": {
+            "uri": "mcp://resource/embedded-blob-1",
+            # NOTE: blob is a STRING, mimeType is sibling
+            "blob": payload,
+            "mimeType": "application/json",
+        },
+    }
+    mock_session.call_tool.return_value = MCPCallToolResult(isError=False, content=[er])
+
+    from strands.tools.mcp import MCPClient
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(tool_use_id="er-blob", name="get_file_contents", arguments={})
+
+        mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None)
+        assert result["status"] == "success"
+        assert len(result["content"]) == 1
+        assert result["content"][0]["text"] == '{"k":"v"}'


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
Hey team! Utilizing strands locally to connect to  ([remote github MCP](https://api.githubcopilot.com/mcp/)), and saw that it was unable to download particular files using github MCP tool `get_file_contents`. 

When I'd attempt I'd see logs like this: 
```
2025-08-22 07:50:55,725 | INFO | Thread-1 (_background_task) | httpx | HTTP Request: POST https://api.githubcopilot.com/mcp/ "HTTP/1.1 200 OK"
2025-08-22 07:50:55,726 | DEBUG | Thread-1 (_background_task) | httpcore.http11 | receive_response_body.started request=<Request [b'POST']>
2025-08-22 07:50:55,853 | DEBUG | Thread-1 (_background_task) | httpcore.http11 | receive_response_body.complete
2025-08-22 07:50:55,854 | DEBUG | Thread-1 (_background_task) | httpcore.http11 | response_closed.started
2025-08-22 07:50:55,854 | DEBUG | Thread-1 (_background_task) | httpcore.http11 | response_closed.complete
2025-08-22 07:50:55,865 | DEBUG | MainThread | strands.tools.mcp.mcp_client | [Thread: MainThread, Session: 838664df-dafb-4a06-865e-91d618eb77f6] received tool result with 2 content items
2025-08-22 07:50:55,865 | DEBUG | MainThread | strands.tools.mcp.mcp_client | [Thread: MainThread, Session: 838664df-dafb-4a06-865e-91d618eb77f6] mapping MCP text content
2025-08-22 07:50:55,865 | DEBUG | MainThread | strands.tools.mcp.mcp_client | [Thread: MainThread, Session: 838664df-dafb-4a06-865e-91d618eb77f6] unhandled content type: EmbeddedResource - dropping content
2025-08-22 07:50:55,865 | DEBUG | MainThread | strands.tools.mcp.mcp_client | [Thread: MainThread, Session: 838664df-dafb-4a06-865e-91d618eb77f6] tool execution completed with status: success
```

The main issues appears to be that the file is not provided as text, it's provided as an EmbeddedResource. This PR provides Slack support for EmbeddedResources that match plaintext-readable types. 

In my local testing, it fixes the behavior, and my strands agent can now read github files without any changes to the github MCP tools. 

## Related Issues

Partially fixes #535 
- Didn't attempt to add Audio content

## Documentation PR

n/a

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

I made the changes to my local version of the sdk-python/src/strands/tools/mcp/mcp_client.py to add support for EmbeddedResource. 

Here is [my agent config file](https://gist.github.com/KyMidd/ef0030600be7a1d9d030d934fcfc8c61), it's an MVP of using github to fetch a file when I noticed it was unable to do so reliably.  

When run, it is now able to fetch the file: 
```
> python github_remote_mcp_with_PAT.py
User question: Fetch this file and print it: https://github.com/orgName/repoName/blob/branchName/path/fileName.tfvars

I'll fetch that file for you from the GitHub repository.
Tool #1: get_file_contents
Here's the content of the `fileName.tfvars` file:

```hcl
(file contents)
# ...
```

- [X] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
