### PR TITLE
fix(tools/loader): load and register all decorated @tool functions from file path

### DIFF
--- a/src/strands/tools/loader.py
+++ b/src/strands/tools/loader.py
@@ -120,7 +120,27 @@ class ToolLoader:
 
     @classmethod
     def load_tool(cls, tool_path: str, tool_name: str) -> AgentTool:
-        """Load a tool based on its file extension.
+        """DEPRECATED: Load a single tool based on its file extension for backwards compatibility.
+
+        Use `load_tools` to retrieve all tools defined in a file (returns a list).
+        This function will emit a `DeprecationWarning` and return the first discovered tool.
+        """
+        warnings.warn(
+            "ToolLoader.load_tool is deprecated and will be removed in Strands SDK 2.0. "
+            "Use ToolLoader.load_tools(...) which always returns a list of AgentTool.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        tools = ToolLoader.load_tools(tool_path, tool_name)
+        if not tools:
+            raise RuntimeError(f"No tools found in {tool_path} for {tool_name}")
+
+        return tools[0]
+
+    @classmethod
+    def load_tools(cls, tool_path: str, tool_name: str) -> list[AgentTool]:
+        """Load tools from a file based on its file extension.
 
         Args:
             tool_path: Path to the tool file.
@@ -142,7 +162,7 @@ class ToolLoader:
 
         try:
             if ext == ".py":
-                return cls.load_python_tool(abs_path, tool_name)
+                return cls.load_python_tools(abs_path, tool_name)
             else:
                 raise ValueError(f"Unsupported tool file type: {ext}")
         except Exception:

--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -24,11 +24,10 @@ from mcp.types import GetPromptResult, ListPromptsResult
 from mcp.types import ImageContent as MCPImageContent
 from mcp.types import TextContent as MCPTextContent
 
-from strands.types.tools import ToolResultContent, ToolResultStatus
-
 from ...types import PaginatedList
 from ...types.exceptions import MCPClientInitializationError
 from ...types.media import ImageFormat
+from ...types.tools import ToolResultContent, ToolResultStatus
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_instrumentation import mcp_instrumentation
 from .mcp_types import MCPToolResult, MCPTransport

--- a/src/strands/tools/registry.py
+++ b/src/strands/tools/registry.py
@@ -18,7 +18,7 @@ from typing_extensions import TypedDict, cast
 from strands.tools.decorator import DecoratedFunctionTool
 
 from ..types.tools import AgentTool, ToolSpec
-from .tools import PythonAgentTool, normalize_loaded_tools, normalize_schema, normalize_tool_spec
+from .tools import PythonAgentTool, normalize_schema, normalize_tool_spec
 
 logger = logging.getLogger(__name__)
 
@@ -127,9 +127,8 @@ class ToolRegistry:
             if not os.path.exists(tool_path):
                 raise FileNotFoundError(f"Tool file not found: {tool_path}")
 
-            loaded_tool = ToolLoader.load_tool(tool_path, tool_name)
-            # normalize_loaded_tools handles single tool or list of tools
-            for t in normalize_loaded_tools(loaded_tool):
+            loaded_tools = ToolLoader.load_tools(tool_path, tool_name)
+            for t in loaded_tools:
                 t.mark_dynamic()
                 # Because we're explicitly registering the tool we don't need an allowlist
                 self.register_tool(t)

--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -8,7 +8,7 @@ import asyncio
 import inspect
 import logging
 import re
-from typing import Any, List, Union
+from typing import Any
 
 from typing_extensions import override
 
@@ -144,13 +144,6 @@ def normalize_tool_spec(tool_spec: ToolSpec) -> ToolSpec:
                 normalized["inputSchema"] = {"json": normalize_schema(normalized["inputSchema"])}
 
     return normalized
-
-
-def normalize_loaded_tools(loaded: Union[AgentTool, List[AgentTool]]) -> List[AgentTool]:
-    """Normalize ToolLoader.load_tool return value to always be a list of AgentTool."""
-    if isinstance(loaded, list):
-        return loaded
-    return [loaded]
 
 
 class PythonAgentTool(AgentTool):

