### PR TITLE
multi agent input

### DIFF
--- a/src/strands/multiagent/base.py
+++ b/src/strands/multiagent/base.py
@@ -12,8 +12,8 @@ from typing import Any, AsyncIterator, Union
 
 from .._async import run_async
 from ..agent import AgentResult
-from ..types.content import ContentBlock
 from ..types.event_loop import Metrics, Usage
+from ..types.multiagent import MultiAgentInput
 
 logger = logging.getLogger(__name__)
 
@@ -173,7 +173,7 @@ class MultiAgentBase(ABC):
 
     @abstractmethod
     async def invoke_async(
-        self, task: str | list[ContentBlock], invocation_state: dict[str, Any] | None = None, **kwargs: Any
+        self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any
     ) -> MultiAgentResult:
         """Invoke asynchronously.
 
@@ -186,7 +186,7 @@ class MultiAgentBase(ABC):
         raise NotImplementedError("invoke_async not implemented")
 
     async def stream_async(
-        self, task: str | list[ContentBlock], invocation_state: dict[str, Any] | None = None, **kwargs: Any
+        self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream events during multi-agent execution.
 
@@ -211,7 +211,7 @@ class MultiAgentBase(ABC):
         yield {"result": result}
 
     def __call__(
-        self, task: str | list[ContentBlock], invocation_state: dict[str, Any] | None = None, **kwargs: Any
+        self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any
     ) -> MultiAgentResult:
         """Invoke synchronously.
 

--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -45,6 +45,7 @@ from ..types._events import (
 )
 from ..types.content import ContentBlock, Messages
 from ..types.event_loop import Metrics, Usage
+from ..types.multiagent import MultiAgentInput
 from .base import MultiAgentBase, MultiAgentResult, NodeResult, Status
 
 logger = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ class GraphState:
     """
 
     # Task (with default empty string)
-    task: str | list[ContentBlock] = ""
+    task: MultiAgentInput = ""
 
     # Execution state
     status: Status = Status.PENDING
@@ -456,7 +457,7 @@ class Graph(MultiAgentBase):
         run_async(lambda: self.hooks.invoke_callbacks_async(MultiAgentInitializedEvent(self)))
 
     def __call__(
-        self, task: str | list[ContentBlock], invocation_state: dict[str, Any] | None = None, **kwargs: Any
+        self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any
     ) -> GraphResult:
         """Invoke the graph synchronously.
 
@@ -472,7 +473,7 @@ class Graph(MultiAgentBase):
         return run_async(lambda: self.invoke_async(task, invocation_state))
 
     async def invoke_async(
-        self, task: str | list[ContentBlock], invocation_state: dict[str, Any] | None = None, **kwargs: Any
+        self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any
     ) -> GraphResult:
         """Invoke the graph asynchronously.
 
@@ -496,7 +497,7 @@ class Graph(MultiAgentBase):
         return cast(GraphResult, final_event["result"])
 
     async def stream_async(
-        self, task: str | list[ContentBlock], invocation_state: dict[str, Any] | None = None, **kwargs: Any
+        self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream events during graph execution.
 

--- a/src/strands/multiagent/swarm.py
+++ b/src/strands/multiagent/swarm.py
@@ -45,6 +45,7 @@ from ..types._events import (
 )
 from ..types.content import ContentBlock, Messages
 from ..types.event_loop import Metrics, Usage
+from ..types.multiagent import MultiAgentInput
 from .base import MultiAgentBase, MultiAgentResult, NodeResult, Status
 
 logger = logging.getLogger(__name__)
@@ -145,7 +146,7 @@ class SwarmState:
     """Current state of swarm execution."""
 
     current_node: SwarmNode | None  # The agent currently executing
-    task: str | list[ContentBlock]  # The original task from the user that is being executed
+    task: MultiAgentInput  # The original task from the user that is being executed
     completion_status: Status = Status.PENDING  # Current swarm execution status
     shared_context: SharedContext = field(default_factory=SharedContext)  # Context shared between agents
     node_history: list[SwarmNode] = field(default_factory=list)  # Complete history of agents that have executed
@@ -277,7 +278,7 @@ class Swarm(MultiAgentBase):
         run_async(lambda: self.hooks.invoke_callbacks_async(MultiAgentInitializedEvent(self)))
 
     def __call__(
-        self, task: str | list[ContentBlock], invocation_state: dict[str, Any] | None = None, **kwargs: Any
+        self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any
     ) -> SwarmResult:
         """Invoke the swarm synchronously.
 
@@ -292,7 +293,7 @@ class Swarm(MultiAgentBase):
         return run_async(lambda: self.invoke_async(task, invocation_state))
 
     async def invoke_async(
-        self, task: str | list[ContentBlock], invocation_state: dict[str, Any] | None = None, **kwargs: Any
+        self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any
     ) -> SwarmResult:
         """Invoke the swarm asynchronously.
 
@@ -316,7 +317,7 @@ class Swarm(MultiAgentBase):
         return cast(SwarmResult, final_event["result"])
 
     async def stream_async(
-        self, task: str | list[ContentBlock], invocation_state: dict[str, Any] | None = None, **kwargs: Any
+        self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream events during swarm execution.
 
@@ -741,7 +742,7 @@ class Swarm(MultiAgentBase):
             )
 
     async def _execute_node(
-        self, node: SwarmNode, task: str | list[ContentBlock], invocation_state: dict[str, Any]
+        self, node: SwarmNode, task: MultiAgentInput, invocation_state: dict[str, Any]
     ) -> AsyncIterator[Any]:
         """Execute swarm node and yield TypedEvent objects."""
         start_time = time.time()

--- a/src/strands/types/agent.py
+++ b/src/strands/types/agent.py
@@ -6,6 +6,6 @@ This module defines the types used for an Agent.
 from typing import TypeAlias
 
 from .content import ContentBlock, Messages
-from .interrupt import InterruptResponse
+from .interrupt import InterruptResponseContent
 
-AgentInput: TypeAlias = str | list[ContentBlock] | list[InterruptResponse] | Messages | None
+AgentInput: TypeAlias = str | list[ContentBlock] | list[InterruptResponseContent] | Messages | None

--- a/src/strands/types/multiagent.py
+++ b/src/strands/types/multiagent.py
@@ -1,0 +1,7 @@
+"""Multi-agent related type definitions for the SDK."""
+
+from typing import TypeAlias
+
+from .content import ContentBlock
+
+MultiAgentInput: TypeAlias = str | list[ContentBlock]


### PR DESCRIPTION
## Description
Support MultiAgentInput
- The type use used in multiple locations and so this simplifies the copying.
- Adds symmetry with [AgentInput](https://github.com/strands-agents/sdk-python/blob/main/src/strands/types/agent.py)
- In a follow up PR, I plan to add `list[InterruptResponseContent]` to the list of supported multi agent input types. This simplifies the addition.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/204

## Documentation PR

API docs will update automatically.

## Type of Change

Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
