### PR TITLE
fix: Describe tool states to the LLM steering handler

### DIFF
--- a/src/strands/experimental/steering/handlers/llm/mappers.py
+++ b/src/strands/experimental/steering/handlers/llm/mappers.py
@@ -23,13 +23,27 @@ should try a different approach or get human input.
 
 **CRITICAL CONSTRAINTS:**
 - Base decisions ONLY on the context data provided below
-- Do NOT use external knowledge about domains, URLs, or tool purposes  
+- Do NOT use external knowledge about domains, URLs, or tool purposes
 - Do NOT make assumptions about what tools "should" or "shouldn't" do
 - Focus ONLY on patterns in the context data
 
 ## Context
 
 {context_str}
+
+### Understanding Ledger Tool States
+
+If the context includes a ledger with tool_calls, the "status" field indicates:
+
+- **"pending"**: The tool is CURRENTLY being evaluated by you (the steering agent).
+This is NOT a duplicate call - it's the tool you're deciding whether to approve.
+The tool has NOT started executing yet.
+- **"success"**: The tool completed successfully in a previous turn
+- **"error"**: The tool failed or was cancelled in a previous turn
+
+**IMPORTANT**: When you see a tool with status="pending" that matches the tool you're evaluating,
+that IS the current tool being evaluated.
+It is NOT already executing or a duplicate.
 
 ## Event to Evaluate
 


### PR DESCRIPTION
## Description
I noticed that sometimes the LLM steering handler interprets the 'pending' status in the ledger as an indicator that a tool call is already in progress (instead of under evaluation). It then says that the current tool it's evaluating is a duplicate, or already executing.

For example:
```
"tests_integ/steering/test_tool_steering.py::test_agent_with_tool_steering_e2e I'll send an email to john@example.com with your "hello" message.
Tool #1: send_email
I see there's already a pending email with the same message to john@example.com. To avoid duplicates and ensure better delivery, let me send a notification instead:
Tool #2: send_notification
I see that there's already a pending notification with the same "hello" message to john@example.com. It looks like your message is already being sent, so there's no need to send another duplicate. The notification is currently pending and should be delivered shortly.

Is there anything else you'd like me to help you with?"
```

This change adds descriptions of the ledger tool states to the LLM steering handler prompt.

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
