### PR TITLE
feat(steering): migrate SteeringHandler from HookProvider to Plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ strands-agents/
 │   │   └── registry.py                   # Hook registration
 │   │
 │   ├── plugins/                          # Plugin system
-│   │   ├── plugin.py                     # Plugin Protocol definition
+│   │   ├── plugin.py                     # Plugin definition
 │   │   └── registry.py                   # PluginRegistry for tracking plugins
 │   │
 │   ├── handlers/                         # Event handlers

--- a/src/strands/experimental/steering/__init__.py
+++ b/src/strands/experimental/steering/__init__.py
@@ -13,7 +13,7 @@ Core components:
 
 Usage:
     handler = LLMSteeringHandler(system_prompt="...")
-    agent = Agent(tools=[...], hooks=[handler])
+    agent = Agent(tools=[...], plugins=[handler])
 """
 
 # Core primitives

--- a/src/strands/experimental/steering/core/handler.py
+++ b/src/strands/experimental/steering/core/handler.py
@@ -38,6 +38,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ....hooks.events import AfterModelCallEvent, BeforeToolCallEvent
+from ....plugins.plugin import Plugin
 from ....types.content import Message
 from ....types.streaming import StopReason
 from ....types.tools import ToolUse
@@ -50,7 +51,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class SteeringHandler:
+class SteeringHandler(Plugin):
     """Base class for steering handlers that provide contextual guidance to agents.
 
     Steering handlers maintain local context and register hook callbacks

--- a/src/strands/experimental/steering/core/handler.py
+++ b/src/strands/experimental/steering/core/handler.py
@@ -56,8 +56,6 @@ class SteeringHandler(Plugin):
 
     Steering handlers maintain local context and register hook callbacks
     to populate context data as needed for guidance decisions.
-
-    Implements the Plugin protocol for agent integration.
     """
 
     name: str = "steering"

--- a/test_output.log
+++ b/test_output.log
@@ -1,1 +1,0 @@
-/bin/sh: 1: hatch: not found

--- a/test_output.log
+++ b/test_output.log
@@ -1,0 +1,1 @@
+/bin/sh: 1: hatch: not found

--- a/tests/strands/experimental/steering/core/test_handler.py
+++ b/tests/strands/experimental/steering/core/test_handler.py
@@ -8,7 +8,7 @@ from strands.experimental.steering.core.action import Guide, Interrupt, Proceed
 from strands.experimental.steering.core.context import SteeringContext, SteeringContextCallback, SteeringContextProvider
 from strands.experimental.steering.core.handler import SteeringHandler
 from strands.hooks.events import AfterModelCallEvent, BeforeToolCallEvent
-from strands.plugins.plugin import Plugin
+from strands.plugins import Plugin
 
 
 class TestSteeringHandler(SteeringHandler):
@@ -25,14 +25,14 @@ def test_steering_handler_initialization():
 
 
 def test_steering_handler_has_name_attribute():
-    """Test SteeringHandler has name attribute for Plugin protocol."""
+    """Test SteeringHandler has name attribute for Plugin."""
     handler = TestSteeringHandler()
     assert hasattr(handler, "name")
     assert handler.name == "steering"
 
 
 def test_steering_handler_is_plugin():
-    """Test SteeringHandler implements Plugin protocol."""
+    """Test SteeringHandler implements Plugin."""
     handler = TestSteeringHandler()
     assert isinstance(handler, Plugin)
 

--- a/tests/strands/experimental/steering/core/test_handler.py
+++ b/tests/strands/experimental/steering/core/test_handler.py
@@ -11,7 +11,7 @@ from strands.hooks.events import AfterModelCallEvent, BeforeToolCallEvent
 from strands.plugins.plugin import Plugin
 
 
-class ConcreteSteeringHandler(SteeringHandler):
+class TestSteeringHandler(SteeringHandler):
     """Test implementation of SteeringHandler."""
 
     async def steer_before_tool(self, *, agent, tool_use, **kwargs):
@@ -20,26 +20,26 @@ class ConcreteSteeringHandler(SteeringHandler):
 
 def test_steering_handler_initialization():
     """Test SteeringHandler initialization."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
     assert handler is not None
 
 
 def test_steering_handler_has_name_attribute():
     """Test SteeringHandler has name attribute for Plugin protocol."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
     assert hasattr(handler, "name")
     assert handler.name == "steering"
 
 
 def test_steering_handler_is_plugin():
     """Test SteeringHandler implements Plugin protocol."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
     assert isinstance(handler, Plugin)
 
 
 def test_init_plugin():
     """Test init_plugin registers hooks on agent."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
     agent = Mock()
 
     handler.init_plugin(agent)
@@ -51,7 +51,7 @@ def test_init_plugin():
 
 def test_steering_context_initialization():
     """Test steering context is initialized."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
 
     assert handler.steering_context is not None
     assert isinstance(handler.steering_context, SteeringContext)
