### PR TITLE
refactor(registry): optimize variable naming

### DIFF
--- a/src/strands/tools/registry.py
+++ b/src/strands/tools/registry.py
@@ -202,7 +202,7 @@ class ToolRegistry:
 
             matching_tools = [
                 tool_name
-                for (tool_name, tool) in self.registry.items()
+                for (tool_name, _) in self.registry.items()
                 if tool_name.replace("-", "_") == normalized_name
             ]
 


### PR DESCRIPTION
## Description
Replace variable names that were declared but not utilized with _, following Python's standard convention for unused variables

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
