### PR TITLE
In PrintingCallbackHandler, make the verbose description and counting…

### DIFF
--- a/src/strands/handlers/callback_handler.py
+++ b/src/strands/handlers/callback_handler.py
@@ -3,17 +3,19 @@
 from collections.abc import Callable
 from typing import Any
 
+
 class PrintingCallbackHandler:
     """Handler for streaming text output and tool invocations to stdout."""
 
     def __init__(self, verbose_tool_use: bool = True) -> None:
         """Initialize handler.
-        
+
         Args:
-            verbose_tool_use: Print out verbose information about tool calls."""
+            verbose_tool_use: Print out verbose information about tool calls.
+        """
         self.tool_count = 0
         self.previous_tool_use = None
-        self.verbose_tool_use = verbose_tool_use
+        self._verbose_tool_use = verbose_tool_use
 
     def __call__(self, **kwargs: Any) -> None:
         """Stream text output and tool invocations to stdout.
@@ -36,12 +38,13 @@ class PrintingCallbackHandler:
         if data:
             print(data, end="" if not complete else "\n")
 
-        if current_tool_use and current_tool_use.get("name") and self.verbose_tool_use:
-            tool_name = current_tool_use.get("name", "Unknown tool")
+        if current_tool_use and current_tool_use.get("name"):
             if self.previous_tool_use != current_tool_use:
                 self.previous_tool_use = current_tool_use
                 self.tool_count += 1
-                print(f"\nTool #{self.tool_count}: {tool_name}")
+                if self._verbose_tool_use:
+                    tool_name = current_tool_use.get("name", "Unknown tool")
+                    print(f"\nTool #{self.tool_count}: {tool_name}")
 
         if complete and data:
             print("\n")

--- a/tests/strands/handlers/test_callback_handler.py
+++ b/tests/strands/handlers/test_callback_handler.py
@@ -202,3 +202,25 @@ def test_composite_handler_forwards_to_all_handlers():
     # Verify each handler was called with the same arguments
     for handler in mock_handlers:
         handler.assert_called_once_with(**kwargs)
+
+
+def test_verbose_tool_use_default():
+    """Test that _verbose_tool_use defaults to True."""
+    handler = PrintingCallbackHandler()
+    assert handler._verbose_tool_use is True
+
+
+def test_verbose_tool_use_disabled(mock_print):
+    """Test that tool use output is suppressed when verbose_tool_use=False but counting still works."""
+    handler = PrintingCallbackHandler(verbose_tool_use=False)
+    assert handler._verbose_tool_use is False
+
+    current_tool_use = {"name": "test_tool", "input": {"param": "value"}}
+    handler(current_tool_use=current_tool_use)
+
+    # Should not print tool information when verbose_tool_use is False
+    mock_print.assert_not_called()
+
+    # Should still update tool count and previous_tool_use
+    assert handler.tool_count == 1
+    assert handler.previous_tool_use == current_tool_use


### PR DESCRIPTION
In PrintingCallbackHandler, make the verbose description and counting of tool use optional.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe): Minor quality-of-life issue

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x ] I ran `hatch run prepare`

## Checklist
- [x ] I have read the CONTRIBUTING document
- [x ] I have added any necessary tests that prove my fix is effective or my feature works
- [x ] I have updated the documentation accordingly
- [x ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x ] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
