### PR TITLE
fix(mcp): prevent agent hang by checking session closure state

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -801,4 +801,10 @@ class MCPClient(ToolProvider):
         return False
 
     def _is_session_active(self) -> bool:
-        return self._background_thread is not None and self._background_thread.is_alive()
+        if self._background_thread is None or not self._background_thread.is_alive():
+            return False
+
+        if self._close_future is not None and self._close_future.done():
+            return False
+
+        return True


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR --> This PR resolves a bug where MCPClient would attempt to schedule tool calls to a background event loop that had already finished its main task but whose thread was still alive. It prevents indefinite hangs when 4xx/5xx errors cause the background loop to exit before the thread is joined.

- Updated `_is_session_active` to check if `_close_future`` is done.

## Related Issues

<!-- Link to related issues using #issue-number format -->
Fixes #1334 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo --> N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
