### PR TITLE
increase test timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ convention = "google"
 testpaths = ["tests"]
 asyncio_default_fixture_loop_scope = "function"
 addopts = "--ignore=tests/strands/experimental/bidi --ignore=tests_integ/bidi --junit-xml=build/test-results.xml"
-timeout = 45
+timeout = 90
 
 
 [tool.coverage.run]


### PR DESCRIPTION
## Description
Tests are failing due to a short timeout of 45sec
For example, saw a pr with the following in the test logs:
```
FAILED tests_integ/models/test_model_openai.py::test_rate_limit_throttling_integration_no_retries - Failed: Timeout (>45.0s) from pytest-timeout.

FAILED tests_integ/test_multiagent_swarm.py::test_swarm_execution_with_string - Failed: Timeout (>45.0s) from pytest-timeout.

FAILED tests_integ/test_multiagent_swarm.py::test_swarm_streaming - Failed: Timeout (>45.0s) from pytest-timeout.
```

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
