### PR TITLE
feat: support greenback for async wrapper (#1406)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ sagemaker = [
     "openai>=1.68.0,<2.0.0",  # SageMaker uses OpenAI-compatible interface
 ]
 otel = ["opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0"]
+greenback = ["greenback>=1.2.0,<2.0.0"]
 docs = [
     "sphinx>=5.0.0,<9.0.0",
     "sphinx-rtd-theme>=1.0.0,<2.0.0",
@@ -79,7 +80,7 @@ bidi = [
 bidi-gemini = ["google-genai>=1.32.0,<2.0.0"]
 bidi-openai = ["websockets>=15.0.0,<16.0.0"]
 
-all = ["strands-agents[a2a,anthropic,docs,gemini,litellm,llamaapi,mistral,ollama,openai,writer,sagemaker,otel]"]
+all = ["strands-agents[a2a,anthropic,docs,gemini,greenback,litellm,llamaapi,mistral,ollama,openai,writer,sagemaker,otel]"]
 bidi-all = ["strands-agents[a2a,bidi,bidi-gemini,bidi-openai,docs,otel]"]
 
 dev = [

--- a/src/strands/_async.py
+++ b/src/strands/_async.py
@@ -2,25 +2,51 @@
 
 import asyncio
 import contextvars
+import os
 from concurrent.futures import ThreadPoolExecutor
-from typing import Awaitable, Callable, TypeVar
+from typing import TYPE_CHECKING, Awaitable, Callable, TypeVar
 
 T = TypeVar("T")
 
+# Try to import greenback; set availability flag
+# Set STRANDS_DISABLE_GREENBACK=1 to force the ThreadPoolExecutor fallback (for testing/debugging)
+_GREENBACK_AVAILABLE = False
+try:
+    import greenback
+
+    if os.environ.get("STRANDS_DISABLE_GREENBACK", "").lower() not in ("1", "true", "yes"):
+        _GREENBACK_AVAILABLE = True
+except ImportError:
+    greenback = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    import greenback
+
 
 def run_async(async_func: Callable[[], Awaitable[T]]) -> T:
-    """Run an async function in a separate thread to avoid event loop conflicts.
+    """Run an async function, using greenback if available or a separate thread otherwise.
 
-    This utility handles the common pattern of running async code from sync contexts
-    by using ThreadPoolExecutor to isolate the async execution.
+    If greenback is installed and a portal has been set up (via `await greenback.ensure_portal()`),
+    this function uses greenback to await the async function on the current event loop. This allows
+    async tools to access resources bound to the main event loop.
+
+    Otherwise, this function uses ThreadPoolExecutor to run the async code in a separate thread
+    with a new event loop, which isolates the async execution but cannot access main-loop resources.
+
+    Set the environment variable STRANDS_DISABLE_GREENBACK=1 to force the ThreadPoolExecutor
+    fallback even when greenback is installed (useful for testing or debugging).
 
     Args:
-        async_func: A callable that returns an awaitable
+        async_func: A callable that returns an awaitable.
 
     Returns:
-        The result of the async function
+        The result of the async function.
     """
+    # Use greenback if available and a portal is active
+    if _GREENBACK_AVAILABLE and greenback.has_portal():
+        return greenback.await_(async_func())
 
+    # Fall back to ThreadPoolExecutor approach
     async def execute_async() -> T:
         return await async_func()
 

--- a/tests/strands/test_async.py
+++ b/tests/strands/test_async.py
@@ -1,8 +1,16 @@
 """Tests for _async module."""
 
+import asyncio
+import importlib
+import sys
+from unittest import mock
+
 import pytest
 
 from strands._async import run_async
+
+# greenback's ensure_portal() has compatibility issues with pytest-asyncio on Python < 3.11
+GREENBACK_PORTAL_COMPATIBLE = sys.version_info >= (3, 11)
 
 
 def test_run_async_with_return_value():
@@ -23,3 +31,271 @@ def test_run_async_exception_propagation():
 
     with pytest.raises(ValueError, match="test exception"):
         run_async(async_with_exception)
+
+
+class TestRunAsyncGreenbackMocked:
+    """Tests for run_async greenback code paths using mocks."""
+
+    @pytest.fixture
+    def mock_greenback(self) -> mock.MagicMock:
+        """Create a mock greenback module."""
+        return mock.MagicMock()
+
+    def test_uses_greenback_when_portal_active(self, mock_greenback: mock.MagicMock) -> None:
+        """Test that greenback.await_ is used when a portal is active."""
+        mock_greenback.has_portal.return_value = True
+        mock_greenback.await_.return_value = "greenback_result"
+
+        with mock.patch("strands._async._GREENBACK_AVAILABLE", True):
+            with mock.patch("strands._async.greenback", mock_greenback):
+                result = run_async(lambda: asyncio.sleep(0))
+
+        mock_greenback.has_portal.assert_called_once()
+        mock_greenback.await_.assert_called_once()
+        assert result == "greenback_result"
+
+    def test_falls_back_without_portal(self, mock_greenback: mock.MagicMock) -> None:
+        """Test that ThreadPoolExecutor is used when no portal is active."""
+        mock_greenback.has_portal.return_value = False
+
+        async def async_fn() -> str:
+            return "thread_result"
+
+        with mock.patch("strands._async._GREENBACK_AVAILABLE", True):
+            with mock.patch("strands._async.greenback", mock_greenback):
+                result = run_async(async_fn)
+
+        mock_greenback.has_portal.assert_called_once()
+        mock_greenback.await_.assert_not_called()
+        assert result == "thread_result"
+
+    def test_falls_back_without_greenback_installed(self) -> None:
+        """Test that ThreadPoolExecutor is used when greenback is not installed."""
+
+        async def async_fn() -> str:
+            return "thread_result"
+
+        with mock.patch("strands._async._GREENBACK_AVAILABLE", False):
+            result = run_async(async_fn)
+
+        assert result == "thread_result"
+
+
+class TestRunAsyncGreenbackReal:
+    """Integration tests that run only when greenback is installed."""
+
+    @pytest.fixture
+    def greenback_module(self):
+        """Import greenback or skip test if not available."""
+        return pytest.importorskip("greenback")
+
+    @pytest.mark.skipif(
+        not GREENBACK_PORTAL_COMPATIBLE, reason="greenback portal incompatible with pytest-asyncio on Python < 3.11"
+    )
+    @pytest.mark.asyncio
+    async def test_run_async_uses_same_event_loop_with_portal(self, greenback_module) -> None:
+        """Test that run_async uses the same event loop when portal is active."""
+        await greenback_module.ensure_portal()
+
+        outer_loop = asyncio.get_running_loop()
+        inner_loop = None
+
+        async def capture_loop() -> str:
+            nonlocal inner_loop
+            inner_loop = asyncio.get_running_loop()
+            return "result"
+
+        # Call run_async from within the async context
+        result = run_async(capture_loop)
+
+        assert result == "result"
+        assert inner_loop is outer_loop, "Expected run_async to use the same event loop"
+
+    @pytest.mark.skipif(
+        not GREENBACK_PORTAL_COMPATIBLE, reason="greenback portal incompatible with pytest-asyncio on Python < 3.11"
+    )
+    @pytest.mark.asyncio
+    async def test_run_async_can_access_outer_task(self, greenback_module) -> None:
+        """Test that async code in run_async can access resources from the outer context."""
+        await greenback_module.ensure_portal()
+
+        # Create a shared resource in the outer async context
+        shared_future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        shared_future.set_result("shared_value")
+
+        async def access_shared() -> str:
+            # This would fail with ThreadPoolExecutor (different loop)
+            return await shared_future
+
+        result = run_async(access_shared)
+        assert result == "shared_value"
+
+    def test_run_async_without_portal_uses_separate_loop(self, greenback_module, monkeypatch) -> None:
+        """Test that run_async uses a separate loop when greenback is disabled."""
+        import strands._async
+
+        # Disable greenback via env var to ensure we test the fallback path
+        monkeypatch.setenv("STRANDS_DISABLE_GREENBACK", "1")
+        importlib.reload(strands._async)
+
+        try:
+
+            async def run_test() -> bool:
+                main_loop_id = id(asyncio.get_running_loop())
+
+                async def get_inner_loop_id() -> int:
+                    return id(asyncio.get_running_loop())
+
+                inner_loop_id = strands._async.run_async(get_inner_loop_id)
+                # With greenback disabled, should be different loops
+                return inner_loop_id != main_loop_id
+
+            result = asyncio.run(run_test())
+            assert result, "Expected different loops when greenback is disabled"
+        finally:
+            monkeypatch.delenv("STRANDS_DISABLE_GREENBACK", raising=False)
+            importlib.reload(strands._async)
+
+
+class TestRunAsyncGreenbackEndToEnd:
+    """End-to-end tests demonstrating the greenback use case from the ticket.
+
+    These tests verify that async resources bound to the main event loop:
+    - Are INACCESSIBLE without a greenback portal (different loop)
+    - Are ACCESSIBLE with a greenback portal (same loop)
+    """
+
+    @pytest.fixture
+    def greenback_module(self):
+        """Import greenback or skip test if not available."""
+        return pytest.importorskip("greenback")
+
+    def test_loop_bound_client_fails_without_portal(self, greenback_module, monkeypatch) -> None:
+        """Test that a loop-bound client fails when accessed from run_async without greenback.
+
+        This simulates the real-world scenario where an httpx.AsyncClient or database
+        connection pool is created on the main loop and cannot be used from a different loop.
+        """
+        import strands._async
+
+        # Disable greenback via env var to ensure we test the fallback path
+        monkeypatch.setenv("STRANDS_DISABLE_GREENBACK", "1")
+        importlib.reload(strands._async)
+
+        try:
+            # We need to run this in an async context to have a "main loop"
+            async def run_test() -> bool:
+                main_loop_id = id(asyncio.get_running_loop())
+
+                class LoopBoundClient:
+                    """Simulates an async client that requires same-loop usage."""
+
+                    def __init__(self, bound_loop_id: int):
+                        self._bound_loop_id = bound_loop_id
+
+                    async def request(self) -> dict:
+                        current_loop_id = id(asyncio.get_running_loop())
+                        if current_loop_id != self._bound_loop_id:
+                            raise RuntimeError(
+                                f"Client bound to loop {self._bound_loop_id}, called from loop {current_loop_id}"
+                            )
+                        return {"status": "ok"}
+
+                client = LoopBoundClient(main_loop_id)
+
+                async def use_client() -> dict:
+                    return await client.request()
+
+                try:
+                    strands._async.run_async(use_client)
+                    return False  # Should have failed
+                except RuntimeError:
+                    return True  # Expected failure
+
+            # Run with greenback disabled - should fail
+            result = asyncio.run(run_test())
+            assert result, "Expected loop-bound client to fail when greenback is disabled"
+        finally:
+            monkeypatch.delenv("STRANDS_DISABLE_GREENBACK", raising=False)
+            importlib.reload(strands._async)
+
+    @pytest.mark.skipif(
+        not GREENBACK_PORTAL_COMPATIBLE, reason="greenback portal incompatible with pytest-asyncio on Python < 3.11"
+    )
+    @pytest.mark.asyncio
+    async def test_loop_bound_client_succeeds_with_portal(self, greenback_module) -> None:
+        """Test that a loop-bound client succeeds when accessed via greenback portal.
+
+        With the portal active, run_async uses greenback.await_() which keeps us on
+        the same event loop, allowing access to loop-bound resources.
+        """
+        await greenback_module.ensure_portal()
+
+        main_loop_id = id(asyncio.get_running_loop())
+
+        class LoopBoundClient:
+            """Simulates an async client that requires same-loop usage."""
+
+            def __init__(self, bound_loop_id: int):
+                self._bound_loop_id = bound_loop_id
+
+            async def request(self) -> dict:
+                current_loop_id = id(asyncio.get_running_loop())
+                if current_loop_id != self._bound_loop_id:
+                    raise RuntimeError(
+                        f"Client bound to loop {self._bound_loop_id}, called from loop {current_loop_id}"
+                    )
+                return {"status": "ok"}
+
+        client = LoopBoundClient(main_loop_id)
+
+        async def use_client() -> dict:
+            return await client.request()
+
+        # With portal - should succeed
+        result = run_async(use_client)
+        assert result == {"status": "ok"}
+
+
+class TestRunAsyncGreenbackEnvVar:
+    """Tests for STRANDS_DISABLE_GREENBACK environment variable."""
+
+    @pytest.fixture
+    def greenback_module(self):
+        """Import greenback or skip test if not available."""
+        return pytest.importorskip("greenback")
+
+    def test_env_var_disables_greenback(self, greenback_module, monkeypatch) -> None:
+        """Test that STRANDS_DISABLE_GREENBACK=1 forces ThreadPoolExecutor fallback.
+
+        Even with greenback installed and a portal active, the env var should
+        force the fallback to ThreadPoolExecutor (different event loop).
+        """
+        import strands._async
+
+        # Set env var and reload module to pick up the change
+        monkeypatch.setenv("STRANDS_DISABLE_GREENBACK", "1")
+        importlib.reload(strands._async)
+
+        try:
+            # Verify the flag was set correctly
+            assert strands._async._GREENBACK_AVAILABLE is False
+
+            # Now run a test that would use greenback if enabled
+            async def run_test() -> bool:
+                await greenback_module.ensure_portal()
+                main_loop_id = id(asyncio.get_running_loop())
+
+                async def get_inner_loop_id() -> int:
+                    return id(asyncio.get_running_loop())
+
+                inner_loop_id = strands._async.run_async(get_inner_loop_id)
+                # With env var set, should be different loops even with portal
+                return inner_loop_id != main_loop_id
+
+            result = asyncio.run(run_test())
+            assert result, "Expected different loops when STRANDS_DISABLE_GREENBACK=1"
+        finally:
+            # Restore module state
+            monkeypatch.delenv("STRANDS_DISABLE_GREENBACK", raising=False)
+            importlib.reload(strands._async)


### PR DESCRIPTION
## Description

Adds optional greenback support to `run_async()`, enabling async tools to access resources bound to the main event loop (httpx.AsyncClient, database connection pools, cached tasks, etc.).

When greenback is installed and a portal has been set up via `await greenback.ensure_portal()`, `run_async()` uses `greenback.await_()` to stay on the same event loop. Otherwise, it falls back to the existing ThreadPoolExecutor approach.

Set `STRANDS_DISABLE_GREENBACK=1` to force the fallback (useful for testing/debugging).

## Related Issues

#1406

## Documentation PR

Not yet -- will edit here if added.

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New feature

## Testing

- Added unit tests
- Added integration tests using greenback (skipped if not installed)
- Added unit tests with mocks for partial coverage even when greenback is _not_ installed
- Added test ensuring that environment-variable override functions as intended

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
