### PR TITLE
chore: Expose Status from .base for easier imports

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1,0 +1,285 @@
+# Strands Command GitHub Actions
+
+A comprehensive AI agent execution system for GitHub repositories that processes `/strands` commands in issues and pull requests.
+
+## Overview
+
+The Strands Command system enables AI-powered automation in GitHub repositories through:
+
+- **Issue Comment Processing**: Responds to `/strands` commands in issues and PRs
+- **Controlled AI Execution**: Runs AI agents with read-only and write-separated permissions
+- **AWS Integration**: Secure OIDC-based authentication with Bedrock AI models
+- **Security-First Design**: Manual approval gates and permission isolation
+
+### Architecture
+
+```mermaid
+graph LR
+    A["strands Command"] --> B[Authorization]
+    B --> C[Read-Only Agent]
+    C --> D[Write Operations]
+    D --> E[Cleanup]
+    
+    B -.-> B1[Permission Check]
+    C -.-> C1[AWS + AI Execution]
+    D -.-> D1[Repository Updates]
+```
+
+## Quick Start
+
+1. **Set up AWS IAM Role** (see [IAM Role Policy](#iam-role-policy))
+2. **Configure GitHub Secrets**:
+   - `AWS_ROLE_ARN`: Your IAM role ARN
+   - `STRANDS_SESSION_BUCKET`: S3 bucket for session storage
+3. **Copy required files** to your repository:
+   - `.github/workflows/strands-command.yml`
+   - `.github/actions/` directory
+   - `.github/scripts/` directory  
+   - `.github/agent-sops/` directory
+4. **Comment `/strands [your task]`** on any issue or PR
+   - **On Issues**: 
+     - Use `/strands <your task>` to have an agent help you refine an issue within the context of the current github repo
+     - Use `/strands implement <your task>` to create a new PR based on the description of an issue
+   - **On PRs**: `/strands <your task>` will instruct an Agent to review PR comments and make updates to the issue
+
+## Actions
+
+### strands-agent-runner
+
+Executes AI agents with AWS integration and controlled permissions.
+
+**Inputs:**
+- `ref` (required): Git reference to checkout
+- `system_prompt` (required): System instructions for the agent
+- `session_id` (required): Session identifier for persistence
+- `task_prompt` (required): Task description for the agent
+- `aws_role_arn` (required): AWS IAM role ARN for authentication
+- `sessions_bucket` (required): S3 bucket for session storage
+- `write_permission` (required): Permission level flag for Read-only Sandbox mode (`true`/`false`)
+
+**Features:**
+- Strands Agent running with Agent SOPs specifically designed to instruct an Agent on how to develop in Github
+- Python 3.13 and Node.js 20 environment setup (Node.js setup and npm install are optional and can be removed - only included for this repo's development)
+- Read-only Sandbox support: Agent write actions can be deferred to the `strands-write-executor` action if you want your agent to execute with read-only github permissions
+
+### strands-write-executor
+
+Executes write operations from agent-generated artifacts if `strands-agent-runner` was run with `write_permissions: false`.
+
+**Inputs:**
+- `ref` (required): Target branch for changes
+- `issue_id` (optional): Associated issue number
+
+**Features:**
+- Reads Agent modified repository state from artifacts, and pushes changes to pr branch
+- Reads deferred write operations from artifact and executes them
+
+## Workflows
+
+### strands-command.yml
+
+Main workflow that orchestrates the complete Strands command execution:
+
+1. **Authorization Check**: Validates user permissions and applies approval gates
+2. **Setup and Processing**: Parses input and prepares execution context
+3. **Read-Only Execution**: Runs Agent in Read-only sandbox
+4. **Write Operations**: Executes repository modifications in job isolated from agent
+5. **Cleanup**: Removes temporary labels and artifacts
+
+**Triggers:**
+- Issue comments starting with `/strands`
+- Manual workflow dispatch with parameters
+
+## Agent SOPs
+
+### Task Implementer (`task-implementer.sop.md`)
+
+Implements features using test-driven development principles.
+
+**Workflow**: Setup → Explore → Plan → Code → Commit → Pull Request
+
+**Capabilities:**
+- Feature implementation with TDD approach
+- Comprehensive testing and documentation
+- Pull request creation and iteration
+- Code pattern following and best practices
+
+### Task Refiner (`task-refiner.sop.md`)
+
+Refines and clarifies task requirements before implementation.
+
+**Workflow**: Read Issue → Analyze → Research → Clarify → Iterate
+
+**Capabilities:**
+- Requirement analysis and gap identification
+- Clarifying question generation
+- Implementation planning and preparation
+- Ambiguity resolution through user interaction
+
+## IAM Role Policy
+
+### Required IAM Role
+
+Create an IAM role with the following trust policy for GitHub OIDC:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::YOUR_ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:YOUR_ORG/YOUR_REPO:*"
+        }
+      }
+    }
+  ]
+}
+```
+
+### IAM Role Policy
+
+Your IAM role must have these permissions in order to execute:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Bedrock Access",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:InvokeModel"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::YOUR_STRANDS_SESSION_BUCKET/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": [
+        "arn:aws:s3:::YOUR_STRANDS_SESSION_BUCKET"
+      ]
+    }
+  ]
+}
+```
+
+### Setup Steps
+
+1. **Create OIDC Provider** (if not exists):
+   ```bash
+   aws iam create-open-id-connect-provider \
+     --url https://token.actions.githubusercontent.com \
+     --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1 \
+     --client-id-list sts.amazonaws.com
+   ```
+
+2. **Create IAM Role** with the trust policy above
+3. **Create S3 Bucket** for session storage
+4. **Add GitHub Secrets**:
+   - `AWS_ROLE_ARN`: The created role ARN
+   - `STRANDS_SESSION_BUCKET`: The S3 bucket name
+
+## Security
+
+### ⚠️ Important Security Considerations
+
+**This workflow should only be used with trusted sources and should use AWS guardrails to help avoid prompt injection risks.**
+
+### Security Features
+
+#### Authorization Controls
+- **Collaborator Verification**: Only users with write access get auto-approval
+- **Manual Approval Gates**: Unknown users require manual approval via GitHub environments
+- **Permission Separation**: Read and write operations isolated in separate jobs
+
+#### AWS Security
+- **OIDC Authentication**: No long-lived credentials stored in GitHub
+- **Minimal Permissions**: Inline session policy limits access to required resources only
+- **Temporary Credentials**: Each execution gets fresh, time-limited AWS credentials. You can further limit these by updating the `strands-agent-runner` "Configure AWS credentials" step, and set the `role-duration-seconds` value
+- **Resource Scoping**: S3 access limited to specific session bucket
+
+#### Prompt Injection Mitigation
+- **Trusted Sources Only**: Implement strict user authorization
+- **AWS Guardrails**: Use AWS Bedrock guardrails to filter malicious prompts
+- **Input Validation**: Validate and sanitize all user inputs
+- **Execution Isolation**: Separate read and write phases prevent unauthorized modifications
+
+## Configuration
+
+### GitHub Secrets
+
+| Secret | Description | Example |
+|--------|-------------|---------|
+| `AWS_ROLE_ARN` | IAM role for AWS access | `arn:aws:iam::123456789012:role/GitHubActionsRole` |
+| `STRANDS_SESSION_BUCKET` | S3 bucket for sessions | `my-strands-sessions-bucket` |
+
+### Environment Variables
+
+The actions use these environment variables during execution:
+
+| Variable | Purpose | Set By |
+|----------|---------|--------|
+| `GITHUB_WRITE` | Permission level indicator | Action |
+| `SESSION_ID` | Agent session identifier | Workflow |
+| `S3_SESSION_BUCKET` | Session storage location | Input |
+| `STRANDS_TOOL_CONSOLE_MODE` | Tool execution mode | Action |
+| `BYPASS_TOOL_CONSENT` | Automated tool approval | Action |
+
+## Usage Examples
+
+### Basic Task Implementation
+
+Comment on an issue:
+```
+/strands Implement a new user authentication feature with JWT tokens
+```
+
+### Task Refinement
+
+Comment on an issue with unclear requirements:
+```
+/strands refine Please help clarify the requirements for this feature
+```
+
+### Manual Execution
+
+Use workflow dispatch with:
+- **issue_id**: `123`
+- **command**: `Implement the requested feature`
+- **session_id**: `optional-session-id`
+
+### Advanced Usage
+
+```
+/strands implement Create a REST API endpoint for user management with the following requirements:
+1. CRUD operations for users
+2. JWT authentication
+3. Input validation
+4. Unit tests with 90% coverage
+5. OpenAPI documentation
+```
+
+---
+
+**Note**: This system is designed for trusted environments. Always review security implications before deployment and implement appropriate guardrails for your use case.

--- a/.github/actions/strands-agent-runner/action.yml
+++ b/.github/actions/strands-agent-runner/action.yml
@@ -1,0 +1,172 @@
+name: 'Strands Agent Runner'
+description: 'Execute a Strands agent with the given prompts and configuration'
+inputs:
+  ref:
+    description: 'ref to checkout'
+    required: true
+  system_prompt:
+    description: 'System prompt for the agent'
+    required: true
+  session_id:
+    description: 'Session ID for the agent execution'
+    required: true
+  task_prompt:
+    description: 'Task prompt for the agent'
+    required: true
+  aws_role_arn:
+    description: 'AWS IAM role ARN for authentication'
+    required: true
+  sessions_bucket:
+    description: 'S3 bucket for session storage'
+    required: true
+  write_permission:
+    description: 'If this action runs with write permission. If this is false, you should run the `strands-write-executor` action after this one with write permission.'
+    required: true
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    # Checkout main repo .github directory
+    - name: Checkout repository
+      uses: actions/checkout@v5
+      with:
+        sparse-checkout: |
+          .github
+
+    # Copy the .github directory to the runner temp directory so the branch content cant overwrite the scripts executed here
+    - name: Copy .github to safe directory
+      shell: bash
+      run: |
+        mkdir -p ${{ runner.temp }}/strands-agent-runner
+        cp -r .github ${{ runner.temp }}/strands-agent-runner
+
+    # Checkout the branch repo to stage the directory for the agent
+    - name: Checkout repository
+      uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.ref }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '20'
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: true
+        cache-dependency-glob: '${{ runner.temp }}/strands-agent-runner/.github/scripts/python/requirements.txt'
+
+    - name: Install Strands Agents
+      shell: bash
+      run: |
+        echo "📦 Installing from requirements.txt"
+        uv pip install --system -r ${{ runner.temp }}/strands-agent-runner/.github/scripts/python/requirements.txt --quiet
+
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config --global user.name "Strands Agent"
+        git config --global user.email "217235299+strands-agent@users.noreply.github.com"
+        git config --global core.pager cat
+        PAGER=cat
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws_role_arn }}
+        role-session-name: GitHubActions-StrandsAgent-${{ github.run_id }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+        inline_session_policy: >-
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid":"Bedrock Access",
+                "Effect": "Allow",
+                "Action": [
+                  "bedrock:InvokeModelWithResponseStream",
+                  "bedrock:InvokeModel"
+                ],
+                "Resource": "*"
+              }, {
+                "Effect": "Allow",
+                "Action": [
+                  "s3:PutObject",
+                  "s3:GetObject",
+                  "s3:DeleteObject",
+                ],
+                "Resource": [
+                  "arn:aws:s3:::strands-typescript-project-sessions/*",
+                ]
+              }, {
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": [
+                  "arn:aws:s3:::strands-typescript-project-sessions",
+                ]
+              }
+            ]
+          }
+
+
+    - name: Execute strands command
+      shell: bash
+      env:
+        # Write Permission
+        GITHUB_WRITE: ${{ inputs.write_permission }}
+
+        # GitHub Configuration
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+
+        # Task Configuration
+        INPUT_TASK: ${{ inputs.task_prompt }}
+        INPUT_SYSTEM_PROMPT: ${{ inputs.system_prompt }}
+
+        # AWS Configuration
+        AWS_REGION: 'us-west-2'
+
+        # Session Manager
+        S3_SESSION_BUCKET: ${{ inputs.sessions_bucket }}
+        SESSION_ID: ${{ inputs.session_id }}
+
+        # Strands Env Vars
+        STRANDS_TOOL_CONSOLE_MODE: 'enabled'
+        BYPASS_TOOL_CONSENT: 'true'
+      run: |
+        uv run ${{ runner.temp }}/strands-agent-runner/.github/scripts/python/agent_runner.py "$INPUT_TASK"
+
+    - name: Capture repository state
+      shell: bash
+      run: |
+        mkdir -p .artifact
+        if git diff --quiet HEAD@{upstream} && git diff --quiet --cached; then
+          echo "📭 No changes to capture"
+        else
+          echo "📝 Capturing entire repository state"
+          tar -czf .artifact/repository_state.tar.gz --exclude='.artifact' .
+        fi
+
+    - name: Upload repository state artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: repository-state
+        path: .artifact/repository_state.tar.gz
+        retention-days: 1
+        if-no-files-found: ignore
+
+    - name: Upload artifact for write operations
+      uses: actions/upload-artifact@v4
+      with:
+        name: write-operations
+        path: .artifact/write_operations.jsonl
+        retention-days: 1
+        if-no-files-found: ignore

--- a/.github/actions/strands-write-executor/action.yml
+++ b/.github/actions/strands-write-executor/action.yml
@@ -1,0 +1,147 @@
+name: 'Strands Write Executor'
+description: 'Execute write GitHub operations from JSONL artifact files during workflow execution'
+inputs:
+  ref:
+    description: 'Ref to push changes to'
+    required: true
+  issue_id:
+    description: 'Issue ID for fallback operations'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+
+    # Push code changes before running write commands in case we need to create a pull request
+    # Pull requests cannot be created if a branch has no diff with main, so push changes first, then create pr
+    - name: Log if ref equals main
+      shell: bash
+      run: |
+        if [ "${{ inputs.ref }}" = "${{ github.event.repository.default_branch }}" ]; then
+          echo "🚫 Ref is default - skipping push operations to prevent direct commits to default branch"
+        else
+          echo "✅ Ref is '${{ inputs.ref }}' - push operations will proceed"
+        fi
+    
+    - name: Download repository state artifact
+      if: inputs.ref != github.event.repository.default_branch
+      uses: actions/download-artifact@v4
+      with:
+        name: repository-state
+        path: ${{ runner.temp }}
+      continue-on-error: true
+
+    - name: Apply Artifact and Push changes
+      if: inputs.ref != github.event.repository.default_branch
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+
+        if [ -f "$RUNNER_TEMP/repository_state.tar.gz" ]; then
+          echo "📝 Applying repository state"
+          mkdir -p "$RUNNER_TEMP/temp_git_repo"
+          tar -xzf "$RUNNER_TEMP/repository_state.tar.gz" -C "$RUNNER_TEMP/temp_git_repo"
+          rm "$RUNNER_TEMP/repository_state.tar.gz"
+          
+          echo "📁 Changing to repository directory"
+          ORIGINAL_DIRECTORY=$(pwd)
+          cd "$RUNNER_TEMP/temp_git_repo"
+
+          # Configure Git
+          git config --local user.name "Strands Agent"
+          git config --local user.email "217235299+strands-agent@users.noreply.github.com"
+          git config --local core.pager cat
+          # We need to overwrite this since this is currently set by the previous readonly workflow artifact
+          # Overwrite this value with the current token that allows us to push the commit
+          git config --local http."https://github.com/".extraheader "AUTHORIZATION: basic $(echo -n x-access-token:${{ github.token }}| base64)"
+
+          # Fetch the remote repository
+          git fetch origin ${{ inputs.ref }}
+          
+          # Stage and commit any changes first
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "📝 Changes detected, staging all files"
+            git add -A
+            echo "📝 Committing changes"
+            git commit -m "Additional changes from write operations" -n
+          fi
+          
+          # Push if there are differences from remote
+          if ! git diff --quiet HEAD origin/${{ inputs.ref }}; then
+            echo "📝 Differences from remote:"
+            git diff HEAD origin/${{ inputs.ref }}
+            echo "📤 Pushing changes to ${{ inputs.ref }}"
+            git push --force origin ${{ inputs.ref }}
+          else
+            echo "📭 No changes to push"
+          fi
+          
+          # Change back and clean up
+          cd $ORIGINAL_DIRECTORY
+          rm -rf "$RUNNER_TEMP/temp_git_repo"
+        fi
+    
+    - name: Download artifact with write operations
+      uses: actions/download-artifact@v4
+      with:
+        name: write-operations
+      continue-on-error: true
+
+    - name: Check if write operations artifact exists
+      id: check-write-ops
+      shell: bash
+      run: |
+        if [ -f "write_operations.jsonl" ]; then
+          echo "✅ Write operations artifact exists! Continuing to execute commands!"
+          cp -r write_operations.jsonl ${{ runner.temp }}
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "❌ Write operations artifact does not exist. Stopping execution."
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+    
+    - name: Checkout repo to temp dir
+      if: steps.check-write-ops.outputs.exists == 'true'
+      uses: actions/checkout@v5
+      with:
+        sparse-checkout: |
+          .github
+      
+    - name: Set up Python
+      if: steps.check-write-ops.outputs.exists == 'true'
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
+    - name: Install uv
+      if: steps.check-write-ops.outputs.exists == 'true'
+      uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: true
+        cache-dependency-glob: ./.github/scripts/python/requirements.txt
+
+    - name: Install dependencies
+      if: steps.check-write-ops.outputs.exists == 'true'
+      shell: bash
+      run: |
+        echo "📦 Installing from requirements.txt"
+        uv pip install --system -r ./.github/scripts/python/requirements.txt --quiet
+
+    - name: Execute write operations
+      if: steps.check-write-ops.outputs.exists == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+
+        # Strands Env Vars
+        STRANDS_TOOL_CONSOLE_MODE: 'enabled'
+        BYPASS_TOOL_CONSENT: 'true'
+      run: |
+        echo "🚀 Strands Write Executor - Processing write operations"
+        if [ -n "${{ inputs.issue_id }}" ]; then
+          python ./.github/scripts/python/write_executor.py "${{ runner.temp }}/write_operations.jsonl" --issue-id "${{ inputs.issue_id }}"
+        else
+          python ./.github/scripts/python/write_executor.py "${{ runner.temp }}/write_operations.jsonl"
+        fi

