### PR TITLE
fix: fix integ test for mcp elicitation_server

### DIFF
--- a/tests_integ/mcp/elicitation_server.py
+++ b/tests_integ/mcp/elicitation_server.py
@@ -19,6 +19,7 @@ def server() -> None:
             The elicitation result from the user.
         """
         request = ElicitRequest(
+            method="elicitation/create",
             params=ElicitRequestParams(
                 message="Do you approve",
                 requestedSchema={


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
fix integ test.
request example:
https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation

## Related Issues

<!-- Link to related issues using #issue-number format -->
Error message:

FAILED tests_integ/mcp/test_mcp_elicitation.py::test_mcp_elicitation - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
