### PR TITLE
feat: add automated issue auto-close workflows with dry-run testing

### DIFF
--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -8,17 +8,17 @@ on:
       dry_run:
         description: 'Run in dry-run mode (no actions taken, only logging)'
         required: false
-        default: 'true'
+        default: 'false'
         type: boolean
 
 env:
   LABEL_NAME: 'autoclose in 3 days'
-  DAYS_TO_WAIT: '0'
+  DAYS_TO_WAIT: '3'
   AUTHORIZED_USERS: ''  # Comma-separated list (ex: user1,user2,user3) *required for 'users' mode
   AUTH_MODE: 'write-access'  # Options: 'users', 'write-access'
   ISSUE_TYPES: 'issues'  # Options: 'issues', 'pulls', 'both'
   DRY_RUN: 'false'  # Set to 'true' to enable dry-run mode (no actions taken)
-  REPLACEMENT_LABEL: 'invalid'  # Optional: Label to add when removing the auto-close label
+  REPLACEMENT_LABEL: ''  # Optional: Label to add when removing the auto-close label
   CLOSE_MESSAGE: 'This issue has been automatically closed as it was marked for auto-closure by the team and no additional responses was received within the allotted time.'
 
 jobs:

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -18,6 +18,7 @@ env:
   AUTH_MODE: 'write-access'  # Options: 'users', 'write-access'
   ISSUE_TYPES: 'issues'  # Options: 'issues', 'pulls', 'both'
   DRY_RUN: 'true'  # Set to 'true' to enable dry-run mode (no actions taken)
+  REPLACEMENT_LABEL: ''  # Optional: Label to add when removing the auto-close label
 
 jobs:
   auto-close:
@@ -70,7 +71,8 @@ jobs:
               daysToWait: parseInt(process.env.DAYS_TO_WAIT),
               authMode: process.env.AUTH_MODE,
               authorizedUsers: process.env.AUTHORIZED_USERS?.split(',').map(u => u.trim()).filter(u => u) || [],
-              issueTypes: process.env.ISSUE_TYPES
+              issueTypes: process.env.ISSUE_TYPES,
+              replacementLabel: process.env.REPLACEMENT_LABEL?.trim() || null
             };
             
             const cutoffDate = new Date();
@@ -178,7 +180,7 @@ jobs:
                     
                     const isAuthorized = await isAuthorizedUser(comment.user.login);
                     if (!isAuthorized) {
-                      console.log(`❌ Unauthorized comment from ${comment.user.login}`);
+                      console.log(`❌ New comment from ${comment.user.login}`);
                       hasUnauthorizedComment = true;
                       break;
                     }