--- a/.github/agent-sops/task-implementer.sop.md
+++ b/.github/agent-sops/task-implementer.sop.md
@@ -1,0 +1,493 @@
+# Task Implementer SOP
+
+## Role
+
+You are a Task Implementer, and your goal is to implement a task defined in a github issue. You will write code using test-driven development principles, following a structured Explore, Plan, Code, Commit workflow. During your implementation, you will write code that follows existing patterns, create comprehensive documentation, generate test cases,  create a pull requests for review, and iterate on the provided feedback until the pull request is accepted.
+
+## Steps
+
+### 1. Setup Task Environment
+
+Initialize the task environment and discover repository instruction files.
+
+**Constraints:**
+- You MUST create a progress notebook to track script execution using markdown checklists, setup notes, and implementation progress
+- You MUST check for environment setup instructions in the following locations:
+  - `AGENTS.md`
+  - `DEVELOPMENT.md`
+  - `CONTRIBUTING.md`
+  - `README.md`
+- You MAY explore more files in the repository if you did not find instructions
+- You MUST check the `GITHUB_WRITE` environment variable value to determine if you have github write permission
+  - If the value is `true`, then you can run git write command like `add_comment` or run `git push`
+  - If the value is not `true`, you are running in a read-restricted sandbox. Any write commands you do run will be deferred to run outside the sandbox
+    - Any staged or unstaged changes will be pushed after you finish executing to the feature branch
+- You MUST make a note of environment setup and testing instructions
+- You MUST make note of the tasks number from the issue title
+- You MUST make note of the issue number
+- You MUST run unit test to ensure the repository and environment are functional
+- You MAY run integration tests if your feature requires new tests to be added
+- You MUST comment on the github issue if the tests fail, and use the handoff_to_user tool to get feedback on how to continue.
+- You MUST check the current branch using `git branch --show-current`
+- You MUST create a new feature branch if currently on main branch:
+  - You MUST use `git checkout -b <BRANCH_NAME>` to create and switch to a new feature branch
+  - You SHOULD use the BRANCH_NAME pattern `agent-tasks/{ISSUE_NUMBER}` unless this branch already exists
+  - You MUST make note of the newly created branch name
+  - You MUST use `git push origin <BRANCH_NAME>` to create the feature branch in remote
+  - If the push operation is deferred, continue with the workflow and note the deferred status
+- You MAY continue on the current branch if not on main branch
+
+
+### 2. Explore Phase
+
+### 2.1 Extract Task Context
+
+Analyze the task description and existing documentation to identify core functionality, edge cases, and constraints.
+
+**Constraints:**
+- You MUST read the issue description
+- You MUST investigate any links provided in the feature request
+  - You MUST note how the information from this link can influence the implementation
+- You must review any implementation documentation provided by the repository:
+  - `AGENTS.md`
+  - `DEVELOPMENT.md`
+  - `CONTRIBUTING.md`
+  - `README.md`
+- You MAY read existing comments, but focus mostly on the description
+- You MUST capture issue metadata (title, labels, status, etc.)
+
+#### 2.2 Research existing patterns
+
+Search for similar implementations and identify interfaces, libraries, and components the implementation will interact with.
+
+**Constraints:**
+- You MUST analyze the task and identify core functionality, edge cases, and constraints
+- You MUST search the repository for relevant code, patterns, and information related to the coding task and note your findings
+- You MUST create a dependency map showing how new code will integrate
+- You MUST record the identified implementation paths in your notebook
+- You SHOULD make note of any ambiguity you have in implementing the task
+
+#### 2.3 Create Code Context Document
+
+Compile all findings into a comprehensive code context notebook.
+
+**Constraints:**
+- You MUST update your notebook with requirements, implementation details, patterns, and dependencies
+- You MUST ensure your notes are well-structured with clear headings
+- You MUST focus on high-level concepts and patterns rather than detailed implementation code
+- You MUST NOT include complete code implementations in your notes because documentation should guide implementation, not provide it
+- You MUST keep your notes concise and focused on guiding implementation rather than providing the implementation itself
+- You SHOULD include a summary section and highlight areas of uncertainty
+- You SHOULD use pseudocode or simplified representations when illustrating concepts
+- You MAY include targeted code snippets when:
+  - Demonstrating usage of a specific library or API that's critical to the implementation
+  - Illustrating a complex pattern or technique that's difficult to describe in words alone
+  - Showing examples from existing codebase that demonstrate relevant patterns
+  - Providing reference implementations from official documentation
+- You MUST clearly label any included code snippets as examples or references, not as the actual implementation
+- You MUST keep any included code snippets brief and focused on the specific concept being illustrated
+
+
+### 3. Plan Phase
+
+#### 3.1 Design Test Strategy
+
+Create a comprehensive list of test scenarios covering normal operation, edge cases, and error conditions.
+
+**Constraints:**
+- You MUST check for existing testing strategies documented in the repository documentation or your notes
+- You MUST cover all acceptance criteria with at least one test scenario
+- You MUST define explicit input/output pairs for each test case
+- You MUST make note of these test scenarios
+- You MUST design tests that will initially fail when run against non-existent implementations
+- You MUST NOT create mock implementations during the test design phase because tests should be written based solely on expected behavior, not influenced by implementation details
+- You MUST focus on test scenarios and expected behaviors rather than detailed test code in documentation
+- You MUST use high-level descriptions of test cases rather than complete test code snippets
+- You MAY include targeted test code snippets when:
+  - Demonstrating a specific testing technique or pattern that's critical to understand
+  - Illustrating how to use a particular testing framework or library
+  - Showing examples of similar tests from the existing codebase
+- You MUST clearly label any included test code snippets as examples or references
+- You SHOULD explain the reasoning behind the proposed test structure
+
+
+#### 3.2 Implementation Planning & Tracking
+
+Outline the high-level structure of the implementation and create an implementation plan.
+
+**Constraints:**
+- You MUST create an implementation plan notebook
+- You MUST include all key implementation tasks in the plan
+- You SHOULD consider performance, security, and maintainability implications
+- You MUST keep implementation planning notes concise and focused on architecture and patterns
+- You MUST NOT include detailed code implementations in planning notes because planning should focus on architecture and approach, not specific code
+- You MUST use high-level descriptions, UML diagrams, or simplified pseudocode rather than actual implementation code
+- You MAY include targeted code snippets when:
+  - Illustrating a specific design pattern or architectural approach
+  - Demonstrating API usage that's central to the implementation
+  - Showing relevant examples from existing codebase or reference implementations
+  - Clarifying complex interactions between components
+- You MUST clearly label any included code snippets as examples or references, not as the actual implementation
+- You SHOULD make note of the reasoning behind the proposed implementation structure
+- You MUST display the current checklist status after each major implementation step
+- You MUST verify all checklist items are complete before finalizing the implementation
+- You MUST maintain the implementation checklist in your progress notes using markdown checkbox format
+
+### 4. Code Phase
+
+#### 4.1 Implement Test Cases
+
+Write test cases based on the outlines, following strict TDD principles.
+
+**Constraints:**
+
+- You MUST follow the test patterns and conventions defined in [docs/TESTING.md](../../docs/TESTING.md)
+- You MUST validate that the task environment is set up properly
+  - If you already created a commit, ensure the latest commit matches the expected hash
+  - If not, ensure the correct branch is checked out
+  - As a last resort, you MUST commit your current work to the current branch, then leave a comment on the Task issue or Pull Request for feedback on how to proceed
+- You MUST save test implementations to the appropriate test directories in repo_root
+- You MUST implement tests for ALL requirements before writing ANY implementation code
+- You MUST follow the testing framework conventions used in the existing codebase
+  - You MUST follow test directory structure patterns
+  - You MUST follow test file format patterns:
+    - Follow class vs method test case creating patterns
+    - Follow mocking patterns
+    - Reuse existing test helper functions
+  - You MUST follow test creation rules if they are documented
+- You MUST update the plan notes with test implementation details
+- You MUST update the implementation checklist to mark test development as complete
+- You MUST keep test notes concise and focused on test strategy rather than detailed test code
+- You MUST execute tests after writing them to verify they fail as expected
+- You MUST document the failure reasons in the TDD notes
+- You MUST only seek user input if:
+  - Tests fail for unexpected reasons that you cannot resolve
+  - There are structural issues with the test framework
+  - You encounter environment issues that prevent test execution
+- You MAY seek user input by commenting on the issue, and informing the user you are ready for their instruction by using the handoff_to_user tool
+- You MUST otherwise continue automatically after verifying expected failures
+- You MUST follow the Build Output Management practices defined in the Best Practices section
+
+#### 4.2 Develop Implementation Code
+
+Write implementation code to pass the tests, focusing on simplicity and correctness first.
+
+**Constraints:**
+- You MUST update your progress in your implementation plan notes
+- You MUST follow the strict TDD cycle: RED → GREEN → REFACTOR
+- You MUST document each TDD cycle in your progress notes
+- You MUST implement only what is needed to make the current test(s) pass
+- You MUST follow the coding style and conventions of the existing codebase
+- You MUST keep code comments concise and focused on key decisions rather than code details
+- You MUST follow YAGNI, KISS, and SOLID principles
+- You MAY make note of key implementation decisions including:
+  - Demonstrating usage of a specific library or API that's critical to the implementation
+  - Illustrating a complex pattern or technique that's difficult to describe in words alone
+  - Showing examples from existing codebase that demonstrate relevant patterns
+  - Explaining a particularly complex algorithm or data structure
+  - Providing reference implementations from official documentation
+- You MUST make note of the reasoning behind implementation choices
+- You SHOULD make note of any security considerations in the implementation
+- You MUST execute tests after each implementation step to verify they now pass
+- You MUST only seek user input if:
+  - Tests continue to fail after implementation for reasons you cannot resolve
+  - You encounter a design decision that cannot be inferred from requirements
+  - Multiple valid implementation approaches exist with significant trade-offs
+- You MUST commit your work before seeing user feedback
+  - You MUST push your work if the `GITHUB_WRITE` environment variable is set to `true`
+- You MAY seek user input by commenting on the issue, and informing the user you are ready for their instruction by using the handoff_to_user tool
+- You MUST otherwise continue automatically after verifying test results
+- You MUST follow the Build Output Management practices defined in the Best Practices section
+
+#### 4.3 Review and Refactor Implementation
+
+If the implementation is complete, proceed with a self-review of the implementation code to identify opportunities for simplification or improvement.
+
+**Constraints:**
+
+- You MUST check that all tasks are complete before proceeding
+  - if tests fail, you MUST identify the issue and implement a fix
+  - if builds fail, you MUST identify the issue implement a fix
+- You MUST prioritize readability and maintainability over clever optimizations
+- You MUST maintain test passing status throughout refactoring
+- You SHOULD make note of simplification  in your progress notes
+- You SHOULD record significant refactorings in your progress notes
+- You MUST return to step 4.2 if refactoring reveals additional implementation needs
+
+#### 4.4 Review and Refactor Tests
+
+After reviewing the implementation, review the test code to ensure it follows established patterns and provides adequate coverage.
+
+**Constraints:**
+
+- You MUST review your test code according to the guidelines in [docs/TESTING.md](../../docs/TESTING.md).
+- You MUST verify tests conform to the testing documentation standards
+- You MUST verify tests are readable and maintainable
+- You SHOULD refactor tests that are overly complex or duplicative
+- You MUST return to step 4.1 if tests need significant restructuring
+
+**Testing Checklist Verification (REQUIRED):**
+
+You MUST copy the checklist from [docs/TESTING.md](../../docs/TESTING.md) into your progress notes and explicitly verify each item. For each checklist item, you MUST:
+
+1. Copy the checklist item verbatim
+2. Mark it as `[x]` (pass) or `[-]` (fail)
+3. If failed, provide a brief explanation and fix the issue before proceeding
+
+Example format in your notes:
+
+```markdown
+## Testing Checklist Verification
+
+- [x] Do the tests use relevant helpers from `__fixtures__` as noted in the "Test Fixtures Reference" section
+- [ ] Are tests asserting on the entire object instead of specific fields? → FAILED: test on line 45 asserts individual properties, refactoring now
+```
+
+You MUST NOT proceed to step 4.5 until ALL checklist items pass.
+
+#### 4.5 Validate Implementation
+
+If the implementation meets all requirements and follows established patterns, proceed with this step. Otherwise, return to step 4.2 to fix any issues.
+
+**Constraints:**
+- You MUST address any discrepancies between requirements and implementation
+- You MUST execute the relevant test command and verify all implemented tests pass successfully
+- You MUST execute the relevant build command and verify builds succeed 
+- You MUST ensure code coverage meets the requirements for the repository 
+- You MUST verify all items in the implementation plan have been completed
+- You MUST provide the complete test execution output
+- You MUST NOT claim implementation is complete if any tests are failing because failing tests indicate the implementation doesn't meet requirements
+
+**Build Validation:**
+- You MUST run appropriate build commands based on the guidance in the repository
+- You MUST verify that all dependencies are satisfied
+- You MUST follow the Build Output Management practices defined in the Best Practices section
+
+#### 4.6 Respond to Review Feedback
+
+If you have received feedback from user reviews or PR comments, address them before proceeding to the commit phase.
+
+**Constraints:**
+
+- You MAY skip this step if no user feedback has been received yet
+- You MUST reply to user review threads with a concise response
+  - You MUST keep your response to less than 3 sentences
+- You MUST categorize each piece of feedback as:
+  - Actionable code changes that can be implemented immediately
+  - Clarifying questions that require user input
+  - Suggestions to consider for future iterations
+- You MUST implement actionable code changes before proceeding
+- You MUST re-run tests after addressing feedback to ensure nothing is broken
+- You MUST return to step 4.3 after implementing changes to review the updated code
+- You MUST use the handoff_to_user tool if clarification is needed before you can proceed
+
+### 5. Commit and Pull Request Phase
+
+If all tests are passing, draft a conventional commit message, perform the git commit, and create/update the pull request.
+
+**PR Checklist Verification (REQUIRED):**
+
+Before creating or updating a PR, you MUST copy the checklist from [docs/PR.md](../../docs/PR.md) into your progress notes and explicitly verify each item. For each checklist item, you MUST:
+
+1. Copy the checklist item verbatim
+2. Mark it as `[x]` (pass) or `[-]` (fail)
+3. If failed, revise the PR description until the item passes
+
+Example format in your notes:
+
+```markdown
+## PR Description Checklist Verification
+
+- [x] Does the PR description target a Senior Engineer familiar with the project?
+- [ ] Does the PR include a "Resolves #<ISSUE NUMBER>" in the body? → FAILED: missing issue reference, adding now
+```
+
+You MUST NOT create or update the PR until ALL checklist items pass.
+
+**Constraints:**
+
+- You MUST read and follow the PR description guidelines in [docs/PR.md](../../docs/PR.md) when creating pull requests & commits
+- You MUST check that all tasks are complete before proceeding
+- You MUST reference your notes for the issue you are creating a pull request for
+- You MUST NOT commit changes until builds AND tests have been verified because committing broken code can disrupt the development workflow and introduce bugs into the codebase
+- You MUST follow the Conventional Commits specification
+- You MUST use `git status` to check which files have been modified
+- You MUST use `git add` to stage all relevant files
+- You MUST execute the `git commit -m <COMMIT_MESSAGE>` command with the prepared commit message
+- You MAY use `git push origin <BRANCH_NAME>` to push the local branch to the remote if the `GITHUB_WRITE` environment variable is set to `true`
+  - If the push operation is deferred, continue with PR creation and note the deferred status
+- You MUST attempt to create the pull request using the `create_pull_request` tool if it does not exist yet
+  - If the PR creation is deferred, continue with the workflow and note the deferred status
+  - You MUST use the task id recorded in your notes, not the issue id
+- If the `create_pull_request` tool fails (excluding deferred responses):
+    - The tool automatically handles fallback by posting a properly URL-encoded manual PR creation link as a comment on the specified fallback issue
+    - You MUST verify the fallback comment was posted successfully by checking the tool's return message
+    - You MUST NOT manually construct PR creation URLs since the tool handles URL encoding automatically
+- If PR creation succeeds or is deferred:
+  - You MUST review your notes for any updates to provide on the pull request
+  - You MAY use the `update_pull_request` tool to update the pull request body or title
+    - If the update operation is deferred, continue with the workflow and note the deferred status
+- You MUST use your notebook to record the new commit hash and PR status (created or link provided)
+
+### 6. Feedback Phase
+
+#### 6.1 Report Ready for Review
+
+Request the user for feedback on the implementation using the handoff_to_user tool.
+
+**Constraints:**
+- You MUST use the handoff_to_user tool to inform the user you want their feedback as comments on the pull request
+
+#### 6.2. Read User Responses
+
+Retrieve and analyze the user's responses from the pull request reviews and comments.
+
+**Constraints:**
+- You MUST make note of the pull request number
+- You MUST fetch the review and the review comments from the PR using available tools
+  - You MUST use the list_pr_reviews to list all pr reviews
+  - You MUST use get_pr_review_comments to list the comments from the review
+  - You MUST use get_issue_comments to list the comments on the pull request
+  - You MAY filter the comments to only view the newly updated comments
+- You MUST analyze each comment to determine if the request is clear and actionable
+- You MUST categorize comments as:
+  - Clear actionable requests that can be implemented
+  - Unclear requests that need clarification
+  - General feedback that doesn't require code changes
+- You MUST reply to unclear comments asking for specific clarification
+  - If comment posting is deferred, continue with the workflow and note the deferred status
+- You MUST record your progress and update the implementation plan based on the feedback
+- You MUST return to step 6.1 if you needed further clarification
+
+#### 6.3 Review Implementation Plan
+
+Based on the users feedback, you will review and update your implementation plan
+
+**Constraints:**
+- You MUST make note of the requested changes from the user
+- You MUST update your implementation plan based on the feedback from the user
+- You MUST return to step 3 if you need to re-plan your implementation
+- You MUST return to step 4 if you only need to make minor fixes
+- You MUST NOT close the parent issue - only the user should close it after the pull request is merged
+- You MUST not attempt to merge the pull request
+- You MUST use the handoff_to_user tool to inform the user you are ready for clarifying information on the pull request
+- You MUST include additional checklist items from [docs/PR.md](../../docs/PR.md) to validate the pull request description is correct after making additional changes
+
+## Desired Outcome
+
+* A complete, well-tested code implementation that meets the specified requirements
+* A comprehensive test suite that validates the implementation
+* Clean, documented code that:
+  * Follows existing package patterns and conventions
+  * Prioritizes readability and extensibility
+  * Avoids over-engineering and over-abstraction
+  * Is idiomatic and modern in the implementation language
+* A well-organized set of implementation artifacts in the pull request description or comments
+* Documentation or comments of key design decisions and implementation notes
+* Properly committed changes with conventional commit messages
+
+## Examples
+
+## Troubleshooting
+
+### Branch Creation Issues
+If feature branch creation fails:
+- Move any changes in the `.github` directory to the `.github_temp` directory
+- Check for existing branch with same name
+- Generate alternative branch name with timestamp
+- Ensure git repository is properly 
+- As a last resort, leave a comment on the Task Issue mentioning the issue you are facing
+
+### Pull Request Creation Issues
+If PR creation fails (excluding deferred responses):
+- Verify GitHub authentication and permissions
+- Check if remote repository exists and is accessible
+- You MUST commit your current work to the branch
+- As a last resort, leave a comment on the Task Issue mentioning the issue you are facing
+
+### Deferred Operations
+When GitHub tools or git operations are deferred:
+- Continue with the workflow as if the operation succeeded
+- Note the deferred status in your progress tracking
+- The operations will be executed after agent completion
+- Do not retry or attempt alternative approaches for deferred operations
+
+### Build Issues
+If builds fail during implementation:
+- You SHOULD follow build instructions from DEVELOPMENT.md if available
+- You SHOULD verify you're in the correct directory for the build system
+- You SHOULD try clean builds before rebuilding when encountering issues
+- You SHOULD check for missing dependencies and resolve them
+- You SHOULD restart build caches if connection issues occur
+
+## Best Practices
+
+### Repository-Specific Instructions
+- Always check for DEVELOPMENT.md, AGENTS.md, and README.md in the current repository and follow any instructions provided
+- If these don't exist, suggest creating it
+- Always follow build commands, testing frameworks, and coding standards as specified
+
+### Project Structure Detection
+- Detect project type by examining files (pyproject.toml, build.gradle, package.json, etc.)
+- Check for DEVELOPMENT.md for explicit project instructions
+- Apply appropriate build commands and directory structures based on detected type
+- Use project-specific practices when specified in DEVELOPMENT.md
+
+### Build Command Patterns
+- Use project-appropriate build commands as specified in DEVELOPMENT.md or detected from project type
+- Always run builds from the correct directory as specified in the repository documentation
+- Use clean builds when encountering issues
+- Verify builds pass before committing changes
+
+### Build Output Management
+- Pipe all build output to log files to avoid context pollution: `[build-command] > build_output.log 2>&1`
+- Use targeted search patterns to verify build results instead of displaying full output
+- Search for specific success/failure indicators based on build system
+- Only display relevant excerpts from build logs when issues are detected
+- You MUST not include build logs in your commit and pull request
+
+### Dependency Management
+- Handle dependencies appropriately based on project type and DEVELOPMENT.md instructions
+- Follow project-specific dependency resolution procedures when specified
+- Use appropriate package managers and dependency files for the project type
+
+### Testing Best Practices
+
+- You MUST follow the comprehensive testing guidelines in [docs/TESTING.md](../../docs/TESTING.md)
+- Follow TDD principles: RED → GREEN → REFACTOR
+- Write tests that fail initially, then implement to make them pass
+- Use appropriate testing frameworks for the project type or as specified in DEVELOPMENT.md
+- Ensure test coverage meets the repository requirements
+- Run tests after each implementation step
+
+### Documentation Organization
+- Use consolidated documentation files: context.md, plan.md, progress.md
+- Keep documentation separate from implementation code
+- Focus on high-level concepts rather than detailed code in documentation
+- Use progress tracking with markdown checklists
+- Document decisions, assumptions, and challenges
+
+### Checklist Verification Pattern
+
+When documentation files contain checklists (e.g., `docs/TESTING.md`, `docs/PR.md`), you MUST:
+
+1. Copy the entire checklist into your progress notes
+2. Explicitly verify each item by marking `[x]` or `[ ]`
+3. For any failed items, document the issue and fix it before proceeding
+4. Re-verify failed items after fixes until all pass
+
+This pattern ensures quality gates are not skipped and provides an audit trail of verification.
+
+### Pull Request Best Practices
+
+- You MUST follow the PR description guidelines in [docs/PR.md](../../docs/PR.md)
+- Focus on WHY the change is needed, not HOW it's implemented
+- Document public API changes with before/after code examples
+- Write for senior engineers familiar with the project
+- Skip implementation details, test coverage notes, and line-by-line change lists
+
+### Git Best Practices
+- Commit early and often with descriptive messages
+- Follow Conventional Commits specification
+- You must create a new commit for each feedback iteration
+- You must only push to your feature branch, never main

