### PR TITLE
feat: implemented pruning conversation manager

### DIFF
--- a/src/strands/agent/conversation_manager/__init__.py
+++ b/src/strands/agent/conversation_manager/__init__.py
@@ -8,6 +8,7 @@ It includes:
   size while preserving conversation coherence
 - SummarizingConversationManager: An implementation that summarizes older context instead
   of simply trimming it
+- PruningConversationManager: An implementation that selectively prunes messages using configurable strategies
 
 Conversation managers help control memory usage and context length while maintaining relevant conversation state, which
 is critical for effective agent interactions.
@@ -15,7 +16,13 @@ is critical for effective agent interactions.
 
 from .conversation_manager import ConversationManager
 from .null_conversation_manager import NullConversationManager
+from .pruning_conversation_manager import MessageContext, PruningContext, PruningConversationManager, PruningStrategy
 from .sliding_window_conversation_manager import SlidingWindowConversationManager
+
+# Import strategies
+from .strategies import (
+    LargeToolResultPruningStrategy,
+)
 from .summarizing_conversation_manager import SummarizingConversationManager
 
 __all__ = [
@@ -23,4 +30,9 @@ __all__ = [
     "NullConversationManager",
     "SlidingWindowConversationManager",
     "SummarizingConversationManager",
+    "PruningConversationManager",
+    "PruningStrategy",
+    "PruningContext",
+    "MessageContext",
+    "LargeToolResultPruningStrategy",
 ]

--- a/src/strands/agent/conversation_manager/pruning_conversation_manager.py
+++ b/src/strands/agent/conversation_manager/pruning_conversation_manager.py
@@ -1,0 +1,441 @@
+"""Conversation manager that selectively prunes messages using configurable strategies."""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from typing_extensions import TypedDict, override
+
+from ...types.content import Message, Messages
+from ...types.exceptions import ContextWindowOverflowException
+from .conversation_manager import ConversationManager
+
+if TYPE_CHECKING:
+    from ...agent.agent import Agent
+
+logger = logging.getLogger(__name__)
+
+
+class MessageContext(TypedDict):
+    """Context information for a specific message in a conversation.
+
+    This type represents the context data returned by get_message_context(),
+    providing metadata about a message that can be used for pruning decisions.
+
+    Attributes:
+        token_count: Estimated number of tokens in the message.
+        has_tool_use: Whether the message contains tool use content.
+        has_tool_result: Whether the message contains tool result content.
+        message_index: The index position of the message in the conversation.
+        total_messages: Total number of messages in the conversation.
+    """
+
+    token_count: int
+    has_tool_use: bool
+    has_tool_result: bool
+    message_index: int
+    total_messages: int
+
+
+class PruningStrategy(ABC):
+    """Abstract interface for message pruning strategies.
+
+    This class defines the contract that all pruning strategies must implement.
+    Strategies can selectively compress or remove messages based on their own
+    criteria while preserving conversation integrity.
+    """
+
+    @abstractmethod
+    def should_prune_message(self, message: Message, context: MessageContext) -> bool:
+        """Determine if a message should be pruned.
+
+        Args:
+            message: The message to evaluate for pruning
+            context: Context information including message age, token count, etc.
+
+        Returns:
+            True if the message should be pruned, False otherwise
+        """
+        pass
+
+    @abstractmethod
+    def prune_message(self, message: Message, agent: "Agent") -> Optional[Message]:
+        """Prune a message, returning the compressed version or None to remove.
+
+        Args:
+            message: The message to prune
+            agent: The agent instance for context and LLM access
+
+        Returns:
+            Compressed message, or None to remove the message entirely
+        """
+        pass
+
+    @abstractmethod
+    def get_strategy_name(self) -> str:
+        """Get the name of this pruning strategy.
+
+        Returns:
+            The strategy name
+        """
+        pass
+
+
+class PruningContext:
+    """Context information for pruning decisions.
+
+    This class provides rich context information to pruning strategies,
+    enabling intelligent decision-making about which messages to prune
+    and how to prune them.
+    """
+
+    def __init__(self, messages: Messages, agent: "Agent"):
+        """Initialize pruning context.
+
+        Args:
+            messages: The conversation messages to analyze
+            agent: The agent instance for additional context
+        """
+        self.messages = messages
+        self.agent = agent
+        self.token_counts = self._estimate_token_counts()
+
+    def get_message_context(self, index: int) -> MessageContext:
+        """Get context information for a specific message.
+
+        Args:
+            index: The index of the message in the conversation
+
+        Returns:
+            MessageContext containing context information for the message
+
+        Raises:
+            IndexError: If the message index is out of range
+        """
+        if index < 0 or index >= len(self.messages):
+            raise IndexError(f"Message index {index} out of range")
+
+        return {
+            "token_count": self.token_counts[index],
+            "has_tool_use": self._has_tool_use(self.messages[index]),
+            "has_tool_result": self._has_tool_result(self.messages[index]),
+            "message_index": index,
+            "total_messages": len(self.messages),
+        }
+
+    def _estimate_token_counts(self) -> List[int]:
+        """Estimate token count for each message.
+
+        This provides a rough estimation of token usage for each message.
+        The estimation can be enhanced with actual tokenization in the future.
+
+        Returns:
+            List of estimated token counts for each message
+        """
+        token_counts = []
+        for message in self.messages:
+            count = 0
+            for content in message.get("content", []):
+                if "text" in content:
+                    # Rough token estimation: ~1.3 tokens per word
+                    count += int(len(content["text"].split()) * 1.3)
+                elif "toolResult" in content:
+                    result_content = content["toolResult"].get("content", [])
+                    for result_item in result_content:
+                        if "text" in result_item:
+                            count += int(len(result_item["text"].split()) * 1.3)
+                        elif "json" in result_item:
+                            count += int(len(str(result_item["json"]).split()) * 1.3)
+                elif "toolUse" in content:
+                    # Rough estimate for tool use overhead
+                    count += 50
+                    # Add input parameter tokens
+                    input_str = str(content["toolUse"].get("input", {}))
+                    count += int(len(input_str.split()) * 1.3)
+            token_counts.append(int(count))
+        return token_counts
+
+    def _has_tool_use(self, message: Message) -> bool:
+        """Check if message contains tool use.
+
+        Args:
+            message: The message to check
+
+        Returns:
+            True if the message contains tool use, False otherwise
+        """
+        return any("toolUse" in content for content in message.get("content", []))
+
+    def _has_tool_result(self, message: Message) -> bool:
+        """Check if message contains tool result.
+
+        Args:
+            message: The message to check
+
+        Returns:
+            True if the message contains tool result, False otherwise
+        """
+        return any("toolResult" in content for content in message.get("content", []))
+
+
+class PruningConversationManager(ConversationManager):
+    """Conversation manager that selectively prunes messages using configurable strategies.
+
+    Unlike summarization which collapses multiple messages into one, pruning returns
+    a list of messages where some have been compressed, removed, or truncated while
+    others remain intact. This preserves conversation structure and flow.
+    """
+
+    def __init__(
+        self,
+        pruning_strategies: List[PruningStrategy],
+        preserve_initial_messages: int = 1,
+        preserve_recent_messages: int = 2,
+        enable_proactive_pruning: bool = True,
+        pruning_threshold: float = 0.7,
+        context_window_size: int = 200000,
+    ):
+        """Initialize the pruning conversation manager.
+
+        Args:
+            pruning_strategies: List of strategies to apply for message pruning
+            preserve_initial_messages: Number of initial messages to never prune
+            preserve_recent_messages: Number of recent messages to never prune
+            enable_proactive_pruning: Whether to prune proactively based on threshold
+            pruning_threshold: Context usage threshold to trigger proactive pruning (0.1-1.0)
+            context_window_size: Maximum context window size in tokens (default: 200000)
+        """
+        super().__init__()
+        self.pruning_strategies = pruning_strategies
+        self.preserve_recent_messages = preserve_recent_messages
+        self.preserve_initial_messages = preserve_initial_messages
+        self.enable_proactive_pruning = enable_proactive_pruning
+        self.pruning_threshold = max(0.1, min(1.0, pruning_threshold))
+        self.context_window_size = context_window_size
+
+    @override
+    def apply_management(self, agent: "Agent", **kwargs: Any) -> None:
+        """Apply pruning management strategy.
+
+        For proactive pruning, this method checks if the conversation has grown
+        beyond the configured threshold and applies pruning strategies if needed.
+
+        Args:
+            agent: The agent whose conversation history will be managed
+            **kwargs: Additional keyword arguments for future extensibility
+        """
+        if self.enable_proactive_pruning and self._should_prune_proactively(agent):
+            logger.debug("Applying proactive pruning based on threshold")
+            self.reduce_context(agent, **kwargs)
+
+    @override
+    def reduce_context(self, agent: "Agent", e: Optional[Exception] = None, **kwargs: Any) -> None:
+        """Reduce context through selective message pruning.
+
+        This method applies the configured pruning strategies to reduce the conversation
+        context size while preserving important messages and conversation structure.
+
+        Args:
+            agent: The agent whose conversation history will be reduced
+            e: The exception that triggered the context reduction, if any
+            **kwargs: Additional keyword arguments for future extensibility
+
+        Raises:
+            ContextWindowOverflowException: If the context cannot be pruned sufficiently
+        """
+        if len(agent.messages) == 0:
+            raise ContextWindowOverflowException("No messages to prune")
+
+        original_messages = agent.messages.copy()
+        original_count = len(original_messages)
+
+        try:
+            pruned_messages, removed_count = self._prune_messages(agent.messages, agent)
+
+            # Validate that pruning actually reduced context
+            if self._validate_pruning_effectiveness(original_messages, pruned_messages, agent):
+                agent.messages[:] = pruned_messages
+                self.removed_message_count += removed_count
+
+                logger.info(
+                    "Pruning completed: %d -> %d messages (%d removed)",
+                    original_count,
+                    len(pruned_messages),
+                    removed_count,
+                )
+            else:
+                # Fallback to more aggressive pruning or raise exception
+                self._handle_pruning_failure(agent, e)
+
+        except Exception as pruning_error:
+            logger.error("Pruning failed: %s", pruning_error)
+            raise pruning_error from e
+
+    def _prune_messages(self, messages: Messages, agent: "Agent") -> tuple[Messages, int]:
+        """Apply pruning strategies to messages.
+
+        When the token threshold is exceeded, all messages outside the preserved ranges
+        (initial and recent) will be pruned according to the configured strategies.
+
+        Args:
+            messages: The messages to prune
+            agent: The agent instance for context
+
+        Returns:
+            A tuple of (pruned messages list, count of removed messages)
+
+        Raises:
+            ContextWindowOverflowException: If there are insufficient messages to prune safely
+        """
+        total_preserved = self.preserve_recent_messages + self.preserve_initial_messages
+        if len(messages) <= total_preserved:
+            logger.debug("Too few messages to prune safely")
+            raise ContextWindowOverflowException("Insufficient messages for pruning")
+
+        # Create pruning context
+        context = PruningContext(messages, agent)
+
+        # Determine which messages can be pruned
+        # Exclude initial messages (0 to preserve_initial_messages-1)
+        # Exclude recent messages (len(messages) - preserve_recent_messages to end)
+        min_prunable_index = self.preserve_initial_messages
+        max_prunable_index = len(messages) - self.preserve_recent_messages
+
+        pruned_messages = []
+        removed_count = 0
+
+        for i, message in enumerate(messages):
+            # Always preserve initial messages
+            if i < min_prunable_index:
+                pruned_messages.append(message)
+                continue
+
+            # Always preserve recent messages
+            if i >= max_prunable_index:
+                pruned_messages.append(message)
+                continue
+
+            # For messages in the prunable range
+            message_context = context.get_message_context(i)
+            should_prune = False
+
+            # Apply pruning strategies to determine if message should be pruned
+            for strategy in self.pruning_strategies:
+                if strategy.should_prune_message(message, message_context):
+                    should_prune = True
+                    break
+
+            if should_prune:
+                # Try to prune the message
+                pruned_message = None
+                for strategy in self.pruning_strategies:
+                    if strategy.should_prune_message(message, message_context):
+                        pruned_message = strategy.prune_message(message, agent)
+                        break
+
+                if pruned_message is not None:
+                    # Message was compressed
+                    pruned_messages.append(pruned_message)
+                else:
+                    # Message was removed entirely - don't add to pruned_messages
+                    removed_count += 1
+                    # Note: we don't append anything to pruned_messages, effectively removing it
+            else:
+                # Keep message unchanged
+                pruned_messages.append(message)
+
+        return pruned_messages, removed_count
+
+    def _should_prune_proactively(self, agent: "Agent") -> bool:
+        """Determine if proactive pruning should be triggered.
+
+        Args:
+            agent: The agent to evaluate
+
+        Returns:
+            True if proactive pruning should be applied
+        """
+        if not agent.messages:
+            return False
+
+        # Create pruning context to calculate total tokens
+        context = PruningContext(agent.messages, agent)
+        total_tokens = sum(context.token_counts)
+
+        # Apply threshold to context window size
+        threshold_tokens = self.context_window_size * self.pruning_threshold
+
+        logger.debug(
+            "Proactive pruning check: %d tokens / %d threshold (%d limit * %s threshold)",
+            total_tokens,
+            threshold_tokens,
+            self.context_window_size,
+            self.pruning_threshold,
+        )
+
+        return total_tokens > threshold_tokens
+
+    def _validate_pruning_effectiveness(
+        self, original_messages: Messages, pruned_messages: Messages, agent: "Agent"
+    ) -> bool:
+        """Validate that pruning actually reduced context size.
+
+        Args:
+            original_messages: The original message list
+            pruned_messages: The pruned message list
+            agent: The agent instance
+
+        Returns:
+            True if pruning was effective, False otherwise
+        """
+        # Calculate total estimated tokens for original and pruned messages
+        original_context = PruningContext(original_messages, agent)
+        pruned_context = PruningContext(pruned_messages, agent)
+
+        original_tokens = sum(original_context.token_counts)
+        pruned_tokens = sum(pruned_context.token_counts)
+
+        logger.debug("Token comparison: original=%d, pruned=%d", original_tokens, pruned_tokens)
+
+        return pruned_tokens < original_tokens
+
+    def _handle_pruning_failure(self, agent: "Agent", e: Optional[Exception]) -> None:
+        """Handle cases where pruning fails to reduce context sufficiently.
+
+        Args:
+            agent: The agent instance
+            e: The original exception that triggered pruning, if any
+
+        Raises:
+            ContextWindowOverflowException: When pruning fails to reduce context
+        """
+        logger.error("Pruning failed to reduce context sufficiently")
+
+        # Could implement more aggressive fallback strategies here
+        # For now, raise the original exception
+        if e:
+            raise e
+        else:
+            raise ContextWindowOverflowException("Pruning failed to reduce context")
+
+    @override
+    def get_state(self) -> Dict[str, Any]:
+        """Get the current state including pruning statistics.
+
+        Returns:
+            Dictionary containing the manager's state for session persistence
+        """
+        return super().get_state()
+
+    @override
+    def restore_from_session(self, state: Dict[str, Any]) -> Optional[List[Message]]:
+        """Restore pruning manager state from session.
+
+        Args:
+            state: The state dictionary to restore from
+
+        Returns:
+            None (no messages to prepend)
+        """
+        super().restore_from_session(state)
+        return None

--- a/src/strands/agent/conversation_manager/strategies/__init__.py
+++ b/src/strands/agent/conversation_manager/strategies/__init__.py
@@ -1,0 +1,7 @@
+"""Concrete implementations of pruning strategies."""
+
+from .tool_result_pruning import LargeToolResultPruningStrategy
+
+__all__ = [
+    "LargeToolResultPruningStrategy",
+]

--- a/src/strands/agent/conversation_manager/strategies/tool_result_pruning.py
+++ b/src/strands/agent/conversation_manager/strategies/tool_result_pruning.py
@@ -1,0 +1,251 @@
+"""Strategy for pruning large tool results while preserving tool use context."""
+
+import copy
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from typing_extensions import override
+
+from ....types.content import Message
+from ....types.tools import ToolResult, ToolResultContent
+from .. import MessageContext, PruningStrategy
+
+if TYPE_CHECKING:
+    from ....agent.agent import Agent
+
+logger = logging.getLogger(__name__)
+
+
+class LargeToolResultPruningStrategy(PruningStrategy):
+    """Prune large tool results while preserving tool use context.
+
+    This strategy identifies tool results that exceed a specified token threshold
+    and compresses them while maintaining the essential information about the
+    tool execution and its status.
+    """
+
+    def __init__(
+        self,
+        max_tool_result_tokens: int = 50_000,
+        compression_template: str = (
+            "[Tool result compressed: {original_size} tokens -> {compressed_size} tokens. Original status: {status}]"
+        ),
+        enable_llm_compression: bool = False,
+    ):
+        """Initialize the tool result pruning strategy.
+
+        Args:
+            max_tool_result_tokens: Maximum tokens allowed in tool results before compression
+            compression_template: Template for compression messages
+            enable_llm_compression: Whether to use LLM for intelligent compression (future feature)
+        """
+        self.max_tool_result_tokens = max_tool_result_tokens
+        self.compression_template = compression_template
+        self.enable_llm_compression = enable_llm_compression
+
+    @override
+    def get_strategy_name(self) -> str:
+        """Get the name of this pruning strategy.
+
+        Returns:
+            The strategy name
+        """
+        return "LargeToolResultPruningStrategy"
+
+    @override
+    def should_prune_message(self, message: Message, context: MessageContext) -> bool:
+        """Check if message contains large tool results that should be pruned.
+
+        Args:
+            message: The message to evaluate
+            context: Context information about the message
+
+        Returns:
+            True if the message contains tool results exceeding the size threshold
+        """
+        # Check if message has tool results
+        has_tool_result = context.get("has_tool_result", False)
+
+        if not has_tool_result:
+            return False
+
+        for content in message.get("content", []):
+            if "toolResult" in content and content["toolResult"]:
+                result_size = self._estimate_tool_result_tokens(content["toolResult"])
+                if result_size > self.max_tool_result_tokens:
+                    logger.debug("Tool result size %d exceeds threshold %d", result_size, self.max_tool_result_tokens)
+                    return True
+        return False
+
+    @override
+    def prune_message(self, message: Message, agent: "Agent") -> Optional[Message]:
+        """Compress large tool results while preserving structure.
+
+        Args:
+            message: The message to prune
+            agent: The agent instance for context
+
+        Returns:
+            The message with compressed tool results
+        """
+        pruned_message = self._deep_copy_message(message)
+
+        for content in pruned_message.get("content", []):
+            if "toolResult" in content:
+                tool_result = content["toolResult"]
+                original_size = self._estimate_tool_result_tokens(tool_result)
+
+                if original_size > self.max_tool_result_tokens:
+                    if self.enable_llm_compression:
+                        compressed_result = self._llm_compress_tool_result(tool_result, agent)
+                    else:
+                        compressed_result = self._simple_compress_tool_result(tool_result)
+
+                    content["toolResult"] = compressed_result
+
+                    compressed_size = self._estimate_tool_result_tokens(compressed_result)
+                    logger.info("Compressed tool result: %d -> %d tokens", original_size, compressed_size)
+
+        return pruned_message
+
+    def _estimate_tool_result_tokens(self, tool_result: ToolResult) -> int:
+        """Estimate token count for a tool result.
+
+        Args:
+            tool_result: The tool result to estimate
+
+        Returns:
+            Estimated token count
+        """
+        total_tokens = 0
+
+        for content_item in tool_result.get("content", []):
+            if "text" in content_item:
+                text = content_item["text"]
+                # estimation: ~4 characters per token on average
+                char_count = len(text)
+                total_tokens += int(char_count / 4)
+            elif "json" in content_item:
+                # JSON content estimation
+                json_str = str(content_item["json"])
+                char_count = len(json_str)
+                total_tokens += int(char_count / 4)
+            elif "document" in content_item:
+                # Document content estimation (simplified)
+                total_tokens += len(content_item["document"]["source"]["bytes"])
+            elif "image" in content_item:
+                # Image content estimation (simplified)
+                total_tokens += len(content_item["image"]["source"]["bytes"])
+
+        return total_tokens
+
+    def _simple_compress_tool_result(self, tool_result: ToolResult) -> ToolResult:
+        """Apply simple compression to tool result.
+
+        Args:
+            tool_result: The tool result to compress
+
+        Returns:
+            Compressed tool result
+        """
+        original_size = self._estimate_tool_result_tokens(tool_result)
+
+        # Create compressed version
+        compressed_content: list[ToolResultContent] = []
+
+        for content_item in tool_result.get("content", []):
+            if "text" in content_item:
+                text = content_item["text"]
+                if len(text) > 500:  # Truncate long text
+                    compressed_text = text[:500] + f"... [truncated from {len(text)} chars]"
+                    compressed_content.append({"text": compressed_text})
+                else:
+                    compressed_content.append(content_item)
+            elif "json" in content_item:
+                # Simplify JSON content
+                json_data = content_item["json"]
+                if isinstance(json_data, dict) and len(str(json_data)) > 500:
+                    compressed_json = {
+                        "_compressed": True,
+                        "_n_original_keys": len(list(json_data.keys())),
+                        "_size": len(str(json_data)),
+                        "_type": "dict",
+                    }
+                    # Include a few sample values if they're small
+                    for idx, (key, value) in enumerate(json_data.items()):
+                        value_str = str(value)
+                        if len(value_str) < 100:
+                            compressed_json[key] = json_data[key]
+                        if idx >= 100:
+                            break
+                elif isinstance(json_data, list) and len(str(json_data)) > 500:
+                    compressed_json = {
+                        "_compressed": True,
+                        "_length": len(json_data),
+                        "_size": len(str(json_data)),
+                        "_type": "list",
+                    }
+                    samples = []
+                    for idx, item in enumerate(json_data):
+                        if len(str(item)) < 100:
+                            samples.append(item)
+                        if idx >= 100:
+                            break
+                    compressed_json["_sample"] = samples
+                    compressed_content.append({"json": compressed_json})
+                else:
+                    compressed_content.append(content_item)
+            else:
+                # Keep other content types as-is for now
+                compressed_content.append(content_item)
+
+        # Calculate compressed size
+        compressed_size = self._estimate_tool_result_tokens(
+            ToolResult(
+                content=compressed_content,
+                status=tool_result["status"],
+                toolUseId=tool_result["toolUseId"],
+            )
+        )
+
+        # Create compression note
+        compression_note = self.compression_template.format(
+            original_size=original_size,
+            compressed_size=compressed_size,
+            status=tool_result["status"],
+        )
+
+        # Create the compressed tool result first
+        compressed_content = [{"text": compression_note}, *compressed_content]
+        compressed_tool_result = ToolResult(
+            content=compressed_content,
+            status=tool_result["status"],
+            toolUseId=tool_result["toolUseId"],
+        )
+
+        return compressed_tool_result
+
+    def _llm_compress_tool_result(self, tool_result: ToolResult, agent: "Agent") -> ToolResult:
+        """Use LLM to intelligently compress tool result.
+
+        This is a placeholder for future LLM-based compression functionality.
+
+        Args:
+            tool_result: The tool result to compress
+            agent: The agent instance for LLM access
+
+        Returns:
+            Compressed tool result
+        """
+        raise NotImplementedError("LLM-based tool result compression not implemented yet!")
+
+    def _deep_copy_message(self, message: Message) -> Message:
+        """Create a deep copy of a message.
+
+        Args:
+            message: The message to copy
+
+        Returns:
+            Deep copy of the message
+        """
+        return copy.deepcopy(message)

--- a/tests/strands/agent/test_pruning_context.py
+++ b/tests/strands/agent/test_pruning_context.py
@@ -1,0 +1,161 @@
+"""Tests for PruningContext class."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from strands.agent.conversation_manager import PruningContext
+from strands.types.content import Messages
+
+
+class TestPruningContext:
+    """Test the PruningContext class."""
+
+    @pytest.fixture
+    def sample_messages(self) -> Messages:
+        return [
+            {"role": "user", "content": [{"text": "Hello"}]},
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "123", "name": "test", "input": {}}}]},
+            {
+                "role": "user",
+                "content": [{"toolResult": {"toolUseId": "123", "content": [{"text": "Result"}], "status": "success"}}],
+            },
+            {"role": "assistant", "content": [{"text": "Final response"}]},
+        ]
+
+    @pytest.fixture
+    def mock_agent(self):
+        return Mock()
+
+    def test_initialization(self, sample_messages, mock_agent):
+        """Test PruningContext initialization."""
+        context = PruningContext(sample_messages, mock_agent)
+
+        assert context.messages == sample_messages
+        assert context.agent == mock_agent
+        assert len(context.token_counts) == len(sample_messages)
+
+    def test_token_counts_estimation(self, sample_messages, mock_agent):
+        """Test that token counts are estimated for each message."""
+        context = PruningContext(sample_messages, mock_agent)
+
+        assert len(context.token_counts) == len(sample_messages)
+        assert all(isinstance(count, int) for count in context.token_counts)
+        assert all(count >= 0 for count in context.token_counts)
+
+    def test_get_message_context(self, sample_messages, mock_agent):
+        """Test getting context for a specific message."""
+        context = PruningContext(sample_messages, mock_agent)
+
+        message_context = context.get_message_context(1)  # Assistant with tool use
+
+        assert message_context["has_tool_use"] is True
+        assert message_context["has_tool_result"] is False
+        assert message_context["message_index"] == 1
+        assert message_context["total_messages"] == 4
+        assert isinstance(message_context["token_count"], int)
+
+    def test_get_message_context_out_of_range(self, sample_messages, mock_agent):
+        """Test that out of range indices raise IndexError."""
+        context = PruningContext(sample_messages, mock_agent)
+
+        with pytest.raises(IndexError, match="Message index 10 out of range"):
+            context.get_message_context(10)
+
+        with pytest.raises(IndexError, match="Message index -1 out of range"):
+            context.get_message_context(-1)
+
+    def test_tool_usage_detection(self, sample_messages, mock_agent):
+        """Test tool usage detection in messages."""
+        context = PruningContext(sample_messages, mock_agent)
+
+        # Message 1 has tool use
+        assert context._has_tool_use(sample_messages[1]) is True
+        assert context._has_tool_result(sample_messages[1]) is False
+
+        # Message 2 has tool result
+        assert context._has_tool_use(sample_messages[2]) is False
+        assert context._has_tool_result(sample_messages[2]) is True
+
+        # Message 0 has neither
+        assert context._has_tool_use(sample_messages[0]) is False
+        assert context._has_tool_result(sample_messages[0]) is False
+
+    def test_token_count_estimation_with_different_content_types(self, mock_agent):
+        """Test token estimation with various content types."""
+        messages: Messages = [
+            {"role": "user", "content": [{"text": "Simple text message"}]},
+            {
+                "role": "assistant",
+                "content": [{"toolUse": {"toolUseId": "123", "name": "test", "input": {"param": "value"}}}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"toolResult": {"toolUseId": "123", "content": [{"text": "Tool result text"}], "status": "success"}}
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "456",
+                            "content": [{"json": {"key": "value", "data": [1, 2, 3]}}],
+                            "status": "success",
+                        }
+                    }
+                ],
+            },
+        ]
+
+        context = PruningContext(messages, mock_agent)
+
+        # All messages should have positive token counts
+        assert all(count > 0 for count in context.token_counts)
+
+        # Tool use message should have reasonable token count (base + input)
+        assert context.token_counts[1] >= 50  # Base tool use overhead
+
+        # Tool result with JSON should have tokens estimated
+        assert context.token_counts[3] > context.token_counts[0]  # JSON content should be more tokens
+
+    def test_empty_messages_list(self, mock_agent):
+        """Test behavior with empty messages list."""
+        messages: Messages = []
+        context = PruningContext(messages, mock_agent)
+
+        assert context.token_counts == []
+
+    def test_single_message(self, mock_agent):
+        """Test behavior with single message."""
+        messages: Messages = [{"role": "user", "content": [{"text": "Single message"}]}]
+        context = PruningContext(messages, mock_agent)
+
+        assert len(context.token_counts) == 1
+        assert context.token_counts[0] > 0
+
+        message_context = context.get_message_context(0)
+        assert message_context["total_messages"] == 1
+
+    def test_message_with_multiple_content_blocks(self, mock_agent):
+        """Test token estimation for messages with multiple content blocks."""
+        messages: Messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"text": "First part of message"},
+                    {"text": "Second part of message"},
+                    {"toolResult": {"toolUseId": "123", "content": [{"text": "Tool output"}], "status": "success"}},
+                ],
+            }
+        ]
+
+        context = PruningContext(messages, mock_agent)
+
+        # Should count tokens from all content blocks
+        assert context.token_counts[0] > 0
+
+        # Should detect tool result
+        assert context._has_tool_result(messages[0]) is True
+        assert context._has_tool_use(messages[0]) is False

--- a/tests/strands/agent/test_pruning_conversation_manager.py
+++ b/tests/strands/agent/test_pruning_conversation_manager.py
@@ -1,0 +1,449 @@
+"""Tests for PruningConversationManager class."""
+
+from typing import Optional
+from unittest.mock import Mock, patch
+
+import pytest
+
+from strands.agent.conversation_manager.pruning_conversation_manager import (
+    MessageContext,
+    PruningConversationManager,
+    PruningStrategy,
+)
+from strands.agent.conversation_manager.strategies.tool_result_pruning import LargeToolResultPruningStrategy
+from strands.types.content import Message
+from strands.types.exceptions import ContextWindowOverflowException
+
+
+class TestPruningStrategy(PruningStrategy):
+    """Simple test strategy that prunes messages based on content."""
+
+    def should_prune_message(self, message: Message, context: MessageContext) -> bool:
+        """Prune messages that contain 'Old message' in their text."""
+        for content in message.get("content", []):
+            if "text" in content and "Old message" in content["text"]:
+                return True
+        return False
+
+    def prune_message(self, message: Message, agent) -> Optional[Message]:
+        """Remove the message entirely."""
+        return None
+
+    def get_strategy_name(self) -> str:
+        """Get the name of this pruning strategy."""
+        return "TestPruningStrategy"
+
+
+class TestPruningConversationManager:
+    """Test the PruningConversationManager class."""
+
+    @pytest.fixture
+    def strategies(self):
+        return [
+            LargeToolResultPruningStrategy(max_tool_result_tokens=100),
+        ]
+
+    @pytest.fixture
+    def test_strategies(self):
+        """Strategies that can prune regular text messages for testing."""
+        return [
+            TestPruningStrategy(),
+        ]
+
+    @pytest.fixture
+    def manager(self, strategies):
+        return PruningConversationManager(
+            pruning_strategies=strategies, preserve_recent_messages=2, context_window_size=10000
+        )
+
+    @pytest.fixture
+    def test_manager(self, test_strategies):
+        """Manager with test strategies for regular message pruning."""
+        return PruningConversationManager(
+            pruning_strategies=test_strategies, preserve_recent_messages=2, context_window_size=10000
+        )
+
+    @pytest.fixture
+    def mock_agent(self):
+        agent = Mock()
+        agent.messages = []
+        return agent
+
+    def test_initialization(self, strategies):
+        """Test manager initialization with parameters."""
+        manager = PruningConversationManager(
+            pruning_strategies=strategies,
+            preserve_recent_messages=5,
+            preserve_initial_messages=2,
+            enable_proactive_pruning=False,
+            pruning_threshold=0.8,
+            context_window_size=150000,
+        )
+
+        assert manager.pruning_strategies == strategies
+        assert manager.preserve_recent_messages == 5
+        assert manager.preserve_initial_messages == 2
+        assert manager.enable_proactive_pruning is False
+        assert manager.pruning_threshold == 0.8
+        assert manager.context_window_size == 150000
+        assert manager.removed_message_count == 0
+
+    def test_parameter_clamping(self, strategies):
+        """Test that parameters are clamped to valid ranges."""
+        manager = PruningConversationManager(
+            pruning_strategies=strategies,
+            pruning_threshold=2.0,  # Should be clamped to 1.0
+        )
+
+        assert manager.pruning_threshold == 1.0
+
+        # Test lower bounds
+        manager2 = PruningConversationManager(
+            pruning_strategies=strategies,
+            pruning_threshold=0.05,  # Should be clamped to 0.1
+        )
+
+        assert manager2.pruning_threshold == 0.1
+
+    def test_reduce_context_with_empty_messages(self, manager, mock_agent):
+        """Test that reduce_context raises exception with empty messages."""
+        mock_agent.messages = []
+
+        with pytest.raises(ContextWindowOverflowException, match="No messages to prune"):
+            manager.reduce_context(mock_agent)
+
+    def test_reduce_context_with_insufficient_messages(self, manager, mock_agent):
+        """Test behavior with too few messages to prune safely."""
+        mock_agent.messages = [{"role": "user", "content": [{"text": "Message 1"}]}]
+
+        with pytest.raises(ContextWindowOverflowException, match="Insufficient messages for pruning"):
+            manager.reduce_context(mock_agent)
+
+    def test_successful_pruning(self, test_manager, mock_agent):
+        """Test successful message pruning."""
+        # Create messages with some that should be pruned
+        mock_agent.messages = [
+            {"role": "user", "content": [{"text": "Old message 1"}]},  # Age 5 - should be pruned
+            {"role": "user", "content": [{"text": "Old message 2"}]},  # Age 4 - should be pruned
+            {"role": "user", "content": [{"text": "Old message 3"}]},  # Age 3 - should be pruned
+            {"role": "user", "content": [{"text": "Recent message 1"}]},  # Age 1 - preserved
+            {"role": "user", "content": [{"text": "Recent message 2"}]},  # Age 0 - preserved
+        ]
+
+        original_count = len(mock_agent.messages)
+
+        with patch.object(test_manager, "_validate_pruning_effectiveness", return_value=True):
+            test_manager.reduce_context(mock_agent)
+
+        # Should have fewer messages after pruning
+        assert len(mock_agent.messages) < original_count
+        assert test_manager.removed_message_count > 0
+
+    def test_proactive_pruning_disabled(self, manager, mock_agent):
+        """Test that proactive pruning can be disabled."""
+        manager.enable_proactive_pruning = False
+        mock_agent.messages = [{"role": "user", "content": [{"text": f"Message {i}"}]} for i in range(100)]
+
+        # Should not trigger pruning
+        manager.apply_management(mock_agent)
+
+        assert len(mock_agent.messages) == 100  # No change
+
+    def test_proactive_pruning_enabled(self, manager, mock_agent):
+        """Test that proactive pruning works when enabled."""
+        manager.enable_proactive_pruning = True
+        mock_agent.messages = [{"role": "user", "content": [{"text": f"Message {i}"}]} for i in range(100)]
+
+        with patch.object(manager, "_should_prune_proactively", return_value=True):
+            with patch.object(manager, "reduce_context") as mock_reduce:
+                manager.apply_management(mock_agent)
+                mock_reduce.assert_called_once()
+
+    def test_preserve_recent_messages(self, manager, mock_agent):
+        """Test that recent messages are always preserved."""
+        mock_agent.messages = [{"role": "user", "content": [{"text": f"Message {i}"}]} for i in range(10)]
+
+        with patch.object(manager, "_validate_pruning_effectiveness", return_value=True):
+            manager.reduce_context(mock_agent)
+
+        # Should have at least preserve_recent_messages (2) remaining
+        assert len(mock_agent.messages) >= manager.preserve_recent_messages
+
+    def test_token_threshold_pruning(self, test_manager, mock_agent):
+        """Test that pruning is triggered when token threshold is exceeded."""
+        # Create messages that exceed the token threshold
+        # With context_window_size=10000 and threshold=0.7, threshold is 7000 tokens
+        large_text = "Old message with many words to exceed the token threshold. " * 50
+        mock_agent.messages = (
+            [{"role": "user", "content": [{"text": "Initial message"}]}]  # Preserved
+            + [{"role": "user", "content": [{"text": large_text}]} for i in range(10)]  # Should be pruned
+            + [
+                {"role": "user", "content": [{"text": "Recent message 1"}]},  # Preserved
+                {"role": "user", "content": [{"text": "Recent message 2"}]},  # Preserved
+            ]
+        )
+
+        original_count = len(mock_agent.messages)
+
+        with patch.object(test_manager, "_validate_pruning_effectiveness", return_value=True):
+            test_manager.reduce_context(mock_agent)
+
+        # Should have pruned the middle messages when threshold exceeded
+        assert len(mock_agent.messages) < original_count
+        # Should preserve initial and recent messages
+        assert (
+            len(mock_agent.messages) >= test_manager.preserve_recent_messages + test_manager.preserve_initial_messages
+        )
+
+    def test_validation_failure_handling(self, manager, mock_agent):
+        """Test handling when pruning validation fails."""
+        mock_agent.messages = [{"role": "user", "content": [{"text": f"Message {i}"}]} for i in range(10)]
+
+        with patch.object(manager, "_validate_pruning_effectiveness", return_value=False):
+            with patch.object(manager, "_handle_pruning_failure") as mock_handle:
+                manager.reduce_context(mock_agent)
+                mock_handle.assert_called_once()
+
+    def test_pruning_effectiveness_validation(self, manager, mock_agent):
+        """Test pruning effectiveness validation."""
+        original_messages = [{"role": "user", "content": [{"text": f"Message {i}"}]} for i in range(10)]
+
+        # Test successful reduction
+        pruned_messages = original_messages[:5]  # 50% reduction
+        assert manager._validate_pruning_effectiveness(original_messages, pruned_messages, mock_agent) is True
+
+        # Test small reduction - still considered effective as long as there's any reduction
+        pruned_messages = original_messages[:9]  # 10% reduction
+        assert manager._validate_pruning_effectiveness(original_messages, pruned_messages, mock_agent) is True
+
+        # Test no reduction
+        pruned_messages = original_messages.copy()
+        assert manager._validate_pruning_effectiveness(original_messages, pruned_messages, mock_agent) is False
+
+    def test_state_management(self, manager):
+        """Test state serialization and restoration."""
+        # Modify some stats
+        manager.removed_message_count = 15
+
+        # Get state
+        state = manager.get_state()
+
+        assert state["removed_message_count"] == 15
+
+        # Create new manager and restore state
+        new_manager = PruningConversationManager(pruning_strategies=[])
+        new_manager.restore_from_session(state)
+
+        assert new_manager.removed_message_count == 15
+
+    def test_should_prune_proactively(self, manager, mock_agent):
+        """Test proactive pruning threshold logic."""
+        # Test with few messages - should not prune (below threshold)
+        # With context_window_size=10000 and threshold=0.7, we need > 7000 tokens to trigger pruning
+        mock_agent.messages = [{"role": "user", "content": [{"text": "Short message"}]} for i in range(10)]
+        assert manager._should_prune_proactively(mock_agent) is False
+
+        # Test with many large messages - should prune (above threshold)
+        # Create messages that will exceed the token threshold
+        large_text = "This is a very long message that contains many words to increase token count. " * 100
+        mock_agent.messages = [{"role": "user", "content": [{"text": large_text}]} for i in range(10)]
+        assert manager._should_prune_proactively(mock_agent) is True
+
+        # Test with empty messages
+        mock_agent.messages = []
+        assert manager._should_prune_proactively(mock_agent) is False
+
+    def test_handle_pruning_failure_with_exception(self, manager, mock_agent):
+        """Test pruning failure handling with original exception."""
+        original_exception = ContextWindowOverflowException("Original error")
+
+        with pytest.raises(ContextWindowOverflowException, match="Original error"):
+            manager._handle_pruning_failure(mock_agent, original_exception)
+
+    def test_handle_pruning_failure_without_exception(self, manager, mock_agent):
+        """Test pruning failure handling without original exception."""
+        with pytest.raises(ContextWindowOverflowException, match="Pruning failed to reduce context"):
+            manager._handle_pruning_failure(mock_agent, None)
+
+    def test_pruning_with_tool_result_strategy(self, mock_agent):
+        """Test pruning with tool result compression strategy."""
+        # Create a manager with tool result compression strategy
+        strategies = [
+            LargeToolResultPruningStrategy(max_tool_result_tokens=50),  # Compresses
+        ]
+        manager = PruningConversationManager(
+            pruning_strategies=strategies, preserve_recent_messages=2, context_window_size=10000
+        )
+
+        # Create messages with large tool results
+        mock_agent.messages = [
+            {"role": "user", "content": [{"text": "Regular message"}]},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "123",
+                            "content": [{"text": "A" * 1000}],  # Large result - should be compressed
+                            "status": "success",
+                        }
+                    }
+                ],
+            },
+            {"role": "user", "content": [{"text": "Recent message 1"}]},  # Should be preserved
+            {"role": "user", "content": [{"text": "Recent message 2"}]},  # Should be preserved
+        ]
+
+        with patch.object(manager, "_validate_pruning_effectiveness", return_value=True):
+            manager.reduce_context(mock_agent)
+
+        # Recent messages should be preserved
+        assert len(mock_agent.messages) >= manager.preserve_recent_messages
+
+    def test_error_propagation_during_pruning(self, manager, mock_agent):
+        """Test that errors during pruning are properly propagated."""
+        mock_agent.messages = [{"role": "user", "content": [{"text": f"Message {i}"}]} for i in range(10)]
+
+        # Mock an error during message pruning
+        with patch.object(manager, "_prune_messages", side_effect=RuntimeError("Pruning error")):
+            original_exception = ContextWindowOverflowException("Original")
+
+            with pytest.raises(RuntimeError, match="Pruning error"):
+                manager.reduce_context(mock_agent, original_exception)
+
+    def test_preserve_initial_messages(self, strategies, mock_agent):
+        """Test that initial messages are preserved when preserve_initial_messages is set."""
+        manager = PruningConversationManager(
+            pruning_strategies=strategies,
+            preserve_recent_messages=2,
+            preserve_initial_messages=2,
+            context_window_size=10000,
+        )
+
+        # Create 10 messages: first 2 should be preserved, last 2 should be preserved
+        mock_agent.messages = [
+            {"role": "user", "content": [{"text": "Initial message 1"}]},  # Should be preserved
+            {"role": "user", "content": [{"text": "Initial message 2"}]},  # Should be preserved
+            {"role": "user", "content": [{"text": "Middle message 1"}]},  # Can be pruned
+            {"role": "user", "content": [{"text": "Middle message 2"}]},  # Can be pruned
+            {"role": "user", "content": [{"text": "Middle message 3"}]},  # Can be pruned
+            {"role": "user", "content": [{"text": "Middle message 4"}]},  # Can be pruned
+            {"role": "user", "content": [{"text": "Middle message 5"}]},  # Can be pruned
+            {"role": "user", "content": [{"text": "Middle message 6"}]},  # Can be pruned
+            {"role": "user", "content": [{"text": "Recent message 1"}]},  # Should be preserved
+            {"role": "user", "content": [{"text": "Recent message 2"}]},  # Should be preserved
+        ]
+
+        with patch.object(manager, "_validate_pruning_effectiveness", return_value=True):
+            manager.reduce_context(mock_agent)
+
+        # Should have at least 4 messages (2 initial + 2 recent)
+        assert len(mock_agent.messages) >= 4
+
+        # Check that initial messages are preserved
+        assert mock_agent.messages[0]["content"][0]["text"] == "Initial message 1"
+        assert mock_agent.messages[1]["content"][0]["text"] == "Initial message 2"
+
+        # Check that recent messages are preserved
+        assert mock_agent.messages[-2]["content"][0]["text"] == "Recent message 1"
+        assert mock_agent.messages[-1]["content"][0]["text"] == "Recent message 2"
+
+    def test_preserve_initial_and_recent_with_insufficient_messages(self, strategies, mock_agent):
+        """Test behavior when total preserved messages exceed available messages."""
+        manager = PruningConversationManager(
+            pruning_strategies=strategies,
+            preserve_recent_messages=3,
+            preserve_initial_messages=3,
+            context_window_size=10000,
+        )
+
+        # Only 5 messages, but we want to preserve 6 (3 initial + 3 recent)
+        mock_agent.messages = [{"role": "user", "content": [{"text": f"Message {i}"}]} for i in range(5)]
+
+        with pytest.raises(ContextWindowOverflowException, match="Insufficient messages for pruning"):
+            manager.reduce_context(mock_agent)
+
+    def test_preserve_initial_messages_default_one(self, strategies):
+        """Test that preserve_initial_messages defaults to 1."""
+        manager = PruningConversationManager(
+            pruning_strategies=strategies,
+            preserve_recent_messages=2,
+        )
+
+        assert manager.preserve_initial_messages == 1
+
+    def test_context_window_size_configuration(self, strategies):
+        """Test that context window size can be configured."""
+        manager = PruningConversationManager(
+            pruning_strategies=strategies,
+            context_window_size=50000,
+            pruning_threshold=0.8,
+        )
+
+        assert manager.context_window_size == 50000
+        assert manager.pruning_threshold == 0.8
+
+    def test_pruning_context_token_calculation(self, manager, mock_agent):
+        """Test that PruningContext is used for token calculation."""
+        messages = [
+            {"role": "user", "content": [{"text": "Hello world"}]},
+            {"role": "assistant", "content": [{"text": "Hi there how are you"}]},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "123",
+                            "content": [{"text": "Tool result text"}],
+                            "status": "success",
+                        }
+                    }
+                ],
+            },
+        ]
+        mock_agent.messages = messages
+
+        # Test that _should_prune_proactively uses PruningContext
+        result = manager._should_prune_proactively(mock_agent)
+
+        # Should not prune with small messages and default threshold
+        assert result is False
+
+    def test_aggressive_pruning_when_threshold_exceeded(self, test_manager, mock_agent):
+        """Test that all eligible messages are pruned when token threshold is exceeded."""
+        # Create messages that will exceed the threshold
+        large_text = "Old message with many words to exceed the token threshold. " * 50
+        mock_agent.messages = [
+            {"role": "user", "content": [{"text": "Initial message"}]},  # Should be preserved
+            {"role": "user", "content": [{"text": large_text}]},  # Should be pruned
+            {"role": "user", "content": [{"text": large_text}]},  # Should be pruned
+            {"role": "user", "content": [{"text": large_text}]},  # Should be pruned
+            {"role": "user", "content": [{"text": "Recent message 1"}]},  # Should be preserved
+            {"role": "user", "content": [{"text": "Recent message 2"}]},  # Should be preserved
+        ]
+
+        original_count = len(mock_agent.messages)
+
+        with patch.object(test_manager, "_validate_pruning_effectiveness", return_value=True):
+            test_manager.reduce_context(mock_agent)
+
+        # Should have aggressively pruned middle messages
+        assert len(mock_agent.messages) < original_count
+        # Should preserve initial and recent messages
+        expected_preserved = test_manager.preserve_initial_messages + test_manager.preserve_recent_messages
+        assert len(mock_agent.messages) >= expected_preserved
+
+    def test_token_based_proactive_pruning_integration(self, manager, mock_agent):
+        """Test the complete token-based proactive pruning workflow."""
+        # Create messages that exceed the threshold (0.7 * 10000 = 7000 tokens)
+        large_text = "This is a message with many words to simulate a large conversation history. " * 50
+        mock_agent.messages = [{"role": "user", "content": [{"text": large_text}]} for i in range(10)]
+
+        # Should trigger proactive pruning
+        assert manager._should_prune_proactively(mock_agent) is True
+
+        # Test that apply_management calls reduce_context when proactive pruning is enabled
+        manager.enable_proactive_pruning = True
+        with patch.object(manager, "reduce_context") as mock_reduce:
+            manager.apply_management(mock_agent)
+            mock_reduce.assert_called_once()

--- a/tests/strands/agent/test_pruning_strategy.py
+++ b/tests/strands/agent/test_pruning_strategy.py
@@ -1,0 +1,120 @@
+"""Tests for pruning strategies."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from strands.agent.conversation_manager import PruningStrategy
+from strands.agent.conversation_manager.strategies.tool_result_pruning import LargeToolResultPruningStrategy
+from strands.types.content import Message
+
+
+class TestPruningStrategy:
+    """Test the abstract PruningStrategy interface."""
+
+    def test_abstract_methods_must_be_implemented(self):
+        """Test that PruningStrategy cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            PruningStrategy()
+
+
+class TestLargeToolResultPruningStrategy:
+    """Test the LargeToolResultPruningStrategy implementation."""
+
+    @pytest.fixture
+    def strategy(self):
+        return LargeToolResultPruningStrategy(max_tool_result_tokens=100)
+
+    @pytest.fixture
+    def mock_agent(self):
+        agent = Mock()
+        agent.messages = []
+        return agent
+
+    def test_should_prune_message_with_large_tool_result(self, strategy):
+        """Test that large tool results are identified for pruning."""
+        message: Message = {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "123",
+                        "content": [{"text": "A" * 1000}],  # Large content
+                        "status": "success",
+                    }
+                }
+            ],
+        }
+        context = {"has_tool_result": True}
+
+        assert strategy.should_prune_message(message, context) is True
+
+    def test_should_not_prune_message_with_small_tool_result(self, strategy):
+        """Test that small tool results are not pruned."""
+        message: Message = {
+            "role": "user",
+            "content": [
+                {"toolResult": {"toolUseId": "123", "content": [{"text": "Small result"}], "status": "success"}}
+            ],
+        }
+        context = {"has_tool_result": True}
+
+        assert strategy.should_prune_message(message, context) is False
+
+    def test_should_not_prune_message_without_tool_result(self, strategy):
+        """Test that messages without tool results are not pruned."""
+        message: Message = {"role": "user", "content": [{"text": "Regular message"}]}
+        context = {"has_tool_result": False}
+
+        assert strategy.should_prune_message(message, context) is False
+
+    def test_prune_message_compresses_large_tool_result(self, strategy, mock_agent):
+        """Test that large tool results are properly compressed."""
+        message: Message = {
+            "role": "user",
+            "content": [{"toolResult": {"toolUseId": "123", "content": [{"text": "A" * 1000}], "status": "success"}}],
+        }
+
+        pruned = strategy.prune_message(message, mock_agent)
+
+        assert pruned is not None
+        assert pruned["role"] == "user"
+
+        # Check that compression occurred
+        tool_result = pruned["content"][0]["toolResult"]
+        assert len(tool_result["content"]) >= 1
+        assert "compressed" in tool_result["content"][0]["text"].lower()
+
+    def test_estimate_tool_result_tokens(self, strategy):
+        """Test token estimation for tool results."""
+        tool_result = {
+            "toolUseId": "123",
+            "content": [
+                {"text": "This is a test message with ten words total"},
+                {"json": {"key": "value", "number": 42}},
+            ],
+            "status": "success",
+        }
+
+        tokens = strategy._estimate_tool_result_tokens(tool_result)
+        assert tokens > 0
+        assert isinstance(tokens, int)
+
+    def test_simple_compress_tool_result(self, strategy):
+        """Test simple compression of tool results."""
+        tool_result = {
+            "toolUseId": "123",
+            "content": [{"text": "A" * 500}],  # Long text
+            "status": "success",
+        }
+
+        compressed = strategy._simple_compress_tool_result(tool_result)
+
+        assert compressed["toolUseId"] == "123"
+        assert compressed["status"] == "success"
+        assert len(compressed["content"]) >= 1
+        assert "compressed" in compressed["content"][0]["text"].lower()
+
+    def test_get_strategy_name(self, strategy):
+        """Test strategy name retrieval."""
+        assert strategy.get_strategy_name() == "LargeToolResultPruningStrategy"


### PR DESCRIPTION
## Description

Implement Pruning conversation manager to prune messages in the agent conversation history. Heuristic pruning strategy implemented for tool responses that are too long.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/556

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

https://github.com/strands-agents/docs/pull/229

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
