### PR TITLE
feat(models): use tool for structured_output when supports_response_schema=false

### DIFF
--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -12,6 +12,8 @@ from litellm.utils import supports_response_schema
 from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
+from ..event_loop import streaming
+from ..tools import convert_pydantic_to_tool_spec
 from ..types.content import ContentBlock, Messages
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
@@ -196,6 +198,10 @@ class LiteLLMModel(OpenAIModel):
     ) -> AsyncGenerator[dict[str, Union[T, Any]], None]:
         """Get structured output from the model.
 
+        Some models do not support native structured output via response_format.
+        In cases of proxies, we may not have a way to determine support, so we
+        fallback to using tool calling to achieve structured output.
+
         Args:
             output_model: The output model to use for the agent.
             prompt: The prompt messages to use for the agent.
@@ -205,33 +211,64 @@ class LiteLLMModel(OpenAIModel):
         Yields:
             Model events with the last being the structured output.
         """
-        if not supports_response_schema(self.get_config()["model_id"]):
-            raise ValueError("Model does not support response_format")
+        if supports_response_schema(self.get_config()["model_id"]):
+            result = await self._structured_output_using_response_schema(output_model, prompt, system_prompt)
+        else:
+            result = await self._structured_output_using_tool(output_model, prompt, system_prompt)
 
+        yield {"output": result}
+
+    async def _structured_output_using_response_schema(
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None
+    ) -> T:
+        """Get structured output using native response_format support."""
         response = await litellm.acompletion(
             **self.client_args,
             model=self.get_config()["model_id"],
             messages=self.format_request(prompt, system_prompt=system_prompt)["messages"],
             response_format=output_model,
         )
-
+        
         if len(response.choices) > 1:
             raise ValueError("Multiple choices found in the response.")
+        if not response.choices or response.choices[0].finish_reason != "tool_calls":
+            raise ValueError("No tool_calls found in response")
 
-        # Find the first choice with tool_calls
-        for choice in response.choices:
-            if choice.finish_reason == "tool_calls":
-                try:
-                    # Parse the tool call content as JSON
-                    tool_call_data = json.loads(choice.message.content)
-                    # Instantiate the output model with the parsed data
-                    yield {"output": output_model(**tool_call_data)}
-                    return
-                except (json.JSONDecodeError, TypeError, ValueError) as e:
-                    raise ValueError(f"Failed to parse or load content into model: {e}") from e
+        choice = response.choices[0]
+        try:
+            # Parse the message content as JSON
+            tool_call_data = json.loads(choice.message.content)
+            # Instantiate the output model with the parsed data
+            return output_model(**tool_call_data)
+        except (json.JSONDecodeError, TypeError, ValueError) as e:
+            raise ValueError(f"Failed to parse or load content into model: {e}") from e
 
