### PR TITLE
fix: Populate tool_args correctly for steering

### DIFF
--- a/src/strands/experimental/steering/context_providers/ledger_provider.py
+++ b/src/strands/experimental/steering/context_providers/ledger_provider.py
@@ -47,7 +47,7 @@ class LedgerBeforeToolCall(SteeringContextCallback[BeforeToolCallEvent]):
         tool_call_entry = {
             "timestamp": datetime.now().isoformat(),
             "tool_name": event.tool_use.get("name"),
-            "tool_args": event.tool_use.get("arguments", {}),
+            "tool_args": event.tool_use.get("input", {}),
             "status": "pending",
         }
         ledger["tool_calls"].append(tool_call_entry)

--- a/tests/strands/experimental/steering/context_providers/test_ledger_provider.py
+++ b/tests/strands/experimental/steering/context_providers/test_ledger_provider.py
@@ -30,7 +30,7 @@ def test_ledger_before_tool_call_new_ledger(mock_datetime):
     callback = LedgerBeforeToolCall()
     steering_context = SteeringContext()
 
-    tool_use = {"name": "test_tool", "arguments": {"param": "value"}}
+    tool_use = {"name": "test_tool", "input": {"param": "value"}}
     event = Mock(spec=BeforeToolCallEvent)
     event.tool_use = tool_use
 
@@ -65,7 +65,7 @@ def test_ledger_before_tool_call_existing_ledger(mock_datetime):
     }
     steering_context.data.set("ledger", existing_ledger)
 
-    tool_use = {"name": "new_tool", "arguments": {"param": "value"}}
+    tool_use = {"name": "new_tool", "input": {"param": "value"}}
     event = Mock(spec=BeforeToolCallEvent)
     event.tool_use = tool_use
 

--- a/tests/strands/experimental/steering/core/test_handler.py
+++ b/tests/strands/experimental/steering/core/test_handler.py
@@ -241,7 +241,7 @@ def test_context_callbacks_receive_steering_context():
 
     # Create a mock event and call the callback
     event = Mock(spec=BeforeToolCallEvent)
-    event.tool_use = {"name": "test_tool", "arguments": {}}
+    event.tool_use = {"name": "test_tool", "input": {}}
 
     # The callback should execute without error and update the steering context
     before_callback(event)


### PR DESCRIPTION
## Description
Currently, the ledger tool_args is never populated. This fix populates it from the correct field in BeforeToolCallEvent, and adds integ tests to verify that the ledger is populated correctly.

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