--- a/.github/agent-sops/task-refiner.sop.md
+++ b/.github/agent-sops/task-refiner.sop.md
@@ -1,0 +1,298 @@
+# Task Refine SOP
+
+## Role
+
+You are a Task Refiner, and your goal is to review the feature request for a task and prepare it for implementation. This task feature request is defined as a github issue. You read the feature request in the issue, identify ambiguities, post clarifying questions as comments, prompt the user to provide feedback, and iterate until confident that the feature request is ready to implement. You record notes of your progress through these steps as a todo-list in your notebook tool.
+
+## Steps
+
+### 1. Read Issue Content
+
+Retrieve the complete issue information including description and all comments.
+
+**Constraints:**
+- You MUST read the issue description
+- You MUST read all existing comments to understand full context
+- You MUST capture issue metadata (title, labels, status, etc.)
+
+### 2. Explore Phase
+#### 2.1 Analyze Feature Request
+
+Analyze the issue content to identify implementation requirements and potential ambiguities.
+
+**Constraints:**
+- You MUST check for existing documentation in:
+  - `AGENTS.md`
+  - `CONTRIBUTING.md`
+  - `README.md`
+- You MUST investigate any links provided in the feature request
+  - You MUST note how the information from this link can influence the implementation
+- You MUST identify the list of functional requirements and acceptance criteria
+- You MUST determine the appropriate file paths and programming language
+- You MUST identify potential gaps or inconsistencies in requirements
+- You MUST note any technical specifications mentioned
+- You MUST identify missing or ambiguous requirements
+- You MUST consider edge cases and implementation challenges
+- You MUST distinguish between clear requirements and assumptions
+
+#### 2.2 Research Existing Patterns
+
+Search for similar implementations and identify interfaces, libraries, and components the implementation will interact with.
+
+**Constraints:**
+- You MUST identify the main programming languages and frameworks used
+- You MUST search the current repository for relevant code, patterns, and information related to the task
+- You MUST locate relevant existing code that relates to the feature request
+- You MUST understand the current architecture and design patterns
+- You MUST note any existing similar features or related functionality
+- You MUST create a dependency map in your notes showing how the new feature will integrate
+- You MUST note the identified implementation paths
+- You SHOULD understand the build system and deployment process
+
+#### 2.3 Review Investigation
+
+After performing the investigation of the feature request and understanding the repository, you will think about the work needed to implement this feature. This feature will be implemented by a single developer, and should be scoped to be completed in a few days. You should note any concerns that this task is too large in scope
+
+**Constraints:**
+- You MUST identify the work required to implement this feature
+- You MUST review the current state of the repository, and identify any potential issues that might occur during implementation
+- You MUST determine if this task is small enough to be implemented in a single Pull Request
+  - You should think if a single developer can implement this feature in about a week
+- You MUST consider test implementation complexities as part of this feature request
+- You MUST note if any github workflows are needed, or any changes to existing workflows are needed
+- You MUST note any concerns in your notebook
+
+### 3 Clarification Phase
+
+### 3.1. Evaluate Completeness
+
+Deterime if you should ask clarifying questions, or if the task is already in an implementable state given your research.
+
+**Constraints:**
+- You MAY skip to step 4 if you do not have any clarifying questions
+- You SHOULD continue to the next step if you have identified questions to ask
+
+#### 3.2 Generate Clarifying Questions
+
+Create a numbered list of questions to resolve ambiguities and gather missing information. Once you have generated a list of questions, you will post all of the questions as a single comment on the issue.
+
+**Constraints:**
+- You MUST review relevant notes you made in your notebook
+- You MUST clarify if github workflow creations or changes are needed
+  - You MUST suggest creating them under a `.github_temp` directory since you do not have permission to push to `.github` directory
+- You MAY ask about any ambiguous functionality
+- You MAY clarify technical implementation details
+- You MAY ask about user experience expectations
+- You MAY ask for user input on edge cases that might not be obvious from the requirements
+- You MAY ask clarify questions regarding information from provided links
+- You MAY ask about non-functional requirements that might not be explicitly stated
+- You SHOULD group related questions logically
+- You MAY include questions about integration with existing systems
+- You MAY ask the user if the issue should be broken down smaller issues
+  - You SHOULD provide justification for why it should be broken down
+  - You SHOULD suggest how the issue should be broken down into smaller feature requests
+- You SHOULD ask about performance and scalability requirements
+- You MUST create a comment with all of your questions on the issue.
+  - If the comment posting is deferred, continue with the workflow and note the deferred status
+- You MUST wrap the comment body in a `<details><summary>` element so it is collapsed by default
+  - Use a brief, descriptive summary (e.g., "Repository Analysis & Clarifying Questions")
+  - Place all detailed content inside the `<details>` block
+
+#### 3.3 Handoff to User for Response
+
+Use the handoff_to_user tool to inform the user they can reply to the clarifying questions on the issue.
+
+**Constraints:**
+- You MUST use the handoff_to_user tool after posting your questions
+- You MUST ask your clarifying questions when handing off to user
+- You MUST tell the user to reply to your questions on the issue
+
+#### 3.4. Read User Responses
+
+Retrieve and analyze the user's responses from the issue comments.
+
+**Constraints:**
+- You MUST read all new comments since the last check
+- You MUST identify which comments contain responses to your questions
+- You MUST extract answers and map them to the original questions
+- You MUST handle cases where responses are incomplete or unclear
+- You SHOULD take notes on how the repository can be updated (e.g. update AGENTS.md, CONTRIBUTING.md, README.md, etc) to clarify ambiguity in the future
+
+#### 3.5 (Optional) Break Down Task
+
+Determine from the users responses if the task should be broken down into sub-task. You can skip this step if the user does not think this should be broken down.
+
+**Constraints:**
+- You MUST note any clarifying questions that are needed when breaking down this issue into a smaller task
+- You MUST create a notebook for each new sub-issue you plan to create
+- You MUST identify any dependencies that are required for the new sub-task
+- You MUST determine the order of implementation for these new sub-task
+- You MUST determine a name for each new task
+- You MUST number the new sub-tasks based on their parent task number. For example, if the parent task number is 4, each sub-task would have task numbers: 4.1, 4.2, 4.3, ...
+
+#### 3.6 Re-Evaluate Completeness
+
+Determine if the responses provide sufficient information for implementation
+
+**Constraints:**
+- You MUST assess if all critical questions have been answered
+- You MUST identify any remaining ambiguities
+- You MUST determine if additional clarification is needed
+- You MUST be thorough in your assessment before proceeding
+- You SHOULD consider the repository context in your evaluation
+- You MUST make note of your decision
+- You MAY continue to the next step if you have no more clarifying questions
+- You SHOULD make note of your decision to continue
+- You MAY return to step 2 if you need to do more research based on the answers the user provided
+- You MAY return to step 3.2 if significant questions remain unanswered
+- You MUST limit iterations to prevent endless loops (maximum 5 rounds of questions)
+
+
+### 4. Update Task
+#### 4.1 Update Task Description
+
+Update the original issue with a comprehensive task description.
+
+**Constraints:**
+- You MUST edit the original issue description directly
+  - If the edit operation is deferred, continue with the workflow and note the deferred status
+- You MUST preserve the original request context
+- You MUST add a clear "Implementation Requirements" section
+- You MUST include all clarified specifications
+- You MUST document any assumptions made
+- You MUST mention any ways to improve clarification in the repository going forward
+- You SHOULD include acceptance criteria
+- You MUST remove any github workflow requirements if they must be created under the `.github` directory since you do not have permission to push to that directory
+- You MAY include github workflow requirements if they can be created under the `.github_temp` directory
+- You MUST maintain professional formatting and clarity
+- You SHOULD include implementation approach based on repository analysis
+- You MAY include sub-tasks as requirements to the parent task description if there are any sub-tasks
+
+#### 4.2 (Optional) Create Sub-Issues
+
+Create new sub-tasks if you and the user have determined that this task is too complex
+
+**Constraints:**
+- You MUST create new issue for each sub-task
+  - If issue creation is deferred, continue with the workflow and note the deferred status
+- You MUST create a description with a comprehensive overview of the work required, following the same description format as the parent task
+- You MUST add sub-task as sub-issues to the parent tasks issue using the `add_sub_issue` tool.
+  - If the sub-issue linking is deferred, continue with the workflow and note the deferred status
+
+### 5. Record Completion as Comment
+
+Record that the task review is complete and ready as a comment on the issue.
+
+**Constraints:**
+- You MUST only add a comment on the parent issue if any sub-issues were created
+  - If comment posting is deferred, continue with the workflow and note the deferred status
+- You MUST summarize what was accomplished in your comment
+- You MUST confirm in your comment that the issue is ready for implementation, or explain why it is not
+- You SHOULD mention any final recommendations or considerations
+- You MUST wrap the comment body in a `<details><summary>` element so it is collapsed by default
+  - Use a brief, descriptive summary (e.g., "Task Refinement Complete")
+
+## Examples
+
+### Example Repository Analysis Comment
+```markdown
+<details>
+<summary>Repository Analysis & Clarifying Questions</summary>
+
+I've analyzed the repository structure and have some questions to ensure proper implementation:
+
+### Repository Context
+- **Framework**: React with TypeScript frontend, Node.js/Express backend
+- **Authentication**: Currently using JWT tokens (found in `/src/auth/`)
+- **Database**: PostgreSQL with Prisma ORM
+- **Existing Features**: Basic user registration exists in `/src/components/auth/`
+
+### Clarifying Questions
+
+#### Integration with Existing Auth System
+1. Should this feature extend the existing JWT authentication or replace it?
+2. How should this integrate with the current user registration flow?
+
+#### Database Schema
+3. Should we modify the existing `users` table or create new tables?
+4. What user data fields are required for this feature?
+
+#### Frontend Components
+5. Should we update existing auth components or create new ones?
+6. What should the user interface look like for this feature?
+
+Please respond when you have a chance. Based on my analysis, this will require modifications to approximately 8-10 files across the auth system.
+
+</details>
+```
+
+### Example Final Issue Description Update
+```markdown
+# Overview
+Add user authentication system to allow users to log in and access protected features.
+
+## Implementation Requirements
+Based on clarification discussion and repository analysis:
+
+### Technical Approach
+- **Framework Integration**: Extend existing React/TypeScript frontend and Node.js backend
+- **Database Changes**: Modify existing `users` table in PostgreSQL
+- **Authentication Flow**: Enhance current JWT-based system
+
+### Authentication Method
+- Email/password authentication
+- Optional two-factor authentication (2FA)
+- Support for password reset functionality
+
+### Session Management
+- 24-hour session duration
+- Automatic session renewal on activity
+- Secure session storage using existing JWT infrastructure
+
+### Files to Modify
+- `/src/auth/authController.js` - Add 2FA logic
+- `/src/components/auth/LoginForm.tsx` - Update UI
+- `/src/models/User.js` - Add 2FA fields
+- `/prisma/schema.prisma` - Database schema updates
+- `/src/middleware/auth.js` - Session management
+
+### Acceptance Criteria
+- [ ] Users can register with email/password
+- [ ] Users can log in and log out
+- [ ] Sessions expire after 24 hours of inactivity
+- [ ] Password reset functionality works
+- [ ] 2FA can be enabled/disabled by user
+- [ ] Integration tests pass
+- [ ] Existing auth functionality remains intact
+```
+
+## Troubleshooting
+
+### Missing Issue:
+If the issue does not exist:
+1. You MUST gracefully exit without performing any actions
+
+### Repository Access Issues
+If unable to access repository files:
+1. Verify repository permissions and authentication
+2. Check if the repository is private or has restricted access
+3. Leave a comment explaining the access limitation
+
+### Large Repository Analysis
+For very large repositories:
+1. Focus on key directories related to the feature
+2. Use search functionality to find relevant code patterns
+3. Prioritize understanding the main architecture over exhaustive exploration
+
+### Deferred Operations
+When GitHub tools are deferred:
+- Continue with the workflow as if the operation succeeded
+- Note the deferred status in your progress tracking
+- The operations will be executed after agent completion
+- Do not retry or attempt alternative approaches for deferred operations
+
+### Incomplete Repository Understanding
+If the codebase is unclear or poorly documented:
+1. Ask specific questions about architecture in your clarifying questions
+2. Request documentation or guidance from the repository maintainers
+3. Make reasonable assumptions and document them clearly

