### PR TITLE
fix(agent): extract text from citationsContent in AgentResult.__str__

### DIFF
--- a/src/strands/agent/agent_result.py
+++ b/src/strands/agent/agent_result.py
@@ -48,8 +48,15 @@ class AgentResult:
 
         result = ""
         for item in content_array:
-            if isinstance(item, dict) and "text" in item:
-                result += item.get("text", "") + "\n"
+            if isinstance(item, dict):
+                if "text" in item:
+                    result += item.get("text", "") + "\n"
+                elif "citationsContent" in item:
+                    citations_block = item["citationsContent"]
+                    if "content" in citations_block:
+                        for content in citations_block["content"]:
+                            if isinstance(content, dict) and "text" in content:
+                                result += content.get("text", "") + "\n"
 
         if not result and self.structured_output:
             result = self.structured_output.model_dump_json()

--- a/tests/strands/agent/test_agent_result.py
+++ b/tests/strands/agent/test_agent_result.py
@@ -225,3 +225,61 @@ def test__str__empty_message_with_structured_output(mock_metrics, empty_message:
     assert "example" in message_string
     assert "123" in message_string
     assert "optional" in message_string
+
+
+@pytest.fixture
+def citations_message():
+    """Message with citationsContent block."""
+    return {
+        "role": "assistant",
+        "content": [
+            {
+                "citationsContent": {
+                    "citations": [
+                        {
+                            "title": "Source Document",
+                            "location": {"document": {"pageNumber": 1}},
+                            "sourceContent": [{"text": "source text"}],
+                        }
+                    ],
+                    "content": [{"text": "This is cited text from the document."}],
+                }
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def mixed_text_and_citations_message():
+    """Message with both plain text and citationsContent blocks."""
+    return {
+        "role": "assistant",
+        "content": [
+            {"text": "Introduction paragraph"},
+            {
+                "citationsContent": {
+                    "citations": [{"title": "Doc", "location": {}, "sourceContent": []}],
+                    "content": [{"text": "Cited content here."}],
+                }
+            },
+            {"text": "Conclusion paragraph"},
+        ],
+    }
+
+
+def test__str__with_citations_content(mock_metrics, citations_message: Message):
+    """Test that str() extracts text from citationsContent blocks."""
+    result = AgentResult(stop_reason="end_turn", message=citations_message, metrics=mock_metrics, state={})
+
+    message_string = str(result)
+    assert message_string == "This is cited text from the document.\n"
+
+
+def test__str__mixed_text_and_citations_content(mock_metrics, mixed_text_and_citations_message: Message):
+    """Test that str() works with both plain text and citationsContent blocks."""
+    result = AgentResult(
+        stop_reason="end_turn", message=mixed_text_and_citations_message, metrics=mock_metrics, state={}
+    )
+
+    message_string = str(result)
+    assert message_string == "Introduction paragraph\nCited content here.\nConclusion paragraph\n"


### PR DESCRIPTION

## Description

  `AgentResult.__str__()` skips text contained in citationsContent blocks. When citations are enabled, streaming generates `{"citationsContent": {"citations": [...], "content": [{"text": "..."}]}}` structure, but `__str__()` only processes plain `{"text": "..."}` blocks. This causes text from cited responses to be missing when converting the result to string.

  This fix adds handling for citationsContent blocks in `AgentResult.__str__()` to extract text from nested content.


## Related Issues

<!-- Link to related issues using #issue-number format -->

closes #1488

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
