### PR TITLE
fix: Allow none structured output context in tool executors

### DIFF
--- a/src/strands/tools/executors/_executor.py
+++ b/src/strands/tools/executors/_executor.py
@@ -283,7 +283,7 @@ class ToolExecutor(abc.ABC):
         cycle_trace: Trace,
         cycle_span: Any,
         invocation_state: dict[str, Any],
-        structured_output_context: "StructuredOutputContext",
+        structured_output_context: "StructuredOutputContext | None" = None,
     ) -> AsyncGenerator[TypedEvent, None]:
         """Execute the given tools according to this executor's strategy.
 

--- a/src/strands/tools/executors/concurrent.py
+++ b/src/strands/tools/executors/concurrent.py
@@ -27,7 +27,7 @@ class ConcurrentToolExecutor(ToolExecutor):
         cycle_trace: Trace,
         cycle_span: Any,
         invocation_state: dict[str, Any],
-        structured_output_context: "StructuredOutputContext",
+        structured_output_context: "StructuredOutputContext | None" = None,
     ) -> AsyncGenerator[TypedEvent, None]:
         """Execute tools concurrently.
 
@@ -88,7 +88,7 @@ class ConcurrentToolExecutor(ToolExecutor):
         task_queue: asyncio.Queue,
         task_event: asyncio.Event,
         stop_event: object,
-        structured_output_context: "StructuredOutputContext",
+        structured_output_context: "StructuredOutputContext | None",
     ) -> None:
         """Execute a single tool and put results in the task queue.
 

--- a/src/strands/tools/executors/sequential.py
+++ b/src/strands/tools/executors/sequential.py
@@ -26,7 +26,7 @@ class SequentialToolExecutor(ToolExecutor):
         cycle_trace: Trace,
         cycle_span: Any,
         invocation_state: dict[str, Any],
-        structured_output_context: "StructuredOutputContext",
+        structured_output_context: "StructuredOutputContext | None" = None,
     ) -> AsyncGenerator[TypedEvent, None]:
         """Execute tools sequentially.
 


### PR DESCRIPTION
## Description
Make `structured_output_context` optional in tool executors. This is causing a bug for bidirectional streaming tool executions as they do not provide this context. 

This param is already nullable in some places, and not nullable in others. This will make it consistent

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change
Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
