### PR TITLE
fix: session management on A2A server

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -844,3 +844,47 @@ class Agent:
         """Appends a message to the agent's list of messages and invokes the callbacks for the MessageCreatedEvent."""
         self.messages.append(message)
         self.hooks.invoke_callbacks(MessageAddedEvent(agent=self, message=message))
+
+    def with_session_manager(
+        self, session_manager: SessionManager, request_metadata: dict[str, Any] | None = None
+    ) -> "Agent":
+        """Create a new agent instance with session management enabled.
+
+        This method creates a copy of the current agent instance and adds session
+        management capabilities while preserving all other configuration. The original
+        agent must not already have a session manager or any messages.
+
+        Args:
+            session_manager: The session manager to add to the new agent instance.
+            request_metadata: Optional metadata to add to the new agent's state.
+
+        Returns:
+            A new Agent instance with the same configuration plus session management.
+
+        Raises:
+            ValueError: If the current agent already has a session manager or messages.
+        """
+        import copy
+
+        if self._session_manager is not None:
+            raise ValueError("Agent must not have a session manager")
+
+        if self.messages:
+            raise ValueError("Agent must not have messages")
+
+        # Create a deep copy of the current agent
+        new_agent = copy.deepcopy(self)
+
+        # Reset the session manager and messages
+        new_agent._session_manager = session_manager
+
+        # Add request metadata to the new agent's state
+        if request_metadata:
+            new_agent.state.set("request_metadata", request_metadata)
+
+        # Re-register the new session manager hook
+        # Since we can't easily remove the old session manager hook, we'll just add the new one
+        # The new session manager will register its own hooks
+        new_agent.hooks.add_hook(session_manager)
+
+        return new_agent

--- a/tests/strands/multiagent/a2a/conftest.py
+++ b/tests/strands/multiagent/a2a/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for A2A module tests."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
 from a2a.server.agent_execution import RequestContext
@@ -31,6 +31,19 @@ def mock_strands_agent():
     mock_tool_registry.get_all_tools_config.return_value = {}
     agent.tool_registry = mock_tool_registry
 
+    # Setup with_session_manager to return a copy of the agent
+    def mock_with_session_manager(session_manager=None, request_metadata=None):
+        """Create a copy of the agent with session manager."""
+        agent_copy = MagicMock(spec=SAAgent)
+        agent_copy.name = agent.name
+        agent_copy.description = agent.description
+        agent_copy.invoke_async = agent.invoke_async
+        agent_copy.stream_async = agent.stream_async
+        agent_copy.tool_registry = agent.tool_registry
+        return agent_copy
+
+    agent.with_session_manager = MagicMock(side_effect=mock_with_session_manager)
+
     return agent
 
 
@@ -39,6 +52,7 @@ def mock_request_context():
     """Create a mock RequestContext for testing."""
     context = MagicMock(spec=RequestContext)
     context.get_user_input.return_value = "Test input"
+    type(context).context_id = PropertyMock(return_value="test-context-id")
     return context
 
 


### PR DESCRIPTION
## Description
- Added a method to the Strands Agent which creates a copy of itself with a new session manager and option to pass the request metadata defined by A2A into the agent state to use it downstream inside the tools
- Kept backwards compatibility 
- Added a FileSessionManager as default to the server
- Added SessionManager factory method to create new sessions during request handling in A2A server

- To possible improvements (let me know if you prefer): 
- more precise assertion for stream_async in in the unit test
- define a private method to attach the session manager to the hooks and reuse in the method

## Related Issues


Closes #990 

## Documentation PR

Will provide once review is done

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
