### PR TITLE
interrupt - activate - set context separately

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -483,7 +483,8 @@ async def _handle_tool_execution(
 
     if interrupts:
         # Session state stored on AfterInvocationEvent.
-        agent._interrupt_state.activate(context={"tool_use_message": message, "tool_results": tool_results})
+        agent._interrupt_state.context = {"tool_use_message": message, "tool_results": tool_results}
+        agent._interrupt_state.activate()
 
         agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
         yield EventLoopStopEvent(

--- a/src/strands/interrupt.py
+++ b/src/strands/interrupt.py
@@ -53,13 +53,8 @@ class _InterruptState:
     context: dict[str, Any] = field(default_factory=dict)
     activated: bool = False
 
-    def activate(self, context: dict[str, Any] | None = None) -> None:
-        """Activate the interrupt state.
-
-        Args:
-            context: Context associated with the interrupt event.
-        """
-        self.context = context or {}
+    def activate(self) -> None:
+        """Activate the interrupt state."""
         self.activated = True
 
     def deactivate(self) -> None:

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -2001,8 +2001,9 @@ def test_agent__call__resume_interrupt(mock_model, tool_decorated, agenerator):
         reason="test reason",
     )
 
-    agent._interrupt_state.activate(context={"tool_use_message": tool_use_message, "tool_results": []})
+    agent._interrupt_state.context = {"tool_use_message": tool_use_message, "tool_results": []}
     agent._interrupt_state.interrupts[interrupt.id] = interrupt
+    agent._interrupt_state.activate()
 
     interrupt_response = {}
 

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -964,8 +964,9 @@ async def test_event_loop_cycle_interrupt_resume(agent, model, tool, tool_times_
         },
     ]
 
-    agent._interrupt_state.activate(context={"tool_use_message": tool_use_message, "tool_results": tool_results})
+    agent._interrupt_state.context = {"tool_use_message": tool_use_message, "tool_results": tool_results}
     agent._interrupt_state.interrupts[interrupt.id] = interrupt
+    agent._interrupt_state.activate()
 
     interrupt_response = {}
 

--- a/tests/strands/test_interrupt.py
+++ b/tests/strands/test_interrupt.py
@@ -27,13 +27,8 @@ def test_interrupt_to_dict(interrupt):
 def test_interrupt_state_activate():
     interrupt_state = _InterruptState()
 
-    interrupt_state.activate(context={"test": "context"})
-
+    interrupt_state.activate()
     assert interrupt_state.activated
-
-    tru_context = interrupt_state.context
-    exp_context = {"test": "context"}
-    assert tru_context == exp_context
 
 
 def test_interrupt_state_deactivate():


### PR DESCRIPTION
## Description
The _InterruptState activate method only allows you to set the context. You cannot add to it. We are going to need a bit more flexibility though for supporting interrupts in graphs and swarms. With that said, I am removing the context arg from activate and instead having users (meaning us as it is an internal construct) set it directly. I think this makes anyway since _InterruptState is a dataclass.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/204

## Documentation PR

Internal only change.

## Type of Change

Other (please describe): Internal interface update.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: Updated unit tests.
- [x] I ran `hatch test tests_integ/interrupts/*.py`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
