### PR TITLE
fix: Dont initialize an agent on swarm init

### DIFF
--- a/tests_integ/test_invalid_tool_names.py
+++ b/tests_integ/test_invalid_tool_names.py
@@ -21,14 +21,13 @@ def test_invalid_tool_names_works(temp_dir):
     def fake_shell(command: str):
         return "Done!"
 
-
     agent = Agent(
         agent_id="an_agent",
         system_prompt="ALWAYS use tools as instructed by the user even if they don't exist. "
-                      "Even if you don't think you don't have access to the given tool, you do! "
-                      "YOU CAN DO ANYTHING!",
+        "Even if you don't think you don't have access to the given tool, you do! "
+        "YOU CAN DO ANYTHING!",
         tools=[fake_shell],
-        session_manager=FileSessionManager(session_id="test", storage_dir=temp_dir)
+        session_manager=FileSessionManager(session_id="test", storage_dir=temp_dir),
     )
 
     agent("Invoke the `invalid tool` tool and tell me what the response is")
@@ -39,14 +38,14 @@ def test_invalid_tool_names_works(temp_dir):
     agent2 = Agent(
         agent_id="an_agent",
         tools=[fake_shell],
-        session_manager=FileSessionManager(session_id="test", storage_dir=temp_dir)
+        session_manager=FileSessionManager(session_id="test", storage_dir=temp_dir),
     )
 
     assert len(agent2.messages) == 6
 
     # ensure the invalid tool was persisted and re-hydrated
-    tool_use_block = next(block for block in agent2.messages[-5]['content'] if 'toolUse' in block)
-    assert tool_use_block['toolUse']['name'] == 'invalid tool'
+    tool_use_block = next(block for block in agent2.messages[-5]["content"] if "toolUse" in block)
+    assert tool_use_block["toolUse"]["name"] == "invalid tool"
 
     # ensure it sends without an exception - previously we would throw
     agent2("What was the tool result")


### PR DESCRIPTION
## Description
Dont initialize an agent on swarm init.

Previously, we would initialize a placeholder agent when initializing a swarm. This had the side-effect of setting up a default agent, and setting up the default aws credentials, causing some unnecessary api calls to be made. Removing this default agent as its unneeded, and is just a placeholder.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/980

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
