### PR TITLE
feat(bedrock): Add support for server-side tools (system tools)

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -185,6 +185,9 @@ def handle_content_block_start(event: ContentBlockStartEvent) -> dict[str, Any]:
         current_tool_use["toolUseId"] = tool_use_data["toolUseId"]
         current_tool_use["name"] = tool_use_data["name"]
         current_tool_use["input"] = ""
+        # Preserve type field for server-side tools (e.g., "server_tool_use" for nova_grounding)
+        if "type" in tool_use_data:
+            current_tool_use["type"] = tool_use_data["type"]
 
     return current_tool_use
 
@@ -280,11 +283,15 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
         tool_use_id = current_tool_use["toolUseId"]
         tool_use_name = current_tool_use["name"]
 
-        tool_use = ToolUse(
-            toolUseId=tool_use_id,
-            name=tool_use_name,
-            input=current_tool_use["input"],
-        )
+        tool_use: ToolUse = {
+            "toolUseId": tool_use_id,
+            "name": tool_use_name,
+            "input": current_tool_use["input"],
+        }
+        # Preserve type field for server-side tools (e.g., "server_tool_use" for nova_grounding)
+        if "type" in current_tool_use:
+            tool_use["type"] = current_tool_use["type"]
+
         content.append({"toolUse": tool_use})
         state["current_tool_use"] = {}
 

--- a/src/strands/types/content.py
+++ b/src/strands/types/content.py
@@ -8,7 +8,7 @@ SDK. These types are modeled after the Bedrock API.
 
 from typing import Dict, List, Literal, Optional
 
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from .citations import CitationsContentBlock
 from .media import DocumentContent, ImageContent, VideoContent
@@ -129,10 +129,12 @@ class ContentBlockStartToolUse(TypedDict):
     Attributes:
         name: The name of the tool that the model is requesting to use.
         toolUseId: The ID for the tool request.
+        type: Optional type identifier (e.g., "server_tool_use" for server-side tools).
     """
 
     name: str
     toolUseId: str
+    type: NotRequired[str]
 
 
 class ContentBlockStart(TypedDict, total=False):

--- a/src/strands/types/tools.py
+++ b/src/strands/types/tools.py
@@ -57,11 +57,13 @@ class ToolUse(TypedDict):
             Can be any JSON-serializable type.
         name: The name of the tool to invoke.
         toolUseId: A unique identifier for this specific tool use request.
+        type: Optional type identifier for the tool use (e.g., "server_tool_use" for server-side tools).
     """
 
     input: Any
     name: str
     toolUseId: str
+    type: NotRequired[str]
 
 
 class ToolResultContent(TypedDict, total=False):

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -124,6 +124,11 @@ def test_handle_message_start():
             {"start": {"toolUse": {"toolUseId": "test", "name": "test"}}},
             {"toolUseId": "test", "name": "test", "input": ""},
         ),
+        # Server-side tool with type field (e.g., nova_grounding)
+        (
+            {"start": {"toolUse": {"toolUseId": "server-1", "name": "nova_grounding", "type": "server_tool_use"}}},
+            {"toolUseId": "server-1", "name": "nova_grounding", "input": "", "type": "server_tool_use"},
+        ),
     ],
 )
 def test_handle_content_block_start(chunk: ContentBlockStartEvent, exp_tool_use):
@@ -321,6 +326,39 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, event_type, s
             },
             {
                 "content": [{"toolUse": {"toolUseId": "123", "name": "test", "input": {}}}],
+                "current_tool_use": {},
+                "text": "",
+                "reasoningText": "",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+        ),
+        # Server-side tool with type field (e.g., nova_grounding)
+        (
+            {
+                "content": [],
+                "current_tool_use": {
+                    "toolUseId": "server-1",
+                    "name": "nova_grounding",
+                    "input": "{}",
+                    "type": "server_tool_use",
+                },
+                "text": "",
+                "reasoningText": "",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+            {
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "server-1",
+                            "name": "nova_grounding",
+                            "input": {},
+                            "type": "server_tool_use",
+                        }
+                    }
+                ],
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -543,6 +543,143 @@ def test_format_request_cache(model, messages, model_id, tool_spec, cache_type):
     assert tru_request == exp_request
 
 
