### PR TITLE
bidi - move 3.12 check to nova sonic module

### DIFF
--- a/src/strands/experimental/bidi/__init__.py
+++ b/src/strands/experimental/bidi/__init__.py
@@ -1,10 +1,5 @@
 """Bidirectional streaming package."""
 
-import sys
-
-if sys.version_info < (3, 12):
-    raise ImportError("bidi only supported for >= Python 3.12")
-
 # Main components - Primary user interface
 # Re-export standard agent events for tool handling
 from ...types._events import (
@@ -19,7 +14,6 @@ from .io.audio import BidiAudioIO
 
 # Model interface (for custom implementations)
 from .models.model import BidiModel
-from .models.nova_sonic import BidiNovaSonicModel
 
 # Built-in tools
 from .tools import stop_conversation
@@ -48,8 +42,6 @@ __all__ = [
     "BidiAgent",
     # IO channels
     "BidiAudioIO",
-    # Model providers
-    "BidiNovaSonicModel",
     # Built-in tools
     "stop_conversation",
     # Input Event types

--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -32,7 +32,6 @@ from ...hooks.events import BidiAgentInitializedEvent, BidiMessageAddedEvent
 from ...tools import ToolProvider
 from .._async import _TaskGroup, stop_all
 from ..models.model import BidiModel
-from ..models.nova_sonic import BidiNovaSonicModel
 from ..types.agent import BidiAgentInput
 from ..types.events import (
     BidiAudioInputEvent,
@@ -100,13 +99,13 @@ class BidiAgent:
             ValueError: If model configuration is invalid or state is invalid type.
             TypeError: If model type is unsupported.
         """
-        self.model = (
-            BidiNovaSonicModel()
-            if not model
-            else BidiNovaSonicModel(model_id=model)
-            if isinstance(model, str)
-            else model
-        )
+        if isinstance(model, BidiModel):
+            self.model = model
+        else:
+            from ..models.nova_sonic import BidiNovaSonicModel
+
+            self.model = BidiNovaSonicModel(model_id=model) if isinstance(model, str) else BidiNovaSonicModel()
+
         self.system_prompt = system_prompt
         self.messages = messages or []
 

--- a/src/strands/experimental/bidi/models/__init__.py
+++ b/src/strands/experimental/bidi/models/__init__.py
@@ -3,27 +3,26 @@
 from typing import Any
 
 from .model import BidiModel, BidiModelTimeoutError
-from .nova_sonic import BidiNovaSonicModel
 
 __all__ = [
     "BidiModel",
     "BidiModelTimeoutError",
-    "BidiNovaSonicModel",
 ]
 
 
 def __getattr__(name: str) -> Any:
-    """
-    Lazy load bidi model implementations only when accessed.
-    
-    This defers the import of optional dependencies until actually needed:
-    - BidiGeminiLiveModel requires google-generativeai (lazy loaded)
-    - BidiOpenAIRealtimeModel requires openai (lazy loaded)
+    """Lazy load bidi model implementations only when accessed.
+
+    This defers the import of optional dependencies until actually needed.
     """
     if name == "BidiGeminiLiveModel":
         from .gemini_live import BidiGeminiLiveModel
 
         return BidiGeminiLiveModel
+    if name == "BidiNovaSonicModel":
+        from .nova_sonic import BidiNovaSonicModel
+
+        return BidiNovaSonicModel
     if name == "BidiOpenAIRealtimeModel":
         from .openai_realtime import BidiOpenAIRealtimeModel
 

--- a/src/strands/experimental/bidi/models/model.py
+++ b/src/strands/experimental/bidi/models/model.py
@@ -14,7 +14,7 @@ Features:
 """
 
 import logging
-from typing import Any, AsyncIterable, Protocol
+from typing import Any, AsyncIterable, Protocol, runtime_checkable
 
 from ....types._events import ToolResultEvent
 from ....types.content import Messages
@@ -27,6 +27,7 @@ from ..types.events import (
 logger = logging.getLogger(__name__)
 
 
+@runtime_checkable
 class BidiModel(Protocol):
     """Protocol for bidirectional streaming models.
 

--- a/src/strands/experimental/bidi/models/nova_sonic.py
+++ b/src/strands/experimental/bidi/models/nova_sonic.py
@@ -11,7 +11,14 @@ Nova Sonic specifics:
 - Tool execution with content containers and identifier tracking
 - 8-minute connection limits with proper cleanup sequences
 - Interruption detection through stopReason events
+
+Note, BidiNovaSonicModel is only supported for Python 3.12+
 """
+
+import sys
+
+if sys.version_info < (3, 12):
+    raise ImportError("BidiNovaSonicModel is only supported for Python 3.12+")
 
 import asyncio
 import base64
@@ -92,6 +99,8 @@ class BidiNovaSonicModel(BidiModel):
     Combines model configuration and connection state in a single class.
     Manages Nova Sonic's complex event sequencing, audio format conversion, and
     tool execution patterns while providing the standard BidiModel interface.
+
+    Note, BidiNovaSonicModel is only supported for Python 3.12+.
 
     Attributes:
         _stream: open bedrock stream to nova sonic.

--- a/tests/strands/experimental/bidi/_async/test_task_group.py
+++ b/tests/strands/experimental/bidi/_async/test_task_group.py
@@ -19,6 +19,7 @@ async def test_task_group__aexit__():
 @pytest.mark.asyncio
 async def test_task_group__aexit__task_exception():
     wait_event = asyncio.Event()
+
     async def wait():
         await wait_event.wait()
 
@@ -49,12 +50,14 @@ async def test_task_group__aexit__task_cancelled():
 @pytest.mark.asyncio
 async def test_task_group__aexit__context_cancelled():
     wait_event = asyncio.Event()
+
     async def wait():
         await wait_event.wait()
 
     tasks = []
 
     run_event = asyncio.Event()
+
     async def run():
         async with _TaskGroup() as task_group:
             tasks.append(task_group.create_task(wait()))

--- a/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/tests/strands/experimental/bidi/agent/test_agent.py
@@ -1,13 +1,13 @@
 """Unit tests for BidiAgent."""
 
 import asyncio
+import sys
 import unittest.mock
 from uuid import uuid4
 
 import pytest
 
 from strands.experimental.bidi.agent.agent import BidiAgent
-from strands.experimental.bidi.models.nova_sonic import BidiNovaSonicModel
 from strands.experimental.bidi.types.events import (
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
@@ -125,18 +125,22 @@ def test_bidi_agent_init_with_various_configurations():
     assert agent_with_config.system_prompt == system_prompt
     assert agent_with_config.agent_id == "test_agent"
 
-    # Test with string model ID
-    model_id = "amazon.nova-sonic-v1:0"
-    agent_with_string = BidiAgent(model=model_id)
-
-    assert isinstance(agent_with_string.model, BidiNovaSonicModel)
-    assert agent_with_string.model.model_id == model_id
-
     # Test model config access
     config = agent.model.config
     assert config["audio"]["input_rate"] == 16000
     assert config["audio"]["output_rate"] == 24000
     assert config["audio"]["channels"] == 1
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="BidiNovaSonicModel is only supported for Python 3.12+")
+def test_bidi_agent_init_with_model_id():
+    from strands.experimental.bidi.models.nova_sonic import BidiNovaSonicModel
+
+    model_id = "amazon.nova-sonic-v1:0"
+    agent = BidiAgent(model=model_id)
+
+    assert isinstance(agent.model, BidiNovaSonicModel)
+    assert agent.model.model_id == model_id
 
 
 @pytest.mark.asyncio

--- a/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/tests/strands/experimental/bidi/agent/test_loop.py
@@ -5,7 +5,7 @@ import pytest_asyncio
 
 from strands import tool
 from strands.experimental.bidi import BidiAgent
-from strands.experimental.bidi.models import BidiModelTimeoutError
+from strands.experimental.bidi.models import BidiModel, BidiModelTimeoutError
 from strands.experimental.bidi.types.events import BidiConnectionRestartEvent, BidiTextInputEvent
 from strands.types._events import ToolResultEvent, ToolResultMessageEvent, ToolUseStreamEvent
 
@@ -21,7 +21,7 @@ def time_tool():
 
 @pytest.fixture
 def agent(time_tool):
-    return BidiAgent(model=unittest.mock.AsyncMock(), tools=[time_tool])
+    return BidiAgent(model=unittest.mock.AsyncMock(spec=BidiModel), tools=[time_tool])
 
 
 @pytest_asyncio.fixture

--- a/tests/strands/experimental/bidi/models/test_openai_realtime.py
+++ b/tests/strands/experimental/bidi/models/test_openai_realtime.py
@@ -9,6 +9,7 @@ Tests the unified BidiOpenAIRealtimeModel interface including:
 """
 
 import base64
+import itertools
 import json
 import unittest.mock
 
@@ -522,7 +523,7 @@ async def test_receive_lifecycle_events(mock_websocket, model):
 @unittest.mock.patch("strands.experimental.bidi.models.openai_realtime.time.time")
 @pytest.mark.asyncio
 async def test_receive_timeout(mock_time, model):
-    mock_time.side_effect = [1, 2]
+    mock_time.side_effect = itertools.count()
     model.timeout_s = 1
 
     await model.start()


### PR DESCRIPTION
## Description
Move the bidi python 3.12+ check into the nova_sonic.py module, which is the only python 3.12+ component.

## Follow Up
With these changes, we can start to remove the bidi specific build logic from the pyproject.toml ([draft](https://github.com/strands-agents/sdk-python/pull/1297/changes)). We however need to do something about the pyaudio dependency first. It requires portaudio as a system level install, which can be a hassle for people to set up especially if they are contributing to unrelated components in the SDK.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1299

## Documentation PR

The bidi quickstart [prerequisites](https://strandsagents.com/latest/documentation/docs/user-guide/concepts/experimental/bidirectional-streaming/quickstart/?h=3.12#prerequisites) lists 3.12+ as a requirement. Will update this line.

## Type of Change

Other (please describe): Updating python version support.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I ran `hatch run bidi:prepare`
- [x] I ran `hatch run bidi-test:test tests_integ/bidi`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
