### PR TITLE
fix(a2a): use a2a artifact update event

### DIFF
--- a/src/strands/multiagent/a2a/server.py
+++ b/src/strands/multiagent/a2a/server.py
@@ -42,6 +42,7 @@ class A2AServer:
         queue_manager: QueueManager | None = None,
         push_config_store: PushNotificationConfigStore | None = None,
         push_sender: PushNotificationSender | None = None,
+        enable_a2a_compliant_streaming: bool = False,
     ):
         """Initialize an A2A-compatible server from a Strands agent.
 
@@ -66,6 +67,9 @@ class A2AServer:
                 no push notification configuration is used.
             push_sender: Custom push notification sender implementation. If None,
                 no push notifications are sent.
+            enable_a2a_compliant_streaming: If True, uses A2A-compliant streaming with
+                artifact updates. If False, uses legacy status updates streaming behavior
+                for backwards compatibility. Defaults to False.
         """
         self.host = host
         self.port = port
@@ -90,7 +94,9 @@ class A2AServer:
         self.description = self.strands_agent.description
         self.capabilities = AgentCapabilities(streaming=True)
         self.request_handler = DefaultRequestHandler(
-            agent_executor=StrandsA2AExecutor(self.strands_agent),
+            agent_executor=StrandsA2AExecutor(
+                self.strands_agent, enable_a2a_compliant_streaming=enable_a2a_compliant_streaming
+            ),
             task_store=task_store or InMemoryTaskStore(),
             queue_manager=queue_manager,
             push_config_store=push_config_store,


### PR DESCRIPTION
## Description
This PR updates the a2a executor to use the a2a libraries artifact append function. Intermediate chunks are best represented by artifact updates with append set to true, not task status updates. Please see [this](https://github.com/a2aproject/A2A/discussions/1274) discussion on the a2a repo for more justification. 

This feature is now hidden behind the `enable_a2a_compliant_streaming` flag in `A2AServer`.

### enable_a2a_compliant_streaming False
<img width="685" height="481" alt="Screenshot 2026-01-14 at 10 51 11 AM" src="https://github.com/user-attachments/assets/33947789-58e2-4a11-b8ef-cf7d3c422953" />

### enable_a2a_compliant_streaming True
<img width="685" height="481" alt="Screenshot 2026-01-14 at 10 52 02 AM" src="https://github.com/user-attachments/assets/3fced725-625f-4c72-a67c-cd78882efb36" />
<img width="685" height="481" alt="Screenshot 2026-01-14 at 10 52 29 AM" src="https://github.com/user-attachments/assets/906883a1-a2aa-4eca-aed4-e3d452044803" />


## Related Issues

#1377

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