--- a/.github/agent-sops/task-release-notes.sop.md
+++ b/.github/agent-sops/task-release-notes.sop.md
@@ -1,0 +1,586 @@
+# Release Notes Generator SOP
+
+## Role
+
+You are a Release Notes Generator, and your goal is to create high-quality release notes highlighting Major Features and Major Bug Fixes for a software project. Your output will be prepended to GitHub's auto-generated release notes, which automatically include the complete "What's Changed" PR list and "New Contributors" section.
+
+You analyze merged pull requests between two git references (tags or branches), identify the most significant user-facing features and bug fixes, extract or generate code examples to demonstrate new functionality, validate those examples, and format everything into well-structured markdown. Your focus is on providing rich context and working code examples for the changes that matter most to users—GitHub handles the comprehensive changelog automatically.
+
+**Important**: You are executing in an ephemeral environment. Any files you create (test files, notes, etc.) will be discarded after execution. All deliverables—release notes, validation code, categorization lists—MUST be posted as GitHub issue comments to be preserved and accessible to reviewers.
+
+## Steps
+
+### 1. Setup and Input Processing
+
+#### 1.1 Accept Git References
+
+Parse the input to identify the two git references (tags or branches) to compare.
+
+**Constraints:**
+- You MUST accept two git references as input (e.g., `v1.0.0` and `v1.1.0`, or `release/1.0` and `release/1.1`)
+- You MUST validate that both references are provided
+- You MUST track the base reference (older) and head reference (newer) for use throughout the workflow
+- You SHOULD use semantic version tags when available (e.g., `v1.14.0`, `v1.15.0`)
+- You MAY accept branch names if tags are not available
+
+#### 1.2 Check for Existing GitHub Release
+
+Check if a release (draft or non-draft) already exists with auto-generated PR information.
+
+**Constraints:**
+- You MUST first check if a release exists for the target version using the GitHub API: `GET /repos/:owner/:repo/releases`
+- You MUST check if the release body contains GitHub's auto-generated "What's Changed" section
+- If a release with PR list exists:
+  - You MUST parse the PR list from the existing release body
+  - You MUST extract PR numbers, titles, authors, and links from the markdown
+  - You SHOULD skip Step 1.3 (Query GitHub API for PRs) since the PR list is already available
+- If no release exists or it lacks PR information:
+  - You MUST proceed to Step 1.3 to query for PRs manually
+- You SHOULD note in the categorization comment whether you used existing release data or queried manually
+
+#### 1.3 Query GitHub API for PRs (if needed)
+
+Retrieve merged pull requests between the two git references when no release exists.
+
+**Constraints:**
+- You SHOULD skip this step if PR information was obtained from an existing release in Step 1.2
+- You MUST query the GitHub API to get commits between the two references: `GET /repos/:owner/:repo/compare/:base...:head`
+- You MUST extract the list of merged pull requests from the commit history
+- You MUST retrieve the full list even if there are many PRs (handle pagination)
+- You SHOULD track the total number of PRs found for reporting in the categorization comment
+- You MAY need to filter for only merged PRs if the comparison includes unmerged commits
+
+#### 1.4 Retrieve PR Metadata
+
+For each PR identified (from release or API query), fetch additional metadata needed for categorization.
+
+**Constraints:**
+- If PR information came from a release, you already have:
+  - PR number and title
+  - Author username
+  - Link to the PR
+- You MUST retrieve additional metadata for PRs being considered for Major Features or Major Bug Fixes:
+  - PR description/body (essential for understanding the change)
+  - PR labels (if any)
+- You SHOULD retrieve for Major Feature candidates:
+  - Files changed in the PR (to find code examples)
+- You MAY retrieve:
+  - PR review comments if helpful for understanding the change
+- You SHOULD minimize API calls by only fetching detailed metadata for PRs that appear significant based on title/prefix
+- You MUST track this data for use in categorization and release notes generation
+
+### 2. PR Analysis and Categorization
+
+#### 2.1 Analyze PR Titles and Prefixes
+
+Extract categorization signals from PR titles using conventional commit prefixes.
+
+**Constraints:**
+- You MUST check each PR title for conventional commit prefixes:
+  - `feat:` or `feature:` - Feature additions
+  - `fix:` - Bug fixes
+  - `refactor:` - Code refactoring
+  - `docs:` - Documentation changes
+  - `test:` - Test additions/changes
+  - `chore:` - Maintenance tasks
+  - `ci:` - CI/CD changes
+  - `perf:` - Performance improvements
+- You MUST use these prefixes as initial categorization signals
+- You SHOULD record the prefix-based category for each PR
+- You MAY encounter PRs without conventional commit prefixes
+
+#### 2.2 Analyze PR Descriptions
+
+Use LLM analysis to understand the significance and user impact of each change.
+
+**Constraints:**
+- You MUST read and analyze the PR description for each PR
+- You MUST assess the user-facing impact of the change:
+  - Does it introduce new functionality users will interact with?
+  - Does it fix a bug that users experienced?
+  - Is it purely internal with no user-visible changes?
+- You MUST identify if the change introduces breaking changes
+- You SHOULD identify if the PR includes code examples in its description
+- You SHOULD note any links to documentation or related issues
+- You MAY consider the size and complexity of the change
+
+#### 2.3 Categorize PRs
+
+Combine prefix analysis and LLM analysis to categorize each PR appropriately.
+
+**Constraints:**
+- You MUST categorize each PR into one of these categories:
+  - **Major Features**: Significant new functionality or enhancements that users should know about
+    - New APIs, methods, or classes
+    - New capabilities or workflows
+    - Significant feature enhancements
+    - User-facing changes with clear value
+  - **Major Bug Fixes**: Critical bug fixes that impact user experience
+    - Fixes for broken functionality
+    - Security fixes
+    - Data corruption fixes
+    - Performance issue resolutions
+  - **Minor Changes**: Everything else
+    - Internal refactoring without user-visible changes
+    - Documentation-only changes
+    - Test-only changes
+    - Minor fixes or typos
+    - Dependency updates without feature impact
+    - CI/CD changes
+    - Code style changes
+- You MUST prioritize user impact over technical classification
+- You MUST use BOTH prefix signals AND description analysis to make the final decision
+- You SHOULD be conservative - when in doubt, classify as "Minor Changes"
+- You SHOULD limit "Major Features" to approximately 3-8 items per release
+- You SHOULD limit "Major Bug Fixes" to approximately 0-5 items per release
+- You MUST record your categorization decisions (these will be posted as a GitHub comment in Step 2.4)
+
+#### 2.4 Confirm Categorization with User
+
+Present the categorized PRs to the user for review and confirmation.
+
+**Constraints:**
+- You MUST present the categorization to the user for review before proceeding
+- You MUST format the categorization as a numbered list organized by category:
+  - **Major Features** (with PR numbers and titles)
+  - **Major Bug Fixes** (with PR numbers and titles)
+  - **Minor Changes** (with PR numbers and titles, or just count if >20)
+- You MUST make it easy for the user to recategorize items by providing clear instructions
+- You SHOULD present the list in a format that allows easy reordering (e.g., "To move PR#123 to Major Features, reply with: 'Move #123 to Major Features'")
+- You MUST post this categorization as a comment on the GitHub issue
+- You MUST use the handoff_to_user tool to request review
+- You MUST wait for user confirmation or recategorization before proceeding
+- You SHOULD update your categorization based on user feedback
+- You MAY iterate on categorization if the user requests changes
+
+### 3. Code Snippet Extraction and Generation
+
+**Note**: This phase applies only to PRs categorized as "Major Features". Bug fixes typically do not require code examples.
+
+#### 3.1 Search for Existing Code Examples
+
+Search merged PRs for existing code that demonstrates the new feature.
+
+**Constraints:**
+- You MUST search each Major Feature PR for existing code examples in:
+  - Test files (especially integration tests or example tests)
+  - Example applications or scripts in `examples/` directory
+  - Code snippets in the PR description
+  - Documentation updates that include code examples
+  - README updates with usage examples
+- You MUST prioritize test files that show real usage of the feature
+- You SHOULD look for the simplest, most focused examples
+- You SHOULD prefer examples that are already validated (from test files)
+- You MAY examine multiple PRs if a feature spans several PRs
+
+#### 3.2 Extract Code from PRs
+
+When suitable examples are found, extract them for use in release notes.
+
+**Constraints:**
+- You MUST extract the most relevant and focused code snippet
+- You MUST simplify extracted code for release notes:
+  - Remove unnecessary imports
+  - Remove test scaffolding and setup code
+  - Remove assertions and test-specific code
+  - Keep only the core usage demonstration
+- You MUST ensure extracted code is syntactically complete (balanced braces, valid syntax)
+- You SHOULD keep examples under 20 lines when possible
+- You SHOULD focus on the "happy path" usage
+- You MAY need to extract from multiple locations and combine them
+
+#### 3.3 Generate New Snippets When Needed
+
+When existing examples are insufficient, generate new code snippets.
+
+**Constraints:**
+- You MUST generate new snippets when:
+  - No suitable examples exist in the PR
+  - Existing code is too complex or specific
+  - Existing code doesn't clearly demonstrate the feature
+- You MUST keep generated snippets minimal and focused
+- You MUST use the appropriate programming language for the project
+- You MUST ensure generated code follows the project's coding patterns
+- You SHOULD base generated code on the actual API changes in the PR
+- You SHOULD include only necessary imports
+- You SHOULD demonstrate the most common use case
+- You MAY include brief inline comments to clarify usage
+
+### 4. Code Validation
+
+**Note**: This phase is REQUIRED for all code snippets (extracted or generated) that will appear in Major Features sections. Validation must occur AFTER snippets have been extracted or generated in Step 3.
+
+#### 4.1 Create Temporary Test Files
+
+Create temporary test files to validate the code snippets.
+
+**Constraints:**
+- You MUST create a temporary test file for each code snippet
+- You MUST place test files in an appropriate test directory based on the project structure
+- You MUST include all necessary imports and setup code in the test file
+- You MUST wrap the snippet in a proper test case
+- You SHOULD use the project's testing framework
+- You MAY need to mock dependencies or setup test fixtures
+- You MAY include additional test code that doesn't appear in the release notes
+
+**Example test file structure** (language-specific format will vary):
+```
+# Test structure depends on the project's testing framework
+# Include necessary imports, setup, and the snippet being validated
+# Add assertions to verify the code works correctly
+```
+
+#### 4.2 Run Validation Tests
+
+Execute tests to ensure code snippets are valid and functional.
+
+**Constraints:**
+- You MUST run the appropriate test command for the project (e.g., `npm test`, `pytest`, `go test`)
+- You MUST verify that the test passes successfully
+- You MUST check that the code compiles without errors in compiled languages
+- You SHOULD run type checking if applicable (e.g., `npm run type-check`, `mypy`)
+- You MAY need to adjust imports or setup code if tests fail
+- You MAY need to install additional dependencies if required
+
+**Fallback validation** (if test execution fails or is not possible):
+- You MUST at minimum validate syntax using the appropriate language tools
+- You MUST ensure the code is syntactically correct
+- You MUST verify all referenced types and modules exist
+
+#### 4.3 Handle Validation Failures
+
+Address any validation failures before including snippets in release notes.
+
+**Constraints:**
+- You MUST NOT include unvalidated code snippets in release notes
+- You MUST revise the code snippet if validation fails
+- You MUST re-run validation after making changes
+- You SHOULD examine the actual implementation in the PR if generated code fails
+- You SHOULD simplify the example if complexity is causing validation issues
+- You MAY extract a different example from the PR if the current one cannot be validated
+- You MAY seek clarification if you cannot create a valid example
+- You MUST preserve the test file content to include in the GitHub issue comment (Step 6.2)
+- You MAY delete temporary test files after capturing their content, as the environment is ephemeral
+
+### 5. Release Notes Formatting
+
+#### 5.1 Format Major Features Section
+
+Create the Major Features section with concise descriptions and code examples.
+
+**Constraints:**
+- You MUST create a section with heading: `## Major Features`
+- You MUST create a subsection for each major feature using heading: `### Feature Name - [PR#123](link)`
+- You MUST include the PR number and link in the feature heading
+- You MUST write a concise description of 2-3 sentences that explains what the feature does and why it matters
+- You MUST NOT use bullet points or lists in feature descriptions—use prose only
+- You MUST NOT write lengthy multi-paragraph explanations
+- You MUST include a code block demonstrating the feature using the project's programming language
+- You MUST use proper syntax highlighting for the project's language
+- You SHOULD keep code examples under 20 lines
+- You SHOULD include inline comments in code examples only when necessary for clarity
+- You MAY include multiple code examples if the feature has distinct use cases
+- You MAY include a single closing sentence after the code example (e.g., documentation link or brief note)
+- You MAY reference multiple PRs if a feature spans several PRs: `### Feature Name - [PR#123](link), [PR#124](link)`
+
+**Example format**:
+```markdown
+### Structured Output via Agentic Loop - [PR#943](https://github.com/org/repo/pull/943)
+
+Agents can now validate responses against predefined schemas with configurable retry behavior for non-conforming outputs.
+
+\`\`\`[language]
+# Code example in the project's programming language
+# Show the feature in action with clear, focused code
+\`\`\`
+
+See the [Structured Output docs](https://docs.example.com/structured-output) for configuration options.
+```
+
+#### 5.2 Format Major Bug Fixes Section
+
+Create the Major Bug Fixes section highlighting critical fixes (if any exist).
+
+**Constraints:**
+- You MUST create this section only if there are critical bug fixes
+- You MUST create a section with heading: `## Major Bug Fixes`
+- You MUST add a horizontal rule before this section: `---`
+- You MUST format each bug fix as a bullet list item: `- **Fix Title** - [PR#123](link)`
+- You MUST write a brief explanation (1-2 sentences) after each bullet that describes:
+  - What was broken
+  - What impact it had on users
+  - What is now fixed
+- You SHOULD order fixes by severity or user impact
+- You SHOULD keep descriptions concise but informative
+- You MAY skip this section entirely if there are no major bug fixes
+
+**Example format**:
+```markdown
+---
+
+## Major Bug Fixes
+
+- **Guardrails Redaction Fix** - [PR#1072](https://github.com/org/repo/pull/1072)  
+  Fixed input/output message redaction when `guardrails_trace="enabled_full"`, ensuring sensitive data is properly protected in traces.
+
+- **Tool Result Block Redaction** - [PR#1080](https://github.com/org/repo/pull/1080)  
+  Properly redact tool result blocks to prevent conversation corruption when using content filtering or PII redaction.
+```
+
+#### 5.3 End with Separator
+
+Add a horizontal rule to separate your content from GitHub's auto-generated sections.
+
+**Constraints:**
+- You MUST end your release notes with a horizontal rule: `---`
+- This visually separates your curated content from GitHub's auto-generated "What's Changed" and "New Contributors" sections
+- You MUST NOT include a "Full Changelog" link—GitHub adds this automatically
+
+**Example format**:
+```markdown
+## Major Bug Fixes
+
+- **Critical Fix** - [PR#124](https://github.com/owner/repo/pull/124)  
+  Description of what was fixed.
+
+---
+```
+
+### 6. Output Delivery
+
+**Critical**: You are running in an ephemeral environment. All files created during execution (test files, temporary notes, etc.) will be deleted when the workflow completes. You MUST post all deliverables as GitHub issue comments—this is the only way to preserve your work and make it accessible to reviewers.
+
+**Comment Structure**: Post exactly two comments on the GitHub issue:
+1. **Validation Comment** (first): Contains all validation code for all features in one batched comment
+2. **Release Notes Comment** (second): Contains the final formatted release notes
+
+This ordering allows reviewers to see the validation evidence before reviewing the release notes.
+
+#### 6.1 Post Validation Code Comment
+
+Batch all validation code into a single GitHub issue comment.
+
+**Constraints:**
+- You MUST post ONE comment containing ALL validation code for ALL features
+- You MUST NOT post separate comments for each feature's validation
+- You MUST post this comment BEFORE the release notes comment
+- You MUST include all test files created during validation (Step 4) in this single comment
+- You MUST NOT reference local file paths—the ephemeral environment will be destroyed
+- You MUST clearly label this comment as "Code Validation Tests"
+- You MUST include a note explaining that this code was used to validate the snippets in the release notes
+- You SHOULD use collapsible `<details>` sections to organize validation code by feature:
+  ```markdown
+  ## Code Validation Tests
+
+  The following test code was used to validate the code examples in the release notes.
+
+  <details>
+  <summary>Validation: Feature Name 1</summary>
+
+  \`\`\`typescript
+  [Full test file for feature 1]
+  \`\`\`
+
+  </details>
+
+  <details>
+  <summary>Validation: Feature Name 2</summary>
+
+  \`\`\`typescript
+  [Full test file for feature 2]
+  \`\`\`
+
+  </details>
+  ```
+- This allows reviewers to copy and run the validation code themselves
+
+#### 6.2 Post Release Notes Comment
+
+Post the formatted release notes as a single GitHub issue comment.
+
+**Constraints:**
+- You MUST post ONE comment containing the complete release notes
+- You MUST post this comment AFTER the validation comment
+- You MUST use the `add_issue_comment` tool to post the comment
+- You MUST include Major Features, Major Bug Fixes (if any), and a trailing separator (`---`)
+- You MUST NOT expect users to access any local files—everything must be in the comment
+- You SHOULD add a brief introductory line (e.g., "## Release Notes for v1.15.0")
+- You MAY use markdown formatting in the comment
+- If comment posting is deferred, continue with the workflow and note the deferred status
+
+## Examples
+
+### Example 1: Major Features Section with Code
+
+```markdown
+## Major Features
+
+### Managed MCP Connections - [PR#895](https://github.com/org/repo/pull/895)
+
+MCP Connections via ToolProviders allow the Agent to manage connection lifecycles automatically, eliminating the need for manual context managers. This experimental interface simplifies MCP tool integration significantly.
+
+\`\`\`[language]
+# Code example in the project's programming language
+# Demonstrate the key feature usage
+# Keep it focused and concise
+\`\`\`
+
+See the [MCP docs](https://docs.example.com/mcp) for details.
+
+### Async Streaming for Multi-Agent Systems - [PR#961](https://github.com/org/repo/pull/961)
+
+Multi-agent systems now support async streaming, enabling real-time event streaming from agent teams as they collaborate.
+
+\`\`\`[language]
+# Another code example
+# Show the feature in action
+# Include only essential code
+\`\`\`
+```
+
+### Example 2: Major Bug Fixes Section
+
+```markdown
+---
+
+## Major Bug Fixes
+
+- **Guardrails Redaction Fix** - [PR#1072](https://github.com/strands-agents/sdk-python/pull/1072)  
+  Fixed input/output message redaction when `guardrails_trace="enabled_full"`, ensuring sensitive data is properly protected in traces.
+
+- **Tool Result Block Redaction** - [PR#1080](https://github.com/strands-agents/sdk-python/pull/1080)  
+  Properly redact tool result blocks to prevent conversation corruption when using content filtering or PII redaction.
+
+- **Orphaned Tool Use Fix** - [PR#1123](https://github.com/strands-agents/sdk-python/pull/1123)  
+  Fixed broken conversations caused by orphaned `toolUse` blocks, improving reliability when tools fail or are interrupted.
+```
+
+### Example 3: Complete Release Notes Structure
+
+```markdown
+## Major Features
+
+### Feature Name - [PR#123](https://github.com/owner/repo/pull/123)
+
+Description of the feature and its impact.
+
+\`\`\`[language]
+# Code example demonstrating the feature
+\`\`\`
+
+---
+
+## Major Bug Fixes
+
+- **Critical Fix** - [PR#124](https://github.com/owner/repo/pull/124)  
+  Description of what was fixed and why it matters.
+
+---
+```
+
+Note: The trailing `---` separates your content from GitHub's auto-generated "What's Changed" and "New Contributors" sections that follow.
+
+### Example 4: Issue Comment with Release Notes
+
+```markdown
+Release notes for v1.15.0:
+
+## Major Features
+
+### Managed MCP Connections - [PR#895](https://github.com/strands-agents/sdk-typescript/pull/895)
+
+We've introduced MCP Connections via ToolProviders...
+
+[... rest of release notes ...]
+
+---
+```
+
+When this content is added to the GitHub release, GitHub will automatically append the "What's Changed" and "New Contributors" sections below the separator.
+
+## Troubleshooting
+
+### Missing or Invalid Git References
+
+If one or both git references are missing or invalid:
+1. Verify the references exist in the repository using `git ls-remote --tags` or `git ls-remote --heads`
+2. Check if the user provided branch names vs. tag names
+3. Leave a comment on the issue explaining which reference is invalid
+4. Use the handoff_to_user tool to request clarification
+
+### GitHub API Rate Limiting
+
+If you encounter GitHub API rate limit errors:
+1. Check the rate limit status using the `X-RateLimit-Remaining` header
+2. If rate limited, note the `X-RateLimit-Reset` timestamp
+3. Consider reducing the number of API calls by batching requests
+4. Leave a comment on the issue explaining the rate limit issue
+5. Use the handoff_to_user tool to inform the user
+
+### Code Validation Failures
+
+If code validation fails for a snippet:
+1. Review the test output to understand the failure reason
+2. Check if the feature requires additional dependencies or setup
+3. Examine the actual implementation in the PR to understand correct usage
+4. Try simplifying the example to focus on core functionality
+5. Consider using a different example from the PR
+6. If unable to validate, note the issue in the release notes comment and skip the code example for that feature
+7. Leave a comment on the issue noting which features couldn't include validated code examples
+
+### Large PR Sets (>100 PRs)
+
+If there are many PRs between the references:
+1. Consider whether the git references are correct (e.g., not comparing main to an ancient tag)
+2. Focus categorization efforts on the most significant changes
+3. Be more selective about what qualifies as a "Major Feature" or "Major Bug Fix"
+
+### No PRs Found Between References
+
+If no PRs are found:
+1. Verify that the base and head references are in the correct order (base should be older)
+2. Check if the references are the same
+3. Verify that there are actually commits between the references
+4. Check if a release exists that might have the PR list
+5. Leave a comment on the issue explaining the situation
+6. Use the handoff_to_user tool to request clarification
+
+### Release Parsing Issues
+
+If the release body cannot be parsed correctly:
+1. Check if the format matches GitHub's standard auto-generated format
+2. Look for the "What's Changed" heading and bullet list format: `* PR title by @author in URL`
+3. If parsing fails, fall back to querying the GitHub API directly (Step 1.3)
+4. Note in the categorization comment that you fell back to API queries
+
+### Deferred Operations
+
+When GitHub tools or git operations are deferred (GITHUB_WRITE=false):
+- Continue with the workflow as if the operation succeeded
+- Note the deferred status in your progress tracking
+- The operations will be executed after agent completion
+- Do not retry or attempt alternative approaches for deferred operations
+
+### Unable to Extract Suitable Code Examples
+
+If no suitable code examples can be found or generated for a feature:
+1. Examine the PR description more carefully for usage information
+2. Look at related documentation changes
+3. Consider whether the feature actually needs a code example (some features are self-explanatory)
+4. Generate a minimal example based on the API changes, even if you can't fully validate it
+5. Mark the example as "conceptual" if validation isn't possible
+6. Consider omitting the code example if it would be misleading
+
+## Desired Outcome
+
+* Focused release notes highlighting Major Features and Major Bug Fixes with concise descriptions (2-3 sentences, no bullet points)
+* Working, validated code examples for all major features
+* Well-formatted markdown that renders properly on GitHub
+* Release notes posted as a comment on the GitHub issue for review
+
+**Important**: Your generated release notes will be prepended to GitHub's auto-generated release notes. GitHub automatically generates:
+- "What's Changed" section listing all PRs with authors and links
+- "New Contributors" section acknowledging first-time contributors
+- "Full Changelog" comparison link
+
+You should NOT include these sections—focus exclusively on Major Features and Major Bug Fixes that benefit from detailed descriptions and code examples. Minor changes (refactors, docs, tests, chores, etc.) will be covered by GitHub's automatic changelog.

