### PR TITLE
chore: Expose Status from .base for easier imports

### DIFF
--- a/src/strands/multiagent/__init__.py
+++ b/src/strands/multiagent/__init__.py
@@ -8,7 +8,7 @@ Submodules:
          standardized communication between agents.
 """
 
-from .base import MultiAgentBase, MultiAgentResult
+from .base import MultiAgentBase, MultiAgentResult, Status
 from .graph import GraphBuilder, GraphResult
 from .swarm import Swarm, SwarmResult
 
@@ -17,6 +17,7 @@ __all__ = [
     "GraphResult",
     "MultiAgentBase",
     "MultiAgentResult",
+    "Status",
     "Swarm",
     "SwarmResult",
 ]


### PR DESCRIPTION

## Description

Currently if you want to check the Status using the enum, you have to import from strands.multiagent.base which is a little odd, so expose it at that level.

I noticed this when generating the release notes for v1.20: [R​elease v1.20.0 · strands-agents/sdk-python](https://github.com/strands-agents/sdk-python/releases/tag/v1.20.0)

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Expose `Status` more directly

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
