### PR TITLE
fix(models): patch litellm bug to honor passing in use_litellm_proxy as client_args

### DIFF
--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -64,17 +64,6 @@ class LiteLLMModel(OpenAIModel):
         self.config.update(model_config)
         self._apply_proxy_prefix()
 
-    def _apply_proxy_prefix(self) -> None:
-        """Apply litellm_proxy/ prefix to model_id when use_litellm_proxy is True.
-
-        This is a workaround for https://github.com/BerriAI/litellm/issues/13454
-        where use_litellm_proxy parameter is not honored.
-        """
-        if self.client_args.get("use_litellm_proxy") and "model_id" in self.config:
-            model_id = self.config["model_id"]
-            if not model_id.startswith("litellm_proxy/"):
-                self.config["model_id"] = f"litellm_proxy/{model_id}"
-
     @override
     def get_config(self) -> LiteLLMConfig:
         """Get the LiteLLM model configuration.
@@ -236,3 +225,14 @@ class LiteLLMModel(OpenAIModel):
 
         # If no tool_calls found, raise an error
         raise ValueError("No tool_calls found in response")
+
+    def _apply_proxy_prefix(self) -> None:
+        """Apply litellm_proxy/ prefix to model_id when use_litellm_proxy is True.
+
+        This is a workaround for https://github.com/BerriAI/litellm/issues/13454
+        where use_litellm_proxy parameter is not honored.
+        """
+        if self.client_args.get("use_litellm_proxy") and "model_id" in self.config:
+            model_id = self.config["model_id"]
+            if not model_id.startswith("litellm_proxy/"):
+                self.config["model_id"] = f"litellm_proxy/{model_id}"

--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -50,6 +50,7 @@ class LiteLLMModel(OpenAIModel):
         """
         self.client_args = client_args or {}
         self.config = dict(model_config)
+        self._apply_proxy_prefix()
 
         logger.debug("config=<%s> | initializing", self.config)
 
@@ -61,6 +62,18 @@ class LiteLLMModel(OpenAIModel):
             **model_config: Configuration overrides.
         """
         self.config.update(model_config)
+        self._apply_proxy_prefix()
+
+    def _apply_proxy_prefix(self) -> None:
+        """Apply litellm_proxy/ prefix to model_id when use_litellm_proxy is True.
+
+        This is a workaround for https://github.com/BerriAI/litellm/issues/13454
+        where use_litellm_proxy parameter is not honored.
+        """
+        if self.client_args.get("use_litellm_proxy") and "model_id" in self.config:
+            model_id = self.config["model_id"]
+            if not model_id.startswith("litellm_proxy/"):
+                self.config["model_id"] = f"litellm_proxy/{model_id}"
 
     @override
     def get_config(self) -> LiteLLMConfig:

--- a/tests/strands/models/test_litellm.py
+++ b/tests/strands/models/test_litellm.py
@@ -230,9 +230,6 @@ async def test_stream(litellm_acompletion, api_key, model_id, model, agenerator,
     litellm_acompletion.assert_called_once_with(**expected_request)
 
 
-
-
-
 @pytest.mark.asyncio
 async def test_stream_empty(litellm_acompletion, api_key, model_id, model, agenerator, alist):
     mock_delta = unittest.mock.Mock(content=None, tool_calls=None, reasoning_content=None)
@@ -288,6 +285,3 @@ async def test_structured_output(litellm_acompletion, model, test_output_model_c
 
     exp_result = {"output": test_output_model_cls(name="John", age=30)}
     assert tru_result == exp_result
-
-
-


### PR DESCRIPTION
## Description

A customer complained that when they ran 

```
litellm_model = LiteLLMModel(
        client_args={
            "api_key": "sk-1234",
            "api_base": LITELLM_PROXY_URL  # also fails for "base_url": LITELLM_PROXY_URL
        },
        model_id="amazon.nova-lite-v1:0"
    )
```

They were seeing `httpx.HTTPStatusError: Client error '404 Not Found' for url '{LITELLM_PROXY_URL}/model/amazon.nova-pro-v1%3A0/converse'`

The reason for this is that LiteLLM recognizes the model as a Bedrock model, so it selects the BedrockModel provider. Then it uses api_base in a similar way to how in the Strand BedrockModel we have `endpoint_url`. So LiteLLM, as a client, is making a request to Bedrock but assuming Bedrock is behind some other endpoint. 

What the customer expected, is that the request would be route to their own [LiteLLM Proxy Server](https://docs.litellm.ai/docs/simple_proxy). As stated above, setting the api_base does NOT indicate that the LiteLLM Proxy Server should be used, it indicates that the selected model provider happens to. have an endpoint different than the default one - for example for bedrock the default is `https://bedrock-runtime.{region}.amazonaws.com`

So the primary fix will be to update https://strandsagents.com/latest/documentation/docs/user-guide/concepts/model-providers/litellm/.

The fix in this PR is to make it easier for customers to use the proxy. There are three methods described in https://github.com/BerriAI/litellm/issues/13454 but according to https://github.com/BerriAI/litellm/issues/13454 passing in as a dynamic param is broken. Meaning without this fix, customers would need to break the abstraction in Strands and directly do `os.environ["USE_LITELLM_PROXY"] = "True"` or `litellm.use_litellm_proxy = True`. 

This, and the doc fix, will address https://github.com/strands-agents/sdk-python/issues/661 which until now we did not realize was the same issue.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/661

## Documentation PR

pending

## Type of Change

Bug fix


## Testing


Run `export LITELLM_PROXY_API_KEY=sk-1234; litellm -m amazon.nova-lite-v1:0`


then 

```
from strands import Agent
from strands.models.litellm import LiteLLMModel
    
import litellm
litellm._turn_on_debug()

litellm_model = LiteLLMModel(
    client_args={
        "api_key": "sk-1234",
        "api_base": "http://0.0.0.0:4000"
    },
    model_id="amazon.nova-lite-v1:0"
)

agent = Agent(model=litellm_model)
agent("Tell me a story")
```

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [pending] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
