### PR TITLE
share thread context

### DIFF
--- a/src/strands/_async.py
+++ b/src/strands/_async.py
@@ -1,6 +1,7 @@
 """Private async execution utilities."""
 
 import asyncio
+import contextvars
 from concurrent.futures import ThreadPoolExecutor
 from typing import Awaitable, Callable, TypeVar
 
@@ -27,5 +28,6 @@ def run_async(async_func: Callable[[], Awaitable[T]]) -> T:
         return asyncio.run(execute_async())
 
     with ThreadPoolExecutor() as executor:
-        future = executor.submit(execute)
+        context = contextvars.copy_context()
+        future = executor.submit(context.run, execute)
         return future.result()

--- a/tests_integ/tools/test_thread_context.py
+++ b/tests_integ/tools/test_thread_context.py
@@ -1,0 +1,47 @@
+import contextvars
+
+import pytest
+
+from strands import Agent, tool
+
+
+@pytest.fixture
+def result():
+    return {}
+
+
+@pytest.fixture
+def contextvar():
+    return contextvars.ContextVar("agent")
+
+
+@pytest.fixture
+def context_tool(result, contextvar):
+    @tool(name="context_tool")
+    def tool_():
+        result["context_value"] = contextvar.get("local_context")
+
+    return tool_
+
+
+@pytest.fixture
+def agent(context_tool):
+    return Agent(tools=[context_tool])
+
+
+def test_agent_invoke_context_sharing(result, contextvar, agent):
+    contextvar.set("shared_context")
+    agent("Execute context_tool")
+
+    tru_context = result["context_value"]
+    exp_context = contextvar.get()
+    assert tru_context == exp_context
+
+
+def test_tool_call_context_sharing(result, contextvar, agent):
+    contextvar.set("shared_context")
+    agent.tool.context_tool()
+
+    tru_context = result["context_value"]
+    exp_context = contextvar.get()
+    assert tru_context == exp_context


### PR DESCRIPTION
## Description
`agent(...)` is a sync invocation that internally invokes `stream_async`. To run `stream_async` in a sync context, we create a thread so as to isolate the creation of an async event loop. As part of that thread creation, we are not copying [contextvars](https://docs.python.org/3/library/contextvars.html) from the main thread. Customers are asking to have this context copied. The thread we create is not meant for context isolation, only async event loop isolation.

Note, I was initially hesitant to make this change because of the following scenario:
- Customer defines a thread local contextvar in their sync tool func that is invoked by the agent, which itself is invoked synchronously.
- Contextvars from the main thread are now copied into that tool func.
- The tool func defines a contextvar with the same name as a contextvar in the main thread.
- The contextvar in the main thread overwrites the contextvar in the tool thread.

I think this is okay though because the use of threads is an internal implementation detail of Strands. Customers are not designing their tools with our use of threads in mind. Additionally, the use of threads here is specifically meant for asyncio event loop isolation, not context isolation. Thus, this is a bug we are fixing here.

Another note, customers may also want to copy context out of the agent threads. However, modifications made to a contextvar in a subthread do not propagate to the parent thread. The context copy only goes one way.

## Shout outs

Shout out to @patrickbradshawdallas for proposing this change in https://github.com/strands-agents/sdk-python/issues/946.

## Related Issues

* https://github.com/strands-agents/sdk-python/issues/946
* https://github.com/strands-agents/sdk-python/issues/769

## Documentation PR

Not necessary as this is an implementation detail of Strands.

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I ran `hatch test tests_integ/tools/test_thread_context.py`: New integ test for thread context sharing.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
