### PR TITLE
fix(bedrock): add 'prompt is too long' to context window overflow mes…

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -42,6 +42,7 @@ BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
     "Input is too long for requested model",
     "input length and `max_tokens` exceed context limit",
     "too many total text bytes",
+    "prompt is too long",
 ]
 
 # Models that should include tool result status (include_tool_result_status = True)

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -19,7 +19,7 @@ from strands.models.bedrock import (
     DEFAULT_BEDROCK_REGION,
     DEFAULT_READ_TIMEOUT,
 )
-from strands.types.exceptions import ModelThrottledException
+from strands.types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from strands.types.tools import ToolSpec
 
 FORMATTED_DEFAULT_MODEL_ID = DEFAULT_BEDROCK_MODEL_ID.format("us")
@@ -1514,6 +1514,31 @@ async def test_add_note_on_validation_exception_throughput(bedrock_client, model
         "└ For more information see "
         "https://strandsagents.com/latest/user-guide/concepts/model-providers/amazon-bedrock/#on-demand-throughput-isnt-supported",
     ]
+
+
+@pytest.mark.parametrize(
+    "overflow_message",
+    [
+        "Input is too long for requested model",
+        "input length and `max_tokens` exceed context limit",
+        "too many total text bytes",
+        "prompt is too long: 903884 tokens > 200000 maximum",
+    ],
+)
+@pytest.mark.asyncio
+async def test_stream_context_window_overflow(overflow_message, bedrock_client, model, alist, messages):
+    """Test that ClientError with overflow messages raises ContextWindowOverflowException."""
+    error_response = {
+        "Error": {
+            "Code": "ValidationException",
+            "Message": f"An error occurred (ValidationException) when calling the ConverseStream operation: "
+            f"The model returned the following errors: {overflow_message}",
+        }
+    }
+    bedrock_client.converse_stream.side_effect = ClientError(error_response, "ConverseStream")
+
+    with pytest.raises(ContextWindowOverflowException):
+        await alist(model.stream(messages))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Claude Opus 4.6 via Bedrock returns a different error message when the context window is exceeded:

```
botocore.errorfactory.ValidationException: An error occurred (ValidationException)
when calling the ConverseStream operation: The model returned the following errors:
prompt is too long: 903884 tokens > 200000 maximum
```

This message was not recognized by the Bedrock provider's `BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES` list, causing the agent to raise a raw `ClientError` instead of `ContextWindowOverflowException`. This prevents the agent's `reduce_context()` recovery mechanism from triggering.

The Anthropic direct API provider already handles this message (`"prompt is too long:"` in `AnthropicModel.OVERFLOW_MESSAGES`), but the Bedrock provider was missing it.

**Fix:** Add `"prompt is too long"` to `BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES`.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Added a parametrized test (`test_stream_context_window_overflow`) covering all 4 overflow message variants, including the new `"prompt is too long"` message.

- [x] I ran `hatch run prepare`

**Results:** 1764 passed, 4 skipped, 0 failures.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
