### PR TITLE
Attach usage and metrics to MessageAddedEvent.

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -403,7 +403,9 @@ async def _handle_model_execution(
 
         # Add the response message to the conversation
         agent.messages.append(message)
-        await agent.hooks.invoke_callbacks_async(MessageAddedEvent(agent=agent, message=message))
+        await agent.hooks.invoke_callbacks_async(
+            MessageAddedEvent(agent=agent, message=message, usage=usage, metrics=metrics)
+        )
 
         # Update metrics
         agent.event_loop_metrics.update_usage(usage)

--- a/src/strands/hooks/events.py
+++ b/src/strands/hooks/events.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from ..agent.agent_result import AgentResult
 
 from ..types.content import Message, Messages
+from ..types.event_loop import Metrics, Usage
 from ..types.interrupt import _Interruptible
 from ..types.streaming import StopReason
 from ..types.tools import AgentTool, ToolResult, ToolUse
@@ -105,6 +106,8 @@ class MessageAddedEvent(HookEvent):
     """
 
     message: Message
+    usage: Usage | None = None
+    metrics: Metrics | None = None
 
 
 @dataclass

--- a/tests/strands/agent/test_agent_hooks.py
+++ b/tests/strands/agent/test_agent_hooks.py
@@ -178,7 +178,12 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, mock_model, tool_u
         exception=None,
     )
 
-    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[1])
+    assert next(events) == MessageAddedEvent(
+        agent=agent,
+        message=agent.messages[1],
+        usage={"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+        metrics={"latencyMs": 0, "timeToFirstByteMs": 0},
+    )
     assert next(events) == BeforeToolCallEvent(
         agent=agent,
         selected_tool=agent_tool,
@@ -202,7 +207,12 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, mock_model, tool_u
         ),
         exception=None,
     )
-    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[3])
+    assert next(events) == MessageAddedEvent(
+        agent=agent,
+        message=agent.messages[3],
+        usage={"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+        metrics={"latencyMs": 0, "timeToFirstByteMs": 0},
+    )
 
     assert next(events) == AfterInvocationEvent(agent=agent, result=result)
 
@@ -248,7 +258,12 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, mock_m
         exception=None,
     )
 
-    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[1])
+    assert next(events) == MessageAddedEvent(
+        agent=agent,
+        message=agent.messages[1],
+        usage={"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+        metrics={"latencyMs": 0, "timeToFirstByteMs": 0},
+    )
     assert next(events) == BeforeToolCallEvent(
         agent=agent,
         selected_tool=agent_tool,
@@ -272,7 +287,12 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, mock_m
         ),
         exception=None,
     )
-    assert next(events) == MessageAddedEvent(agent=agent, message=agent.messages[3])
+    assert next(events) == MessageAddedEvent(
+        agent=agent,
+        message=agent.messages[3],
+        usage={"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+        metrics={"latencyMs": 0, "timeToFirstByteMs": 0},
+    )
 
     assert next(events) == AfterInvocationEvent(agent=agent, result=result)
 

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -884,7 +884,10 @@ async def test_event_loop_cycle_exception_model_hooks(mock_sleep, agent, model, 
 
     # Final message
     assert next(events) == MessageAddedEvent(
-        agent=agent, message={"content": [{"text": "test text"}], "role": "assistant"}
+        agent=agent,
+        message={"content": [{"text": "test text"}], "role": "assistant"},
+        usage={"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+        metrics={"latencyMs": 0, "timeToFirstByteMs": 0},
     )
 
 


### PR DESCRIPTION
## Description
This PR attaches usage and metrics to MessageAddedEvent.

Hooks are a very powerful way to work with events during the event loop. One of those is the message added event. 

With this change, it enables a some use cases, like storing values in a database, understand session token usage / conversation cost, etc.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1532
https://github.com/strands-agents/sdk-python/issues/1503
https://github.com/strands-agents/sdk-python/issues/1197

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
