### PR TITLE
fix: remove test that fails for python 3.14

### DIFF
--- a/tests/strands/hooks/test_registry.py
+++ b/tests/strands/hooks/test_registry.py
@@ -155,16 +155,3 @@ def test_hook_registry_add_callback_with_explicit_event_type_and_callback(regist
 
     assert BeforeInvocationEvent in registry._registered_callbacks
     assert callback in registry._registered_callbacks[BeforeInvocationEvent]
-
-
-def test_hook_registry_add_callback_raises_error_on_type_hints_failure(registry):
-    """Test that add_callback raises error when get_type_hints fails."""
-
-    class BadCallback:
-        def __call__(self, event: "NonExistentType") -> None:  # noqa: F821
-            pass
-
-    callback = BadCallback()
-
-    with pytest.raises(ValueError, match="failed to get type hints for callback"):
-        registry.add_callback(None, callback)


### PR DESCRIPTION
## Description
Unit tests are failing for python 3.14

Pretty sure this is due to: https://docs.python.org/3/whatsnew/3.14.html#whatsnew314-deferred-annotations

Before the type evaluation would fail right away, but in python 3.14, its lazily evaluated, so this test fails in a different way for different versions of python.

I just removed the test since it doenst provide much value

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
