### PR TITLE
feat(types): add native audio support to ContentBlock type

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -533,6 +533,16 @@ class BedrockModel(Model):
             result = {"format": video["format"], "source": formatted_source}
             return {"video": result}
 
+        # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_AudioBlock.html
+        if "audio" in content:
+            audio = content["audio"]
+            source = audio["source"]
+            formatted_source = {}
+            if "bytes" in source:
+                formatted_source = {"bytes": source["bytes"]}
+            result = {"format": audio["format"], "source": formatted_source}
+            return {"audio": result}
+
         # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CitationsContentBlock.html
         if "citationsContent" in content:
             citations = content["citationsContent"]

--- a/src/strands/multiagent/a2a/executor.py
+++ b/src/strands/multiagent/a2a/executor.py
@@ -27,6 +27,8 @@ from ...agent.agent import Agent as SAAgent
 from ...agent.agent import AgentResult as SAAgentResult
 from ...types.content import ContentBlock
 from ...types.media import (
+    AudioContent,
+    AudioSource,
     DocumentContent,
     DocumentSource,
     ImageContent,
@@ -46,7 +48,7 @@ class StrandsA2AExecutor(AgentExecutor):
     """
 
     # Default formats for each file type when MIME type is unavailable or unrecognized
-    DEFAULT_FORMATS = {"document": "txt", "image": "png", "video": "mp4", "unknown": "txt"}
+    DEFAULT_FORMATS = {"audio": "mp3", "document": "txt", "image": "png", "video": "mp4", "unknown": "txt"}
 
     # Handle special cases where format differs from extension
     FORMAT_MAPPINGS = {"jpg": "jpeg", "htm": "html", "3gp": "three_gp", "3gpp": "three_gp", "3g2": "three_gp"}
@@ -231,7 +233,9 @@ class StrandsA2AExecutor(AgentExecutor):
         logger.warning("Cancellation requested but not supported")
         raise ServerError(error=UnsupportedOperationError())
 
-    def _get_file_type_from_mime_type(self, mime_type: str | None) -> Literal["document", "image", "video", "unknown"]:
+    def _get_file_type_from_mime_type(
+        self, mime_type: str | None
+    ) -> Literal["audio", "document", "image", "video", "unknown"]:
         """Classify file type based on MIME type.
 
         Args:
@@ -247,6 +251,8 @@ class StrandsA2AExecutor(AgentExecutor):
 
         if mime_type.startswith("image/"):
             return "image"
+        elif mime_type.startswith("audio/"):
+            return "audio"
         elif mime_type.startswith("video/"):
             return "video"
         elif (
@@ -347,6 +353,15 @@ class StrandsA2AExecutor(AgentExecutor):
                                     image=ImageContent(
                                         format=file_format,  # type: ignore
                                         source=ImageSource(bytes=decoded_bytes),
+                                    )
+                                )
+                            )
+                        elif file_type == "audio":
+                            content_blocks.append(
+                                ContentBlock(
+                                    audio=AudioContent(
+                                        format=file_format,  # type: ignore
+                                        source=AudioSource(bytes=decoded_bytes),
                                     )
                                 )
                             )

--- a/src/strands/types/content.py
+++ b/src/strands/types/content.py
@@ -11,7 +11,7 @@ from typing import Literal
 from typing_extensions import TypedDict
 
 from .citations import CitationsContentBlock
-from .media import DocumentContent, ImageContent, VideoContent
+from .media import AudioContent, DocumentContent, ImageContent, VideoContent
 from .tools import ToolResult, ToolUse
 
 
@@ -75,6 +75,7 @@ class ContentBlock(TypedDict, total=False):
     """A block of content for a message that you pass to, or receive from, a model.
 
     Attributes:
+        audio: Audio to include in the message.
         cachePoint: A cache point configuration to optimize conversation history.
         document: A document to include in the message.
         guardContent: Contains the content to assess with the guardrail.
@@ -87,6 +88,7 @@ class ContentBlock(TypedDict, total=False):
         citationsContent: Contains the citations for a document.
     """
 
+    audio: AudioContent
     cachePoint: CachePoint
     document: DocumentContent
     guardContent: GuardContent

--- a/src/strands/types/media.py
+++ b/src/strands/types/media.py
@@ -91,3 +91,29 @@ class VideoContent(TypedDict):
 
     format: VideoFormat
     source: VideoSource
+
+
+AudioFormat = Literal["mp3", "wav", "flac", "ogg", "webm"]
+"""Supported audio formats."""
+
+
+class AudioSource(TypedDict):
+    """Contains the content of an audio file.
+
+    Attributes:
+        bytes: The binary content of the audio.
+    """
+
+    bytes: bytes
+
+
+class AudioContent(TypedDict):
+    """An audio file to include in a message.
+
+    Attributes:
+        format: The format of the audio (e.g., "mp3", "wav").
+        source: The source containing the audio's binary content.
+    """
+
+    format: AudioFormat
+    source: AudioSource

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2240,3 +2240,30 @@ async def test_format_request_with_guardrail_latest_message(model):
     # Latest user message image should also be wrapped
     assert "guardContent" in formatted_messages[2]["content"][1]
     assert formatted_messages[2]["content"][1]["guardContent"]["image"]["format"] == "png"
