### PR TITLE
Add issue-responder action agent

### DIFF
--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -1,0 +1,66 @@
+name: Issue Responder
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  respond-to-issue:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.STRANDS_AGENTCORE_ACTIONS_ROLE }}
+          aws-region: us-west-2
+      - name: Invoke AgentCore with issue details
+        env:
+          GH_ISSUE_AGENTCORE_RUNTIME_ARN: ${{ secrets.GH_ISSUE_AGENTCORE_RUNTIME_ARN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          npm install @aws-sdk/client-bedrock-agentcore
+          node - <<'JSEOF'
+          const { BedrockAgentCoreClient, InvokeAgentRuntimeCommand } = require("@aws-sdk/client-bedrock-agentcore");
+
+          const payload = JSON.stringify({
+            source: "github",
+            action: "issue_opened",
+            issue: {
+              number: parseInt(process.env.ISSUE_NUMBER),
+              title: process.env.ISSUE_TITLE,
+              body: process.env.ISSUE_BODY,
+              url: process.env.ISSUE_URL,
+              author: process.env.ISSUE_AUTHOR,
+              repo: process.env.REPO
+            }
+          });
+
+          console.log("Invoking AgentCore with payload:");
+          console.log(JSON.stringify(JSON.parse(payload), null, 2));
+
+          const client = new BedrockAgentCoreClient({ region: "us-west-2" });
+          
+          const sessionId = `github-issue-${process.env.ISSUE_NUMBER}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+          
+          const command = new InvokeAgentRuntimeCommand({
+            agentRuntimeArn: process.env.GH_ISSUE_AGENTCORE_RUNTIME_ARN,
+            runtimeSessionId: sessionId,
+            payload: Buffer.from(payload)
+          });
+
+          (async () => {
+            const response = await client.send(command);
+            const textResponse = await response.response.transformToString();
+            console.log("Response:", textResponse);
+          })();
+          JSEOF


### PR DESCRIPTION
## Description
This pull request introduces a new GitHub Actions workflow to automate responses to newly opened issues by invoking a a Strands agent hosted on AgentCore Runtime. The workflow is designed to trigger on issue creation, securely configure AWS credentials, and send relevant issue details to the AgentCore runtime. The strands agent will send the suggested response to Slack. Agent code and Slack details will be shared internally.


**New GitHub Actions workflow for automated issue response:**

* Added `.github/workflows/issue-responder.yml` to trigger on new GitHub issues and invoke AWS AgentCore Runtime with issue metadata for automated responses.

**Integration with AWS services:**

* Configures AWS credentials using `aws-actions/configure-aws-credentials` and securely passes necessary secrets for role assumption and AgentCore runtime ARN.
* Uses Node.js and the `@aws-sdk/client-bedrock-agentcore` package to construct and send a payload containing issue details to AgentCore, and outputs the response for logging.


Notes: 
This is working on my forked repo. We can see the [action here](https://github.com/afarntrog/sdk-python/actions/runs/20142654926/job/57814324963). Will internally share a link to the result.


## Related Issues

Hackweek Automate issues responses

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


