### PR TITLE
fix: Fix github workflow to use fmt instead of hatch run

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -90,5 +90,5 @@ jobs:
 
       - name: Run lint
         id: lint
-        run: hatch run test-lint
+        run: hatch fmt --linter --check
         continue-on-error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@ repos:
     hooks:
       - id: hatch-format
         name: Format code
-        entry: hatch run test-format
+        entry: hatch fmt --formatter --check
         language: system
         pass_filenames: false
         types: [python]
         stages: [pre-commit]
       - id: hatch-lint
         name: Lint code
-        entry: hatch run test-lint
+        entry: hatch fmt --linter --check
         language: system
         pass_filenames: false
         types: [python]


### PR DESCRIPTION
## Description
There is a bug in click which is impacting `hatch run`: https://github.com/pypa/hatch/issues/2052

This pr updates our automation to use `hatch fmt` instead of `hatch run` to help avoid this issue while its fixed.

## Related Issues

https://github.com/pypa/hatch/issues/2052

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
