### PR TITLE
pyproject.toml - remove bidi specific logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,12 +75,11 @@ bidi = [
     "prompt_toolkit>=3.0.0,<4.0.0",
     "pyaudio>=0.2.13,<1.0.0",
     "smithy-aws-core>=0.0.1; python_version>='3.12'",
+    "strands-agents[gemini]",
+    "websockets>=15.0.0,<16.0.0",
 ]
-bidi-gemini = ["google-genai>=1.32.0,<2.0.0"]
-bidi-openai = ["websockets>=15.0.0,<16.0.0"]
 
-all = ["strands-agents[a2a,anthropic,docs,gemini,litellm,llamaapi,mistral,ollama,openai,writer,sagemaker,otel]"]
-bidi-all = ["strands-agents[a2a,bidi,bidi-gemini,bidi-openai,docs,otel]"]
+all = ["strands-agents[a2a,anthropic,bidi,docs,gemini,litellm,llamaapi,mistral,ollama,openai,writer,sagemaker,otel]"]
 
 dev = [
     "commitizen>=4.4.0,<5.0.0",
@@ -130,7 +129,7 @@ format-fix = [
 ]
 lint-check = [
     "ruff check",
-    "mypy ./src"
+    "mypy -p src"
 ]
 lint-fix = [
     "ruff check --fix"
@@ -204,16 +203,10 @@ warn_no_return = true
 warn_unreachable = true
 follow_untyped_imports = true
 ignore_missing_imports = false
-exclude = ["src/strands/experimental/bidi"]
-
-[[tool.mypy.overrides]]
-module = ["strands.experimental.bidi.*"]
-follow_imports = "skip"
 
 [tool.ruff]
 line-length = 120
 include = ["examples/**/*.py", "src/**/*.py", "tests/**/*.py", "tests_integ/**/*.py"]
-exclude = ["src/strands/experimental/bidi/**/*.py", "tests/strands/experimental/bidi/**/*.py", "tests_integ/bidi/**/*.py"]
 
 [tool.ruff.lint]
 select = [
@@ -236,8 +229,7 @@ convention = "google"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_default_fixture_loop_scope = "function"
-addopts = "--ignore=tests/strands/experimental/bidi --ignore=tests_integ/bidi"
-
+addopts = "--ignore=tests_integ/bidi"  # TODO: install portaudio for github workflow
 
 [tool.coverage.run]
 branch = true
@@ -245,7 +237,6 @@ source = ["src"]
 context = "thread"
 parallel = true
 concurrency = ["thread", "multiprocessing"]
-omit = ["src/strands/experimental/bidi/*"]
 
 [tool.coverage.report]
 show_missing = true
@@ -275,48 +266,3 @@ style = [
     ["text", ""],
     ["disabled", "fg:#858585 italic"]
 ]
-
-# =========================
-# Bidi development configs
-# =========================
-
-[tool.hatch.envs.bidi]
-dev-mode = true
-features = ["dev", "bidi-all"]
-installer = "uv"
-
-[tool.hatch.envs.bidi.scripts]
-prepare = [
-    "hatch run bidi-lint:format-fix",
-    "hatch run bidi-lint:quality-fix",
-    "hatch run bidi-lint:type-check",
-    "hatch run bidi-test:test-cov",
-]
-
-[tools.hatch.envs.bidi-lint]
-template = "bidi"
-
-[tool.hatch.envs.bidi-lint.scripts]
-format-check = "format-fix --check"
-format-fix = "ruff format {args} --target-version py312 ./src/strands/experimental/bidi/**/*.py"
-quality-check = "ruff check {args} --target-version py312 ./src/strands/experimental/bidi/**/*.py"
-quality-fix = "quality-check --fix"
-type-check = "mypy {args} --python-version 3.12 ./src/strands/experimental/bidi/**/*.py"
-
-[tool.hatch.envs.bidi-test]
-template = "bidi"
-
-[tool.hatch.envs.bidi-test.scripts]
-test = "pytest {args} tests/strands/experimental/bidi"
-test-cov = """
-test \
-    --cov=strands.experimental.bidi \
-    --cov-config= \
-    --cov-branch \
-    --cov-report=term-missing \
-    --cov-report=xml:build/coverage/bidi-coverage.xml \
-    --cov-report=html:build/coverage/bidi-html
-"""
-
-[[tool.hatch.envs.bidi-test.matrix]]
-python = ["3.13", "3.12"]

--- a/src/strands/experimental/bidi/models/nova_sonic.py
+++ b/src/strands/experimental/bidi/models/nova_sonic.py
@@ -20,7 +20,7 @@ import sys
 if sys.version_info < (3, 12):
     raise ImportError("BidiNovaSonicModel is only supported for Python 3.12+")
 
-import asyncio
+import asyncio  # type: ignore[unreachable]
 import base64
 import json
 import logging
@@ -28,17 +28,24 @@ import uuid
 from typing import Any, AsyncGenerator, cast
 
 import boto3
-from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
-from aws_sdk_bedrock_runtime.models import (
+from aws_sdk_bedrock_runtime.client import (  # type: ignore[import-not-found]
+    BedrockRuntimeClient,
+    InvokeModelWithBidirectionalStreamOperationInput,
+)
+from aws_sdk_bedrock_runtime.config import (  # type: ignore[import-not-found]
+    Config,
+    HTTPAuthSchemeResolver,
+    SigV4AuthScheme,
+)
+from aws_sdk_bedrock_runtime.models import (  # type: ignore[import-not-found]
     BidirectionalInputPayloadPart,
     InvokeModelWithBidirectionalStreamInputChunk,
     ModelTimeoutException,
     ValidationException,
 )
-from smithy_aws_core.identity.static import StaticCredentialsResolver
-from smithy_core.aio.eventstream import DuplexEventStream
-from smithy_core.shapes import ShapeID
+from smithy_aws_core.identity.static import StaticCredentialsResolver  # type: ignore[import-not-found]
+from smithy_core.aio.eventstream import DuplexEventStream  # type: ignore[import-not-found]
+from smithy_core.shapes import ShapeID  # type: ignore[import-not-found]
 
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
 from ....types.content import Messages


### PR DESCRIPTION
## Description
Bidi is now Python 3.10+ compatible and thus can be targeted by `hatch run prepare`. This means we can remove the bidi specific build configs in pyproject.toml.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1459

## Documentation PR

N/A

## Type of Change

Other (please describe): build config updates.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
