### PR TITLE
fix(telemetry): make strands agent invoke_agent span as INTERNAL spanKind

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -293,7 +293,7 @@ class Tracer:
         # Add additional kwargs as attributes
         attributes.update({k: v for k, v in kwargs.items() if isinstance(v, (str, int, float, bool))})
 
-        span = self._start_span("chat", parent_span, attributes=attributes, span_kind=trace_api.SpanKind.CLIENT)
+        span = self._start_span("chat", parent_span, attributes=attributes, span_kind=trace_api.SpanKind.INTERNAL)
         self._add_event_messages(span, messages)
 
         return span

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -153,7 +153,7 @@ def test_start_model_invoke_span(mock_tracer):
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "chat"
-        assert mock_tracer.start_span.call_args[1]["kind"] == SpanKind.CLIENT
+        assert mock_tracer.start_span.call_args[1]["kind"] == SpanKind.INTERNAL
         mock_span.set_attribute.assert_any_call("gen_ai.system", "strands-agents")
         mock_span.set_attribute.assert_any_call("gen_ai.operation.name", "chat")
         mock_span.set_attribute.assert_any_call("gen_ai.request.model", model_id)
@@ -188,7 +188,7 @@ def test_start_model_invoke_span_latest_conventions(mock_tracer):
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "chat"
-        assert mock_tracer.start_span.call_args[1]["kind"] == SpanKind.CLIENT
+        assert mock_tracer.start_span.call_args[1]["kind"] == SpanKind.INTERNAL
         mock_span.set_attribute.assert_any_call("gen_ai.provider.name", "strands-agents")
         mock_span.set_attribute.assert_any_call("gen_ai.operation.name", "chat")
         mock_span.set_attribute.assert_any_call("gen_ai.request.model", model_id)


### PR DESCRIPTION
## Description
Setting the `invoke_agent` span to **INTERNAL** spanKind to follow the semantic convention. 

It is [arguable](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#inference) that `invoke_agent` can be `CLIENT` in an A2A scenario. However, since `invoke_agent` is an internal process most of the time, we decided to set the spanKind to `INTERNAL`.

## Related Issues
https://github.com/strands-agents/sdk-python/issues/1044

## Follow up Task
As mentioned, in the A2A world, `invoke_agent` could be CLIENT spanKind. We will decide whether to allow customer to pass the spanKind for strands agent to set directly, or to have a separate opinionated A2A `invoke_agent` with CLIENT spanKind.

## Documentation PR

N/A

## Type of Change

Bug fix
Breaking change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
