### PR TITLE
fix(bedrock): emit contentBlockStart event for text, reasoning, and citations content

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -812,6 +812,8 @@ class BedrockModel(Model):
 
                 yield {"contentBlockDelta": {"delta": {"toolUse": {"input": input_value}}}}
             elif "text" in content:
+                # Yield contentBlockStart for text content
+                yield {"contentBlockStart": {"start": {}}}
                 # Then yield the text as a delta
                 yield {
                     "contentBlockDelta": {
@@ -819,6 +821,8 @@ class BedrockModel(Model):
                     }
                 }
             elif "reasoningContent" in content:
+                # Yield contentBlockStart for reasoning content
+                yield {"contentBlockStart": {"start": {}}}
                 # Then yield the reasoning content as a delta
                 yield {
                     "contentBlockDelta": {
@@ -837,6 +841,8 @@ class BedrockModel(Model):
                         }
                     }
             elif "citationsContent" in content:
+                # Yield contentBlockStart for citations content
+                yield {"contentBlockStart": {"start": {}}}
                 # For non-streaming citations, emit text and metadata deltas in sequence
                 # to match streaming behavior where they flow naturally
                 if "content" in content["citationsContent"]:

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1090,6 +1090,7 @@ async def test_stream_with_streaming_false(bedrock_client, alist, messages):
     tru_events = await alist(response)
     exp_events = [
         {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
         {"contentBlockDelta": {"delta": {"text": "test"}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "end_turn", "additionalModelResponseFields": None}},
@@ -1157,6 +1158,7 @@ async def test_stream_with_streaming_false_and_reasoning(bedrock_client, alist, 
     tru_events = await alist(response)
     exp_events = [
         {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
         {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "Thinking really hard...."}}}},
         {"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "123"}}}},
         {"contentBlockStop": {}},
@@ -1195,6 +1197,7 @@ async def test_stream_and_reasoning_no_signature(bedrock_client, alist, messages
     tru_events = await alist(response)
     exp_events = [
         {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
         {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "Thinking really hard...."}}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "tool_use", "additionalModelResponseFields": None}},
@@ -1222,6 +1225,7 @@ async def test_stream_with_streaming_false_with_metrics_and_usage(bedrock_client
     tru_events = await alist(response)
     exp_events = [
         {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
         {"contentBlockDelta": {"delta": {"text": "test"}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "tool_use", "additionalModelResponseFields": None}},
@@ -1263,6 +1267,7 @@ async def test_stream_input_guardrails(bedrock_client, alist, messages):
     tru_events = await alist(response)
     exp_events = [
         {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
         {"contentBlockDelta": {"delta": {"text": "test"}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "end_turn", "additionalModelResponseFields": None}},
@@ -1314,6 +1319,7 @@ async def test_stream_output_guardrails(bedrock_client, alist, messages):
     tru_events = await alist(response)
     exp_events = [
         {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
         {"contentBlockDelta": {"delta": {"text": "test"}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "end_turn", "additionalModelResponseFields": None}},
@@ -1367,6 +1373,7 @@ async def test_stream_output_guardrails_redacts_output(bedrock_client, alist, me
     tru_events = await alist(response)
     exp_events = [
         {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
         {"contentBlockDelta": {"delta": {"text": "test"}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "end_turn", "additionalModelResponseFields": None}},


### PR DESCRIPTION
## Description

Fixes the missing `contentBlockStart` event in the async streaming event flow for Bedrock's non-streaming path.

### Problem
When using `agent.stream_async()` with Bedrock (streaming=False), the `contentBlockStart` event was not emitted before `contentBlockDelta` for text, reasoning, and citations content. The event flow was:

```
messageStart -> contentBlockDelta -> ... -> contentBlockStop -> messageStop
```

But it should be:
```
messageStart -> contentBlockStart -> contentBlockDelta -> ... -> contentBlockStop -> messageStop
```

### Root Cause
The `_convert_non_streaming_to_streaming()` method in `bedrock.py` only emitted `contentBlockStart` for `toolUse` content blocks, but not for:
- `text` content
- `reasoningContent`
- `citationsContent`

### Fix
Added `yield {"contentBlockStart": {"start": {}}}` before `contentBlockDelta` for all content types, aligning with other model providers (Anthropic, OpenAI, Ollama, etc.) that already emit `contentBlockStart` for text content.

## Related Issues

Fixes #1460

## Documentation PR

No documentation changes required.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] I ran `hatch run prepare` (locally tested bedrock model tests)
- All 94 bedrock model tests pass
- Updated expected events in relevant tests to include `contentBlockStart`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective
- [x] I have updated the documentation accordingly (N/A)
- [x] My changes generate no new warnings

---

🦆

---
🤖 *This is an experimental AI agent response from the Strands team, powered by [Strands Agents](https://github.com/strands-agents). We're exploring how AI agents can help with community support and development. Your feedback helps us improve! If you'd prefer human assistance, please let us know.*