@@ -188,6 +190,9 @@ jobs:
                     // Remove label due to unauthorized comment (regardless of time elapsed)
                     if (isDryRun) {
                       console.log(`🧪 DRY-RUN: Would remove ${config.labelName} label from #${issue.number}`);
+                      if (config.replacementLabel) {
+                        console.log(`🧪 DRY-RUN: Would add ${config.replacementLabel} label to #${issue.number}`);
+                      }
                     } else {
                       await github.rest.issues.removeLabel({
                         owner: context.repo.owner,
@@ -196,6 +201,16 @@ jobs:
                         name: config.labelName
                       });
                       console.log(`🏷️ Removed ${config.labelName} label from #${issue.number}`);
+                      
+                      if (config.replacementLabel) {
+                        await github.rest.issues.addLabels({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: issue.number,
+                          labels: [config.replacementLabel]
+                        });
+                        console.log(`🏷️ Added ${config.replacementLabel} label to #${issue.number}`);
+                      }
                     }
                     labelRemovedCount++;
                     continue;

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   LABEL_NAME: 'autoclose in 3 days'
-  DAYS_TO_WAIT: '1'
+  DAYS_TO_WAIT: '0'
   AUTHORIZED_USERS: ''  # Comma-separated list (ex: user1,user2,user3) *required for 'users' mode
   AUTH_MODE: 'write-access'  # Options: 'users', 'write-access'
   ISSUE_TYPES: 'issues'  # Options: 'issues', 'pulls', 'both'

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -1,0 +1,243 @@
+name: Auto Close Issues
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # Daily at 9 AM UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no actions taken, only logging)'
+        required: false
+        default: 'true'
+        type: boolean
+
+env:
+  LABEL_NAME: 'autoclose in 3 days'
+  DAYS_TO_WAIT: '3'
+  AUTHORIZED_USERS: ''  # Comma-separated list (ex: user1,user2,user3) *required for 'users' mode
+  AUTH_MODE: 'write-access'  # Options: 'users', 'write-access'
+  ISSUE_TYPES: 'issues'  # Options: 'issues', 'pulls', 'both'
+  DRY_RUN: 'true'  # Set to 'true' to enable dry-run mode (no actions taken)
+
+jobs:
+  auto-close:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate configuration
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { LABEL_NAME, DAYS_TO_WAIT, AUTH_MODE, AUTHORIZED_USERS, ISSUE_TYPES, DRY_RUN } = process.env;
+            
+            // Check for manual dry-run override
+            const isDryRun = '${{ inputs.dry_run }}' === 'true' || DRY_RUN === 'true';
+            
+            // Validate required fields
+            if (!LABEL_NAME) throw new Error('LABEL_NAME is required');
+            if (!DAYS_TO_WAIT || isNaN(parseInt(DAYS_TO_WAIT)) || parseInt(DAYS_TO_WAIT) < 1) {
+              throw new Error('DAYS_TO_WAIT must be a positive integer');
+            }
+            if (!['users', 'write-access'].includes(AUTH_MODE)) {
+              throw new Error('AUTH_MODE must be "users" or "write-access"');
+            }
+            if (!['issues', 'pulls', 'both'].includes(ISSUE_TYPES)) {
+              throw new Error('ISSUE_TYPES must be "issues", "pulls", or "both"');
+            }
+            if (AUTH_MODE === 'users' && (!AUTHORIZED_USERS || AUTHORIZED_USERS.trim() === '')) {
+              throw new Error('AUTHORIZED_USERS is required when AUTH_MODE is "users"');
+            }
+            
+            console.log('✅ Configuration validated successfully');
+            console.log(`Label: "${LABEL_NAME}", Days: ${DAYS_TO_WAIT}, Auth: ${AUTH_MODE}, Types: ${ISSUE_TYPES}`);
+            if (isDryRun) {
+              console.log('🧪 DRY-RUN MODE: No actions will be taken, only logging what would happen');
+            }
+
+      - name: Find and process labeled issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // Constants
+            const REQUIRED_PERMISSIONS = ['write', 'admin'];
+            const CLOSE_MESSAGE = `This issue has been automatically closed as it was marked for auto-closure by the team and no response was received within ${process.env.DAYS_TO_WAIT} days.`;
+            
+            // Check for dry-run mode
+            const isDryRun = '${{ inputs.dry_run }}' === 'true' || process.env.DRY_RUN === 'true';
+            
+            // Parse configuration
+            const config = {
+              labelName: process.env.LABEL_NAME,
+              daysToWait: parseInt(process.env.DAYS_TO_WAIT),
+              authMode: process.env.AUTH_MODE,
+              authorizedUsers: process.env.AUTHORIZED_USERS?.split(',').map(u => u.trim()).filter(u => u) || [],
+              issueTypes: process.env.ISSUE_TYPES
+            };
+            
+            const cutoffDate = new Date();
+            cutoffDate.setDate(cutoffDate.getDate() - config.daysToWait);
+            
+            // Authorization check function
+            async function isAuthorizedUser(username) {
+              try {
+                if (config.authMode === 'users') {
+                  return config.authorizedUsers.includes(username);
+                } else if (config.authMode === 'write-access') {
+                  const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    username: username
+                  });
+                  return REQUIRED_PERMISSIONS.includes(data.permission);
+                }
+              } catch (error) {
+                console.log(`⚠️ Failed to check authorization for ${username}: ${error.message}`);
+                return false;
+              }
+              return false;
+            }
+            
+            // Find issues with the target label
+            const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:open label:"${config.labelName}"`;
+            const typeFilter = config.issueTypes === 'pulls' ? 'is:pr' : 
+                              config.issueTypes === 'both' ? '' : 'is:issue';
+            
+            try {
+              const { data: searchResults } = await github.rest.search.issuesAndPullRequests({
+                q: `${searchQuery} ${typeFilter}`.trim(),
+                sort: 'updated',
+                order: 'desc'
+              });
+              
+              const targetIssues = searchResults.items.filter(issue => {
+                if (config.issueTypes === 'issues' && issue.pull_request) return false;
+                if (config.issueTypes === 'pulls' && !issue.pull_request) return false;
+                return true;
+              });
+              
+              console.log(`🔍 Found ${targetIssues.length} items with label "${config.labelName}"`);
+              
+              if (targetIssues.length === 0) {
+                console.log('✅ No items to process');
+                return;
+              }
+              
+              // Process each issue
+              let closedCount = 0;
+              let labelRemovedCount = 0;
+              let skippedCount = 0;
+              
+              for (const issue of targetIssues) {
+                console.log(`\n📋 Processing #${issue.number}: ${issue.title}`);
+                
+                try {
+                  // Get label events to find when label was last added
+                  const { data: events } = await github.rest.issues.listEvents({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number
+                  });
+                  
+                  const labelEvents = events
+                    .filter(e => e.event === 'labeled' && e.label?.name === config.labelName)
+                    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+                  
+                  if (labelEvents.length === 0) {
+                    console.log(`⚠️ No label events found for #${issue.number}`);
+                    skippedCount++;
+                    continue;
+                  }
+                  
+                  const lastLabelAdded = new Date(labelEvents[0].created_at);
+                  const labelAdder = labelEvents[0].actor.login;
+                  
+                  // Check if enough time has passed
+                  if (lastLabelAdded > cutoffDate) {
+                    const daysRemaining = Math.ceil((lastLabelAdded - cutoffDate) / (1000 * 60 * 60 * 24));
+                    console.log(`⏳ Label added too recently (${daysRemaining} days remaining)`);
+                    skippedCount++;
+                    continue;
+                  }
+                  
+                  // Check comments since label was added
+                  const { data: comments } = await github.rest.issues.listComments({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    since: lastLabelAdded.toISOString()
+                  });
+                  
+                  let hasUnauthorizedComment = false;
+                  
+                  for (const comment of comments) {
+                    // Skip comments from the person who added the label
+                    if (comment.user.login === labelAdder) continue;
+                    
+                    const isAuthorized = await isAuthorizedUser(comment.user.login);
+                    if (!isAuthorized) {
+                      console.log(`❌ Unauthorized comment from ${comment.user.login}`);
+                      hasUnauthorizedComment = true;
+                      break;
+                    }
+                  }
+                  
+                  if (hasUnauthorizedComment) {
+                    // Remove label due to unauthorized comment
+                    if (isDryRun) {
+                      console.log(`🧪 DRY-RUN: Would remove ${config.labelName} label from #${issue.number}`);
+                    } else {
+                      await github.rest.issues.removeLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue.number,
+                        name: config.labelName
+                      });
+                      console.log(`🏷️ Removed ${config.labelName} label from #${issue.number}`);
+                    }
+                    labelRemovedCount++;
+                  } else {
+                    // Close the issue
+                    if (isDryRun) {
+                      console.log(`🧪 DRY-RUN: Would close #${issue.number} with comment`);
+                      console.log(`🧪 DRY-RUN: Comment would be: "${CLOSE_MESSAGE}"`);
+                    } else {
+                      await github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue.number,
+                        body: CLOSE_MESSAGE
+                      });
+                      
+                      await github.rest.issues.update({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue.number,
+                        state: 'closed'
+                      });
+                      
+                      console.log(`🔒 Closed #${issue.number}`);
+                    }
+                    closedCount++;
+                  }
+                } catch (error) {
+                  console.log(`❌ Error processing #${issue.number}: ${error.message}`);
+                  skippedCount++;
+                }
+              }
+              
+              // Summary
+              console.log(`\n📊 Summary:`);
+              if (isDryRun) {
+                console.log(`   🧪 DRY-RUN MODE - No actual changes made:`);
+                console.log(`   • Issues that would be closed: ${closedCount}`);
+                console.log(`   • Labels that would be removed: ${labelRemovedCount}`);
+              } else {
+                console.log(`   • Issues closed: ${closedCount}`);
+                console.log(`   • Labels removed: ${labelRemovedCount}`);
+              }
+              console.log(`   • Issues skipped: ${skippedCount}`);
+              console.log(`   • Total processed: ${targetIssues.length}`);
+              
+            } catch (error) {
+              console.log(`❌ Failed to search for issues: ${error.message}`);
+              throw error;
+            }

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -96,23 +96,34 @@ jobs:
               return false;
             }
             
