### PR TITLE
fix: Move AgentInput to types submodule

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -22,7 +22,6 @@ from typing import (
     Mapping,
     Optional,
     Type,
-    TypeAlias,
     TypeVar,
     Union,
     cast,
@@ -51,6 +50,7 @@ from ..tools.executors import ConcurrentToolExecutor
 from ..tools.executors._executor import ToolExecutor
 from ..tools.registry import ToolRegistry
 from ..tools.watcher import ToolWatcher
+from ..types.agent import AgentInput
 from ..types.content import ContentBlock, Message, Messages
 from ..types.exceptions import ContextWindowOverflowException
 from ..types.tools import ToolResult, ToolUse
@@ -66,8 +66,6 @@ logger = logging.getLogger(__name__)
 
 # TypeVar for generic structured output
 T = TypeVar("T", bound=BaseModel)
-
-AgentInput: TypeAlias = str | list[ContentBlock] | Messages | None
 
 
 # Sentinel class and object to distinguish between explicit None and default parameter value

--- a/src/strands/types/agent.py
+++ b/src/strands/types/agent.py
@@ -1,0 +1,10 @@
+"""Agent-related type definitions for the SDK.
+
+This module defines the types used for an Agent.
+"""
+
+from typing import TypeAlias
+
+from .content import ContentBlock, Messages
+
+AgentInput: TypeAlias = str | list[ContentBlock] | Messages | None


### PR DESCRIPTION
## Description
Move AgentInput to types submodule

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Quick fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
