### PR TITLE
feat: add supports_hot_reload property to PythonAgentTool

### DIFF
--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -190,6 +190,15 @@ class PythonAgentTool(AgentTool):
         return self._tool_spec
 
     @property
+    def supports_hot_reload(self) -> bool:
+        """Check if this tool supports automatic reloading when modified.
+
+        Returns:
+            Always true for function-based tools.
+        """
+        return True
+
+    @property
     def tool_type(self) -> str:
         """Identifies this as a Python-based tool implementation.
 

--- a/tests/strands/tools/test_registry.py
+++ b/tests/strands/tools/test_registry.py
@@ -124,8 +124,16 @@ def test_process_tools_flattens_lists_and_tuples_and_sets():
 
 def test_register_tool_duplicate_name_without_hot_reload():
     """Test that registering a tool with duplicate name raises ValueError when hot reload is not supported."""
-    tool_1 = PythonAgentTool(tool_name="duplicate_tool", tool_spec=MagicMock(), tool_func=lambda: None)
-    tool_2 = PythonAgentTool(tool_name="duplicate_tool", tool_spec=MagicMock(), tool_func=lambda: None)
+    # Create mock tools that don't support hot reload
+    tool_1 = MagicMock()
+    tool_1.tool_name = "duplicate_tool"
+    tool_1.supports_hot_reload = False
+    tool_1.is_dynamic = False
+
+    tool_2 = MagicMock()
+    tool_2.tool_name = "duplicate_tool"
+    tool_2.supports_hot_reload = False
+    tool_2.is_dynamic = False
 
     tool_registry = ToolRegistry()
     tool_registry.register_tool(tool_1)

--- a/tests/strands/tools/test_tools.py
+++ b/tests/strands/tools/test_tools.py
@@ -487,7 +487,7 @@ def test_tool_type(identity_tool):
 
 @pytest.mark.parametrize("identity_tool", ["identity_invoke", "identity_invoke_async"], indirect=True)
 def test_supports_hot_reload(identity_tool):
-    assert not identity_tool.supports_hot_reload
+    assert identity_tool.supports_hot_reload
 
 
 @pytest.mark.parametrize("identity_tool", ["identity_invoke", "identity_invoke_async"], indirect=True)


### PR DESCRIPTION
I've noticed that in our module based tools, we're not setting the `supports_hot_reload` property, which leads to not hot-reload those tools.

- Add supports_hot_reload property that returns True for function-based tools
- This enables proper hot reload support for TOOL_SPEC + function() pattern tools
- Aligns with the conditional check in PR #772 for tool reloading logic

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
