### PR TITLE
multiagents - temporarily raise exception when interrupted

### DIFF
--- a/src/strands/hooks/registry.py
+++ b/src/strands/hooks/registry.py
@@ -7,6 +7,7 @@ functions, supporting both individual callback registration and bulk registratio
 via hook provider objects.
 """
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generator, Generic, Protocol, Type, TypeVar
 
@@ -14,6 +15,8 @@ from ..interrupt import Interrupt, InterruptException
 
 if TYPE_CHECKING:
     from ..agent import Agent
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -219,9 +222,9 @@ class HookRegistry:
             except InterruptException as exception:
                 interrupt = exception.interrupt
                 if interrupt.name in interrupts:
-                    raise ValueError(
-                        f"interrupt_name=<{interrupt.name}> | interrupt name used more than once"
-                    ) from exception
+                    message = f"interrupt_name=<{interrupt.name}> | interrupt name used more than once"
+                    logger.error(message)
+                    raise ValueError(message) from exception
 
                 # Each callback is allowed to raise their own interrupt.
                 interrupts[interrupt.name] = interrupt

--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -578,6 +578,14 @@ class Graph(MultiAgentBase):
                     else:
                         agent_response = await node.executor.invoke_async(node_input, invocation_state=invocation_state)
 
+                    if agent_response.stop_reason == "interrupt":
+                        node.executor.messages.pop()  # remove interrupted tool use message
+                        node.executor._interrupt_state.deactivate()
+
+                        raise RuntimeError(
+                            "user raised interrupt from agent | interrupts are not yet supported in graphs"
+                        )
+
                     # Extract metrics from agent response
                     usage = Usage(inputTokens=0, outputTokens=0, totalTokens=0)
                     metrics = Metrics(latencyMs=0)

--- a/src/strands/multiagent/swarm.py
+++ b/src/strands/multiagent/swarm.py
@@ -637,6 +637,12 @@ class Swarm(MultiAgentBase):
             node.reset_executor_state()
             result = await node.executor.invoke_async(node_input, invocation_state=invocation_state)
 
+            if result.stop_reason == "interrupt":
+                node.executor.messages.pop()  # remove interrupted tool use message
+                node.executor._interrupt_state.deactivate()
+
+                raise RuntimeError("user raised interrupt from agent | interrupts are not yet supported in swarms")
+
             execution_time = round((time.time() - start_time) * 1000)
 
             # Create NodeResult


### PR DESCRIPTION
## Description
Temporarily warn customers that single agent interrupts are not supported in multi-agent networks.

We do plan to support interrupts in multi-agents, but if customers start using single agent interrupts before then, they should know the limitations.

## Related Issues

* https://github.com/strands-agents/sdk-python/pull/987
* https://github.com/strands-agents/sdk-python/issues/204

## Documentation PR

Interrupts will be documented once all related PRs are merged.

## Type of Change

Other (please describe): Warning to users that interrupt feature is not fully ready.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Ran the following test script:

```Python
from strands import Agent, tool
from strands.hooks import BeforeToolCallEvent, HookProvider
from strands.multiagent import GraphBuilder

@tool
def my_tool_01() -> str:
    print("MY TOOL 01")
    return "stored data"

@tool
def my_tool_02() -> str:
    print("MY TOOL 02")
    return "logged data"

class ToolInterruptHook(HookProvider):
    def register_hooks(self, registry, **kwargs):
        registry.add_callback(BeforeToolCallEvent, self.interrupt)

    def interrupt(self, event):
        response = event.interrupt("my_interrupt")
        print(f"RESPONSE: {response}")

agent_01 = Agent(name="agent_01", hooks=[ToolInterruptHook()], tools=[my_tool_01], callback_handler=None)
agent_02 = Agent(name="agent_01", tools=[my_tool_02], callback_handler=None)

### GRAPH
builder = GraphBuilder()
builder.add_node(agent_01, "agent_01")
builder.add_node(agent_02, "agent_02")
builder.add_edge("agent_01", "agent_02")
builder.set_entry_point("agent_01")

graph = builder.build()

try:
    graph("Call my tools")
except Exception:
    print(f"NODE 0 - INTERRUPT STATE: {graph.nodes["agent_01"].executor._interrupt_state}")
    print(f"NODE 0 - MESSAGES: {graph.nodes["agent_01"].executor.messages}")
    print(f"NODE 1 - INTERRUPT STATE: {graph.nodes["agent_02"].executor._interrupt_state}")
    print(f"NODE 1 - MESSAGES: {graph.nodes["agent_02"].executor.messages}")

"""
Output:
RuntimeError: user raised interrupt from agent | interrupts are not yet supported in graphs
NODE 0 - INTERRUPT STATE: InterruptState(interrupts={}, context={}, activated=False)
NODE 0 - MESSAGES: [{'role': 'user', 'content': [{'text': 'Call my tools'}]}]
NODE 1 - INTERRUPT STATE: InterruptState(interrupts={}, context={}, activated=False)
NODE 1 - MESSAGES: []
"""

#### SWARM
swarm = Swarm([agent_01, agent_02], entry_point=agent_01)

swarm("Call my tools")
print(f"NODE 0 - INTERRUPT STATE: {swarm.nodes["agent_01"].executor._interrupt_state}")
print(f"NODE 0 - MESSAGES: {swarm.nodes["agent_01"].executor.messages}")
print(f"NODE 1 - INTERRUPT STATE: {swarm.nodes["agent_02"].executor._interrupt_state}")
print(f"NODE 1 - MESSAGES: {swarm.nodes["agent_02"].executor.messages}")

"""
Output:
RuntimeError: user raised interrupt from agent | interrupts are not yet supported in swarms
NODE 0 - INTERRUPT STATE: InterruptState(interrupts={}, context={}, activated=False)
NODE 0 - MESSAGES: [{'role': 'user', 'content': [{'text': "Context:\nUser Request: Call my tools\n\nOther agents available for collaboration:\nAgent name: agent_02.\n\nYou have access to swarm coordination tools if you need help from other agents. If you don't hand off to another agent, the swarm will consider the task complete.\n\n"}]}]
NODE 1 - INTERRUPT STATE: InterruptState(interrupts={}, context={}, activated=False)
NODE 1 - MESSAGES: []
"""
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings: They intentionally do.
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
