### PR TITLE
fix(mcp): do not verify _background_session is present in stop()

### DIFF
--- a/tests_integ/test_mcp_client.py
+++ b/tests_integ/test_mcp_client.py
@@ -297,3 +297,4 @@ def test_mcp_client_timeout_integration():
     with client:
         tools = client.list_tools_sync()
         assert len(tools) >= 0  # Should work now
+


### PR DESCRIPTION
## Description

There was a race condition in #833, where if the session never got set we triggered the exception in 

```
    def _invoke_on_background_thread(self, coro: Coroutine[Any, Any, T]) -> futures.Future[T]:
        if self._background_thread_session is None or self._background_thread_event_loop is None:
            raise MCPClientInitializationError("the client session was not initialized")
        return asyncio.run_coroutine_threadsafe(coro=coro, loop=self._background_thread_event_loop)
```

The fix here is that we actually do not need to check for the existence of the _background_thread_session. The `_invoke_on_background_thread` is more so targeted for post-connection operations so it validates. But for `stop()` we just want to set the `_close_event` which does not depend on the session existing. 

It is possible that the session has died in `_async_background_thread`. But in this case setting the `_close_event` does nothing and we will still safely `join()` the thread.

## Related Issues
#833 

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
