### PR TITLE
chore: Update release notes sop

### DIFF
--- a/.github/agent-sops/task-release-notes.sop.md
+++ b/.github/agent-sops/task-release-notes.sop.md
@@ -246,8 +246,8 @@ Validation tests MUST verify the actual behavior of the feature, not just syntax
 
 **Available Testing Resources:**
 - **Amazon Bedrock**: You have access to Bedrock models for testing. Use Bedrock when a feature requires a real model provider.
-- **Project test fixtures**: The project includes mocked model providers and test utilities in `tests/fixtures/`
-- **Integration test patterns**: Examine `tests_integ/` for patterns that test real model interactions
+- **Project test fixtures**: The project includes mocked model providers and test utilities (commonly in `tests/fixtures/`, `__mocks__/`, or similar)
+- **Integration test patterns**: Examine integration test directories (commonly in `tests_integ/` or `test/integ`) for patterns that test real model interactions
 
 **Features that genuinely cannot be validated (rare):**
 - Features requiring paid third-party API credentials with no mock option AND no Bedrock alternative
@@ -274,7 +274,7 @@ Validation tests MUST verify the actual behavior of the feature, not just syntax
 - You MAY need to setup test fixtures that enable behavioral verification
 - You MAY include additional test code that doesn't appear in the release notes
 
-**Example of GOOD validation** (verifies behavior):
+**Example of GOOD validation** (verifies behavior) - adapt syntax to project language:
 ```python
 def test_structured_output_validation():
     """Verify that structured output actually validates against the schema."""
@@ -294,7 +294,7 @@ def test_structured_output_validation():
     assert isinstance(result.output.age, int)
 ```
 
-**Example of BAD validation** (only verifies syntax):
+**Example of BAD validation** (only verifies syntax) - adapt syntax to project language:
 ```python
 def test_structured_output_syntax():
     """BAD: This only verifies the code runs without errors."""
@@ -320,7 +320,7 @@ For each Major Feature, follow this workflow in order:
    - Try using Bedrock instead of other model providers
    - Try installing missing dependencies
    - Try mocking external services
-   - Try using project test fixtures (`tests/fixtures/mocked_model_provider.py`)
+   - Try using project test fixtures (e.g., mocked model providers)
    - Try simplifying the example
 4. **Document each attempt** and its result in the Validation Comment
 5. **Only after documented failures** can you use the engineer review fallback
@@ -337,12 +337,12 @@ For each Major Feature, follow this workflow in order:
 
 **Installing Dependencies:**
 - You MUST attempt to install missing dependencies when tests fail due to import errors
-- You SHOULD check the project's `pyproject.toml`, `package.json`, or equivalent for optional dependency groups
-- You SHOULD use the project's package manager to install dependencies (e.g., `pip install`, `npm install`, `hatch`)
-- For Python projects with optional extras, try: `pip install -e ".[extra_name]"` or `pip install package_name`
+- You SHOULD check the project's dependency manifest (`pyproject.toml`, `package.json`, `Cargo.toml`, etc.) for optional dependency groups
+- You SHOULD use the project's package manager to install dependencies (e.g., `pip install`, `npm install`, `cargo add`)
+- For projects with optional extras, use the appropriate syntax (e.g., `pip install -e ".[extra]"` for Python, `npm install --save-dev` for Node.js)
 - You SHOULD only fall back to mocking if the dependency cannot be installed (e.g., requires paid API keys, proprietary software)
 
-**Example of mocking external dependencies:**
+**Example of mocking external dependencies** - adapt syntax to project language:
 ```python
 def test_custom_http_client():
     """Verify custom HTTP client is passed to the provider."""


### PR DESCRIPTION

## Description

Update the release notes SOP that was most effective after several iterations of having it generate the v1.21.0 release notes - final flow is at https://github.com/zastrowm/sdk-python/issues/19.

The flow on this was tweaking the SOP and then running the agent, and attempting to have it update in response.  The biggest problems to solve was that:

 - It blindly trusted examples in PRs, resulting in examples that were wrong because of stale PRs
 - It would not generate useful tests

I do not have the step-by-steps results with the different prompt variants as I deleted the older issues to avoid too many references being added to old PRs, but viewing the [final issue with results](https://github.com/zastrowm/sdk-python/issues/19) shows the SOP results with one shot run after verifying which features should go in.


## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Agent Change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