+def test_format_request_system_tools_only(model, messages, model_id):
+    """System tools work without agent tools."""
+    system_tools = [{"systemTool": {"name": "nova_grounding"}}]
+    model.update_config(system_tools=system_tools)
+
+    tru_request = model._format_request(messages, tool_specs=None)
+    exp_request = {
+        "inferenceConfig": {},
+        "modelId": model_id,
+        "messages": messages,
+        "system": [],
+        "toolConfig": {
+            "tools": [{"systemTool": {"name": "nova_grounding"}}],
+            "toolChoice": {"auto": {}},
+        },
+    }
+
+    assert tru_request == exp_request
+
+
+def test_format_request_system_tools_with_agent_tools(model, messages, model_id, tool_spec):
+    """System tools are merged after agent tools."""
+    system_tools = [{"systemTool": {"name": "nova_grounding"}}]
+    model.update_config(system_tools=system_tools)
+
+    tru_request = model._format_request(messages, tool_specs=[tool_spec])
+    exp_request = {
+        "inferenceConfig": {},
+        "modelId": model_id,
+        "messages": messages,
+        "system": [],
+        "toolConfig": {
+            "tools": [
+                {"toolSpec": tool_spec},
+                {"systemTool": {"name": "nova_grounding"}},
+            ],
+            "toolChoice": {"auto": {}},
+        },
+    }
+
+    assert tru_request == exp_request
+
+
+def test_format_request_system_tools_with_cache(model, messages, model_id, tool_spec, cache_type):
+    """System tools appear after cache_tools."""
+    system_tools = [{"systemTool": {"name": "nova_grounding"}}]
+    model.update_config(system_tools=system_tools, cache_tools=cache_type)
+
+    tru_request = model._format_request(messages, tool_specs=[tool_spec])
+    exp_request = {
+        "inferenceConfig": {},
+        "modelId": model_id,
+        "messages": messages,
+        "system": [],
+        "toolConfig": {
+            "tools": [
+                {"toolSpec": tool_spec},
+                {"cachePoint": {"type": cache_type}},
+                {"systemTool": {"name": "nova_grounding"}},
+            ],
+            "toolChoice": {"auto": {}},
+        },
+    }
+
+    assert tru_request == exp_request
+
+
+def test_format_request_empty_system_tools(model, messages, model_id):
+    """Empty system_tools list doesn't add toolConfig."""
+    model.update_config(system_tools=[])
+
+    tru_request = model._format_request(messages, tool_specs=None)
+    exp_request = {
+        "inferenceConfig": {},
+        "modelId": model_id,
+        "messages": messages,
+        "system": [],
+    }
+
+    assert tru_request == exp_request
+
+
+def test_format_request_multiple_system_tools(model, messages, model_id):
+    """Multiple system tools are all included."""
+    system_tools = [
+        {"systemTool": {"name": "nova_grounding"}},
+        {"systemTool": {"name": "another_tool"}},
+    ]
+    model.update_config(system_tools=system_tools)
+
+    tru_request = model._format_request(messages, tool_specs=None)
+    exp_request = {
+        "inferenceConfig": {},
+        "modelId": model_id,
+        "messages": messages,
+        "system": [],
+        "toolConfig": {
+            "tools": [
+                {"systemTool": {"name": "nova_grounding"}},
+                {"systemTool": {"name": "another_tool"}},
+            ],
+            "toolChoice": {"auto": {}},
+        },
+    }
+
+    assert tru_request == exp_request
+
+
+def test_format_request_warns_on_conflicting_toolconfig(model, messages, model_id):
+    """Warning is emitted when additional_args contains toolConfig."""
+    model.update_config(additional_args={"toolConfig": {"tools": []}})
+
+    with pytest.warns(UserWarning, match="additional_args contains 'toolConfig'"):
+        model._format_request(messages, tool_specs=None)
+
+
+def test_format_request_warns_on_conflicting_inferenceconfig(model, messages, model_id):
+    """Warning is emitted when additional_args contains inferenceConfig."""
+    model.update_config(additional_args={"inferenceConfig": {"maxTokens": 100}})
+
+    with pytest.warns(UserWarning, match="additional_args contains 'inferenceConfig'"):
+        model._format_request(messages, tool_specs=None)
+
+
+def test_format_request_no_warning_for_safe_additional_args(model, messages, model_id):
+    """No warning for non-conflicting additional_args keys."""
+    model.update_config(additional_args={"customField": "value"})
+
+    # Should not emit any warnings
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        model._format_request(messages, tool_specs=None)
+        assert len(w) == 0
+
+
 @pytest.mark.asyncio
 async def test_stream_throttling_exception_from_event_stream_error(bedrock_client, model, messages, alist):
     error_message = "Rate exceeded"
@@ -2143,3 +2280,171 @@ async def test_citations_content_preserves_tagged_union_structure(bedrock_client
         "(documentChar, documentPage, documentChunk, searchResultLocation, or web) "
         "with the location fields nested inside."
     )
