### PR TITLE
docs: improve docstring formatting

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -425,7 +425,7 @@ class Agent:
             **kwargs: Additional parameters to pass through the event loop.
 
         Returns:
-            Result object containing:
+            Result: object containing:
 
                 - stop_reason: Why the event loop stopped (e.g., "end_turn", "max_tokens")
                 - message: The final message from the model


### PR DESCRIPTION
## Description

Change in doctring for  [`invoke_async`](https://github.com/strands-agents/sdk-python/blob/main/src/strands/agent/agent.py#L410) function in `Agent` class for better VS Code hover view.

## Related Issues

No related issues.

## Type of Change

Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Miscellaneous

Previously:

<img width="947" height="386" alt="image" src="https://github.com/user-attachments/assets/14dbb44d-58f2-4fb9-be10-6b4e14bf2866" />

Now:

<img width="960" height="405" alt="image" src="https://github.com/user-attachments/assets/17a23540-cf03-4709-b906-941d6903a288" />

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
