### PR TITLE
feat: make pyaudio an optional dependency by lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ Build real-time voice and audio conversations with persistent streaming connecti
 - Google Gemini Live
 - OpenAI Realtime API
 
+**Installation:**
+
+```bash
+# Server-side only (no audio I/O dependencies)
+pip install strands-agents[bidi]
+
+# With audio I/O support (includes PyAudio dependency)
+pip install strands-agents[bidi,bidi-io]
+```
+
 **Quick Example:**
 
 ```python
@@ -223,7 +233,7 @@ async def main():
     model = BidiNovaSonicModel()
     agent = BidiAgent(model=model, tools=[calculator, stop_conversation])
 
-    # Setup audio and text I/O
+    # Setup audio and text I/O (requires bidi-io extra)
     audio_io = BidiAudioIO()
     text_io = BidiTextIO()
 
@@ -237,6 +247,8 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+> **Note**: `BidiAudioIO` and `BidiTextIO` require the `bidi-io` extra. For server-side deployments where audio I/O is handled by clients (browsers, mobile apps), install only `strands-agents[bidi]` and implement custom input/output handlers using the `BidiInput` and `BidiOutput` protocols.
 
 **Configuration Options:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,15 +73,17 @@ a2a = [
 
 bidi = [
     "aws_sdk_bedrock_runtime; python_version>='3.12'",
+    "smithy-aws-core>=0.0.1; python_version>='3.12'",
+]
+bidi-io = [
     "prompt_toolkit>=3.0.0,<4.0.0",
     "pyaudio>=0.2.13,<1.0.0",
-    "smithy-aws-core>=0.0.1; python_version>='3.12'",
 ]
 bidi-gemini = ["google-genai>=1.32.0,<2.0.0"]
 bidi-openai = ["websockets>=15.0.0,<17.0.0"]
 
 all = ["strands-agents[a2a,anthropic,docs,gemini,litellm,llamaapi,mistral,ollama,openai,writer,sagemaker,otel]"]
-bidi-all = ["strands-agents[a2a,bidi,bidi-gemini,bidi-openai,docs,otel]"]
+bidi-all = ["strands-agents[a2a,bidi,bidi-io,bidi-gemini,bidi-openai,docs,otel]"]
 
 dev = [
     "commitizen>=4.4.0,<5.0.0",

--- a/src/strands/experimental/bidi/__init__.py
+++ b/src/strands/experimental/bidi/__init__.py
@@ -1,5 +1,7 @@
 """Bidirectional streaming package."""
 
+from typing import Any
+
 # Main components - Primary user interface
 # Re-export standard agent events for tool handling
 from ...types._events import (
@@ -8,9 +10,6 @@ from ...types._events import (
     ToolUseStreamEvent,
 )
 from .agent.agent import BidiAgent
-
-# IO channels - Hardware abstraction
-from .io.audio import BidiAudioIO
 
 # Model interface (for custom implementations)
 from .models.model import BidiModel
@@ -40,8 +39,6 @@ from .types.events import (
 __all__ = [
     # Main interface
     "BidiAgent",
-    # IO channels
-    "BidiAudioIO",
     # Built-in tools
     "stop_conversation",
     # Input Event types
@@ -68,3 +65,19 @@ __all__ = [
     # Model interface
     "BidiModel",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy load IO implementations only when accessed.
+
+    This defers the import of optional dependencies until actually needed.
+    """
+    if name == "BidiAudioIO":
+        from .io.audio import BidiAudioIO
+
+        return BidiAudioIO
+    if name == "BidiTextIO":
+        from .io.text import BidiTextIO
+
+        return BidiTextIO
+    raise AttributeError(f"cannot import name '{name}' from '{__name__}' ({__file__})")


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
BidiAgent currently requires PyAudio and other client-side audio dependencies even for server-side deployments where audio I/O is handled by clients (browsers, mobile apps, native applications). This creates unnecessary dependencies. In this PR, we split the `bidi` extra into separate components:

```bash
# Before: everything bundled together
pip install strands-agents[bidi]  # Includes PyAudio

# After: server-side without audio I/O
pip install strands-agents[bidi]

# After: with audio I/O for local demos
pip install strands-agents[bidi,bidi-io]
```

This PR cleanly implements the implementation contributed by @massi-ang in https://github.com/strands-agents/sdk-python/pull/1361. The previous PR had some formatting and linting issues that are more cleanly resolved here. 


## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/1360

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->


New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
