### PR TITLE
feat(mcp): Add a new field _meta to MCPToolResult

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -372,6 +372,7 @@ class MCPClient:
             status=status,
             toolUseId=tool_use_id,
             content=mapped_contents,
+            _meta=call_tool_result.meta,
         )
 
         if call_tool_result.structuredContent:

--- a/src/strands/tools/mcp/mcp_types.py
+++ b/src/strands/tools/mcp/mcp_types.py
@@ -55,9 +55,12 @@ class MCPToolResult(ToolResult):
     that provides structured results beyond the standard text/image/document content.
 
     Attributes:
+        _meta:
+            See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+            for notes on _meta usage.
         structuredContent: Optional JSON object containing structured data returned
             by the MCP tool. This allows MCP tools to return complex data structures
             that can be processed programmatically by agents or other tools.
     """
-
+    _meta: NotRequired[Dict[str, Any]]
     structuredContent: NotRequired[Dict[str, Any]]


### PR DESCRIPTION
## Description
#881

```python
# file:src/strands/tools/mcp/mcp_types.py
# because it is a TypedDict, we use `_meta` instead of `meta`.
class MCPToolResult(ToolResult):
    _meta: NotRequired[Dict[str, Any]]  # add logic,
    structuredContent: NotRequired[Dict[str, Any]]

# file:src/strands/tools/mcp/mcp_client.py
# method:_handle_tool_result
result = MCPToolResult(
    status=status,
    toolUseId=tool_use_id,
    content=mapped_contents,
    _meta=call_tool_result.meta,  # add logic
)
```

## Related Issues

[Issues #881](https://github.com/strands-agents/sdk-python/issues/881)

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug fix

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
