### PR TITLE
security(tool_loader): prevent tool name and sys modules collisions i…

### DIFF
--- a/src/strands/tools/loader.py
+++ b/src/strands/tools/loader.py
@@ -17,6 +17,8 @@ from .tools import PythonAgentTool
 
 logger = logging.getLogger(__name__)
 
+_TOOL_MODULE_PREFIX = "_strands_tool_"
+
 
 def load_tool_from_string(tool_string: str) -> List[AgentTool]:
     """Load tools follows strands supported input string formats.
@@ -65,7 +67,7 @@ def load_tools_from_file_path(tool_path: str) -> List[AgentTool]:
 
     module = importlib.util.module_from_spec(spec)
     # Load, or re-load, the module
-    sys.modules[module_name] = module
+    sys.modules[f"{_TOOL_MODULE_PREFIX}{module_name}"] = module
     # Execute the module to run any top level code
     spec.loader.exec_module(module)
 
@@ -200,7 +202,7 @@ class ToolLoader:
                 raise ImportError(f"No loader available for {tool_name}")
 
             module = importlib.util.module_from_spec(spec)
-            sys.modules[tool_name] = module
+            sys.modules[f"{_TOOL_MODULE_PREFIX}{tool_name}"] = module
             spec.loader.exec_module(module)
 
             # Collect function-based tools decorated with @tool


### PR DESCRIPTION
## Description

This PR adds a prefix when we load modules in the tool loader. This addresses the risk that an engineer, or adversary, writes a tool with a conflicting name with an existing sys module.

## Related Issues


https://github.com/strands-agents/docs/pull/338

## Documentation PR

https://github.com/strands-agents/docs/pull/338

## Type of Change

New feature


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
