### PR TITLE
conversation manager - summarization - noop tool

### DIFF
--- a/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
+++ b/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 from typing_extensions import override
 
+from ...tools import tool
+from ...tools.registry import ToolRegistry
 from ...types.content import Message
 from ...types.exceptions import ContextWindowOverflowException
 from .conversation_manager import ConversationManager
@@ -23,6 +25,10 @@ Format Requirements:
 - You MUST create a structured and concise summary in bullet-point format.
 - You MUST NOT respond conversationally.
 - You MUST NOT address the user directly.
+- You MUST NOT comment on tool availability.
+
+Assumptions:
+- You MUST NOT assume tool executions failed unless otherwise stated.
 
 Task:
 Your task is to create a structured summary document:
@@ -182,9 +188,10 @@ class SummarizingConversationManager(ConversationManager):
         # Choose which agent to use for summarization
         summarization_agent = self.summarization_agent if self.summarization_agent is not None else agent
 
-        # Save original system prompt and messages to restore later
+        # Save original system prompt, messages, and tool registry to restore later
         original_system_prompt = summarization_agent.system_prompt
         original_messages = summarization_agent.messages.copy()
+        original_tool_registry = summarization_agent.tool_registry
 
         try:
             # Only override system prompt if no agent was provided during initialization
@@ -197,6 +204,13 @@ class SummarizingConversationManager(ConversationManager):
                 )
                 # Temporarily set the system prompt for summarization
                 summarization_agent.system_prompt = system_prompt
+
+            # Add no-op tool if agent has no tools to satisfy tool spec requirement
+            if not summarization_agent.tool_names:
+                tool_registry = ToolRegistry()
+                tool_registry.register_tool(self._noop_tool)
+                summarization_agent.tool_registry = tool_registry
+
             summarization_agent.messages = messages
 
             # Use the agent to generate summary with rich content (can use tools if needed)
@@ -207,6 +221,7 @@ class SummarizingConversationManager(ConversationManager):
             # Restore original agent state
             summarization_agent.system_prompt = original_system_prompt
             summarization_agent.messages = original_messages
+            summarization_agent.tool_registry = original_tool_registry
 
     def _adjust_split_point_for_tool_pairs(self, messages: List[Message], split_point: int) -> int:
         """Adjust the split point to avoid breaking ToolUse/ToolResult pairs.
@@ -249,3 +264,13 @@ class SummarizingConversationManager(ConversationManager):
             raise ContextWindowOverflowException("Unable to trim conversation context!")
 
         return split_point
+
+    @tool(name="noop", description="MUST NOT call or summarize")
+    def _noop_tool(self) -> None:
+        """No-op tool to satisfy tool spec requirement when tool messages are present.
+
+        Some model provides (e.g., Bedrock) will return an error response if tool uses and tool results are present in
+        messages without any tool specs configured. Consequently, if the summarization agent has no registered tools,
+        summarization will fail. As a workaround, we register the no-op tool.
+        """
+        pass

--- a/tests_integ/test_summarizing_conversation_manager_integration.py
+++ b/tests_integ/test_summarizing_conversation_manager_integration.py
@@ -372,3 +372,39 @@ def test_dedicated_summarization_agent(model, summarization_model):
             break
 
     assert summary_text
+
+
+def test_summarization_with_tool_messages_and_no_tools():
+    agent = Agent(
+        messages=[
+            {"role": "user", "content": [{"text": "What is the current time?"}]},
+            {
+                "role": "assistant",
+                "content": [{"toolUse": {"toolUseId": "t1", "name": "time_tool", "input": {}}}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "t1",
+                            "content": [{"text": "12:00"}],
+                            "status": "success",
+                        }
+                    }
+                ],
+            },
+            {"role": "assistant", "content": [{"text": "The current time is 12:00."}]},
+            {"role": "user", "content": [{"text": "Thank you"}]},
+            {"role": "assistant", "content": [{"text": "You are welcome."}]},
+        ],
+    )
+
+    conversation_manager = SummarizingConversationManager(summary_ratio=1, preserve_recent_messages=2)
+    conversation_manager.reduce_context(agent)
+
+    assert len(agent.tool_names) == 0
+    assert len(agent.messages) == 3
+
+    summary = str(agent.messages[0]).lower()
+    assert "12:00" in summary


### PR DESCRIPTION
## Description
Bedrock model requests will fail if messages contain any tool use or tool result blocks and no toolConfig is provided. To demonstrate, you can run the following script:
```Python
from strands import Agent

agent = Agent(
    messages=[
        {
            "role": "user",
            "content": [
                {
                    "text": "What is the current time in New York."
                },
            ],
        },
        {
            "role": "assistant",
            "content": [
                {
                    "toolUse": {
                        "input": {
                            "city": "New York",
                        },
                        "name": "current_time",
                        "toolUseId": "t1",
                    },
                },
            ],
        },
        {
            "role": "user",
            "content": [
                {
                    "toolResult": {
                        "content": [
                            {
                                "text": "12:31",
                            },
                        ],
                        "status": "success",
                        "toolUseId": "t1",
                    },
                },
            ],
        },
    ],
)
agent("Please summarize this conversation.")
```
This will result in the following error:
```txt
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the ConverseStream operation: The toolConfig field must be defined when using toolUse and toolResult content blocks.
```

This is problematic for our summarization manager when configured with a bedrock agent that uses no tools. To fix, I am adding a noop tool to the agent tool registry when no tools are configured.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/998

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: Wrote new unit tests
- [x] `hatch test tests_integ/test_summarizing_conversation_manager_integration.py`: Wrote new integ tests.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