-            // Find issues with the target label
-            const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:open label:"${config.labelName}"`;
-            const typeFilter = config.issueTypes === 'pulls' ? 'is:pr' : 
-                              config.issueTypes === 'both' ? '' : 'is:issue';
+            // Find issues with the target label using Issues API instead of deprecated Search API
+            let allIssues = [];
+            let page = 1;
+            const perPage = 100;
             
-            try {
-              const { data: searchResults } = await github.rest.search.issuesAndPullRequests({
-                q: `${searchQuery} ${typeFilter}`.trim(),
+            while (true) {
+              const { data: issues } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: config.labelName,
                 sort: 'updated',
-                order: 'desc'
+                direction: 'desc',
+                per_page: perPage,
+                page: page
               });
               
-              const targetIssues = searchResults.items.filter(issue => {
-                if (config.issueTypes === 'issues' && issue.pull_request) return false;
-                if (config.issueTypes === 'pulls' && !issue.pull_request) return false;
-                return true;
-              });
+              if (issues.length === 0) break;
+              allIssues = allIssues.concat(issues);
+              if (issues.length < perPage) break;
+              page++;
+            }
+            
+            const targetIssues = allIssues.filter(issue => {
+              if (config.issueTypes === 'issues' && issue.pull_request) return false;
+              if (config.issueTypes === 'pulls' && !issue.pull_request) return false;
+              return true;
+            });
               
               console.log(`🔍 Found ${targetIssues.length} items with label "${config.labelName}"`);
               
@@ -238,6 +249,6 @@ jobs:
               console.log(`   • Total processed: ${targetIssues.length}`);
               
             } catch (error) {
-              console.log(`❌ Failed to search for issues: ${error.message}`);
+              console.log(`❌ Failed to fetch issues: ${error.message}`);
               throw error;
             }

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   LABEL_NAME: 'autoclose in 3 days'
-  DAYS_TO_WAIT: '3'
+  DAYS_TO_WAIT: '1'
   AUTHORIZED_USERS: ''  # Comma-separated list (ex: user1,user2,user3) *required for 'users' mode
   AUTH_MODE: 'write-access'  # Options: 'users', 'write-access'
   ISSUE_TYPES: 'issues'  # Options: 'issues', 'pulls', 'both'

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { LABEL_NAME, DAYS_TO_WAIT, AUTH_MODE, AUTHORIZED_USERS, ISSUE_TYPES, DRY_RUN } = process.env;
+            const { LABEL_NAME, DAYS_TO_WAIT, AUTH_MODE, AUTHORIZED_USERS, ISSUE_TYPES, DRY_RUN, GITHUB_EVENT_NAME } = process.env;
             
-            const isManualTrigger = !!github.event.workflow_dispatch;
+            const isManualTrigger = GITHUB_EVENT_NAME === 'workflow_dispatch';
             // Check for manual dry-run override
             const isDryRun = isManualTrigger ? '${{ inputs.dry_run }}' === 'true' : DRY_RUN === 'true';
             

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -35,8 +35,8 @@ jobs:
             
             // Validate required fields
             if (!LABEL_NAME) throw new Error('LABEL_NAME is required');
-            if (!DAYS_TO_WAIT || isNaN(parseInt(DAYS_TO_WAIT)) || parseInt(DAYS_TO_WAIT) < 1) {
-              throw new Error('DAYS_TO_WAIT must be a positive integer');
+            if (!DAYS_TO_WAIT || isNaN(parseInt(DAYS_TO_WAIT)) || parseInt(DAYS_TO_WAIT) < 0) {
+              throw new Error('DAYS_TO_WAIT must be a positive integer or zero');
             }
             if (!['users', 'write-access'].includes(AUTH_MODE)) {
               throw new Error('AUTH_MODE must be "users" or "write-access"');

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -162,14 +162,6 @@ jobs:
                   const lastLabelAdded = new Date(labelEvents[0].created_at);
                   const labelAdder = labelEvents[0].actor.login;
                   
-                  // Check if enough time has passed
-                  if (lastLabelAdded > cutoffDate) {
-                    const daysRemaining = Math.ceil((lastLabelAdded - cutoffDate) / (1000 * 60 * 60 * 24));
-                    console.log(`⏳ Label added too recently (${daysRemaining} days remaining)`);
-                    skippedCount++;
-                    continue;
-                  }
-                  
                   // Check comments since label was added
                   const { data: comments } = await github.rest.issues.listComments({
                     owner: context.repo.owner,
@@ -193,7 +185,7 @@ jobs:
                   }
                   
                   if (hasUnauthorizedComment) {
-                    // Remove label due to unauthorized comment
+                    // Remove label due to unauthorized comment (regardless of time elapsed)
                     if (isDryRun) {
                       console.log(`🧪 DRY-RUN: Would remove ${config.labelName} label from #${issue.number}`);
                     } else {
@@ -206,30 +198,39 @@ jobs:
                       console.log(`🏷️ Removed ${config.labelName} label from #${issue.number}`);
                     }
                     labelRemovedCount++;
