### PR TITLE
fix: do not block asyncio event loop between retries

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -8,8 +8,8 @@ The event loop allows agents to:
 4. Manage recursive execution cycles
 """
 
+import asyncio
 import logging
-import time
 import uuid
 from typing import TYPE_CHECKING, Any, AsyncGenerator
 
@@ -189,7 +189,7 @@ async def event_loop_cycle(agent: "Agent", invocation_state: dict[str, Any]) -> 
                         MAX_ATTEMPTS,
                         attempt + 1,
                     )
-                    time.sleep(current_delay)
+                    await asyncio.sleep(current_delay)
                     current_delay = min(current_delay * 2, MAX_DELAY)
 
                     yield EventLoopThrottleEvent(delay=current_delay)

--- a/tests/strands/agent/hooks/test_agent_events.py
+++ b/tests/strands/agent/hooks/test_agent_events.py
@@ -31,8 +31,10 @@ async def streaming_tool():
 
 
 @pytest.fixture
-def mock_time():
-    with unittest.mock.patch.object(strands.event_loop.event_loop, "time") as mock:
+def mock_asyncio():
+    with unittest.mock.patch.object(
+        strands.event_loop.event_loop, "asyncio", new_callable=unittest.mock.AsyncMock
+    ) as mock:
         yield mock
 
 
@@ -322,7 +324,7 @@ async def test_stream_e2e_success(alist):
 
 
 @pytest.mark.asyncio
-async def test_stream_e2e_throttle_and_redact(alist, mock_time):
+async def test_stream_e2e_throttle_and_redact(alist, mock_asyncio):
     model = MagicMock()
     model.stream.side_effect = [
         ModelThrottledException("ThrottlingException | ConverseStream"),
@@ -389,7 +391,7 @@ async def test_stream_e2e_throttle_and_redact(alist, mock_time):
 async def test_event_loop_cycle_text_response_throttling_early_end(
     agenerator,
     alist,
-    mock_time,
+    mock_asyncio,
 ):
     model = MagicMock()
     model.stream.side_effect = [

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -26,8 +26,10 @@ from tests.fixtures.mock_hook_provider import MockHookProvider
 
 
 @pytest.fixture
-def mock_time():
-    with unittest.mock.patch.object(strands.event_loop.event_loop, "time") as mock:
+def mock_asyncio():
+    with unittest.mock.patch.object(
+        strands.event_loop.event_loop, "asyncio", new_callable=unittest.mock.AsyncMock
+    ) as mock:
         yield mock
 
 
@@ -186,7 +188,7 @@ async def test_event_loop_cycle_text_response(
 
 @pytest.mark.asyncio
 async def test_event_loop_cycle_text_response_throttling(
-    mock_time,
+    mock_asyncio,
     agent,
     model,
     agenerator,
@@ -215,12 +217,12 @@ async def test_event_loop_cycle_text_response_throttling(
 
     assert tru_stop_reason == exp_stop_reason and tru_message == exp_message and tru_request_state == exp_request_state
     # Verify that sleep was called once with the initial delay
-    mock_time.sleep.assert_called_once()
+    mock_asyncio.sleep.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_event_loop_cycle_exponential_backoff(
-    mock_time,
+    mock_asyncio,
     agent,
     model,
     agenerator,
@@ -254,13 +256,13 @@ async def test_event_loop_cycle_exponential_backoff(
 
     # Verify that sleep was called with increasing delays
     # Initial delay is 4, then 8, then 16
-    assert mock_time.sleep.call_count == 3
-    assert mock_time.sleep.call_args_list == [call(4), call(8), call(16)]
+    assert mock_asyncio.sleep.call_count == 3
+    assert mock_asyncio.sleep.call_args_list == [call(4), call(8), call(16)]
 
 
 @pytest.mark.asyncio
 async def test_event_loop_cycle_text_response_throttling_exceeded(
-    mock_time,
+    mock_asyncio,
     agent,
     model,
     alist,
@@ -281,7 +283,7 @@ async def test_event_loop_cycle_text_response_throttling_exceeded(
         )
         await alist(stream)
 
-    mock_time.sleep.assert_has_calls(
+    mock_asyncio.sleep.assert_has_calls(
         [
             call(4),
             call(8),
@@ -687,7 +689,7 @@ async def test_event_loop_tracing_with_throttling_exception(
     ]
 
     # Mock the time.sleep function to speed up the test
-    with patch("strands.event_loop.event_loop.time.sleep"):
+    with patch("strands.event_loop.event_loop.asyncio.sleep", new_callable=unittest.mock.AsyncMock):
         stream = strands.event_loop.event_loop.event_loop_cycle(
             agent=agent,
             invocation_state={},
@@ -816,7 +818,7 @@ async def test_prepare_next_cycle_in_tool_execution(agent, model, tool_stream, a
 
 
 @pytest.mark.asyncio
-async def test_event_loop_cycle_exception_model_hooks(mock_time, agent, model, agenerator, alist, hook_provider):
+async def test_event_loop_cycle_exception_model_hooks(mock_asyncio, agent, model, agenerator, alist, hook_provider):
     """Test that model hooks are correctly emitted even when throttled."""
     # Set up the model to raise throttling exceptions multiple times before succeeding
     exception = ModelThrottledException("ThrottlingException | ConverseStream")


### PR DESCRIPTION
## Description

`time.sleep` blocks asyncio event loop and should not be used in an async context.

## Related Issues


## Documentation PR


## Type of Change


Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
