### PR TITLE
fix: fix normalized tool property default type incorrect for objects

### DIFF
--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -88,7 +88,8 @@ def _normalize_property(prop_name: str, prop_def: Any) -> dict[str, Any]:
     if "$ref" in normalized_prop:
         return normalized_prop
 
-    normalized_prop.setdefault("type", "string")
+    if "anyOf" not in normalized_prop:
+        normalized_prop.setdefault("type", "string")
     normalized_prop.setdefault("description", f"Property {prop_name}")
     return normalized_prop
 

--- a/tests/strands/tools/test_tools.py
+++ b/tests/strands/tools/test_tools.py
@@ -509,3 +509,18 @@ async def test_stream(identity_tool, alist):
     tru_events = await alist(stream)
     exp_events = [ToolResultEvent(({"tool_use": 1}, 2))]
     assert tru_events == exp_events
+
+
+def test_normalize_schema_with_anyof():
+    """Test that anyOf properties don't get default type."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "optional_field": {"anyOf": [{"items": {"type": "string"}, "type": "array"}, {"type": "null"}]},
+            "regular_field": {},
+        },
+    }
+    normalized = normalize_schema(schema)
+
+    assert "type" not in normalized["properties"]["optional_field"]
+    assert normalized["properties"]["regular_field"]["type"] == "string"


### PR DESCRIPTION


## Description
<!-- Provide a detailed description of the changes in this PR -->

Add logic in _normalize_property() skips setting default type: "string" when anyOf is present.
Add a 

## Related Issues

<!-- Link to related issues using #issue-number format -->

https://github.com/strands-agents/sdk-python/issues/1190

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x ] I ran `hatch run prepare`

## Checklist
- [x ] I have read the CONTRIBUTING document
- [x ] I have added any necessary tests that prove my fix is effective or my feature works
- [x ] I have updated the documentation accordingly
- [x ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x ] My changes generate no new warnings
- [x ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
