### PR TITLE
fix(summarizing_conversation_manager): use model stream to generate summary

### DIFF
--- a/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
+++ b/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 from typing_extensions import override
 
+from ..._async import run_async
+from ...event_loop.streaming import process_stream
 from ...tools._tool_helpers import noop_tool
 from ...tools.registry import ToolRegistry
 from ...types.content import Message
@@ -176,9 +178,17 @@ class SummarizingConversationManager(ConversationManager):
     def _generate_summary(self, messages: list[Message], agent: "Agent") -> Message:
         """Generate a summary of the provided messages.
 
+        When a dedicated summarization_agent was provided at init time, it is invoked as before
+        (full agent pipeline, tool execution, etc.).
+
+        In the default case (no summarization_agent), the parent agent's *model* is called
+        directly via ``model.stream()``.  This avoids re-entering the agent pipeline which
+        would deadlock on ``_invocation_lock`` and corrupt metrics / traces / interrupt state.
+
         Args:
             messages: The messages to summarize.
-            agent: The agent instance to use for summarization.
+            agent: The agent instance whose model will be used for summarization when no
+                dedicated summarization_agent was configured.
 
         Returns:
             A message containing the conversation summary.
@@ -186,26 +196,32 @@ class SummarizingConversationManager(ConversationManager):
         Raises:
             Exception: If summary generation fails.
         """
-        # Choose which agent to use for summarization
-        summarization_agent = self.summarization_agent if self.summarization_agent is not None else agent
+        if self.summarization_agent is not None:
+            return self._generate_summary_with_agent(messages)
 
-        # Save original system prompt, messages, and tool registry to restore later
+        return self._generate_summary_with_model(messages, agent)
+
+    # ------------------------------------------------------------------
+    # Path 1 – dedicated summarization agent (backward-compatible)
+    # ------------------------------------------------------------------
+
+    def _generate_summary_with_agent(self, messages: list[Message]) -> Message:
+        """Generate a summary using the dedicated summarization agent.
+
+        Args:
+            messages: The messages to summarize.
+
+        Returns:
+            A message containing the conversation summary.
+        """
+        summarization_agent = self.summarization_agent
+        assert summarization_agent is not None  # guaranteed by caller
+
         original_system_prompt = summarization_agent.system_prompt
         original_messages = summarization_agent.messages.copy()
         original_tool_registry = summarization_agent.tool_registry
 
         try:
-            # Only override system prompt if no agent was provided during initialization
-            if self.summarization_agent is None:
-                # Use custom system prompt if provided, otherwise use default
-                system_prompt = (
-                    self.summarization_system_prompt
-                    if self.summarization_system_prompt is not None
-                    else DEFAULT_SUMMARIZATION_PROMPT
-                )
-                # Temporarily set the system prompt for summarization
-                summarization_agent.system_prompt = system_prompt
-
             # Add no-op tool if agent has no tools to satisfy tool spec requirement
             if not summarization_agent.tool_names:
                 tool_registry = ToolRegistry()
@@ -214,15 +230,60 @@ class SummarizingConversationManager(ConversationManager):
 
             summarization_agent.messages = messages
 
-            # Use the agent to generate summary with rich content (can use tools if needed)
             result = summarization_agent("Please summarize this conversation.")
             return cast(Message, {**result.message, "role": "user"})
 
         finally:
-            # Restore original agent state
             summarization_agent.system_prompt = original_system_prompt
             summarization_agent.messages = original_messages
             summarization_agent.tool_registry = original_tool_registry
