### PR TITLE
fix: Handle "prompt is too long" from Anthropic

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -39,6 +39,7 @@ class AnthropicModel(Model):
     }
 
     OVERFLOW_MESSAGES = {
+        "prompt is too long:",
         "input is too long",
         "input length exceeds context window",
         "input and output tokens exceed your context limit",


### PR DESCRIPTION
## Description

#1078 mentioned that context overflows were not handled, but I wasn't able to reproduce using the code changes in it.  However, in testing (using @dea's suggested test) I was able to reproduce and consistently got a "prompt is too long:" error.  This change addresses that error.

I also added a test case using the expected error and validated that it works.  If we swap out ConversationManagers, the agent loop does automatically trim the context (not propagating the error) as expected.

[B​est practices to handle prompts that are too long for the LLM API (eg., Anthropic, OpenAi)? - DEV Community](https://dev.to/brando90/best-practices-to-handle-prompts-that-are-too-long-for-the-llm-api-eg-anthropic-openai-2m4a) also indicates that this is an error that is not unique to us.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
