### PR TITLE
feat(telemetry): add configuration to disable OpenTelemetry instrumentation

### DIFF
--- a/tests/strands/tools/test_decorator_pep563.py
+++ b/tests/strands/tools/test_decorator_pep563.py
@@ -10,10 +10,10 @@ https://github.com/strands-agents/sdk-python/issues/1208
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import pytest
-from typing_extensions import Literal, TypedDict
+from typing_extensions import TypedDict
 
 from strands import tool
 


### PR DESCRIPTION
## Description

Adds an `enabled` parameter to `StrandsTelemetry` class that allows disabling OpenTelemetry instrumentation. This addresses the use case where Strands Agents is used as part of a system that already has OpenTelemetry enabled, and the user doesn't want to include child spans from Strands.

## Related Issues

Resolves #1059

## Documentation PR

No documentation changes required - the feature is self-documenting via docstrings and follows the existing patterns.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

### `StrandsTelemetry` class enhancements:

1. **New `enabled` parameter** in constructor:
   - Defaults to `True` unless `STRANDS_OTEL_ENABLED` environment variable is set to `false`/`0`/`no`/`off`
   - Explicit `enabled=False` overrides environment variable

2. **`NoOpTracerProvider` usage**:
   - When disabled, uses OpenTelemetry's built-in `NoOpTracerProvider` instead of `SDKTracerProvider`
   - No spans are created or exported

3. **No-op setup methods**:
   - `setup_console_exporter()`, `setup_otlp_exporter()`, and `setup_meter()` become no-ops when disabled
   - Methods still return `self` to maintain method chaining compatibility

4. **New `enabled` property**:
   - Read-only property to check if telemetry is enabled

## Usage Examples

```python
# Disable via constructor
StrandsTelemetry(enabled=False)

# Disable via environment variable
# export STRANDS_OTEL_ENABLED=false
StrandsTelemetry()  # Will use NoOpTracerProvider

# Method chaining still works when disabled
StrandsTelemetry(enabled=False).setup_console_exporter().setup_otlp_exporter()
```

## Testing

Added 10 new unit tests covering:
- Disabling via constructor
- Disabling via environment variable (multiple formats: `false`, `0`, `off`, `no`)
- Explicit enable overriding environment variable
- No-op behavior of setup methods when disabled
- Method chaining compatibility when disabled

- [x] I ran `hatch run prepare` (all checks pass locally)

## CI Status Notes

✅ **All unit tests pass** (Python 3.10-3.13 on Linux, Windows, macOS)
✅ **Lint checks pass** (rebased onto latest main)
⚠️ **check-api failure is EXPECTED and ACCEPTABLE** - This PR intentionally adds a new public API parameter (`enabled`) to `StrandsTelemetry`. This is a non-breaking addition (defaults maintain existing behavior).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective
- [x] My changes generate no new warnings
- [x] This is a non-breaking change (existing code continues to work unchanged)

---

🤖 *This is an experimental AI agent response from the Strands team, powered by [Strands Agents](https://github.com/strands-agents). We're exploring how AI agents can help with community support and development. Your feedback helps us improve! If you'd prefer human assistance, please let us know.*