### PR TITLE
feat: added agent_invocations

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -562,6 +562,8 @@ class Agent:
         """
         self._interrupt_state.resume(prompt)
 
+        self.event_loop_metrics.reset_usage_metrics()
+
         merged_state = {}
         if kwargs:
             warnings.warn("`**kwargs` parameter is deprecating, use `invocation_state` instead.", stacklevel=2)

--- a/src/strands/telemetry/metrics.py
+++ b/src/strands/telemetry/metrics.py
@@ -152,6 +152,34 @@ class ToolMetrics:
 
 
 @dataclass
+class EventLoopCycleMetric:
+    """Aggregated metrics for a single event loop cycle.
+
+    Attributes:
+        event_loop_cycle_id: Current eventLoop cycle id.
+        usage: Total token usage for the entire cycle (succeeded model invocation, excluding tool invocations).
+    """
+
+    event_loop_cycle_id: str
+    usage: Usage
+
+
+@dataclass
+class AgentInvocation:
+    """Metrics for a single agent invocation.
+
+    AgentInvocation contains all the event loop cycles and accumulated token usage for that invocation.
+
+    Attributes:
+        cycles: List of event loop cycles that occurred during this invocation.
+        usage: Accumulated token usage for this invocation across all cycles.
+    """
+
+    cycles: list[EventLoopCycleMetric] = field(default_factory=list)
+    usage: Usage = field(default_factory=lambda: Usage(inputTokens=0, outputTokens=0, totalTokens=0))
+
+
+@dataclass
 class EventLoopMetrics:
     """Aggregated metrics for an event loop's execution.
 
@@ -159,15 +187,17 @@ class EventLoopMetrics:
         cycle_count: Number of event loop cycles executed.
         tool_metrics: Metrics for each tool used, keyed by tool name.
         cycle_durations: List of durations for each cycle in seconds.
+        agent_invocations: Agent invocation metrics containing cycles and usage data.
         traces: List of execution traces.
-        accumulated_usage: Accumulated token usage across all model invocations.
+        accumulated_usage: Accumulated token usage across all model invocations (across all requests).
         accumulated_metrics: Accumulated performance metrics across all model invocations.
     """
 
     cycle_count: int = 0
-    tool_metrics: Dict[str, ToolMetrics] = field(default_factory=dict)
-    cycle_durations: List[float] = field(default_factory=list)
-    traces: List[Trace] = field(default_factory=list)
+    tool_metrics: dict[str, ToolMetrics] = field(default_factory=dict)
+    cycle_durations: list[float] = field(default_factory=list)
+    agent_invocations: list[AgentInvocation] = field(default_factory=list)
+    traces: list[Trace] = field(default_factory=list)
     accumulated_usage: Usage = field(default_factory=lambda: Usage(inputTokens=0, outputTokens=0, totalTokens=0))
     accumulated_metrics: Metrics = field(default_factory=lambda: Metrics(latencyMs=0))
 
@@ -176,14 +206,23 @@ class EventLoopMetrics:
         """Get the singleton MetricsClient instance."""
         return MetricsClient()
 
+    @property
+    def latest_agent_invocation(self) -> Optional[AgentInvocation]:
+        """Get the most recent agent invocation.
+
+        Returns:
+            The most recent AgentInvocation, or None if no invocations exist.
+        """
+        return self.agent_invocations[-1] if self.agent_invocations else None
+
     def start_cycle(
         self,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Dict[str, Any],
     ) -> Tuple[float, Trace]:
         """Start a new event loop cycle and create a trace for it.
 
         Args:
-            attributes: attributes of the metrics.
+            attributes: attributes of the metrics, including event_loop_cycle_id.
 
         Returns:
             A tuple containing the start time and the cycle trace object.
@@ -194,6 +233,14 @@ class EventLoopMetrics:
         start_time = time.time()
         cycle_trace = Trace(f"Cycle {self.cycle_count}", start_time=start_time)
         self.traces.append(cycle_trace)
