### PR TITLE
feat: implement concurrent message reading for session managers

### DIFF
--- a/src/strands/session/file_session_manager.py
+++ b/src/strands/session/file_session_manager.py
@@ -1,5 +1,6 @@
 """File-based session manager for local filesystem storage."""
 
+import asyncio
 import json
 import logging
 import os
@@ -231,11 +232,20 @@ class FileSessionManager(RepositorySessionManager, SessionRepository):
         else:
             message_files = message_files[offset:]
 
-        # Load only the message files
-        messages: list[SessionMessage] = []
-        for filename in message_files:
+        return asyncio.run(self._load_messages_concurrently(messages_dir, message_files))
+
+    async def _load_messages_concurrently(self, messages_dir: str, message_files: list[str]) -> list[SessionMessage]:
+        """Load multiple message files concurrently using async."""
+        if not message_files:
+            return []
+
+        async def load_message(filename: str) -> SessionMessage:
             file_path = os.path.join(messages_dir, filename)
-            message_data = self._read_file(file_path)
-            messages.append(SessionMessage.from_dict(message_data))
+            loop = asyncio.get_event_loop()
+            message_data = await loop.run_in_executor(None, self._read_file, file_path)
+            return SessionMessage.from_dict(message_data)
+
+        tasks = [load_message(filename) for filename in message_files]
+        messages = await asyncio.gather(*tasks)
 
         return messages


### PR DESCRIPTION
## Description
Replace sequential message loading with async concurrent reading in both S3SessionManager and FileSessionManager to improve performance for long conversations. Uses asyncio.gather() with run_in_executor() to read multiple messages simultaneously while maintaining proper ordering.

## Related Issues

Resolves: #874

## Type of Change
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
