### PR TITLE
callback handler - fix reporting of tool when missing delta

### DIFF
--- a/src/strands/handlers/callback_handler.py
+++ b/src/strands/handlers/callback_handler.py
@@ -14,7 +14,6 @@ class PrintingCallbackHandler:
             verbose_tool_use: Print out verbose information about tool calls.
         """
         self.tool_count = 0
-        self.previous_tool_use = None
         self._verbose_tool_use = verbose_tool_use
 
     def __call__(self, **kwargs: Any) -> None:
@@ -25,12 +24,12 @@ class PrintingCallbackHandler:
                 - reasoningText (Optional[str]): Reasoning text to print if provided.
                 - data (str): Text content to stream.
                 - complete (bool): Whether this is the final chunk of a response.
-                - current_tool_use (dict): Information about the current tool being used.
+                - event (dict): ModelStreamChunkEvent.
         """
         reasoningText = kwargs.get("reasoningText", False)
         data = kwargs.get("data", "")
         complete = kwargs.get("complete", False)
-        current_tool_use = kwargs.get("current_tool_use", {})
+        tool_use = kwargs.get("event", {}).get("contentBlockStart", {}).get("start", {}).get("toolUse")
 
         if reasoningText:
             print(reasoningText, end="")
@@ -38,13 +37,11 @@ class PrintingCallbackHandler:
         if data:
             print(data, end="" if not complete else "\n")
 
-        if current_tool_use and current_tool_use.get("name"):
-            if self.previous_tool_use != current_tool_use:
-                self.previous_tool_use = current_tool_use
-                self.tool_count += 1
-                if self._verbose_tool_use:
-                    tool_name = current_tool_use.get("name", "Unknown tool")
-                    print(f"\nTool #{self.tool_count}: {tool_name}")
+        if tool_use:
+            self.tool_count += 1
+            if self._verbose_tool_use:
+                tool_name = tool_use["name"]
+                print(f"\nTool #{self.tool_count}: {tool_name}")
 
         if complete and data:
             print("\n")


### PR DESCRIPTION
## Description
In the `PrintCallbackHandler`, we only report a tool if a ToolUseStreamEvent is emitted. This however is only emitted if the model streams tool input deltas. Consequently, if a tool does not have inputs, the model won't produce deltas and thus won't be printed to console. Consider the following example:

```Python
from strands import Agent, tool
from strands.models import BedrockModel

@tool
def get_user_info() -> dict:
    """Get user information."""
    return {"name": "Alice", "card": "LIB-456789"}

@tool
def get_book_status(book_id: str) -> dict:
    """Get book status."""
    return {"book_id": book_id, "status": "ACTIVE"}

agent = Agent(
    model=BedrockModel(model_id="qwen.qwen3-next-80b-a3b"),
    tools=[get_user_info, get_book_status],
    system_prompt="You are a helpful assistant."
)

result = agent("Please provide user info and check the status of book BOOK-123")
```

The result right now is:
```txt
Tool #1: get_book_status
User Information:
- Name: Alice
- Card: LIB-456789

Book Status:
- Book ID: BOOK-123
- Status: ACTIVE
```

With changes in this PR, the output is:
```
Tool #1: get_user_info


Tool #2: get_book_status
User Information:
- Name: Alice
- Card: LIB-456789

Book Status:
- Book ID: BOOK-123
- Status: ACTIVE
```

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1551

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: Updated unit tests

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