+
+    # ------------------------------------------------------------------
+    # Path 2 – default case: call model.stream() directly
+    # ------------------------------------------------------------------
+
+    def _generate_summary_with_model(self, messages: list[Message], agent: "Agent") -> Message:
+        """Generate a summary by calling the agent's model directly.
+
+        This bypasses the full agent pipeline (lock, metrics, traces, tool loop) and
+        simply asks the underlying model to summarize the conversation.
+
+        Args:
+            messages: The messages to summarize.
+            agent: The parent agent whose model is used.
+
+        Returns:
+            A message containing the conversation summary.
+        """
+        system_prompt = (
+            self.summarization_system_prompt
+            if self.summarization_system_prompt is not None
+            else DEFAULT_SUMMARIZATION_PROMPT
+        )
+
+        # Build the message list: conversation history + summarization request
+        summarization_messages = list(messages) + [
+            {"role": "user", "content": [{"text": "Please summarize this conversation."}]}
+        ]
+
+        async def _call_model() -> Message:
+            chunks = agent.model.stream(
+                summarization_messages,
+                tool_specs=None,
+                system_prompt=system_prompt,
+            )
+
+            result_message: Message | None = None
+            async for event in process_stream(chunks):
+                if "stop" in event:
+                    _, result_message, _, _ = event["stop"]
+
+            if result_message is None:
+                raise RuntimeError("Failed to generate summary: no response from model")
+            return result_message
+
+        message = run_async(_call_model)
+        return cast(Message, {**message, "role": "user"})
 
     def _adjust_split_point_for_tool_pairs(self, messages: list[Message], split_point: int) -> int:
         """Adjust the split point to avoid breaking ToolUse/ToolResult pairs.


### PR DESCRIPTION
## Description

When `SummarizingConversationManager` is used **without** a separate `summarization_agent` and a `ContextWindowOverflowException` occurs, the agent crashes with:

```
ConcurrencyException: Agent is already processing a request. Concurrent invocations are not supported.
```

**Root cause:** `_generate_summary()` calls `agent("Please summarize this conversation.")`, which re-enters `stream_async()` on the same agent instance. The `_invocation_lock` (`threading.Lock`, non-reentrant) is already held by the outer `stream_async()` call, so the inner call fails immediately.

**The fix:** Split `_generate_summary()` into two code paths:

1. **When a separate `summarization_agent` IS provided** — keep existing behavior, call `summarization_agent(...)`. This is safe because it's a different agent instance with its own lock.

2. **When NO separate agent is provided** (the bug case) — call `agent.model.stream()` directly instead of `agent(...)`. Summarization only needs the model to produce text; it doesn't need tools, callback handlers, tracing, or any other agent machinery. The response stream is processed via `process_stream()` (the same function the event loop uses internally).

This approach:
- Zero changes to `agent.py` — the core stays simple
- No concurrency mechanism changes (no `RLock`, no lock release/reacquire hacks)
- No agent state corruption (metrics, traces, interrupt state are untouched)
- Fix is scoped exactly where the problem is

## Related Issues

Fixes the re-entrant lock deadlock in `SummarizingConversationManager` when no dedicated `summarization_agent` is configured.

## Documentation PR

N/A — no public API changes; behavior is now correct where it previously crashed.

## Type of Change

Bug fix

## Testing

How have you tested the change?

**37 tests total** (28 existing updated + 9 new), all passing:

- **Unit tests** cover both code paths (model-direct vs. dedicated agent), system prompt handling, message construction, error propagation, tool registry behavior, and agent state isolation.
- **Integration test** (`test_full_agent_pipeline_no_reentrant_lock_on_context_overflow`) reproduces the exact bug scenario end-to-end: a real `Agent` instance calls `agent("prompt")` → model raises `ContextWindowOverflowException` → `reduce_context()` fires while the lock is held → summary is generated via `model.stream()` → event loop retries → agent returns successfully. This test would have caught the original bug.

```
$ python -m pytest tests/strands/agent/test_summarizing_conversation_manager.py -v
37 passed in 0.31s

$ python -m pytest tests/strands/agent/test_agent.py -v -k "concurren"
2 passed in 0.18s

$ python -m pytest tests/strands/agent/test_agent.py -v
100 passed in 3.28s

$ python -m pytest tests/strands/agent/test_conversation_manager.py -v
26 passed in 0.89s
```

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.