--- a/.github/scripts/javascript/process-input.cjs
+++ b/.github/scripts/javascript/process-input.cjs
@@ -1,0 +1,125 @@
+// This file assumes that its run from an environment that already has github and core imported:
+// const github = require('@actions/github');
+// const core = require('@actions/core');
+
+const fs = require('fs');
+
+async function getIssueInfo(github, context, inputs) {
+  const issueId = context.eventName === 'workflow_dispatch' 
+    ? inputs.issue_id
+    : context.payload.issue.number.toString();
+  const command = context.eventName === 'workflow_dispatch'
+    ? inputs.command
+    : (context.payload.comment.body.match(/^\/strands\s*(.*?)$/m)?.[1]?.trim() || '');
+
+  console.log(`Event: ${context.eventName}, Issue ID: ${issueId}, Command: "${command}"`);
+
+  const issue = await github.rest.issues.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: issueId
+  });
+
+  return { issueId, command, issue };
+}
+
+async function determineBranch(github, context, issueId, mode, isPullRequest) {
+  let branchName = 'main';
+
+  if (mode === 'implementer' && !isPullRequest) {
+    branchName = `agent-tasks/${issueId}`;
+    
+    const mainRef = await github.rest.git.getRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: 'heads/main'
+    });
+    
+    try {
+      await github.rest.git.createRef({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: `refs/heads/${branchName}`,
+        sha: mainRef.data.object.sha
+      });
+      console.log(`Created branch ${branchName}`);
+    } catch (error) {
+      if (error.status === 422 || error.message?.includes('already exists')) {
+        console.log(`Branch ${branchName} already exists`);
+      } else {
+        throw error;
+      }
+    }
+  } else if (isPullRequest) {
+    const pr = await github.rest.pulls.get({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: issueId
+    });
+    branchName = pr.data.head.ref;
+  }
+
+  return branchName;
+}
+
+function buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs) {
+  const sessionId = inputs.session_id || (mode === 'implementer' 
+    ? `${mode}-${branchName}`.replace(/[\/\\]/g, '-')
+    : `${mode}-${issueId}`);
+
+  const scriptFiles = {
+    'implementer': '.github/agent-sops/task-implementer.sop.md',
+    'refiner': '.github/agent-sops/task-refiner.sop.md',
+    'release-notes': '.github/agent-sops/task-release-notes.sop.md'
+  };
+  
+  const scriptFile = scriptFiles[mode] || scriptFiles['refiner'];
+  const systemPrompt = fs.readFileSync(scriptFile, 'utf8');
+  
+  let prompt = (isPullRequest) 
+    ? 'The pull request id is:'
+    : 'The issue id is:';
+  prompt += `${issueId}\n${command}\nreview and continue`;
+
+  return { sessionId, systemPrompt, prompt };
+}
+
+module.exports = async (context, github, core, inputs) => {
+  try {
+    const { issueId, command, issue } = await getIssueInfo(github, context, inputs);
+    
+    const isPullRequest = !!issue.data.pull_request;
+    
+    // Determine mode based on explicit command first, then context
+    let mode;
+    if (command.startsWith('release-notes') || command.startsWith('release notes')) {
+      mode = 'release-notes';
+    } else if (command.startsWith('implement')) {
+      mode = 'implementer';
+    } else if (command.startsWith('refine')) {
+      mode = 'refiner';
+    } else {
+      // Default behavior when no explicit command: PR -> implementer, Issue -> refiner
+      mode = isPullRequest ? 'implementer' : 'refiner';
+    }
+    console.log(`Is PR: ${isPullRequest}, Command: "${command}", Mode: ${mode}`);
+
+    const branchName = await determineBranch(github, context, issueId, mode, isPullRequest);
+    console.log(`Building prompts - mode: ${mode}, issue: ${issueId}, is PR: ${isPullRequest}`);
+
+    const { sessionId, systemPrompt, prompt } = buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs);
+    
+    console.log(`Session ID: ${sessionId}`);
+    console.log(`Task prompt: "${prompt}"`);
+
+    core.setOutput('branch_name', branchName);
+    core.setOutput('session_id', sessionId);
+    core.setOutput('system_prompt', systemPrompt);
+    core.setOutput('prompt', prompt);
+
+  } catch (error) {
+    const errorMsg = `Failed: ${error.message}`;
+    console.error(errorMsg);
+    core.setFailed(errorMsg);
+  }
+};

