### PR TITLE
feat(tools): add aws sigv4 signing tool

### DIFF
--- a/aws_sigv4.md
+++ b/aws_sigv4.md
@@ -1,0 +1,57 @@
+# AWS SigV4 Signing Tool
+
+## Description
+`AwsSigV4Tool` produces AWS Signature Version 4 headers for HTTP requests.
+It can be used with the Strands HTTP tool to securely call any AWS service without external dependencies.
+
+## Usage
+
+```
+from aws_sigv4_tool import AwsSigV4Tool
+
+tool = AwsSigV4Tool()
+
+signed_headers = tool(
+    method="GET",
+    service="s3",
+    region="us-east-1",
+    host="examplebucket.s3.amazonaws.com",
+    uri="/test.txt",
+    query="",
+    headers={},
+    body="",
+    access_key="AKIA...",
+    secret_key="SECRET..."
+)
+# Use signed_headers["headers"] with the Strands HTTP tool
+```
+## Parameters
+
+| Name       | Type | Description                   |
+| ---------- | ---- | ----------------------------- |
+| method     | str  | HTTP method (GET, POST, etc.) |
+| service    | str  | AWS service name (e.g., s3)   |
+| region     | str  | AWS region (e.g., us-east-1)  |
+| host       | str  | AWS service endpoint host     |
+| uri        | str  | Request URI (path)            |
+| query      | str  | Query string                  |
+| headers    | dict | Existing headers to include   |
+| body       | str  | Request body                  |
+| access_key | str  | AWS Access Key ID             |
+| secret_key | str  | AWS Secret Access Key         |
+
+## Returns
+
+```
+{
+    "headers": {
+        "x-amz-date": "20251130T190000Z",
+        "Authorization": "AWS4-HMAC-SHA256 Credential=..."
+    }
+}
+```
+
+## Notes
+    Fully compatible with Strands HTTP tool.
+    No external dependencies; pure Python.
+    Safe for testing — no actual AWS credentials required.

--- a/src/strands/tools/aws_sigv4.py
+++ b/src/strands/tools/aws_sigv4.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+import hashlib
+import hmac
+from typing import Dict
+
+
+class AwsSigV4Tool:
+    """
+    Tool: aws_sigv4
+    Description: Produces AWS Signature Version 4 headers for an HTTP request.
+
+    Usage:
+        tool = AwsSigV4Tool()
+        headers = tool(
+            method="GET",
+            service="s3",
+            region="us-east-1",
+            host="examplebucket.s3.amazonaws.com",
+            uri="/test.txt",
+            query="",
+            headers={},
+            body="",
+            access_key="AKIA...",
+            secret_key="SECRET..."
+        )
+    """
+
+    def __call__(
+        self,
+        method: str,
+        service: str,
+        region: str,
+        host: str,
+        uri: str,
+        query: str,
+        headers: Dict[str, str],
+        body: str,
+        access_key: str,
+        secret_key: str,
+    ) -> Dict[str, Dict[str, str]]:
+
+        def _sign(key, msg):
+            return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+        def _get_signature_key(key, date_stamp, region_name, service_name):
+            k_date = _sign(("AWS4" + key).encode("utf-8"), date_stamp)
+            k_region = _sign(k_date, region_name)
+            k_service = _sign(k_region, service_name)
+            k_signing = _sign(k_service, "aws4_request")
+            return k_signing
+
+        # Step 1: Prepare timestamps
+        t = datetime.utcnow()
+        amz_date = t.strftime("%Y%m%dT%H%M%SZ")
+        date_stamp = t.strftime("%Y%m%d")
+
+        # Step 2: Canonical request
+        canonical_uri = uri
+        canonical_querystring = query
+        canonical_headers = f"host:{host}\n" + f"x-amz-date:{amz_date}\n"
+        signed_headers = "host;x-amz-date"
+        payload_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        canonical_request = (
+            f"{method}\n{canonical_uri}\n{canonical_querystring}\n"
+            f"{canonical_headers}\n{signed_headers}\n{payload_hash}"
+        )
+
+        # Step 3: String to sign
+        algorithm = "AWS4-HMAC-SHA256"
+        credential_scope = f"{date_stamp}/{region}/{service}/aws4_request"
+        string_to_sign = (
+            f"{algorithm}\n{amz_date}\n{credential_scope}\n"
+            f"{hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()}"
+        )
+
+        # Step 4: Signing key
+        signing_key = _get_signature_key(secret_key, date_stamp, region, service)
+
+        # Step 5: Signature
+        signature = hmac.new(
+            signing_key, string_to_sign.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+
+        # Step 6: Authorization header
+        authorization_header = (
+            f"{algorithm} Credential={access_key}/{credential_scope}, "
+            f"SignedHeaders={signed_headers}, Signature={signature}"
+        )
+
+        headers["x-amz-date"] = amz_date
+        headers["Authorization"] = authorization_header
+
+        return {"headers": headers}

--- a/tests/strands/tools/test_aws_sigv4.py
+++ b/tests/strands/tools/test_aws_sigv4.py
@@ -1,0 +1,25 @@
+import pytest
+from strands.tools.aws_sigv4 import AwsSigV4Tool
+
+
+def test_sigv4_returns_headers():
+    tool = AwsSigV4Tool()
+    result = tool(
+        method="GET",
+        service="service",
+        region="us-east-1",
+        host="example.com",
+        uri="/",
+        query="",
+        headers={},
+        body="",
+        access_key="AKIAEXAMPLE",
+        secret_key="SECRETEXAMPLE",
+    )
+
+    assert "headers" in result
+    headers = result["headers"]
+    assert "Authorization" in headers
+    assert "x-amz-date" in headers
+    # basic format checks
+    assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")


### PR DESCRIPTION
## Description
This PR adds a new tool, 'AwsSigV4Tool', which generates AWS signature version 4 headers for HTTP requests.
It is fully compatible with the strands HTTP tool and does not require any external dependencies like boto3.
This allow strands user to securely call any AWS services with minimal setup.

The PR includes:
- The tool implementation in 'src/strands/tool/aws_sigv4.py
- Unit tests in tests/strands/tool/test_aws_sigv4.py
- Documentation in aws_sigv4.md with usage example and parameter description.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

- [ X] I ran `hatch run prepare`
- [X ] Unit test pass ('hatch test')
- [X ] Integration test pass ('hatch run test-integ')
- [ X] Verified no warning in consuming repo

## Checklist
- [ X] I have read the CONTRIBUTING document
- [X ] I have added any necessary tests that prove my fix is effective or my feature works
- [X ] I have updated the documentation accordingly
- [X ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X ] My changes generate no new warnings
- [ X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