-                  } else {
-                    // Close the issue
-                    if (isDryRun) {
-                      console.log(`🧪 DRY-RUN: Would close #${issue.number} with comment`);
-                      console.log(`🧪 DRY-RUN: Comment would be: "${CLOSE_MESSAGE}"`);
-                    } else {
-                      await github.rest.issues.createComment({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: issue.number,
-                        body: CLOSE_MESSAGE
-                      });
-                      
-                      await github.rest.issues.update({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: issue.number,
-                        state: 'closed'
-                      });
-                      
-                      console.log(`🔒 Closed #${issue.number}`);
-                    }
-                    closedCount++;
+                    continue;
                   }
+                  
+                  // Check if enough time has passed for auto-close
+                  if (lastLabelAdded > cutoffDate) {
+                    const daysRemaining = Math.ceil((lastLabelAdded - cutoffDate) / (1000 * 60 * 60 * 24));
+                    console.log(`⏳ Label added too recently (${daysRemaining} days remaining)`);
+                    skippedCount++;
+                    continue;
+                  }
+                  
+                  // Close the issue (only if time has elapsed AND no unauthorized comments)
+                  if (isDryRun) {
+                    console.log(`🧪 DRY-RUN: Would close #${issue.number} with comment`);
+                    console.log(`🧪 DRY-RUN: Comment would be: "${CLOSE_MESSAGE}"`);
+                  } else {
+                    await github.rest.issues.createComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      body: CLOSE_MESSAGE
+                    });
+                    
+                    await github.rest.issues.update({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      state: 'closed'
+                    });
+                    
+                    console.log(`🔒 Closed #${issue.number}`);
+                  }
+                  closedCount++;
                 } catch (error) {
                   console.log(`❌ Error processing #${issue.number}: ${error.message}`);
                   skippedCount++;

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -17,7 +17,7 @@ env:
   AUTHORIZED_USERS: ''  # Comma-separated list (ex: user1,user2,user3) *required for 'users' mode
   AUTH_MODE: 'write-access'  # Options: 'users', 'write-access'
   ISSUE_TYPES: 'issues'  # Options: 'issues', 'pulls', 'both'
-  DRY_RUN: 'true'  # Set to 'true' to enable dry-run mode (no actions taken)
+  DRY_RUN: 'false'  # Set to 'true' to enable dry-run mode (no actions taken)
   REPLACEMENT_LABEL: 'invalid'  # Optional: Label to add when removing the auto-close label
 
 jobs:
@@ -30,8 +30,10 @@ jobs:
           script: |
             const { LABEL_NAME, DAYS_TO_WAIT, AUTH_MODE, AUTHORIZED_USERS, ISSUE_TYPES, DRY_RUN } = process.env;
             
+            const isManualTrigger = !!github.event.workflow_dispatch;
             // Check for manual dry-run override
-            const isDryRun = '${{ inputs.dry_run }}' === 'true' || DRY_RUN === 'true';
+            const isDryRun = isManualTrigger ? '${{ inputs.dry_run }}' === 'true' : DRY_RUN === 'true';
+            
             
             // Validate required fields
             if (!LABEL_NAME) throw new Error('LABEL_NAME is required');

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -97,33 +97,34 @@ jobs:
             }
             
             // Find issues with the target label using Issues API instead of deprecated Search API
