### PR TITLE
fix(integ): make calculator tool more robust to LLM output variations

### DIFF
--- a/tests_integ/test_structured_output_agent_loop.py
+++ b/tests_integ/test_structured_output_agent_loop.py
@@ -132,16 +132,23 @@ class NameWithValidation(BaseModel):
 
 @tool
 def calculator(operation: str, a: float, b: float) -> float:
-    """Simple calculator tool for testing."""
-    if operation == "add":
+    """Simple calculator tool for testing.
+
+    Args:
+        operation: The operation to perform. One of: add, subtract, multiply, divide, power
+        a: The first number
+        b: The second number
+    """
+    op = operation.lower().strip()
+    if op in ("add", "+"):
         return a + b
-    elif operation == "subtract":
+    elif op in ("subtract", "-", "sub"):
         return a - b
-    elif operation == "multiply":
+    elif op in ("multiply", "*", "mul"):
         return a * b
-    elif operation == "divide":
-        return b / a if a != 0 else 0
-    elif operation == "power":
+    elif op in ("divide", "/", "div"):
+        return a / b if b != 0 else 0
+    elif op in ("power", "**", "pow"):
         return a**b
     else:
         return 0


### PR DESCRIPTION
## Description

Fixes a flaky integration test in `test_structured_output_agent_loop.py` where `test_tool_use_with_structured_output` would fail intermittently.

### Root Cause

The LLM sometimes outputs `'+'` instead of `'add'` as the operation string. The original calculator tool only accepted exact string matches like `"add"`, `"subtract"`, etc., causing the function to return `0` when the LLM used symbols.

**Example of failure:**
```python
# LLM called: calculator(operation='+', a=2, b=2)
# Expected: 4
# Got: 0 (because '+' didn't match 'add')
```

This was observed in PR #1444 CI run: https://github.com/strands-agents/sdk-python/actions/runs/20875011420/job/59982925582?pr=1444

### Changes

- Accept both word and symbol forms for all operations:
  - `add` / `+`
  - `subtract` / `-` / `sub`
  - `multiply` / `*` / `mul`
  - `divide` / `/` / `div`
  - `power` / `**` / `pow`
- Normalize input with `lower()` and `strip()`
- Fix divide operation (was `b/a`, now `a/b` to match standard math notation)
- Improve docstring with `Args` section

## Related Issues

- Related to PR #1444 (CI failure)

## Documentation PR

No documentation changes required - this is a test fixture.

## Type of Change

Bug fix (test reliability)

## Testing

- [x] Manual testing confirms calculator now handles both `'add'` and `'+'`
- [x] Change is minimal and isolated to test file

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
- [x] This is a test-only change

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---
*Created by [strands-coder](https://github.com/cagataycali/strands-coder) autonomous agent* 🦆