### PR TITLE
[FIX] models - gemini - start and stop reasoningContent

### DIFF
--- a/tests/strands/models/test_gemini.py
+++ b/tests/strands/models/test_gemini.py
@@ -523,10 +523,8 @@ async def test_stream_response_tool_use(gemini_client, model, messages, agenerat
     tru_chunks = await alist(model.stream(messages))
     exp_chunks = [
         {"messageStart": {"role": "assistant"}},
-        {"contentBlockStart": {"start": {}}},
         {"contentBlockStart": {"start": {"toolUse": {"name": "calculator", "toolUseId": "c1"}}}},
         {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"expression": "2+2"}'}}}},
-        {"contentBlockStop": {}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "tool_use"}},
         {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
@@ -564,8 +562,6 @@ async def test_stream_response_reasoning(gemini_client, model, messages, agenera
     tru_chunks = await alist(model.stream(messages))
     exp_chunks = [
         {"messageStart": {"role": "assistant"}},
-        {"contentBlockStart": {"start": {}}},
-        {"contentBlockStop": {}},
         {"contentBlockStart": {"start": {}}},
         {"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "abc", "text": "test reason"}}}},
         {"contentBlockStop": {}},
@@ -625,8 +621,6 @@ async def test_stream_response_reasoning_and_text(gemini_client, model, messages
     tru_chunks = await alist(model.stream(messages))
     exp_chunks = [
         {"messageStart": {"role": "assistant"}},
-        {"contentBlockStart": {"start": {}}},
-        {"contentBlockStop": {}},
         {"contentBlockStart": {"start": {}}},
         {"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "sig1", "text": "thinking about math"}}}},
         {"contentBlockStop": {}},
@@ -689,8 +683,6 @@ async def test_stream_response_none_candidates(gemini_client, model, messages, a
     tru_chunks = await alist(model.stream(messages))
     exp_chunks = [
         {"messageStart": {"role": "assistant"}},
-        {"contentBlockStart": {"start": {}}},
-        {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "end_turn"}},
         {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
     ]
@@ -709,8 +701,6 @@ async def test_stream_response_empty_stream(gemini_client, model, messages, agen
     tru_chunks = await alist(model.stream(messages))
     exp_chunks = [
         {"messageStart": {"role": "assistant"}},
-        {"contentBlockStart": {"start": {}}},
-        {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "end_turn"}},
     ]
     assert tru_chunks == exp_chunks

--- a/tests_integ/models/test_model_gemini.py
+++ b/tests_integ/models/test_model_gemini.py
@@ -216,6 +216,6 @@ def test_agent_with_reasoning_content(model, assistant_agent):
         },
     )
 
-    result = assistant_agent("What is 2+2")
+    result = assistant_agent("Think about what 2+2 is")
     assert "reasoningContent" in result.message["content"][0]
     assert result.message["content"][0]["reasoningContent"]["reasoningText"]["text"]


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

When using Gemini models with thinking_config enabled, the reasoning/thinking content was being printed to console but not captured in the agent's message history. 

This PR:
Modified the Gemini model provider to properly capture reasoning content by implementing content type switching:

- Stream Handler Enhancement: Added logic to detect transitions between "text" and "reasoning_content" types
- Content Block Lifecycle: When content type changes, emit contentBlockStop for the previous type and contentBlockStart for the new type
- Delta Events: Reasoning content is now emitted as contentBlockDelta events with data_type: "reasoning_content"

Referenced fix:
https://github.com/strands-agents/sdk-python/pull/947/files#diff-a1ec2ea9af3dcd76184638c766807d737d33e9c308d229c075423e961a00174c

## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/1394


## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
