### PR TITLE
feat(agent-interface): introduce AgentBase Protocol as the interface for agent classes to implement

### DIFF
--- a/src/strands/__init__.py
+++ b/src/strands/__init__.py
@@ -2,11 +2,13 @@
 
 from . import agent, models, telemetry, types
 from .agent.agent import Agent
+from .agent.base import AgentBase
 from .tools.decorator import tool
 from .types.tools import ToolContext
 
 __all__ = [
     "Agent",
+    "AgentBase",
     "agent",
     "models",
     "tool",

--- a/src/strands/agent/__init__.py
+++ b/src/strands/agent/__init__.py
@@ -8,6 +8,7 @@ It includes:
 
 from .agent import Agent
 from .agent_result import AgentResult
+from .base import AgentBase
 from .conversation_manager import (
     ConversationManager,
     NullConversationManager,
@@ -17,6 +18,7 @@ from .conversation_manager import (
 
 __all__ = [
     "Agent",
+    "AgentBase",
     "AgentResult",
     "ConversationManager",
     "NullConversationManager",

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -89,7 +89,7 @@ _DEFAULT_AGENT_ID = "default"
 
 
 class Agent:
-    """Core Agent interface.
+    """Core Agent implementation.
 
     An agent orchestrates the following workflow:
 

--- a/src/strands/agent/base.py
+++ b/src/strands/agent/base.py
@@ -1,0 +1,66 @@
+"""Agent Interface.
+
+Defines the minimal interface that all agent types must implement.
+"""
+
+from typing import Any, AsyncIterator, Protocol, runtime_checkable
+
+from ..types.agent import AgentInput
+from .agent_result import AgentResult
+
+
+@runtime_checkable
+class AgentBase(Protocol):
+    """Protocol defining the interface for all agent types in Strands.
+
+    This protocol defines the minimal contract that all agent implementations
+    must satisfy.
+    """
+
+    async def invoke_async(
+        self,
+        prompt: AgentInput = None,
+        **kwargs: Any,
+    ) -> AgentResult:
+        """Asynchronously invoke the agent with the given prompt.
+
+        Args:
+            prompt: Input to the agent.
+            **kwargs: Additional arguments.
+
+        Returns:
+            AgentResult containing the agent's response.
+        """
+        ...
+
+    def __call__(
+        self,
+        prompt: AgentInput = None,
+        **kwargs: Any,
+    ) -> AgentResult:
+        """Synchronously invoke the agent with the given prompt.
+
+        Args:
+            prompt: Input to the agent.
+            **kwargs: Additional arguments.
+
+        Returns:
+            AgentResult containing the agent's response.
+        """
+        ...
+
+    def stream_async(
+        self,
+        prompt: AgentInput = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[Any]:
+        """Stream agent execution asynchronously.
+
+        Args:
+            prompt: Input to the agent.
+            **kwargs: Additional arguments.
+
+        Yields:
+            Events representing the streaming execution.
+        """
+        ...


### PR DESCRIPTION
## Description
Adds an `AgentBase` Protocol that defines a minimal interface for agent classes.

This is in part to support https://github.com/strands-agents/sdk-python/issues/907 where we will introduce an `A2AAgent` class alongside the current `Agent` class. Both `Agent` and `A2AAgent` need the same functions and signatures for our multiagent classes like `Graph` to consume - `AgentBase` is that consistent interface.

The purpose of the `AgentBase` interface is to define the signatures for methods that are used in higher level primitives, like multiagent orchestrators (e.g. `Graph`).

## Related Issues

#573

## Documentation PR

TODO

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [N/A] I have added any necessary tests that prove my fix is effective or my feature works
- [TODO] I have updated the documentation accordingly
- [TODO] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
