### PR TITLE
fix(litellm): handle missing usage attribute on ModelResponseStream

### DIFF
--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -547,8 +547,8 @@ class LiteLLMModel(OpenAIModel):
         # Skip remaining events as we don't have use for anything except the final usage payload
         async for event in response:
             _ = event
-            if event.usage:
-                yield self.format_chunk({"chunk_type": "metadata", "data": event.usage})
+            if usage := getattr(event, "usage", None):
+                yield self.format_chunk({"chunk_type": "metadata", "data": usage})
 
         logger.debug("finished streaming response from model")
 


### PR DESCRIPTION
 Fix `AttributeError: 'ModelResponseStream' object has no attribute 'usage'` when streaming with LiteLLM.

   ### The Bug

Core bug was that this was moved inside the for loop but now we can safely check during each event https://github.com/strands-agents/sdk-python/blob/3efc9c01ebfd1e6ca1f6c555d78a2b5bd861561b/src/strands/models/litellm.py#L337
   ### Why Unit Tests Didn't Catch It

   The existing unit tests used `unittest.mock.Mock()` which auto-creates attributes on demand. So `mock_event.usage` returns another Mock object (truthy) instead of raising
   `AttributeError`.

   ### Why Integration Tests Didn't Catch It

   With Bedrock through LiteLLM, after `finish_reason` is received, typically only ONE more event is sent and it HAS the `usage` attribute. So the bug doesn't trigger in that
   specific provider flow. However, different providers/configurations may send multiple trailing events, not all with the `usage` attribute.

   ### The Fix

   Changed to use `getattr()` with a default of `None`:

   ```python
   # After (fixed):
   if usage := getattr(event, "usage", None):
       yield self.format_chunk({"chunk_type": "metadata", "data": usage})
   ```

   This matches the pattern used in the OpenAI parent class.

   ### Tests Added

   **Unit tests** (`tests/strands/models/test_litellm.py`):
   - `test_stream_with_events_missing_usage_attribute` - Uses explicit class (not Mock) to verify no `AttributeError` when events lack `usage`
   - `test_stream_with_usage_in_final_event` - Verifies usage is correctly extracted when present

   **Integration test** (`tests_integ/models/test_model_litellm.py`):
   - `test_streaming_returns_usage_metrics` - Parameterized test for both streaming and non-streaming that asserts usage metrics are returned

   ## Related Issues

   Fixes the bug introduced in commit 2f04bc0 (feat(litellm): handle litellm non streaming responses #512)

   ## Documentation PR

   N/A

   ## Type of Change

   Bug fix

   ## Testing

   - [x] I ran `hatch run prepare`
   - [x] Added unit tests with explicit class mocks that properly simulate real LiteLLM behavior
   - [x] Added integration test that verifies usage metrics are returned

   ## Checklist
   - [x] I have read the CONTRIBUTING document
   - [x] I have added any necessary tests that prove my fix is effective or my feature works
   - [x] I have updated the documentation accordingly
   - [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
   - [x] My changes generate no new warnings
   - [x] Any dependent changes have been merged and published

   ----
