### PR TITLE
feat(agent): add generic type parameters for structured output type i…

### DIFF
--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -5,7 +5,7 @@ providing a structured way to observe to different events of the event loop and
 agent lifecycle.
 """
 
-from typing import TYPE_CHECKING, Any, Sequence, cast
+from typing import TYPE_CHECKING, Any, Generic, Sequence, TypeVar, cast
 
 from pydantic import BaseModel
 from typing_extensions import override
@@ -21,6 +21,9 @@ from .tools import ToolResult, ToolUse
 if TYPE_CHECKING:
     from ..agent import AgentResult
     from ..multiagent.base import MultiAgentResult, NodeResult
+
+# TypeVar for generic AgentResult type parameter
+T = TypeVar("T", bound=BaseModel)
 
 
 class TypedEvent(dict):
@@ -408,8 +411,8 @@ class ForceStopEvent(TypedEvent):
         )
 
 
-class AgentResultEvent(TypedEvent):
-    def __init__(self, result: "AgentResult"):
+class AgentResultEvent(TypedEvent, Generic[T]):
+    def __init__(self, result: "AgentResult[T]"):
         super().__init__({"result": result})
 
 

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -2240,8 +2240,8 @@ def test_agent_backwards_compatibility_single_text_block():
 
     # Should extract text for backwards compatibility
     assert agent.system_prompt == text
-    
-    
+
+
 @pytest.mark.parametrize(
     "content, expected",
     [

--- a/tests/strands/agent/test_agent_type_inference.py
+++ b/tests/strands/agent/test_agent_type_inference.py
@@ -1,0 +1,296 @@
+"""Type inference tests for Agent with structured output.
+
+This test file validates that mypy correctly infers types when using
+Agent with structured_output_model. These tests are designed to pass
+mypy type checking without requiring explicit type casting.
+
+Run mypy on this file to verify type inference:
+    mypy tests/strands/agent/test_agent_type_inference.py
+"""
+
+from typing import Type
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from strands import Agent
+from strands.agent.agent_result import AgentResult
+from strands.telemetry.metrics import EventLoopMetrics
+from strands.types._events import EventLoopStopEvent
+
+
+class UserProfile(BaseModel):
+    """Test model for user profile data."""
+
+    name: str
+    age: int
+    email: str
+
+
+class ProductInfo(BaseModel):
+    """Test model for product information."""
+
+    product_id: str
+    price: float
+    in_stock: bool
+
+
+@pytest.fixture
+def mock_model():
+    """Create a mock model."""
+    model = Mock()
+
+    async def mock_stream(*args, **kwargs):
+        yield {"contentBlockDelta": {"delta": {"text": "test response"}}}
+        yield {"contentBlockStop": {}}
+        yield {"messageStop": {"stopReason": "end_turn"}}
+
+    model.stream.side_effect = lambda *args, **kwargs: mock_stream(*args, **kwargs)
+    return model
+
+
+@pytest.fixture
+def mock_metrics():
+    return Mock(spec=EventLoopMetrics)
+
+
+class TestAgentTypeInferenceWithModel:
+    """Test type inference when Agent is initialized with structured_output_model."""
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_type_inference_with_structured_output_model(self, mock_event_loop, mock_model, mock_metrics):
+        """Test that mypy infers AgentResult[UserProfile] when agent has structured_output_model."""
+        test_output = UserProfile(name="John Doe", age=30, email="john@example.com")
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        # Type inference: agent should be Agent[UserProfile]
+        agent = Agent(model=mock_model, structured_output_model=UserProfile)
+
+        # Type inference: result should be AgentResult[UserProfile]
+        result = agent("Extract user info")
+
+        # Type inference: structured_output should be UserProfile | None
+        assert result.structured_output is not None
+
+        # After None check, mypy should know these fields exist
+        # No type: ignore needed after fix
+        name: str = result.structured_output.name
+        age: int = result.structured_output.age
+        email: str = result.structured_output.email
+
+        assert name == "John Doe"
+        assert age == 30
+        assert email == "john@example.com"
+
+    @pytest.mark.asyncio
+    @patch("strands.agent.agent.event_loop_cycle")
+    async def test_async_invocation_type_inference(self, mock_event_loop, mock_model, mock_metrics):
+        """Test type inference with async invocation."""
+        test_output = UserProfile(name="Jane Smith", age=25, email="jane@example.com")
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        agent = Agent(model=mock_model, structured_output_model=UserProfile)
+        result = await agent.invoke_async("Extract user info")
+
+        assert result.structured_output is not None
+        name: str = result.structured_output.name
+        assert name == "Jane Smith"
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_explicit_type_annotation(self, mock_event_loop, mock_model, mock_metrics):
+        """Test that explicit type annotations work correctly."""
+        test_output = ProductInfo(product_id="ABC123", price=99.99, in_stock=True)
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        agent: Agent[ProductInfo] = Agent(model=mock_model, structured_output_model=ProductInfo)
+        result: AgentResult[ProductInfo] = agent("Get product info")
+
+        assert result.structured_output is not None
+        product_id: str = result.structured_output.product_id
+        price: float = result.structured_output.price
+        in_stock: bool = result.structured_output.in_stock
+
+        assert product_id == "ABC123"
+        assert price == 99.99
+        assert in_stock is True
+
+
+class TestAgentTypeInferenceWithoutModel:
+    """Test backward compatibility when Agent is used without structured_output_model."""
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_type_inference_without_model(self, mock_event_loop, mock_model, mock_metrics):
+        """Test that Agent without structured_output_model defaults to BaseModel."""
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=None,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        # Type inference: agent should be Agent[BaseModel]
+        agent = Agent(model=mock_model)
+
+        # Type inference: result should be AgentResult[BaseModel]
+        result = agent("Hello")
+
+        # Type inference: structured_output should be BaseModel | None
+        output: BaseModel | None = result.structured_output
+        assert output is None
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_backward_compatibility_with_none_output(self, mock_event_loop, mock_model, mock_metrics):
+        """Test that None structured_output works correctly."""
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=None,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        agent = Agent(model=mock_model, structured_output_model=UserProfile)
+        result = agent("Extract user info")
+
+        # structured_output can be None
+        assert result.structured_output is None
+
+
+class TestGenericFunctionTypePreservation:
+    """Test that generic type parameters are preserved through function calls."""
+
+    def test_generic_function_return_type(self, mock_model):
+        """Test type preservation through generic function."""
+
+        def create_typed_agent(model_type: Type[UserProfile]) -> Agent[UserProfile]:
+            """Create an agent with specific model type."""
+            return Agent(model=mock_model, structured_output_model=model_type)
+
+        # Type should be preserved through function
+        agent: Agent[UserProfile] = create_typed_agent(UserProfile)
+        assert agent._default_structured_output_model == UserProfile
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_generic_function_with_invocation(self, mock_event_loop, mock_model, mock_metrics):
+        """Test type preservation through generic function with invocation."""
+        test_output = UserProfile(name="Test User", age=40, email="test@example.com")
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        def create_and_invoke(model_type: Type[UserProfile], prompt: str) -> AgentResult[UserProfile]:
+            """Create agent and invoke it."""
+            agent = Agent(model=mock_model, structured_output_model=model_type)
+            return agent(prompt)
+
+        result = create_and_invoke(UserProfile, "Extract user info")
+        assert result.structured_output is not None
+        name: str = result.structured_output.name
+        assert name == "Test User"
+
+
+class TestNoneCheckingRequirements:
+    """Test that mypy properly requires None checking for structured_output."""
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_none_check_required_before_field_access(self, mock_event_loop, mock_model, mock_metrics):
+        """Test that None checking is required before accessing fields.
+
+        This test verifies that mypy requires None checking even with proper type inference.
+        The structured_output field is Optional (T | None), so None checks are necessary.
+        """
+        test_output = UserProfile(name="Alice Brown", age=28, email="alice@example.com")
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        agent = Agent(model=mock_model, structured_output_model=UserProfile)
+        result = agent("Extract user info")
+
+        # Without None check, mypy should error (if strict optional checking is enabled)
+        # With None check, field access should work
+        if result.structured_output is not None:
+            name: str = result.structured_output.name
+            age: int = result.structured_output.age
+            assert name == "Alice Brown"
+            assert age == 28
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_none_value_handling(self, mock_event_loop, mock_model, mock_metrics):
+        """Test that None values are properly typed."""
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=None,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        agent = Agent(model=mock_model, structured_output_model=UserProfile)
+        result = agent("Extract user info")
+
+        # Type inference: structured_output is UserProfile | None
+        output: UserProfile | None = result.structured_output
+        assert output is None
+
+        # Attempting to access fields without None check should be caught by mypy
+        # (This would fail at runtime if not checked)
+        if output is not None:
+            _ = output.name  # This line is never reached but shows proper None checking

--- a/tests/strands/agent/test_structured_output_type_issue.py
+++ b/tests/strands/agent/test_structured_output_type_issue.py
@@ -1,0 +1,239 @@
+"""Reproduction test demonstrating type inference issue with structured output.
+
+This test file demonstrates the current limitation where mypy cannot infer
+the specific type of structured_output from AgentResult when an agent is
+initialized with structured_output_model.
+
+Expected mypy errors (before fix):
+- Line ~40: error: Item "None" has no attribute "name"
+- Line ~41: error: Item "None" has no attribute "age"
+- Line ~42: error: Item "BaseModel" has no attribute "name"
+- Line ~43: error: Item "BaseModel" has no attribute "age"
+
+After implementing generic types, these errors should be resolved without
+needing explicit type casting.
+"""
+
+from typing import cast
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from strands import Agent
+from strands.agent.agent_result import AgentResult
+from strands.telemetry.metrics import EventLoopMetrics
+from strands.types._events import EventLoopStopEvent
+
+
+class TestOutputModel(BaseModel):
+    """Test model for structured output type inference."""
+
+    name: str
+    age: int
+    email: str
+
+
+@pytest.fixture
+def mock_model():
+    """Create a mock model."""
+    model = Mock()
+
+    async def mock_stream(*args, **kwargs):
+        yield {"contentBlockDelta": {"delta": {"text": "test response"}}}
+        yield {"contentBlockStop": {}}
+        yield {"messageStop": {"stopReason": "end_turn"}}
+
+    model.stream.side_effect = lambda *args, **kwargs: mock_stream(*args, **kwargs)
+    return model
+
+
+@pytest.fixture
+def mock_metrics():
+    return Mock(spec=EventLoopMetrics)
+
+
+class TestStructuredOutputTypeInference:
+    """Test cases demonstrating the type inference issue."""
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_current_type_inference_issue(self, mock_event_loop, mock_model, mock_metrics):
+        """Demonstrate current type inference limitation requiring explicit casting.
+
+        This test shows that with the current implementation, mypy cannot infer
+        the specific type of structured_output, requiring manual type casting.
+        """
+        # Setup mock event loop to return structured output
+        test_output = TestOutputModel(name="John Doe", age=30, email="john@example.com")
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        # Create agent with structured_output_model
+        agent = Agent(model=mock_model, structured_output_model=TestOutputModel)
+        result = agent("Extract user info")
+
+        # Current issue: mypy sees result.structured_output as BaseModel | None
+        # This requires explicit casting to access model-specific fields
+        assert result.structured_output is not None
+
+        # After fix: mypy should understand the specific type
+        # No type: ignore needed
+        name = result.structured_output.name
+        age = result.structured_output.age
+
+        assert name == "John Doe"
+        assert age == 30
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_workaround_with_explicit_casting(self, mock_event_loop, mock_model, mock_metrics):
+        """Show the current workaround using explicit type casting.
+
+        This is what developers currently need to do to satisfy mypy.
+        """
+        test_output = TestOutputModel(name="Jane Smith", age=25, email="jane@example.com")
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        agent = Agent(model=mock_model, structured_output_model=TestOutputModel)
+        result = agent("Extract user info")
+
+        # Current workaround: explicit casting
+        if result.structured_output is not None:
+            typed_output = cast(TestOutputModel, result.structured_output)
+            name = typed_output.name  # mypy is happy with this
+            age = typed_output.age
+
+            assert name == "Jane Smith"
+            assert age == 25
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_desired_type_inference_behavior(self, mock_event_loop, mock_model, mock_metrics):
+        """Demonstrate the desired behavior after implementing generic types.
+
+        After the fix, this test should pass mypy without type: ignore comments
+        or explicit casting.
+        """
+        test_output = TestOutputModel(name="Bob Johnson", age=35, email="bob@example.com")
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        # Create agent with structured_output_model
+        agent = Agent(model=mock_model, structured_output_model=TestOutputModel)
+        result = agent("Extract user info")
+
+        # After fix: mypy should understand that result is AgentResult[TestOutputModel]
+        # and structured_output is TestOutputModel | None
+        assert result.structured_output is not None
+
+        # These should work without type: ignore after the fix
+        name = result.structured_output.name
+        age = result.structured_output.age
+        email = result.structured_output.email
+
+        assert name == "Bob Johnson"
+        assert age == 35
+        assert email == "bob@example.com"
+
+    @pytest.mark.asyncio
+    @patch("strands.agent.agent.event_loop_cycle")
+    async def test_async_invocation_type_inference(self, mock_event_loop, mock_model, mock_metrics):
+        """Test type inference with async invocation."""
+        test_output = TestOutputModel(name="Alice Brown", age=28, email="alice@example.com")
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        agent = Agent(model=mock_model, structured_output_model=TestOutputModel)
+        result = await agent.invoke_async("Extract user info")
+
+        # After fix: async invocation should also have proper type inference
+        assert result.structured_output is not None
+        name = result.structured_output.name
+        assert name == "Alice Brown"
+
+    def test_agent_result_type_annotation(self):
+        """Test that AgentResult type annotation works correctly.
+
+        This demonstrates that even with explicit type annotations,
+        the current implementation doesn't provide proper type inference.
+        """
+        # Create a mock result
+        test_output = TestOutputModel(name="Test User", age=40, email="test@example.com")
+
+        result: AgentResult = AgentResult(
+            stop_reason="end_turn",
+            message={"role": "assistant", "content": [{"text": "Response"}]},
+            metrics=EventLoopMetrics(),
+            state={},
+            structured_output=test_output,
+        )
+
+        # After fix: explicit type annotations should work correctly
+        assert result.structured_output is not None
+        name = result.structured_output.name
+        assert name == "Test User"
+
+    @patch("strands.agent.agent.event_loop_cycle")
+    def test_none_checking_requirement(self, mock_event_loop, mock_model, mock_metrics):
+        """Test that None checking is properly required.
+
+        After the fix, mypy should still require None checking before
+        accessing fields on structured_output.
+        """
+        test_output = TestOutputModel(name="Charlie Davis", age=45, email="charlie@example.com")
+
+        async def mock_cycle(*args, **kwargs):
+            yield EventLoopStopEvent(
+                stop_reason="end_turn",
+                message={"role": "assistant", "content": [{"text": "Response"}]},
+                metrics=mock_metrics,
+                request_state={},
+                structured_output=test_output,
+            )
+
+        mock_event_loop.side_effect = mock_cycle
+
+        agent = Agent(model=mock_model, structured_output_model=TestOutputModel)
+        result = agent("Extract user info")
+
+        # Without None check, mypy should error (even after fix)
+        # This is correct behavior - structured_output can be None
+        if result.structured_output is not None:
+            # After None check, should be able to access fields
+            name = result.structured_output.name
+            assert name == "Charlie Davis"


### PR DESCRIPTION
Fix type inference for
   AgentResult.structured_output" --body "

## Summary
   - Add generic type parameters to `Agent` and `AgentResult` for proper type inference of `structured_output`
   - Resolves issue where `AgentResult.structured_output` returns `BaseModel | None` instead of the specific model type
   - Eliminates need for manual type casting when using structured outputs

   ## Changes
   - Updated `Agent` class to accept generic type parameter `TStructuredOutput`
   - Updated `AgentResult` to use generic type parameter for `structured_output` field
   - Type inference now correctly propagates from `Agent[TestOutputModel]` to `agent_response.structured_output`

## Related Issues
#1114 

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
