### PR TITLE
feat(telemetry): updated traces to match OTEL v1.37 semantic conventions

### DIFF
--- a/src/strands/types/traces.py
+++ b/src/strands/types/traces.py
@@ -1,5 +1,20 @@
 """Tracing type definitions for the SDK."""
 
-from typing import List, Union
+from typing import List, Mapping, Optional, Sequence, Union
 
-AttributeValue = Union[str, bool, float, int, List[str], List[bool], List[float], List[int]]
+AttributeValue = Union[
+    str,
+    bool,
+    float,
+    int,
+    List[str],
+    List[bool],
+    List[float],
+    List[int],
+    Sequence[str],
+    Sequence[bool],
+    Sequence[int],
+    Sequence[float],
+]
+
+Attributes = Optional[Mapping[str, AttributeValue]]


### PR DESCRIPTION
## Description
Following OTEL suggestions to update semantic conventions for v1.37

### Details
1. Detect `gen_ai_latest_experimental` is in env `OTEL_SEMCONV_STABILITY_OPT_IN` or not for conventions switch
2. For the latest conventions: 
  2.1 Replaced gen_ai.system with `gen_ai.provider.name`
  2.2 Updated all events with inputs / outputs to the event name: `[gen_ai.client.inference.operation.details](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-eventgen_aiclientinferenceoperationdetails)`
  2.3 Move all inputs to the event attribute of [gen_ai.input.messages](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-input-messages)
  2.4 Move all outputs to the event attribute of [gen_ai.output.messages](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-output-messages) 

**[NOTE]** Currently I'm serializing the inputs / output as string for `gen_ai.input.messages`. Although [the example](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-input-messages) shows that it can be a complex object, the add_event API does not take nested object / list.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/877

## Documentation PR

TBD

## Type of Change
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
