### PR TITLE
fix: fix loading tools with same tool name

### DIFF
--- a/src/strands/tools/registry.py
+++ b/src/strands/tools/registry.py
@@ -190,6 +190,14 @@ class ToolRegistry:
             tool.is_dynamic,
         )
 
+        # Check duplicate tool name, throw on duplicate tool names except if hot_reloading is enabled
+        if tool.tool_name in self.registry:
+            if not tool.supports_hot_reload:
+                raise ValueError(
+                    f"Tool name '{tool.tool_name}' already exists. Cannot register tools with exact same name."
+                )
+
+        # Check for normalized name conflicts (- vs _)
         if self.registry.get(tool.tool_name) is None:
             normalized_name = tool.tool_name.replace("-", "_")
 

--- a/src/strands/tools/registry.py
+++ b/src/strands/tools/registry.py
@@ -191,8 +191,7 @@ class ToolRegistry:
         )
 
         # Check duplicate tool name, throw on duplicate tool names except if hot_reloading is enabled
-        if tool.tool_name in self.registry:
-            if not tool.supports_hot_reload:
+        if tool.tool_name in self.registry and not tool.supports_hot_reload:
                 raise ValueError(
                     f"Tool name '{tool.tool_name}' already exists. Cannot register tools with exact same name."
                 )

--- a/tests/strands/tools/test_registry.py
+++ b/tests/strands/tools/test_registry.py
@@ -120,3 +120,39 @@ def test_process_tools_flattens_lists_and_tuples_and_sets():
         "tool_f",
     ]
     assert tru_tool_names == exp_tool_names
+
+
+def test_register_tool_duplicate_name_without_hot_reload():
+    """Test that registering a tool with duplicate name raises ValueError when hot reload is not supported."""
+    tool_1 = PythonAgentTool(tool_name="duplicate_tool", tool_spec=MagicMock(), tool_func=lambda: None)
+    tool_2 = PythonAgentTool(tool_name="duplicate_tool", tool_spec=MagicMock(), tool_func=lambda: None)
+
+    tool_registry = ToolRegistry()
+    tool_registry.register_tool(tool_1)
+
+    with pytest.raises(
+        ValueError, match="Tool name 'duplicate_tool' already exists. Cannot register tools with exact same name."
+    ):
+        tool_registry.register_tool(tool_2)
+
+
+def test_register_tool_duplicate_name_with_hot_reload():
+    """Test that registering a tool with duplicate name succeeds when hot reload is supported."""
+    # Create mock tools with hot reload support
+    tool_1 = MagicMock(spec=PythonAgentTool)
+    tool_1.tool_name = "hot_reload_tool"
+    tool_1.supports_hot_reload = True
+    tool_1.is_dynamic = False
+
+    tool_2 = MagicMock(spec=PythonAgentTool)
+    tool_2.tool_name = "hot_reload_tool"
+    tool_2.supports_hot_reload = True
+    tool_2.is_dynamic = False
+
+    tool_registry = ToolRegistry()
+    tool_registry.register_tool(tool_1)
+
+    tool_registry.register_tool(tool_2)
+
+    # Verify the second tool replaced the first
+    assert tool_registry.registry["hot_reload_tool"] == tool_2


### PR DESCRIPTION
## Description
fix duplicate tool names, throw Value Erro while tools have same name, except tool.support_hot_reload is true.


## Related Issues
https://github.com/strands-agents/sdk-python/issues/715

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing
test with aws mcp server.
```
stdio_mcp_client = MCPClient(lambda: stdio_client(
    StdioServerParameters(
        command="uvx",
        args=["awslabs.aws-documentation-mcp-server@latest"]
    )
))

@tool
def read_documentation():
    return ""

test_tool = None

with stdio_mcp_client:
    for tool in stdio_mcp_client.list_tools_sync():
        if tool.tool_name == "read_documentation":
            test_tool = tool
  
    agent = Agent(tools=[read_documentation,test_tool])
    print(agent.tool_names)
```

```
[08/29/25 15:32:47] INFO     Processing request of type ListToolsRequest                                                                                                                                                                                                                                    server.py:624
Jack need your name: read_documentation
Traceback (most recent call last):
  File "/Volumes/workplace/Strands/personal/agent.py", line 30, in <module>
    agent = Agent(tools=[read_documentation,test_tool])
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/workplace/Strands/sdk-python/src/strands/agent/agent.py", line 312, in __init__
    self.tool_registry.process_tools(tools)
  File "/Volumes/workplace/Strands/sdk-python/src/strands/tools/registry.py", line 108, in process_tools
    add_tool(a_tool)
  File "/Volumes/workplace/Strands/sdk-python/src/strands/tools/registry.py", line 98, in add_tool
    self.register_tool(tool)
  File "/Volumes/workplace/Strands/sdk-python/src/strands/tools/registry.py", line 196, in register_tool
    raise ValueError(f"Tool name '{tool.tool_name}' already exists. "
ValueError: Tool name 'read_documentation' already exists. Cannot register tools with exact same name.
```

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x ] I ran `hatch run prepare`

## Checklist
- [ x] I have read the CONTRIBUTING document
- [ x] I have added any necessary tests that prove my fix is effective or my feature works
- [ x] I have updated the documentation accordingly
- [ x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x ] My changes generate no new warnings
- [x ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
