### PR TITLE
fix: litellm structured_output test with more descriptive model

### DIFF
--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -204,6 +204,9 @@ class LiteLLMModel(OpenAIModel):
         Yields:
             Model events with the last being the structured output.
         """
+        if not supports_response_schema(self.get_config()["model_id"]):
+            raise ValueError("Model does not support response_format")
+
         response = await litellm.acompletion(
             **self.client_args,
             model=self.get_config()["model_id"],
@@ -211,11 +214,9 @@ class LiteLLMModel(OpenAIModel):
             response_format=output_model,
         )
 
-        if not supports_response_schema(self.get_config()["model_id"]):
-            raise ValueError("Model does not support response_format")
         if len(response.choices) > 1:
             raise ValueError("Multiple choices found in the response.")
-
+        
         # Find the first choice with tool_calls
         for choice in response.choices:
             if choice.finish_reason == "tool_calls":

--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -216,7 +216,7 @@ class LiteLLMModel(OpenAIModel):
 
         if len(response.choices) > 1:
             raise ValueError("Multiple choices found in the response.")
-        
+
         # Find the first choice with tool_calls
         for choice in response.choices:
             if choice.finish_reason == "tool_calls":

--- a/tests/strands/models/test_litellm.py
+++ b/tests/strands/models/test_litellm.py
@@ -289,6 +289,18 @@ async def test_structured_output(litellm_acompletion, model, test_output_model_c
     assert tru_result == exp_result
 
 
+@pytest.mark.asyncio
+async def test_structured_output_unsupported_model(litellm_acompletion, model, test_output_model_cls):
+    messages = [{"role": "user", "content": [{"text": "Generate a person"}]}]
+
+    with unittest.mock.patch.object(strands.models.litellm, "supports_response_schema", return_value=False):
+        with pytest.raises(ValueError, match="Model does not support response_format"):
+            stream = model.structured_output(test_output_model_cls, messages)
+            await stream.__anext__()
+
+    litellm_acompletion.assert_not_called()
+
+
 def test_config_validation_warns_on_unknown_keys(litellm_acompletion, captured_warnings):
     """Test that unknown config keys emit a warning."""
     LiteLLMModel(client_args={"api_key": "test"}, model_id="test-model", invalid_param="test")

--- a/tests_integ/models/test_model_litellm.py
+++ b/tests_integ/models/test_model_litellm.py
@@ -34,8 +34,8 @@ def weather():
     class Weather(pydantic.BaseModel):
         """Extracts the time and weather from the user's message with the exact strings."""
 
-        time: str
-        weather: str
+        time: str = pydantic.Field(description="The time in HH:MM format (e.g., '12:00', '09:30')")
+        weather: str = pydantic.Field(description="The weather condition (e.g., 'sunny', 'rainy', 'cloudy')")
 
     return Weather(time="12:00", weather="sunny")
 

--- a/tests_integ/models/test_model_litellm.py
+++ b/tests_integ/models/test_model_litellm.py
@@ -44,13 +44,13 @@ def weather():
 def yellow_color():
     class Color(pydantic.BaseModel):
         """Describes a color with its basic name.
-        
+
         Used to extract and normalize color names from text or images.
         The color name should be a simple, common color like 'red', 'blue', 'yellow', etc.
         """
 
         simple_color_name: str = pydantic.Field(
-            description="The basic color name (e.g., 'red', 'blue', 'yellow', 'green', 'orange', 'purple', 'black', 'white')"
+            description="The basic color name (e.g., 'red', 'blue', 'yellow', 'green', 'orange', 'purple')"
         )
 
         @pydantic.field_validator("simple_color_name", mode="after")

--- a/tests_integ/models/test_model_litellm.py
+++ b/tests_integ/models/test_model_litellm.py
@@ -43,16 +43,22 @@ def weather():
 @pytest.fixture
 def yellow_color():
     class Color(pydantic.BaseModel):
-        """Describes a color."""
+        """Describes a color with its basic name.
+        
+        Used to extract and normalize color names from text or images.
+        The color name should be a simple, common color like 'red', 'blue', 'yellow', etc.
+        """
 
-        name: str
+        simple_color_name: str = pydantic.Field(
+            description="The basic color name (e.g., 'red', 'blue', 'yellow', 'green', 'orange', 'purple', 'black', 'white')"
+        )
 
-        @pydantic.field_validator("name", mode="after")
+        @pydantic.field_validator("simple_color_name", mode="after")
         @classmethod
         def lower(_, value):
             return value.lower()
 
-    return Color(name="yellow")
+    return Color(simple_color_name="yellow")
 
 
 def test_agent_invoke(agent):


### PR DESCRIPTION
## Description

Our integ test has been failing for some time.  I am not certain what changed but my expectation is it is the quality of the underlying model. To fix this I made the pydantic model more descriptive. I am comfortable with this rather than diving deeper on a fix because the change did not modify our test logic at all. Rather, this simply provides more context to the llm.

## Type of Change

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
