### PR TITLE
feat: add plugins parameter to Agent

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -323,7 +323,7 @@ class Agent(AgentBase):
 
         if plugins:
             for plugin in plugins:
-                self._plugin_registry.add_plugin(plugin)
+                self._plugin_registry.add_and_init(plugin)
 
         self.hooks.invoke_callbacks(AgentInitializedEvent(agent=self))
 

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -2669,24 +2669,6 @@ def test_agent_plugins_multiple_in_order():
     assert call_order == ["plugin1", "plugin2"]
 
 
-def test_agent_plugins_empty_list():
-    """Test that empty plugins list doesn't cause errors."""
-    agent = Agent(
-        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
-        plugins=[],
-    )
-    assert agent is not None
-
-
-def test_agent_plugins_none():
-    """Test that None plugins parameter doesn't cause errors."""
-    agent = Agent(
-        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
-        plugins=None,
-    )
-    assert agent is not None
-
-
 def test_agent_plugins_can_register_hooks():
     """Test that plugins can register hooks during initialization."""
     hook_called = []
@@ -2698,7 +2680,7 @@ def test_agent_plugins_can_register_hooks():
             def hook_callback(event: BeforeModelCallEvent):
                 hook_called.append(True)
 
-            agent.add_hook(hook_callback, BeforeModelCallEvent)
+            agent.add_hook(hook_callback)
 
     agent = Agent(
         model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),


### PR DESCRIPTION
Add plugins parameter to Agent class that accepts a list of Plugin
instances for extending agent functionality. Plugins are initialized
via PluginRegistry after hooks registration and before
AgentInitializedEvent is fired.

- Add plugins: list[Plugin] | None = None parameter to Agent.__init__
- Initialize PluginRegistry and use it to add plugins
- PluginRegistry handles both sync and async init_plugin methods
- Add Plugin import from strands.plugins
- Add comprehensive unit tests for plugin initialization

Resolves #1687

🤖 Assisted by the code-assist SOP

## Description
<!-- Provide a detailed description of the changes in this PR -->

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
