### PR TITLE
docs: add guidance on using Protocol instead of Callable for extensible interfaces

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -57,3 +57,20 @@ logger.warning("Retry limit approaching! attempt=%d max_attempts=%d", attempt, m
 ```
 
 By following these log formatting guidelines, we ensure that logs are both human-readable and machine-parseable, making debugging and monitoring more efficient.
+
+## Type Annotations
+
+### Avoid `Callable` for Extensible Interfaces
+
+Do not use `Callable` for function type annotations that may need additional parameters in the future. `Callable` signatures are fixed and cannot be expanded without breaking existing implementations.
+
+```python
+# Bad: Cannot add parameters later without breaking all existing implementations
+EdgeCondition = Callable[[GraphState], bool]
+
+# Good: Protocol allows adding optional keyword arguments in the future
+class EdgeCondition(Protocol):
+    def __call__(self, state: GraphState, **kwargs: Any) -> bool: ...
+```
+
+Using `Protocol` with `**kwargs` allows the interface to evolve by adding new keyword arguments without breaking existing implementations that don't use them.


### PR DESCRIPTION
Callable type annotations cannot be expanded with additional parameters without breaking existing implementations. Using Protocol with **kwargs allows interfaces to evolve by adding new keyword arguments while maintaining backwards compatibility.

Ref: https://github.com/strands-agents/sdk-python/issues/1346


## Related Issues

https://github.com/strands-agents/sdk-python/issues/1346

## Type of Change

Documentation update


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
