### PR TITLE
fix(tools): make nullable-typed params without defaults non-required in schema

### DIFF
--- a/tests/strands/agent/hooks/test_events.py
+++ b/tests/strands/agent/hooks/test_events.py
@@ -206,8 +206,6 @@ def test_invocation_state_is_available_in_model_call_events(agent):
     assert after_event.invocation_state["request_id"] == "req-456"
 
 
-
-
 def test_before_invocation_event_messages_default_none(agent):
     """Test that BeforeInvocationEvent.messages defaults to None for backward compatibility."""
     event = BeforeInvocationEvent(agent=agent)


### PR DESCRIPTION
## Description
The `_clean_pydantic_schema` method simplifies `anyOf[Type, null]` to just the non-null type, but left nullable-without-default fields in the required array — making the model unable to omit or null them.

Now when the null branch of an `anyOf` is stripped, the field is also removed from `required`. To prevent Pydantic from rejecting the omitted field at validation time, `_create_input_model` detects `T | None` params without explicit defaults and gives them `default=None` in the Pydantic model.

This is a two-site change: `_clean_pydantic_schema` (schema output) and `_create_input_model` (validation input), both required to avoid trading one failure mode for another.

## Related Issues
#1525 

## Documentation PR
Not required

## Type of Change
Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
