### PR TITLE
feat: add default read timeout to Bedrock config

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -45,6 +45,7 @@ _MODELS_INCLUDE_STATUS = [
 
 T = TypeVar("T", bound=BaseModel)
 
+DEFAULT_READ_TIMEOUT = 120
 
 class BedrockModel(Model):
     """AWS Bedrock model provider implementation.
@@ -147,7 +148,7 @@ class BedrockModel(Model):
 
             client_config = boto_client_config.merge(BotocoreConfig(user_agent_extra=new_user_agent))
         else:
-            client_config = BotocoreConfig(user_agent_extra="strands-agents")
+            client_config = BotocoreConfig(user_agent_extra="strands-agents", read_timeout=DEFAULT_READ_TIMEOUT)
 
         resolved_region = region_name or session.region_name or os.environ.get("AWS_REGION") or DEFAULT_BEDROCK_REGION
 

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -11,7 +11,7 @@ from botocore.exceptions import ClientError, EventStreamError
 
 import strands
 from strands.models import BedrockModel
-from strands.models.bedrock import DEFAULT_BEDROCK_MODEL_ID, DEFAULT_BEDROCK_REGION
+from strands.models.bedrock import DEFAULT_BEDROCK_MODEL_ID, DEFAULT_BEDROCK_REGION, DEFAULT_READ_TIMEOUT
 from strands.types.exceptions import ModelThrottledException
 from strands.types.tools import ToolSpec
 
@@ -216,6 +216,20 @@ def test__init__default_user_agent(bedrock_client):
         assert kwargs["service_name"] == "bedrock-runtime"
         assert isinstance(kwargs["config"], BotocoreConfig)
         assert kwargs["config"].user_agent_extra == "strands-agents"
+        assert kwargs["config"].read_timeout == DEFAULT_READ_TIMEOUT
+
+
+def test__init__default_read_timeout(bedrock_client):
+    """Set default read timeout when no boto_client_config is provided."""
+    with unittest.mock.patch("strands.models.bedrock.boto3.Session") as mock_session_cls:
+        mock_session = mock_session_cls.return_value
+        _ = BedrockModel()
+
+        # Verify the client was created with the correct read timeout
+        mock_session.client.assert_called_once()
+        args, kwargs = mock_session.client.call_args
+        assert isinstance(kwargs["config"], BotocoreConfig)
+        assert kwargs["config"].read_timeout == DEFAULT_READ_TIMEOUT
 
 
 def test__init__with_custom_boto_client_config_no_user_agent(bedrock_client):


### PR DESCRIPTION

## Description
- Set DEFAULT_READ_TIMEOUT constant to 120 seconds
- Configure BotocoreConfig with read_timeout when no custom config provided
- Add test coverage for default read timeout behavior

In the following link we can see some more re:Posts regarding this timeout issue and the AWS suggested approach.
- https://repost.aws/knowledge-center/bedrock-large-model-read-timeouts
>The timeout errors occur when the [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) client queries the LLM but doesn't receive a response within botocore's default read timeout period. To resolve read timeout errors, increase the read timeout or use streaming APIs.

Note:  I was not able to reproduce the read timeout when trying with > ~70,000 tokens (as per a comment on the #699 issue). Tried with many different models as well. 

## Related Issues
#699 
<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
