### PR TITLE
fix(anthropic): incorrect exception raised when context limit exceeded

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -42,6 +42,7 @@ class AnthropicModel(Model):
         "input is too long",
         "input length exceeds context window",
         "input and output tokens exceed your context limit",
+        "input length and `max_tokens` exceed context limit,
     }
 
     class AnthropicConfig(TypedDict, total=False):


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
Added handling for "input length and `max_tokens` exceed context limit" to raise ContextWindowOverflowException

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->
Previously, a generic error was raised instead of ContextWindowOverflowException.
Now it correctly maps the "input length and `max_tokens` exceed context limit" error.

Handle Anthropic/LLM API errors containing "input length and `max_tokens` exceed context limit" by explicitly raising ContextWindowOverflowException instead of generic RemoteProtocolError(for strands-agent 0.12.0) or EventLoopException or anthropic.BadRequestError(for anthropic 0.71.0, strands-agent 0.13.0)

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
