### PR TITLE
[DRAFT] tool interrupt

### DIFF
--- a/src/strands/agent/agent_result.py
+++ b/src/strands/agent/agent_result.py
@@ -4,8 +4,9 @@ This module defines the AgentResult class which encapsulates the complete respon
 """
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
+from ..hooks.interrupt import Interrupt
 from ..telemetry.metrics import EventLoopMetrics
 from ..types.content import Message
 from ..types.streaming import StopReason
@@ -26,6 +27,7 @@ class AgentResult:
     message: Message
     metrics: EventLoopMetrics
     state: Any
+    interrupts: Optional[list[Interrupt]] = None
 
     def __str__(self) -> str:
         """Get the agent's last message as a string.

--- a/src/strands/agent/execution_state.py
+++ b/src/strands/agent/execution_state.py
@@ -1,0 +1,14 @@
+"""Agent execution state."""
+
+from enum import Enum
+
+
+class ExecutionState(Enum):
+    """Represents the current execution state of an agent.
+
+    ASSISTANT: Agent is waiting for user message (default).
+    INTERRUPT: Agent is waiting for user feedback to resume tool execution.
+    """
+    
+    ASSISTANT = "assistant"
+    INTERRUPT = "interrupt"

--- a/src/strands/experimental/hooks/events.py
+++ b/src/strands/experimental/hooks/events.py
@@ -7,13 +7,14 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 from ...hooks import HookEvent
+from ...hooks.interrupt import InterruptEvent
 from ...types.content import Message
 from ...types.streaming import StopReason
 from ...types.tools import AgentTool, ToolResult, ToolUse
 
 
 @dataclass
-class BeforeToolInvocationEvent(HookEvent):
+class BeforeToolInvocationEvent(HookEvent, InterruptEvent):
     """Event triggered before a tool is invoked.
 
     This event is fired just before the agent executes a tool, allowing hook
@@ -26,14 +27,17 @@ class BeforeToolInvocationEvent(HookEvent):
             to change which tool gets executed. This may be None if tool lookup failed.
         tool_use: The tool parameters that will be passed to selected_tool.
         invocation_state: Keyword arguments that will be passed to the tool.
+        cancel: A user defined message that when set, will lead to canceling of the tool call.
+            The message is used to populate a tool result with status "error".
     """
 
     selected_tool: Optional[AgentTool]
     tool_use: ToolUse
     invocation_state: dict[str, Any]
+    cancel: Optional[str] = None
 
     def _can_write(self, name: str) -> bool:
-        return name in ["selected_tool", "tool_use"]
+        return name in ["cancel", "interrupt", "selected_tool", "tool_use"]
 
 
 @dataclass

--- a/src/strands/hooks/interrupt.py
+++ b/src/strands/hooks/interrupt.py
@@ -1,0 +1,37 @@
+"""<TODO>."""
+import abc
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Interrupt:
+    """<TODO>."""
+
+    name: str
+    reasons: list[Any]
+    resume: Any = None
+    activated: bool = False
+
+    def __call__(self, reason: Any) -> Any:
+        """<TODO>."""
+        if self.resume:
+            self.activated = False
+            return self.resume
+
+        self.reasons.append(reason)
+        self.activated = True
+        raise InterruptException(self)
+
+
+class InterruptException(Exception):
+    """<TODO>."""
+    def __init__(self, interrupt: Interrupt) -> None:
+        self.interrupt = interrupt
+
+
+@dataclass
+class InterruptEvent:
+    """<TODO>."""
+
+    interrupt: Interrupt

--- a/src/strands/hooks/registry.py
+++ b/src/strands/hooks/registry.py
@@ -10,6 +10,8 @@ via hook provider objects.
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generator, Generic, Protocol, Type, TypeVar
 
+from .interrupt import InterruptException
+
 if TYPE_CHECKING:
     from ..agent import Agent
 
