### PR TITLE
fix(models): make tool_choice an optional keyword arg instead positional

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -370,6 +370,7 @@ class AnthropicModel(Model):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -571,6 +571,7 @@ class BedrockModel(Model):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:

--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -114,6 +114,7 @@ class LiteLLMModel(OpenAIModel):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:

--- a/src/strands/models/llamaapi.py
+++ b/src/strands/models/llamaapi.py
@@ -330,6 +330,7 @@ class LlamaAPIModel(Model):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:

--- a/src/strands/models/llamacpp.py
+++ b/src/strands/models/llamacpp.py
@@ -513,6 +513,7 @@ class LlamaCppModel(Model):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:

--- a/src/strands/models/mistral.py
+++ b/src/strands/models/mistral.py
@@ -397,6 +397,7 @@ class MistralModel(Model):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -70,6 +70,7 @@ class Model(abc.ABC):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncIterable[StreamEvent]:

--- a/src/strands/models/ollama.py
+++ b/src/strands/models/ollama.py
@@ -287,6 +287,7 @@ class OllamaModel(Model):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:

--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -357,6 +357,7 @@ class OpenAIModel(Model):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:

--- a/src/strands/models/sagemaker.py
+++ b/src/strands/models/sagemaker.py
@@ -292,6 +292,7 @@ class SageMakerAIModel(OpenAIModel):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:

--- a/src/strands/models/writer.py
+++ b/src/strands/models/writer.py
@@ -355,6 +355,7 @@ class WriterModel(Model):
         messages: Messages,
         tool_specs: Optional[list[ToolSpec]] = None,
         system_prompt: Optional[str] = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:


### PR DESCRIPTION
## Description

The release of v1.8.0 introduced [tool_choice to the Model interface to better support structured_output](https://github.com/strands-agents/sdk-python/pull/720). This was accidentally added as a positional argument instead of a keyword argument. This is breaking for custom implementations of the Model interface.

The fix here is to switch to an optional keyword arg.

## Type of Change

Bug fix
Breaking change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
