### PR TITLE
fix(deps): add CRT support to boto3 and botocore for aws login

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "boto3[crt]>=1.26.0,<2.0.0",
-    "botocore[crt]>=1.29.0,<2.0.0",
+    "boto3>=1.26.0,<2.0.0",
+    "botocore>=1.29.0,<2.0.0",
     "docstring_parser>=0.15,<1.0",
     "jsonschema>=4.0.0,<5.0.0",
     "mcp>=1.11.0,<2.0.0",
@@ -43,6 +43,7 @@ dependencies = [
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.21.0,<1.0.0"]
+crt = ["boto3[crt]>=1.26.0,<2.0.0", "botocore[crt]>=1.29.0,<2.0.0"]
 gemini = ["google-genai>=1.32.0,<2.0.0"]
 litellm = ["litellm>=1.75.9,<2.0.0", "openai>=1.68.0,<1.110.0"]
 llamaapi = ["llama-api-client>=0.1.0,<1.0.0"]


### PR DESCRIPTION
## Description

Enable CRT (Common Runtime) support in boto3 and botocore to support the new `aws login` command for authentication. This provides browser-based credential generation with short-lived temporary credentials, improving security by reducing the need for long-lived programmatic access keys.

References:
- https://aws.amazon.com/blogs/security/simplified-developer-access-to-aws-with-aws-login/
- https://aws.amazon.com/about-aws/whats-new/2025/11/console-credentials-aws-cli-sdk-authentication/

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