-        # If no tool_calls found, raise an error
-        raise ValueError("No tool_calls found in response")
+    async def _structured_output_using_tool(
+        self, output_model: Type[T], prompt: Messages, system_prompt: Optional[str] = None
+    ) -> T:
+        """Get structured output using tool calling fallback."""
+        tool_spec = convert_pydantic_to_tool_spec(output_model)
+        request = self.format_request(prompt, [tool_spec], system_prompt, cast(ToolChoice, {"any": {}}))
+        args = {**self.client_args, **request, 'stream': False}
+        response = await litellm.acompletion(**args)
+        
+        if len(response.choices) > 1:
+            raise ValueError("Multiple choices found in the response.")
+        if not response.choices or response.choices[0].finish_reason != "tool_calls":
+            raise ValueError("No tool_calls found in response")
+
+        choice = response.choices[0]
+        try:
+            # Parse the tool call content as JSON
+            tool_call = choice.message.tool_calls[0]
+            tool_call_data = json.loads(tool_call.function.arguments)
+            # Instantiate the output model with the parsed data
+            return output_model(**tool_call_data)
+        except (json.JSONDecodeError, TypeError, ValueError) as e:
+            raise ValueError(f"Failed to parse or load content into model: {e}") from e
+
+
+                
 
     def _apply_proxy_prefix(self) -> None:
         """Apply litellm_proxy/ prefix to model_id when use_litellm_proxy is True.

--- a/tests/strands/models/test_litellm.py
+++ b/tests/strands/models/test_litellm.py
@@ -290,15 +290,27 @@ async def test_structured_output(litellm_acompletion, model, test_output_model_c
 
 
 @pytest.mark.asyncio
-async def test_structured_output_unsupported_model(litellm_acompletion, model, test_output_model_cls):
+async def test_structured_output_unsupported_model(litellm_acompletion, model, test_output_model_cls, alist):
     messages = [{"role": "user", "content": [{"text": "Generate a person"}]}]
 
-    with unittest.mock.patch.object(strands.models.litellm, "supports_response_schema", return_value=False):
-        with pytest.raises(ValueError, match="Model does not support response_format"):
-            stream = model.structured_output(test_output_model_cls, messages)
-            await stream.__anext__()
+    mock_tool_call = unittest.mock.Mock()
+    mock_tool_call.function.arguments = '{"name": "John", "age": 30}'
+    
+    mock_choice = unittest.mock.Mock()
+    mock_choice.finish_reason = "tool_calls"
+    mock_choice.message.tool_calls = [mock_tool_call]
+    mock_response = unittest.mock.Mock()
+    mock_response.choices = [mock_choice]
 
-    litellm_acompletion.assert_not_called()
+    litellm_acompletion.return_value = mock_response
+
+    with unittest.mock.patch.object(strands.models.litellm, "supports_response_schema", return_value=False):
+        stream = model.structured_output(test_output_model_cls, messages)
+        events = await alist(stream)
+        tru_result = events[-1]
+
+    exp_result = {"output": test_output_model_cls(name="John", age=30)}
+    assert tru_result == exp_result
 
 
 def test_config_validation_warns_on_unknown_keys(litellm_acompletion, captured_warnings):

--- a/tests_integ/models/test_model_litellm.py
+++ b/tests_integ/models/test_model_litellm.py
@@ -1,5 +1,6 @@
 import pydantic
 import pytest
+import unittest.mock
 
 import strands
 from strands import Agent
@@ -38,6 +39,33 @@ def weather():
         weather: str = pydantic.Field(description="The weather condition (e.g., 'sunny', 'rainy', 'cloudy')")
 
     return Weather(time="12:00", weather="sunny")
+
+
+class Location(pydantic.BaseModel):
+    """Location information."""
+    city: str = pydantic.Field(description="The city name")
+    country: str = pydantic.Field(description="The country name")
+
+class WeatherCondition(pydantic.BaseModel):
+    """Weather condition details."""
+    condition: str = pydantic.Field(description="The weather condition (e.g., 'sunny', 'rainy', 'cloudy')")
+    temperature: int = pydantic.Field(description="Temperature in Celsius")
+
+class NestedWeather(pydantic.BaseModel):
+    """Weather report with nested location and condition information."""
+    time: str = pydantic.Field(description="The time in HH:MM format")
+    location: Location = pydantic.Field(description="Location information")
+    weather: WeatherCondition = pydantic.Field(description="Weather condition details")
+
+
+@pytest.fixture
+def nested_weather():
+
+    return NestedWeather(
+        time="12:00",
+        location=Location(city="New York", country="USA"),
+        weather=WeatherCondition(condition="sunny", temperature=25)
+    )
 
 
 @pytest.fixture
@@ -134,3 +162,25 @@ def test_structured_output_multi_modal_input(agent, yellow_img, yellow_color):
     tru_color = agent.structured_output(type(yellow_color), content)
     exp_color = yellow_color
     assert tru_color == exp_color
+
+def test_structured_output_unsupported_model(model, nested_weather):
+    # Mock supports_response_schema to return False to test fallback mechanism
+    with unittest.mock.patch.multiple(
+        'strands.models.litellm',
+        supports_response_schema=unittest.mock.DEFAULT,
+    ) as mocks, \
+    unittest.mock.patch.object(model, '_structured_output_using_tool', wraps=model._structured_output_using_tool) as mock_tool, \
+    unittest.mock.patch.object(model, '_structured_output_using_response_schema', wraps=model._structured_output_using_response_schema) as mock_schema:
+        
+        mocks['supports_response_schema'].return_value = False
+        
+        # Test that structured output still works via tool calling fallback
+        agent = Agent(model=model)
+        prompt = "The time is 12:00 in New York, USA and the weather is sunny with temperature 25 degrees Celsius"
+        tru_weather = agent.structured_output(NestedWeather, prompt)
+        exp_weather = nested_weather
+        assert tru_weather == exp_weather
+        
+        # Verify that the tool method was called and schema method was not
+        mock_tool.assert_called_once()
+        mock_schema.assert_not_called()


### PR DESCRIPTION
## Description

In LiteLLMModel we currently attempt to perform structured_output using the model's native capabilities. This is checked using the `supports_response_schema` method.

This has two edge cases which are causing customer failures.

1. The first obvious one is that if a model does not support structured output we are failing hard. This means that if a customer changes the model id, code that previously worked will now fail with `ValueError("Model does not support response_format")`.

2. The second is what appears to be a bug in LiteLLM. `supports_response_schema` does not appear to work with proxies. Looking at their [code](https://github.com/BerriAI/litellm/blob/7ec7e5332c648fc7871e1084a2c7bb74b60a0204/litellm/utils.py#L1955), they are not passing along proxy information, meaning there is no ability to perform a runtime check for proxies.

To fix this, when `supports_response_schema` returns false, we now fallback to the similar tool approach used in other model providers. A fix in LiteLLM will be explored but in the immediate term we need to unblock customers.

## Related Issues

#862 
#909

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
