### PR TITLE
fix(telemetry): prevent double counting of usage metrics

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -666,7 +666,23 @@ class Tracer:
                     event_attributes={"message": str(response), "finish_reason": str(response.stop_reason)},
                 )
 
-
+            if hasattr(response, "metrics") and hasattr(response.metrics, "accumulated_usage"):
+                if "langfuse" in os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "") or "langfuse" in os.getenv(
+                    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""
+                ):
+                    attributes.update({"langfuse.observation.type": "span"})
+                accumulated_usage = response.metrics.accumulated_usage
+                attributes.update(
+                    {
+                        "gen_ai.usage.prompt_tokens": accumulated_usage["inputTokens"],
+                        "gen_ai.usage.completion_tokens": accumulated_usage["outputTokens"],
+                        "gen_ai.usage.input_tokens": accumulated_usage["inputTokens"],
+                        "gen_ai.usage.output_tokens": accumulated_usage["outputTokens"],
+                        "gen_ai.usage.total_tokens": accumulated_usage["totalTokens"],
+                        "gen_ai.usage.cache_read_input_tokens": accumulated_usage.get("cacheReadInputTokens", 0),
+                        "gen_ai.usage.cache_write_input_tokens": accumulated_usage.get("cacheWriteInputTokens", 0),
+                    }
+                )
 
         self._end_span(span, attributes, error)
 


### PR DESCRIPTION
## Description
This is a fix for the below bug:
_[BUG] OpenTelemetry token/cost metrics double-counted in Langfuse due to duplicate reporting on parent and child spans https://github.com/strands-agents/sdk-python/issues/1267

- The solution is provided [here](https://github.com/strands-agents/sdk-python/issues/1267#issuecomment-3666286154). By adding the obsrevation_type to **span**, the tokens will not be counted multiple times.
- We check if customer uses Langfuse or not as the destination (via **OTEL_EXPORTER_OTLP_ENDPOINT** or **OTEL_EXPORTER_OTLP_TRACES_ENDPOINT**) to decide adding the attribute or not.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1267

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug fix

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
