### PR TITLE
hooks - before node call - cancel node

### DIFF
--- a/src/strands/experimental/hooks/multiagent/events.py
+++ b/src/strands/experimental/hooks/multiagent/events.py
@@ -35,11 +35,18 @@ class BeforeNodeCallEvent(BaseHookEvent):
         source: The multi-agent orchestrator instance
         node_id: ID of the node about to execute
         invocation_state: Configuration that user passes in
+        cancel_node: A user defined message that when set, will cancel the node execution with status FAILED.
+            The message will be emitted under a MultiAgentNodeCancel event. If set to `True`, Strands will cancel the
+            node using a default cancel message.
     """
 
     source: "MultiAgentBase"
     node_id: str
     invocation_state: dict[str, Any] | None = None
+    cancel_node: bool | str = False
+
+    def _can_write(self, name: str) -> bool:
+        return name in ["cancel_node"]
 
 
 @dataclass

--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -38,6 +38,7 @@ from ..session import SessionManager
 from ..telemetry import get_tracer
 from ..types._events import (
     MultiAgentHandoffEvent,
+    MultiAgentNodeCancelEvent,
     MultiAgentNodeStartEvent,
     MultiAgentNodeStopEvent,
     MultiAgentNodeStreamEvent,
@@ -776,8 +777,6 @@ class Graph(MultiAgentBase):
 
     async def _execute_node(self, node: GraphNode, invocation_state: dict[str, Any]) -> AsyncIterator[Any]:
         """Execute a single node and yield TypedEvent objects."""
-        await self.hooks.invoke_callbacks_async(BeforeNodeCallEvent(self, node.node_id, invocation_state))
-
         # Reset the node's state if reset_on_revisit is enabled, and it's being revisited
         if self.reset_on_revisit and node in self.state.completed_nodes:
             logger.debug("node_id=<%s> | resetting node state for revisit", node.node_id)
@@ -793,8 +792,20 @@ class Graph(MultiAgentBase):
         )
         yield start_event
 
+        before_event, _ = await self.hooks.invoke_callbacks_async(
+            BeforeNodeCallEvent(self, node.node_id, invocation_state)
+        )
+
         start_time = time.time()
         try:
+            if before_event.cancel_node:
+                cancel_message = (
+                    before_event.cancel_node if isinstance(before_event.cancel_node, str) else "node cancelled by user"
+                )
+                logger.debug("reason=<%s> | cancelling execution", cancel_message)
+                yield MultiAgentNodeCancelEvent(node.node_id, cancel_message)
+                raise RuntimeError(cancel_message)
+
             # Build node input from satisfied dependencies
             node_input = self._build_node_input(node)
 

--- a/src/strands/multiagent/swarm.py
+++ b/src/strands/multiagent/swarm.py
@@ -38,6 +38,7 @@ from ..telemetry import get_tracer
 from ..tools.decorator import tool
 from ..types._events import (
     MultiAgentHandoffEvent,
+    MultiAgentNodeCancelEvent,
     MultiAgentNodeStartEvent,
     MultiAgentNodeStopEvent,
     MultiAgentNodeStreamEvent,
@@ -678,11 +679,23 @@ class Swarm(MultiAgentBase):
                     len(self.state.node_history) + 1,
                 )
 
+                before_event, _ = await self.hooks.invoke_callbacks_async(
+                    BeforeNodeCallEvent(self, current_node.node_id, invocation_state)
+                )
+
                 # TODO: Implement cancellation token to stop _execute_node from continuing
                 try:
-                    await self.hooks.invoke_callbacks_async(
-                        BeforeNodeCallEvent(self, current_node.node_id, invocation_state)
-                    )
+                    if before_event.cancel_node:
+                        cancel_message = (
+                            before_event.cancel_node
+                            if isinstance(before_event.cancel_node, str)
+                            else "node cancelled by user"
+                        )
+                        logger.debug("reason=<%s> | cancelling execution", cancel_message)
+                        yield MultiAgentNodeCancelEvent(current_node.node_id, cancel_message)
+                        self.state.completion_status = Status.FAILED
+                        break
+
                     node_stream = self._stream_with_timeout(
                         self._execute_node(current_node, self.state.task, invocation_state),
                         self.node_timeout,
@@ -692,40 +705,42 @@ class Swarm(MultiAgentBase):
                         yield event
 
                     self.state.node_history.append(current_node)
-                    await self.hooks.invoke_callbacks_async(
-                        AfterNodeCallEvent(self, current_node.node_id, invocation_state)
-                    )
-
-                    logger.debug("node=<%s> | node execution completed", current_node.node_id)
-
-                    # Check if handoff requested during execution
-                    if self.state.handoff_node:
-                        previous_node = current_node
-                        current_node = self.state.handoff_node
-
-                        self.state.handoff_node = None
-                        self.state.current_node = current_node
-
-                        handoff_event = MultiAgentHandoffEvent(
-                            from_node_ids=[previous_node.node_id],
-                            to_node_ids=[current_node.node_id],
-                            message=self.state.handoff_message or "Agent handoff occurred",
-                        )
-                        yield handoff_event
-                        logger.debug(
-                            "from_node=<%s>, to_node=<%s> | handoff detected",
-                            previous_node.node_id,
-                            current_node.node_id,
-                        )
-
-                    else:
-                        logger.debug("node=<%s> | no handoff occurred, marking swarm as complete", current_node.node_id)
-                        self.state.completion_status = Status.COMPLETED
-                        break
 
                 except Exception:
                     logger.exception("node=<%s> | node execution failed", current_node.node_id)
                     self.state.completion_status = Status.FAILED
+                    break
+
+                finally:
+                    await self.hooks.invoke_callbacks_async(
+                        AfterNodeCallEvent(self, current_node.node_id, invocation_state)
+                    )
+
+                logger.debug("node=<%s> | node execution completed", current_node.node_id)
+
+                # Check if handoff requested during execution
+                if self.state.handoff_node:
+                    previous_node = current_node
+                    current_node = self.state.handoff_node
+
+                    self.state.handoff_node = None
+                    self.state.current_node = current_node
+
+                    handoff_event = MultiAgentHandoffEvent(
+                        from_node_ids=[previous_node.node_id],
+                        to_node_ids=[current_node.node_id],
+                        message=self.state.handoff_message or "Agent handoff occurred",
+                    )
+                    yield handoff_event
+                    logger.debug(
+                        "from_node=<%s>, to_node=<%s> | handoff detected",
+                        previous_node.node_id,
+                        current_node.node_id,
+                    )
+
+                else:
+                    logger.debug("node=<%s> | no handoff occurred, marking swarm as complete", current_node.node_id)
+                    self.state.completion_status = Status.COMPLETED
                     break
 
         except Exception:

--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -524,3 +524,22 @@ class MultiAgentNodeStreamEvent(TypedEvent):
                 "event": agent_event,  # Nest agent event to avoid field conflicts
             }
         )
+
+
+class MultiAgentNodeCancelEvent(TypedEvent):
+    """Event emitted when a user cancels node execution from their BeforeNodeCallEvent hook."""
+
+    def __init__(self, node_id: str, message: str) -> None:
+        """Initialize with cancel message.
+
+        Args:
+            node_id: Unique identifier for the node.
+            message: The node cancellation message.
+        """
+        super().__init__(
+            {
+                "type": "multiagent_node_cancel",
+                "node_id": node_id,
+                "message": message,
+            }
+        )

--- a/tests_integ/hooks/multiagent/test_cancel.py
+++ b/tests_integ/hooks/multiagent/test_cancel.py
@@ -1,0 +1,88 @@
+import pytest
+
+from strands import Agent
+from strands.experimental.hooks.multiagent import BeforeNodeCallEvent
+from strands.hooks import HookProvider
+from strands.multiagent import GraphBuilder, Swarm
+from strands.multiagent.base import Status
+from strands.types._events import MultiAgentNodeCancelEvent
+
+
+@pytest.fixture
+def cancel_hook():
+    class Hook(HookProvider):
+        def register_hooks(self, registry):
+            registry.add_callback(BeforeNodeCallEvent, self.cancel)
+
+        def cancel(self, event):
+            if event.node_id == "weather":
+                event.cancel_node = "test cancel"
+
+    return Hook()
+
+
+@pytest.fixture
+def info_agent():
+    return Agent(name="info")
+
+
+@pytest.fixture
+def weather_agent():
+    return Agent(name="weather")
+
+
+@pytest.fixture
+def swarm(cancel_hook, info_agent, weather_agent):
+    return Swarm([info_agent, weather_agent], hooks=[cancel_hook])
+
+
+@pytest.fixture
+def graph(cancel_hook, info_agent, weather_agent):
+    builder = GraphBuilder()
+    builder.add_node(info_agent, "info")
+    builder.add_node(weather_agent, "weather")
+    builder.add_edge("info", "weather")
+    builder.set_entry_point("info")
+    builder.set_hook_providers([cancel_hook])
+
+    return builder.build()
+
+
+@pytest.mark.asyncio
+async def test_swarm_cancel_node(swarm):
+    tru_cancel_event = None
+    async for event in swarm.stream_async("What is the weather"):
+        if event.get("type") == "multiagent_node_cancel":
+            tru_cancel_event = event
+
+    multiagent_result = event["result"]
+
+    exp_cancel_event = MultiAgentNodeCancelEvent(node_id="weather", message="test cancel")
+    assert tru_cancel_event == exp_cancel_event
+
+    tru_status = multiagent_result.status
+    exp_status = Status.FAILED
+    assert tru_status == exp_status
+
+    assert len(multiagent_result.node_history) == 1
+    tru_node_id = multiagent_result.node_history[0].node_id
+    exp_node_id = "info"
+    assert tru_node_id == exp_node_id
+
+
+@pytest.mark.asyncio
+async def test_graph_cancel_node(graph):
+    tru_cancel_event = None
+    with pytest.raises(RuntimeError, match="test cancel"):
+        async for event in graph.stream_async("What is the weather"):
+            if event.get("type") == "multiagent_node_cancel":
+                tru_cancel_event = event
+
+    exp_cancel_event = MultiAgentNodeCancelEvent(node_id="weather", message="test cancel")
+    assert tru_cancel_event == exp_cancel_event
+
+    state = graph.state
+
+    tru_status = state.status
+    exp_status = Status.FAILED
+    assert tru_status == exp_status


### PR DESCRIPTION
## Description
Allow users to cancel multiagent node execution from their BeforeNodeCallEvent hooks. This change mirrors tool cancellation introduced in https://github.com/strands-agents/sdk-python/pull/964. Cancellation is particularly useful for HIL approval/rejection workflows operated through interrupts.

## Usage
```Python
class CancelHook(HookProvider):
    def register_hooks(self, registry) -> None:
        registry.add_callback(BeforeNodeCallEvent, self.cancel)

    def cancel(self, event: BeforeToolCallEvent) -> None:
        if event.node_id == "delete":
            response = event.interrupt("my_interrupt", reason="need approval")
            if response != "APPROVE":
                event.cancel_node = "node rejected"

system_agent = Agent(name="system")
delete_agent = Agent(name="delete")
swarm = Swarm([system_agent, delete_agent], hooks=[CancelHook()])

result = swarm("Delete my file")
...
```
If rejected, the delete node will not be executed and the swarm will end with a FAILED status. Similar behavior occurs with node cancellation in Graph.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/204

## Documentation PR

Will add documentation to https://strandsagents.com/latest/documentation/docs/user-guide/concepts/interrupts/ once multi-agent interrupt work is complete. In the meanwhile, customers will have the API reference docs, which will automatically update on next release.

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: Wrote new unit tests.
- [x] I ran `hatch test tests_integ/hooks/multiagent/test_cancel.py`: Wrote new integ tests.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
