### PR TITLE
fix: update allowed roles to include maintainer

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           skip-check: ${{ github.event_name == 'merge_group' }}
           username: ${{ github.event.pull_request.user.login || 'invalid' }}
-          allowed-roles: 'triage,write,admin'
+          allowed-roles: 'maintain,triage,write,admin'
   
   check-access-and-checkout:
     runs-on: ubuntu-latest

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           skip-check: ${{ github.event_name == 'workflow_dispatch' }}
           username: ${{ github.event.comment.user.login || 'invalid' }}
-          allowed-roles: 'triage,write,admin'
+          allowed-roles: 'maintain,triage,write,admin'
   
   setup-and-process:
     needs: [authorization-check]


### PR DESCRIPTION
## Description
Fixes the following to allow workflows to run for maintainers:
```
with:
    result-encoding: string
    script: const checkAuthorization = require('./_authorization-check/authorization-check/scripts/check-authorization.cjs');
  return await checkAuthorization(context, github, {
    username: 'afarntrog',
    allowedRoles: 'triage,write,admin'
  });
  
    github-token: ***
    debug: false
    user-agent: actions/github-script
    retries: 0
    retry-exempt-status-codes: 400,401,403,404,422
User afarntrog does not have write access to the repository (role: maintain, allowed: triage, write, admin)
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