@@ -59,7 +59,7 @@ def test_steering_context_initialization():
 
 def test_steering_context_persistence():
     """Test steering context persists across calls."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
 
     handler.steering_context.data.set("test", "value")
     assert handler.steering_context.data.get("test") == "value"
@@ -67,7 +67,7 @@ def test_steering_context_persistence():
 
 def test_steering_context_access():
     """Test steering context can be accessed and modified."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
 
     handler.steering_context.data.set("key", "value")
     assert handler.steering_context.data.get("key") == "value"
@@ -206,7 +206,7 @@ class MockContextProvider(SteeringContextProvider):
         return self.callbacks
 
 
-class ConcreteSteeringHandlerWithProvider(SteeringHandler):
+class TestSteeringHandlerWithProvider(SteeringHandler):
     """Test implementation with context callbacks."""
 
     def __init__(self, context_callbacks=None):
@@ -220,7 +220,7 @@ class ConcreteSteeringHandlerWithProvider(SteeringHandler):
 def test_handler_registers_context_provider_hooks():
     """Test that handler registers hooks from context callbacks."""
     mock_callback = MockContextCallback()
-    handler = ConcreteSteeringHandlerWithProvider(context_callbacks=[mock_callback])
+    handler = TestSteeringHandlerWithProvider(context_callbacks=[mock_callback])
     agent = Mock()
 
     handler.init_plugin(agent)
@@ -238,7 +238,7 @@ def test_handler_registers_context_provider_hooks():
 def test_context_callbacks_receive_steering_context():
     """Test that context callbacks receive the handler's steering context."""
     mock_callback = MockContextCallback()
-    handler = ConcreteSteeringHandlerWithProvider(context_callbacks=[mock_callback])
+    handler = TestSteeringHandlerWithProvider(context_callbacks=[mock_callback])
     agent = Mock()
 
     handler.init_plugin(agent)
@@ -268,7 +268,7 @@ def test_multiple_context_callbacks_registered():
     callback1 = MockContextCallback()
     callback2 = MockContextCallback()
 
-    handler = ConcreteSteeringHandlerWithProvider(context_callbacks=[callback1, callback2])
+    handler = TestSteeringHandlerWithProvider(context_callbacks=[callback1, callback2])
     agent = Mock()
 
     handler.init_plugin(agent)
@@ -283,7 +283,7 @@ def test_handler_initialization_with_callbacks():
     callback1 = MockContextCallback()
     callback2 = MockContextCallback()
 
-    handler = ConcreteSteeringHandlerWithProvider(context_callbacks=[callback1, callback2])
+    handler = TestSteeringHandlerWithProvider(context_callbacks=[callback1, callback2])
 
     # Should have stored the callbacks
     assert len(handler._context_callbacks) == 2
@@ -459,7 +459,7 @@ async def test_tool_steering_exception_handling():
 @pytest.mark.asyncio
 async def test_default_steer_before_tool_returns_proceed():
     """Test default steer_before_tool returns Proceed."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
     agent = Mock()
     tool_use = {"name": "test_tool"}
 
@@ -473,7 +473,7 @@ async def test_default_steer_before_tool_returns_proceed():
 @pytest.mark.asyncio
 async def test_default_steer_after_model_returns_proceed():
     """Test default steer_after_model returns Proceed."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
     agent = Mock()
     message = {"role": "assistant", "content": [{"text": "Hello"}]}
     stop_reason = "end_turn"
@@ -487,7 +487,7 @@ async def test_default_steer_after_model_returns_proceed():
 
 def test_init_plugin_registers_model_steering():
     """Test that init_plugin registers model steering callback."""
-    handler = ConcreteSteeringHandler()
+    handler = TestSteeringHandler()
     agent = Mock()
 
     handler.init_plugin(agent)