+
+        self.agent_invocations[-1].cycles.append(
+            EventLoopCycleMetric(
+                event_loop_cycle_id=attributes["event_loop_cycle_id"],
+                usage=Usage(inputTokens=0, outputTokens=0, totalTokens=0),
+            )
+        )
+
         return start_time, cycle_trace
 
     def end_cycle(self, start_time: float, cycle_trace: Trace, attributes: Optional[Dict[str, Any]] = None) -> None:
@@ -252,32 +299,53 @@ class EventLoopMetrics:
         )
         tool_trace.end()
 
+    def _accumulate_usage(self, target: Usage, source: Usage) -> None:
+        """Helper method to accumulate usage from source to target.
+
+        Args:
+            target: The Usage object to accumulate into.
+            source: The Usage object to accumulate from.
+        """
+        target["inputTokens"] += source["inputTokens"]
+        target["outputTokens"] += source["outputTokens"]
+        target["totalTokens"] += source["totalTokens"]
+
+        if "cacheReadInputTokens" in source:
+            target["cacheReadInputTokens"] = target.get("cacheReadInputTokens", 0) + source["cacheReadInputTokens"]
+
+        if "cacheWriteInputTokens" in source:
+            target["cacheWriteInputTokens"] = target.get("cacheWriteInputTokens", 0) + source["cacheWriteInputTokens"]
+
     def update_usage(self, usage: Usage) -> None:
         """Update the accumulated token usage with new usage data.
 
         Args:
             usage: The usage data to add to the accumulated totals.
         """
+        # Record metrics to OpenTelemetry
         self._metrics_client.event_loop_input_tokens.record(usage["inputTokens"])
         self._metrics_client.event_loop_output_tokens.record(usage["outputTokens"])
-        self.accumulated_usage["inputTokens"] += usage["inputTokens"]
-        self.accumulated_usage["outputTokens"] += usage["outputTokens"]
-        self.accumulated_usage["totalTokens"] += usage["totalTokens"]
 
-        # Handle optional cached token metrics
+        # Handle optional cached token metrics for OpenTelemetry
         if "cacheReadInputTokens" in usage:
-            cache_read_tokens = usage["cacheReadInputTokens"]
-            self._metrics_client.event_loop_cache_read_input_tokens.record(cache_read_tokens)
-            self.accumulated_usage["cacheReadInputTokens"] = (
-                self.accumulated_usage.get("cacheReadInputTokens", 0) + cache_read_tokens
-            )
-
+            self._metrics_client.event_loop_cache_read_input_tokens.record(usage["cacheReadInputTokens"])
         if "cacheWriteInputTokens" in usage:
