### PR TITLE
interrupts - multiagent - do not emit AfterNodeCallEvent on interrupt

### DIFF
--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -1005,7 +1005,8 @@ class Graph(MultiAgentBase):
             raise
 
         finally:
-            await self.hooks.invoke_callbacks_async(AfterNodeCallEvent(self, node.node_id, invocation_state))
+            if node.execution_status != Status.INTERRUPTED:
+                await self.hooks.invoke_callbacks_async(AfterNodeCallEvent(self, node.node_id, invocation_state))
 
     def _accumulate_metrics(self, node_result: NodeResult) -> None:
         """Accumulate metrics from a node result."""

--- a/src/strands/multiagent/swarm.py
+++ b/src/strands/multiagent/swarm.py
@@ -782,9 +782,10 @@ class Swarm(MultiAgentBase):
                     break
 
                 finally:
-                    await self.hooks.invoke_callbacks_async(
-                        AfterNodeCallEvent(self, current_node.node_id, invocation_state)
-                    )
+                    if self.state.completion_status != Status.INTERRUPTED:
+                        await self.hooks.invoke_callbacks_async(
+                            AfterNodeCallEvent(self, current_node.node_id, invocation_state)
+                        )
 
                 logger.debug("node=<%s> | node execution completed", current_node.node_id)
 

--- a/tests/strands/multiagent/conftest.py
+++ b/tests/strands/multiagent/conftest.py
@@ -1,15 +1,22 @@
 import pytest
 
-from strands.hooks import BeforeNodeCallEvent, HookProvider
+from strands.hooks import AfterNodeCallEvent, BeforeNodeCallEvent, HookProvider
 
 
 @pytest.fixture
 def interrupt_hook():
     class Hook(HookProvider):
+        def __init__(self):
+            self.after_count = 0
+
         def register_hooks(self, registry):
             registry.add_callback(BeforeNodeCallEvent, self.interrupt)
+            registry.add_callback(AfterNodeCallEvent, self.cleanup)
 
         def interrupt(self, event):
             return event.interrupt("test_name", reason="test_reason")
+
+        def cleanup(self, event):
+            self.after_count += 1
 
     return Hook()

--- a/tests/strands/multiagent/test_graph.py
+++ b/tests/strands/multiagent/test_graph.py
@@ -2126,6 +2126,10 @@ def test_graph_interrupt_on_before_node_call_event(interrupt_hook):
     ]
     assert tru_interrupts == exp_interrupts
 
+    tru_after_count = interrupt_hook.after_count
+    exp_after_count = 0
+    assert tru_after_count == exp_after_count
+
     interrupt = multiagent_result.interrupts[0]
     responses = [
         {
@@ -2151,5 +2155,9 @@ def test_graph_interrupt_on_before_node_call_event(interrupt_hook):
     tru_message = agent_result.result.message["content"][0]["text"]
     exp_message = "Task completed"
     assert tru_message == exp_message
+
+    tru_after_count = interrupt_hook.after_count
+    exp_after_count = 1
+    assert tru_after_count == exp_after_count
 
     assert multiagent_result.execution_time >= first_execution_time

--- a/tests/strands/multiagent/test_swarm.py
+++ b/tests/strands/multiagent/test_swarm.py
@@ -1259,6 +1259,10 @@ def test_swarm_interrupt_on_before_node_call_event(interrupt_hook):
     ]
     assert tru_interrupts == exp_interrupts
 
+    tru_after_count = interrupt_hook.after_count
+    exp_after_count = 0
+    assert tru_after_count == exp_after_count
+
     interrupt = multiagent_result.interrupts[0]
     responses = [
         {
@@ -1280,6 +1284,10 @@ def test_swarm_interrupt_on_before_node_call_event(interrupt_hook):
     tru_message = agent_result.result.message["content"][0]["text"]
     exp_message = "Task completed"
     assert tru_message == exp_message
+
+    tru_after_count = interrupt_hook.after_count
+    exp_after_count = 1
+    assert tru_after_count == exp_after_count
 
     assert multiagent_result.execution_time >= first_execution_time
 


### PR DESCRIPTION
## Description
For single-agents, if a tool is interrupted, we do not emit the AfterToolCallEvent ([src](https://github.com/strands-agents/sdk-python/blob/main/src/strands/tools/executors/_executor.py)). There are a few motivations for this behavior:
* AfterToolCallEvent expects a tool result which we won't have until after the tool finishes executing.
* By its name, AfterToolCallEvent should happen after the tool is called, which is not the case if we are in the middle of processing an interrupt.

For multi-agents, we always emit an AfterNodeCallEvent even if the node is interrupted. In this PR, we fix the behavior to match AfterToolCallEvent. We will not emit an AfterNodeCallEvent if the node is in the middle of an interrupt.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1538

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: Wrote new unit tests
- [x] I ran `hatch test tests_integ/interrupts/multiagent`: Relying on existing integ tests

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
