### PR TITLE
feat(models): add Portkey AI gateway model provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ llamaapi = ["llama-api-client>=0.1.0,<1.0.0"]
 mistral = ["mistralai>=1.8.2"]
 ollama = ["ollama>=0.4.8,<1.0.0"]
 openai = ["openai>=1.68.0,<2.0.0"]
+portkey = ["portkey-ai>=1.0.0,<2.0.0", "openai>=1.68.0,<2.0.0"]
 writer = ["writer-sdk>=2.2.0,<3.0.0"]
 sagemaker = [
     "boto3-stubs[sagemaker-runtime]>=1.26.0,<2.0.0",
@@ -79,7 +80,7 @@ bidi = [
 bidi-gemini = ["google-genai>=1.32.0,<2.0.0"]
 bidi-openai = ["websockets>=15.0.0,<17.0.0"]
 
-all = ["strands-agents[a2a,anthropic,docs,gemini,litellm,llamaapi,mistral,ollama,openai,writer,sagemaker,otel]"]
+all = ["strands-agents[a2a,anthropic,docs,gemini,litellm,llamaapi,mistral,ollama,openai,portkey,writer,sagemaker,otel]"]
 bidi-all = ["strands-agents[a2a,bidi,bidi-gemini,bidi-openai,docs,otel]"]
 
 dev = [

--- a/src/strands/models/__init__.py
+++ b/src/strands/models/__init__.py
@@ -55,6 +55,10 @@ def __getattr__(name: str) -> Any:
         from .openai import OpenAIModel
 
         return OpenAIModel
+    if name == "PortkeyModel":
+        from .portkey import PortkeyModel
+
+        return PortkeyModel
     if name == "SageMakerAIModel":
         from .sagemaker import SageMakerAIModel
 

--- a/src/strands/models/portkey.py
+++ b/src/strands/models/portkey.py
@@ -1,0 +1,180 @@
+"""Portkey model provider.
+
+- Docs: https://portkey.ai/docs
+"""
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, TypedDict, cast
+
+from typing_extensions import Unpack, override
+
+from ._validation import validate_config_keys
+from .openai import OpenAIModel
+
+logger = logging.getLogger(__name__)
+
+# Keys in PortkeyConfig that are passed to the AsyncPortkey client constructor
+# rather than included in the API request.
+_PORTKEY_CLIENT_KEYS = frozenset(
+    {
+        "api_key",
+        "virtual_key",
+        "config",
+        "provider",
+        "base_url",
+        "trace_id",
+        "metadata",
+    }
+)
+
+
+class PortkeyModel(OpenAIModel):
+    """Portkey model provider implementation.
+
+    The Portkey AI gateway adds observability, caching, fallbacks, load balancing, and other
+    production features on top of LLM providers. This integration uses the Portkey Python SDK
+    (``portkey-ai``) which wraps the OpenAI client and routes requests through the Portkey gateway.
+
+    Portkey normalizes responses from all providers (OpenAI, Anthropic, Google, Mistral, etc.)
+    into the OpenAI-compatible format, so a single ``PortkeyModel`` works with any provider.
+    The gateway automatically routes requests to the correct provider based on the ``model_id``.
+
+    Usage:
+        Basic usage — only ``api_key`` and ``model_id`` are required::
+
+            from strands import Agent
+            from strands.models.portkey import PortkeyModel
+
+            model = PortkeyModel(api_key="your-portkey-api-key", model_id="gpt-4o")
+            agent = Agent(model=model)
+            response = agent("Hello!")
+
+        Switching providers — just change the ``model_id``::
+
+            # Anthropic
+            model = PortkeyModel(api_key="your-portkey-api-key", model_id="claude-sonnet-4-20250514")
+
+            # Google
+            model = PortkeyModel(api_key="your-portkey-api-key", model_id="gemini-2.0-flash")
+
+        Using a Portkey config for routing, fallbacks, or load balancing::
+
+            model = PortkeyModel(
+                api_key="your-portkey-api-key",
+                config="your-portkey-config-slug",
+                model_id="gpt-4o",
+            )
+
+        Using a pre-configured client for advanced options::
+
+            from portkey_ai import AsyncPortkey
+            from strands.models.portkey import PortkeyModel
+
+            client = AsyncPortkey(api_key="your-portkey-api-key")
+            model = PortkeyModel(client=client, model_id="gpt-4o")
+    """
+
+    class PortkeyConfig(TypedDict, total=False):
+        """Configuration options for Portkey models.
+
+        Attributes:
+            model_id: Model ID (e.g., "gpt-4o", "claude-sonnet-4-20250514", "gemini-2.0-flash").
+                Portkey's gateway automatically routes to the correct provider based on the model ID.
+                For a complete list of supported models, see https://portkey.ai/docs/integrations/llms.
+            api_key: Portkey API key. Can also be set via the PORTKEY_API_KEY environment variable.
+            params: Model parameters (e.g., max_tokens, temperature).
+                For a complete list of supported parameters, see
+                https://portkey.ai/docs/api-reference/chat-completions.
+            virtual_key: Optional. Virtual key referencing provider credentials stored in Portkey's
+                vault. Only needed if not using default provider keys configured in your Portkey
+                dashboard. See https://portkey.ai/docs/product/ai-gateway/virtual-keys.
+            config: Optional. Portkey config slug (e.g., "cf-xxx") or config object for routing,
+                fallbacks, and load balancing. See https://portkey.ai/docs/product/ai-gateway/configs.
+            provider: Optional. Explicit provider slug (e.g., "openai", "anthropic", "google").
+                Usually not needed as the gateway infers the provider from model_id.
+            base_url: Optional. Override the Portkey gateway URL.
+            trace_id: Optional. Trace ID for request tracking and observability.
+            metadata: Optional. Custom metadata dict attached to requests.
+        """
+
+        model_id: str
+        api_key: str
+        params: dict[str, Any] | None
+        virtual_key: str
+        config: str | dict[str, Any]
+        provider: str
+        base_url: str
+        trace_id: str
+        metadata: dict[str, Any]
+
+    def __init__(
+        self,
+        client: Any | None = None,
+        **model_config: Unpack[PortkeyConfig],
+    ) -> None:
+        """Initialize provider instance.
+
+        Args:
+            client: Pre-configured AsyncPortkey client to reuse across requests.
+                When provided, this client will be reused for all requests and will NOT be closed
+                by the model. The caller is responsible for managing the client lifecycle.
+                This is useful for:
+                - Reusing connection pools within a single event loop/worker
+                - Centralizing observability, retries, and networking policy
+                - Custom client configurations (e.g., AWS, Azure, Vertex AI parameters)
+            **model_config: Configuration options for the Portkey model.
+                See ``PortkeyConfig`` for available options.
+        """
+        validate_config_keys(model_config, self.PortkeyConfig)
+        self.config = dict(model_config)
+        self._custom_client = client
+
+        logger.debug("config=<%s> | initializing", self.config)
+
+    @override
+    def update_config(self, **model_config: Unpack[PortkeyConfig]) -> None:  # type: ignore[override]
+        """Update the Portkey model configuration with the provided arguments.
+
+        Args:
+            **model_config: Configuration overrides.
+        """
+        validate_config_keys(model_config, self.PortkeyConfig)
+        self.config.update(model_config)
+
+    @override
+    def get_config(self) -> PortkeyConfig:
+        """Get the Portkey model configuration.
+
+        Returns:
+            The Portkey model configuration.
+        """
+        return cast(PortkeyModel.PortkeyConfig, self.config)
+
+    @asynccontextmanager
+    @override
+    async def _get_client(self) -> AsyncIterator[Any]:
+        """Get a Portkey client for making requests.
+
+        This context manager handles client lifecycle management:
+        - If an injected client was provided during initialization, it yields that client
+          without closing it (caller manages lifecycle).
+        - Otherwise, creates a new AsyncPortkey client from config parameters.
+
+        Yields:
+            An AsyncPortkey client instance.
+        """
+        if self._custom_client is not None:
+            yield self._custom_client
+        else:
+            from portkey_ai import AsyncPortkey
+
+            portkey_args = {k: v for k, v in self.config.items() if k in _PORTKEY_CLIENT_KEYS}
+            client = AsyncPortkey(**portkey_args)
+            try:
+                yield client
+            finally:
+                # Close the underlying HTTP client to release connections
+                if hasattr(client, "close"):
+                    await client.close()

--- a/tests/strands/models/test_portkey.py
+++ b/tests/strands/models/test_portkey.py
@@ -1,0 +1,363 @@
+import unittest.mock
+
+import openai
+import pydantic
+import pytest
+
+from strands.models.portkey import PortkeyModel
+from strands.types.exceptions import ContextWindowOverflowException, ModelThrottledException
+
+
+@pytest.fixture
+def mock_portkey_client():
+    """Create a mock AsyncPortkey client."""
+    mock_client = unittest.mock.AsyncMock()
+    mock_client.close = unittest.mock.AsyncMock()
+    return mock_client
+
+
+@pytest.fixture
+def model_id():
+    return "gpt-4o"
+
+
+@pytest.fixture
+def model(mock_portkey_client, model_id):
+    return PortkeyModel(client=mock_portkey_client, model_id=model_id)
+
+
+@pytest.fixture
+def messages():
+    return [{"role": "user", "content": [{"text": "test"}]}]
+
+
+@pytest.fixture
+def system_prompt():
+    return "s1"
+
+
+@pytest.fixture
+def tool_specs():
+    return [
+        {
+            "name": "test_tool",
+            "description": "A test tool",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "input": {"type": "string"},
+                    },
+                    "required": ["input"],
+                },
+            },
+        },
+    ]
+
+
+@pytest.fixture
+def test_output_model_cls():
+    class TestOutputModel(pydantic.BaseModel):
+        name: str
+        age: int
+
+    return TestOutputModel
+
+
+def test__init__with_api_key_only():
+    """Test simplest initialization with just api_key and model_id."""
+    model = PortkeyModel(api_key="pk-test", model_id="gpt-4o")
+
+    config = model.get_config()
+    assert config["model_id"] == "gpt-4o"
+    assert config["api_key"] == "pk-test"
+
+
+def test__init__with_virtual_key():
+    """Test initialization with api_key and virtual_key."""
+    model = PortkeyModel(api_key="pk-test", virtual_key="vk-openai", model_id="gpt-4o")
+
+    config = model.get_config()
+    assert config["api_key"] == "pk-test"
+    assert config["virtual_key"] == "vk-openai"
+    assert config["model_id"] == "gpt-4o"
+
+
+def test__init__with_config_slug():
+    """Test initialization with a Portkey config slug for routing/fallbacks."""
+    model = PortkeyModel(api_key="pk-test", config="cf-xxx", model_id="gpt-4o")
+
+    config = model.get_config()
+    assert config["config"] == "cf-xxx"
+
+
+def test__init__with_provider():
+    """Test initialization with an explicit provider."""
+    model = PortkeyModel(api_key="pk-test", provider="anthropic", model_id="claude-sonnet-4-20250514")
+
+    config = model.get_config()
+    assert config["provider"] == "anthropic"
+    assert config["model_id"] == "claude-sonnet-4-20250514"
+
+
+def test__init__with_params():
+    """Test initialization with model parameters."""
+    model = PortkeyModel(api_key="pk-test", model_id="gpt-4o", params={"max_tokens": 100, "temperature": 0.7})
+
+    config = model.get_config()
+    assert config["params"] == {"max_tokens": 100, "temperature": 0.7}
+
+
+def test__init__with_injected_client(mock_portkey_client):
+    """Test initialization with a pre-configured client."""
+    model = PortkeyModel(client=mock_portkey_client, model_id="gpt-4o")
+
+    assert model._custom_client is mock_portkey_client
+    assert model.get_config()["model_id"] == "gpt-4o"
+
+
+def test_update_config(model):
+    model.update_config(model_id="claude-sonnet-4-20250514")
+
+    assert model.get_config()["model_id"] == "claude-sonnet-4-20250514"
+
+
+def test_update_config_portkey_args(model):
+    """Test that Portkey client args can be updated via update_config."""
+    model.update_config(trace_id="trace-123", metadata={"user": "test"})
+
+    config = model.get_config()
+    assert config["trace_id"] == "trace-123"
+    assert config["metadata"] == {"user": "test"}
+
+
+def test_config_validation_warns_on_unknown_keys(mock_portkey_client, captured_warnings):
+    """Test that unknown config keys emit a warning."""
+    PortkeyModel(client=mock_portkey_client, model_id="gpt-4o", invalid_param="test")
+
+    assert len(captured_warnings) == 1
+    assert "Invalid configuration parameters" in str(captured_warnings[0].message)
+    assert "invalid_param" in str(captured_warnings[0].message)
+
+
+def test_update_config_validation_warns_on_unknown_keys(model, captured_warnings):
+    """Test that update_config warns on unknown keys."""
+    model.update_config(wrong_param="test")
+
+    assert len(captured_warnings) == 1
+    assert "Invalid configuration parameters" in str(captured_warnings[0].message)
+    assert "wrong_param" in str(captured_warnings[0].message)
+
+
+@pytest.mark.asyncio
+async def test_stream(mock_portkey_client, model, model_id, agenerator, alist):
+    mock_delta_1 = unittest.mock.Mock(content="Hello", tool_calls=None, reasoning_content=None)
+    mock_delta_2 = unittest.mock.Mock(content=" world", tool_calls=None, reasoning_content=None)
+    mock_delta_3 = unittest.mock.Mock(content="", tool_calls=None, reasoning_content=None)
+
+    mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_1)])
+    mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_2)])
+    mock_event_3 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="stop", delta=mock_delta_3)])
+    mock_event_4 = unittest.mock.Mock()
+
+    mock_portkey_client.chat.completions.create = unittest.mock.AsyncMock(
+        return_value=agenerator([mock_event_1, mock_event_2, mock_event_3, mock_event_4])
+    )
+
+    messages = [{"role": "user", "content": [{"text": "say hello"}]}]
+    response = model.stream(messages)
+    tru_events = await alist(response)
+
+    exp_events = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": "Hello"}}},
+        {"contentBlockDelta": {"delta": {"text": " world"}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {
+            "metadata": {
+                "usage": {
+                    "inputTokens": mock_event_4.usage.prompt_tokens,
+                    "outputTokens": mock_event_4.usage.completion_tokens,
+                    "totalTokens": mock_event_4.usage.total_tokens,
+                },
+                "metrics": {"latencyMs": 0},
+            }
+        },
+    ]
+
+    assert tru_events == exp_events
+
+    mock_portkey_client.chat.completions.create.assert_called_once_with(
+        messages=[{"role": "user", "content": [{"text": "say hello", "type": "text"}]}],
+        model=model_id,
+        stream=True,
+        stream_options={"include_usage": True},
+        tools=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_with_tool_calls(mock_portkey_client, model, agenerator, alist):
+    mock_tool_call = unittest.mock.Mock(index=0)
+    mock_delta_1 = unittest.mock.Mock(content="Let me check", tool_calls=[mock_tool_call], reasoning_content=None)
+    mock_delta_2 = unittest.mock.Mock(content="", tool_calls=None, reasoning_content=None)
+
+    mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_1)])
+    mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="tool_calls", delta=mock_delta_2)])
+    mock_event_3 = unittest.mock.Mock(usage=None)
+
+    mock_portkey_client.chat.completions.create = unittest.mock.AsyncMock(
+        return_value=agenerator([mock_event_1, mock_event_2, mock_event_3])
+    )
+
+    messages = [{"role": "user", "content": [{"text": "use a tool"}]}]
+    response = model.stream(messages)
+    tru_events = await alist(response)
+
+    assert tru_events[0] == {"messageStart": {"role": "assistant"}}
+    assert {"messageStop": {"stopReason": "tool_use"}} in tru_events
+
+
+@pytest.mark.asyncio
+async def test_stream_empty(mock_portkey_client, model, model_id, agenerator, alist):
+    mock_delta = unittest.mock.Mock(content=None, tool_calls=None, reasoning_content=None)
+
+    mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta)])
+    mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="stop", delta=mock_delta)])
+    mock_event_3 = unittest.mock.Mock()
+    mock_event_4 = unittest.mock.Mock(usage=None)
+
+    mock_portkey_client.chat.completions.create = unittest.mock.AsyncMock(
+        return_value=agenerator([mock_event_1, mock_event_2, mock_event_3, mock_event_4]),
+    )
+
+    messages = [{"role": "user", "content": []}]
+    response = model.stream(messages)
+    tru_events = await alist(response)
+
+    exp_events = [
+        {"messageStart": {"role": "assistant"}},
+        {"messageStop": {"stopReason": "end_turn"}},
+    ]
+
+    assert len(tru_events) == len(exp_events)
+
+
+@pytest.mark.asyncio
+async def test_structured_output(mock_portkey_client, model, test_output_model_cls, alist):
+    messages = [{"role": "user", "content": [{"text": "Generate a person"}]}]
+
+    mock_parsed_instance = test_output_model_cls(name="John", age=30)
+    mock_choice = unittest.mock.Mock()
+    mock_choice.message.parsed = mock_parsed_instance
+    mock_response = unittest.mock.Mock()
+    mock_response.choices = [mock_choice]
+
+    mock_portkey_client.beta.chat.completions.parse = unittest.mock.AsyncMock(return_value=mock_response)
+
+    stream = model.structured_output(test_output_model_cls, messages)
+    events = await alist(stream)
+
+    tru_result = events[-1]
+    exp_result = {"output": test_output_model_cls(name="John", age=30)}
+    assert tru_result == exp_result
+
+
+@pytest.mark.asyncio
+async def test_stream_context_overflow_exception(mock_portkey_client, model, messages):
+    """Test that context overflow errors are properly converted."""
+    mock_error = openai.BadRequestError(
+        message="This model's maximum context length is 4096 tokens.",
+        response=unittest.mock.MagicMock(),
+        body={"error": {"code": "context_length_exceeded"}},
+    )
+    mock_error.code = "context_length_exceeded"
+
+    mock_portkey_client.chat.completions.create.side_effect = mock_error
+
+    with pytest.raises(ContextWindowOverflowException):
+        async for _ in model.stream(messages):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_stream_rate_limit_as_throttle(mock_portkey_client, model, messages):
+    """Test that rate limit errors are converted to ModelThrottledException."""
+    mock_error = openai.RateLimitError(
+        message="Rate limit exceeded.",
+        response=unittest.mock.MagicMock(),
+        body={"error": {"code": "rate_limit_exceeded"}},
+    )
+    mock_error.code = "rate_limit_exceeded"
+
+    mock_portkey_client.chat.completions.create.side_effect = mock_error
+
+    with pytest.raises(ModelThrottledException):
+        async for _ in model.stream(messages):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_get_client_creates_async_portkey_from_config():
+    """Test that _get_client extracts Portkey args from config and creates an AsyncPortkey client."""
+    mock_module = unittest.mock.MagicMock()
+    mock_client = unittest.mock.AsyncMock()
+    mock_client.close = unittest.mock.AsyncMock()
+    mock_module.AsyncPortkey.return_value = mock_client
+
+    with unittest.mock.patch.dict("sys.modules", {"portkey_ai": mock_module}):
+        model = PortkeyModel(api_key="pk-test", virtual_key="vk-openai", model_id="gpt-4o")
+
+        async with model._get_client() as client:
+            assert client is mock_client
+
+        # Only Portkey client keys should be passed, not model_id or params
+        mock_module.AsyncPortkey.assert_called_once_with(api_key="pk-test", virtual_key="vk-openai")
+        mock_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_client_uses_injected_client(mock_portkey_client):
+    """Test that _get_client uses the injected client and does not close it."""
+    model = PortkeyModel(client=mock_portkey_client, model_id="gpt-4o")
+
+    async with model._get_client() as client:
+        assert client is mock_portkey_client
+
+    mock_portkey_client.close.assert_not_called()
+
+
+def test_format_request(model, messages, tool_specs, system_prompt):
+    """Test that format_request produces OpenAI-compatible request (inherited)."""
+    tru_request = model.format_request(messages, tool_specs, system_prompt)
+
+    assert tru_request["model"] == "gpt-4o"
+    assert tru_request["stream"] is True
+    assert tru_request["stream_options"] == {"include_usage": True}
+    assert len(tru_request["tools"]) == 1
+    assert tru_request["tools"][0]["function"]["name"] == "test_tool"
+    # Portkey client keys should NOT appear in the request
+    assert "api_key" not in tru_request
+    assert "virtual_key" not in tru_request
+
+
+def test_format_request_does_not_leak_portkey_args():
+    """Test that Portkey client args (api_key, virtual_key, etc.) don't leak into API requests."""
+    model = PortkeyModel(
+        api_key="pk-test",
+        virtual_key="vk-test",
+        provider="openai",
+        trace_id="trace-123",
+        model_id="gpt-4o",
+    )
+
+    messages = [{"role": "user", "content": [{"text": "hello"}]}]
+    request = model.format_request(messages)
+
+    assert "api_key" not in request
+    assert "virtual_key" not in request
+    assert "provider" not in request
+    assert "trace_id" not in request
+    assert request["model"] == "gpt-4o"


