### PR TITLE
Updating Bedrock Converse API citations format to handle web citations

### DIFF
--- a/src/strands/types/citations.py
+++ b/src/strands/types/citations.py
@@ -77,8 +77,22 @@ class DocumentPageLocation(TypedDict, total=False):
     end: int
 
 
+class WebLocation(TypedDict, total=False):
+    """Specifies a web-based location for cited content.
+
+    Provides location information for content cited from web sources.
+
+    Attributes:
+        url: The URL of the web page containing the cited content.
+        domain: The domain of the web page containing the cited content.
+    """
+
+    url: str
+    domain: str
+
+
 # Union type for citation locations
-CitationLocation = Union[DocumentCharLocation, DocumentChunkLocation, DocumentPageLocation]
+CitationLocation = Union[DocumentCharLocation, DocumentChunkLocation, DocumentPageLocation, WebLocation]
 
 
 class CitationSourceContent(TypedDict, total=False):


### PR DESCRIPTION
## Description

This PR fixes citation location handling in the Bedrock Converse API to properly preserve the tagged union structure required by the API.

**Problem:**
The Bedrock API requires `CitationLocation` to be a tagged union with exactly one wrapper key (`web`, `documentChar`, `documentPage`, `documentChunk`, or `searchResultLocation`). The previous implementation was flattening document-based citations, causing validation errors like:
```
botocore.exceptions.ParamValidationError: Must set one of the following keys for tagged union structure...
```

**Solution:**
- Refactored citation type definitions to properly model the tagged union structure with wrapper types (`DocumentCharLocation`, etc.) and inner content types (`DocumentCharLocationInner`, etc.)
- Added `_format_citation_location` helper method that preserves the union structure when filtering citation locations
- Added `SearchResultLocation` type for complete API coverage
- Added comprehensive tests for all 5 location types

**Changes:**
- `src/strands/types/citations.py`: Refactored types to model tagged union structure correctly
- `src/strands/models/bedrock.py`: Added `_format_citation_location` helper method
- `tests/strands/models/test_bedrock.py`: Added tests for all citation location types

## Related Issues

- Fixes #1323 (CitationLocation Tagged Union Structure Error)
- Blocking issue for #1154

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- [X] I ran `hatch run prepare` (1616 tests pass)
- [X] All citation location types tested (web, documentChar, documentPage, documentChunk, searchResultLocation)
- [X] Edge cases tested (optional fields, invalid locations)

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
