### PR TITLE
docs: update github agent action to reference S3_SESSION_BUCKET

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -198,7 +198,7 @@ Your IAM role must have these permissions in order to execute:
 3. **Create S3 Bucket** for session storage
 4. **Add GitHub Secrets**:
    - `AWS_ROLE_ARN`: The created role ARN
-   - `S3_SESSION_BUCKET`: The S3 bucket name
+   - `AGENT_SESSIONS_BUCKET`: The S3 bucket name
 
 ## Security
 


### PR DESCRIPTION
## Description

This is a one line docs change. The action code uses S3_SESSION_BUCKET but the README states STRANDS_SESSION_BUCKET https://github.com/search?q=repo%3Astrands-agents%2Fsdk-python%20S3_SESSION_BUCKET&type=code