--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -33,22 +33,22 @@ def validate_tool_use(tool: ToolUse) -> None:
     validate_tool_use_name(tool)
 
 
-def validate_tool_use_name(tool_use: ToolUse) -> None:
+def validate_tool_use_name(tool: ToolUse) -> None:
     """Validate the name of a tool use.
 
     Args:
-        tool_use: The tool use to validate.
+        tool: The tool use to validate.
 
     Raises:
         InvalidToolUseNameException: If the tool name is invalid.
     """
     # We need to fix some typing here, because we don't actually expect a ToolUse, but dict[str, Any]
-    if "name" not in tool_use:
+    if "name" not in tool:
         message = "tool name missing"  # type: ignore[unreachable]
         logger.warning(message)
         raise InvalidToolUseNameException(message)
 
-    tool_name = tool_use["name"]
+    tool_name = tool["name"]
     tool_name_pattern = r"^[a-zA-Z0-9_\-]{1,}$"
     tool_name_max_length = 64
     valid_name_pattern = bool(re.match(tool_name_pattern, tool_name))

--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -8,7 +8,7 @@ import asyncio
 import inspect
 import logging
 import re
-from typing import Any
+from typing import Any, List, Union
 
 from typing_extensions import override
 
@@ -33,22 +33,22 @@ def validate_tool_use(tool: ToolUse) -> None:
     validate_tool_use_name(tool)
 
 
-def validate_tool_use_name(tool: ToolUse) -> None:
+def validate_tool_use_name(tool_use: ToolUse) -> None:
     """Validate the name of a tool use.
 
     Args:
-        tool: The tool use to validate.
+        tool_use: The tool use to validate.
 
     Raises:
         InvalidToolUseNameException: If the tool name is invalid.
     """
     # We need to fix some typing here, because we don't actually expect a ToolUse, but dict[str, Any]
-    if "name" not in tool:
+    if "name" not in tool_use:
         message = "tool name missing"  # type: ignore[unreachable]
         logger.warning(message)
         raise InvalidToolUseNameException(message)
 
-    tool_name = tool["name"]
+    tool_name = tool_use["name"]
     tool_name_pattern = r"^[a-zA-Z0-9_\-]{1,}$"
     tool_name_max_length = 64
     valid_name_pattern = bool(re.match(tool_name_pattern, tool_name))
@@ -144,6 +144,13 @@ def normalize_tool_spec(tool_spec: ToolSpec) -> ToolSpec:
                 normalized["inputSchema"] = {"json": normalize_schema(normalized["inputSchema"])}
 
     return normalized
+
+
+def normalize_loaded_tools(loaded: Union[AgentTool, List[AgentTool]]) -> List[AgentTool]:
+    """Normalize ToolLoader.load_tool return value to always be a list of AgentTool."""
+    if isinstance(loaded, list):
+        return loaded
+    return [loaded]
 
 
 class PythonAgentTool(AgentTool):

--- a/tests/strands/tools/test_loader.py
+++ b/tests/strands/tools/test_loader.py
@@ -236,6 +236,15 @@ def test_load_tool_no_spec(tool_path):
     with pytest.raises(AttributeError, match="Tool no_spec missing TOOL_SPEC"):
         ToolLoader.load_tool(tool_path, "no_spec")
 
+    with pytest.raises(AttributeError, match="Tool no_spec missing TOOL_SPEC"):
+        ToolLoader.load_tools(tool_path, "no_spec")
+
+    with pytest.raises(AttributeError, match="Tool no_spec missing TOOL_SPEC"):
+        ToolLoader.load_python_tool(tool_path, "no_spec")
+
+    with pytest.raises(AttributeError, match="Tool no_spec missing TOOL_SPEC"):
+        ToolLoader.load_python_tools(tool_path, "no_spec")
+
 
 @pytest.mark.parametrize(
     "tool_path",
@@ -257,10 +266,47 @@ def test_load_tool_no_spec(tool_path):
     indirect=True,
 )
 def test_load_python_tool_path_multiple_function_based(tool_path):
