### PR TITLE
Add invocation_state to ToolContext

### DIFF
--- a/src/strands/tools/decorator.py
+++ b/src/strands/tools/decorator.py
@@ -268,7 +268,9 @@ class FunctionToolMetadata:
             invocation_state: Context for the tool invocation, including agent state.
         """
         if self._context_param and self._context_param in self.signature.parameters:
-            tool_context = ToolContext(tool_use=tool_use, agent=invocation_state["agent"])
+            tool_context = ToolContext(
+                tool_use=tool_use, agent=invocation_state["agent"], invocation_state=invocation_state
+            )
             validated_input[self._context_param] = tool_context
 
         # Inject agent if requested (backward compatibility)

--- a/src/strands/types/tools.py
+++ b/src/strands/types/tools.py
@@ -132,6 +132,8 @@ class ToolContext:
         tool_use: The complete ToolUse object containing tool invocation details.
         agent: The Agent instance executing this tool, providing access to conversation history,
                model configuration, and other agent state.
+        invocation_state: Keyword arguments passed to agent invocation methods (agent(), agent.invoke_async(), etc.).
+                          Provides access to invocation-specific context and parameters.
 
     Note:
         This class is intended to be instantiated by the SDK. Direct construction by users
@@ -140,6 +142,7 @@ class ToolContext:
 
     tool_use: ToolUse
     agent: "Agent"
+    invocation_state: dict[str, Any]
 
 
 ToolChoice = Union[

--- a/tests/strands/tools/test_decorator.py
+++ b/tests/strands/tools/test_decorator.py
@@ -1039,7 +1039,7 @@ async def test_tool_with_complex_anyof_schema(alist):
     assert "NoneType: None" in result["content"][0]["text"]
 
 
-async def _run_context_injection_test(context_tool: AgentTool):
+async def _run_context_injection_test(context_tool: AgentTool, additional_context=None):
     """Common test logic for context injection tests."""
     tool: AgentTool = context_tool
     generator = tool.stream(
@@ -1052,6 +1052,7 @@ async def _run_context_injection_test(context_tool: AgentTool):
         },
         invocation_state={
             "agent": Agent(name="test_agent"),
+            **(additional_context or {}),
         },
     )
     tool_results = [value async for value in generator]
@@ -1081,6 +1082,8 @@ async def test_tool_context_injection_default():
         tool_name = tool_context.tool_use["name"]
         agent_from_tool_context = tool_context.agent
 
+        assert tool_context.invocation_state["new_value"] == 13
+
         return {
             "status": "success",
             "content": [
@@ -1090,7 +1093,12 @@ async def test_tool_context_injection_default():
             ],
         }
 
-    await _run_context_injection_test(context_tool)
+    await _run_context_injection_test(
+        context_tool,
+        {
+            "new_value": 13,
+        },
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

#557 provided ToolContext which enabled tool_use but we held off on invocation_state until we had customer demand/use-cases. Issues #579 and #750 point out use cases that can't be easily solved today, so we'll allow invocation_state to be plumbed through.

We still have problems with the SDK updating the invocation_state, but it's an existing problem that we can't address until 2.0.

## Related Issues

Addresses issue #579, #750

## Documentation PR

Will be a follow-up PR in the docs repo

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
