### PR TITLE
feat: add image field support to GuardContent type

### DIFF
--- a/src/strands/types/content.py
+++ b/src/strands/types/content.py
@@ -27,14 +27,38 @@ class GuardContentText(TypedDict):
     text: str
 
 
-class GuardContent(TypedDict):
+class GuardrailConverseImageSource(TypedDict):
+    """Contains the image source (bytes) for the guardrail converse image block.
+
+    Attributes:
+        bytes: The binary content of the image.
+    """
+
+    bytes: bytes
+
+
+class GuardContentImage(TypedDict):
+    """Image content to be evaluated by guardrails.
+
+    Attributes:
+        format: The format of the image (png or jpeg).
+        source: The image source containing the binary content.
+    """
+
+    format: Literal["png", "jpeg"]
+    source: GuardrailConverseImageSource
+
+
+class GuardContent(TypedDict, total=False):
     """Content block to be evaluated by guardrails.
 
     Attributes:
         text: Text within content block to be evaluated by the guardrail.
+        image: Image within content block to be evaluated by the guardrail.
     """
 
     text: GuardContentText
+    image: GuardContentImage
 
 
 class ReasoningTextBlock(TypedDict, total=False):

--- a/tests/strands/types/test_content.py
+++ b/tests/strands/types/test_content.py
@@ -1,0 +1,84 @@
+"""Tests for content-related type definitions."""
+
+
+class TestGuardrailConverseImageSource:
+    """Tests for GuardrailConverseImageSource TypedDict."""
+
+    def test_structure_with_bytes(self):
+        """Test GuardrailConverseImageSource structure accepts bytes."""
+        from strands.types.content import GuardrailConverseImageSource
+
+        image_bytes = b"fake image data"
+        source: GuardrailConverseImageSource = {"bytes": image_bytes}
+
+        assert source["bytes"] == image_bytes
+        assert isinstance(source["bytes"], bytes)
+
+
+class TestGuardContentImage:
+    """Tests for GuardContentImage TypedDict."""
+
+    def test_structure_with_png_format(self):
+        """Test GuardContentImage with png format."""
+        from strands.types.content import GuardContentImage
+
+        image_bytes = b"fake png data"
+        image: GuardContentImage = {"format": "png", "source": {"bytes": image_bytes}}
+
+        assert image["format"] == "png"
+        assert image["source"]["bytes"] == image_bytes
+
+    def test_structure_with_jpeg_format(self):
+        """Test GuardContentImage with jpeg format."""
+        from strands.types.content import GuardContentImage
+
+        image_bytes = b"fake jpeg data"
+        image: GuardContentImage = {"format": "jpeg", "source": {"bytes": image_bytes}}
+
+        assert image["format"] == "jpeg"
+        assert image["source"]["bytes"] == image_bytes
+
+
+class TestGuardContent:
+    """Tests for GuardContent TypedDict with image support."""
+
+    def test_with_text_only(self):
+        """Test GuardContent with text field only (existing behavior)."""
+        from strands.types.content import GuardContent
+
+        guard: GuardContent = {"text": {"text": "sample text", "qualifiers": ["query"]}}
+
+        assert guard["text"]["text"] == "sample text"
+        assert guard["text"]["qualifiers"] == ["query"]
+
+    def test_with_image_only(self):
+        """Test GuardContent with image field only."""
+        from strands.types.content import GuardContent
+
+        image_bytes = b"fake image data"
+        guard: GuardContent = {"image": {"format": "png", "source": {"bytes": image_bytes}}}
+
+        assert guard["image"]["format"] == "png"
+        assert guard["image"]["source"]["bytes"] == image_bytes
+
+    def test_with_both_text_and_image(self):
+        """Test GuardContent with both text and image fields."""
+        from strands.types.content import GuardContent
+
+        image_bytes = b"fake image data"
+        guard: GuardContent = {
+            "text": {"text": "sample text", "qualifiers": ["query"]},
+            "image": {"format": "jpeg", "source": {"bytes": image_bytes}},
+        }
+
+        assert guard["text"]["text"] == "sample text"
+        assert guard["image"]["format"] == "jpeg"
+        assert guard["image"]["source"]["bytes"] == image_bytes
+
+    def test_optional_fields(self):
+        """Test that GuardContent fields are optional."""
+        from strands.types.content import GuardContent
+
+        # Empty guard should be valid (all fields optional)
+        guard: GuardContent = {}
+        assert isinstance(guard, dict)

--- a/tests/strands/types/test_content.py
+++ b/tests/strands/types/test_content.py
@@ -1,84 +1,69 @@
 """Tests for content-related type definitions."""
 
+import pytest
 
-class TestGuardrailConverseImageSource:
-    """Tests for GuardrailConverseImageSource TypedDict."""
-
-    def test_structure_with_bytes(self):
-        """Test GuardrailConverseImageSource structure accepts bytes."""
-        from strands.types.content import GuardrailConverseImageSource
-
-        image_bytes = b"fake image data"
-        source: GuardrailConverseImageSource = {"bytes": image_bytes}
-
-        assert source["bytes"] == image_bytes
-        assert isinstance(source["bytes"], bytes)
+from strands.types.content import GuardContent, GuardContentImage, GuardrailConverseImageSource
 
 
-class TestGuardContentImage:
-    """Tests for GuardContentImage TypedDict."""
-
-    def test_structure_with_png_format(self):
-        """Test GuardContentImage with png format."""
-        from strands.types.content import GuardContentImage
-
-        image_bytes = b"fake png data"
-        image: GuardContentImage = {"format": "png", "source": {"bytes": image_bytes}}
-
-        assert image["format"] == "png"
-        assert image["source"]["bytes"] == image_bytes
-
-    def test_structure_with_jpeg_format(self):
-        """Test GuardContentImage with jpeg format."""
-        from strands.types.content import GuardContentImage
-
-        image_bytes = b"fake jpeg data"
-        image: GuardContentImage = {"format": "jpeg", "source": {"bytes": image_bytes}}
-
-        assert image["format"] == "jpeg"
-        assert image["source"]["bytes"] == image_bytes
+@pytest.fixture
+def image_bytes():
+    """Provide sample image bytes for testing."""
+    return b"fake image data"
 
 
-class TestGuardContent:
-    """Tests for GuardContent TypedDict with image support."""
+@pytest.fixture
+def sample_text():
+    """Provide sample text content for GuardContent."""
+    return {"text": "sample text", "qualifiers": ["query"]}
 
