### PR TITLE
Moved tool_spec retrieval to after the before model invocation callback

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -132,13 +132,13 @@ async def event_loop_cycle(agent: "Agent", invocation_state: dict[str, Any]) -> 
             model_id=model_id,
         )
         with trace_api.use_span(model_invoke_span):
-            tool_specs = agent.tool_registry.get_all_tool_specs()
-
             agent.hooks.invoke_callbacks(
                 BeforeModelInvocationEvent(
                     agent=agent,
                 )
             )
+
+            tool_specs = agent.tool_registry.get_all_tool_specs()
 
             try:
                 async for event in stream_messages(agent.model, agent.system_prompt, agent.messages, tool_specs):


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

This shouldn't require a documentation changes.

## Type of Change
Other (please describe): Moved the tool_spec retrieval in the event_loop to be AFTER the before model invocation callback. The reason behind this is that I have a use case for dynamically swapping the tools available for the model in-between each event loop iteration. I'd like to use the before model invocation event callback to make this happen.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

I ran `hatch test` and everything succeeded.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [N/A] I have added any necessary tests that prove my fix is effective or my feature works
- [N/A] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [N/A] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