-            let allIssues = [];
-            let page = 1;
-            const perPage = 100;
-            
-            while (true) {
-              const { data: issues } = await github.rest.issues.listForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                labels: config.labelName,
-                sort: 'updated',
-                direction: 'desc',
-                per_page: perPage,
-                page: page
-              });
+            try {
+              let allIssues = [];
+              let page = 1;
+              const perPage = 100;
               
-              if (issues.length === 0) break;
-              allIssues = allIssues.concat(issues);
-              if (issues.length < perPage) break;
-              page++;
-            }
-            
-            const targetIssues = allIssues.filter(issue => {
-              if (config.issueTypes === 'issues' && issue.pull_request) return false;
-              if (config.issueTypes === 'pulls' && !issue.pull_request) return false;
-              return true;
-            });
+              while (true) {
+                const { data: issues } = await github.rest.issues.listForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  labels: config.labelName,
+                  sort: 'updated',
+                  direction: 'desc',
+                  per_page: perPage,
+                  page: page
+                });
+                
+                if (issues.length === 0) break;
+                allIssues = allIssues.concat(issues);
+                if (issues.length < perPage) break;
+                page++;
+              }
+              
+              const targetIssues = allIssues.filter(issue => {
+                if (config.issueTypes === 'issues' && issue.pull_request) return false;
+                if (config.issueTypes === 'pulls' && !issue.pull_request) return false;
+                return true;
+              });
               
               console.log(`🔍 Found ${targetIssues.length} items with label "${config.labelName}"`);
               

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -19,6 +19,7 @@ env:
   ISSUE_TYPES: 'issues'  # Options: 'issues', 'pulls', 'both'
   DRY_RUN: 'false'  # Set to 'true' to enable dry-run mode (no actions taken)
   REPLACEMENT_LABEL: 'invalid'  # Optional: Label to add when removing the auto-close label
