### PR TITLE
interrupts - graph - multiagent nodes

### DIFF
--- a/tests_integ/interrupts/multiagent/test_node.py
+++ b/tests_integ/interrupts/multiagent/test_node.py
@@ -65,13 +65,13 @@ def swarm(weather_agent):
 
 
 @pytest.fixture
-def graph(info_agent, day_agent, time_agent, weather_agent):
+def graph(info_agent, day_agent, time_agent, swarm):
     builder = GraphBuilder()
 
     builder.add_node(info_agent, "info")
     builder.add_node(day_agent, "day")
     builder.add_node(time_agent, "time")
-    builder.add_node(weather_agent, "weather")
+    builder.add_node(swarm, "weather")
 
     builder.add_edge("info", "day")
     builder.add_edge("info", "time")
@@ -82,7 +82,7 @@ def graph(info_agent, day_agent, time_agent, weather_agent):
     return builder.build()
 
 
-def test_swarm_interrupt_agent(swarm):
+def test_swarm_interrupt_node(swarm):
     multiagent_result = swarm("What is the weather?")
 
     tru_status = multiagent_result.status
@@ -122,7 +122,7 @@ def test_swarm_interrupt_agent(swarm):
     assert "sunny" in weather_message
 
 
-def test_graph_interrupt_agent(graph):
+def test_graph_interrupt_node(graph):
     multiagent_result = graph("What is the day, time, and weather?")
 
     tru_result_status = multiagent_result.status
@@ -180,7 +180,9 @@ def test_graph_interrupt_agent(graph):
 
     day_message = json.dumps(multiagent_result.results["day"].result.message).lower()
     time_message = json.dumps(multiagent_result.results["time"].result.message).lower()
-    weather_message = json.dumps(multiagent_result.results["weather"].result.message).lower()
     assert "monday" in day_message
     assert "12:01" in time_message
+
+    nested_multiagent_result = multiagent_result.results["weather"].result
+    weather_message = json.dumps(nested_multiagent_result.results["weather"].result.message).lower()
     assert "sunny" in weather_message

--- a/tests_integ/interrupts/multiagent/test_session.py
+++ b/tests_integ/interrupts/multiagent/test_session.py
@@ -72,15 +72,23 @@ def test_swarm_interrupt_session(weather_tool, tmpdir):
 
 
 def test_graph_interrupt_session(weather_tool, tmpdir):
+    parent_sm = FileSessionManager(session_id="parent-session", storage_dir=tmpdir / "parent")
+    child_sm = FileSessionManager(session_id="child-session", storage_dir=tmpdir / "child")
+
     weather_agent = Agent(name="weather", tools=[weather_tool])
     summarizer_agent = Agent(name="summarizer")
-    session_manager = FileSessionManager(session_id="strands-interrupt-test", storage_dir=tmpdir)
+
+    weather_builder = GraphBuilder()
+    weather_builder.add_node(weather_agent, "weather")
+    weather_builder.set_entry_point("weather")
+    weather_builder.set_session_manager(child_sm)
+    weather_graph = weather_builder.build()
 
     builder = GraphBuilder()
-    builder.add_node(weather_agent, "weather")
+    builder.add_node(weather_graph, "weather")
     builder.add_node(summarizer_agent, "summarizer")
     builder.add_edge("weather", "summarizer")
-    builder.set_session_manager(session_manager)
+    builder.set_session_manager(parent_sm)
     graph = builder.build()
 
     multiagent_result = graph("Can you check the weather and then summarize the results?")
@@ -105,15 +113,23 @@ def test_graph_interrupt_session(weather_tool, tmpdir):
 
     interrupt = multiagent_result.interrupts[0]
 
+    parent_sm = FileSessionManager(session_id="parent-session", storage_dir=tmpdir / "parent")
+    child_sm = FileSessionManager(session_id="child-session", storage_dir=tmpdir / "child")
+
     weather_agent = Agent(name="weather", tools=[weather_tool])
     summarizer_agent = Agent(name="summarizer")
-    session_manager = FileSessionManager(session_id="strands-interrupt-test", storage_dir=tmpdir)
+
+    weather_builder = GraphBuilder()
+    weather_builder.add_node(weather_agent, "weather")
+    weather_builder.set_entry_point("weather")
+    weather_builder.set_session_manager(child_sm)
+    weather_graph = weather_builder.build()
 
     builder = GraphBuilder()
-    builder.add_node(weather_agent, "weather")
+    builder.add_node(weather_graph, "weather")
     builder.add_node(summarizer_agent, "summarizer")
     builder.add_edge("weather", "summarizer")
-    builder.set_session_manager(session_manager)
+    builder.set_session_manager(parent_sm)
     graph = builder.build()
 
     responses = [


### PR DESCRIPTION
## Description
Adding support for MultiAgentBase node interrupts in Graph. This is a follow up to https://github.com/strands-agents/sdk-python/pull/1533, which added support for raising interrupts from Agent nodes.

Note, for session persistence, a MultiAgentBase node must pass in its own session manager. I wrote an integ test for this case and will document for the user.

## Usage

```python
from strands import Agent, tool
from strands.interrupt import Interrupt
from strands.multiagent import GraphBuilder, Status
from strands.types.tools import ToolContext


@tool(context=True)
def weather_tool(tool_context: ToolContext) -> str:
    response = tool_context.interrupt("weather_interrupt", reason="need weather")
    return response


weather_agent = Agent(name="weather", tools=[weather_tool])

# Create a nested graph (inner multiagent)
inner_builder = GraphBuilder()
inner_builder.add_node(weather_agent, "weather_agent")
inner_graph = inner_builder.build()

# Create outer graph with the inner graph as a node
outer_builder = GraphBuilder()
outer_builder.add_node(inner_graph, "inner_graph")
outer_graph = outer_builder.build()

multiagent_result = outer_graph("What is the weather?")

while multiagent_result.status == Status.INTERRUPTED:
    responses = []
    for interrupt in multiagent_result.interrupts:
        if interrupt.name == "weather_interrupt":
            response = input(f"{interrupt.reason}: ")
            responses.append(
                {
                    "interruptResponse": {
                        "interruptId": interrupt.id,
                        "response": response,
                    },
                },
            )
    multiagent_result = outer_graph(responses)

print(multiagent_result.results)
```

Note, works for any MultiAgentBase node (e.g., Graph, Swarm, something custom).

## Related Issues

https://github.com/strands-agents/sdk-python/issues/204

## Documentation PR

Will remove warning about no multiagent node interrupt support from https://strandsagents.com/latest/documentation/docs/user-guide/concepts/interrupts/#graph.

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`: Wrote new unit test
- [x] I ran `hatch test tests_integ/interrupts/multiagent`: Wrote new integ tests

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
