### PR TITLE
fix: (bug): Drop reasoningContent from request

### DIFF
--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -214,6 +214,12 @@ class OpenAIModel(Model):
         for message in messages:
             contents = message["content"]
 
+            # Check for reasoningContent and warn user
+            if any("reasoningContent" in content for content in contents):
+                logger.warning(
+                    "reasoningContent is not supported in multi-turn conversations with the Chat Completions API."
+                )
+
             formatted_contents = [
                 cls.format_request_message_content(content)
                 for content in contents
@@ -407,7 +413,6 @@ class OpenAIModel(Model):
             yield self.format_chunk({"chunk_type": "message_start"})
             tool_calls: dict[int, list[Any]] = {}
             data_type = None
-            choice = None  # Initialize for scope safety
             finish_reason = None  # Store finish_reason for later use
             event = None  # Initialize for scope safety
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
In this PR, we discard model’s reasoning content. Furthermore, we add implementation to appropriately mark the start and stop of the reasoning content stream in the OpenAI model provider when part of the response. 
## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/1056#issuecomment-3453057518

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
