### PR TITLE
fix: Update prepare to use format instead of test-format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ test = "hatch test {args}"
 test-integ = "hatch test tests_integ {args}"
 
 prepare = [
-    "hatch run test-format",
+    "hatch run format",
     "hatch run test-lint",
     "hatch test --all"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ test-integ = "hatch test tests_integ {args}"
 
 prepare = [
     "hatch run format",
+    "hatch run lint",
     "hatch run test-lint",
     "hatch test --all"
 ]


### PR DESCRIPTION

## Description

`hatch run prepare` should prep all the files to ensure it's ready for a PR, so switch it to format files instead of testing the format. Otherwise it just quits with output of the files that need to be formatted

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
