### PR TITLE
fix: only add signature to reasoning blocks if signature is provided

### DIFF
--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -198,10 +198,6 @@ class ModelStopReason(TypedEvent):
         super().__init__({"stop": (stop_reason, message, usage, metrics)})
 
     @property
-    def message(self) -> Message:
-        return cast(Message, self["stop"][1])
-
-    @property
     @override
     def is_callback_event(self) -> bool:
         return False

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -6,6 +6,7 @@ import pytest
 import strands
 import strands.event_loop
 from strands.types._events import ModelStopReason, TypedEvent
+from strands.types.content import Message
 from strands.types.streaming import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
@@ -566,6 +567,10 @@ async def test_process_stream(response, exp_events, agenerator, alist):
     assert non_typed_events == []
 
 
+def _get_message_from_event(event: ModelStopReason) -> Message:
+    return cast(Message, event["stop"][1])
+
+
 @pytest.mark.asyncio
 async def test_process_stream_with_no_signature(agenerator, alist):
     response = [
@@ -598,8 +603,10 @@ async def test_process_stream_with_no_signature(agenerator, alist):
 
     last_event = cast(ModelStopReason, (await alist(stream))[-1])
 
-    assert "signature" not in last_event.message["content"][0]["reasoningContent"]["reasoningText"]
-    assert last_event.message["content"][1]["text"] == "Sure! Let’s do it"
+    message = _get_message_from_event(last_event)
+
+    assert "signature" not in message["content"][0]["reasoningContent"]["reasoningText"]
+    assert message["content"][1]["text"] == "Sure! Let’s do it"
 
 
 @pytest.mark.asyncio
@@ -636,8 +643,10 @@ async def test_process_stream_with_signature(agenerator, alist):
 
     last_event = cast(ModelStopReason, (await alist(stream))[-1])
 
-    assert last_event.message["content"][0]["reasoningContent"]["reasoningText"]["signature"] == "test-signature"
-    assert last_event.message["content"][1]["text"] == "Sure! Let’s do it"
+    message = _get_message_from_event(last_event)
+
+    assert message["content"][0]["reasoningContent"]["reasoningText"]["signature"] == "test-signature"
+    assert message["content"][1]["text"] == "Sure! Let’s do it"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


## Description

Per #790, right now we're adding a blank signature to all reasoning content, which breaks providers (openai.gpt-oss-120b-1:0) which don't provide signatures. We already add a signature if it's not already present, so the fix here is just to blank out the signature.

Added some tests to catch future regressions.

## Related Issues

#790, #799

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
