### PR TITLE
mcp - elicitation - fix server request test

### DIFF
--- a/tests_integ/mcp/elicitation_server.py
+++ b/tests_integ/mcp/elicitation_server.py
@@ -4,7 +4,11 @@
 """
 
 from mcp.server import FastMCP
-from mcp.types import ElicitRequest, ElicitRequestParams, ElicitResult
+from pydantic import BaseModel, Field
+
+
+class ApprovalSchema(BaseModel):
+    message: str = Field(description="request message")
 
 
 def server() -> None:
@@ -18,21 +22,10 @@ def server() -> None:
         Returns:
             The elicitation result from the user.
         """
-        request = ElicitRequest(
-            method="elicitation/create",
-            params=ElicitRequestParams(
-                message="Do you approve",
-                requestedSchema={
-                    "type": "object",
-                    "properties": {
-                        "message": {"type": "string", "description": "request message"},
-                    },
-                    "required": ["message"],
-                },
-            ),
+        result = await server_.get_context().elicit(
+            message="Do you approve",
+            schema=ApprovalSchema,
         )
-        result = await server_.get_context().session.send_request(request, ElicitResult)
-
         return result.model_dump_json()
 
     server_.run(transport="stdio")

--- a/tests_integ/mcp/test_mcp_elicitation.py
+++ b/tests_integ/mcp/test_mcp_elicitation.py
@@ -11,7 +11,7 @@ from strands.tools.mcp import MCPClient
 @pytest.fixture
 def callback():
     async def callback_(_, params):
-        return ElicitResult(action="accept", content={"message": params.message})
+        return ElicitResult(action="accept", content={"message": f"server_message=<{params.message}>"})
 
     return callback_
 
@@ -36,5 +36,5 @@ def test_mcp_elicitation(client):
     tool_result = agent.messages[-2]
 
     tru_result = json.loads(tool_result["content"][0]["toolResult"]["content"][0]["text"])
-    exp_result = {"meta": None, "action": "accept", "content": {"message": "Do you approve"}}
+    exp_result = {"action": "accept", "data": {"message": "server_message=<Do you approve>"}}
     assert tru_result == exp_result


### PR DESCRIPTION
## Description
MCP recently changed ElicitRequestParams to a Union ([commit](https://github.com/modelcontextprotocol/python-sdk/commit/02b78899296ce3631565345501e3d956b83ffe94)). This breaks our elicitation integ test. Fixing by utilizing the new `elicit` method.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I ran `hatch test tests_integ/mcp/test_mcp_elicitation.py`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
