### PR TITLE
fix: Update retry_strategy=None to turn off retries

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -78,7 +78,14 @@ class _DefaultCallbackHandlerSentinel:
     pass
 
 
+class _DefaultRetryStrategySentinel:
+    """Sentinel class to distinguish between explicit None and default parameter value for retry_strategy."""
+
+    pass
+
+
 _DEFAULT_CALLBACK_HANDLER = _DefaultCallbackHandlerSentinel()
+_DEFAULT_RETRY_STRATEGY = _DefaultRetryStrategySentinel()
 _DEFAULT_AGENT_NAME = "Strands Agents"
 _DEFAULT_AGENT_ID = "default"
 
@@ -119,7 +126,7 @@ class Agent:
         hooks: list[HookProvider] | None = None,
         session_manager: SessionManager | None = None,
         tool_executor: ToolExecutor | None = None,
-        retry_strategy: ModelRetryStrategy | None = None,
+        retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
     ):
         """Initialize the Agent with the specified configuration.
 
@@ -251,14 +258,25 @@ class Agent:
 
         # In the future, we'll have a RetryStrategy base class but until
         # that API is determined we only allow ModelRetryStrategy
-        if retry_strategy and type(retry_strategy) is not ModelRetryStrategy:
+        if (
+            retry_strategy is not None
+            and not isinstance(retry_strategy, _DefaultRetryStrategySentinel)
+            and type(retry_strategy) is not ModelRetryStrategy
+        ):
             raise ValueError("retry_strategy must be an instance of ModelRetryStrategy")
 
-        self._retry_strategy = (
-            retry_strategy
-            if retry_strategy is not None
-            else ModelRetryStrategy(max_attempts=MAX_ATTEMPTS, max_delay=MAX_DELAY, initial_delay=INITIAL_DELAY)
-        )
+        # If not provided (using the default), create a new ModelRetryStrategy instance
+        # If explicitly set to None, disable retries (max_attempts=1 means no retries)
+        # Otherwise use the passed retry_strategy
+        if isinstance(retry_strategy, _DefaultRetryStrategySentinel):
+            self._retry_strategy = ModelRetryStrategy(
+                max_attempts=MAX_ATTEMPTS, max_delay=MAX_DELAY, initial_delay=INITIAL_DELAY
+            )
+        elif retry_strategy is None:
+            # If no retry strategy is passed in, then we turn retries off
+            self._retry_strategy = ModelRetryStrategy(max_attempts=1)
+        else:
+            self._retry_strategy = retry_strategy
 
         # Initialize session management functionality
         self._session_manager = session_manager


### PR DESCRIPTION


## Description

Per #1579, we currently aren't disabling retry strategies when someone passes None - instead we were applying the default retry strategy (for backwards compatibility when retry_strategy was introduced).

Instead, we now accept None as an alias to turn off all SDK retries and if no value is passed in, the old/previous retry strategy is used.  

> [!WARNING]
> This is a breaking change in that the behavior of passing in `None` has changed.  However, we thinks the change in behavior is more obvious and and the use-case for passing in None explicitly isn't a common one, when not specifying the parameter also applies the default retry strategy.
>
> That combined with the fact that this feature was recently released (2 weeks ago) and we think it warrants the change in behavior.


### API

```python
from strands import Agent, ModelRetryStrategy

agent = Agent(
    retry_strategy=None
)
```

will now have the same behavior as:

```python
from strands import Agent, ModelRetryStrategy

agent = Agent(
    retry_strategy=ModelRetryStrategy(max_attempts=1)
)
```

which is an explicit way of disabling retires.

The previous behavior of not passing in any retry_strategy to get the default behavior, has not changed:

```python
agent = Agent()
```

## Implementation notes

We use a sentinel class/value much like we did for the callback_handler default parameter, because if we did not then - because of the way that python default values work - the same retry strategy object would be shared among all agents.

## Related Issues

#1579

## Documentation PR

As a follow-up

## Type of Change

Bug fix
Breaking change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
