### PR TITLE
Revert "feat: implement concurrent message reading for session managers (#897)"

### DIFF
--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -1,6 +1,5 @@
 """S3-based session manager for cloud storage."""
 
-import asyncio
 import json
 import logging
 from typing import Any, Dict, List, Optional, cast
@@ -284,23 +283,14 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             else:
                 message_keys = message_keys[offset:]
 
-            # Load message objects concurrently using async
-            return asyncio.run(self._load_messages_concurrently(message_keys))
+            # Load only the required message objects
+            messages: List[SessionMessage] = []
+            for key in message_keys:
+                message_data = self._read_s3_object(key)
+                if message_data:
+                    messages.append(SessionMessage.from_dict(message_data))
+
+            return messages
 
         except ClientError as e:
             raise SessionException(f"S3 error reading messages: {e}") from e
-
-    async def _load_messages_concurrently(self, message_keys: List[str]) -> List[SessionMessage]:
-        """Load multiple message objects concurrently using async."""
-        if not message_keys:
-            return []
-
-        async def load_message(key: str) -> Optional[SessionMessage]:
-            loop = asyncio.get_event_loop()
-            message_data = await loop.run_in_executor(None, self._read_s3_object, key)
-            return SessionMessage.from_dict(message_data) if message_data else None
-
-        tasks = [load_message(key) for key in message_keys]
-        loaded_messages = await asyncio.gather(*tasks)
-
-        return [msg for msg in loaded_messages if msg is not None]


### PR DESCRIPTION
This reverts commit 08dc4aeaad6e75dc273d41a9898e0d08df09863b.

## Description
When the session manager is executed in an async environment, the `asyncio.run` will fail with a "cannot be called from a running event loop" error. This was introduced in https://github.com/strands-agents/sdk-python/pull/897 as a means to improve the performance of session reads. As a fix, we could wrap the `asyncio.run` in a thread similar to what we do elsewhere in code. However, since this is a breaking change, we are going to revert the change and work on the fix separately.

Note, I made these changes with `git revert`.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1012

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: We can rely on the existing tests as this is a revert of an optimization rather than a behavioral change.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