@@ -200,7 +202,10 @@ class HookRegistry:
             ```
         """
         for callback in self.get_callbacks_for(event):
-            callback(event)
+            try:
+                callback(event)
+            except InterruptException:
+                pass
 
         return event
 

--- a/src/strands/tools/executors/concurrent.py
+++ b/src/strands/tools/executors/concurrent.py
@@ -72,7 +72,7 @@ class ConcurrentToolExecutor(ToolExecutor):
             yield event
             task_events[task_id].set()
 
-        asyncio.gather(*tasks)
+        await asyncio.gather(*tasks)
 
     async def _task(
         self,

--- a/src/strands/tools/executors/sequential.py
+++ b/src/strands/tools/executors/sequential.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator
 from typing_extensions import override
 
 from ...telemetry.metrics import Trace
-from ...types._events import TypedEvent
+from ...types._events import ToolInterruptEvent, TypedEvent
 from ...types.tools import ToolResult, ToolUse
 from ._executor import ToolExecutor
 
@@ -45,3 +45,6 @@ class SequentialToolExecutor(ToolExecutor):
             )
             async for event in events:
                 yield event
+
+            if isinstance(event, ToolInterruptEvent):
+                break

--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -5,10 +5,11 @@ providing a structured way to observe to different events of the event loop and
 agent lifecycle.
 """
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from typing_extensions import override
 
+from ..hooks.interrupt import Interrupt
 from ..telemetry import EventLoopMetrics
 from .citations import Citation
 from .content import Message
@@ -220,6 +221,7 @@ class EventLoopStopEvent(TypedEvent):
         message: Message,
         metrics: "EventLoopMetrics",
         request_state: Any,
+        interrupts: Optional[list[Interrupt]] = None
     ) -> None:
         """Initialize with the final execution results.
 
@@ -228,8 +230,9 @@ class EventLoopStopEvent(TypedEvent):
             message: Final message from the model
             metrics: Execution metrics and performance data
             request_state: Final state of the agent execution
+            interrupts: TODO.
         """
-        super().__init__({"stop": (stop_reason, message, metrics, request_state)})
+        super().__init__({"stop": (stop_reason, message, metrics, request_state, interrupts)})
 
     @property
     @override
@@ -296,6 +299,14 @@ class ToolStreamEvent(TypedEvent):
     def tool_use_id(self) -> str:
         """The toolUseId associated with this stream."""
         return cast(str, cast(ToolUse, cast(dict, self.get("tool_stream_event")).get("tool_use")).get("toolUseId"))
+
+
+class ToolInterruptEvent(TypedEvent):
+    """Event emitted when a tool is interrupted."""
+
+    def __init__(self, interrupt: Interrupt) -> None:
+        """TODO."""
+        super().__init__({"tool_interrupt_event": {"interrupt": interrupt}})
 
 
 class ModelMessageEvent(TypedEvent):

--- a/src/strands/types/agent.py
+++ b/src/strands/types/agent.py
@@ -7,4 +7,4 @@ from typing import TypeAlias
 
 from .content import ContentBlock, Messages
 
-AgentInput: TypeAlias = str | list[ContentBlock] | Messages | None
+AgentInput: TypeAlias = str | ContentBlock | list[ContentBlock] | Messages | None

--- a/src/strands/types/content.py
+++ b/src/strands/types/content.py
@@ -6,7 +6,7 @@ SDK. These types are modeled after the Bedrock API.
 - Bedrock docs: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Types_Amazon_Bedrock_Runtime.html
 """
 
-from typing import Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from typing_extensions import TypedDict
 
@@ -80,6 +80,7 @@ class ContentBlock(TypedDict, total=False):
         guardContent: Contains the content to assess with the guardrail.
         image: Image to include in the message.
         reasoningContent: Contains content regarding the reasoning that is carried out by the model.
+        resume: TODO
         text: Text to include in the message.
         toolResult: The result for a tool request that a model makes.
         toolUse: Information about a tool use request from a model.
@@ -92,6 +93,7 @@ class ContentBlock(TypedDict, total=False):
     guardContent: GuardContent
     image: ImageContent
     reasoningContent: ReasoningContentBlock
+    resume: dict[str, Any]
     text: str
     toolResult: ToolResult
     toolUse: ToolUse

--- a/src/strands/types/event_loop.py
+++ b/src/strands/types/event_loop.py
@@ -37,6 +37,7 @@ StopReason = Literal[
     "content_filtered",
     "end_turn",
     "guardrail_intervened",
+    "interrupt",
     "max_tokens",
     "stop_sequence",
     "tool_use",
@@ -46,6 +47,7 @@ StopReason = Literal[
 - "content_filtered": Content was filtered due to policy violation
 - "end_turn": Normal completion of the response
 - "guardrail_intervened": Guardrail system intervened
+- "interrupt": Agent was interrupted
 - "max_tokens": Maximum token limit reached
 - "stop_sequence": Stop sequence encountered
 - "tool_use": Model requested to use a tool

--- a/src/strands/types/tools.py
+++ b/src/strands/types/tools.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Lite
 
 from typing_extensions import TypedDict
 
+from ..hooks.interrupt import Interrupt
 from .media import DocumentContent, ImageContent
 
 if TYPE_CHECKING:
@@ -134,6 +135,7 @@ class ToolContext:
                model configuration, and other agent state.
         invocation_state: Caller-provided kwargs that were passed to the agent when it was invoked (agent(),
                           agent.invoke_async(), etc.).
+        interrupt: TODO
 
     Note:
         This class is intended to be instantiated by the SDK. Direct construction by users
@@ -143,6 +145,7 @@ class ToolContext:
     tool_use: ToolUse
     agent: "Agent"
     invocation_state: dict[str, Any]
+    interrupt: Interrupt
 
 
 # Individual ToolChoice type aliases


### PR DESCRIPTION
## Description
Support interrupting tool calls to ask for human feedback.
- Users can interrupt from their BeforeToolInvocationEvent hooks and their python tools.
- Interrupting places the agent in an interrupt state.
- The result returned from the agent contains an "interrupt" stop reason along with a list of the interrupt instances.
- Users parse the reasons from the interrupt reasons to construct a resume prompt.
- Users pass a resume prompt to agent invoke when ready. This resume prompt contains the context needed to continue the tool execution.

For more details, see Usage section below and comments under "Files changed".

## Related Issues

https://github.com/strands-agents/sdk-python/issues/204

## Documentation PR

TODO

## Usage

```Python
import json
from typing import Any

