### PR TITLE
feat: Implement async generator tools

### DIFF
--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -275,24 +275,19 @@ class ToolResultEvent(TypedEvent):
 class ToolStreamEvent(TypedEvent):
     """Event emitted when a tool yields sub-events as part of tool execution."""
 
-    def __init__(self, tool_use: ToolUse, tool_sub_event: Any) -> None:
+    def __init__(self, tool_use: ToolUse, tool_stream_data: Any) -> None:
         """Initialize with tool streaming data.
 
         Args:
             tool_use: The tool invocation producing the stream
-            tool_sub_event: The yielded event from the tool execution
+            tool_stream_data: The yielded event from the tool execution
         """
-        super().__init__({"tool_stream_tool_use": tool_use, "tool_stream_event": tool_sub_event})
+        super().__init__({"tool_stream_tool_use": tool_use, "tool_stream_data": tool_stream_data})
 
     @property
     def tool_use_id(self) -> str:
         """The toolUseId associated with this stream."""
         return cast(str, cast(ToolUse, self.get("tool_stream_tool_use")).get("toolUseId"))
-
-    @property
-    @override
-    def is_callback_event(self) -> bool:
-        return False
 
 
 class ModelMessageEvent(TypedEvent):

--- a/tests/strands/agent/hooks/test_agent_events.py
+++ b/tests/strands/agent/hooks/test_agent_events.py
@@ -261,17 +261,17 @@ async def test_stream_e2e_success(alist):
             }
         },
         {
+            "tool_stream_data": {"tool_streaming": True},
+            "tool_stream_tool_use": {"input": {}, "name": "streaming_tool", "toolUseId": "12345"},
+        },
+        {
+            "tool_stream_data": "Final result",
+            "tool_stream_tool_use": {"input": {}, "name": "streaming_tool", "toolUseId": "12345"},
+        },
+        {
             "message": {
                 "content": [
-                    {
-                        "toolResult": {
-                            # TODO update this text when we get tool streaming implemented; right now this
-                            # TODO is of the form '<async_generator object streaming_tool at 0x107d18a00>'
-                            "content": [{"text": ANY}],
-                            "status": "success",
-                            "toolUseId": "12345",
-                        }
-                    },
+                    {"toolResult": {"content": [{"text": "Final result"}], "status": "success", "toolUseId": "12345"}}
                 ],
                 "role": "user",
             }


### PR DESCRIPTION
## Description

Enable decorated tools to be an async generator, enabling streaming of tool events back to to the caller.  Assuming #773 is merged, the changes needed are fairly minor, as currently we're just swallowing tool stream events.

Implements strands-agents/sdk-python#543

**Api Bar-raising**

The tool event being emitted (as a dictionary) needs to go through bar-raising.

**Proposed new Event**

(event type is purely our internal name).

`ToolStreamEvent`:  
 - `tool_stream_tool_use: ToolUse` - the tool use that emitted the event
 - `tool_stream_data: Any` - the data that was streamed/yielded from the tool

Our existing events are as follows:

| Event Type                      | Dictionary Properties                                        |
| ------------------------------- | ------------------------------------------------------------ |
| `InitEventLoopEvent`            | `init_event_loop: bool`                                      |
| `StartEvent`                    | `start: bool`                                                |
| `StartEventLoopEvent`           | `start_event_loop: bool`                                     |
| `ModelStreamChunkEvent`         | `event: StreamEvent`                                         |
| `ToolUseStreamEvent`            | `delta: ContentBlockDelta` <br /> `current_tool_use: dict[str, Any]` |
| `TextStreamEvent`               | `data: str`, <br />`delta: ContentBlockDelta`                |
| `ReasoningTextStreamEvent`    | `reasoningText: str \| None`  <br />`delta: ContentBlockDelta` <br />`reasoning: bool` |
| `ReasoningSignatureStreamEvent` | `reasoning_signature: str \| None`, <br />`delta: ContentBlockDelta`, <br />`reasoning: bool` |
| `EventLoopThrottleEvent`        | `event_loop_throttled_delay: int`                            |
| `ModelMessageEvent`             | `message: Message`                                           |
| `ToolResultMessageEvent`        | `message: Any`                                               |
| `ForceStopEvent`                | `force_stop: bool`, <br />`force_stop_reason: str`           |
| `AgentResultEvent`              | `result: AgentResult`                                        |




## Related Issues

strands-agents/sdk-python#543

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
