### PR TITLE
fix: Pass CODECOV_TOKENS through for code-coverage stats

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -17,3 +17,5 @@ jobs:
       contents: read
     with:
       ref: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -12,6 +12,8 @@ jobs:
       contents: read
     with:
       ref: ${{ github.event.release.target_commitish }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build distribution 📦

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -6,6 +6,9 @@ on:
       ref:
         required: true
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   unit-test:


### PR DESCRIPTION
## Description

Pass CODECOV_TOKENS through for code-coverage stats: We need to plumb this through so that protected branches (like main) correctly report code coverage to codecov.  Prior to this PRs did not have incremental diffs because main builds didn't have this token; only `main` needs the token [because it's a protected branch][0].

This token is already a secret in this repository.

[0]: https://docs.codecov.com/docs/codecov-tokens#when-do-i-need-a-token

This **should** fix the:

> "Unable to compare commits because no base commit was found." 

error that we get on PRs

### Notes

 - PR passing build (note no failures about missing token): https://github.com/strands-agents/sdk-python/actions/runs/20380250388/job/58568701964?pr=1374
 - main build (note the failure about missing token): https://github.com/strands-agents/sdk-python/actions/runs/20377783348/job/58717048861

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Infra

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [-] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
