### PR TITLE
reafactor: remove redundant None from dict.get() calls

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -187,7 +187,7 @@ class Agent:
             """Lookup the tool represented by name, replacing characters with underscores as necessary."""
             tool_registry = self._agent.tool_registry.registry
 
-            if tool_registry.get(name, None):
+            if tool_registry.get(name):
                 return name
 
             # If the desired name contains underscores, it might be a placeholder for characters that can't be

--- a/src/strands/models/sagemaker.py
+++ b/src/strands/models/sagemaker.py
@@ -343,7 +343,7 @@ class SageMakerAIModel(OpenAIModel):
                         logger.info("choice=<%s>", json.dumps(choice, indent=2))
 
                         # Handle text content
-                        if choice["delta"].get("content", None):
+                        if choice["delta"].get("content"):
                             if not text_content_started:
                                 yield self.format_chunk({"chunk_type": "content_start", "data_type": "text"})
                                 text_content_started = True
@@ -357,7 +357,7 @@ class SageMakerAIModel(OpenAIModel):
                             )
 
                         # Handle reasoning content
-                        if choice["delta"].get("reasoning_content", None):
+                        if choice["delta"].get("reasoning_content"):
                             if not reasoning_content_started:
                                 yield self.format_chunk(
                                     {"chunk_type": "content_start", "data_type": "reasoning_content"}
@@ -382,7 +382,7 @@ class SageMakerAIModel(OpenAIModel):
                             finish_reason = choice["finish_reason"]
                             break
 
-                        if choice.get("usage", None):
+                        if choice.get("usage"):
                             yield self.format_chunk(
                                 {"chunk_type": "metadata", "data": UsageMetadata(**choice["usage"])}
                             )
@@ -402,7 +402,7 @@ class SageMakerAIModel(OpenAIModel):
                 # Handle tool calling
                 logger.info("tool_calls=<%s>", json.dumps(tool_calls, indent=2))
                 for tool_deltas in tool_calls.values():
-                    if not tool_deltas[0]["function"].get("name", None):
+                    if not tool_deltas[0]["function"].get("name"):
                         raise Exception("The model did not provide a tool name.")
                     yield self.format_chunk(
                         {"chunk_type": "content_start", "data_type": "tool", "data": ToolCall(**tool_deltas[0])}
@@ -443,7 +443,7 @@ class SageMakerAIModel(OpenAIModel):
                     yield self.format_chunk({"chunk_type": "content_stop", "data_type": "text"})
 
                 # Handle reasoning content
-                if message.get("reasoning_content", None):
+                if message.get("reasoning_content"):
                     yield self.format_chunk({"chunk_type": "content_start", "data_type": "reasoning_content"})
                     yield self.format_chunk(
                         {
@@ -455,7 +455,7 @@ class SageMakerAIModel(OpenAIModel):
                     yield self.format_chunk({"chunk_type": "content_stop", "data_type": "reasoning_content"})
 
                 # Handle the tool calling, if any
-                if message.get("tool_calls", None) or message_stop_reason == "tool_calls":
+                if message.get("tool_calls") or message_stop_reason == "tool_calls":
                     if not isinstance(message["tool_calls"], list):
                         message["tool_calls"] = [message["tool_calls"]]
                     for tool_call in message["tool_calls"]:
@@ -474,9 +474,9 @@ class SageMakerAIModel(OpenAIModel):
                 # Message close
                 yield self.format_chunk({"chunk_type": "message_stop", "data": message_stop_reason})
                 # Handle usage metadata
-                if final_response_json.get("usage", None):
+                if final_response_json.get("usage"):
                     yield self.format_chunk(
-                        {"chunk_type": "metadata", "data": UsageMetadata(**final_response_json.get("usage", None))}
+                        {"chunk_type": "metadata", "data": UsageMetadata(**final_response_json.get("usage"))}
                     )
         except (
             self.client.exceptions.InternalFailure,
@@ -544,7 +544,7 @@ class SageMakerAIModel(OpenAIModel):
                 "thinking": content["reasoningContent"].get("reasoningText", {}).get("text", ""),
                 "type": "thinking",
             }
-        elif not content.get("reasoningContent", None):
+        elif not content.get("reasoningContent"):
             content.pop("reasoningContent", None)
 
         if "video" in content:


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR --> Removes explicit 'None' default values from '.get()' calls in 'agent.py' and 'sagemaker.py'.

The 'dict.get()' method defaults to 'None' already, so this change makes explicitly passing None as the second argument
unnecessary.

## Related Issues

<!-- Link to related issues using #issue-number format --> N/A

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo --> N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest --> Refactor

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
