### PR TITLE
Add conditional execution for finalize step

### DIFF
--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -79,6 +79,7 @@ jobs:
           write_permission: 'false'
 
   finalize:
+    if: always()
     needs: [setup-and-process, execute-readonly-agent]
     permissions:
       contents: write


### PR DESCRIPTION
## Description
Add `always()` so that label cleanup always happens

example where we need this: https://github.com/strands-agents/sdk-python/actions/runs/21530320818/job/62044415203

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
