### PR TITLE
models - openai - use client context

### DIFF
--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -8,14 +8,11 @@ from strands.models.openai import OpenAIModel
 
 
 @pytest.fixture
-def openai_client_cls():
+def openai_client():
     with unittest.mock.patch.object(strands.models.openai.openai, "AsyncOpenAI") as mock_client_cls:
-        yield mock_client_cls
-
-
-@pytest.fixture
-def openai_client(openai_client_cls):
-    return openai_client_cls.return_value
+        mock_client = unittest.mock.AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        yield mock_client
 
 
 @pytest.fixture
@@ -68,15 +65,13 @@ def test_output_model_cls():
     return TestOutputModel
 
 
-def test__init__(openai_client_cls, model_id):
-    model = OpenAIModel({"api_key": "k1"}, model_id=model_id, params={"max_tokens": 1})
+def test__init__(model_id):
+    model = OpenAIModel(model_id=model_id, params={"max_tokens": 1})
 
     tru_config = model.get_config()
     exp_config = {"model_id": "m1", "params": {"max_tokens": 1}}
 
     assert tru_config == exp_config
-
-    openai_client_cls.assert_called_once_with(api_key="k1")
 
 
 def test_update_config(model, model_id):


### PR DESCRIPTION
## Description
The OpenAI async client has an issue where making multiple requests with separate `asyncio.run()` calls causes the second request to fail with "Event loop is closed" error. The reason is that the client uses httpx internally, which maintains a connection pool that persists beyond individual event loops. This means connections created in the first event loop remain in the pool after that loop closes, and when the second `asyncio.run()` creates a new event loop, httpx tries to reuse those existing pooled connections that are still tied to the first event loop instead of the new event loop, thus causing a failure.

This is a problem for Strands as `Agent.__call__` runs `asyncio.run()` on every invocation. We have seen this problem before with the Mistral model provider ([PR](https://github.com/strands-agents/sdk-python/pull/434)).

The fix is to establish a new OpenAI client connection on every call to `stream`. This fits with the suggestion in https://github.com/openai/openai-python/issues/1254#issuecomment-2020181455 and the httpx [docs](https://www.python-httpx.org/async/).

## Related Issues

https://github.com/strands-agents/sdk-python/issues/604

## Documentation PR

N/A

## Type of Change

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Ran the customer script documented in https://github.com/strands-agents/sdk-python/issues/604. There are no longer any `RuntimeError: <asyncio.locks.Event object at 0x00000210EEF46650 [unset]> is bound to a different event loop` lines in the generated logs.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