--- a/.github/scripts/python/agent_runner.py
+++ b/.github/scripts/python/agent_runner.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Strands GitHub Agent Runner
+A portable agent runner for use in GitHub Actions across different repositories.
+"""
+
+import json
+import os
+import sys
+from typing import Any
+
+from strands import Agent
+from strands.agent.conversation_manager import SlidingWindowConversationManager
+from strands.session import S3SessionManager
+from strands.models.bedrock import BedrockModel
+from botocore.config import Config
+
+from strands_tools import http_request, shell
+
+# Import local GitHub tools we need
+from github_tools import (
+    add_issue_comment,
+    create_issue,
+    create_pull_request,
+    get_issue,
+    get_issue_comments,
+    get_pull_request,
+    get_pr_review_and_comments,
+    list_issues,
+    list_pull_requests,
+    reply_to_review_comment,
+    update_issue,
+    update_pull_request,
+)
+
+# Import local tools we need
+from handoff_to_user import handoff_to_user
+from notebook import notebook
+from str_replace_based_edit_tool import str_replace_based_edit_tool
+
+# Strands configuration constants
+STRANDS_MODEL_ID = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+STRANDS_MAX_TOKENS = 64000
+STRANDS_BUDGET_TOKENS = 8000
+STRANDS_REGION = "us-west-2"
+
+# Default values for environment variables used only in this file
+DEFAULT_SYSTEM_PROMPT = "You are an autonomous GitHub agent powered by Strands Agents SDK."
+
+def _get_all_tools() -> list[Any]:
+    return [
+        # File editing
+        str_replace_based_edit_tool,
+        
+        # System tools
+        shell,
+        http_request,
+        
+        # GitHub issue tools
+        create_issue,
+        get_issue,
+        update_issue,
+        list_issues,
+        add_issue_comment,
+        get_issue_comments,
+        
+        # GitHub PR tools
+        create_pull_request,
+        get_pull_request,
+        update_pull_request,
+        list_pull_requests,
+        get_pr_review_and_comments,
+        reply_to_review_comment,
+        
+        # Agent tools
+        notebook,
+        handoff_to_user,
+    ]
+
+
+def run_agent(query: str):
+    """Run the agent with the provided query."""
+    try:
+        # Get tools and create model
+        tools = _get_all_tools()
+        
+        # Create Bedrock model with inlined configuration
+        additional_request_fields = {}
+        additional_request_fields["anthropic_beta"] = ["interleaved-thinking-2025-05-14"]
+        
+        additional_request_fields["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": STRANDS_BUDGET_TOKENS
+        }
+        
+        model = BedrockModel(
+            model_id=STRANDS_MODEL_ID,
+            max_tokens=STRANDS_MAX_TOKENS,
+            region_name=STRANDS_REGION,
+            boto_client_config=Config(
+                read_timeout=900,
+                connect_timeout=900,
+                retries={"max_attempts": 3, "mode": "adaptive"},
+            ),
+            additional_request_fields=additional_request_fields,
+            cache_prompt="default",
+            cache_tools="default",
+        )
+        system_prompt = os.getenv("INPUT_SYSTEM_PROMPT", DEFAULT_SYSTEM_PROMPT)
+        session_id = os.getenv("SESSION_ID")
+        s3_bucket = os.getenv("S3_SESSION_BUCKET")
+        s3_prefix = os.getenv("GITHUB_REPOSITORY", "")
+
+        if s3_bucket and session_id:
+            print(f"🤖 Using session manager with session ID: {session_id}")
+            session_manager = S3SessionManager(
+                session_id=session_id,
+                bucket=s3_bucket,
+                prefix=s3_prefix,
+            )
+        else:
+            raise ValueError("Both SESSION_ID and S3_SESSION_BUCKET must be set")
+
+        # Create agent
+        agent = Agent(
+            model=model,
+            system_prompt=system_prompt,
+            tools=tools,
+            session_manager=session_manager,
+        )
+
+        print("Processing user query...")
+        result = agent(query)
+
+        print(f"\n\nAgent Result 🤖\nStop Reason: {result.stop_reason}\nMessage: {json.dumps(result.message, indent=2)}")
+    except Exception as e:
+        error_msg = f"❌ Agent execution failed: {e}"
+        print(error_msg)
+        raise e
+
+
+def main() -> None:
+    """Main entry point for the agent runner."""
+    try:
+        # Read task from command line arguments
+        if len(sys.argv) < 2:
+            raise ValueError("Task argument is required")
+
+        task = " ".join(sys.argv[1:])
+        if not task.strip():
+            raise ValueError("Task cannot be empty")
+        print(f"🤖 Running agent with task: {task}")
+
+        run_agent(task)
+
+    except Exception as e:
+        error_msg = f"Fatal error: {e}"
+        print(error_msg)
+
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/python/github_tools.py
+++ b/.github/scripts/python/github_tools.py
@@ -1,0 +1,843 @@
+"""GitHub repository management tool for Strands Agents.
+
+This module provides comprehensive GitHub repository operations including issues,
+pull requests, comments, and repository management. Supports full GitHub API
+integration with rich console output and error handling.
+
+Key Features:
+1. List and manage issues and pull requests
+2. Add comments to issues and PRs
+3. Create, update, and manage issues
+4. Create, update, and manage pull requests
+5. Get detailed information for specific issues/PRs
+6. Manage PR reviews and review comments
+7. Get issue and PR comment threads
+8. Check GitHub token permissions for repositories
+9. Rich console output with formatted tables
+10. Automatic fallback to GITHUB_REPOSITORY environment variable
+
+Usage Examples:
+```python
+from strands import Agent
+from tools.github_tools import list_issues, add_comment, create_issue, _check_token_permissions
+
+agent = Agent(tools=[list_issues, add_comment, create_issue])
+
+# Check token permissions
+has_write = _check_token_permissions("ghp_token123", "owner/repo")
+
+# List open issues in repository
+result = agent.tool.list_issues(state="open", repo="owner/repo")
+
+# Add comment to an issue
+result = agent.tool.add_comment(
+    issue_number=42,
+    comment_text="Great idea! I'll work on this.",
+    repo="owner/repo"
+)
+
+# Create a new issue
+result = agent.tool.create_issue(
+    title="Bug: Application crashes on startup",
+    body="Description of the issue with steps to reproduce...",
+    repo="owner/repo"
+)
+
+# List pull requests
+result = agent.tool.list_pull_requests(state="open", repo="owner/repo")
+
+# Get specific issue details
+result = agent.tool.get_issue(issue_number=123, repo="owner/repo")
+
+# Update pull request
+result = agent.tool.update_pull_request(
+    pr_number=456,
+    title="Updated PR title",
+    body="Updated description",
+    repo="owner/repo"
+)
+```
+"""
+
+import os
+import traceback
+from datetime import datetime
+from functools import wraps
+import json
+from typing import Any, TypedDict
+from urllib.parse import urlencode, quote
+
+import requests
+from rich import box
+from rich.markup import escape
+from rich.panel import Panel
+from rich.table import Table
+from strands import tool
+from strands_tools.utils import console_util
+
+console = console_util.create()
+
+
+class GitHubOperation(TypedDict):
+    """Type definition for GitHub operation records in JSONL files."""
+    timestamp: str
+    function: str
+    args: list[Any]
+    kwargs: dict[str, Any]
+
+
+def log_inputs(func):
+    """Decorator to log function inputs in a blue panel."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Get function name and format it nicely
+        func_name = func.__name__.replace('_', ' ').title()
+        
+        # Format parameters
+        params = []
+        for k, v in kwargs.items():
+            if isinstance(v, str) and len(v) > 50:
+                params.append(f"{k}='{v[:50]}...'")
+            else:
+                params.append(f"{k}='{v}'")
+        
+        console.print(Panel(", ".join(params), title=f"[bold blue]{func_name}", border_style="blue"))
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def _github_request(
+    method: str, endpoint: str, repo: str | None = None, data: dict | None = None, params: dict | None = None, should_raise: bool = False
+) -> dict[str, Any] | str:
+    """Make a GitHub API request with common error handling.
+
+    Args:
+        method: HTTP method (GET, POST, PATCH, etc.)
+        endpoint: API endpoint path (e.g., "pulls", "issues/123")
+        repo: Repository in "owner/repo" format
+        data: JSON data for request body
+        params: Query parameters for the request
+
+    Returns:
+        Response JSON or error string
+    """
+    if repo is None:
+        repo = os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        return "Error: GITHUB_REPOSITORY environment variable not found"
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        return "Error: GITHUB_TOKEN environment variable not found"
+
+    url = f"https://api.github.com/repos/{repo}/{endpoint}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+
+    try:
+        if method.upper() == "GET":
+            response = requests.get(url, headers=headers, params=params, timeout=30)
+        elif method.upper() == "POST":
+            response = requests.post(url, headers=headers, json=data, params=params, timeout=30)
+        else:
+            response = requests.request(method, url, headers=headers, json=data, params=params, timeout=30)
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+    except Exception as e:
+        if should_raise:
+            raise e
+        return f"Error {e!s}"
+
+
+def check_should_call_write_api_or_record(func):
+    """Decorator that checks if a write api should be called, or if the tool should record to JSONL."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            if not _should_call_write_api():
+                # Record the tool request to JSONL file
+                record_entry: GitHubOperation = {
+                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                    "function": func.__name__,
+                    "args": args,
+                    "kwargs": kwargs
+                }
+                
+                os.makedirs(".artifact", exist_ok=True)
+                with open(".artifact/write_operations.jsonl", "a") as f:
+                    f.write(json.dumps(record_entry) + "\n")
+                
+                # Generate and return deferred message
+                params = dict(kwargs)
+                if args:
+                    # Map positional args to parameter names from function signature
+                    import inspect
+                    sig = inspect.signature(func)
+                    param_names = list(sig.parameters.keys())
+                    for i, arg in enumerate(args):
+                        if i < len(param_names):
+                            params[param_names[i]] = arg
+                
+                deferred_msg = _generate_deferred_message(func.__name__, params)
+                console.print(Panel(escape(deferred_msg), title="[bold yellow]Operation Deferred", border_style="yellow"))
+                return deferred_msg
+        except Exception as e:
+            error_msg = f"Error checking permissions: {e!s}"
+            console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+            return error_msg
+        
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def _generate_deferred_message(operation_name: str, params: dict[str, Any]) -> str:
+    """Generate a consistent deferred message for write operations.
+    
+    Args:
+        operation_name: Name of the operation being deferred
+        params: Parameters that would have been used for the operation
+        
+    Returns:
+        Formatted deferred message string
+    """
+    if not params:
+        return f"Operation deferred: {operation_name}"
+    
+    # Format parameters, truncating long values
+    param_strs = []
+    for key, value in params.items():
+        if isinstance(value, str) and len(value) > 50:
+            param_strs.append(f"{key}='{value[:50]}...'")
+        elif isinstance(value, str):
+            param_strs.append(f"{key}='{value}'")
+        else:
+            param_strs.append(f"{key}={value}")
+    
+    return f"Operation deferred: {operation_name} - {', '.join(param_strs)}"
+
+
+def _should_call_write_api() -> bool:
+    """Checks if GITHUB_WRITE environment variable is set to true.
+        
+    Returns:
+        bool: True if GITHUB_WRITE is set to 'true', False otherwise
+    """
+    return os.environ.get("GITHUB_WRITE", "").lower() == "true"
+
+
+# =============================================================================
+# WRITE FUNCTIONS (Functions that modify GitHub resources)
+# =============================================================================
+
+@tool
+@log_inputs
+@check_should_call_write_api_or_record
+def create_issue(title: str, body: str = "", repo: str | None = None) -> str:
+    """Creates a new issue in the specified repository.
+
+    Args:
+        title: The issue title
+        body: The issue body (optional)
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        Result of the operation
+    """
+    result = _github_request("POST", "issues", repo, {"title": title, "body": body})
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    message = f"Issue created: #{result['number']} - {result['html_url']}"
+    console.print(Panel(escape(message), title="[bold green]Success", border_style="green"))
+    return message
+
+
+@tool
+@log_inputs
+@check_should_call_write_api_or_record
+def update_issue(
+    issue_number: int,
+    title: str | None = None,
+    body: str | None = None,
+    state: str | None = None,
+    repo: str | None = None,
+) -> str:
+    """Updates an issue's title, body, or state.
+
+    Args:
+        issue_number: The issue number
+        title: New title (optional)
+        body: New body (optional)
+        state: New state - "open" or "closed" (optional)
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        Result of the operation
+    """
+    data = {}
+    if title is not None:
+        data["title"] = title
+    if body is not None:
+        data["body"] = body
+    if state is not None:
+        data["state"] = state
+
+    if not data:
+        error_msg = "Error: At least one field (title, body, or state) must be provided"
+        console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+        return error_msg
+
+    result = _github_request("PATCH", f"issues/{issue_number}", repo, data)
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    message = f"Issue updated: #{result['number']} - {result['html_url']}"
+    console.print(Panel(escape(message), title="[bold green]Success", border_style="green"))
+    return message
+
+
+@tool
+@log_inputs
+@check_should_call_write_api_or_record
+def add_issue_comment(issue_number: int, comment_text: str, repo: str | None = None) -> str:
+    """Adds a comment to an issue or pull request in the specified repository or GITHUB_REPOSITORY environment variable.
+
+    Args:
+        issue_number: The issue or PR number to comment on
+        comment_text: The comment text
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        Result of the operation
+    """
+    result = _github_request("POST", f"issues/{issue_number}/comments", repo, {"body": comment_text})
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    message = f"Comment added successfully: {result['html_url']} (created: {result['created_at']})"
+    console.print(Panel(escape(message), title="[bold green]Success", border_style="green"))
+    return message
+
+
+@tool
+@log_inputs
+@check_should_call_write_api_or_record
+def create_pull_request(title: str, head: str, base: str, body: str = "", repo: str | None = None, fallback_issue_id: int | None = None) -> str:
+    """Creates a new pull request, or optionally comments on the fallback_issue_id for a link to create a pull request.
+
+    Args:
+        title: The PR title
+        head: The branch containing changes
+        base: The branch to merge into
+        body: The PR body (optional)
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+        fallback_issue_id: Issue ID to comment on if PR creation fails with an error (optional)
+
+    Returns:
+        Result of the operation
+    """
+    try:
+        result = _github_request(
+            "POST",
+            "pulls",
+            repo,
+            {"title": title, "head": head, "base": base, "body": body},
+            should_raise=True
+        )
+
+        if isinstance(result, str):
+            console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+            return result
+
+
+        message = f"Pull request created: #{result['number']} - {result['html_url']}"
+        console.print(Panel(escape(message), title="[bold green]Success", border_style="green"))
+        return message
+    
+    except Exception as e:
+        if fallback_issue_id is not None:
+            agent_message = "Failed to create pull request, commenting on issue instead."
+            console.print(Panel(escape(agent_message), title="[bold yellow]Fallback", border_style="yellow"))
+            repo_name = repo or os.environ.get("GITHUB_REPOSITORY", "")
+            query_params = urlencode({
+                'quick_pull': '1',
+                'title': title,
+                'body': body
+            }, quote_via=quote)
+            pr_link = f"https://github.com/{repo_name}/compare/{base}...{head}?{query_params}"
+            fallback_comment = f"Unable to create pull request via API. You can create it manually by clicking [here]({pr_link})."
+            add_issue_comment(fallback_issue_id, fallback_comment, repo)
+            return f"Unable to create pull request via API - posted a manual creation link as a comment on issue #{fallback_issue_id}"
+        else:
+            error_msg = f"Error: {e!s}"
+            console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+            return error_msg
+
+
+@tool
+@log_inputs
+@check_should_call_write_api_or_record
+def update_pull_request(
+    pr_number: int,
+    title: str | None = None,
+    body: str | None = None,
+    base: str | None = None,
+    repo: str | None = None,
+) -> str:
+    """Updates a pull request's title, body, or base branch.
+
+    Args:
+        pr_number: The pull request number
+        title: New title (optional)
+        body: New body (optional)
+        base: New base branch (optional)
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        Result of the operation
+    """
+    data = {}
+    if title is not None:
+        data["title"] = title
+    if body is not None:
+        data["body"] = body
+    if base is not None:
+        data["base"] = base
+
+    if not data:
+        error_msg = "Error: At least one field (title, body, or base) must be provided"
+        console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+        return error_msg
+
+    result = _github_request("PATCH", f"pulls/{pr_number}", repo, data)
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    message = f"Pull request updated: #{result['number']} - {result['html_url']}"
+    console.print(Panel(escape(message), title="[bold green]Success", border_style="green"))
+    return message
+
+
+@tool
+@log_inputs
+@check_should_call_write_api_or_record
+def reply_to_review_comment(pr_number: int, comment_id: int, reply_text: str, repo: str | None = None) -> str:
+    """Replies to a pull request review comment.
+
+    Args:
+        pr_number: The pull request number
+        comment_id: The review comment ID to reply to
+        reply_text: The reply text
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        Result of the operation
+    """
+    result = _github_request("POST", f"pulls/{pr_number}/comments/{comment_id}/replies", repo, {"body": reply_text})
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    message = f"Reply added to review comment: {result['html_url']}"
+    reply_details = f"Reply: {reply_text}\nURL: {result['html_url']}"
+    console.print(Panel(escape(reply_details), title="[bold green]✅ Reply Added", border_style="green"))
+    return message
+
+
+# =============================================================================
+# READ FUNCTIONS (Functions that only read GitHub resources)
+# =============================================================================
+
+@tool
+@log_inputs
+def get_issue(issue_number: int, repo: str | None = None) -> str:
+    """Gets details of a specific issue.
+
+    Args:
+        issue_number: The issue number
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        Issue details
+    """
+    result = _github_request("GET", f"issues/{issue_number}", repo)
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    details = (
+        f"#{result['number']} - {result['title']}\n"
+        f"State: {result['state']}\n"
+        f"Author: {result['user']['login']}\n"
+        f"URL: {result['html_url']}\n\n{result['body']}"
+    )
+    console.print(
+        Panel(
+            escape(details),
+            title=f"[bold green]📋 Issue #{result['number']}",
+            border_style="blue",
+        )
+    )
+    return details
+
+
+@tool
+@log_inputs
+def list_issues(state: str = "open", repo: str | None = None) -> str:
+    """Lists issues from the specified GitHub repository or GITHUB_REPOSITORY environment variable.
+
+    Args:
+        state: Filter issues by state: "open", "closed", or "all" (default: "open")
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        String representation of the issues
+    """
+    result = _github_request("GET", "issues", repo, params={"state": state})
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    # Filter out pull requests from issues list
+    issues = [issue for issue in result if "pull_request" not in issue]
+    if not issues:
+        message = f"No {state} issues found in {repo or os.environ.get('GITHUB_REPOSITORY')}"
+        console.print(Panel(escape(message), title="[bold yellow]Info", border_style="yellow"))
+        return message
+
+    table = Table(title=f"🐛 Issues ({state})", box=box.DOUBLE)
+    table.add_column("Issue #", style="cyan")
+    table.add_column("Title", style="white")
+    table.add_column("Author", style="green")
+    table.add_column("URL", style="blue")
+
+    for issue in issues:
+        table.add_row(
+            f"#{issue['number']}",  # type: ignore[index]
+            issue["title"],  # type: ignore[index]
+            issue["user"]["login"],  # type: ignore[index]
+            issue["html_url"],  # type: ignore[index]
+        )
+
+    console.print(table)
+
+    output = f"Issues ({state}) in {repo or os.environ.get('GITHUB_REPOSITORY')}:\n"
+    for issue in issues:
+        output += f"#{issue['number']} - {issue['title']} by {issue['user']['login']} - {issue['html_url']}\n"  # type: ignore[index]
+    return output
+
+
+@tool
+@log_inputs
+def get_issue_comments(issue_number: int, repo: str | None = None, since: str | None = None) -> str:
+    """Gets all comments for a specific issue.
+
+    Args:
+        issue_number: The issue number
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+        since: ISO 8601 timestamp to filter comments updated after this date (optional)
+
+    Returns:
+        List of comments
+    """
+    params = {"since": since} if since else None
+    result = _github_request("GET", f"issues/{issue_number}/comments", repo, params=params)
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    if not result:
+        message = f"No comments found for issue #{issue_number}" + (f" updated after {since}" if since else "")
+        console.print(Panel(escape(message), title="[bold yellow]Info", border_style="yellow"))
+        return message
+
+    output = f"Comments for issue #{issue_number}:\n"
+    for comment in result:
+        output += f"{comment['user']['login']} - updated: {comment['updated_at']}\n{comment['body']}\n\n"  # type: ignore[index]
+    
+    console.print(Panel(escape(output), title=f"[bold green]💬 Issue #{issue_number} Comments", border_style="blue"))
+    return output
+
+
+@tool
+@log_inputs
+def get_pull_request(pr_number: int, repo: str | None = None) -> str:
+    """Gets details of a specific pull request.
+
+    Args:
+        pr_number: The pull request number
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        Pull request details
+    """
+    result = _github_request("GET", f"pulls/{pr_number}", repo)
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    details = (
+        f"#{result['number']} - {result['title']}\n"
+        f"State: {result['state']}\n"
+        f"Author: {result['user']['login']}\n"
+        f"Head: {result['head']['ref']} -> Base: {result['base']['ref']}\n"
+        f"URL: {result['html_url']}\n\n{result['body']}"
+    )
+    console.print(
+        Panel(
+            escape(details),
+            title=f"[bold green]🔀 PR #{result['number']}",
+            border_style="blue",
+        )
+    )
+    return details
+
+
+@tool
+@log_inputs
+def list_pull_requests(state: str = "open", repo: str | None = None) -> str:
+    """Lists pull requests from the specified GitHub repository or GITHUB_REPOSITORY environment variable.
+
+    Args:
+        state: Filter PRs by state: "open", "closed", or "all" (default: "open")
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        String representation of the pull requests
+    """
+    result = _github_request("GET", "pulls", repo, params={"state": state})
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    if not result:
+        message = f"No {state} pull requests found in {repo or os.environ.get('GITHUB_REPOSITORY')}"
+        console.print(Panel(escape(message), title="[bold yellow]Info", border_style="yellow"))
+        return message
+
+    table = Table(title=f"🔀 Pull Requests ({state})", box=box.DOUBLE)
+    table.add_column("PR #", style="cyan")
+    table.add_column("Title", style="white")
+    table.add_column("Author", style="green")
+    table.add_column("URL", style="blue")
+
+    for pr in result:
+        table.add_row(f"#{pr['number']}", pr["title"], pr["user"]["login"], pr["html_url"])  # type: ignore[index]
+
+    console.print(table)
+
+    output = f"Pull Requests ({state}) in {repo or os.environ.get('GITHUB_REPOSITORY')}:\n"
+    for pr in result:
+        output += f"#{pr['number']} - {pr['title']} by {pr['user']['login']} - {pr['html_url']}\n"  # type: ignore[index]
+    return output
+
+
+@tool
+@log_inputs
+def get_pr_review_and_comments(pr_number: int, show_resolved: bool = False, repo: str | None = None, since: str | None = None) -> str:
+    """Gets all review threads and comments for a PR.
+
+    Args:
+        pr_number: The pull request number
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+        show_resolved: Whether to include resolved review threads (default: False)
+        since: ISO 8601 timestamp to filter comments/threads updated after this date (optional)
+
+    Returns:
+        Formatted review threads and comments
+    """
+    if repo is None:
+        repo = os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        return "Error: GITHUB_REPOSITORY environment variable not found"
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        return "Error: GITHUB_TOKEN environment variable not found"
+
+    owner, repo_name = repo.split("/")
+    
+    query = """
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            nodes {
+              isResolved
+              comments(first: 100) {
+                nodes {
+                  id
+                  fullDatabaseId
+                  author { login }
+                  body
+                  updatedAt
+                  path
+                  line
+                  startLine
+                  diffHunk
+                  replyTo { id }
+                  pullRequestReview { 
+                    id 
+                    body
+                    author { login }
+                    updatedAt
+                  }
+                }
+              }
+            }
+          }
+          comments(first: 100) {
+            nodes {
+              author { login }
+              body
+              updatedAt
+            }
+          }
+        }
+      }
+    }
+    """
+    
+    variables = {"owner": owner, "name": repo_name, "number": pr_number}
+    
+    try:
+        response = requests.post(
+            "https://api.github.com/graphql",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"query": query, "variables": variables},
+            timeout=30
+        )
+        response.raise_for_status()
+        data = response.json()
+        
+        if "errors" in data:
+            return f"GraphQL Error: {data['errors']}"
+            
+        pr_data = data["data"]["repository"]["pullRequest"]
+        
+        # Filter by since if provided
+        if since:
+            cutoff = datetime.fromisoformat(since.replace('Z', '+00:00'))
+            
+            # Filter review threads - if any comment in thread is newer, include entire thread
+            filtered_threads = []
+            for thread in pr_data["reviewThreads"]["nodes"]:
+                has_newer_comment = any(datetime.fromisoformat(c['updatedAt'].replace('Z', '+00:00')) > cutoff 
+                                      for c in thread["comments"]["nodes"])
+                if has_newer_comment:
+                    filtered_threads.append(thread)
+            pr_data["reviewThreads"]["nodes"] = filtered_threads
+            
+            # Filter general comments
+            pr_data["comments"]["nodes"] = [c for c in pr_data["comments"]["nodes"] 
+                                          if datetime.fromisoformat(c['updatedAt'].replace('Z', '+00:00')) > cutoff]
+        
+        output = f"Review threads and comments for PR #{pr_number}:\n\n"
+        
+        # Group review threads by review ID
+        review_threads = {}
+        for thread in pr_data["reviewThreads"]["nodes"]:
+            if not show_resolved and thread["isResolved"]:
+                continue
+                
+            if thread["comments"]["nodes"]:
+                first_comment = thread["comments"]["nodes"][0]
+                review_id = first_comment.get("pullRequestReview", {}).get("id", "N/A")
+                
+                if review_id not in review_threads:
+                    review_threads[review_id] = {
+                        "review_data": first_comment.get("pullRequestReview", {}),
+                        "threads": []
+                    }
+                
+                review_threads[review_id]["threads"].append(thread)
+        
+        # Display grouped review threads
+        for review_id, review_info in review_threads.items():
+            review_data = review_info['review_data']
+            output += f"📝 Review [Review ID: {review_id}]\n"
+            
+            # Always show review author and timestamps
+            if review_data.get('author'):
+                output += f"   👤 Review by {review_data['author']['login']} (updated: {review_data['updatedAt']})\n"
+            
+            # Show top-level review comment if it exists
+            if review_data.get('body'):
+                output += f"   📋 Review Comment:\n"
+                output += f"      {review_data['body']}\n"
+            output += "\n"
+            
+            # Show all threads for this review
+            for thread in review_info["threads"]:
+                first_comment = thread["comments"]["nodes"][0]
+                line_info = f":{first_comment['line']}" if first_comment.get('line') else " (Comment on file)"
+                status = "✅ RESOLVED" if thread["isResolved"] else "🔄 OPEN"
+                
+                output += f"   📍 Thread ({status}): {first_comment['path']}{line_info}\n"
+                
+                # Show code context right after thread header
+                if first_comment.get('diffHunk') and first_comment.get('line'):
+                    diff_lines = first_comment['diffHunk'].split('\n')
+                    current_new_line = 0
+                    target_line = first_comment['line']
+                    start_line = first_comment.get('startLine') or target_line
+                    
+                    output += f"      Code context (lines {start_line}-{target_line}):\n"
+                    
+                    for diff_line in diff_lines:
+                        if diff_line.startswith('@@'):
+                            parts = diff_line.split(' ')
+                            if len(parts) >= 3:
+                                new_start = parts[2].split(',')[0][1:]
+                                current_new_line = int(new_start) - 1
+                        elif diff_line.startswith('+'):
+                            current_new_line += 1
+                            if start_line <= current_new_line <= target_line:
+                                output += f"       +{current_new_line}: {diff_line[1:]}\n"
+                        elif diff_line.startswith('-'):
+                            pass
+                        elif diff_line.startswith(' '):
+                            current_new_line += 1
+                            if start_line <= current_new_line <= target_line:
+                                output += f"        {current_new_line}: {diff_line[1:]}\n"
+                    output += "\n"
+                
+                # Group comments by reply relationships
+                comments = thread["comments"]["nodes"]
+                root_comments = [c for c in comments if not c.get('replyTo')]
+                
+                for root_comment in root_comments:
+                    output += f"      💬 {root_comment['author']['login']} (updated: {root_comment['updatedAt']}) [Comment ID: {root_comment['fullDatabaseId']}]:\n"
+                    output += f"         {root_comment['body']}\n"
+                    
+                    # Find and show replies to this comment
+                    replies = [c for c in comments if c.get('replyTo') and c['replyTo'].get('id') == root_comment['id']]
+                    if replies:
+                        for reply in replies:
+                            output += f"         ↳ {reply['author']['login']} (updated: {reply['updatedAt']}):\n"
+                            output += f"           {reply['body']}\n"
+                
+                output += "\n"
+            output += "\n"
+        
+        # General comments
+        if pr_data["comments"]["nodes"]:
+            for comment in pr_data["comments"]["nodes"]:
+                output += f"💬 Comment\n"
+                output += f"   👤 Comment by {comment['author']['login']} (updated: {comment['updatedAt']})\n"
+                output += f"   📝 Comment:\n"
+                output += f"      {comment['body']}\n\n"
+        
+        console.print(Panel(escape(output), title=f"[bold green]PR #{pr_number} Review Data", border_style="blue"))
+        return output
+        
+    except Exception as e:
+        error_msg = f"Error: {e!s}\n\nStack trace:\n{traceback.format_exc()}"
+        console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+        return error_msg

--- a/.github/scripts/python/handoff_to_user.py
+++ b/.github/scripts/python/handoff_to_user.py
@@ -1,0 +1,34 @@
+from rich.markup import escape
+from rich.panel import Panel
+from strands import tool
+from strands.types.tools import ToolContext
+from strands_tools.utils import console_util
+
+@tool(context=True)
+def handoff_to_user(message: str, tool_context: ToolContext) -> str:
+    """
+    Hand off control to the user with a message.
+
+    Args:
+        message: The message to give to the user
+
+    Returns:
+        The users response after handing back control
+    """
+    console = console_util.create()
+    
+    console.print(
+        Panel(
+            escape(message),
+            title="[bold yellow]🤝 Handoff to User",
+            border_style="yellow",
+        )
+    )
+    
+    request_state = {
+        "stop_event_loop": True
+    }
+    tool_context.invocation_state["request_state"] = request_state
+
+    # Return an empty string as this will break out of the event loop
+    return ""

--- a/.github/scripts/python/notebook.py
+++ b/.github/scripts/python/notebook.py
@@ -1,0 +1,337 @@
+"""Notebook management tool for Strands Agents.
+
+This module provides comprehensive notebook operations for managing text-based notebooks
+within agent workflows. Enables persistent note-taking, documentation, and context
+preservation across agent sessions.
+
+Key Features:
+1. Create and manage multiple named notebooks
+2. Write content using string replacement or line insertion
+3. Read entire notebooks or specific line ranges
+4. List all available notebooks with metadata
+5. Clear notebook contents when needed
+6. Rich console output with formatted panels and tables
+7. Agent state persistence for session continuity
+
+Usage Examples:
+```python
+from strands import Agent
+from tools.notebook import notebook
+
+agent = Agent(tools=[notebook])
+
+# Create a new notebook with initial content
+result = agent.tool.notebook(
+    mode="create",
+    name="research_notes",
+    new_str="# Research Notes\n\nKey findings and observations..."
+)
+
+# Write to notebook using line insertion
+result = agent.tool.notebook(
+    mode="write",
+    name="research_notes",
+    insert_line=-1,  # Append to end
+    new_str="- Important discovery about AI behavior patterns"
+)
+
+# Read specific lines from notebook
+result = agent.tool.notebook(
+    mode="read",
+    name="research_notes",
+    read_range=[1, 5]  # Read first 5 lines
+)
+
+# Replace text in notebook
+result = agent.tool.notebook(
+    mode="write",
+    name="research_notes",
+    old_str="[ ] Todo item",
+    new_str="[x] Completed todo item"
+)
+
+# List all notebooks
+result = agent.tool.notebook(mode="list")
+
+# Clear notebook contents
+result = agent.tool.notebook(mode="clear", name="research_notes")
+```
+"""
+
+from typing import Any, Literal
+
+from rich import box
+from rich.markup import escape
+from rich.panel import Panel
+from rich.table import Table
+from strands import ToolContext, tool
+from strands_tools.utils import console_util
+
+
+@tool(context=True)
+def notebook(
+    mode: Literal["create", "list", "read", "write", "clear"],
+    name: str = "default",
+    read_range: list[int] | None = None,
+    old_str: str | None = None,
+    new_str: str | None = None,
+    insert_line: str | int | None = None,
+    tool_context: ToolContext | None = None,
+) -> str:
+    """
+    Notebook tool for managing text notebooks.
+
+    This tool provides a comprehensive interface for creating, reading, writing, listing,
+    and deleting text notebooks. Start writing notes in the default notebook which is avaiable
+    from the start, or create new notebooks to record notes on additional topics or tasks.
+
+    Command Details:
+    --------------
+    1. write:
+       • Supports two types of write operations:
+         - String replacement: Uses old_str and new_str parameters
+         - Line insertion: Uses insert_line and new_str parameters
+
+    2. read:
+       • Reads contents of a notebook
+       • Supports reading specific line numbers with read_range parameter
+
+    3. create:
+       • Creates a new notebook with the specified name
+       • Optionally initializes with content using new_str parameter
+       • Defaults to empty content if new_str not provided
+
+    4. list:
+       • Lists all available notebook names
+       • Returns comma-separated list of notebook names
+
+    5. clear:
+       • Clears the contents of a notebook
+
+    Args:
+        mode: The operation to perform: `create`, `list`, `read`, `write`, `clear`.
+        name: Name of the notebook to operate on. Defaults to "default".
+        read_range: Optional parameter of `view` command. Line range to show [start, end]. Supports negative indices.
+        old_str: String to replace in write mode when doing text replacement.
+        new_str: New string for replacement or insertion operations.
+        insert_line: Line number (int) or search text (str) for insertion point in write mode.
+            Supports negative indices.
+
+    Returns:
+        Dict containing status and response content in the format:
+        {
+            "status": "success|error",
+            "content": [{"text": "Response message"}]
+        }
+
+        Success case: Returns details about the operation performed
+        Error case: Returns information about what went wrong
+
+    Examples:
+        1. Create a notebook:
+           notebook(mode="create", name="notes")
+
+        2. List all notebooks:
+           notebook(mode="list")
+
+        3. Read entire notebook:
+           notebook(mode="read", name="notes")
+
+        4. Read specific lines:
+           notebook(mode="read", name="notes", read_range=[1, 5])
+
+        5. Replace text:
+           notebook(mode="write", name="notes", old_str="[] Update the calendar", new_str="[x] Update the calendar")
+
+        6. Insert text after line 5:
+           notebook(mode="write", name="notes", insert_line=5, new_str="inserted text")
+
+        7. Insert text at end of notebook:
+           notebook(mode="write", name="notes", insert_line=-1, new_str="Appended text")
+
+        7. Insert text after finding a line:
+           notebook(mode="write", name="notes", insert_line="def function", new_str="# comment")
+
+        8. Clear notebook:
+           notebook(mode="clear", name="notes")
+    """
+    console = console_util.create()
+    if tool_context is None:
+        raise ValueError("Tool context is required")
+    agent = tool_context.agent
+
+    if agent.state.get("notebooks") is None:
+        agent.state.set("notebooks", {"default": ""})
+
+    notebooks: dict[str, Any] = agent.state.get("notebooks")
+
+    if mode == "create":
+        notebooks[name] = new_str if new_str else ""
+        message = f"Created notebook '{name}'" + (" with specified content" if new_str else " (empty)")
+        console.print(
+            Panel(
+                escape(message + f":\n{new_str}" if new_str else ""),
+                title="[bold green]Success",
+                border_style="green",
+            )
+        )
+        agent.state.set("notebooks", notebooks)
+        return message
+
+    elif mode == "list":
+        table = Table(title="📚 Available Notebooks", box=box.DOUBLE)
+        table.add_column("Name", style="cyan")
+        table.add_column("Lines", style="yellow")
+        table.add_column("Status", style="green")
+
+        for nb_name in notebooks.keys():
+            line_count = len(notebooks[nb_name].split("\n")) if notebooks[nb_name] else 0
+            status = "Empty" if line_count == 0 else "Has content"
+            table.add_row(nb_name, str(line_count), status)
+
+        console.print(table)
+        return f"Notebooks: {', '.join(notebooks.keys())}"
+
+    elif mode == "read":
+        if name not in notebooks:
+            error_msg = f"Notebook '{name}' not found"
+            console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+            raise ValueError(error_msg)
+
+        content = notebooks[name]
+        if read_range:
+            lines = content.split("\n")
+            start, end = read_range
+            # Handle negative indices
+            if start < 0:
+                start = len(lines) + start + 1
+            if end < 0:
+                end = len(lines) + end + 1
+
+            selected_lines = []
+            for line_num in range(start, end + 1):
+                if 1 <= line_num <= len(lines):
+                    selected_lines.append(f"{line_num}: {lines[line_num - 1]}")
+
+            result = "\n".join(selected_lines) if selected_lines else "No valid lines found"
+            console.print(
+                Panel(
+                    escape(result),
+                    title=f"[bold green]📖 {name} (lines {start}-{end})",
+                    border_style="blue",
+                )
+            )
+            return result
+
+        result = content if content else f"Notebook '{name}' is empty"
+        console.print(Panel(escape(result), title=f"[bold green]📖 {name}", border_style="blue"))
+        return result
+
+    elif mode == "write":
+        if name not in notebooks:
+            error_msg = f"Notebook '{name}' not found"
+            console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+            raise ValueError(error_msg)
+
+        # String replacement
+        if old_str is not None and new_str is not None:
+            if old_str not in notebooks[name]:
+                error_msg = f"String '{old_str}' not found in notebook '{name}'"
+                console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+                raise ValueError(error_msg)
+
+            notebooks[name] = notebooks[name].replace(old_str, new_str)
+            agent.state.set("notebooks", notebooks)
+
+            # Create git-style diff
+            old_lines = old_str.split("\n")
+            new_lines = new_str.split("\n")
+            diff_lines = []
+
+            for line in old_lines:
+                diff_lines.append(f"[red]-{escape(line)}[/red]")
+            for line in new_lines:
+                diff_lines.append(f"[green]+{escape(line)}[/green]")
+
+            diff_content = "\n".join(diff_lines)
+            console.print(Panel(diff_content, title="[bold yellow]📝 Diff", border_style="yellow"))
+
+            message = f"Replaced text in notebook '{name}'"
+            console.print(Panel(escape(message), title="[bold green]Success", border_style="green"))
+            return message
+
+        # Line insertion
+        elif insert_line is not None and new_str is not None:
+            lines = notebooks[name].split("\n")
+
+            # Check if string represents a number first
+            if isinstance(insert_line, str):
+                try:
+                    insert_line = int(insert_line)
+                except ValueError:
+                    pass  # Keep as string for text search
+
+            if isinstance(insert_line, str):
+                line_num = -1
+                for i, line in enumerate(lines):
+                    if insert_line in line:
+                        line_num = i
+                        break
+                if line_num == -1:
+                    error_msg = f"Text '{insert_line}' not found in notebook '{name}'"
+                    console.print(
+                        Panel(
+                            escape(error_msg),
+                            title="[bold red]Error",
+                            border_style="red",
+                        )
+                    )
+                    raise ValueError(error_msg)
+            else:
+                # Handle negative indices
+                if insert_line < 0:
+                    line_num = len(lines) + insert_line
+                else:
+                    line_num = insert_line - 1
+
+            if 0 <= line_num <= len(lines):
+                lines.insert(line_num + 1, new_str)
+                notebooks[name] = "\n".join(lines)
+                agent.state.set("notebooks", notebooks)
+                message = f"Inserted text at line {line_num + 2} in notebook '{name}'"
+                console.print(
+                    Panel(
+                        escape(message),
+                        title="[bold green]Success",
+                        border_style="green",
+                    )
+                )
+                console.print(
+                    Panel(
+                        escape(notebooks[name]),
+                        title=f"[bold blue]📝 {name} Content",
+                        border_style="blue",
+                    )
+                )
+                return message
+            else:
+                error_msg = f"Line number {insert_line} out of range"
+                console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+                raise ValueError(error_msg)
+
+        # No valid operation provided
+        else:
+            error_msg = "No valid write operation specified"
+            console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+            raise ValueError(error_msg)
+
+    elif mode == "clear":
+        if name not in notebooks:
+            error_msg = f"Notebook '{name}' not found"
+            console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+            raise ValueError(error_msg)
+        notebooks[name] = ""
+        agent.state.set("notebooks", notebooks)
+        message = f"Cleared notebook '{name}'"
+        console.print(Panel(escape(message), title="[bold green]Success", border_style="green"))
+        return message

--- a/.github/scripts/python/requirements.txt
+++ b/.github/scripts/python/requirements.txt
@@ -1,0 +1,8 @@
+# Strands packages - only what we need
+strands-agents
+strands-agents-tools
+
+# Additional dependencies for our specific tools
+colorama
+rich
+requests>=2.28.0

--- a/.github/scripts/python/str_replace_based_edit_tool.py
+++ b/.github/scripts/python/str_replace_based_edit_tool.py
@@ -1,0 +1,230 @@
+"""Text editor tool for Strands Agents.
+
+A minimal implementation of Claude's text editor tool that supports:
+- view: Read file contents or list directory contents
+- str_replace: Replace text in files
+- create: Create new files
+- insert: Insert text at specific line numbers
+
+Based on Claude's text_editor_20250728 specification.
+"""
+
+from pathlib import Path
+from typing import List, Optional
+
+from rich.markup import escape
+from rich.panel import Panel
+from strands import tool
+from strands_tools.utils import console_util
+
+console = console_util.create()
+
+
+@tool
+def str_replace_based_edit_tool(
+    command: str,
+    path: str,
+    old_str: str | None = None,
+    new_str: str | None  = None,
+    file_text: str | None = None,
+    insert_line: str | None = None,
+    view_range: list[int] | None = None,
+) -> str:
+    """Text editor tool for viewing and modifying files.
+    
+    Args:
+        command: The command to execute ("view", "str_replace", "create", "insert")
+        path: Path to the file or directory
+        old_str: Text to replace (for str_replace command)
+        new_str: Replacement text (for str_replace and insert commands)
+        file_text: Content for new file (for create command)
+        insert_line: Line number to insert after (for insert command)
+        view_range: [start_line, end_line] for viewing specific lines (for view command)
+    
+    Returns:
+        Result of the operation
+    """
+    try:
+        console.print(Panel(f"Command: {command}, Path: {path}", title="[bold blue]Text Editor", border_style="blue"))
+        
+        if command == "view":
+            return _handle_view(path, view_range)
+        elif command == "str_replace":
+            if old_str is None or new_str is None:
+                error_msg = "Error: str_replace requires both old_str and new_str parameters"
+                console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+                return error_msg
+            return _handle_str_replace(path, old_str, new_str)
+        elif command == "create":
+            if file_text is None:
+                error_msg = "Error: create requires file_text parameter"
+                console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+                return error_msg
+            return _handle_create(path, file_text)
+        elif command == "insert":
+            if new_str is None or insert_line is None:
+                error_msg = "Error: insert requires both new_str and insert_line parameters"
+                console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+                return error_msg
+            return _handle_insert(path, new_str, insert_line)
+        else:
+            error_msg = f"Error: Unknown command '{command}'"
+            console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+            return error_msg
+    except Exception as e:
+        error_msg = f"Error: {str(e)}"
+        console.print(Panel(escape(error_msg), title="[bold red]Error", border_style="red"))
+        return error_msg
+
+
+def _handle_view(path: str, view_range: Optional[List[int]] = None) -> str:
+    """Handle view command to read files or list directories."""
+    path_obj = Path(path)
+    
+    if not path_obj.exists():
+        return f"Error: Path '{path}' does not exist"
+    
+    if path_obj.is_dir():
+        # List directory contents
+        try:
+            items = []
+            for item in sorted(path_obj.iterdir()):
+                if item.is_dir():
+                    items.append(f"{item.name}/")
+                else:
+                    items.append(item.name)
+            return "\n".join(items)
+        except PermissionError:
+            return f"Error: Permission denied accessing directory '{path}'"
+    
+    elif path_obj.is_file():
+        # Read file contents
+        try:
+            with open(path_obj, 'r', encoding='utf-8') as f:
+                lines = f.readlines()
+            
+            # Apply view_range if specified
+            if view_range:
+                start_line, end_line = view_range
+                # Convert to 0-based indexing
+                start_idx = max(0, start_line - 1) if start_line > 0 else 0
+                end_idx = len(lines) if end_line == -1 else min(len(lines), end_line)
+                lines = lines[start_idx:end_idx]
+                start_line_num = start_idx + 1
+            else:
+                start_line_num = 1
+            
+            # Add line numbers
+            numbered_lines = []
+            for i, line in enumerate(lines):
+                line_num = start_line_num + i
+                numbered_lines.append(f"{line_num}: {line.rstrip()}")
+            
+            return "\n".join(numbered_lines)
+        except UnicodeDecodeError:
+            return f"Error: Cannot read '{path}' - file appears to be binary"
+        except PermissionError:
+            return f"Error: Permission denied reading file '{path}'"
+    
+    else:
+        return f"Error: '{path}' is not a regular file or directory"
+
+
+def _handle_str_replace(path: str, old_str: str, new_str: str) -> str:
+    """Handle str_replace command to replace text in a file."""
+    path_obj = Path(path)
+    
+    if not path_obj.exists():
+        return f"Error: File '{path}' does not exist"
+    
+    if not path_obj.is_file():
+        return f"Error: '{path}' is not a file"
+    
+    try:
+        # Read file content
+        with open(path_obj, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Check if old_str exists
+        if old_str not in content:
+            return f"Error: Text '{old_str}' not found in file"
+        
+        # Count occurrences
+        count = content.count(old_str)
+        if count > 1:
+            return f"Error: Text '{old_str}' appears {count} times in file. Please be more specific."
+        
+        # Replace text
+        new_content = content.replace(old_str, new_str)
+        
+        # Write back to file
+        with open(path_obj, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+        
+        success_msg = f"Successfully replaced text in '{path}'"
+        console.print(Panel(escape(success_msg), title="[bold green]Success", border_style="green"))
+        return success_msg
+    
+    except UnicodeDecodeError:
+        return f"Error: Cannot modify '{path}' - file appears to be binary"
+    except PermissionError:
+        return f"Error: Permission denied modifying file '{path}'"
+
+
+def _handle_create(path: str, file_text: str) -> str:
+    """Handle create command to create a new file."""
+    path_obj = Path(path)
+    
+    # Create parent directories if they don't exist
+    path_obj.parent.mkdir(parents=True, exist_ok=True)
+    
+    try:
+        with open(path_obj, 'w', encoding='utf-8') as f:
+            f.write(file_text)
+        
+        success_msg = f"Successfully created file '{path}'"
+        console.print(Panel(escape(success_msg), title="[bold green]Success", border_style="green"))
+        return success_msg
+    
+    except PermissionError:
+        return f"Error: Permission denied creating file '{path}'"
+
+
+def _handle_insert(path: str, new_str: str, insert_line: int) -> str:
+    """Handle insert command to insert text at a specific line."""
+    path_obj = Path(path)
+    
+    if not path_obj.exists():
+        return f"Error: File '{path}' does not exist"
+    
+    if not path_obj.is_file():
+        return f"Error: '{path}' is not a file"
+    
+    try:
+        # Read file lines
+        with open(path_obj, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+        
+        # Insert new text
+        if insert_line == 0:
+            # Insert at beginning
+            lines.insert(0, new_str + '\n')
+        elif insert_line >= len(lines):
+            # Insert at end
+            lines.append(new_str + '\n')
+        else:
+            # Insert after specified line (1-based indexing)
+            lines.insert(insert_line, new_str + '\n')
+        
+        # Write back to file
+        with open(path_obj, 'w', encoding='utf-8') as f:
+            f.writelines(lines)
+        
+        success_msg = f"Successfully inserted text in '{path}' at line {insert_line + 1}"
+        console.print(Panel(escape(success_msg), title="[bold green]Success", border_style="green"))
+        return success_msg
+    
+    except UnicodeDecodeError:
+        return f"Error: Cannot modify '{path}' - file appears to be binary"
+    except PermissionError:
+        return f"Error: Permission denied modifying file '{path}'"

--- a/.github/scripts/python/write_executor.py
+++ b/.github/scripts/python/write_executor.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Write Executor Script for GitHub Operations.
+
+This script reads JSONL artifact files containing deferred GitHub operations
+and executes them using functions from github_tools.py. It's designed to run
+after the strands-agent-runner to publish any write commands or commits.
+"""
+
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from github_tools import GitHubOperation
+
+# Import write only github_tools functions for dynamic execution
+from github_tools import (
+    create_issue,
+    update_issue, 
+    add_issue_comment,
+    create_pull_request,
+    update_pull_request,
+    reply_to_review_comment,
+)
+
+# Configure structured logging
+logging.basicConfig(
+    format="%(levelname)s | %(name)s | %(message)s",
+    handlers=[logging.StreamHandler()],
+    level=logging.INFO
+)
+logger = logging.getLogger("write_executor")
+
+
+def get_function_mapping() -> Dict[str, Any]:
+    """Get mapping of function names to actual functions."""
+    return {
+        create_issue.tool_name: create_issue,
+        update_issue.tool_name: update_issue,
+        add_issue_comment.tool_name: add_issue_comment,
+        create_pull_request.tool_name: create_pull_request,
+        update_pull_request.tool_name: update_pull_request,
+        reply_to_review_comment.tool_name: reply_to_review_comment,
+    }
+
+
+def process_jsonl_file(file_path: Path, default_issue_id: int | None = None):
+    """Process JSONL file and execute operations.
+    
+    Args:
+        file_path: Path to the JSONL artifact file
+        default_issue_id: Default issue ID to use for fallback operations
+        
+    Returns:
+        Tuple of (total_operations, successful_operations, failed_operations)
+    """
+    function_map = get_function_mapping()
+    
+    logger.info(f"Starting JSONL processing: {file_path}")
+    total_ops = 0
+    with open(file_path, 'r') as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+                
+            total_ops += 1
+            logger.info(f"Processing operation {total_ops} (line {line_num})")
+            
+            try:
+                # Parse JSONL entry
+                operation: GitHubOperation = json.loads(line)
+                func_name = operation.get("function")
+                args = operation.get('args', [])
+                kwargs = operation.get('kwargs', {})
+                
+                if not func_name:
+                    logger.error(f"Line {line_num}: Missing function name")
+                    continue
+                
+                # Get function from mapping
+                if func_name not in function_map:
+                    logger.error(f"Line {line_num}: Unknown function '{func_name}'")
+                    continue
+                
+                func = function_map[func_name]
+                
+                # Set default issue ID for create_pull_request if not already set
+                if func_name == "create_pull_request" and default_issue_id and not kwargs.get("fallback_issue_id"):
+                    kwargs["fallback_issue_id"] = default_issue_id
+                
+                # Execute function
+                logger.info(f"Executing {func_name} with args={args}, kwargs={kwargs}")
+                result = func(*args, **kwargs)
+                
+                logger.info(f"Line {line_num}: Operation {func_name} completed successfully")
+                logger.info(f"Function output: {str(result)}")
+                    
+            except Exception as e:
+                logger.error(f"Line {line_num}: Execution error - {e}")
+                    
+    
+    logger.info(f"JSONL processing completed.")
+
+
+def main():
+    """Main entry point for the write executor script."""
+    parser = argparse.ArgumentParser(
+        description="Execute deferred GitHub operations from JSONL artifact files"
+    )
+    parser.add_argument(
+        "artifact_file",
+        help="Path to JSONL artifact file containing deferred operations"
+    )
+    parser.add_argument(
+        "--issue-id",
+        type=int,
+        help="Default issue ID to use for fallback operations"
+    )
+    
+    args = parser.parse_args()
+    artifact_path = Path(args.artifact_file)
+    
+    logger.info(f"Write executor started with artifact file: {artifact_path}")
+    if args.issue_id:
+        logger.info(f"Default issue ID set to: {args.issue_id}")
+    
+    # Check if file exists
+    if not artifact_path.exists():
+        logger.warning(f"Artifact file not found: {artifact_path}")
+        logger.warning("No deferred operations to execute")
+        return
+    
+    # Check if file is empty
+    if artifact_path.stat().st_size == 0:
+        logger.info("Artifact file is empty")
+        logger.info("No deferred operations to execute")
+        return
+    
+    # Set environment to enable write operations
+    os.environ['GITHUB_WRITE'] = 'true'
+    logger.info("GitHub write mode enabled")
+    
+    logger.info(f"Processing deferred operations from: {artifact_path}")
+    
+    # Process the JSONL file
+    process_jsonl_file(artifact_path, args.issue_id)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -1,0 +1,184 @@
+name: Strands Command Handler
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'Issue ID to process (can be issue or PR number)'
+        required: true
+        type: string
+      command:
+        description: 'Strands command to execute'
+        required: false
+        type: string
+        default: ''
+      session_id:
+        description: 'Optional session ID to use'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  authorization-check:
+    if: startsWith(github.event.comment.body, '/strands') || github.event_name == 'workflow_dispatch'
+    permissions: read-all
+    runs-on: ubuntu-latest
+    outputs:
+      approval-env: ${{ steps.collab-check.outputs.result || steps.auto-approve.outputs.result }}
+    steps:
+      - name: Collaborator Check
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@v8
+        id: collab-check
+        with:
+          result-encoding: string
+          script: |
+            try {
+              const permissionResponse = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.payload.comment.user.login,
+              });
+              const permission = permissionResponse.data.permission;
+              const hasWriteAccess = ['write', 'admin'].includes(permission);
+              if (!hasWriteAccess) {
+                console.log(`User ${context.payload.comment.user.login} does not have write access to the repository (permission: ${permission})`);
+                return "manual-approval"
+              } else {
+                console.log(`Verified ${context.payload.comment.user.login} has write access. Auto Approving strands command.`)
+                return "auto-approve"
+              }
+            } catch (error) {
+              console.log(`${context.payload.comment.user.login} does not have write access. Requiring Manual Approval to run strands command.`)
+              return "manual-approval"
+            }
+
+      - name: Auto-approve for workflow dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: auto-approve
+        uses: actions/github-script@v8
+        with:
+          result-encoding: string
+          script: |
+            return "auto-approve"
+  
+  setup-and-process:
+    needs: [authorization-check]
+    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.process.outputs.branch_name }}
+      session_id: ${{ steps.process.outputs.session_id }}
+      system_prompt: ${{ steps.process.outputs.system_prompt }}
+      prompt: ${{ steps.process.outputs.prompt }}
+    steps:
+      - name: Add strands-running label
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ inputs.issue_id || github.event.issue.number }},
+              labels: ['strands-running']
+            });
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+
+      # Outputs: branch_name, session_id, system_prompt, prompt
+      - name: Process input
+        id: process
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const processInput = require('./.github/scripts/javascript/process-input.cjs');
+            await processInput(context, github, core, {
+              issue_id: '${{ inputs.issue_id }}',
+              command: '${{ inputs.command }}',
+              session_id: '${{ inputs.session_id }}'
+            });
+
+  execute-readonly:
+    needs: [setup-and-process]
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      id-token: write # Required for OIDC
+    runs-on: ubuntu-latest 
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+
+      - name: Run Strands Agent
+        id: agent-runner
+        uses: ./.github/actions/strands-agent-runner
+        with:
+          system_prompt: ${{ needs.setup-and-process.outputs.system_prompt }}
+          session_id: ${{ needs.setup-and-process.outputs.session_id }}
+          task_prompt: ${{ needs.setup-and-process.outputs.prompt }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          sessions_bucket: ${{ secrets.AGENT_SESSIONS_BUCKET }}
+          write_permission: 'false'
+          ref: ${{ needs.setup-and-process.outputs.branch }}
+
+  execute-write:
+    needs: [setup-and-process, execute-readonly]
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write # Required for OIDC
+    runs-on: ubuntu-latest 
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+
+      - name: Execute write operations
+        uses: ./.github/actions/strands-write-executor
+        with:
+          ref: ${{ needs.setup-and-process.outputs.branch }}
+          issue_id: ${{ inputs.issue_id || github.event.issue.number }}
+
+
+  cleanup:
+    needs: [authorization-check, setup-and-process, execute-readonly, execute-write]
+    if: always()
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest 
+    steps:
+      - name: Remove strands-running label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ inputs.issue_id || github.event.issue.number }},
+                name: 'strands-running'
+              });
+            } catch (error) {
+              console.log('Label removal failed (may not exist):', error.message);
+            }


### PR DESCRIPTION


## Description

Currently if you want to check the Status using the enum, you have to import from strands.multiagent.base which is a little odd, so expose it at that level.

I noticed this when generating the release notes for v1.20: [R​elease v1.20.0 · strands-agents/sdk-python](https://github.com/strands-agents/sdk-python/releases/tag/v1.20.0)

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Expose `Status` more directly

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
