### PR TITLE
feat: Use TypedEvent inheritance for callback behavior

### DIFF
--- a/src/strands/tools/executors/concurrent.py
+++ b/src/strands/tools/executors/concurrent.py
@@ -1,12 +1,13 @@
 """Concurrent tool executor implementation."""
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 from typing_extensions import override
 
 from ...telemetry.metrics import Trace
-from ...types.tools import ToolGenerator, ToolResult, ToolUse
+from ...types._events import TypedEvent
+from ...types.tools import ToolResult, ToolUse
 from ._executor import ToolExecutor
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -25,7 +26,7 @@ class ConcurrentToolExecutor(ToolExecutor):
         cycle_trace: Trace,
         cycle_span: Any,
         invocation_state: dict[str, Any],
-    ) -> ToolGenerator:
+    ) -> AsyncGenerator[TypedEvent, None]:
         """Execute tools concurrently.
 
         Args:

--- a/src/strands/tools/executors/sequential.py
+++ b/src/strands/tools/executors/sequential.py
@@ -1,11 +1,12 @@
 """Sequential tool executor implementation."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 from typing_extensions import override
 
 from ...telemetry.metrics import Trace
-from ...types.tools import ToolGenerator, ToolResult, ToolUse
+from ...types._events import TypedEvent
+from ...types.tools import ToolResult, ToolUse
 from ._executor import ToolExecutor
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -24,7 +25,7 @@ class SequentialToolExecutor(ToolExecutor):
         cycle_trace: Trace,
         cycle_span: Any,
         invocation_state: dict[str, Any],
-    ) -> ToolGenerator:
+    ) -> AsyncGenerator[TypedEvent, None]:
         """Execute tools sequentially.
 
         Args:

--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -7,12 +7,17 @@ agent lifecycle.
 
 from typing import TYPE_CHECKING, Any
 
+from typing_extensions import override
+
 from ..telemetry import EventLoopMetrics
 from .content import Message
 from .event_loop import Metrics, StopReason, Usage
 from .streaming import ContentBlockDelta, StreamEvent
+from .tools import ToolResult, ToolUse
 
 if TYPE_CHECKING:
+    from ..agent import AgentResult
+
     pass
 
 
@@ -27,6 +32,23 @@ class TypedEvent(dict):
         """
         super().__init__(data or {})
 
+    @property
+    def is_callback_event(self) -> bool:
+        """True if this event should trigger the callback_handler to fire."""
+        return True
+
+    def as_dict(self) -> dict:
+        """Convert this event to a raw dictionary for emitting purposes."""
+        return {**self}
+
+    def prepare(self, invocation_state: dict) -> None:
+        """Prepare the event for emission by adding invocation state.
+
+        This allows a subset of events to merge with the invocation_state without needing to
+        pass around the invocation_state throughout the system.
+        """
+        ...
+
 
 class InitEventLoopEvent(TypedEvent):
     """Event emitted at the very beginning of agent execution.
@@ -38,9 +60,13 @@ class InitEventLoopEvent(TypedEvent):
             invocation_state: The invocation state passed into the request
     """
 
-    def __init__(self, invocation_state: dict) -> None:
+    def __init__(self) -> None:
         """Initialize the event loop initialization event."""
-        super().__init__({"callback": {"init_event_loop": True, **invocation_state}})
+        super().__init__({"init_event_loop": True})
+
+    @override
+    def prepare(self, invocation_state: dict) -> None:
+        self.update(**invocation_state)
 
 
 class StartEvent(TypedEvent):
@@ -55,7 +81,7 @@ class StartEvent(TypedEvent):
 
     def __init__(self) -> None:
         """Initialize the event loop start event."""
-        super().__init__({"callback": {"start": True}})
+        super().__init__({"start": True})
 
 
 class StartEventLoopEvent(TypedEvent):
@@ -67,7 +93,7 @@ class StartEventLoopEvent(TypedEvent):
 
     def __init__(self) -> None:
         """Initialize the event loop processing start event."""
-        super().__init__({"callback": {"start_event_loop": True}})
+        super().__init__({"start_event_loop": True})
 
 
 class ModelStreamChunkEvent(TypedEvent):
@@ -79,7 +105,11 @@ class ModelStreamChunkEvent(TypedEvent):
         Args:
             chunk: Incremental streaming data from the model response
         """
-        super().__init__({"callback": {"event": chunk}})
+        super().__init__({"event": chunk})
+
+    @property
+    def chunk(self) -> StreamEvent:
+        return self.get("event")  # type: ignore
 
 
 class ModelStreamEvent(TypedEvent):
@@ -97,13 +127,23 @@ class ModelStreamEvent(TypedEvent):
         """
         super().__init__(delta_data)
 