-    def test_with_text_only(self):
-        """Test GuardContent with text field only (existing behavior)."""
-        from strands.types.content import GuardContent
 
-        guard: GuardContent = {"text": {"text": "sample text", "qualifiers": ["query"]}}
+def test_structure_with_bytes(image_bytes):
+    """Test GuardrailConverseImageSource structure accepts bytes."""
+    source: GuardrailConverseImageSource = {"bytes": image_bytes}
 
-        assert guard["text"]["text"] == "sample text"
-        assert guard["text"]["qualifiers"] == ["query"]
+    assert source["bytes"] == image_bytes
+    assert isinstance(source["bytes"], bytes)
 
-    def test_with_image_only(self):
-        """Test GuardContent with image field only."""
-        from strands.types.content import GuardContent
 
-        image_bytes = b"fake image data"
-        guard: GuardContent = {"image": {"format": "png", "source": {"bytes": image_bytes}}}
+def test_structure_with_png_format(image_bytes):
+    """Test GuardContentImage with png format."""
+    image: GuardContentImage = {"format": "png", "source": {"bytes": image_bytes}}
 
-        assert guard["image"]["format"] == "png"
-        assert guard["image"]["source"]["bytes"] == image_bytes
+    assert image["format"] == "png"
+    assert image["source"]["bytes"] == image_bytes
 
-    def test_with_both_text_and_image(self):
-        """Test GuardContent with both text and image fields."""
-        from strands.types.content import GuardContent
 
-        image_bytes = b"fake image data"
-        guard: GuardContent = {
-            "text": {"text": "sample text", "qualifiers": ["query"]},
-            "image": {"format": "jpeg", "source": {"bytes": image_bytes}},
-        }
+def test_structure_with_jpeg_format(image_bytes):
+    """Test GuardContentImage with jpeg format."""
+    image: GuardContentImage = {"format": "jpeg", "source": {"bytes": image_bytes}}
 
-        assert guard["text"]["text"] == "sample text"
-        assert guard["image"]["format"] == "jpeg"
-        assert guard["image"]["source"]["bytes"] == image_bytes
+    assert image["format"] == "jpeg"
+    assert image["source"]["bytes"] == image_bytes
 
-    def test_optional_fields(self):
-        """Test that GuardContent fields are optional."""
-        from strands.types.content import GuardContent
 
-        # Empty guard should be valid (all fields optional)
-        guard: GuardContent = {}
-        assert isinstance(guard, dict)
+def test_with_text_only(sample_text):
+    """Test GuardContent with text field only (existing behavior)."""
+    guard: GuardContent = {"text": sample_text}
+
+    assert guard["text"]["text"] == "sample text"
+    assert guard["text"]["qualifiers"] == ["query"]
+
+
+def test_with_image_only(image_bytes):
+    """Test GuardContent with image field only."""
+    guard: GuardContent = {"image": {"format": "png", "source": {"bytes": image_bytes}}}
+
+    assert guard["image"]["format"] == "png"
+    assert guard["image"]["source"]["bytes"] == image_bytes
+
+
+def test_with_both_text_and_image(sample_text, image_bytes):
+    """Test GuardContent with both text and image fields."""
+    guard: GuardContent = {
+        "text": sample_text,
+        "image": {"format": "jpeg", "source": {"bytes": image_bytes}},
+    }
+
+    assert guard["text"]["text"] == "sample text"
+    assert guard["image"]["format"] == "jpeg"
+    assert guard["image"]["source"]["bytes"] == image_bytes


### PR DESCRIPTION
## Motivation

The Bedrock model provider is adding a guardrail_latest_message feature flag that allows guardrails to evaluate both text and image content in the latest user message. The current GuardContent type only supports text evaluation, limiting the ability to apply content safety checks to images submitted by users.

Resolves #1423

AWS DOCS: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_GuardrailConverseImageBlock.html

## Public API Changes

The `GuardContent` TypedDict now includes an optional `image` field alongside the existing `text` field:

```python
# Before: text only
guard: GuardContent = {
    "text": {
        "text": "sample text",
        "qualifiers": ["query"]
    }
}

# After: can include image
guard: GuardContent = {
    "text": {
        "text": "sample text",
        "qualifiers": ["query"]
    },
    "image": {
        "format": "png",  # or "jpeg"
        "source": {"bytes": image_bytes}
    }
}

# Or image only
guard: GuardContent = {
    "image": {
        "format": "jpeg",
        "source": {"bytes": image_bytes}
    }
}
```

Both `text` and `image` fields are optional (TypedDict with `total=False`), allowing flexible content evaluation configurations.

**New Types:**
- `GuardrailConverseImageSource`: Contains the image bytes
- `GuardContentImage`: Defines image format (png/jpeg) and source

The implementation follows the AWS Bedrock GuardrailConverseImageBlock API specification, supporting only PNG and JPEG formats as required by the service.