### PR TITLE
fix: prevent UnboundLocalError for choice variable in stream method

### DIFF
--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -351,6 +351,7 @@ class OpenAIModel(Model):
         yield self.format_chunk({"chunk_type": "content_start", "data_type": "text"})
 
         tool_calls: dict[int, list[Any]] = {}
+        choice = None
 
         async for event in response:
             # Defensive: skip events with empty or missing choices
@@ -388,7 +389,8 @@ class OpenAIModel(Model):
 
             yield self.format_chunk({"chunk_type": "content_stop", "data_type": "tool"})
 
-        yield self.format_chunk({"chunk_type": "message_stop", "data": choice.finish_reason})
+        if choice and choice.finish_reason:
+            yield self.format_chunk({"chunk_type": "message_stop", "data": choice.finish_reason})
 
         # Skip remaining events as we don't have use for anything except the final usage payload
         async for event in response:


### PR DESCRIPTION
## Description
The `choice` variable in the `stream` method could be unbound when accessing `choice.finish_reason`, causing an `UnboundLocalError`

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
