### PR TITLE
event loop - handle model execution

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -219,7 +219,25 @@ async def _handle_model_execution(
     invocation_state: dict[str, Any],
     tracer: Tracer,
 ) -> AsyncGenerator[TypedEvent, None]:
-    """<TODO>."""
+    """Handle model execution with retry logic for throttling exceptions.
+
+    Executes the model inference with automatic retry handling for throttling exceptions.
+    Manages tracing, hooks, and metrics collection throughout the process.
+
+    Args:
+        agent: The agent executing the model.
+        cycle_span: Span object for tracing the cycle.
+        cycle_trace: Trace object for the current event loop cycle.
+        invocation_state: State maintained across cycles.
+        tracer: Tracer instance for span management.
+
+    Yields:
+        Model stream events and throttle events during retries.
+
+    Raises:
+        ModelThrottledException: If max retry attempts are exceeded.
+        Exception: Any other model execution errors.
+    """
     # Create a trace for the stream_messages call
     stream_trace = Trace("stream_messages", parent_id=cycle_trace.id)
     cycle_trace.add_child(stream_trace)


### PR DESCRIPTION
## Description
Moving the model execution logic in the agent loop into a function so that we can more easily condition around it when resuming after interrupt. For more details, please see comments under the files changed page.

To get a rough idea of what the end result will be for resuming, see [here](https://github.com/strands-agents/sdk-python/pull/879/files#diff-5f029d26e91e9d8730fb72845b97f604c5999e3678f7176fc322a695c03bf7cbR119).

## Related Issues

https://github.com/strands-agents/sdk-python/issues/204

## Documentation PR

N/A

## Type of Change

Other (please describe): Code reorg.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: I am not changing any logic in this PR and so we can rely on the existing unit/integ tests.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
