### PR TITLE
fix: attached custom attributes to all spans

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -133,7 +133,10 @@ async def event_loop_cycle(
     # Create tracer span for this event loop cycle
     tracer = get_tracer()
     cycle_span = tracer.start_event_loop_cycle_span(
-        invocation_state=invocation_state, messages=agent.messages, parent_span=agent.trace_span
+        invocation_state=invocation_state,
+        messages=agent.messages,
+        parent_span=agent.trace_span,
+        custom_trace_attributes=agent.trace_attributes,
     )
     invocation_state["event_loop_cycle_span"] = cycle_span
 
@@ -320,6 +323,7 @@ async def _handle_model_execution(
             messages=agent.messages,
             parent_span=cycle_span,
             model_id=model_id,
+            custom_trace_attributes=agent.trace_attributes,
         )
         with trace_api.use_span(model_invoke_span):
             await agent.hooks.invoke_callbacks_async(

--- a/src/strands/multiagent/base.py
+++ b/src/strands/multiagent/base.py
@@ -8,12 +8,13 @@ import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, AsyncIterator, Union
+from typing import Any, AsyncIterator, Mapping, Union
 
 from .._async import run_async
 from ..agent import AgentResult
 from ..types.event_loop import Metrics, Usage
 from ..types.multiagent import MultiAgentInput
+from ..types.traces import AttributeValue
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +238,18 @@ class MultiAgentBase(ABC):
     def deserialize_state(self, payload: dict[str, Any]) -> None:
         """Restore orchestrator state from a session dict."""
         raise NotImplementedError
+
+    def _parse_trace_attributes(
+        self, attributes: Mapping[str, AttributeValue] | None = None
+    ) -> dict[str, AttributeValue]:
+        trace_attributes: dict[str, AttributeValue] = {}
+        if attributes:
+            for k, v in attributes.items():
+                if isinstance(v, (str, int, float, bool)) or (
+                    isinstance(v, list) and all(isinstance(x, (str, int, float, bool)) for x in v)
+                ):
+                    trace_attributes[k] = v
+        return trace_attributes
 
 
 # Private helper function to avoid duplicate code

--- a/src/strands/multiagent/swarm.py
+++ b/src/strands/multiagent/swarm.py
@@ -18,7 +18,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Callable, Optional, Tuple, cast
+from typing import Any, AsyncIterator, Callable, Mapping, Optional, Tuple, cast
 
 from opentelemetry import trace as trace_api
 
@@ -46,6 +46,7 @@ from ..types._events import (
 from ..types.content import ContentBlock, Messages
 from ..types.event_loop import Metrics, Usage
 from ..types.multiagent import MultiAgentInput
+from ..types.traces import AttributeValue
 from .base import MultiAgentBase, MultiAgentResult, NodeResult, Status
 
 logger = logging.getLogger(__name__)
@@ -226,6 +227,7 @@ class Swarm(MultiAgentBase):
         session_manager: Optional[SessionManager] = None,
         hooks: Optional[list[HookProvider]] = None,
         id: str = _DEFAULT_SWARM_ID,
+        trace_attributes: Optional[Mapping[str, AttributeValue]] = None,
     ) -> None:
         """Initialize Swarm with agents and configuration.
 
@@ -243,6 +245,7 @@ class Swarm(MultiAgentBase):
                 Disabled by default (default: 0)
             session_manager: Session manager for persisting graph state and execution history (default: None)
             hooks: List of hook providers for monitoring and extending graph execution behavior (default: None)
+            trace_attributes: Custom trace attributes to apply to the agent's trace span (default: None)
         """
         super().__init__()
         self.id = id
@@ -262,6 +265,7 @@ class Swarm(MultiAgentBase):
             completion_status=Status.PENDING,
         )
         self.tracer = get_tracer()
+        self.trace_attributes: dict[str, AttributeValue] = self._parse_trace_attributes(trace_attributes)
 
         self.session_manager = session_manager
         self.hooks = HookRegistry()
@@ -356,7 +360,7 @@ class Swarm(MultiAgentBase):
             self.state.completion_status = Status.EXECUTING
             self.state.start_time = time.time()
 
-        span = self.tracer.start_multiagent_span(task, "swarm")
+        span = self.tracer.start_multiagent_span(task, "swarm", custom_trace_attributes=self.trace_attributes)
         with trace_api.use_span(span, end_on_exit=True):
             try:
                 current_node = cast(SwarmNode, self.state.current_node)

--- a/src/strands/tools/executors/_executor.py
+++ b/src/strands/tools/executors/_executor.py
@@ -249,7 +249,9 @@ class ToolExecutor(abc.ABC):
 
         tracer = get_tracer()
 
-        tool_call_span = tracer.start_tool_call_span(tool_use, cycle_span)
+        tool_call_span = tracer.start_tool_call_span(
+            tool_use, cycle_span, custom_trace_attributes=agent.trace_attributes
+        )
         tool_trace = Trace(f"Tool: {tool_name}", parent_id=cycle_trace.id, raw_name=tool_name)
         tool_start_time = time.time()
 

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -143,6 +143,7 @@ def agent(model, system_prompt, messages, tool_registry, thread_pool, hook_regis
     mock.hooks = hook_registry
     mock.tool_executor = tool_executor
     mock._interrupt_state = _InterruptState()
+    mock.trace_attributes = {}
 
     return mock
 
@@ -738,7 +739,10 @@ async def test_event_loop_cycle_with_parent_span(
 
     # Verify parent_span was used when creating cycle span
     mock_tracer.start_event_loop_cycle_span.assert_called_once_with(
-        invocation_state=unittest.mock.ANY, parent_span=parent_span, messages=messages
+        invocation_state=unittest.mock.ANY,
+        parent_span=parent_span,
+        messages=messages,
+        custom_trace_attributes=unittest.mock.ANY,
     )
 
 

--- a/tests/strands/event_loop/test_event_loop_structured_output.py
+++ b/tests/strands/event_loop/test_event_loop_structured_output.py
@@ -40,6 +40,7 @@ def mock_agent():
     agent.hooks = Mock()
     agent.hooks.invoke_callbacks_async = AsyncMock()
     agent.trace_span = None
+    agent.trace_attributes = {}
     agent.tool_executor = Mock()
     agent._append_message = AsyncMock()
 

--- a/tests/strands/tools/executors/conftest.py
+++ b/tests/strands/tools/executors/conftest.py
@@ -105,6 +105,7 @@ def agent(tool_registry, hook_registry):
     mock_agent.tool_registry = tool_registry
     mock_agent.hooks = hook_registry
     mock_agent._interrupt_state = _InterruptState()
+    mock_agent.trace_attributes = {}
     return mock_agent
 
 

--- a/tests/strands/tools/executors/test_executor.py
+++ b/tests/strands/tools/executors/test_executor.py
@@ -209,7 +209,9 @@ async def test_executor_stream_with_trace(
     exp_results = [exp_events[-1].tool_result]
     assert tru_results == exp_results
 
-    tracer.start_tool_call_span.assert_called_once_with(tool_use, cycle_span)
+    tracer.start_tool_call_span.assert_called_once_with(
+        tool_use, cycle_span, custom_trace_attributes=agent.trace_attributes
+    )
     tracer.end_tool_call_span.assert_called_once_with(
         tracer.start_tool_call_span.return_value,
         {"content": [{"text": "sunny"}], "status": "success", "toolUseId": "1"},


### PR DESCRIPTION
## Description
When specifying custom attributes, the attributes are only added into the agent span. This change propagates the attributes to all underlying spans.

## Related Issues
N/A

## Documentation PR
N/A

## Type of Change

Bug fix / Chore change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
