### PR TITLE
Add tool_name_prefix parameter to MCP client to prevent tool name collisions

### DIFF
--- a/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/src/strands/tools/mcp/mcp_agent_tool.py
@@ -28,26 +28,28 @@ class MCPAgentTool(AgentTool):
     seamlessly within the agent framework.
     """
 
-    def __init__(self, mcp_tool: MCPTool, mcp_client: "MCPClient") -> None:
+    def __init__(self, mcp_tool: MCPTool, mcp_client: "MCPClient", tool_name_prefix: str = "") -> None:
         """Initialize a new MCPAgentTool instance.
 
         Args:
             mcp_tool: The MCP tool to adapt
             mcp_client: The MCP server connection to use for tool invocation
+            tool_name_prefix: Optional prefix to add to the tool name to avoid collisions
         """
         super().__init__()
-        logger.debug("tool_name=<%s> | creating mcp agent tool", mcp_tool.name)
         self.mcp_tool = mcp_tool
         self.mcp_client = mcp_client
+        self._name = f"{tool_name_prefix}{mcp_tool.name}"
+        logger.debug("tool_name=<%s> | creating mcp agent tool", self._name)
 
     @property
     def tool_name(self) -> str:
         """Get the name of the tool.
 
         Returns:
-            str: The name of the MCP tool
+            str: The optionally prefixed name of the MCP tool
         """
-        return self.mcp_tool.name
+        return self._name
 
     @property
     def tool_spec(self) -> ToolSpec:
@@ -63,7 +65,7 @@ class MCPAgentTool(AgentTool):
 
         spec: ToolSpec = {
             "inputSchema": {"json": self.mcp_tool.inputSchema},
-            "name": self.mcp_tool.name,
+            "name": self._name,
             "description": description,
         }
 

--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -188,11 +188,17 @@ class MCPClient:
         self._background_thread_event_loop = None
         self._session_id = uuid.uuid4()
 
-    def list_tools_sync(self, pagination_token: Optional[str] = None) -> PaginatedList[MCPAgentTool]:
+    def list_tools_sync(
+        self, pagination_token: Optional[str] = None, tool_name_prefix: str = ""
+    ) -> PaginatedList[MCPAgentTool]:
         """Synchronously retrieves the list of available tools from the MCP server.
 
         This method calls the asynchronous list_tools method on the MCP session
         and adapts the returned tools to the AgentTool interface.
+
+        Args:
+            pagination_token: Optional token for pagination
+            tool_name_prefix: Optional prefix to add to tool names
 
         Returns:
             List[AgentTool]: A list of available tools adapted to the AgentTool interface
@@ -207,7 +213,7 @@ class MCPClient:
         list_tools_response: ListToolsResult = self._invoke_on_background_thread(_list_tools_async()).result()
         self._log_debug_with_thread("received %d tools from MCP server", len(list_tools_response.tools))
 
-        mcp_tools = [MCPAgentTool(tool, self) for tool in list_tools_response.tools]
+        mcp_tools = [MCPAgentTool(tool, self, tool_name_prefix) for tool in list_tools_response.tools]
         self._log_debug_with_thread("successfully adapted %d MCP tools", len(mcp_tools))
         return PaginatedList[MCPAgentTool](mcp_tools, token=list_tools_response.nextCursor)
 


### PR DESCRIPTION
## Description

When using multiple MCP servers with an agent, tool name collisions occur when different MCP servers provide tools with identical names. This causes the agent to crash with:

```
ERROR: Tool name 'search' already exists
```

For example:
- **Atlassian MCP** provides a `search` tool for finding Confluence pages
- **Azure MCP** provides a `search` tool for Azure resources

This is a common scenario when building agents that connect to multiple services. The more MCP servers you add, the more likely you'll encounter collisions with common tool names like `search`, `fetch`, `list`, etc.

I'm able to work around this using [a python middleware class](https://gist.github.com/KyMidd/23bd6489de7bae9da6202a34aa912bb5) that shims prefixed tool names. 

It's fine, but I'm worried it's fragile, and it makes sense to bring this fix to Strands as first-class fucntionality. 

## Related Issues

#731 

## Solution

This PR adds a `tool_name_prefix` parameter directly to `MCPClient.list_tools_sync()`, making tool prefixing a first-class feature.

### New API

```python
github_tools = github_client.list_tools_sync(tool_name_prefix="github_")
atlassian_tools = atlassian_client.list_tools_sync(tool_name_prefix="atlassian_")
azure_tools = azure_client.list_tools_sync(tool_name_prefix="azure_")
pagerduty_tools = pagerduty_client.list_tools_sync(tool_name_prefix="pagerduty_")
```

**Before:**
- Atlassian: `search`, `fetch`
- Azure: `search` <-- Collision! Agent crashes

**After:**
- Atlassian: `atlassian_search`, `atlassian_fetch`
- Azure: `azure_search` <-- No collision, agent doesn't crash, tools are available with distinct names

### Implementation Details

The implementation is minimal and non-breaking, with default behavior exactly identical to current behavior. 

The prefix is optional and defaults to an empty string, preserving backward compatibility.

## Testing

Added comprehensive unit tests covering:

1. **`test_list_tools_sync_with_prefix`** - Verifies prefix is correctly applied to tool names
2. **`test_list_tools_sync_without_prefix`** - Verifies default behavior (no prefix)
3. **`test_list_tools_sync_with_empty_prefix`** - Verifies empty string prefix works correctly
4. **`test_list_tools_sync_prefix_multiple_tools`** - Verifies prefix applied to all tools in a batch

All tests use the existing mock fixtures and follow the established testing patterns.

## Checklist

- [x] I have read the [contributing document](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I agree to the terms in the [contributor guidelines](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md#Contributor-License-Agreement)
