### PR TITLE
bidi - async - remove cancelling call

### DIFF
--- a/tests/strands/experimental/bidi/_async/test_task_group.py
+++ b/tests/strands/experimental/bidi/_async/test_task_group.py
@@ -17,7 +17,7 @@ async def test_task_group__aexit__():
 
 
 @pytest.mark.asyncio
-async def test_task_group__aexit__exception():
+async def test_task_group__aexit__task_exception():
     wait_event = asyncio.Event()
     async def wait():
         await wait_event.wait()
@@ -35,7 +35,19 @@ async def test_task_group__aexit__exception():
 
 
 @pytest.mark.asyncio
-async def test_task_group__aexit__cancelled():
+async def test_task_group__aexit__task_cancelled():
+    async def wait():
+        asyncio.current_task().cancel()
+        await asyncio.sleep(0)
+
+    async with _TaskGroup() as task_group:
+        wait_task = task_group.create_task(wait())
+
+    assert wait_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_task_group__aexit__context_cancelled():
     wait_event = asyncio.Event()
     async def wait():
         await wait_event.wait()


### PR DESCRIPTION
## Description
Removing another Python 3.11+ feature from bidi. Specifically, removing the asyncio `task.cancelling` call. This call was used in determining how to propagate `asyncio.CancelledError`s in our `_TaskGroup` implementation.

Note, this PR is part of a larger effort to add Python 3.10 and 3.11 support to `bidi`. The final PR for this work is currently in draft [here](https://github.com/strands-agents/sdk-python/pull/1297).

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1299

## Documentation PR

N/A

## Type of Change

Other (please describe): Compatibility update.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I ran `hatch run bidi:prepare`: Relying on both existing and new unit tests
- [x] I ran `hatch run bidi-test:test tests_integ/bidi`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
