### PR TITLE
fix: prevent path traversal for message_id in file_session_manager

### DIFF
--- a/src/strands/_identifier.py
+++ b/src/strands/_identifier.py
@@ -9,6 +9,7 @@ class Identifier(enum.Enum):
 
     AGENT = "agent"
     SESSION = "session"
+    MESSAGE = "message"
 
 
 def validate(id_: str, type_: Identifier) -> str:

--- a/src/strands/_identifier.py
+++ b/src/strands/_identifier.py
@@ -9,7 +9,6 @@ class Identifier(enum.Enum):
 
     AGENT = "agent"
     SESSION = "session"
-    MESSAGE = "message"
 
 
 def validate(id_: str, type_: Identifier) -> str:

--- a/src/strands/session/file_session_manager.py
+++ b/src/strands/session/file_session_manager.py
@@ -86,9 +86,16 @@ class FileSessionManager(RepositorySessionManager, SessionRepository):
             message_id: Index of the message
         Returns:
             The filename for the message
+        
+        Raises:
+            ValueError: If message id contains path separators.
         """
+        # Validate message_id to prevent path traversal
+        message_id_str = str(message_id)
+        message_id_str = _identifier.validate(message_id_str, _identifier.Identifier.MESSAGE)
+        
         agent_path = self._get_agent_path(session_id, agent_id)
-        return os.path.join(agent_path, "messages", f"{MESSAGE_PREFIX}{message_id}.json")
+        return os.path.join(agent_path, "messages", f"{MESSAGE_PREFIX}{message_id_str}.json")
 
     def _read_file(self, path: str) -> dict[str, Any]:
         """Read JSON file."""

--- a/src/strands/session/file_session_manager.py
+++ b/src/strands/session/file_session_manager.py
@@ -86,16 +86,15 @@ class FileSessionManager(RepositorySessionManager, SessionRepository):
             message_id: Index of the message
         Returns:
             The filename for the message
-        
+
         Raises:
-            ValueError: If message id contains path separators.
+            ValueError: If message_id is not an integer.
         """
-        # Validate message_id to prevent path traversal
-        message_id_str = str(message_id)
-        message_id_str = _identifier.validate(message_id_str, _identifier.Identifier.MESSAGE)
+        if not isinstance(message_id, int):
+            raise ValueError(f"message_id=<{message_id}> | message id must be an integer")
         
         agent_path = self._get_agent_path(session_id, agent_id)
-        return os.path.join(agent_path, "messages", f"{MESSAGE_PREFIX}{message_id_str}.json")
+        return os.path.join(agent_path, "messages", f"{MESSAGE_PREFIX}{message_id}.json")
 
     def _read_file(self, path: str) -> dict[str, Any]:
         """Read JSON file."""

--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -113,11 +113,16 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             session_id: ID of the session
             agent_id: ID of the agent
             message_id: Index of the message
-            **kwargs: Additional keyword arguments for future extensibility.
 
         Returns:
             The key for the message
