### PR TITLE
fix(citations): Preserve tagged union structure for CitationLocation

### DIFF
--- a/src/strands/types/citations.py
+++ b/src/strands/types/citations.py
@@ -1,6 +1,7 @@
 """Citation type definitions for the SDK.
 
 These types are modeled after the Bedrock API.
+https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CitationLocation.html
 """
 
 from typing import List, Union
@@ -18,11 +19,8 @@ class CitationsConfig(TypedDict):
     enabled: bool
 
 
-class DocumentCharLocation(TypedDict, total=False):
-    """Specifies a character-level location within a document.
-
-    Provides precise positioning information for cited content using
-    start and end character indices.
+class DocumentCharLocationInner(TypedDict, total=False):
+    """Inner content for character-level location within a document.
 
     Attributes:
         documentIndex: The index of the document within the array of documents
@@ -38,11 +36,8 @@ class DocumentCharLocation(TypedDict, total=False):
     end: int
 
 
-class DocumentChunkLocation(TypedDict, total=False):
-    """Specifies a chunk-level location within a document.
-
-    Provides positioning information for cited content using logical
-    document segments or chunks.
+class DocumentChunkLocationInner(TypedDict, total=False):
+    """Inner content for chunk-level location within a document.
 
     Attributes:
         documentIndex: The index of the document within the array of documents
@@ -58,10 +53,8 @@ class DocumentChunkLocation(TypedDict, total=False):
     end: int
 
 
-class DocumentPageLocation(TypedDict, total=False):
-    """Specifies a page-level location within a document.
-
-    Provides positioning information for cited content using page numbers.
+class DocumentPageLocationInner(TypedDict, total=False):
+    """Inner content for page-level location within a document.
 
     Attributes:
         documentIndex: The index of the document within the array of documents
@@ -77,7 +70,37 @@ class DocumentPageLocation(TypedDict, total=False):
     end: int
 
 
-# Union type for citation locations
+class DocumentCharLocation(TypedDict, total=False):
+    """Tagged union wrapper for character-level document location.
+
+    Attributes:
+        documentChar: The character-level location data.
+    """
+
+    documentChar: DocumentCharLocationInner
+
+
+class DocumentChunkLocation(TypedDict, total=False):
+    """Tagged union wrapper for chunk-level document location.
+
+    Attributes:
+        documentChunk: The chunk-level location data.
+    """
+
+    documentChunk: DocumentChunkLocationInner
+
+
+class DocumentPageLocation(TypedDict, total=False):
+    """Tagged union wrapper for page-level document location.
+
+    Attributes:
+        documentPage: The page-level location data.
+    """
+
+    documentPage: DocumentPageLocationInner
+
+
+# Union type for citation locations - tagged union where exactly one key is present
 CitationLocation = Union[DocumentCharLocation, DocumentChunkLocation, DocumentPageLocation]
 
 

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -533,7 +533,7 @@ def test_stop_closes_event_loop():
     mock_thread.join = MagicMock()
     mock_event_loop = MagicMock()
     mock_event_loop.close = MagicMock()
-    
+
     client._background_thread = mock_thread
     client._background_thread_event_loop = mock_event_loop
 
@@ -542,7 +542,7 @@ def test_stop_closes_event_loop():
 
     # Verify thread was joined
     mock_thread.join.assert_called_once()
-    
+
     # Verify event loop was closed
     mock_event_loop.close.assert_called_once()
 


### PR DESCRIPTION
## Description

This PR fixes citation location handling in the Bedrock Converse API to properly preserve the tagged union structure required by the API.

**Problem:**
The Bedrock API requires `CitationLocation` to be a tagged union with exactly one wrapper key (`documentChar`, `documentPage`, or `documentChunk`). The previous implementation was flattening the structure, causing validation errors:
```
botocore.exceptions.ParamValidationError: Must set one of the following keys 
for tagged union structure: web, documentChar, documentPage, documentChunk, searchResultLocation
```

**Solution:**
- Refactored citation type definitions to use `*Inner` types + wrapper types for proper tagged union modeling
- Added `_format_citation_location` helper method to preserve the union structure when filtering
- Added comprehensive tests for all document-based citation location types

**BREAKING CHANGE:** `CitationLocation` types now use wrapper structure (e.g., `{"documentChar": {"documentIndex": 0, ...}}`) instead of flat structure. This matches the actual Bedrock API specification and fixes the runtime error.

## Related Issues

Fixes #1323

## Type of Change

Bug fix (breaking - but the previous behavior was incorrect and caused runtime errors)

## Testing

- [X] I ran `hatch run prepare` (1615 tests pass)
- [X] Tests for documentChar, documentPage, documentChunk location types
- [X] Tests for field filtering and unknown location types

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
