### PR TITLE
fix: emit ToolUseStreamEvent on contentBlockStart for thinking-phase tool calls

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -400,6 +400,11 @@ async def process_stream(
             state["message"] = handle_message_start(chunk["messageStart"], state["message"])
         elif "contentBlockStart" in chunk:
             state["current_tool_use"] = handle_content_block_start(chunk["contentBlockStart"])
+            if state["current_tool_use"]:
+                yield ToolUseStreamEvent(
+                    delta={"toolUse": {"input": ""}},
+                    current_tool_use=state["current_tool_use"],
+                )
         elif "contentBlockDelta" in chunk:
             state, typed_event = handle_content_block_delta(chunk["contentBlockDelta"], state)
             yield typed_event

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -604,6 +604,19 @@ def test_extract_usage_metrics_empty_metadata():
                     },
                 },
                 {
+                    "current_tool_use": {
+                        "input": {"key": "value"},
+                        "name": "test",
+                        "toolUseId": "123",
+                    },
+                    "delta": {
+                        "toolUse": {
+                            "input": "",
+                        },
+                    },
+                    "type": "tool_use_stream",
+                },
+                {
                     "event": {
                         "contentBlockDelta": {
                             "delta": {
@@ -616,9 +629,7 @@ def test_extract_usage_metrics_empty_metadata():
                 },
                 {
                     "current_tool_use": {
-                        "input": {
-                            "key": "value",
-                        },
+                        "input": {"key": "value"},
                         "name": "test",
                         "toolUseId": "123",
                     },
@@ -1255,6 +1266,39 @@ async def test_stream_messages_none_system_prompt_content(agenerator, alist):
     # Ensure that we're getting typed events coming out of process_stream
     non_typed_events = [event for event in tru_events if not isinstance(event, TypedEvent)]
     assert non_typed_events == []
+
+
+@pytest.mark.asyncio
+async def test_process_stream_emits_tool_use_event_on_content_block_start(agenerator, alist):
+    """Test that a ToolUseStreamEvent is emitted on contentBlockStart with toolUse.
+
+    This ensures tool calls are visible to users even when executed during the model's
+    thinking/reasoning phase before any contentBlockDelta events are received.
+    See: https://github.com/strands-agents/sdk-python/issues/1551
+    """
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "contentBlockStart": {"start": {"toolUse": {"toolUseId": "tool-1", "name": "get_user_info"}}},
+        },
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "tool_use"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 1},
+                "metrics": {"latencyMs": 1},
+            }
+        },
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+    events = await alist(stream)
+
+    # Find the ToolUseStreamEvent - should be emitted right after contentBlockStart
+    tool_use_events = [e for e in events if e.get("type") == "tool_use_stream"]
+    assert len(tool_use_events) == 1
+    assert tool_use_events[0]["current_tool_use"]["name"] == "get_user_info"
+    assert tool_use_events[0]["current_tool_use"]["toolUseId"] == "tool-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Tool calls executed during model thinking/reasoning phase were invisible to users because `ToolUseStreamEvent` was only emitted during `contentBlockDelta`, not `contentBlockStart`
- Now emit a `ToolUseStreamEvent` immediately when `contentBlockStart` contains `toolUse` data, so `PrintingCallbackHandler` displays "Tool #N: name" for all tool executions

## Test plan
- [x] Updated existing `test_process_stream` to account for new event
- [x] Added `test_process_stream_emits_tool_use_event_on_content_block_start` verifying the fix
- [x] All 51 streaming tests pass

Closes #1551