### PR TITLE
interrupt - docstring - fix formatting

### DIFF
--- a/src/strands/types/interrupt.py
+++ b/src/strands/types/interrupt.py
@@ -1,60 +1,22 @@
 """Interrupt related type definitions for human-in-the-loop workflows.
 
 Interrupt Flow:
-    ┌─────────────────┐
-    │ Agent Invoke    │
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Hook Calls      │
-    | on Event        |
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────┐    No     ┌─────────────────┐
-    │ Interrupts      │ ────────► │ Continue        │
-    │ Raised?         │           │ Execution       │
-    └────────┬────────┘           └─────────────────┘
-             │ Yes
-             ▼
-    ┌─────────────────┐
-    │ Stop Event Loop │◄───────────────────┐
-    └────────┬────────┘                    |
-             │                             |
-             ▼                             |
-    ┌─────────────────┐                    |
-    │ Return          |                    |
-    | Interrupts      │                    |
-    └────────┬────────┘                    |
-             │                             |
-             ▼                             |
-    ┌─────────────────┐                    |
-    │ Agent Invoke    │                    |
-    │ with Responses  │                    |
-    └────────┬────────┘                    |
-             │                             |
-             ▼                             |
-    ┌─────────────────┐                    |
-    │ Hook Calls      │                    |
-    | on Event        |                    |
-    | with Responses  |                    |
-    └────────┬────────┘                    |
-             │                             |
-             ▼                             |
-    ┌─────────────────┐    Yes    ┌────────┴────────┐
-    │ New Interrupts  │ ────────► │ Store State     │
-    │ Raised?         │           │                 │
-    └────────┬────────┘           └─────────────────┘
-             │ No
-             ▼
-    ┌─────────────────┐
-    │ Continue        │
-    │ Execution       │
-    └─────────────────┘
+    ```mermaid
+    flowchart TD
+        A[Invoke Agent] --> B[Execute Hook/Tool]
+        B --> C{Interrupts Raised?}
+        C -->|No| D[Continue Agent Loop]
+        C -->|Yes| E[Stop Agent Loop]
+        E --> F[Return Interrupts]
+        F --> G[Respond to Interrupts]
+        G --> H[Execute Hook/Tool with Responses]
+        H --> I{New Interrupts?}
+        I -->|Yes| E
+        I -->|No| D
+    ```
 
 Example:
-    ```
+    ```Python
     from typing import Any
 
     from strands import Agent, tool
@@ -99,7 +61,6 @@ Example:
     ```
 
 Details:
-
     - User raises interrupt on their hook event by calling `event.interrupt()`.
     - User can raise one interrupt per hook callback.
     - Interrupts stop the agent event loop.


### PR DESCRIPTION
## Description
Fixing the appearance of some interrupt docstrings for API Reference pages in https://strandsagents.com/latest/documentation/docs/api-reference/agent/.

## Related Issues

N/A

## Documentation PR

https://github.com/strands-agents/docs/pull/292

## Type of Change

Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
