### PR TITLE
fix: correct output reference for approval-env in integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ jobs:
     permissions: read-all
     runs-on: ubuntu-latest
     outputs:
-      approval-env: ${{ steps.auth.outputs.result }}
+      approval-env: ${{ steps.auth.outputs.approval-env }}
     steps:
       - name: Check Authorization
         id: auth


### PR DESCRIPTION


## Description

Changed `steps.auth.outputs.result` to `steps.auth.outputs.approval-env` to correctly reference the named output from the auth step. https://github.com/strands-agents/devtools/blob/main/authorization-check/action.yml#L16-L19

## Related Issues


## Documentation PR


## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