+  CLOSE_MESSAGE: 'This issue has been automatically closed as it was marked for auto-closure by the team and no additional responses was received within the allotted time.'
 
 jobs:
   auto-close:
@@ -62,7 +63,7 @@ jobs:
           script: |
             // Constants
             const REQUIRED_PERMISSIONS = ['write', 'admin'];
-            const CLOSE_MESSAGE = `This issue has been automatically closed as it was marked for auto-closure by the team and no addtional responses was received within ${process.env.DAYS_TO_WAIT} days.`;
+            const CLOSE_MESSAGE = process.env.CLOSE_MESSAGE;
             
             // Check for dry-run mode
             const isDryRun = '${{ inputs.dry_run }}' === 'true' || process.env.DRY_RUN === 'true';

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -1,8 +1,8 @@
-name: Auto Close Issues
+name: Auto Close 3 Days
 
 on:
   schedule:
-    - cron: '0 9 * * *'  # Daily at 9 AM UTC
+    - cron: '0 14 * * 1-5'  # 9 AM EST (2 PM UTC) Monday through Friday
   workflow_dispatch:
     inputs:
       dry_run:
@@ -60,7 +60,7 @@ jobs:
           script: |
             // Constants
             const REQUIRED_PERMISSIONS = ['write', 'admin'];
-            const CLOSE_MESSAGE = `This issue has been automatically closed as it was marked for auto-closure by the team and no response was received within ${process.env.DAYS_TO_WAIT} days.`;
+            const CLOSE_MESSAGE = `This issue has been automatically closed as it was marked for auto-closure by the team and no addtional responses was received within ${process.env.DAYS_TO_WAIT} days.`;
             
             // Check for dry-run mode
             const isDryRun = '${{ inputs.dry_run }}' === 'true' || process.env.DRY_RUN === 'true';

--- a/.github/workflows/auto-close-3-days.yml
+++ b/.github/workflows/auto-close-3-days.yml
@@ -18,7 +18,7 @@ env:
   AUTH_MODE: 'write-access'  # Options: 'users', 'write-access'
   ISSUE_TYPES: 'issues'  # Options: 'issues', 'pulls', 'both'
   DRY_RUN: 'true'  # Set to 'true' to enable dry-run mode (no actions taken)
-  REPLACEMENT_LABEL: ''  # Optional: Label to add when removing the auto-close label
+  REPLACEMENT_LABEL: 'invalid'  # Optional: Label to add when removing the auto-close label
 
 jobs:
   auto-close:

--- a/.github/workflows/auto-close-7-days.yml
+++ b/.github/workflows/auto-close-7-days.yml
@@ -1,0 +1,274 @@
+name: Auto Close 7 Days
+
+on:
+  schedule:
+    - cron: '0 14 * * 1-5'  # 9 AM EST (2 PM UTC) Monday through Friday
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no actions taken, only logging)'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  LABEL_NAME: 'autoclose in 7 days'
+  DAYS_TO_WAIT: '7'
+  AUTHORIZED_USERS: ''  # Comma-separated list (ex: user1,user2,user3) *required for 'users' mode
+  AUTH_MODE: 'write-access'  # Options: 'users', 'write-access'
+  ISSUE_TYPES: 'issues'  # Options: 'issues', 'pulls', 'both'
+  DRY_RUN: 'false'  # Set to 'true' to enable dry-run mode (no actions taken)
+  REPLACEMENT_LABEL: ''  # Optional: Label to add when removing the auto-close label
+  CLOSE_MESSAGE: 'This issue has been automatically closed as it was marked for auto-closure by the team and no additional responses was received within the allotted time.'
+
+jobs:
+  auto-close:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate configuration
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { LABEL_NAME, DAYS_TO_WAIT, AUTH_MODE, AUTHORIZED_USERS, ISSUE_TYPES, DRY_RUN, GITHUB_EVENT_NAME } = process.env;
+            
+            const isManualTrigger = GITHUB_EVENT_NAME === 'workflow_dispatch';
+            // Check for manual dry-run override
+            const isDryRun = isManualTrigger ? '${{ inputs.dry_run }}' === 'true' : DRY_RUN === 'true';
+            
+            
+            // Validate required fields
+            if (!LABEL_NAME) throw new Error('LABEL_NAME is required');
+            if (!DAYS_TO_WAIT || isNaN(parseInt(DAYS_TO_WAIT)) || parseInt(DAYS_TO_WAIT) < 0) {
+              throw new Error('DAYS_TO_WAIT must be a positive integer or zero');
+            }
+            if (!['users', 'write-access'].includes(AUTH_MODE)) {
+              throw new Error('AUTH_MODE must be "users" or "write-access"');
+            }
+            if (!['issues', 'pulls', 'both'].includes(ISSUE_TYPES)) {
+              throw new Error('ISSUE_TYPES must be "issues", "pulls", or "both"');
+            }
+            if (AUTH_MODE === 'users' && (!AUTHORIZED_USERS || AUTHORIZED_USERS.trim() === '')) {
+              throw new Error('AUTHORIZED_USERS is required when AUTH_MODE is "users"');
+            }
+            
+            console.log('✅ Configuration validated successfully');
+            console.log(`Label: "${LABEL_NAME}", Days: ${DAYS_TO_WAIT}, Auth: ${AUTH_MODE}, Types: ${ISSUE_TYPES}`);
+            if (isDryRun) {
+              console.log('🧪 DRY-RUN MODE: No actions will be taken, only logging what would happen');
+            }
+
+      - name: Find and process labeled issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // Constants
+            const REQUIRED_PERMISSIONS = ['write', 'admin'];
+            const CLOSE_MESSAGE = process.env.CLOSE_MESSAGE;
+            
+            // Check for dry-run mode
+            const isDryRun = '${{ inputs.dry_run }}' === 'true' || process.env.DRY_RUN === 'true';
+            
+            // Parse configuration
+            const config = {
+              labelName: process.env.LABEL_NAME,
+              daysToWait: parseInt(process.env.DAYS_TO_WAIT),
+              authMode: process.env.AUTH_MODE,
+              authorizedUsers: process.env.AUTHORIZED_USERS?.split(',').map(u => u.trim()).filter(u => u) || [],
+              issueTypes: process.env.ISSUE_TYPES,
+              replacementLabel: process.env.REPLACEMENT_LABEL?.trim() || null
+            };
+            
+            const cutoffDate = new Date();
+            cutoffDate.setDate(cutoffDate.getDate() - config.daysToWait);
+            
+            // Authorization check function
+            async function isAuthorizedUser(username) {
+              try {
+                if (config.authMode === 'users') {
+                  return config.authorizedUsers.includes(username);
+                } else if (config.authMode === 'write-access') {
+                  const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    username: username
+                  });
+                  return REQUIRED_PERMISSIONS.includes(data.permission);
+                }
+              } catch (error) {
+                console.log(`⚠️ Failed to check authorization for ${username}: ${error.message}`);
+                return false;
+              }
+              return false;
+            }
+            
+            // Find issues with the target label using Issues API instead of deprecated Search API
+            try {
+              let allIssues = [];
+              let page = 1;
+              const perPage = 100;
+              
+              while (true) {
+                const { data: issues } = await github.rest.issues.listForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  labels: config.labelName,
+                  sort: 'updated',
+                  direction: 'desc',
+                  per_page: perPage,
+                  page: page
+                });
+                
+                if (issues.length === 0) break;
+                allIssues = allIssues.concat(issues);
+                if (issues.length < perPage) break;
+                page++;
+              }
+              
+              const targetIssues = allIssues.filter(issue => {
+                if (config.issueTypes === 'issues' && issue.pull_request) return false;
+                if (config.issueTypes === 'pulls' && !issue.pull_request) return false;
+                return true;
+              });
+              
+              console.log(`🔍 Found ${targetIssues.length} items with label "${config.labelName}"`);
+              
+              if (targetIssues.length === 0) {
+                console.log('✅ No items to process');
+                return;
+              }
+              
+              // Process each issue
+              let closedCount = 0;
+              let labelRemovedCount = 0;
+              let skippedCount = 0;
+              
+              for (const issue of targetIssues) {
+                console.log(`\n📋 Processing #${issue.number}: ${issue.title}`);
+                
+                try {
+                  // Get label events to find when label was last added
+                  const { data: events } = await github.rest.issues.listEvents({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number
+                  });
+                  
+                  const labelEvents = events
+                    .filter(e => e.event === 'labeled' && e.label?.name === config.labelName)
+                    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+                  
+                  if (labelEvents.length === 0) {
+                    console.log(`⚠️ No label events found for #${issue.number}`);
+                    skippedCount++;
+                    continue;
+                  }
+                  
+                  const lastLabelAdded = new Date(labelEvents[0].created_at);
+                  const labelAdder = labelEvents[0].actor.login;
+                  
+                  // Check comments since label was added
+                  const { data: comments } = await github.rest.issues.listComments({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    since: lastLabelAdded.toISOString()
+                  });
+                  
+                  let hasUnauthorizedComment = false;
+                  
+                  for (const comment of comments) {
+                    // Skip comments from the person who added the label
+                    if (comment.user.login === labelAdder) continue;
+                    
+                    const isAuthorized = await isAuthorizedUser(comment.user.login);
+                    if (!isAuthorized) {
+                      console.log(`❌ New comment from ${comment.user.login}`);
+                      hasUnauthorizedComment = true;
+                      break;
+                    }
+                  }
+                  
+                  if (hasUnauthorizedComment) {
+                    // Remove label due to unauthorized comment (regardless of time elapsed)
+                    if (isDryRun) {
+                      console.log(`🧪 DRY-RUN: Would remove ${config.labelName} label from #${issue.number}`);
+                      if (config.replacementLabel) {
+                        console.log(`🧪 DRY-RUN: Would add ${config.replacementLabel} label to #${issue.number}`);
+                      }
+                    } else {
+                      await github.rest.issues.removeLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue.number,
+                        name: config.labelName
+                      });
+                      console.log(`🏷️ Removed ${config.labelName} label from #${issue.number}`);
+                      
+                      if (config.replacementLabel) {
+                        await github.rest.issues.addLabels({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: issue.number,
+                          labels: [config.replacementLabel]
+                        });
+                        console.log(`🏷️ Added ${config.replacementLabel} label to #${issue.number}`);
+                      }
+                    }
+                    labelRemovedCount++;
+                    continue;
+                  }
+                  
+                  // Check if enough time has passed for auto-close
+                  if (lastLabelAdded > cutoffDate) {
+                    const daysRemaining = Math.ceil((lastLabelAdded - cutoffDate) / (1000 * 60 * 60 * 24));
+                    console.log(`⏳ Label added too recently (${daysRemaining} days remaining)`);
+                    skippedCount++;
+                    continue;
+                  }
+                  
+                  // Close the issue (only if time has elapsed AND no unauthorized comments)
+                  if (isDryRun) {
+                    console.log(`🧪 DRY-RUN: Would close #${issue.number} with comment`);
+                    console.log(`🧪 DRY-RUN: Comment would be: "${CLOSE_MESSAGE}"`);
+                  } else {
+                    await github.rest.issues.createComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      body: CLOSE_MESSAGE
+                    });
+                    
+                    await github.rest.issues.update({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      state: 'closed'
+                    });
+                    
+                    console.log(`🔒 Closed #${issue.number}`);
+                  }
+                  closedCount++;
+                } catch (error) {
+                  console.log(`❌ Error processing #${issue.number}: ${error.message}`);
+                  skippedCount++;
+                }
+              }
+              
+              // Summary
+              console.log(`\n📊 Summary:`);
+              if (isDryRun) {
+                console.log(`   🧪 DRY-RUN MODE - No actual changes made:`);
+                console.log(`   • Issues that would be closed: ${closedCount}`);
+                console.log(`   • Labels that would be removed: ${labelRemovedCount}`);
+              } else {
+                console.log(`   • Issues closed: ${closedCount}`);
+                console.log(`   • Labels removed: ${labelRemovedCount}`);
+              }
+              console.log(`   • Issues skipped: ${skippedCount}`);
+              console.log(`   • Total processed: ${targetIssues.length}`);
+              
+            } catch (error) {
+              console.log(`❌ Failed to fetch issues: ${error.message}`);
+              throw error;
+            }


### PR DESCRIPTION
## Description
Adds two GitHub workflows to automatically manage stale issues with configurable timeouts.

Key features include 
• Environment variables for all settings (label names, timeouts, auth modes)
• Flexible authorization modes (user list or write permissions)
• Label removal when external users respond
• Optional replacement label when removing auto-close labels
• Support for issues, pull requests, or both
• Weekday-only scheduling (9 AM EST, Monday-Friday)

### Files Added
• .github/workflows/auto-close-3-days.yml - Auto-close workflow with 3-day timeout
• .github/workflows/auto-close-7-days.yml - Auto-close workflow with 7-day timeout

### Workflow Logic
1. Find Issues: Locate open issues with specified label
2. Check Comments: Analyze comments since the label was added
3. Remove label if external users commented.
4. Close issues after timeout if only authorized users commented.
5. Optional Labeling: Add replacement label when removing auto-close label

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

Tested on a forked branch, tested shadow mode, live mode, removal, and addition of labels.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