### PR DESCRIPTION
## Summary
- Add `PortkeyModel` integration that routes requests through the [Portkey AI gateway](https://portkey.ai/), enabling observability, caching, fallbacks, and load balancing across any LLM provider
- The gateway automatically infers the provider from `model_id`, so only `api_key` and `model_id` are required:
  ```python
  model = PortkeyModel(api_key="pk-...", model_id="gpt-4o")
  ```
- Extends `OpenAIModel` since Portkey normalizes all provider responses into the OpenAI-compatible format
- Add `portkey-ai` as optional dependency (`pip install strands-agents[portkey]`)

### Files changed
| File | Change |
|------|--------|
| `src/strands/models/portkey.py` | New `PortkeyModel` implementation |
| `src/strands/models/__init__.py` | Lazy loading registration |
| `tests/strands/models/test_portkey.py` | 20 unit tests |
| `pyproject.toml` | Optional dependency + `all` extra |

### Usage examples

```python
from strands import Agent
from strands.models.portkey import PortkeyModel

# OpenAI
model = PortkeyModel(api_key="pk-...", model_id="gpt-4o")

# Anthropic — just change the model_id
model = PortkeyModel(api_key="pk-...", model_id="claude-sonnet-4-20250514")

# Google
model = PortkeyModel(api_key="pk-...", model_id="gemini-2.0-flash")

# With Portkey config for routing/fallbacks/load balancing
model = PortkeyModel(api_key="pk-...", config="cf-xxx", model_id="gpt-4o")

agent = Agent(model=model)
agent("Hello!")
```

## Test plan
- [x] `hatch fmt --formatter` — passed
- [x] `hatch fmt --linter` — passed
- [x] `hatch test -- tests/strands/models/test_portkey.py` — 20/20 passed
- [x] Manual verification with Portkey gateway using Bedrock model