+    @property
+    def is_callback_event(self) -> bool:
+        # Only invoke a callback if we're non-empty
+        return len(self.keys()) > 0
+
+    @override
+    def prepare(self, invocation_state: dict) -> None:
+        if "delta" in self:
+            self.update(**invocation_state)
+
 
 class ToolUseStreamEvent(ModelStreamEvent):
     """Event emitted during tool use input streaming."""
 
     def __init__(self, delta: ContentBlockDelta, current_tool_use: dict[str, Any]) -> None:
         """Initialize with delta and current tool use state."""
-        super().__init__({"callback": {"delta": delta, "current_tool_use": current_tool_use}})
+        super().__init__({"delta": delta, "current_tool_use": current_tool_use})
 
 
 class TextStreamEvent(ModelStreamEvent):
@@ -111,7 +151,7 @@ class TextStreamEvent(ModelStreamEvent):
 
     def __init__(self, delta: ContentBlockDelta, text: str) -> None:
         """Initialize with delta and text content."""
-        super().__init__({"callback": {"data": text, "delta": delta}})
+        super().__init__({"data": text, "delta": delta})
 
 
 class ReasoningTextStreamEvent(ModelStreamEvent):
@@ -119,7 +159,7 @@ class ReasoningTextStreamEvent(ModelStreamEvent):
 
     def __init__(self, delta: ContentBlockDelta, reasoning_text: str | None) -> None:
         """Initialize with delta and reasoning text."""
-        super().__init__({"callback": {"reasoningText": reasoning_text, "delta": delta, "reasoning": True}})
+        super().__init__({"reasoningText": reasoning_text, "delta": delta, "reasoning": True})
 
 
 class ReasoningSignatureStreamEvent(ModelStreamEvent):
@@ -127,7 +167,7 @@ class ReasoningSignatureStreamEvent(ModelStreamEvent):
 
     def __init__(self, delta: ContentBlockDelta, reasoning_signature: str | None) -> None:
         """Initialize with delta and reasoning signature."""
-        super().__init__({"callback": {"reasoning_signature": reasoning_signature, "delta": delta, "reasoning": True}})
+        super().__init__({"reasoning_signature": reasoning_signature, "delta": delta, "reasoning": True})
 
 
 class ModelStopReason(TypedEvent):
@@ -150,6 +190,11 @@ class ModelStopReason(TypedEvent):
         """
         super().__init__({"stop": (stop_reason, message, usage, metrics)})
 
+    @property
+    @override
+    def is_callback_event(self) -> bool:
+        return False
+
 
 class EventLoopStopEvent(TypedEvent):
     """Event emitted when the agent execution completes normally."""
@@ -171,18 +216,76 @@ class EventLoopStopEvent(TypedEvent):
         """
         super().__init__({"stop": (stop_reason, message, metrics, request_state)})
 
+    @property
+    @override
+    def is_callback_event(self) -> bool:
+        return False
+
 
 class EventLoopThrottleEvent(TypedEvent):
     """Event emitted when the event loop is throttled due to rate limiting."""
 
-    def __init__(self, delay: int, invocation_state: dict[str, Any]) -> None:
+    def __init__(self, delay: int) -> None:
         """Initialize with the throttle delay duration.
 
         Args:
             delay: Delay in seconds before the next retry attempt
-            invocation_state: The invocation state passed into the request
         """
