### PR TITLE
fix(doc): replace invalid Hook names in doc comment with BeforeInvocationEvent & AfterInvocationEvent

### DIFF
--- a/src/strands/hooks/__init__.py
+++ b/src/strands/hooks/__init__.py
@@ -8,17 +8,17 @@ through strongly-typed event callbacks.
 Example Usage:
     ```python
     from strands.hooks import HookProvider, HookRegistry
-    from strands.hooks.events import StartRequestEvent, EndRequestEvent
+    from strands.hooks.events import BeforeInvocationEvent, AfterInvocationEvent
 
     class LoggingHooks(HookProvider):
         def register_hooks(self, registry: HookRegistry) -> None:
-            registry.add_callback(StartRequestEvent, self.log_start)
-            registry.add_callback(EndRequestEvent, self.log_end)
+            registry.add_callback(BeforeInvocationEvent, self.log_start)
+            registry.add_callback(AfterInvocationEvent, self.log_end)
 
-        def log_start(self, event: StartRequestEvent) -> None:
+        def log_start(self, event: BeforeInvocationEvent) -> None:
             print(f"Request started for {event.agent.name}")
 
-        def log_end(self, event: EndRequestEvent) -> None:
+        def log_end(self, event: AfterInvocationEvent) -> None:
             print(f"Request completed for {event.agent.name}")
 
     # Use with agent


### PR DESCRIPTION
Fix(doc): Replaced StartRequestEvent &  EndRequestEvent with BeforeInvocationEvent & AfterInvocationEvent respectively in the docstring for api reference documentation

## Description
`StartRequestEvent' & 'EndRequestEvent' in the documentation caused some confusion for users. They seem deprecated, and create errors in the code editor when used. 

## Related Issues

Wrong information appearing in the documentation, causing some confusion, so I fixed it in this update: 
https://strandsagents.com/latest/documentation/docs/api-reference/hooks/

<img width="779" height="368" alt="image" src="https://github.com/user-attachments/assets/e1b7d2cf-f388-43c2-8c56-db5d85031bf0" />

---
Corrected version
```python
from strands.hooks import HookProvider, HookRegistry
from strands.hooks.events import BeforeInvocationEvent, AfterInvocationEvent
# from strands_tools.calculator import calculator

class LoggingHooks(HookProvider):
  def register_hooks(self, registry: HookRegistry) -> None:  
    registry.add_callback(BeforeInvocationEvent, self.log_start)
    registry.add_callback(AfterInvocationEvent, self.log_end)
  
  def log_start(self, event: BeforeInvocationEvent):
    print(f"Request started for {event.agent.name}")
  
  def log_end(self, event: AfterInvocationEvent):
    print(f"Request ended for {event.agent.name}")

agent = Agent(hooks=[LoggingHooks()])
```


## Documentation PR

[https://github.com/deepyes02/sdk-python-strand-agents.git](https://github.com/deepyes02/sdk-python-strand-agents.git)

## Type of Change
Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] Not really, this is just text updates. 

## Checklist
- [ yes ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ yes] I have updated the documentation accordingly
- [ yes] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ yes] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
