### PR TITLE
feat(bedrock): add guardrail_latest_message option

### DIFF
--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2229,6 +2229,10 @@ async def test_format_request_with_guardrail_latest_message(model):
     assert "text" in formatted_messages[0]["content"][0]
     assert formatted_messages[0]["content"][0]["text"] == "First message"
 
+    # Assistant message should NOT be wrapped
+    assert "text" in formatted_messages[1]["content"][0]
+    assert formatted_messages[1]["content"][0]["text"] == "First response"
+
     # Latest user message text should be wrapped
     assert "guardContent" in formatted_messages[2]["content"][0]
     assert formatted_messages[2]["content"][0]["guardContent"]["text"]["text"] == "Look at this image"


### PR DESCRIPTION
## Description
This PR adds a new guardrail_latest_message parameter to the BedrockModel that allows users to send only the last user message to AWS Bedrock Guardrails for evaluation, instead of the entire conversation history.

__Key changes:__

- Added `guardrail_latest_message: bool = False` parameter to `BedrockConfig`
- Modified `_format_bedrock_messages()` adding latest user message to `guardContent` when `guardrail_latest_message=True`
- Added comprehensive unit tests for the helper method and request formatting
- Added integration tests to verify the feature works end-to-end with AWS Bedrock Guardrails

__Benefits:__

- Reduces token usage and costs when using guardrails
- Enables conversation recovery after guardrail interventions (blocked content in history won't block future messages)

__Follow up:__
Use coding agent to add image in [GuardContent](https://github.com/strands-agents/sdk-python/blob/695ca66541853e7983b9b39c8649801cd7018875/src/strands/types/content.py#L30)

## Related Issues

#999 

## Documentation PR

https://github.com/strands-agents/docs/pull/340

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