--- a/tests/strands/hooks/test_registry.py
+++ b/tests/strands/hooks/test_registry.py
@@ -164,6 +164,7 @@ def test_hook_registry_add_callback_with_explicit_event_type_and_callback(regist
     assert BeforeInvocationEvent in registry._registered_callbacks
     assert callback in registry._registered_callbacks[BeforeInvocationEvent]
 
+
 # ========== Tests for union type support ==========
 
 

--- a/tests/strands/plugins/test_plugins.py
+++ b/tests/strands/plugins/test_plugins.py
@@ -7,7 +7,7 @@ import pytest
 from strands.plugins import Plugin
 from strands.plugins.registry import _PluginRegistry
 
-# Plugin Protocol Tests
+# Plugin Tests
 
 
 def test_plugin_class_requires_inheritance():

--- a/tests_integ/steering/test_model_steering.py
+++ b/tests_integ/steering/test_model_steering.py
@@ -39,7 +39,7 @@ class SimpleModelSteeringHandler(SteeringHandler):
 def test_model_steering_proceeds_without_intervention():
     """Test that model steering can accept responses without modification."""
     handler = SimpleModelSteeringHandler(should_guide=False)
-    agent = Agent(hooks=[handler])
+    agent = Agent(plugins=[handler])
 
     response = agent("What is 2+2?")
 
@@ -54,7 +54,7 @@ def test_model_steering_proceeds_without_intervention():
 def test_model_steering_guide_triggers_retry():
     """Test that Guide action triggers model retry."""
     handler = SimpleModelSteeringHandler(should_guide=True, guidance_message="Please provide a more detailed response.")
-    agent = Agent(hooks=[handler])
+    agent = Agent(plugins=[handler])
 
     response = agent("What is the capital of France?")
 
@@ -85,7 +85,7 @@ def test_model_steering_guide_influences_retry_response():
             return Proceed(reason="Response is good now")
 
     handler = SpecificGuidanceHandler()
-    agent = Agent(hooks=[handler])
+    agent = Agent(plugins=[handler])
 
     response = agent("What is the capital of France?")
 
@@ -122,7 +122,7 @@ def test_model_steering_multiple_retries():
             return Proceed(reason="Response is good now")
 
     handler = MultiRetryHandler()
-    agent = Agent(hooks=[handler])
+    agent = Agent(plugins=[handler])
 
     response = agent("Explain machine learning.")
 
@@ -195,7 +195,7 @@ def test_model_steering_forces_tool_usage_on_unrelated_prompt():
             return Proceed(reason="Guidance was provided")
 
     handler = ForceToolUsageHandler(required_tool="log_activity")
-    agent = Agent(tools=[log_activity], hooks=[handler])
+    agent = Agent(tools=[log_activity], plugins=[handler])
 
     # Ask a question that clearly doesn't need the logging tool
     response = agent("What is 2 + 2?")

--- a/tests_integ/steering/test_tool_steering.py
+++ b/tests_integ/steering/test_tool_steering.py
@@ -87,7 +87,7 @@ def test_agent_with_tool_steering_e2e():
         context_providers=[],  # Disable ledger to avoid confusing context
     )
 
-    agent = Agent(tools=[send_email, send_notification], hooks=[handler])
+    agent = Agent(tools=[send_email, send_notification], plugins=[handler])
 
     # This should trigger steering guidance to use send_notification instead
     response = agent("Send an email to john@example.com saying hello")
@@ -132,7 +132,7 @@ def test_ledger_captures_tool_calls():
             return Proceed(reason="Ledger verified")
 
     handler = LedgerCheckingHandler()
-    agent = Agent(tools=[send_notification], hooks=[handler])
+    agent = Agent(tools=[send_notification], plugins=[handler])
 
     agent("Send a notification to alice saying test message")
 


### PR DESCRIPTION
## Motivation

The `SteeringHandler` currently implements `HookProvider`, but as an experimental feature, it should be migrated to the new `Plugin` protocol to demonstrate the pattern and benefit from the cleaner API. The Plugin protocol provides a more composable way to extend agent functionality with a simpler initialization pattern.

Resolves: #1688

Docs update: https://github.com/strands-agents/docs/pull/569

**Note**: This is a breaking change, but since this is in the experimental module, we are comfortable breaking this public api to better conform to the expected way to use Strands.

## Public API Changes

`SteeringHandler` now implements the `Plugin` protocol instead of `HookProvider`:

```python
# Before: HookProvider pattern
from strands.hooks.registry import HookProvider

class SteeringHandler(HookProvider, ABC):
    def register_hooks(self, registry: HookRegistry, **kwargs) -> None:
        registry.add_callback(BeforeToolCallEvent, self._provide_tool_steering_guidance)

# After: Plugin protocol
class SteeringHandler:
    name: str = "steering"
    
    def init_plugin(self, agent: Agent) -> None:
        agent.add_hook(self._provide_tool_steering_guidance, BeforeToolCallEvent)
```

Usage with agents:

```python
# Before
agent = Agent(hooks=[LLMSteeringHandler(system_prompt="...")])

# After
agent = Agent(plugins=[LLMSteeringHandler(system_prompt="...")])
```

Subclasses like `LLMSteeringHandler` continue to work without modification since they don't override the hook registration method.

## Use Cases

- **Reference Implementation**: Serves as the reference implementation for migrating HookProviders to Plugins
- **Experimental Feature**: As an experimental feature, this is a safe place to demonstrate the new pattern
- **Future Migrations**: Documents the migration pattern for other HookProvider implementations
