### PR TITLE
fix(litellm): populate cacheWriteInputTokens from cache_creation_input_token not cache_creation_tokens

### DIFF
--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -222,12 +222,11 @@ class LiteLLMModel(OpenAIModel):
 
             # Only LiteLLM over Anthropic supports cache write tokens
             # Waiting until a more general approach is available to set cacheWriteInputTokens
-
             if tokens_details := getattr(event["data"], "prompt_tokens_details", None):
                 if cached := getattr(tokens_details, "cached_tokens", None):
                     usage_data["cacheReadInputTokens"] = cached
-                if creation := getattr(tokens_details, "cache_creation_tokens", None):
-                    usage_data["cacheWriteInputTokens"] = creation
+            if creation := getattr(event["data"], "cache_creation_input_tokens", None):
+                usage_data["cacheWriteInputTokens"] = creation
 
             return StreamEvent(
                 metadata=MetadataEvent(

--- a/tests/strands/models/test_litellm.py
+++ b/tests/strands/models/test_litellm.py
@@ -193,7 +193,7 @@ async def test_stream(litellm_acompletion, api_key, model_id, model, agenerator,
     mock_event_8 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="tool_calls", delta=mock_delta_8)])
     mock_event_9 = unittest.mock.Mock()
     mock_event_9.usage.prompt_tokens_details.cached_tokens = 10
-    mock_event_9.usage.prompt_tokens_details.cache_creation_tokens = 10
+    mock_event_9.usage.cache_creation_input_tokens = 10
 
     litellm_acompletion.side_effect = unittest.mock.AsyncMock(
         return_value=agenerator(
@@ -255,7 +255,7 @@ async def test_stream(litellm_acompletion, api_key, model_id, model, agenerator,
             "metadata": {
                 "usage": {
                     "cacheReadInputTokens": mock_event_9.usage.prompt_tokens_details.cached_tokens,
-                    "cacheWriteInputTokens": mock_event_9.usage.prompt_tokens_details.cache_creation_tokens,
+                    "cacheWriteInputTokens": mock_event_9.usage.cache_creation_input_tokens,
                     "inputTokens": mock_event_9.usage.prompt_tokens,
                     "outputTokens": mock_event_9.usage.completion_tokens,
                     "totalTokens": mock_event_9.usage.total_tokens,

--- a/tests_integ/models/test_model_litellm.py
+++ b/tests_integ/models/test_model_litellm.py
@@ -1,4 +1,5 @@
 import unittest.mock
+from uuid import uuid4
 
 import pydantic
 import pytest
@@ -220,7 +221,7 @@ async def test_cache_read_tokens_multi_turn(model):
 
     system_prompt_content: list[SystemContentBlock] = [
         # Caching only works when prompts are large
-        {"text": "You are a helpful assistant. Always be concise." * 200},
+        {"text": f"You are helpful assistant No. {uuid4()}  Always be concise." * 200},
         {"cachePoint": {"type": "default"}},
     ]
 


### PR DESCRIPTION
## Description

We were previously reading from LiteLLM's [PromptTokensDetailsWrapper](https://github.com/BerriAI/litellm/blob/caddc6dd0fc26931b3fcc4e91e81a3d90080f3ef/litellm/types/utils.py#L954-L979) using the `cache_creation_tokens` property. 

Something, either on the Bedrock, Anthropic, or LiteLLM side, appears to not be populating that. Which was breaking the test_cache_read_tokens_multi_turn integration test for writes.

We had thought that this was possibly the result of cache being set earlier, or tests being executed by someone concurrently. But even when we set a uuid, which should be done anyway, the `cacheWriteInputTokens` were not appearing. 

This switches to reading from the documented `cache_creation_input_token` instead.

## Type of Change


Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
