### PR TITLE
integ tests - interrupts - remove asyncio marker

### DIFF
--- a/tests_integ/interrupts/test_hook.py
+++ b/tests_integ/interrupts/test_hook.py
@@ -48,7 +48,6 @@ def agent(interrupt_hook, time_tool, weather_tool):
     return Agent(hooks=[interrupt_hook], tools=[time_tool, weather_tool])
 
 
-@pytest.mark.asyncio
 def test_interrupt(agent):
     result = agent("What is the time and weather?")
 
@@ -112,7 +111,6 @@ def test_interrupt(agent):
     assert tru_tool_result_message == exp_tool_result_message
 
 
-@pytest.mark.asyncio
 def test_interrupt_reject(agent):
     result = agent("What is the time and weather?")
 

--- a/tests_integ/interrupts/test_session.py
+++ b/tests_integ/interrupts/test_session.py
@@ -47,7 +47,6 @@ def agent(interrupt_hook, time_tool, weather_tool):
     return Agent(hooks=[interrupt_hook], tools=[time_tool, weather_tool])
 
 
-@pytest.mark.asyncio
 def test_interrupt_session(interrupt_hook, time_tool, weather_tool, tmpdir):
     session_manager = FileSessionManager(session_id="strands-interrupt-test", storage_dir=tmpdir)
     agent = Agent(hooks=[interrupt_hook], session_manager=session_manager, tools=[time_tool, weather_tool])

--- a/tests_integ/interrupts/test_tool.py
+++ b/tests_integ/interrupts/test_tool.py
@@ -58,7 +58,6 @@ def agent(interrupt_hook, time_tool, day_tool, weather_tool):
     return Agent(hooks=[interrupt_hook], tools=[time_tool, day_tool, weather_tool])
 
 
-@pytest.mark.asyncio
 def test_interrupt(agent):
     result = agent("What is the time, day, and weather?")
 


### PR DESCRIPTION
## Description
Remove asyncio marker from interrupt integration tests. They are not async and so pytest is emitting warnings.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I ran `hatch test tests_integ/interrupt/*.py`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
