### PR TITLE
Feature: Issue 881 - Support 'meta' field in MCPToolResult.

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -567,6 +567,9 @@ class MCPClient(ToolProvider):
         if call_tool_result.structuredContent:
             result["structuredContent"] = call_tool_result.structuredContent
 
+        if call_tool_result.meta:
+            result["meta"] = call_tool_result.meta
+
         return result
 
     async def _async_background_thread(self) -> None:

--- a/src/strands/tools/mcp/mcp_types.py
+++ b/src/strands/tools/mcp/mcp_types.py
@@ -58,6 +58,10 @@ class MCPToolResult(ToolResult):
         structuredContent: Optional JSON object containing structured data returned
             by the MCP tool. This allows MCP tools to return complex data structures
             that can be processed programmatically by agents or other tools.
+        meta: Optional JSON object containing metadata about the tool execution
+            returned by the MCP tool. This provides additional context or information
+            about how the tool was executed or processed.
     """
 
     structuredContent: NotRequired[Dict[str, Any]]
+    meta: NotRequired[Dict[str, Any]]

--- a/tests_integ/mcp/echo_server.py
+++ b/tests_integ/mcp/echo_server.py
@@ -19,7 +19,7 @@ import base64
 from typing import Literal
 
 from mcp.server import FastMCP
-from mcp.types import BlobResourceContents, EmbeddedResource, TextResourceContents
+from mcp.types import BlobResourceContents, CallToolResult, EmbeddedResource, TextContent, TextResourceContents
 from pydantic import BaseModel
 
 
@@ -49,6 +49,26 @@ def start_echo_server():
     @mcp.tool(description="Echos response back with structured content", structured_output=True)
     def echo_with_structured_content(to_echo: str) -> EchoResponse:
         return EchoResponse(echoed=to_echo, message_length=len(to_echo))
+
+    @mcp.tool(description="Echos response back with meta field")
+    def echo_with_meta(to_echo: str) -> CallToolResult:
+        """Echo tool that returns CallToolResult with meta field."""
+        return CallToolResult(
+            content=[TextContent(type="text", text=to_echo)],
+            isError=False,
+            _meta={"request_id": "test-request-123", "echo_length": len(to_echo)},
+        )
+
+    @mcp.tool(description="Echos response back with both structured content and meta", structured_output=True)
+    def echo_with_structured_content_and_meta(to_echo: str) -> CallToolResult:
+        """Echo tool that returns CallToolResult with both structured content and meta."""
+        response = EchoResponse(echoed=to_echo, message_length=len(to_echo))
+        return CallToolResult(
+            content=[TextContent(type="text", text=response.model_dump_json())],
+            structuredContent=response.model_dump(),
+            isError=False,
+            _meta={"request_id": "test-request-456", "processing_time_ms": 100},
+        )
 
     @mcp.tool(description="Get current weather information for a location")
     def get_weather(location: Literal["New York", "London", "Tokyo"] = "New York"):

--- a/tests_integ/mcp/test_mcp_client_meta_with_hooks.py
+++ b/tests_integ/mcp/test_mcp_client_meta_with_hooks.py
@@ -1,0 +1,132 @@
+"""Integration test demonstrating MCP client meta field support.
+
+This test shows how the MCP client properly handles the meta field returned by
+MCP tools, both with and without structured content.
+"""
+
+from mcp import StdioServerParameters, stdio_client
+
+from strands import Agent
+from strands.hooks import AfterToolCallEvent, HookProvider, HookRegistry
+from strands.tools.mcp.mcp_client import MCPClient
+
+
+class MetaHookProvider(HookProvider):
+    """Hook provider that captures tool results with meta field."""
+
+    def __init__(self):
+        self.captured_results = {}
+
+    def register_hooks(self, registry: HookRegistry) -> None:
+        """Register callback for after tool invocation events."""
+        registry.add_callback(AfterToolCallEvent, self.on_after_tool_invocation)
+
+    def on_after_tool_invocation(self, event: AfterToolCallEvent) -> None:
+        """Capture tool results."""
+        tool_name = event.tool_use["name"]
+        self.captured_results[tool_name] = event.result
+
+
+def test_mcp_client_with_meta_only():
+    """Test that MCP client correctly handles tools that return meta without structured content."""
+    # Create hook provider to capture tool result
+    hook_provider = MetaHookProvider()
+
+    # Set up MCP client for echo server
+    stdio_mcp_client = MCPClient(
+        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
+    )
+
+    with stdio_mcp_client:
+        # Create agent with MCP tools and hook provider
+        agent = Agent(tools=stdio_mcp_client.list_tools_sync(), hooks=[hook_provider])
+
+        # Test meta field functionality
+        test_data = "META_TEST_DATA"
+        agent(f"Use the echo_with_meta tool to echo: {test_data}")
+
+        # Verify hook captured the tool result
+        assert "echo_with_meta" in hook_provider.captured_results
+        result = hook_provider.captured_results["echo_with_meta"]
+
+        # Verify basic result structure
+        assert result["status"] == "success"
+        assert len(result["content"]) == 1
+        assert result["content"][0]["text"] == test_data
+
+        # Verify meta is present and correct
+        assert "meta" in result
+        assert result["meta"]["request_id"] == "test-request-123"
+        assert result["meta"]["echo_length"] == len(test_data)
+
+        # Verify structured content is not present
+        assert result.get("structuredContent") is None
+
+
+def test_mcp_client_with_structured_content_and_meta():
+    """Test that MCP client correctly handles tools that return both structured content and meta."""
+    # Create hook provider to capture tool result
+    hook_provider = MetaHookProvider()
+
+    # Set up MCP client for echo server
+    stdio_mcp_client = MCPClient(
+        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
+    )
+
+    with stdio_mcp_client:
+        # Create agent with MCP tools and hook provider
+        agent = Agent(tools=stdio_mcp_client.list_tools_sync(), hooks=[hook_provider])
+
+        # Test structured content and meta functionality
+        test_data = "BOTH_TEST_DATA"
+        agent(f"Use the echo_with_structured_content_and_meta tool to echo: {test_data}")
+
+        # Verify hook captured the tool result
+        assert "echo_with_structured_content_and_meta" in hook_provider.captured_results
+        result = hook_provider.captured_results["echo_with_structured_content_and_meta"]
+
+        # Verify basic result structure
+        assert result["status"] == "success"
+        assert len(result["content"]) == 1
+
+        # Verify structured content is present
+        assert "structuredContent" in result
+        assert result["structuredContent"]["echoed"] == test_data
+        assert result["structuredContent"]["message_length"] == len(test_data)
+
+        # Verify meta is present and correct
+        assert "meta" in result
+        assert result["meta"]["request_id"] == "test-request-456"
+        assert result["meta"]["processing_time_ms"] == 100
+
+
+def test_mcp_client_without_meta():
+    """Test that MCP client works correctly when tool does not return meta."""
+    # Create hook provider to capture tool result
+    hook_provider = MetaHookProvider()
+
+    # Set up MCP client for echo server
+    stdio_mcp_client = MCPClient(
+        lambda: stdio_client(StdioServerParameters(command="python", args=["tests_integ/mcp/echo_server.py"]))
+    )
+
+    with stdio_mcp_client:
+        # Create agent with MCP tools and hook provider
+        agent = Agent(tools=stdio_mcp_client.list_tools_sync(), hooks=[hook_provider])
+
+        # Test regular echo tool (no meta, no structured content)
+        test_data = "SIMPLE_TEST_DATA"
+        agent(f"Use the echo tool to echo: {test_data}")
+
+        # Verify hook captured the tool result
+        assert "echo" in hook_provider.captured_results
+        result = hook_provider.captured_results["echo"]
+
+        # Verify basic result structure
+        assert result["status"] == "success"
+        assert len(result["content"]) == 1
+        assert result["content"][0]["text"] == test_data
+
+        # Verify neither meta nor structured content is present
+        assert result.get("meta") is None
+        assert result.get("structuredContent") is None


### PR DESCRIPTION
## Description

This PR adds support for the `meta` field in `MCPToolResult`, allowing MCP tools to return metadata alongside their content. The implementation follows the same pattern as `structuredContent`, only including the field when it's not None.

**Changes:**
- Added `meta` field to `MCPToolResult` with documentation
- Updated `_handle_tool_result` in `mcp_client` to conditionally include meta when present
- Modified `echo_server` to add test tools that return `CallToolResult` with meta field
- Added unit tests covering meta field scenarios
- Added integration tests validating end-to-end meta field handling

## Related Issues

Closes #881 

## Documentation PR

No documentation changes needed - the `meta` field is already part of the MCP specification.

## Type of Change

New feature

## Testing

All tests pass:
- Additional unit tests in `test_mcp_client.py`
- New integration tests in `test_mcp_client_meta_with_hooks.py`

- [x] I ran `hatch run prepare` (equivalently ran ruff, mypy, and all tests)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (added inline documentation for the meta field)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
