### PR TITLE
fix: GeminiModel argument in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ agent("Tell me about Agentic AI")
 
 # Google Gemini
 gemini_model = GeminiModel(
-  api_key="your_gemini_api_key",
+  client_args={
+    "api_key": "your_gemini_api_key",
+  },
   model_id="gemini-2.5-flash",
   params={"temperature": 0.7}
 )


### PR DESCRIPTION
## Description
Fix README about GeminiModel argument

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change
Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

The result has no difference between before/after this change.

### For Reference

**NG: It doesn't work with error.**
```python
import os
from strands import Agent
from strands.models.gemini import GeminiModel

gemini_model = GeminiModel(
    api_key=os.environ["MY_API_KEY"],
    model_id="gemini-2.5-flash",
    params={"temperature": 0.7}
)

agent = Agent(model=gemini_model)
agent("Tell me about Agentic AI")
```

**OK: It works.**
```python
import os
from strands import Agent
from strands.models.gemini import GeminiModel

gemini_model = GeminiModel(
    client_args={
        "api_key": os.environ["MY_API_KEY"],
    },
    model_id="gemini-2.5-flash",
    params={"temperature": 0.7}
)

agent = Agent(model=gemini_model)
agent("Tell me about Agentic AI")
```


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