-        super().__init__({"callback": {"event_loop_throttled_delay": delay, **invocation_state}})
+        super().__init__({"event_loop_throttled_delay": delay})
+
+    @override
+    def prepare(self, invocation_state: dict) -> None:
+        self.update(**invocation_state)
+
+
+class ToolResultEvent(TypedEvent):
+    """Event emitted when a tool execution completes."""
+
+    def __init__(self, tool_result: ToolResult) -> None:
+        """Initialize with the completed tool result.
+
+        Args:
+            tool_result: Final result from the tool execution
+        """
+        super().__init__({"tool_result": tool_result})
+
+    @property
+    def tool_use_id(self) -> str:
+        """The toolUseId associated with this result."""
+        return self.get("tool_result").get("toolUseId")  # type: ignore
+
+    @property
+    def tool_result(self) -> ToolResult:
+        """Final result from the completed tool execution."""
+        return self.get("tool_result")  # type: ignore
+
+    @property
+    @override
+    def is_callback_event(self) -> bool:
+        return False
+
+
+class ToolStreamEvent(TypedEvent):
+    """Event emitted when a tool yields sub-events as part of tool execution."""
+
+    def __init__(self, tool_use: ToolUse, tool_sub_event: Any) -> None:
+        """Initialize with tool streaming data.
+
+        Args:
+            tool_use: The tool invocation producing the stream
+            tool_sub_event: The yielded event from the tool execution
+        """
+        super().__init__({"tool_stream_tool_use": tool_use, "tool_stream_event": tool_sub_event})
+
+    @property
+    def tool_use_id(self) -> str:
+        """The toolUseId associated with this stream."""
+        return self.get("tool_stream_tool_use").get("toolUseId")  # type: ignore
+
+    @property
+    @override
+    def is_callback_event(self) -> bool:
+        return False
 
 
 class ModelMessageEvent(TypedEvent):
@@ -198,7 +301,7 @@ class ModelMessageEvent(TypedEvent):
         Args:
             message: The response message from the model
         """
-        super().__init__({"callback": {"message": message}})
+        super().__init__({"message": message})
 
 
 class ToolResultMessageEvent(TypedEvent):
@@ -215,7 +318,7 @@ class ToolResultMessageEvent(TypedEvent):
         Args:
             message: Message containing tool results for conversation history
         """
-        super().__init__({"callback": {"message": message}})
+        super().__init__({"message": message})
 
 
 class ForceStopEvent(TypedEvent):
