### PR TITLE
Fix openai test

### DIFF
--- a/tests_integ/models/test_model_openai.py
+++ b/tests_integ/models/test_model_openai.py
@@ -210,7 +210,7 @@ def test_rate_limit_throttling_integration_no_retries(model):
 
     # Create a message that's very long to trigger token-per-minute rate limits
     # This should be large enough to exceed TPM limits immediately
-    very_long_text = "Really long text " * 20000
+    very_long_text = "Really long text " * 600000
 
     # This should raise ModelThrottledException without retries
     with pytest.raises(ModelThrottledException) as exc_info:
@@ -218,7 +218,7 @@ def test_rate_limit_throttling_integration_no_retries(model):
 
     # Verify it's a rate limit error
     error_message = str(exc_info.value).lower()
-    assert "insufficient_quota" in error_message
+    assert "rate_limit_exceeded" in error_message
 
 
 def test_content_blocks_handling(model):


### PR DESCRIPTION
## Description
Fix the openai integ test to use the new RetryStrategy, and look for the updated error string

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