+
+
+
+def test_has_client_side_tools_to_execute_with_client_tools(model):
+    """Test that client-side tools are correctly identified as needing execution."""
+    message_content = [
+        {
+            "toolUse": {
+                "toolUseId": "tool-123",
+                "name": "my_tool",
+                "input": {"param": "value"},
+            }
+        }
+    ]
+
+    assert model._has_client_side_tools_to_execute(message_content) is True
+
+
+def test_has_client_side_tools_to_execute_with_server_tools(model):
+    """Test that server-side tools (like nova_grounding) are NOT identified as needing execution."""
+    message_content = [
+        {
+            "toolUse": {
+                "toolUseId": "tool-123",
+                "name": "nova_grounding",
+                "type": "server_tool_use",
+                "input": {},
+            }
+        },
+        {
+            "toolResult": {
+                "toolUseId": "tool-123",
+                "content": [{"text": "Grounding result"}],
+            }
+        },
+    ]
+
+    assert model._has_client_side_tools_to_execute(message_content) is False
+
+
+def test_has_client_side_tools_to_execute_with_mixed_tools(model):
+    """Test mixed server and client tools - should return True if client tools need execution."""
+    message_content = [
+        # Server-side tool with result
+        {
+            "toolUse": {
+                "toolUseId": "server-tool-123",
+                "name": "nova_grounding",
+                "type": "server_tool_use",
+                "input": {},
+            }
+        },
+        {
+            "toolResult": {
+                "toolUseId": "server-tool-123",
+                "content": [{"text": "Grounding result"}],
+            }
+        },
+        # Client-side tool without result
+        {
+            "toolUse": {
+                "toolUseId": "client-tool-456",
+                "name": "my_tool",
+                "input": {"param": "value"},
+            }
+        },
+    ]
+
+    assert model._has_client_side_tools_to_execute(message_content) is True
+
+
+def test_has_client_side_tools_to_execute_with_no_tools(model):
+    """Test that no tools returns False."""
+    message_content = [{"text": "Just some text"}]
+
+    assert model._has_client_side_tools_to_execute(message_content) is False
+
+
+@pytest.mark.asyncio
+async def test_stream_server_tool_use_does_not_override_stop_reason(bedrock_client, alist, messages):
+    """Test that stopReason is NOT overridden for server-side tools like nova_grounding."""
+    model = BedrockModel(model_id="amazon.nova-premier-v1:0")
+    model.client = bedrock_client
+
+    # Simulate streaming response with server-side tool use and result
+    bedrock_client.converse_stream.return_value = {
+        "stream": [
+            {"messageStart": {"role": "assistant"}},
+            {
+                "contentBlockStart": {
+                    "start": {
+                        "toolUse": {
+                            "toolUseId": "tool-123",
+                            "name": "nova_grounding",
+                            "type": "server_tool_use",
+                        }
+                    }
+                }
+            },
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}},
+            {"contentBlockStop": {}},
+            {
+                "contentBlockStart": {
+                    "start": {
+                        "toolResult": {
+                            "toolUseId": "tool-123",
+                        }
+                    }
+                }
+            },
+            {"contentBlockDelta": {"delta": {"text": "Grounding result"}}},
+            {"contentBlockStop": {}},
+            {"contentBlockStart": {"start": {}}},
+            {"contentBlockDelta": {"delta": {"text": "Final response"}}},
+            {"contentBlockStop": {}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+    }
+
+    events = await alist(model.stream(messages))
+
+    # Find the messageStop event
+    message_stop_event = next(e for e in events if "messageStop" in e)
+
+    # Verify stopReason was NOT overridden (should remain end_turn for server-side tools)
+    assert message_stop_event["messageStop"]["stopReason"] == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_stream_non_streaming_server_tool_use_does_not_override_stop_reason(bedrock_client, alist, messages):
+    """Test that stopReason is NOT overridden for server-side tools in non-streaming mode."""
+    model = BedrockModel(model_id="amazon.nova-premier-v1:0", streaming=False)
+    model.client = bedrock_client
+
+    bedrock_client.converse.return_value = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "tool-123",
+                            "name": "nova_grounding",
+                            "type": "server_tool_use",
+                            "input": {},
+                        }
+                    },
+                    {
+                        "toolResult": {
+                            "toolUseId": "tool-123",
+                            "content": [{"text": "Grounding result"}],
+                        }
+                    },
+                    {"text": "Final response based on grounding"},
+                ],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 20},
+    }
+
+    events = await alist(model.stream(messages))
+
+    # Find the messageStop event
+    message_stop_event = next(e for e in events if "messageStop" in e)
+
+    # Verify stopReason was NOT overridden (should remain end_turn for server-side tools)
+    assert message_stop_event["messageStop"]["stopReason"] == "end_turn"


### PR DESCRIPTION
## Description

This PR adds support for server-side tools that are handled within the model invocation. When Bedrock returns tool use and tool response together with a specific (`server_tool_use`) type, the SDK now correctly:

- Distinguishes server-side tools (like `nova_grounding`) from client-side tools
- Does NOT override `stopReason` to `tool_use` for server-side tools
- Tracks tool results to determine if tools have already been executed

This enables features like Nova Web Grounding to work correctly without triggering infinite loops or unnecessary tool execution attempts.

**Changes:**
- Updated streaming handler to track tool types and results
- Added `_has_client_side_tools_to_execute()` helper method
- Updated non-streaming handler to use the new helper
- Added comprehensive tests for server-side tool handling

## Related Issues

Fixes #1154

## Documentation PR

N/A

## Type of Change

Bug fix / New feature

## Testing

Tested with Nova Web Grounding in both streaming and non-streaming modes.

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.