@@ -229,10 +332,13 @@ class ForceStopEvent(TypedEvent):
         """
         super().__init__(
             {
-                "callback": {
-                    "force_stop": True,
-                    "force_stop_reason": str(reason),
-                    # "force_stop_reason_exception": reason if reason and isinstance(reason, Exception) else MISSING,
-                }
+                "force_stop": True,
+                "force_stop_reason": str(reason),
+                # "force_stop_reason_exception": reason if reason and isinstance(reason, Exception) else MISSING,
             }
         )
+
+
+class AgentResultEvent(TypedEvent):
+    def __init__(self, result: "AgentResult"):
+        super().__init__({"result": result})

--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -5,7 +5,7 @@ providing a structured way to observe to different events of the event loop and
 agent lifecycle.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from typing_extensions import override
 
@@ -17,8 +17,6 @@ from .tools import ToolResult, ToolUse
 
 if TYPE_CHECKING:
     from ..agent import AgentResult
-
-    pass
 
 
 class TypedEvent(dict):
@@ -66,7 +64,7 @@ class InitEventLoopEvent(TypedEvent):
 
     @override
     def prepare(self, invocation_state: dict) -> None:
-        self.update(**invocation_state)
+        self.update(invocation_state)
 
 
 class StartEvent(TypedEvent):
@@ -109,7 +107,7 @@ class ModelStreamChunkEvent(TypedEvent):
 
     @property
     def chunk(self) -> StreamEvent:
-        return self.get("event")  # type: ignore
+        return cast(StreamEvent, self.get("event"))
 
 
 class ModelStreamEvent(TypedEvent):
@@ -135,7 +133,7 @@ class ModelStreamEvent(TypedEvent):
     @override
     def prepare(self, invocation_state: dict) -> None:
         if "delta" in self:
-            self.update(**invocation_state)
+            self.update(invocation_state)
 
 
 class ToolUseStreamEvent(ModelStreamEvent):
@@ -235,7 +233,7 @@ class EventLoopThrottleEvent(TypedEvent):
 
     @override
     def prepare(self, invocation_state: dict) -> None:
-        self.update(**invocation_state)
+        self.update(invocation_state)
 
 
 class ToolResultEvent(TypedEvent):
@@ -252,12 +250,12 @@ class ToolResultEvent(TypedEvent):
     @property
     def tool_use_id(self) -> str:
         """The toolUseId associated with this result."""
-        return self.get("tool_result").get("toolUseId")  # type: ignore
+        return cast(str, cast(ToolResult, self.get("tool_result")).get("toolUseId"))
 
     @property
     def tool_result(self) -> ToolResult:
         """Final result from the completed tool execution."""
-        return self.get("tool_result")  # type: ignore
+        return cast(ToolResult, self.get("tool_result"))
 
     @property
     @override
@@ -280,7 +278,7 @@ class ToolStreamEvent(TypedEvent):
     @property
     def tool_use_id(self) -> str:
         """The toolUseId associated with this stream."""
-        return self.get("tool_stream_tool_use").get("toolUseId")  # type: ignore
+        return cast(str, cast(ToolUse, self.get("tool_stream_tool_use")).get("toolUseId"))
 
     @property
     @override
@@ -334,7 +332,6 @@ class ForceStopEvent(TypedEvent):
             {
                 "force_stop": True,
                 "force_stop_reason": str(reason),
-                # "force_stop_reason_exception": reason if reason and isinstance(reason, Exception) else MISSING,
             }
         )
 

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -486,7 +486,7 @@ async def test_cycle_exception(
     ]
 
     tru_stop_event = None
-    exp_stop_event = {"callback": {"force_stop": True, "force_stop_reason": "Invalid error presented"}}
+    exp_stop_event = {"force_stop": True, "force_stop_reason": "Invalid error presented"}
 
     with pytest.raises(EventLoopException):
         stream = strands.event_loop.event_loop.event_loop_cycle(

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -146,7 +146,7 @@ def test_handle_content_block_start(chunk: ContentBlockStartEvent, exp_tool_use)
     ],
 )
 def test_handle_content_block_delta(event: ContentBlockDeltaEvent, state, exp_updated_state, callback_args):
-    exp_callback_event = {"callback": {**callback_args, "delta": event["delta"]}} if callback_args else {}
+    exp_callback_event = {**callback_args, "delta": event["delta"]} if callback_args else {}
 
     tru_updated_state, tru_callback_event = strands.event_loop.streaming.handle_content_block_delta(event, state)
 
@@ -316,85 +316,71 @@ def test_extract_usage_metrics_with_cache_tokens():
             ],
             [
                 {
-                    "callback": {
-                        "event": {
-                            "messageStart": {
-                                "role": "assistant",
-                            },
+                    "event": {
+                        "messageStart": {
+                            "role": "assistant",
                         },
                     },
                 },
                 {
-                    "callback": {
-                        "event": {
-                            "contentBlockStart": {
-                                "start": {
-                                    "toolUse": {
-                                        "name": "test",
-                                        "toolUseId": "123",
-                                    },
+                    "event": {
+                        "contentBlockStart": {
+                            "start": {
+                                "toolUse": {
+                                    "name": "test",
+                                    "toolUseId": "123",
                                 },
                             },
                         },
                     },
                 },
                 {
-                    "callback": {
-                        "event": {
-                            "contentBlockDelta": {
-                                "delta": {
-                                    "toolUse": {
-                                        "input": '{"key": "value"}',
-                                    },
+                    "event": {
+                        "contentBlockDelta": {
+                            "delta": {
+                                "toolUse": {
+                                    "input": '{"key": "value"}',
                                 },
                             },
                         },
                     },
                 },
                 {
-                    "callback": {
-                        "current_tool_use": {
-                            "input": {
-                                "key": "value",
-                            },
-                            "name": "test",
-                            "toolUseId": "123",
+                    "current_tool_use": {
+                        "input": {
+                            "key": "value",
                         },
-                        "delta": {
-                            "toolUse": {
-                                "input": '{"key": "value"}',
-                            },
+                        "name": "test",
+                        "toolUseId": "123",
+                    },
+                    "delta": {
+                        "toolUse": {
+                            "input": '{"key": "value"}',
                         },
                     },
                 },
                 {
-                    "callback": {
-                        "event": {
-                            "contentBlockStop": {},
+                    "event": {
+                        "contentBlockStop": {},
+                    },
+                },
+                {
+                    "event": {
+                        "messageStop": {
+                            "stopReason": "tool_use",
                         },
                     },
                 },
                 {
-                    "callback": {
-                        "event": {
-                            "messageStop": {
-                                "stopReason": "tool_use",
+                    "event": {
+                        "metadata": {
+                            "metrics": {
+                                "latencyMs": 1,
                             },
-                        },
-                    },
-                },
-                {
-                    "callback": {
-                        "event": {
-                            "metadata": {
-                                "metrics": {
-                                    "latencyMs": 1,
-                                },
-                                "usage": {
-                                    "inputTokens": 1,
-                                    "outputTokens": 1,
-                                    "totalTokens": 1,
-                                },
+                            "usage": {
+                                "inputTokens": 1,
+                                "outputTokens": 1,
+                                "totalTokens": 1,
                             },
                         },
                     },
@@ -417,9 +403,7 @@ def test_extract_usage_metrics_with_cache_tokens():
             [{}],
             [
                 {
-                    "callback": {
-                        "event": {},
-                    },
+                    "event": {},
                 },
                 {
                     "stop": (
@@ -463,80 +447,64 @@ def test_extract_usage_metrics_with_cache_tokens():
             ],
             [
                 {
-                    "callback": {
-                        "event": {
-                            "messageStart": {
-                                "role": "assistant",
+                    "event": {
+                        "messageStart": {
+                            "role": "assistant",
+                        },
+                    },
+                },
+                {
+                    "event": {
+                        "contentBlockStart": {
+                            "start": {},
+                        },
+                    },
+                },
+                {
+                    "event": {
+                        "contentBlockDelta": {
+                            "delta": {
+                                "text": "Hello!",
                             },
                         },
                     },
                 },
                 {
-                    "callback": {
-                        "event": {
-                            "contentBlockStart": {
-                                "start": {},
+                    "data": "Hello!",
+                    "delta": {
+                        "text": "Hello!",
+                    },
+                },
+                {
+                    "event": {
+                        "contentBlockStop": {},
+                    },
+                },
+                {
+                    "event": {
+                        "messageStop": {
+                            "stopReason": "guardrail_intervened",
+                        },
+                    },
+                },
+                {
+                    "event": {
+                        "redactContent": {
+                            "redactAssistantContentMessage": "REDACTED.",
+                            "redactUserContentMessage": "REDACTED",
+                        },
+                    },
+                },
+                {
+                    "event": {
+                        "metadata": {
+                            "metrics": {
+                                "latencyMs": 1,
                             },
-                        },
-                    },
-                },
-                {
-                    "callback": {
-                        "event": {
-                            "contentBlockDelta": {
-                                "delta": {
-                                    "text": "Hello!",
-                                },
-                            },
-                        },
-                    },
-                },
-                {
-                    "callback": {
-                        "data": "Hello!",
-                        "delta": {
-                            "text": "Hello!",
-                        },
-                    },
-                },
-                {
-                    "callback": {
-                        "event": {
-                            "contentBlockStop": {},
-                        },
-                    },
-                },
-                {
-                    "callback": {
-                        "event": {
-                            "messageStop": {
-                                "stopReason": "guardrail_intervened",
-                            },
-                        },
-                    },
-                },
-                {
-                    "callback": {
-                        "event": {
-                            "redactContent": {
-                                "redactAssistantContentMessage": "REDACTED.",
-                                "redactUserContentMessage": "REDACTED",
-                            },
-                        },
-                    },
-                },
-                {
-                    "callback": {
-                        "event": {
-                            "metadata": {
-                                "metrics": {
-                                    "latencyMs": 1,
-                                },
-                                "usage": {
-                                    "inputTokens": 1,
-                                    "outputTokens": 1,
-                                    "totalTokens": 1,
-                                },
+                            "usage": {
+                                "inputTokens": 1,
+                                "outputTokens": 1,
+                                "totalTokens": 1,
                             },
                         },
                     },
@@ -588,29 +556,23 @@ async def test_stream_messages(agenerator, alist):
     tru_events = await alist(stream)
     exp_events = [
         {
-            "callback": {
-                "event": {
-                    "contentBlockDelta": {
-                        "delta": {
-                            "text": "test",
-                        },
+            "event": {
+                "contentBlockDelta": {
+                    "delta": {
+                        "text": "test",
                     },
                 },
             },
         },
         {
-            "callback": {
-                "data": "test",
-                "delta": {
-                    "text": "test",
-                },
+            "data": "test",
+            "delta": {
+                "text": "test",
             },
         },
         {
-            "callback": {
-                "event": {
-                    "contentBlockStop": {},
-                },
+            "event": {
+                "contentBlockStop": {},
             },
         },
         {

--- a/tests/strands/tools/executors/test_concurrent.py
+++ b/tests/strands/tools/executors/test_concurrent.py
@@ -1,6 +1,8 @@
 import pytest
 
 from strands.tools.executors import ConcurrentToolExecutor
+from strands.types._events import ToolResultEvent, ToolStreamEvent
+from strands.types.tools import ToolUse
 
 
 @pytest.fixture
@@ -12,21 +14,21 @@ def executor():
 async def test_concurrent_executor_execute(
     executor, agent, tool_results, cycle_trace, cycle_span, invocation_state, alist
 ):
-    tool_uses = [
+    tool_uses: list[ToolUse] = [
         {"name": "weather_tool", "toolUseId": "1", "input": {}},
         {"name": "temperature_tool", "toolUseId": "2", "input": {}},
     ]
     stream = executor._execute(agent, tool_uses, tool_results, cycle_trace, cycle_span, invocation_state)
 
-    tru_events = sorted(await alist(stream), key=lambda event: event.get("toolUseId"))
+    tru_events = sorted(await alist(stream), key=lambda event: event.tool_use_id)
     exp_events = [
-        {"toolUseId": "1", "status": "success", "content": [{"text": "sunny"}]},
-        {"toolUseId": "1", "status": "success", "content": [{"text": "sunny"}]},
-        {"toolUseId": "2", "status": "success", "content": [{"text": "75F"}]},
-        {"toolUseId": "2", "status": "success", "content": [{"text": "75F"}]},
+        ToolStreamEvent(tool_uses[0], {"toolUseId": "1", "status": "success", "content": [{"text": "sunny"}]}),
+        ToolResultEvent({"toolUseId": "1", "status": "success", "content": [{"text": "sunny"}]}),
+        ToolStreamEvent(tool_uses[1], {"toolUseId": "2", "status": "success", "content": [{"text": "75F"}]}),
+        ToolResultEvent({"toolUseId": "2", "status": "success", "content": [{"text": "75F"}]}),
     ]
     assert tru_events == exp_events
 
     tru_results = sorted(tool_results, key=lambda result: result.get("toolUseId"))
-    exp_results = [exp_events[1], exp_events[3]]
+    exp_results = [exp_events[1].tool_result, exp_events[3].tool_result]
     assert tru_results == exp_results

--- a/tests/strands/tools/executors/test_sequential.py
+++ b/tests/strands/tools/executors/test_sequential.py
@@ -1,6 +1,7 @@
 import pytest
 
 from strands.tools.executors import SequentialToolExecutor
+from strands.types._events import ToolResultEvent, ToolStreamEvent
 
 
 @pytest.fixture
@@ -20,13 +21,13 @@ async def test_sequential_executor_execute(
 
     tru_events = await alist(stream)
     exp_events = [
-        {"toolUseId": "1", "status": "success", "content": [{"text": "sunny"}]},
-        {"toolUseId": "1", "status": "success", "content": [{"text": "sunny"}]},
-        {"toolUseId": "2", "status": "success", "content": [{"text": "75F"}]},
-        {"toolUseId": "2", "status": "success", "content": [{"text": "75F"}]},
+        ToolStreamEvent(tool_uses[0], {"toolUseId": "1", "status": "success", "content": [{"text": "sunny"}]}),
+        ToolResultEvent({"toolUseId": "1", "status": "success", "content": [{"text": "sunny"}]}),
+        ToolStreamEvent(tool_uses[1], {"toolUseId": "2", "status": "success", "content": [{"text": "75F"}]}),
+        ToolResultEvent({"toolUseId": "2", "status": "success", "content": [{"text": "75F"}]}),
     ]
     assert tru_events == exp_events
 
     tru_results = tool_results
-    exp_results = [exp_events[1], exp_events[2]]
+    exp_results = [exp_events[1].tool_result, exp_events[3].tool_result]
     assert tru_results == exp_results


### PR DESCRIPTION
## Description

This is step step 2/N of implementing typed-events:

Related PRs:

 1. #745

Migrate "callback" nested properties and explicitly passing invocation_state to behaviors on the TypedEvent:

 - `TypedEvent.is_callback_event` for determining if an event should be yielded and or invoked in the callback
 - `TypedEvent.prepare` for taking in invocation_state (and optionally merging it in)
     - This is only for backwards compatibility; certain events need to be merged in with invocation_state, and now we can move away from passing `invocation_state` throughout the system

Customers still only get dictionaries, as we decided that this will remain an implementation detail for the time being, but this makes the events typed all the way up until *just* before we yield events back to the caller

As part of this refactor, we also now strongly typed `ToolResultEvent` and `ToolStreamEvent` - neither of these are currently yielded up to the caller - that will be unlocked/opened in a future PR as part of #543

**Observable changes**: There should be none outside of the Agent; internally there are a couple places where we now sorely return `TypedEvent`s

## Related Issues

#242 

## Documentation PR

Will be once we publish typed events

## Type of Change

Other (please describe): Internal refactor

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
