### PR TITLE
ci: limit permission scope on lambda layer github action

### DIFF
--- a/.github/workflows/publish-lambda-layer.yml
+++ b/.github/workflows/publish-lambda-layer.yml
@@ -38,6 +38,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Validate confirmation
         run: |


### PR DESCRIPTION
## Description

  CodeQL flagged a missing permissions block on the validate job in the Lambda layer publish workflow.   
  Without explicit permissions, the job inherits the default repository GITHUB_TOKEN permissions, which  
  violates the principle of least privilege.                                                             
                                                                                                         
  The validate job only runs a bash string comparison to confirm user intent—it doesn't interact with    
  GitHub APIs or access repository contents. Explicitly setting empty permissions ensures this job has no
   unnecessary access, consistent with how other workflows in this repository are configured.            
                                                                                                         
  Resolves: https://github.com/strands-agents/sdk-python/security/code-scanning/8
## Related Issues

#636 

## Documentation PR

N/A

## Type of Change


Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
