### PR TITLE
test: fix flaky openai structured output test by adding Field guidance

### DIFF
--- a/tests_integ/models/test_model_openai.py
+++ b/tests_integ/models/test_model_openai.py
@@ -45,10 +45,10 @@ def agent(model, tools):
 @pytest.fixture
 def weather():
     class Weather(pydantic.BaseModel):
-        """Extracts the time and weather from the user's message with the exact strings."""
+        """Extract time and weather values."""
 
-        time: str
-        weather: str
+        time: str = pydantic.Field(description="The time value only, e.g. '14:30' not 'The time is 14:30'")
+        weather: str = pydantic.Field(description="The weather condition only, e.g. 'rainy' not 'the weather is rainy'")
 
     return Weather(time="12:00", weather="sunny")
 


### PR DESCRIPTION
## Description


The following test failed in https://github.com/strands-agents/sdk-python/actions/runs/21082854772.

Anecdotally, I have seen this test fail before. I believe the additional description will reduce the flakiness of this test. I ran 10 times and it passed all 10 locally.


## Type of Change

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
