### PR TITLE
fix(telemetry): removed double serialization for events

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -307,7 +307,7 @@ class Tracer:
                         [
                             {
                                 "role": message["role"],
-                                "parts": [{"type": "text", "content": serialize(message["content"])}],
+                                "parts": [{"type": "text", "content": message["content"]}],
                                 "finish_reason": str(stop_reason),
                             }
                         ]
@@ -362,7 +362,7 @@ class Tracer:
                                         "type": "tool_call",
                                         "name": tool["name"],
                                         "id": tool["toolUseId"],
-                                        "arguments": [{"content": serialize(tool["input"])}],
+                                        "arguments": [{"content": tool["input"]}],
                                     }
                                 ],
                             }
@@ -417,7 +417,7 @@ class Tracer:
                                         {
                                             "type": "tool_call_response",
                                             "id": tool_result.get("toolUseId", ""),
-                                            "result": serialize(tool_result.get("content")),
+                                            "result": tool_result.get("content"),
                                         }
                                     ],
                                 }
@@ -504,7 +504,7 @@ class Tracer:
                             [
                                 {
                                     "role": tool_result_message["role"],
-                                    "parts": [{"type": "text", "content": serialize(tool_result_message["content"])}],
+                                    "parts": [{"type": "text", "content": tool_result_message["content"]}],
                                 }
                             ]
                         )
@@ -640,11 +640,7 @@ class Tracer:
             self._add_event(
                 span,
                 "gen_ai.client.inference.operation.details",
-                {
-                    "gen_ai.input.messages": serialize(
-                        [{"role": "user", "parts": [{"type": "text", "content": content}]}]
-                    )
-                },
+                {"gen_ai.input.messages": serialize([{"role": "user", "parts": [{"type": "text", "content": task}]}])},
             )
         else:
             self._add_event(
@@ -722,7 +718,7 @@ class Tracer:
             input_messages: list = []
             for message in messages:
                 input_messages.append(
-                    {"role": message["role"], "parts": [{"type": "text", "content": serialize(message["content"])}]}
+                    {"role": message["role"], "parts": [{"type": "text", "content": message["content"]}]}
                 )
             self._add_event(
                 span, "gen_ai.client.inference.operation.details", {"gen_ai.input.messages": serialize(input_messages)}

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -191,7 +191,7 @@ def test_start_model_invoke_span_latest_conventions(mock_tracer):
                     [
                         {
                             "role": messages[0]["role"],
-                            "parts": [{"type": "text", "content": serialize(messages[0]["content"])}],
+                            "parts": [{"type": "text", "content": messages[0]["content"]}],
                         }
                     ]
                 )
@@ -249,7 +249,7 @@ def test_end_model_invoke_span_latest_conventions(mock_span):
                     [
                         {
                             "role": "assistant",
-                            "parts": [{"type": "text", "content": serialize(message["content"])}],
+                            "parts": [{"type": "text", "content": message["content"]}],
                             "finish_reason": "end_turn",
                         }
                     ]
@@ -318,7 +318,7 @@ def test_start_tool_call_span_latest_conventions(mock_tracer):
                                     "type": "tool_call",
                                     "name": tool["name"],
                                     "id": tool["toolUseId"],
-                                    "arguments": [{"content": serialize(tool["input"])}],
+                                    "arguments": [{"content": tool["input"]}],
                                 }
                             ],
                         }
@@ -398,7 +398,7 @@ def test_start_swarm_span_with_contentblock_task_latest_conventions(mock_tracer)
             "gen_ai.client.inference.operation.details",
             attributes={
                 "gen_ai.input.messages": serialize(
-                    [{"role": "user", "parts": [{"type": "text", "content": '[{"text": "Original Task: foo bar"}]'}]}]
+                    [{"role": "user", "parts": [{"type": "text", "content": [{"text": "Original Task: foo bar"}]}]}]
                 )
             },
         )
@@ -502,7 +502,7 @@ def test_end_tool_call_span_latest_conventions(mock_span):
                             {
                                 "type": "tool_call_response",
                                 "id": tool_result.get("toolUseId", ""),
-                                "result": serialize(tool_result.get("content")),
+                                "result": tool_result.get("content"),
                             }
                         ],
                     }
@@ -559,7 +559,7 @@ def test_start_event_loop_cycle_span_latest_conventions(mock_tracer):
             "gen_ai.client.inference.operation.details",
             attributes={
                 "gen_ai.input.messages": serialize(
-                    [{"role": "user", "parts": [{"type": "text", "content": serialize(messages[0]["content"])}]}]
+                    [{"role": "user", "parts": [{"type": "text", "content": messages[0]["content"]}]}]
                 )
             },
         )
@@ -601,7 +601,7 @@ def test_end_event_loop_cycle_span_latest_conventions(mock_span):
                 [
                     {
                         "role": "assistant",
-                        "parts": [{"type": "text", "content": serialize(tool_result_message["content"])}],
+                        "parts": [{"type": "text", "content": tool_result_message["content"]}],
                     }
                 ]
             )
@@ -676,7 +676,7 @@ def test_start_agent_span_latest_conventions(mock_tracer):
             "gen_ai.client.inference.operation.details",
             attributes={
                 "gen_ai.input.messages": serialize(
-                    [{"role": "user", "parts": [{"type": "text", "content": '[{"text": "test prompt"}]'}]}]
+                    [{"role": "user", "parts": [{"type": "text", "content": [{"text": "test prompt"}]}]}]
                 )
             },
         )


### PR DESCRIPTION
## Description
Remove double serialization when adding events into the span.

## Related Issues

https://github.com/strands-agents/sdk-python/pull/952
https://github.com/strands-agents/sdk-python/issues/877

## Documentation PR

TBD

## Type of Change
Fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
