### PR TITLE
fix: Invoke callback handler for structured_output

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -514,8 +514,11 @@ class Agent:
                     )
                 events = self.model.structured_output(output_model, temp_messages, system_prompt=self.system_prompt)
                 async for event in events:
-                    if "callback" in event:
-                        self.callback_handler(**cast(dict, event["callback"]))
+                    if isinstance(event, TypedEvent):
+                        event.prepare(invocation_state={})
+                        if event.is_callback_event:
+                            self.callback_handler(**event.as_dict())
+
                 structured_output_span.add_event(
                     "gen_ai.choice", attributes={"message": serialize(event["output"].model_dump())}
                 )

--- a/tests/strands/agent/hooks/test_agent_events.py
+++ b/tests/strands/agent/hooks/test_agent_events.py
@@ -3,10 +3,12 @@ import unittest.mock
 from unittest.mock import ANY, MagicMock, call
 
 import pytest
+from pydantic import BaseModel
 
 import strands
 from strands import Agent
 from strands.agent import AgentResult
+from strands.models import BedrockModel
 from strands.types._events import TypedEvent
 from strands.types.exceptions import ModelThrottledException
 from tests.fixtures.mocked_model_provider import MockedModelProvider
@@ -440,3 +442,132 @@ async def test_event_loop_cycle_text_response_throttling_early_end(
     # Ensure that all events coming out of the agent are *not* typed events
     typed_events = [event for event in tru_events if isinstance(event, TypedEvent)]
     assert typed_events == []
+
+
+@pytest.mark.asyncio
+async def test_structured_output(agenerator):
+    # we use bedrock here as it uses the tool implementation
+    model = BedrockModel()
+    model.stream = MagicMock()
+    model.stream.return_value = agenerator(
+        [
+            {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": "tooluse_efwXnrK_S6qTyxzcq1IUMQ", "name": "Person"}},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": ""}}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"na'}}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": 'me"'}}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": ': "J'}}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": 'ohn"'}}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": ', "age": 3'}}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": "1}"}}, "contentBlockIndex": 0}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {
+                "metadata": {
+                    "usage": {"inputTokens": 407, "outputTokens": 53, "totalTokens": 460},
+                    "metrics": {"latencyMs": 1572},
+                }
+            },
+        ]
+    )
+
+    mock_callback = unittest.mock.Mock()
+    agent = Agent(model=model, callback_handler=mock_callback)
+
+    class Person(BaseModel):
+        name: str
+        age: float
+
+    await agent.structured_output_async(Person, "John is 31")
+
+    exp_events = [
+        {
+            "event": {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": "tooluse_efwXnrK_S6qTyxzcq1IUMQ", "name": "Person"}},
+                    "contentBlockIndex": 0,
+                }
+            }
+        },
+        {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": ""}}, "contentBlockIndex": 0}}},
+        {
+            "delta": {"toolUse": {"input": ""}},
+            "current_tool_use": {
+                "toolUseId": "tooluse_efwXnrK_S6qTyxzcq1IUMQ",
+                "name": "Person",
+                "input": {"name": "John", "age": 31},
+            },
+        },
+        {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"na'}}, "contentBlockIndex": 0}}},
+        {
+            "delta": {"toolUse": {"input": '{"na'}},
+            "current_tool_use": {
+                "toolUseId": "tooluse_efwXnrK_S6qTyxzcq1IUMQ",
+                "name": "Person",
+                "input": {"name": "John", "age": 31},
+            },
+        },
+        {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": 'me"'}}, "contentBlockIndex": 0}}},
+        {
+            "delta": {"toolUse": {"input": 'me"'}},
+            "current_tool_use": {
+                "toolUseId": "tooluse_efwXnrK_S6qTyxzcq1IUMQ",
+                "name": "Person",
+                "input": {"name": "John", "age": 31},
+            },
+        },
+        {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": ': "J'}}, "contentBlockIndex": 0}}},
+        {
+            "delta": {"toolUse": {"input": ': "J'}},
+            "current_tool_use": {
+                "toolUseId": "tooluse_efwXnrK_S6qTyxzcq1IUMQ",
+                "name": "Person",
+                "input": {"name": "John", "age": 31},
+            },
+        },
+        {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": 'ohn"'}}, "contentBlockIndex": 0}}},
+        {
+            "delta": {"toolUse": {"input": 'ohn"'}},
+            "current_tool_use": {
+                "toolUseId": "tooluse_efwXnrK_S6qTyxzcq1IUMQ",
+                "name": "Person",
+                "input": {"name": "John", "age": 31},
+            },
+        },
+        {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": ', "age": 3'}}, "contentBlockIndex": 0}}},
+        {
+            "delta": {"toolUse": {"input": ', "age": 3'}},
+            "current_tool_use": {
+                "toolUseId": "tooluse_efwXnrK_S6qTyxzcq1IUMQ",
+                "name": "Person",
+                "input": {"name": "John", "age": 31},
+            },
+        },
+        {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": "1}"}}, "contentBlockIndex": 0}}},
+        {
+            "delta": {"toolUse": {"input": "1}"}},
+            "current_tool_use": {
+                "toolUseId": "tooluse_efwXnrK_S6qTyxzcq1IUMQ",
+                "name": "Person",
+                "input": {"name": "John", "age": 31},
+            },
+        },
+        {"event": {"contentBlockStop": {"contentBlockIndex": 0}}},
+        {"event": {"messageStop": {"stopReason": "tool_use"}}},
+        {
+            "event": {
+                "metadata": {
+                    "usage": {"inputTokens": 407, "outputTokens": 53, "totalTokens": 460},
+                    "metrics": {"latencyMs": 1572},
+                }
+            }
+        },
+    ]
+
+    exp_calls = [call(**event) for event in exp_events]
+    act_calls = mock_callback.call_args_list
+    assert act_calls == exp_calls


### PR DESCRIPTION

## Description

In the switch to typed_events, the case of structured_output invoking the callback handler was missed, resulting in a break in backwards compatibility (see issue #831); this restores the old behavior/fixes backwards compatibility

> [!IMPORTANT] 
> I'm not sure we want this behavior


I'm not entirely convinced we want this behavior - compared to the other callback handlers, the events emitted from `Agent.structured_output` are very provider & implementation-specific.  For instance:
 - Right now bedrock emits a bunch of events because we implemented via tools; if we changed that, the events emitted would change.  
 - The other providers (like OpenAI) do *not* emit *any* events as they provide apis to perform structured_output

I would like to discuss further with the team regarding the issue; I see a couple of paths forward:

1.  We merge this fix in for backwards compatibility 
2.  We decide that callback_handlers should not be invoked for structured_output
3. We decide (2) is correct, but (1) and revert this in 2.0

### Testing

I tested the events emitted before and after typed events were introduced and the test passed in both cases.

## Related Issues

#831 

## Documentation PR

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
