### PR TITLE
fix(mistral): report usage metrics in streaming mode

### DIFF
--- a/src/strands/models/mistral.py
+++ b/src/strands/models/mistral.py
@@ -496,8 +496,8 @@ class MistralModel(Model):
 
                             yield self.format_chunk({"chunk_type": "message_stop", "data": choice.finish_reason})
 
-                            if hasattr(chunk, "usage"):
-                                yield self.format_chunk({"chunk_type": "metadata", "data": chunk.usage})
+                            if hasattr(chunk, "data") and hasattr(chunk.data, "usage") and chunk.data.usage:
+                                yield self.format_chunk({"chunk_type": "metadata", "data": chunk.data.usage})
 
         except Exception as e:
             if "rate" in str(e).lower() or "429" in str(e):

--- a/tests/strands/models/test_mistral.py
+++ b/tests/strands/models/test_mistral.py
@@ -451,9 +451,9 @@ async def test_stream(mistral_client, model, agenerator, alist, captured_warning
                     delta=unittest.mock.Mock(content="test stream", tool_calls=None),
                     finish_reason="end_turn",
                 )
-            ]
+            ],
+            usage=mock_usage,
         ),
-        usage=mock_usage,
     )
 
     mistral_client.chat.stream_async = unittest.mock.AsyncMock(return_value=agenerator([mock_event]))
@@ -477,6 +477,30 @@ async def test_stream(mistral_client, model, agenerator, alist, captured_warning
 
 
 @pytest.mark.asyncio
+async def test_stream_no_usage(mistral_client, model, agenerator, alist):
+    mock_event = unittest.mock.Mock(
+        data=unittest.mock.Mock(
+            choices=[
+                unittest.mock.Mock(
+                    delta=unittest.mock.Mock(content="test stream", tool_calls=None),
+                    finish_reason="end_turn",
+                )
+            ],
+            usage=None,
+        ),
+    )
+
+    mistral_client.chat.stream_async = unittest.mock.AsyncMock(return_value=agenerator([mock_event]))
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    response = model.stream(messages, None, None)
+
+    # Should complete without error and not yield a metadata chunk
+    chunks = await alist(response)
+    assert not any("metadata" in c for c in chunks if isinstance(c, dict))
+
+
+@pytest.mark.asyncio
 async def test_tool_choice_not_supported_warns(mistral_client, model, agenerator, alist, captured_warnings):
     tool_choice = {"auto": {}}
 
@@ -492,9 +516,9 @@ async def test_tool_choice_not_supported_warns(mistral_client, model, agenerator
                     delta=unittest.mock.Mock(content="test stream", tool_calls=None),
                     finish_reason="end_turn",
                 )
-            ]
+            ],
+            usage=mock_usage,
         ),
-        usage=mock_usage,
     )
 
     mistral_client.chat.stream_async = unittest.mock.AsyncMock(return_value=agenerator([mock_event]))

--- a/tests_integ/models/test_model_mistral.py
+++ b/tests_integ/models/test_model_mistral.py
@@ -106,6 +106,11 @@ async def test_agent_stream_async(agent):
 
     assert all(string in text for string in ["12:00", "sunny"])
 
+    assert result.metrics.accumulated_usage is not None
+    assert result.metrics.accumulated_usage["inputTokens"] > 0
+    assert result.metrics.accumulated_usage["outputTokens"] > 0
+    assert result.metrics.accumulated_usage["totalTokens"] > 0
+
 
 def test_agent_structured_output(non_streaming_agent, weather):
     tru_weather = non_streaming_agent.structured_output(type(weather), "The time is 12:00 and the weather is sunny")


### PR DESCRIPTION
## Description
Fixed a bug where Mistral models were not reporting usage metrics (prompt tokens, completion tokens, total tokens) when used in streaming mode. 

The root cause was that the streaming response handler checked for usage data at `chunk.usage` (top-level), but Mistral's v1+ SDK returns all streaming data nested under a `data` property. According to the [Mistral Python SDK migration guide](https://github.com/mistralai/client-python/blob/main/MIGRATION.md), streaming chunks are accessed via `chunk.data.choices[0].delta.content` with the additional `.data` wrapper layer. This same nesting applies to the `usage` field, making the correct path `chunk.data.usage`.

This is confirmed by the [Langfuse Mistral integration example](http://langfuse.com/integrations/model-providers/mistral-sdk#streaming-completions), which shows the correct access pattern:
```python
if chunk.data.choices[0].finish_reason == "stop":
    usage = {
        "input": chunk.data.usage.prompt_tokens,
        "output": chunk.data.usage.completion_tokens
    }
```

This bug manifested silently; Mistral model streaming worked, but we noticed that we never received token data for streaming Mistral models.

## Related Issues

- N/A

## Documentation PR

- N/A

## Type of Change

- Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- I manually tested this before and after:
   - Before: Usage data for streaming Mistral models was empty (0 input tokens, 0 completion tokens).
   - After: Usage data for streaming Mistral models was correct (correct input tokens, correct completed tokens).
- I updated the Mistral tests to mock the usage at the correct level (under data).

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
