### PR TITLE
feat(agent): add concurrent_invocation_mode parameter

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -189,8 +189,9 @@ class Agent(AgentBase):
                 Implement a custom HookProvider for custom retry logic, or pass None to disable retries.
             concurrent_invocation_mode: Mode controlling concurrent invocation behavior.
                 Defaults to "throw" which raises ConcurrencyException if concurrent invocation is attempted.
-                Set to "unsafe_reentrant" to skip lock acquisition entirely, allowing concurrent invocations
-                (restores pre-locking behavior, use with caution).
+                Set to "unsafe_reentrant" to skip lock acquisition entirely, allowing concurrent invocations.
+                Warning: "unsafe_reentrant" makes no guarantees about resulting behavior and is provided
+                only for advanced use cases where the caller understands the risks.
 
         Raises:
             ValueError: If agent id contains path separators.

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -129,7 +129,7 @@ class Agent(AgentBase):
         structured_output_prompt: str | None = None,
         tool_executor: ToolExecutor | None = None,
         retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
-        concurrent_invocation_mode: ConcurrentInvocationMode = "throw",
+        concurrent_invocation_mode: ConcurrentInvocationMode = ConcurrentInvocationMode.THROW,
     ):
         """Initialize the Agent with the specified configuration.
 

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -633,7 +633,7 @@ class Agent(AgentBase):
         # Using threading.Lock instead of asyncio.Lock because run_async() creates
         # separate event loops in different threads
         lock_acquired = False
-        if self._concurrent_invocation_mode == "throw":
+        if self._concurrent_invocation_mode == ConcurrentInvocationMode.THROW:
             lock_acquired = self._invocation_lock.acquire(blocking=False)
             if not lock_acquired:
                 raise ConcurrencyException(

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -54,7 +54,7 @@ from ..tools.registry import ToolRegistry
 from ..tools.structured_output._structured_output_context import StructuredOutputContext
 from ..tools.watcher import ToolWatcher
 from ..types._events import AgentResultEvent, EventLoopStopEvent, InitEventLoopEvent, ModelStreamChunkEvent, TypedEvent
-from ..types.agent import AgentInput
+from ..types.agent import AgentInput, ConcurrentInvocationMode
 from ..types.content import ContentBlock, Message, Messages, SystemContentBlock
 from ..types.exceptions import ConcurrencyException, ContextWindowOverflowException
 from ..types.traces import AttributeValue
@@ -129,6 +129,7 @@ class Agent(AgentBase):
         structured_output_prompt: str | None = None,
         tool_executor: ToolExecutor | None = None,
         retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
+        concurrent_invocation_mode: ConcurrentInvocationMode = "throw",
     ):
         """Initialize the Agent with the specified configuration.
 
@@ -186,6 +187,10 @@ class Agent(AgentBase):
             retry_strategy: Strategy for retrying model calls on throttling or other transient errors.
                 Defaults to ModelRetryStrategy with max_attempts=6, initial_delay=4s, max_delay=240s.
                 Implement a custom HookProvider for custom retry logic, or pass None to disable retries.
+            concurrent_invocation_mode: Mode controlling concurrent invocation behavior.
+                Defaults to "throw" which raises ConcurrencyException if concurrent invocation is attempted.
+                Set to "unsafe_reentrant" to skip lock acquisition entirely, allowing concurrent invocations
+                (restores pre-locking behavior, use with caution).
 
         Raises:
             ValueError: If agent id contains path separators.
@@ -263,6 +268,7 @@ class Agent(AgentBase):
         # Using threading.Lock instead of asyncio.Lock because run_async() creates
         # separate event loops in different threads, so asyncio.Lock wouldn't work
         self._invocation_lock = threading.Lock()
+        self._concurrent_invocation_mode = concurrent_invocation_mode
 
         # In the future, we'll have a RetryStrategy base class but until
         # that API is determined we only allow ModelRetryStrategy
