### PR TITLE
docs: cleanup docs so the yields section renders correctly

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -547,12 +547,12 @@ class Agent:
 
         Yields:
             An async iterator that yields events. Each event is a dictionary containing
-            information about the current state of processing, such as:
+               information about the current state of processing, such as:
 
-            - data: Text content being generated
-            - complete: Whether this is the final chunk
-            - current_tool_use: Information about tools being executed
-            - And other event data provided by the callback handler
+                - data: Text content being generated
+                - complete: Whether this is the final chunk
+                - current_tool_use: Information about tools being executed
+                - And other event data provided by the callback handler
 
         Raises:
             Exception: Any exceptions from the agent invocation will be propagated to the caller.


### PR DESCRIPTION
## Description
cleanup docs so the yields section renders correctly

<img width="2006" height="1566" alt="image" src="https://github.com/user-attachments/assets/ab9f51ef-6b7b-4c7f-b6e4-aea98b3bb0cb" />


## Related Issues

<!-- Link to related issues using #issue-number format -->
[docs repo 217](https://github.com/strands-agents/docs/issues/217)

## Documentation PR

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
