### PR TITLE
tool - executors - concurrent - remove no-op gather

### DIFF
--- a/src/strands/tools/executors/concurrent.py
+++ b/src/strands/tools/executors/concurrent.py
@@ -72,8 +72,6 @@ class ConcurrentToolExecutor(ToolExecutor):
             yield event
             task_events[task_id].set()
 
-        asyncio.gather(*tasks)
-
     async def _task(
         self,
         agent: "Agent",


### PR DESCRIPTION
## Description
Remove the no-op gather from the concurrent tool executor to avoid confusion.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Other (please describe): Code clean up

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: Relying on existing concurrent tool executor unit tests.
- [x] `hatch test tests_integ/tools/executors/test_concurrent.py`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
