### PR TITLE
fix(mcp): add meta field to MCPToolResult for MCP _meta support

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -443,15 +443,21 @@ class MCPClient:
         """
         if isinstance(content, MCPTextContent):
             self._log_debug_with_thread("mapping MCP text content")
-            return {"text": content.text}
+            result = {"text": content.text}
+            if content.meta is not None:
+                result["_meta"] = content.meta
+            return result
         elif isinstance(content, MCPImageContent):
             self._log_debug_with_thread("mapping MCP image content with mime type: %s", content.mimeType)
-            return {
+            result = {
                 "image": {
                     "format": MIME_TO_FORMAT[content.mimeType],
                     "source": {"bytes": base64.b64decode(content.data)},
                 }
             }
+            if content.meta is not None:
+                result["_meta"] = content.meta
+            return result
         else:
             self._log_debug_with_thread("unhandled content type: %s - dropping content", content.__class__.__name__)
             return None

--- a/src/strands/types/tools.py
+++ b/src/strands/types/tools.py
@@ -7,7 +7,7 @@ These types are modeled after the Bedrock API.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Literal, Protocol, Union
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Literal, Protocol, Union, NotRequired, Dict
 
 from typing_extensions import TypedDict
 
@@ -68,12 +68,14 @@ class ToolResultContent(TypedDict, total=False):
         document: Document content returned by the tool.
         image: Image content returned by the tool.
         json: JSON-serializable data returned by the tool.
+        meta: meta content returned by the tool.
         text: Text content returned by the tool.
     """
 
     document: DocumentContent
     image: ImageContent
     json: Any
+    meta: NotRequired[Dict[str, Any]]
     text: str
 
 

--- a/src/strands/types/tools.py
+++ b/src/strands/types/tools.py
@@ -68,14 +68,14 @@ class ToolResultContent(TypedDict, total=False):
         document: Document content returned by the tool.
         image: Image content returned by the tool.
         json: JSON-serializable data returned by the tool.
-        meta: meta content returned by the tool.
+        _meta: meta content returned by the tool.
         text: Text content returned by the tool.
     """
 
     document: DocumentContent
     image: ImageContent
     json: Any
-    meta: NotRequired[Dict[str, Any]]
+    _meta: NotRequired[Dict[str, Any]]
     text: str
 
 


### PR DESCRIPTION
## Description
#881
Add a new `meta` field to [ToolResultContent](https://github.com/strands-agents/sdk-python/blob/main/src/strands/types/tools.py#L84)
```python
meta: NotRequired[Dict[str, Any]]
```
Include the new MCP feature field `_meta` in the returned fields of [_map_mcp_content_to_tool_result_content](https://github.com/strands-agents/sdk-python/blob/main/src/strands/tools/mcp/mcp_client.py#L429)

```python
result = {"text": content.text}
if content.meta is not None:
    result["_meta"] = content.meta
return result
```

I believe adding the `meta` field to ToolResultContent aligns with MCP's design principles.
```python
# mcp sdk
ContentBlock = TextContent | ImageContent | AudioContent | ResourceLink | EmbeddedResource

class CallToolResult(Result):
    """The server's response to a tool call."""

    content: list[ContentBlock]
    structuredContent: dict[str, Any] | None = None
    """An optional JSON object that represents the structured result of the tool call."""
    isError: bool = False

class TextContent(BaseModel):
    """Text content for a message."""

    type: Literal["text"]
    text: str
    """The text content of the message."""
    annotations: Annotations | None = None
    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
```
This is the official MCP SDK's return for a tool call, where `content` is a list that stores ContentBlocks, and ContentBlock includes a `_meta` field.

```python
# strands
class ToolResultContent(TypedDict, total=False):

    document: DocumentContent
    image: ImageContent
    json: Any
    meta: NotRequired[Dict[str, Any]] # new field
    text: str

class MCPToolResult(ToolResult):
    content: list[ToolResultContent]
    status: ToolResultStatus
    toolUseId: str
    structuredContent: NotRequired[Dict[str, Any]]
```
The `content` attribute of ToolResult is of type `list[ToolResultContent]`. Previously, ToolResultContent lacked the `meta` field, so this update introduces that change.

Do not include this in the LLM's response, as it is an MCP business parameter that can be used to carry the token usage for tool execution.  
I handle the business parameter in the meta field by implementing `AfterToolInvocationEvent` and using it in the post hook.

## Related Issues

[Issues #881](https://github.com/strands-agents/sdk-python/issues/881)

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. 