### PR TITLE
feat: Use Global Cross-region inference for default model id

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -28,7 +28,7 @@ from .model import Model
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+DEFAULT_BEDROCK_MODEL_ID = "global.anthropic.claude-sonnet-4-20250514-v1:0"
 DEFAULT_BEDROCK_REGION = "us-west-2"
 
 BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [


### PR DESCRIPTION
## Description

By using Global Cross-region inference, users whose AWS_REGION is not set to a US region can now use the default Agent.

### Error that occurred before the fix
```
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the ConverseStream operation: The provided model identifier is invalid.
└ Bedrock region: ap-northeast-1
└ Model id: us.anthropic.claude-sonnet-4-20250514-v1:0
```

### Code that causes the error

```python
# AWS_REGION environment variable or default profile region is not set to a US region
from strands import Agent

agent = Agent()
agent('Hello')
```

---

An alternative solution is proposed in https://github.com/strands-agents/sdk-python/pull/770. The pros and cons are as follows:
- Pros
  - No overhead from calling the list_inference_profiles API
  - Small change (only 1 line)
  - No changes to the required permissions. With the #770 approach, in addition to bedrock-runtime, the `bedrock:ListInferenceProfiles` permission would also be required.
- Cons
  - Only models that support Global Cross-region inference can be selected as the default model
  - May unexpectedly call models outside of AWS_REGION (however, it's unlikely that users using the default model are aware of this)

## Related Issues

- https://github.com/strands-agents/sdk-python/issues/732
- https://github.com/strands-agents/sdk-python/issues/774

## Documentation PR

N/A

## Type of Change

Other (please describe): Change the default model id

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