+            
+        Raises:
+            ValueError: If message_id is not an integer.
         """
+        if not isinstance(message_id, int):
+            raise ValueError(f"message_id=<{message_id}> | message id must be an integer")
+            
         agent_path = self._get_agent_path(session_id, agent_id)
         return f"{agent_path}messages/{MESSAGE_PREFIX}{message_id}.json"
 

--- a/tests/strands/session/test_file_session_manager.py
+++ b/tests/strands/session/test_file_session_manager.py
@@ -396,12 +396,15 @@ def test__get_agent_path_invalid_agent_id(agent_id, file_manager):
     "message_id",
     [
         "../../../secret",
-        "../../attack",
+        "../../attack", 
         "../escape",
         "path/traversal",
+        "not_an_int",
+        None,
+        [],
     ],
 )
 def test__get_message_path_invalid_message_id(message_id, file_manager):
-    """Test that message_id with path traversal sequences raises ValueError."""
-    with pytest.raises(ValueError, match=f"message_id={message_id} | id cannot contain path separators"):
+    """Test that message_id that is not an integer raises ValueError."""
+    with pytest.raises(ValueError, match=r"message_id=<.*> \| message id must be an integer"):
         file_manager._get_message_path("session1", "agent1", message_id)

--- a/tests/strands/session/test_file_session_manager.py
+++ b/tests/strands/session/test_file_session_manager.py
@@ -390,3 +390,18 @@ def test__get_session_path_invalid_session_id(session_id, file_manager):
 def test__get_agent_path_invalid_agent_id(agent_id, file_manager):
     with pytest.raises(ValueError, match=f"agent_id={agent_id} | id cannot contain path separators"):
         file_manager._get_agent_path("session1", agent_id)
+
+
+@pytest.mark.parametrize(
+    "message_id",
+    [
+        "../../../secret",
+        "../../attack",
+        "../escape",
+        "path/traversal",
+    ],
+)
+def test__get_message_path_invalid_message_id(message_id, file_manager):
+    """Test that message_id with path traversal sequences raises ValueError."""
+    with pytest.raises(ValueError, match=f"message_id={message_id} | id cannot contain path separators"):
+        file_manager._get_message_path("session1", "agent1", message_id)

--- a/tests/strands/session/test_file_session_manager.py
+++ b/tests/strands/session/test_file_session_manager.py
@@ -224,14 +224,14 @@ def test_read_messages_with_new_agent(file_manager, sample_session, sample_agent
     file_manager.create_session(sample_session)
     file_manager.create_agent(sample_session.session_id, sample_agent)
 
-    result = file_manager.read_message(sample_session.session_id, sample_agent.agent_id, "nonexistent_message")
+    result = file_manager.read_message(sample_session.session_id, sample_agent.agent_id, 999)
 
     assert result is None
 
 
 def test_read_nonexistent_message(file_manager, sample_session, sample_agent):
     """Test reading a message that doesnt exist."""
-    result = file_manager.read_message(sample_session.session_id, sample_agent.agent_id, "nonexistent_message")
+    result = file_manager.read_message(sample_session.session_id, sample_agent.agent_id, 999)
     assert result is None
 
 

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -251,7 +251,7 @@ def test_read_nonexistent_message(s3_manager, sample_session, sample_agent, samp
     s3_manager.create_agent(sample_session.session_id, sample_agent)
 
     # Read message
-    result = s3_manager.read_message(sample_session.session_id, sample_agent.agent_id, "nonexistent_message")
+    result = s3_manager.read_message(sample_session.session_id, sample_agent.agent_id, 999)
 
     assert result is None
 

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -356,3 +356,21 @@ def test__get_session_path_invalid_session_id(session_id, s3_manager):
 def test__get_agent_path_invalid_agent_id(agent_id, s3_manager):
     with pytest.raises(ValueError, match=f"agent_id={agent_id} | id cannot contain path separators"):
         s3_manager._get_agent_path("session1", agent_id)
+
+
+@pytest.mark.parametrize(
+    "message_id",
+    [
+        "../../../secret",
+        "../../attack", 
+        "../escape",
+        "path/traversal",
+        "not_an_int",
+        None,
+        [],
+    ],
+)
+def test__get_message_path_invalid_message_id(message_id, s3_manager):
+    """Test that message_id that is not an integer raises ValueError."""
+    with pytest.raises(ValueError, match=r"message_id=<.*> \| message id must be an integer"):
+        s3_manager._get_message_path("session1", "agent1", message_id)


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
Fixing a path_traversal security issue in `FileSessionManager` and `S3SessionManager` specifically in our `_get_message_path()` method. Currently we don't validate the `message_id` but we do validate the other id's such as `session_id` and `agent_id`
## Related Issues

This PR fixes the issue by raising an exception if the message_id contains separators.
<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