-    # load_python_tool returns a list when multiple decorated tools are present
-    loaded = ToolLoader.load_python_tools(tool_path, "alpha")
-    assert isinstance(loaded, list)
-    assert len(loaded) == 2
-    assert all(isinstance(t, DecoratedFunctionTool) for t in loaded)
-    names = {getattr(t, "tool_name", getattr(t, "name", None)) for t in loaded}
-    assert "alpha" in names and "bravo" in names
+    # load_python_tools, load_tools returns a list when multiple decorated tools are present
+    loaded_python_tools = ToolLoader.load_python_tools(tool_path, "alpha")
+
+    assert isinstance(loaded_python_tools, list)
+    assert len(loaded_python_tools) == 2
+    assert all(isinstance(t, DecoratedFunctionTool) for t in loaded_python_tools)
+    names = {t.tool_name for t in loaded_python_tools}
+    assert names == {"alpha", "bravo"}
+
+    loaded_tools = ToolLoader.load_tools(tool_path, "alpha")
+
+    assert isinstance(loaded_tools, list)
+    assert len(loaded_tools) == 2
+    assert all(isinstance(t, DecoratedFunctionTool) for t in loaded_tools)
+    names = {t.tool_name for t in loaded_tools}
+    assert names == {"alpha", "bravo"}
+
+
+@pytest.mark.parametrize(
+    "tool_path",
+    [
+        textwrap.dedent(
+            """
+            import strands
+
+            @strands.tools.tool
+            def alpha():
+                return "alpha"
+
+            @strands.tools.tool
+            def bravo():
+                return "bravo"
+            """
+        )
+    ],
+    indirect=True,
+)
+def test_load_tool_path_returns_single_tool(tool_path):
+    # loaded_python_tool and loaded_tool returns single item
+    loaded_python_tool = ToolLoader.load_python_tool(tool_path, "alpha")
+    loaded_tool = ToolLoader.load_tool(tool_path, "alpha")
+
+    assert loaded_python_tool.tool_name == "alpha"
+    assert loaded_tool.tool_name == "alpha"

--- a/tests/strands/tools/test_loader.py
+++ b/tests/strands/tools/test_loader.py
@@ -258,7 +258,7 @@ def test_load_tool_no_spec(tool_path):
 )
 def test_load_python_tool_path_multiple_function_based(tool_path):
     # load_python_tool returns a list when multiple decorated tools are present
-    loaded = ToolLoader.load_python_tool(tool_path, "alpha")
+    loaded = ToolLoader.load_python_tools(tool_path, "alpha")
     assert isinstance(loaded, list)
     assert len(loaded) == 2
     assert all(isinstance(t, DecoratedFunctionTool) for t in loaded)


### PR DESCRIPTION

## Description

Previously, passing a file path that contained multiple `@tool` decorated functions resulted in only one tool being loaded/registered. This made file-based tool loading inconsistent with directory/module scanning (which returns all decorated tools). This PR fixes that: the file-path loader now collects all decorated function tools and returns them; the registry is updated to register each tool individually. Unit tests and linters were updated and run locally.

### Key Changes

- Collect all `DecoratedFunctionTool` objects when loading a `.py` file and return a `list` when multiple exist.
- Normalize loader results and register each `AgentTool` separately in the registry.
- Add `normalize_loaded_tools` helper to `src/strands/tools/tools.py`.
- Add unit test `test_load_python_tool_path_multiple_function_based` verifying multiple decorated tools are discovered when loading a file path.
- Update callers/registry to iterate loaded tools and call `mark_dynamic()` + `register_tool()` per tool.

## Related Issues

Closes #612 

## Documentation PR

N/A

## Type of Change

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
- [x] I ran hatch run prepare
- [x] I ran formatters and linters locally:
  - `hatch fmt --formatter` → 170 files left unchanged
  - `hatch fmt --linter` → All checks passed
  - `pre-commit run --all-files` → Format: Passed; Lint: Passed; Type linting: Passed; Unit Tests: Passed
- [x] I ran the unit test(s) locally:
  - `pytest -q tests/strands/tools/test_loader.py::test_load_python_tool_path_multiple_function_based` → `1 passed in 0.16s`
- [ ] I ran `hatch run test-integ` locally.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
