### PR TITLE
interrupts - support falsey responses

### DIFF
--- a/src/strands/types/interrupt.py
+++ b/src/strands/types/interrupt.py
@@ -105,7 +105,7 @@ class _Interruptible(Protocol):
         state = agent._interrupt_state
 
         interrupt_ = state.interrupts.setdefault(id, Interrupt(id, name, reason, response))
-        if interrupt_.response:
+        if interrupt_.response is not None:
             return interrupt_.response
 
         raise InterruptException(interrupt_)

--- a/tests/strands/types/test_interrupt.py
+++ b/tests/strands/types/test_interrupt.py
@@ -79,6 +79,12 @@ def test_interrupt_hook_event_interrupt_response_empty(interrupt, agent, interru
         interrupt_hook_event.interrupt("test_name")
 
 
+def test_interrupt_hook_event_interrupt_response_falsey(interrupt_hook_event):
+    tru_response = interrupt_hook_event.interrupt("test_name", response=False)
+    exp_response = False
+    assert tru_response == exp_response
+
+
 def test_interrupt_hook_event_interrupt_missing_agent():
     class Event(_Interruptible):
         pass


### PR DESCRIPTION
## Description
Support falsey interrupt responses. Example usage:
```Python
def my_hook(event: BeforeToolCallEvent):
    response = event.interrupt("my_interrupt", reason=f"get_approval")
    if not response:
        event.cancel_tool = True

...

result = agent("Call my tool")
if result.stop_reason == "interrupt":
    responses = []
    for interrupt in result.interrupts:
        if interrupt.name == "my_interrupt":
            responses.append({
                "interruptId": interrupt.id,
                "response": False
            })
    result = agent(responses)
```

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: Added unit test.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
