### PR TITLE
test(bedrock): add regression test for cachePoint as separate block

### DIFF
--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1913,6 +1913,32 @@ def test_format_request_filters_cache_point_content_blocks(model, model_id):
     assert "extraField" not in cache_point_block
 
 
+def test_format_request_cachepoint_after_text_separate_blocks(model, model_id):
+    """Test that cachePoint after text is kept as separate block (Issue #1219).
+
+    This test verifies that cachePoint blocks are not merged into previous blocks,
+    but are formatted as standalone blocks. The Bedrock API requires each content
+    block to be a tagged union with exactly one key.
+    """
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "Some long text content"},
+                {"cachePoint": {"type": "default"}},
+            ],
+        }
+    ]
+
+    formatted_request = model._format_request(messages)
+
+    # cachePoint should be a separate block, not merged into text block
+    content = formatted_request["messages"][0]["content"]
+    assert len(content) == 2
+    assert content[0] == {"text": "Some long text content"}
+    assert content[1] == {"cachePoint": {"type": "default"}}
+
+
 def test_config_validation_warns_on_unknown_keys(bedrock_client, captured_warnings):
     """Test that unknown config keys emit a warning."""
     BedrockModel(model_id="test-model", invalid_param="test")


### PR DESCRIPTION
## Summary

Add regression test to verify that `cachePoint` content blocks are correctly formatted as standalone blocks (not merged into previous content blocks).

This test confirms that the fix from PR #1438 works correctly for the scenario reported in Issue #1219, where `cachePoint` blocks following `text` blocks were causing `ValidationException` errors.

### What this PR does:
- Adds a test case `test_format_request_cachepoint_after_text_separate_blocks` that verifies:
  - `cachePoint` blocks remain as separate content blocks
  - Each content block contains exactly one key (respecting Bedrock's tagged union structure)
  - The scenario from Issue #1219 works correctly

### Background

Issue #1219 reported that `cachePoint` blocks after text/document content caused `ValidationException`. This was already fixed by PR #1438 (which added proper `cachePoint` handling in `_format_request_message_content`).

This PR adds a regression test to ensure the fix continues to work.

## Test plan

- [x] Added unit test `test_format_request_cachepoint_after_text_separate_blocks`
- [x] Test passes locally with `hatch test tests/strands/models/test_bedrock.py::test_format_request_cachepoint_after_text_separate_blocks`

Closes #1219

🤖 Generated with [Claude Code](https://claude.com/claude-code)