from strands import Agent, tool
from strands.agent import AgentResult
from strands.experimental.hooks import BeforeToolInvocationEvent
from strands.hooks import HookProvider, HookRegistry
from strands.session import FileSessionManager
from strands.types.agent import AgentInput


@tool
def delete_tool(key: str) -> bool:
    print("DELETE_TOOL | deleting")
    return True


class ToolInterruptHook(HookProvider):
    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
        registry.add_callback(BeforeToolInvocationEvent, self.approve)

    def approve(self, event: BeforeToolInvocationEvent):
        if event.tool_use["name"] != "delete_tool":
            return

        approval = event.interrupt("APPROVAL")
        if approval != "A":
            event.cancel = "approval was not granted"


def server(agent: Agent, prompt: AgentInput) -> AgentResult:
    return agent(prompt)


def client(agent: Agent, key: str) -> dict[str, Any]:
    prompt = f"Can you delete object with key {key}"

    while True:
        result = server(agent, prompt)

        match result.stop_reason:
            case "interrupt":
                interrupts = result.interrupts
                print(f"CLIENT | interrupts=<{interrupts}> | processing interrupts")

                resume = {
                    interrupt.name: input(f"(A)PPROVE or (R)EJECT {interrupt.name}: ")
                    for interrupt in interrupts
                }
                prompt = {"resume": resume}

            case _:
                return json.dumps(result.message, indent=2)


def app() -> None:
    agent = Agent(
        hooks=[ToolInterruptHook()],
        tools=[delete_tool],
        system_prompt="You delete objects given their keys.",
        callback_handler=None,
    )
    response = client(agent, key="X")
    print(f"APP | {response}")


if __name__ == "__main__":
    app()
```

## Type of Change

New feature

## Testing

TODO

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
