### PR TITLE
feat: override service name by OTEL_SERVICE_NAME env

### DIFF
--- a/src/strands/telemetry/config.py
+++ b/src/strands/telemetry/config.py
@@ -5,6 +5,7 @@ for OpenTelemetry components and other telemetry infrastructure shared across St
 """
 
 import logging
+import os
 from importlib.metadata import version
 from typing import Any
 
@@ -29,9 +30,11 @@ def get_otel_resource() -> Resource:
     Returns:
         Resource object with standard service information.
     """
+    service_name = os.getenv("OTEL_SERVICE_NAME", "strands-agents").strip()
+
     resource = Resource.create(
         {
-            "service.name": "strands-agents",
+            "service.name": service_name,
             "service.version": version("strands-agents"),
             "telemetry.sdk.name": "opentelemetry",
             "telemetry.sdk.language": "python",
@@ -56,6 +59,7 @@ class StrandsTelemetry:
         Environment variables are handled by the underlying OpenTelemetry SDK:
         - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint URL
         - OTEL_EXPORTER_OTLP_HEADERS: Headers for OTLP requests
+        - OTEL_SERVICE_NAME: Overrides resource service name
 
     Examples:
         Quick setup with method chaining:

--- a/tests/strands/telemetry/test_config.py
+++ b/tests/strands/telemetry/test_config.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+import strands.telemetry.config as telemetry_config
 from strands.telemetry import StrandsTelemetry
 
 
@@ -212,3 +213,21 @@ def test_setup_otlp_exporter_exception(mock_resource, mock_tracer_provider, mock
     telemetry.setup_otlp_exporter()
 
     mock_otlp_exporter.assert_called_once()
+
+
+def test_get_otel_resource_uses_default_service_name(monkeypatch):
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+    monkeypatch.setattr(telemetry_config, "version", lambda _: "0.0.0")
+
+    resource = telemetry_config.get_otel_resource()
+
+    assert resource.attributes.get("service.name") == "strands-agents"
+
+
+def test_get_otel_resource_respects_otel_service_name(monkeypatch):
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "my-service")
+    monkeypatch.setattr(telemetry_config, "version", lambda _: "0.0.0")
+
+    resource = telemetry_config.get_otel_resource()
+
+    assert resource.attributes.get("service.name") == "my-service"


### PR DESCRIPTION
## Description
Override service name by OTEL_SERVICE_NAME env.

When I integrated Datadog to strands, all traces are named to "strands-agents" service and could't override by OTEL_SERVICE_NAME. This PR fix this problem.

## Type of Change

* Bug fix

## Testing

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