@@ -622,14 +628,16 @@ class Agent(AgentBase):
                     yield event["data"]
             ```
         """
-        # Acquire lock to prevent concurrent invocations
+        # Conditionally acquire lock based on concurrent_invocation_mode
         # Using threading.Lock instead of asyncio.Lock because run_async() creates
         # separate event loops in different threads
-        acquired = self._invocation_lock.acquire(blocking=False)
-        if not acquired:
-            raise ConcurrencyException(
-                "Agent is already processing a request. Concurrent invocations are not supported."
-            )
+        lock_acquired = False
+        if self._concurrent_invocation_mode == "throw":
+            lock_acquired = self._invocation_lock.acquire(blocking=False)
+            if not lock_acquired:
+                raise ConcurrencyException(
+                    "Agent is already processing a request. Concurrent invocations are not supported."
+                )
 
         try:
             self._interrupt_state.resume(prompt)
@@ -678,7 +686,8 @@ class Agent(AgentBase):
                     raise
 
         finally:
-            self._invocation_lock.release()
+            if lock_acquired:
+                self._invocation_lock.release()
 
     async def _run_loop(
         self,

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -632,7 +632,6 @@ class Agent(AgentBase):
         # Conditionally acquire lock based on concurrent_invocation_mode
         # Using threading.Lock instead of asyncio.Lock because run_async() creates
         # separate event loops in different threads
-        lock_acquired = False
         if self._concurrent_invocation_mode == ConcurrentInvocationMode.THROW:
             lock_acquired = self._invocation_lock.acquire(blocking=False)
             if not lock_acquired:
@@ -687,7 +686,7 @@ class Agent(AgentBase):
                     raise
 
         finally:
-            if lock_acquired:
+            if self._invocation_lock.locked():
                 self._invocation_lock.release()
 
     async def _run_loop(

--- a/src/strands/types/agent.py
+++ b/src/strands/types/agent.py
@@ -3,9 +3,17 @@
 This module defines the types used for an Agent.
 """
 
-from typing import TypeAlias
+from typing import Literal, TypeAlias
 
 from .content import ContentBlock, Messages
 from .interrupt import InterruptResponseContent
 
 AgentInput: TypeAlias = str | list[ContentBlock] | list[InterruptResponseContent] | Messages | None
+
+ConcurrentInvocationMode = Literal["throw", "unsafe_reentrant"]
+"""Mode controlling concurrent invocation behavior.
+
+Values:
+    throw: Raises ConcurrencyException if concurrent invocation is attempted (default).
+    unsafe_reentrant: Allows concurrent invocations without locking (unsafe, restores pre-lock behavior).
+"""

--- a/src/strands/types/agent.py
+++ b/src/strands/types/agent.py
@@ -3,21 +3,26 @@
 This module defines the types used for an Agent.
 """
 
-from typing import Literal, TypeAlias
+from enum import Enum
+from typing import TypeAlias
 
 from .content import ContentBlock, Messages
 from .interrupt import InterruptResponseContent
 
 AgentInput: TypeAlias = str | list[ContentBlock] | list[InterruptResponseContent] | Messages | None
 
-ConcurrentInvocationMode = Literal["throw", "unsafe_reentrant"]
-"""Mode controlling concurrent invocation behavior.
 
-Values:
-    throw: Raises ConcurrencyException if concurrent invocation is attempted (default).
-    unsafe_reentrant: Allows concurrent invocations without locking.
+class ConcurrentInvocationMode(str, Enum):
+    """Mode controlling concurrent invocation behavior.
 
-Warning:
-    The ``unsafe_reentrant`` mode makes no guarantees about resulting behavior and is
-    provided only for advanced use cases where the caller understands the risks.
-"""
+    Values:
+        THROW: Raises ConcurrencyException if concurrent invocation is attempted (default).
+        UNSAFE_REENTRANT: Allows concurrent invocations without locking.
+
+    Warning:
+        The ``UNSAFE_REENTRANT`` mode makes no guarantees about resulting behavior and is
+        provided only for advanced use cases where the caller understands the risks.
+    """
+
+    THROW = "throw"
+    UNSAFE_REENTRANT = "unsafe_reentrant"

--- a/src/strands/types/agent.py
+++ b/src/strands/types/agent.py
@@ -15,5 +15,9 @@ ConcurrentInvocationMode = Literal["throw", "unsafe_reentrant"]
 
 Values:
     throw: Raises ConcurrencyException if concurrent invocation is attempted (default).
-    unsafe_reentrant: Allows concurrent invocations without locking (unsafe, restores pre-lock behavior).
+    unsafe_reentrant: Allows concurrent invocations without locking.
+
+Warning:
+    The ``unsafe_reentrant`` mode makes no guarantees about resulting behavior and is
+    provided only for advanced use cases where the caller understands the risks.
 """

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -2382,6 +2382,22 @@ def test_agent_concurrent_invocation_mode_stores_value():
     assert agent_reentrant._concurrent_invocation_mode == "unsafe_reentrant"
 
 
+def test_agent_concurrent_invocation_mode_accepts_enum():
+    """Test that concurrent_invocation_mode accepts enum values as well as strings."""
+    from strands.types.agent import ConcurrentInvocationMode
+
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "hello"}]}])
+
+    # Using enum values
+    agent_throw = Agent(model=model, concurrent_invocation_mode=ConcurrentInvocationMode.THROW)
+    assert agent_throw._concurrent_invocation_mode == "throw"
+    assert agent_throw._concurrent_invocation_mode == ConcurrentInvocationMode.THROW
+
+    agent_reentrant = Agent(model=model, concurrent_invocation_mode=ConcurrentInvocationMode.UNSAFE_REENTRANT)
+    assert agent_reentrant._concurrent_invocation_mode == "unsafe_reentrant"
+    assert agent_reentrant._concurrent_invocation_mode == ConcurrentInvocationMode.UNSAFE_REENTRANT
+
+
 @pytest.mark.asyncio
 async def test_agent_sequential_invocations_work():
     """Test that sequential invocations work correctly after lock is released."""

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -2320,6 +2320,115 @@ def test_agent_concurrent_structured_output_raises_exception():
     assert "concurrent" in str(errors[0]).lower() and "invocation" in str(errors[0]).lower()
 
 
+def test_agent_concurrent_call_succeeds_with_unsafe_reentrant_mode():
+    """Test that concurrent __call__() calls succeed when concurrent_invocation_mode is 'unsafe_reentrant'."""
+    model = SyncEventMockedModel(
+        [
+            {"role": "assistant", "content": [{"text": "hello"}]},
+            {"role": "assistant", "content": [{"text": "world"}]},
+        ]
+    )
+    agent = Agent(model=model, concurrent_invocation_mode="unsafe_reentrant")
+
+    results = []
+    errors = []
+    lock = threading.Lock()
+
+    def invoke():
+        try:
+            result = agent("test")
+            with lock:
+                results.append(result)
+        except ConcurrencyException as e:
+            with lock:
+                errors.append(e)
+
+    # Start first thread and wait for it to begin streaming
+    t1 = threading.Thread(target=invoke)
+    t1.start()
+    model.started_event.wait()  # Wait until first thread is in the model.stream()
+
+    # Start second thread while first is still running
+    t2 = threading.Thread(target=invoke)
+    t2.start()
+
+    # Let both threads proceed
+    model.proceed_event.set()
+    t1.join()
+    t2.join()
+
+    # Both should succeed, no ConcurrencyException raised
+    assert len(errors) == 0, f"Expected 0 errors, got {len(errors)}: {errors}"
+    assert len(results) == 2, f"Expected 2 successes, got {len(results)}"
+
+
+def test_agent_concurrent_invocation_mode_throw_raises_exception():
+    """Test that concurrent_invocation_mode='throw' maintains the default behavior."""
+    model = SyncEventMockedModel(
+        [
+            {"role": "assistant", "content": [{"text": "hello"}]},
+            {"role": "assistant", "content": [{"text": "world"}]},
+        ]
+    )
+    # Explicit throw mode should behave same as default
+    agent = Agent(model=model, concurrent_invocation_mode="throw")
+
+    results = []
+    errors = []
+    lock = threading.Lock()
+
+    def invoke():
+        try:
+            result = agent("test")
+            with lock:
+                results.append(result)
+        except ConcurrencyException as e:
+            with lock:
+                errors.append(e)
+
+    # Start first thread and wait for it to begin streaming
+    t1 = threading.Thread(target=invoke)
+    t1.start()
+    model.started_event.wait()  # Wait until first thread is in the model.stream()
+
+    # Start second thread while first is still running
+    t2 = threading.Thread(target=invoke)
+    t2.start()
+
+    # Give second thread time to attempt invocation and fail
+    t2.join(timeout=1.0)
+
+    # Now let first thread complete
+    model.proceed_event.set()
+    t1.join()
+    t2.join()
+
+    # One should succeed, one should raise ConcurrencyException
+    assert len(results) == 1, f"Expected 1 success, got {len(results)}"
+    assert len(errors) == 1, f"Expected 1 error, got {len(errors)}"
+    assert "concurrent" in str(errors[0]).lower() and "invocation" in str(errors[0]).lower()
+
+
+def test_agent_concurrent_invocation_mode_default_is_throw():
+    """Test that the default concurrent_invocation_mode is 'throw'."""
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "hello"}]}])
+    agent = Agent(model=model)
+
+    # Verify the default mode
+    assert agent._concurrent_invocation_mode == "throw"
+
+
+def test_agent_concurrent_invocation_mode_stores_value():
+    """Test that concurrent_invocation_mode is stored correctly as instance variable."""
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "hello"}]}])
+
+    agent_throw = Agent(model=model, concurrent_invocation_mode="throw")
+    assert agent_throw._concurrent_invocation_mode == "throw"
+
+    agent_reentrant = Agent(model=model, concurrent_invocation_mode="unsafe_reentrant")
+    assert agent_reentrant._concurrent_invocation_mode == "unsafe_reentrant"
+
+
 @pytest.mark.asyncio
 async def test_agent_sequential_invocations_work():
     """Test that sequential invocations work correctly after lock is released."""

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -26,6 +26,7 @@ from strands.models.bedrock import DEFAULT_BEDROCK_MODEL_ID, BedrockModel
 from strands.session.repository_session_manager import RepositorySessionManager
 from strands.telemetry.tracer import serialize
 from strands.types._events import EventLoopStopEvent, ModelStreamEvent
+from strands.types.agent import ConcurrentInvocationMode
 from strands.types.content import Messages
 from strands.types.exceptions import ConcurrencyException, ContextWindowOverflowException, EventLoopException
 from strands.types.session import Session, SessionAgent, SessionMessage, SessionType
@@ -2235,16 +2236,13 @@ def test_agent_concurrent_call_raises_exception():
 
     results = []
     errors = []
-    lock = threading.Lock()
 
     def invoke():
         try:
             result = agent("test")
-            with lock:
-                results.append(result)
+            results.append(result)
         except ConcurrencyException as e:
-            with lock:
-                errors.append(e)
+            errors.append(e)
 
     # Start first thread and wait for it to begin streaming
     t1 = threading.Thread(target=invoke)
@@ -2384,7 +2382,6 @@ def test_agent_concurrent_invocation_mode_stores_value():
 
 def test_agent_concurrent_invocation_mode_accepts_enum():
     """Test that concurrent_invocation_mode accepts enum values as well as strings."""
-    from strands.types.agent import ConcurrentInvocationMode
 
     model = MockedModelProvider([{"role": "assistant", "content": [{"text": "hello"}]}])
 


### PR DESCRIPTION
## Motivation

Users who need to re-trigger an agent during invocation (e.g., to provide feedback out-of-band) are currently blocked by `ConcurrencyException` introduced in #1453. While concurrent invocation detection is valuable for safety, power users requested an escape hatch to restore the previous behavior when they need concurrent re-invocations.

Resolves #1702

## Public API Changes

`Agent.__init__` now accepts a `concurrent_invocation_mode` parameter:

```python
# Before: no way to allow concurrent invocations
agent = Agent(model=model)
# Concurrent calls raise ConcurrencyException

# After: opt into unsafe reentrant behavior
agent = Agent(model=model, concurrent_invocation_mode="unsafe_reentrant")
# Concurrent calls proceed without exception (user assumes responsibility)
```

The parameter accepts:
- `"throw"` (default): Maintains existing behavior - raises `ConcurrencyException` on concurrent invocation attempts
- `"unsafe_reentrant"`: Skips lock acquisition entirely, allowing concurrent invocations

The new type `ConcurrentInvocationMode` is available via `strands.types.agent.ConcurrentInvocationMode` for type annotations.

## Use Cases

- **Re-triggering agents**: Users who want to interrupt and re-invoke an agent mid-invocation
- **Legacy behavior**: Teams migrating from pre-#1453 behavior who rely on concurrent invocations
- **Future extensibility**: Opens the door for an `"interrupt"` mode to cleanly interrupt agents with new user messages