+
+
+def test_format_request_filters_audio_content_blocks(model, model_id):
+    """Test that format_request filters extra fields from audio content blocks."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "audio": {
+                        "format": "mp3",
+                        "source": {"bytes": b"audio_data"},
+                        "duration": 60,  # Extra field that should be filtered
+                        "bitrate": "320kbps",  # Extra field that should be filtered
+                    }
+                },
+            ],
+        }
+    ]
+
+    formatted_request = model._format_request(messages)
+
+    audio_block = formatted_request["messages"][0]["content"][0]["audio"]
+    expected = {"format": "mp3", "source": {"bytes": b"audio_data"}}
+    assert audio_block == expected
+    assert "duration" not in audio_block
+    assert "bitrate" not in audio_block

--- a/tests/strands/types/test_media.py
+++ b/tests/strands/types/test_media.py
@@ -1,0 +1,70 @@
+"""Tests for media type definitions."""
+
+
+from strands.types.media import (
+    AudioContent,
+    AudioSource,
+    DocumentContent,
+    ImageContent,
+    VideoContent,
+)
+
+
+def test_audio_content_type():
+    """Test AudioContent TypedDict creation."""
+    audio: AudioContent = {
+        "format": "mp3",
+        "source": {"bytes": b"audio_data"},
+    }
+    assert audio["format"] == "mp3"
+    assert audio["source"]["bytes"] == b"audio_data"
+
+
+def test_audio_source_type():
+    """Test AudioSource TypedDict creation."""
+    source: AudioSource = {"bytes": b"test_audio"}
+    assert source["bytes"] == b"test_audio"
+
+
+def test_audio_format_literals():
+    """Test that all expected audio formats are valid."""
+    valid_formats = ["mp3", "wav", "flac", "ogg", "webm"]
+    for fmt in valid_formats:
+        # This would be a type error if fmt wasn't a valid AudioFormat
+        audio: AudioContent = {
+            "format": fmt,  # type: ignore  # Testing runtime behavior
+            "source": {"bytes": b"data"},
+        }
+        assert audio["format"] == fmt
+
+
+def test_image_content_type():
+    """Test ImageContent TypedDict creation."""
+    image: ImageContent = {
+        "format": "png",
+        "source": {"bytes": b"image_data"},
+    }
+    assert image["format"] == "png"
+    assert image["source"]["bytes"] == b"image_data"
+
+
+def test_video_content_type():
+    """Test VideoContent TypedDict creation."""
+    video: VideoContent = {
+        "format": "mp4",
+        "source": {"bytes": b"video_data"},
+    }
+    assert video["format"] == "mp4"
+    assert video["source"]["bytes"] == b"video_data"
+
+
+def test_document_content_type():
+    """Test DocumentContent TypedDict creation."""
+    doc: DocumentContent = {
+        "format": "pdf",
+        "name": "test.pdf",
+        "source": {"bytes": b"pdf_data"},
+    }
+    assert doc["format"] == "pdf"
+    assert doc["name"] == "test.pdf"
+    assert doc["source"]["bytes"] == b"pdf_data"


### PR DESCRIPTION
## Description

Add native audio content block support to the SDK, following the same pattern as existing video support. This enables type-safe audio handling for multimodal models.

### Changes

**Types (`src/strands/types/media.py`):**
- Add `AudioFormat` Literal type for supported formats: `mp3`, `wav`, `flac`, `ogg`, `webm`
- Add `AudioSource` TypedDict with `bytes` field
- Add `AudioContent` TypedDict with `format` and `source` fields

**Content Block (`src/strands/types/content.py`):**
- Add `audio` field to `ContentBlock` TypedDict
- Import and use `AudioContent` type

**Bedrock Provider (`src/strands/models/bedrock.py`):**
- Add audio handling in `_format_request_message_content` method
- Follow same pattern as video handling (lines 526-534)

**A2A Executor (`src/strands/multiagent/a2a/executor.py`):**
- Add `AudioContent` and `AudioSource` imports
- Add `audio` to `DEFAULT_FORMATS`
- Add audio MIME type detection in `_get_file_type_from_mime_type`
- Add audio content block creation in file handling

**Tests:**
- Add `test_format_request_filters_audio_content_blocks` in `tests/strands/models/test_bedrock.py`
- Add new `tests/strands/types/test_media.py` with comprehensive media type tests

## Related Issues

Closes #866

## Documentation PR

No documentation changes required - this follows existing patterns for video/image.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`
- [x] All existing tests pass
- [x] New tests added for audio content handling

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.