### PR TITLE
fix(gemini): handle tool usage after reasoning content

### DIFF
--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -558,6 +558,10 @@ class GeminiModel(Model):
 
                 for part in parts:
                     if part.function_call:
+                        if data_type is not None:
+                            yield self._format_chunk({"chunk_type": "content_stop", "data_type": data_type})
+                            data_type = None
+
                         yield self._format_chunk({"chunk_type": "content_start", "data_type": "tool", "data": part})
                         yield self._format_chunk({"chunk_type": "content_delta", "data_type": "tool", "data": part})
                         yield self._format_chunk({"chunk_type": "content_stop", "data_type": "tool", "data": part})


### PR DESCRIPTION
When using Gemini 2.0/3.0 models with thinking/reasoning enabled, the model may emit a reasoning block followed immediately by a tool call in the same stream chunk or sequence.

The current implementation initiates the reasoning block but fails to close it before processing the tool call, leading to state errors (nested blocks).

This patch ensures any open content block (like reasoning) is closed before a tool call start event is emitted.