### PR TITLE
Pr size labeler

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -2,7 +2,7 @@ name: PR Size Labeler
 
 on:
   pull_request:
-    branches: pr-size-labeler
+    branches: main
 
 jobs:
   label-size:


### PR DESCRIPTION
## Description

Add PR Size Labeler to Improve Review Velocity
PRs have been taking longer to review because they are not scoped to manageable sizes. Large PRs create review bottlenecks where reviewers struggle to provide thorough feedback and risk missing critical issues in complex changes. This change encourages smaller, focused PRs that are easier to review and helps reviewers prioritize their time. Blocks oversized PRs that should be split, improving overall development velocity through faster review cycles.

### Solution
Adds an automated GitHub Action that labels pull requests based on their size:

size/xs: ≤20 lines

size/s: ≤100 lines

size/m: ≤500 lines

size/l: ≤1000 lines

size/xl: >1000 lines (fails the check)


This change only runs for trusted assignees. We can loosen this in the future. But the reason is that maintainers should only be running "Approve workflows" if they have already reviewed the PR. So if you have already reviewed the PR this is not that useful of a feature.

## Type of Change

CI

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

Tested in dbschmigelski/integ-testing where PRs of multiple sizes were executed against it.

- [x] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