-            cache_write_tokens = usage["cacheWriteInputTokens"]
-            self._metrics_client.event_loop_cache_write_input_tokens.record(cache_write_tokens)
-            self.accumulated_usage["cacheWriteInputTokens"] = (
-                self.accumulated_usage.get("cacheWriteInputTokens", 0) + cache_write_tokens
-            )
+            self._metrics_client.event_loop_cache_write_input_tokens.record(usage["cacheWriteInputTokens"])
+
+        self._accumulate_usage(self.accumulated_usage, usage)
+        self._accumulate_usage(self.agent_invocations[-1].usage, usage)
+
+        if self.agent_invocations[-1].cycles:
+            current_cycle = self.agent_invocations[-1].cycles[-1]
+            self._accumulate_usage(current_cycle.usage, usage)
+
+    def reset_usage_metrics(self) -> None:
+        """Start a new agent invocation by creating a new AgentInvocation.
+
+        This should be called at the start of a new request to begin tracking
+        a new agent invocation with fresh usage and cycle data.
+        """
+        self.agent_invocations.append(AgentInvocation())
 
     def update_metrics(self, metrics: Metrics) -> None:
         """Update the accumulated performance metrics with new metrics data.
@@ -322,6 +390,16 @@ class EventLoopMetrics:
             "traces": [trace.to_dict() for trace in self.traces],
             "accumulated_usage": self.accumulated_usage,
             "accumulated_metrics": self.accumulated_metrics,
+            "agent_invocations": [
+                {
+                    "usage": invocation.usage,
+                    "cycles": [
+                        {"event_loop_cycle_id": cycle.event_loop_cycle_id, "usage": cycle.usage}
+                        for cycle in invocation.cycles
+                    ],
+                }
+                for invocation in self.agent_invocations
+            ],
         }
         return summary
 

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -142,6 +142,7 @@ def agent(model, system_prompt, messages, tool_registry, thread_pool, hook_regis
     mock.tool_registry = tool_registry
     mock.thread_pool = thread_pool
     mock.event_loop_metrics = EventLoopMetrics()
+    mock.event_loop_metrics.reset_usage_metrics()
     mock.hooks = hook_registry
     mock.tool_executor = tool_executor
     mock._interrupt_state = _InterruptState()

--- a/tests/strands/event_loop/test_event_loop_structured_output.py
+++ b/tests/strands/event_loop/test_event_loop_structured_output.py
@@ -37,6 +37,7 @@ def mock_agent():
     agent.messages = []
     agent.tool_registry = ToolRegistry()
     agent.event_loop_metrics = EventLoopMetrics()
+    agent.event_loop_metrics.reset_usage_metrics()
     agent.hooks = Mock()
     agent.hooks.invoke_callbacks_async = AsyncMock()
     agent.trace_span = None


### PR DESCRIPTION
## Description

Currently, our `AgentResult` only contains `accumulated_metrics`, which is the total token count across all requests. This change adds the ability to track metrics for individual agent invocations, allowing users to access metrics for the latest request as well as historical invocations.

Users can access the metrics via the `AgentResult` once it's returned:

```python
# Your agent
response = agent("calculate 10+2*10")

# Access the current (latest) invocation metrics
latest_invocation = response.metrics.latest_agent_invocation
if latest_invocation:
    cycles = latest_invocation.cycles
    usage = latest_invocation.usage

# Or access all invocations
for invocation in response.metrics.agent_invocations:
    print(f"Invocation usage: {invocation.usage}")
    for cycle in invocation.cycles:
        print(f"  Cycle {cycle.event_loop_cycle_id}: {cycle.usage}")

# Or print the summary (includes all invocations)
print(response.metrics.get_summary())
```

## Updated Metrics

1. `agent_invocations`: A list of `AgentInvocation` objects, where each invocation contains:
  -  **`cycles`**: List of metrics for each event loop cycle within that invocation
  - Each cycle contains:
    - **`event_loop_cycle_id`**: Unique identifier for the event loop cycle
    - **`usage`**: Total token usage within that specific event loop cycle
  - **`usage`**: Total token usage for the entire invocation (sum of all cycles)

3. `latest_agent_invocation` Property
Convenient property to access the most recent (latest) agent invocation without needing to use `agent_invocations[-1]`

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1144

## Documentation PR

TBD

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### Example Output ###
The example below shows the agentResult.metrics (only the related fields) from three requests.

```
"agent_invocations": [
    {
      "cycles": [
        {
          "event_loop_cycle_id": "da707ee3-04a0-41e6-84e7-e6ba8a57053d",
          "usage": {
            "inputTokens": 1081,
            "outputTokens": 85,
            "totalTokens": 1166
          }
        },
        {
          "event_loop_cycle_id": "64a8b2b2-a677-4d47-9a1e-35ec737aae44",
          "usage": {
            "inputTokens": 1578,
            "outputTokens": 78,
            "totalTokens": 1656
          }
        }
      ],
      "usage": {
        "inputTokens": 2659,
        "outputTokens": 163,
        "totalTokens": 2822
      }
    },
    {
      "cycles": [
        {
          "event_loop_cycle_id": "51c214cc-8cd4-426b-a210-723cffdfc5c6",
          "usage": {
            "inputTokens": 1666,
            "outputTokens": 79,
            "totalTokens": 1745
          }
        },
        {
          "event_loop_cycle_id": "6d85ce7d-dd08-4efd-9665-12b8508b7c63",
          "usage": {
            "inputTokens": 2173,
            "outputTokens": 116,
            "totalTokens": 2289
          }
        }
      ],
      "usage": {
        "inputTokens": 3839,
        "outputTokens": 195,
        "totalTokens": 4034
      }
    }
  ],
```