### PR TITLE
fix: replace empty user text message as 'blank text'

### DIFF
--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -39,7 +39,7 @@ def moto_autouse(moto_env, moto_mock_aws):
                 {"role": "assistant", "content": [{"text": "a"}, {"text": "[blank text]"}]},
                 {"role": "assistant", "content": [{"text": "[blank text]"}]},
                 {"role": "assistant"},
-                {"role": "user", "content": [{"text": " \n"}]},
+                {"role": "user", "content": [{"text": "[blank text]"}]},
             ],
         ),
         (


### PR DESCRIPTION
## Description
When user sends empty string as user prompt, the model will fail with empty message exception:

```
An error occurred: An error occurred (ValidationException) when calling the ConverseStream operation: The text field in the ContentBlock object at messages.xxx.content.0 is blank. Add text to the text field, and try again.
```

Therefore updating the user text message to `[blank text]` when it's empty. 

## Related Issues

https://github.com/strands-agents/sdk-python/issues/514

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I compared the behaviors before and after the change

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
