### PR TITLE
feat: add optional outputSchema support for tool specifications

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Any, AsyncGenerator, AsyncIterable, Optional
+from typing import Any, AsyncGenerator, AsyncIterable, Optional, cast
 
 from ..models.model import Model
 from ..types._events import (
@@ -346,7 +346,17 @@ async def stream_messages(
     logger.debug("model=<%s> | streaming messages", model)
 
     messages = remove_blank_messages_content_text(messages)
-    chunks = model.stream(messages, tool_specs if tool_specs else None, system_prompt)
+
+    # TODO(#780): Remove outputSchema filtering once model-specific behavior handling is implemented.
+    # For now, we filter out outputSchema from all tool specs to ensure compatibility with all model providers.
+    # Some providers (e.g., Bedrock) will throw validation errors if they receive unknown fields.
+    filtered_tool_specs = None
+    if tool_specs:
+        filtered_tool_specs = cast(
+            list[ToolSpec], [{k: v for k, v in spec.items() if k != "outputSchema"} for spec in tool_specs]
+        )
+
+    chunks = model.stream(messages, filtered_tool_specs, system_prompt)
 
     async for event in process_stream(chunks):
         yield event

--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Any, AsyncGenerator, AsyncIterable, Optional, cast
+from typing import Any, AsyncGenerator, AsyncIterable, Optional
 
 from ..models.model import Model
 from ..types._events import (

--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -346,8 +346,7 @@ async def stream_messages(
     logger.debug("model=<%s> | streaming messages", model)
 
     messages = remove_blank_messages_content_text(messages)
-
-    chunks = model.stream(messages, tool_specs, system_prompt)
+    chunks = model.stream(messages, tool_specs if tool_specs else None, system_prompt)
 
     async for event in process_stream(chunks):
         yield event

--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -347,16 +347,7 @@ async def stream_messages(
 
     messages = remove_blank_messages_content_text(messages)
 
-    # TODO(#780): Remove outputSchema filtering once model-specific behavior handling is implemented.
-    # For now, we filter out outputSchema from all tool specs to ensure compatibility with all model providers.
-    # Some providers (e.g., Bedrock) will throw validation errors if they receive unknown fields.
-    filtered_tool_specs = None
-    if tool_specs:
-        filtered_tool_specs = cast(
-            list[ToolSpec], [{k: v for k, v in spec.items() if k != "outputSchema"} for spec in tool_specs]
-        )
-
-    chunks = model.stream(messages, filtered_tool_specs, system_prompt)
+    chunks = model.stream(messages, tool_specs, system_prompt)
 
     async for event in process_stream(chunks):
         yield event

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -214,7 +214,16 @@ class BedrockModel(Model):
                 {
                     "toolConfig": {
                         "tools": [
-                            *[{"toolSpec": tool_spec} for tool_spec in tool_specs],
+                            *[
+                                {
+                                    "toolSpec": {
+                                        "name": tool_spec["name"],
+                                        "description": tool_spec["description"],
+                                        "inputSchema": tool_spec["inputSchema"],
+                                    }
+                                }
+                                for tool_spec in tool_specs
+                            ],
                             *(
                                 [{"cachePoint": {"type": self.config["cache_tools"]}}]
                                 if self.config.get("cache_tools")

--- a/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/src/strands/tools/mcp/mcp_agent_tool.py
@@ -54,17 +54,23 @@ class MCPAgentTool(AgentTool):
         """Get the specification of the tool.
 
         This method converts the MCP tool specification to the agent framework's
-        ToolSpec format, including the input schema and description.
+        ToolSpec format, including the input schema, description, and optional output schema.
 
         Returns:
             ToolSpec: The tool specification in the agent framework format
         """
         description: str = self.mcp_tool.description or f"Tool which performs {self.mcp_tool.name}"
-        return {
+
+        spec: ToolSpec = {
             "inputSchema": {"json": self.mcp_tool.inputSchema},
             "name": self.mcp_tool.name,
             "description": description,
         }
+
+        if self.mcp_tool.outputSchema:
+            spec["outputSchema"] = {"json": self.mcp_tool.outputSchema}
+
+        return spec
 
     @property
     def tool_type(self) -> str:

--- a/src/strands/types/tools.py
+++ b/src/strands/types/tools.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Literal, Protocol, Union
 
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from .media import DocumentContent, ImageContent
 
@@ -27,11 +27,15 @@ class ToolSpec(TypedDict):
         description: A human-readable description of what the tool does.
         inputSchema: JSON Schema defining the expected input parameters.
         name: The unique name of the tool.
+        outputSchema: Optional JSON Schema defining the expected output format.
+            Note: Not all model providers support this field. Providers that don't
+            support it should filter it out before sending to their API.
     """
 
     description: str
     inputSchema: JSONSchema
     name: str
+    outputSchema: NotRequired[JSONSchema]
 
 
 class Tool(TypedDict):

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1788,3 +1788,25 @@ def test_custom_model_id_not_overridden_by_region_formatting(session_cls):
     model_id = model.get_config().get("model_id")
 
     assert model_id == custom_model_id
+
+
+def test_format_request_filters_output_schema(model, messages, model_id):
+    """Test that outputSchema is filtered out from tool specs in Bedrock requests."""
+    tool_spec_with_output_schema = {
+        "description": "Test tool with output schema",
+        "name": "test_tool",
+        "inputSchema": {"type": "object", "properties": {}},
+        "outputSchema": {"type": "object", "properties": {"result": {"type": "string"}}},
+    }
+
+    request = model.format_request(messages, [tool_spec_with_output_schema])
+
+    tool_spec = request["toolConfig"]["tools"][0]["toolSpec"]
+
+    # Verify outputSchema is not included
+    assert "outputSchema" not in tool_spec
+
+    # Verify other fields are preserved
+    assert tool_spec["name"] == "test_tool"
+    assert tool_spec["description"] == "Test tool with output schema"
+    assert tool_spec["inputSchema"] == {"type": "object", "properties": {}}

--- a/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -48,6 +48,7 @@ def test_tool_spec_with_description(mcp_agent_tool, mock_mcp_tool):
     assert tool_spec["name"] == "test_tool"
     assert tool_spec["description"] == "A test tool"
     assert tool_spec["inputSchema"]["json"] == {"type": "object", "properties": {}}
+    assert "outputSchema" not in tool_spec
 
 
 def test_tool_spec_without_description(mock_mcp_tool, mock_mcp_client):
@@ -67,6 +68,15 @@ def test_tool_spec_with_output_schema(mock_mcp_tool, mock_mcp_client):
 
     assert "outputSchema" in tool_spec
     assert tool_spec["outputSchema"]["json"] == {"type": "object", "properties": {"result": {"type": "string"}}}
+
+
+def test_tool_spec_without_output_schema(mock_mcp_tool, mock_mcp_client):
+    mock_mcp_tool.outputSchema = None
+
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    tool_spec = agent_tool.tool_spec
+
+    assert "outputSchema" not in tool_spec
 
 
 @pytest.mark.asyncio

--- a/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -13,6 +13,7 @@ def mock_mcp_tool():
     mock_tool.name = "test_tool"
     mock_tool.description = "A test tool"
     mock_tool.inputSchema = {"type": "object", "properties": {}}
+    mock_tool.outputSchema = None  # MCP tools can have optional outputSchema
     return mock_tool
 
 
@@ -56,6 +57,16 @@ def test_tool_spec_without_description(mock_mcp_tool, mock_mcp_client):
     tool_spec = agent_tool.tool_spec
 
     assert tool_spec["description"] == "Tool which performs test_tool"
+
+
+def test_tool_spec_with_output_schema(mock_mcp_tool, mock_mcp_client):
+    mock_mcp_tool.outputSchema = {"type": "object", "properties": {"result": {"type": "string"}}}
+
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    tool_spec = agent_tool.tool_spec
+
+    assert "outputSchema" in tool_spec
+    assert tool_spec["outputSchema"]["json"] == {"type": "object", "properties": {"result": {"type": "string"}}}
 
 
 @pytest.mark.asyncio

--- a/tests_integ/mcp/__init__.py
+++ b/tests_integ/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP integration tests package."""

--- a/tests_integ/mcp/echo_server.py
+++ b/tests_integ/mcp/echo_server.py
@@ -15,9 +15,15 @@ Usage:
     $ python echo_server.py
 """
 
-from typing import Any, Dict
-
 from mcp.server import FastMCP
+from pydantic import BaseModel
+
+
+class EchoResponse(BaseModel):
+    """Response model for echo with structured content."""
+
+    echoed: str
+    message_length: int
 
 
 def start_echo_server():
@@ -37,8 +43,8 @@ def start_echo_server():
 
     # FastMCP automatically constructs structured output schema from method signature
     @mcp.tool(description="Echos response back with structured content", structured_output=True)
-    def echo_with_structured_content(to_echo: str) -> Dict[str, Any]:
-        return {"echoed": to_echo}
+    def echo_with_structured_content(to_echo: str) -> EchoResponse:
+        return EchoResponse(echoed=to_echo, message_length=len(to_echo))
 
     mcp.run(transport="stdio")
 

--- a/tests_integ/mcp/test_mcp_client.py
+++ b/tests_integ/mcp/test_mcp_client.py
@@ -76,7 +76,7 @@ def test_mcp_client():
 
     sse_mcp_client = MCPClient(lambda: sse_client("http://127.0.0.1:8000/sse"))
     stdio_mcp_client = MCPClient(
-        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/echo_server.py"]))
+        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
     )
 
     with sse_mcp_client, stdio_mcp_client:
@@ -162,7 +162,7 @@ def test_mcp_client():
 
 def test_can_reuse_mcp_client():
     stdio_mcp_client = MCPClient(
-        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/echo_server.py"]))
+        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
     )
     with stdio_mcp_client:
         stdio_mcp_client.list_tools_sync()
@@ -185,7 +185,7 @@ async def test_mcp_client_async_structured_content():
     that appears in structuredContent field.
     """
     stdio_mcp_client = MCPClient(
-        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/echo_server.py"]))
+        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
     )
 
     with stdio_mcp_client:
@@ -213,7 +213,7 @@ async def test_mcp_client_async_structured_content():
 def test_mcp_client_without_structured_content():
     """Test that MCP client works correctly when tools don't return structured content."""
     stdio_mcp_client = MCPClient(
-        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/echo_server.py"]))
+        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
     )
 
     with stdio_mcp_client:

--- a/tests_integ/mcp/test_mcp_client.py
+++ b/tests_integ/mcp/test_mcp_client.py
@@ -150,14 +150,14 @@ def test_mcp_client():
 
         # With the new MCPToolResult, structured content is in its own field
         assert "structuredContent" in result
-        assert result["structuredContent"]["result"] == {"echoed": "STRUCTURED_DATA_TEST"}
+        assert result["structuredContent"] == {"echoed": "STRUCTURED_DATA_TEST", 'message_length': 20}
 
         # Verify the result is an MCPToolResult (at runtime it's just a dict, but type-wise it should be MCPToolResult)
         assert result["status"] == "success"
         assert result["toolUseId"] == tool_use_id
 
         assert len(result["content"]) == 1
-        assert json.loads(result["content"][0]["text"]) == {"echoed": "STRUCTURED_DATA_TEST"}
+        assert json.loads(result["content"][0]["text"]) == {"echoed": "STRUCTURED_DATA_TEST", 'message_length': 20}
 
 
 def test_can_reuse_mcp_client():
@@ -200,14 +200,14 @@ async def test_mcp_client_async_structured_content():
         assert "structuredContent" in result
         # "result" nesting is not part of the MCP Structured Content specification,
         # but rather a FastMCP implementation detail
-        assert result["structuredContent"]["result"] == {"echoed": "ASYNC_STRUCTURED_TEST"}
+        assert result["structuredContent"] == {"echoed": "ASYNC_STRUCTURED_TEST", 'message_length': 21}
 
         # Verify basic MCPToolResult structure
         assert result["status"] in ["success", "error"]
         assert result["toolUseId"] == tool_use_id
 
         assert len(result["content"]) == 1
-        assert json.loads(result["content"][0]["text"]) == {"echoed": "ASYNC_STRUCTURED_TEST"}
+        assert json.loads(result["content"][0]["text"]) == {"echoed": "ASYNC_STRUCTURED_TEST", 'message_length': 21}
 
 
 def test_mcp_client_without_structured_content():

--- a/tests_integ/mcp/test_mcp_client.py
+++ b/tests_integ/mcp/test_mcp_client.py
@@ -150,14 +150,14 @@ def test_mcp_client():
 
         # With the new MCPToolResult, structured content is in its own field
         assert "structuredContent" in result
-        assert result["structuredContent"] == {"echoed": "STRUCTURED_DATA_TEST", 'message_length': 20}
+        assert result["structuredContent"] == {"echoed": "STRUCTURED_DATA_TEST", "message_length": 20}
 
         # Verify the result is an MCPToolResult (at runtime it's just a dict, but type-wise it should be MCPToolResult)
         assert result["status"] == "success"
         assert result["toolUseId"] == tool_use_id
 
         assert len(result["content"]) == 1
-        assert json.loads(result["content"][0]["text"]) == {"echoed": "STRUCTURED_DATA_TEST", 'message_length': 20}
+        assert json.loads(result["content"][0]["text"]) == {"echoed": "STRUCTURED_DATA_TEST", "message_length": 20}
 
 
 def test_can_reuse_mcp_client():
@@ -200,14 +200,14 @@ async def test_mcp_client_async_structured_content():
         assert "structuredContent" in result
         # "result" nesting is not part of the MCP Structured Content specification,
         # but rather a FastMCP implementation detail
-        assert result["structuredContent"] == {"echoed": "ASYNC_STRUCTURED_TEST", 'message_length': 21}
+        assert result["structuredContent"] == {"echoed": "ASYNC_STRUCTURED_TEST", "message_length": 21}
 
         # Verify basic MCPToolResult structure
         assert result["status"] in ["success", "error"]
         assert result["toolUseId"] == tool_use_id
 
         assert len(result["content"]) == 1
-        assert json.loads(result["content"][0]["text"]) == {"echoed": "ASYNC_STRUCTURED_TEST", 'message_length': 21}
+        assert json.loads(result["content"][0]["text"]) == {"echoed": "ASYNC_STRUCTURED_TEST", "message_length": 21}
 
 
 def test_mcp_client_without_structured_content():

--- a/tests_integ/mcp/test_mcp_client.py
+++ b/tests_integ/mcp/test_mcp_client.py
@@ -279,7 +279,7 @@ def test_mcp_client_timeout_integration():
 
     def slow_transport():
         time.sleep(4)  # Longer than timeout
-        return stdio_client(StdioServerParameters(command="python", args=["tests_integ/echo_server.py"]))
+        return stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
 
     client = MCPClient(slow_transport, startup_timeout=2)
     initial_threads = threading.active_count()

--- a/tests_integ/mcp/test_mcp_client_structured_content_with_hooks.py
+++ b/tests_integ/mcp/test_mcp_client_structured_content_with_hooks.py
@@ -56,10 +56,12 @@ def test_mcp_client_hooks_structured_content():
         assert result["status"] == "success"
         assert len(result["content"]) == 1
 
+        print("here?\n")
+        print(result)
         # Verify structured content is present and correct
         assert "structuredContent" in result
-        assert result["structuredContent"]["result"] == {"echoed": test_data}
+        assert result["structuredContent"] == {"echoed": test_data, 'message_length': 15}
 
         # Verify text content matches structured content
         text_content = json.loads(result["content"][0]["text"])
-        assert text_content == {"echoed": test_data}
+        assert text_content == {"echoed": test_data, 'message_length': 15}

--- a/tests_integ/mcp/test_mcp_client_structured_content_with_hooks.py
+++ b/tests_integ/mcp/test_mcp_client_structured_content_with_hooks.py
@@ -56,12 +56,10 @@ def test_mcp_client_hooks_structured_content():
         assert result["status"] == "success"
         assert len(result["content"]) == 1
 
-        print("here?\n")
-        print(result)
         # Verify structured content is present and correct
         assert "structuredContent" in result
-        assert result["structuredContent"] == {"echoed": test_data, 'message_length': 15}
+        assert result["structuredContent"]["result"] == {"echoed": test_data}
 
         # Verify text content matches structured content
         text_content = json.loads(result["content"][0]["text"])
-        assert text_content == {"echoed": test_data, 'message_length': 15}
+        assert text_content == {"echoed": test_data}

--- a/tests_integ/mcp/test_mcp_client_structured_content_with_hooks.py
+++ b/tests_integ/mcp/test_mcp_client_structured_content_with_hooks.py
@@ -58,8 +58,8 @@ def test_mcp_client_hooks_structured_content():
 
         # Verify structured content is present and correct
         assert "structuredContent" in result
-        assert result["structuredContent"]["result"] == {"echoed": test_data}
+        assert result["structuredContent"] == {"echoed": test_data, "message_length": 15}
 
         # Verify text content matches structured content
         text_content = json.loads(result["content"][0]["text"])
-        assert text_content == {"echoed": test_data}
+        assert text_content == {"echoed": test_data, "message_length": 15}

--- a/tests_integ/mcp/test_mcp_client_structured_content_with_hooks.py
+++ b/tests_integ/mcp/test_mcp_client_structured_content_with_hooks.py
@@ -37,7 +37,7 @@ def test_mcp_client_hooks_structured_content():
 
     # Set up MCP client for echo server
     stdio_mcp_client = MCPClient(
-        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/echo_server.py"]))
+        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
     )
 
     with stdio_mcp_client:

--- a/tests_integ/mcp/test_mcp_output_schema.py
+++ b/tests_integ/mcp/test_mcp_output_schema.py
@@ -1,0 +1,44 @@
+"""Integration test for MCP tools with output schema."""
+
+from mcp import StdioServerParameters, stdio_client
+
+from strands.tools.mcp.mcp_client import MCPClient
+
+from .echo_server import EchoResponse
+
+
+def test_mcp_tool_output_schema():
+    """Test that MCP tools with output schema include it in tool spec."""
+    stdio_mcp_client = MCPClient(
+        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
+    )
+
+    with stdio_mcp_client:
+        tools = stdio_mcp_client.list_tools_sync()
+
+        # Find tools with and without output schema
+        echo_tool = next(tool for tool in tools if tool.tool_name == "echo")
+        structured_tool = next(tool for tool in tools if tool.tool_name == "echo_with_structured_content")
+
+        # Verify echo tool has no output schema
+        echo_spec = echo_tool.tool_spec
+        assert "outputSchema" not in echo_spec
+
+        # Verify structured tool has output schema
+        structured_spec = structured_tool.tool_spec
+        assert "outputSchema" in structured_spec
+
+        # Validate output schema matches expected structure
+        expected_schema = {
+            "description": "Response model for echo with structured content.",
+            "properties": {
+                "echoed": {"title": "Echoed", "type": "string"},
+                "message_length": {"title": "Message Length", "type": "integer"},
+            },
+            "required": ["echoed", "message_length"],
+            "title": "EchoResponse",
+            "type": "object",
+        }
+
+        assert structured_spec["outputSchema"]["json"] == expected_schema
+        assert structured_spec["outputSchema"]["json"] == EchoResponse.model_json_schema()


### PR DESCRIPTION
This PR adds support for MCP output schema tool specifications as defined in the MCP specification (https://modelcontextprotocol.io/specification/2025-06-18/server/tools#data-types). This allows tools to define their expected output structure through outputSchema, which is particularly valuable for LLM agents to better understand tool capabilities and responses.

Note, the LLM is not automatically shown the outputSchema. In the future certain models may accept but. But for now, it is a device that users can leverage internally. For example if someone wanted to create their own dynamic tool loader they could use the outputSchema as a message.

As part of this we needed to make sure the BedrockModel explicitly manages its supported fields (including handling outputSchema appropriately), while other providers naturally drop fields they don't recognize. This maintains backward compatibility while keeping the code cleaner and more maintainable.

Closes #787


## Type of Change
New feature


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
