### PR TITLE
Fix additional_args passing in SageMakerAIModel

### DIFF
--- a/src/strands/models/sagemaker.py
+++ b/src/strands/models/sagemaker.py
@@ -238,6 +238,10 @@ class SageMakerAIModel(OpenAIModel):
             },
         }
 
+        payload_additional_args = self.payload_config.get("additional_args")
+        if payload_additional_args:
+            payload.update(payload_additional_args)
+
         # Remove tools and tool_choice if tools = []
         if not payload["tools"]:
             payload.pop("tools")

--- a/tests/strands/models/test_sagemaker.py
+++ b/tests/strands/models/test_sagemaker.py
@@ -112,12 +112,13 @@ class TestSageMakerAIModel:
             "endpoint_name": "test-endpoint",
             "inference_component_name": "test-component",
             "region_name": "us-west-2",
-            "additional_args": {"test_arg_name": "test_arg_value"},
+            "additional_args": {"test_req_arg_name": "test_req_arg_value"},
         }
         payload_config = {
             "stream": False,
             "max_tokens": 1024,
             "temperature": 0.7,
+            "additional_args": {"test_payload_arg_name": "test_payload_arg_value"},
         }
         client_config = BotocoreConfig(user_agent_extra="test-agent")
 
@@ -130,10 +131,11 @@ class TestSageMakerAIModel:
 
         assert model.endpoint_config["endpoint_name"] == "test-endpoint"
         assert model.endpoint_config["inference_component_name"] == "test-component"
-        assert model.endpoint_config["additional_args"]["test_arg_name"] == "test_arg_value"
+        assert model.endpoint_config["additional_args"]["test_req_arg_name"] == "test_req_arg_value"
         assert model.payload_config["stream"] is False
         assert model.payload_config["max_tokens"] == 1024
         assert model.payload_config["temperature"] == 0.7
+        assert model.payload_config["additional_args"]["test_payload_arg_name"] == "test_payload_arg_value"
 
         boto_session.client.assert_called_once_with(
             service_name="sagemaker-runtime",
@@ -246,16 +248,24 @@ class TestSageMakerAIModel:
         endpoint_config_ext = {
             **endpoint_config,
             "additional_args": {
-                "extra_key": "extra_value",
+                "extra_request_key": "extra_request_value",
+            },
+        }
+        payload_config_ext = {
+            **payload_config,
+            "additional_args": {
+                "extra_payload_key": "extra_payload_value",
             },
         }
         model = SageMakerAIModel(
             boto_session=boto_session,
             endpoint_config=endpoint_config_ext,
-            payload_config=payload_config,
+            payload_config=payload_config_ext,
         )
         request = model.format_request(messages)
-        assert request.get("extra_key") == "extra_value"
+        assert request.get("extra_request_key") == "extra_request_value"
+        payload = json.loads(request["Body"])
+        assert payload.get("extra_payload_key") == "extra_payload_value"
 
     @pytest.mark.asyncio
     async def test_stream_with_streaming_enabled(self, sagemaker_client, model, messages):


### PR DESCRIPTION
## Description

- Fix 982 error where passing an additional_args dict to SageMakerAIModel / SageMakerAIEndpointConfig would raise an AttributeError during inference request preparation, because Python dicts have no '__dict__' attribute.
- Fix 984 issue where additional_args passed to SageMakerAIPayloadSchema were ignored during inference request preparation - instead insert them into the request body/payload.
- Fix typing of `SageMakerAIModel.endpoint_config` and `SageMakerAIModel.payload_config` to use the proper typed dicts for these structures rather than a plain `dict()` (coming from the shallow copy in the model constructor)
- Add a unit test to validate that `format_request()` correctly includes additional_args (both types)

## Related Issues

Fixes #982, Fixes #984

## Documentation PR

None

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
    - This fix doesn't introduce the `additional_args` feature, but it seems like that is missing from the [SageMaker model provider doc](https://strandsagents.com/latest/documentation/docs/user-guide/concepts/model-providers/sagemaker/) in the Strands-Agents User Guide.
    - I also see that SageMaker is generally missing from the Strands [Models API reference](https://strandsagents.com/latest/documentation/docs/api-reference/models/)
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
