### PR TITLE
feat: add region-aware default model ID for Bedrock

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 import os
+import warnings
 from typing import Any, AsyncGenerator, Callable, Iterable, Literal, Optional, Type, TypeVar, Union, cast
 
 import boto3
@@ -29,7 +30,7 @@ from .model import Model
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+DEFAULT_BEDROCK_MODEL_ID = "{}.anthropic.claude-sonnet-4-20250514-v1:0"
 DEFAULT_BEDROCK_REGION = "us-west-2"
 
 BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
@@ -46,6 +47,7 @@ _MODELS_INCLUDE_STATUS = [
 T = TypeVar("T", bound=BaseModel)
 
 DEFAULT_READ_TIMEOUT = 120
+
 
 class BedrockModel(Model):
     """AWS Bedrock model provider implementation.
@@ -129,12 +131,17 @@ class BedrockModel(Model):
         if region_name and boto_session:
             raise ValueError("Cannot specify both `region_name` and `boto_session`.")
 
-        self.config = BedrockModel.BedrockConfig(model_id=DEFAULT_BEDROCK_MODEL_ID, include_tool_result_status="auto")
+        session = boto_session or boto3.Session()
+        resolved_region = region_name or session.region_name or os.environ.get("AWS_REGION") or DEFAULT_BEDROCK_REGION
+        self.config = BedrockModel.BedrockConfig(
+            model_id=DEFAULT_BEDROCK_MODEL_ID.format(
+                BedrockModel.get_model_prefix_with_warning(resolved_region, model_config)
+            ),
+            include_tool_result_status="auto",
+        )
         self.update_config(**model_config)
 
         logger.debug("config=<%s> | initializing", self.config)
-
-        session = boto_session or boto3.Session()
 
         # Add strands-agents to the request user agent
         if boto_client_config:
@@ -149,8 +156,6 @@ class BedrockModel(Model):
             client_config = boto_client_config.merge(BotocoreConfig(user_agent_extra=new_user_agent))
         else:
             client_config = BotocoreConfig(user_agent_extra="strands-agents", read_timeout=DEFAULT_READ_TIMEOUT)
-
-        resolved_region = region_name or session.region_name or os.environ.get("AWS_REGION") or DEFAULT_BEDROCK_REGION
 
         self.client = session.client(
             service_name="bedrock-runtime",
@@ -763,3 +768,38 @@ class BedrockModel(Model):
             raise ValueError("No valid tool use or tool use input was found in the Bedrock response.")
 
         yield {"output": output_model(**output_response)}
+
+    @staticmethod
+    def get_model_prefix_with_warning(region_name: str, model_config: Optional[BedrockConfig] = None) -> str:
+        """Get model prefix for bedrock model based on region.
+
+        If the region is not **known** to support inference then we show a helpful warning
+        that compliments the exception that Bedrock will throw.
+        If the customer provided a model_id in their config then we should not
+        show any warnings as this is only for the **default** model we provide.
+
+        Args:
+            region_name (str): region for bedrock model
+            model_config (Optional[dict[str, Any]]): Model Config that caller passes in on init
+        """
+        prefix_infr_map = {"ap": "apac"}  # some inference endpoints can be a bit different then the region prefix
+        model_config = model_config or {}
+        prefix = "-".join(region_name.split("-")[:-2]).lower()  # handles `us-east-1` or `us-gov-east-1`
+        if prefix not in {"us", "eu", "ap"} and not model_config.get("model_id"):
+            warnings.warn(
+                f"""
+            ================== WARNING ==================
+
+                This region {region_name} does not support
+                our default inference endpoint: {DEFAULT_BEDROCK_MODEL_ID.format(prefix)}.
+                Update the agent to pass in a 'model_id' like so:
+                ```
+                Agent(..., model='valid_model_id', ...)
+                ````
+                Documentation: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+
+            ==================================================
+            """,
+                stacklevel=2,
+            )
+        return prefix_infr_map.get(prefix, prefix)

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -26,6 +26,9 @@ from strands.types.session import Session, SessionAgent, SessionMessage, Session
 from tests.fixtures.mock_session_repository import MockedSessionRepository
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
+# For unit testing we will use the the us inference
+FORMATTED_DEFAULT_MODEL_ID = DEFAULT_BEDROCK_MODEL_ID.format("us")
+
 
 @pytest.fixture
 def mock_randint():
@@ -211,7 +214,7 @@ def test_agent__init__with_default_model():
     agent = Agent()
 
     assert isinstance(agent.model, BedrockModel)
-    assert agent.model.config["model_id"] == DEFAULT_BEDROCK_MODEL_ID
+    assert agent.model.config["model_id"] == FORMATTED_DEFAULT_MODEL_ID
 
 
 def test_agent__init__with_explicit_model(mock_model):
@@ -891,7 +894,7 @@ def test_agent__del__(agent):
 def test_agent_init_with_no_model_or_model_id():
     agent = Agent()
     assert agent.model is not None
-    assert agent.model.get_config().get("model_id") == DEFAULT_BEDROCK_MODEL_ID
+    assert agent.model.get_config().get("model_id") == FORMATTED_DEFAULT_MODEL_ID
 
 
 def test_agent_tool_no_parameter_conflict(agent, tool_registry, mock_randint, agenerator):


### PR DESCRIPTION

## Description
- Format default model ID to use the inference for the region the user is using. If the region does not support inference endpoint then we show a helpful warning and allow the bedrock to throw an exception.
- Update tests to handle formatted default model ID


## Related Issues

#732 #804 #770 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->
Will create a separate pr for docs in the getting started example.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
