### PR TITLE
fix(streaming): ensure process_stream returns non-empty message content

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -413,6 +413,9 @@ async def process_stream(
         elif "redactContent" in chunk:
             handle_redact_content(chunk["redactContent"], state)
 
+    if not state["message"]["content"]:
+        state["message"]["content"].append({"text": ""})
+
     yield ModelStopReason(stop_reason=stop_reason, message=state["message"], usage=usage, metrics=metrics)
 
 

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -578,7 +578,7 @@ def test_extract_usage_metrics_empty_metadata():
                         "end_turn",
                         {
                             "role": "assistant",
-                            "content": [],
+                            "content": [{"text": ""}],
                         },
                         {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
                         {"latencyMs": 0, "timeToFirstByteMs": 0},


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR --> This PR fixes a bug where AgentResult would contain an empty message list if the model returned a stream with no content events as noticed with Claude 3 Haiku. 
Changes:
- Added a check at the end of `process_stream` in streaming.py to add `{"text": ""}` if the accumulated content is empty.
- Updated `test_streaming.py` to assert that empty streams resolve to a message with empty text, rather than an empty list.


## Related Issues

<!-- Link to related issues using #issue-number format -->
Fixes #1264 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo --> N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
