### PR TITLE
feat(plugins): improve plugin creation devex with @hook and @tool decorators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,8 @@ strands-agents/
 │   │
 │   ├── hooks/                            # Event hooks system
 │   │   ├── events.py                     # Hook event definitions
-│   │   └── registry.py                   # Hook registration
+│   │   ├── registry.py                   # Hook registration
+│   │   └── _type_inference.py            # Event type inference from type hints
 │   │
 │   ├── plugins/                          # Plugin system
 │   │   ├── plugin.py                     # Plugin base class

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,8 @@ strands-agents/
 │   │   └── registry.py                   # Hook registration
 │   │
 │   ├── plugins/                          # Plugin system
-│   │   ├── plugin.py                     # Plugin definition
+│   │   ├── plugin.py                     # Plugin base class
+│   │   ├── decorator.py                  # @hook decorator
 │   │   └── registry.py                   # PluginRegistry for tracking plugins
 │   │
 │   ├── handlers/                         # Event handlers

--- a/src/strands/__init__.py
+++ b/src/strands/__init__.py
@@ -4,7 +4,7 @@ from . import agent, models, telemetry, types
 from .agent.agent import Agent
 from .agent.base import AgentBase
 from .event_loop._retry import ModelRetryStrategy
-from .plugins import Plugin, hook
+from .plugins import Plugin
 from .tools.decorator import tool
 from .types.tools import ToolContext
 
@@ -12,7 +12,6 @@ __all__ = [
     "Agent",
     "AgentBase",
     "agent",
-    "hook",
     "models",
     "ModelRetryStrategy",
     "Plugin",

--- a/src/strands/__init__.py
+++ b/src/strands/__init__.py
@@ -4,7 +4,7 @@ from . import agent, models, telemetry, types
 from .agent.agent import Agent
 from .agent.base import AgentBase
 from .event_loop._retry import ModelRetryStrategy
-from .plugins import Plugin
+from .plugins import Plugin, hook
 from .tools.decorator import tool
 from .types.tools import ToolContext
 
@@ -12,6 +12,7 @@ __all__ = [
     "Agent",
     "AgentBase",
     "agent",
+    "hook",
     "models",
     "ModelRetryStrategy",
     "Plugin",

--- a/src/strands/experimental/steering/core/handler.py
+++ b/src/strands/experimental/steering/core/handler.py
@@ -84,7 +84,7 @@ class SteeringHandler(Plugin):
         Args:
             agent: The agent instance to attach steering to.
         """
-        super().init_plugin(agent)
+        super().init_agent(agent)
 
         # Register context update callbacks
         for callback in self._context_callbacks:

--- a/src/strands/experimental/steering/core/handler.py
+++ b/src/strands/experimental/steering/core/handler.py
@@ -38,7 +38,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ....hooks.events import AfterModelCallEvent, BeforeToolCallEvent
-from ....plugins.plugin import Plugin
+from ....plugins import Plugin, hook
 from ....types.content import Message
 from ....types.streaming import StopReason
 from ....types.tools import ToolUse
@@ -66,6 +66,7 @@ class SteeringHandler(Plugin):
         Args:
             context_providers: List of context providers for context updates
         """
+        super().__init__()
         self.steering_context = SteeringContext()
         self._context_callbacks = []
 
@@ -83,17 +84,14 @@ class SteeringHandler(Plugin):
         Args:
             agent: The agent instance to attach steering to.
         """
+        super().init_plugin(agent)
+
         # Register context update callbacks
         for callback in self._context_callbacks:
             agent.add_hook(lambda event, callback=callback: callback(event, self.steering_context), callback.event_type)
 
-        # Register tool steering guidance
-        agent.add_hook(self._provide_tool_steering_guidance, BeforeToolCallEvent)
-
-        # Register model steering guidance
-        agent.add_hook(self._provide_model_steering_guidance, AfterModelCallEvent)
-
-    async def _provide_tool_steering_guidance(self, event: BeforeToolCallEvent) -> None:
+    @hook
+    async def provide_tool_steering_guidance(self, event: BeforeToolCallEvent) -> None:
         """Provide steering guidance for tool call."""
         tool_name = event.tool_use["name"]
         logger.debug("tool_name=<%s> | providing tool steering guidance", tool_name)
@@ -133,7 +131,8 @@ class SteeringHandler(Plugin):
         else:
             raise ValueError(f"Unknown steering action type for tool call: {action}")
 
-    async def _provide_model_steering_guidance(self, event: AfterModelCallEvent) -> None:
+    @hook
+    async def provide_model_steering_guidance(self, event: AfterModelCallEvent) -> None:
         """Provide steering guidance for model response."""
         logger.debug("providing model steering guidance")
 

--- a/src/strands/experimental/steering/core/handler.py
+++ b/src/strands/experimental/steering/core/handler.py
@@ -84,8 +84,6 @@ class SteeringHandler(Plugin):
         Args:
             agent: The agent instance to attach steering to.
         """
-        super().init_agent(agent)
-
         # Register context update callbacks
         for callback in self._context_callbacks:
             agent.add_hook(lambda event, callback=callback: callback(event, self.steering_context), callback.event_type)

--- a/src/strands/hooks/_type_inference.py
+++ b/src/strands/hooks/_type_inference.py
@@ -11,15 +11,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def infer_event_types(callback: "HookCallback[TEvent]", skip_self: bool = False) -> "list[type[TEvent]]":
+def infer_event_types(callback: "HookCallback[TEvent]") -> "list[type[TEvent]]":
     """Infer the event type(s) from a callback's type hints.
 
     Supports both single types and union types (A | B or Union[A, B]).
 
     Args:
         callback: The callback function to inspect.
-        skip_self: If True, skip 'self' parameter when looking for event type hint.
-            Use True for instance methods, False for standalone functions.
 
     Returns:
         A list of event types inferred from the callback's first parameter type hint.
@@ -46,9 +44,9 @@ def infer_event_types(callback: "HookCallback[TEvent]", skip_self: bool = False)
     if not params:
         raise ValueError("callback has no parameters | cannot infer event type, please provide event_type explicitly")
 
-    # For methods, skip 'self' parameter if requested
+    # Skip 'self' parameter for methods
     first_param = params[0]
-    if skip_self and first_param.name == "self" and len(params) > 1:
+    if first_param.name == "self" and len(params) > 1:
         first_param = params[1]
 
     type_hint = hints.get(first_param.name)

--- a/src/strands/hooks/_type_inference.py
+++ b/src/strands/hooks/_type_inference.py
@@ -1,0 +1,80 @@
+"""Utility for inferring event types from callback type hints."""
+
+import inspect
+import logging
+import types
+from typing import TYPE_CHECKING, Union, cast, get_args, get_origin, get_type_hints
+
+if TYPE_CHECKING:
+    from .registry import HookCallback, TEvent
+
+logger = logging.getLogger(__name__)
+
+
+def infer_event_types(callback: "HookCallback[TEvent]", skip_self: bool = False) -> "list[type[TEvent]]":
+    """Infer the event type(s) from a callback's type hints.
+
+    Supports both single types and union types (A | B or Union[A, B]).
+
+    Args:
+        callback: The callback function to inspect.
+        skip_self: If True, skip 'self' parameter when looking for event type hint.
+            Use True for instance methods, False for standalone functions.
+
+    Returns:
+        A list of event types inferred from the callback's first parameter type hint.
+
+    Raises:
+        ValueError: If the event type cannot be inferred from the callback's type hints,
+            or if a union contains None or non-BaseHookEvent types.
+    """
+    # Import here to avoid circular dependency
+    from .registry import BaseHookEvent
+
+    try:
+        hints = get_type_hints(callback)
+    except Exception as e:
+        logger.debug("callback=<%s>, error=<%s> | failed to get type hints", callback, e)
+        raise ValueError(
+            "failed to get type hints for callback | cannot infer event type, please provide event_type explicitly"
+        ) from e
+
+    # Get the first parameter's type hint
+    sig = inspect.signature(callback)
+    params = list(sig.parameters.values())
+
+    if not params:
+        raise ValueError("callback has no parameters | cannot infer event type, please provide event_type explicitly")
+
+    # For methods, skip 'self' parameter if requested
+    first_param = params[0]
+    if skip_self and first_param.name == "self" and len(params) > 1:
+        first_param = params[1]
+
+    type_hint = hints.get(first_param.name)
+
+    if type_hint is None:
+        raise ValueError(
+            f"parameter=<{first_param.name}> has no type hint | "
+            "cannot infer event type, please provide event_type explicitly"
+        )
+
+    # Check if it's a Union type (Union[A, B] or A | B)
+    origin = get_origin(type_hint)
+    if origin is Union or origin is types.UnionType:
+        event_types: list[type[TEvent]] = []
+        for arg in get_args(type_hint):
+            if arg is type(None):
+                raise ValueError("None is not a valid event type in union")
+            if not (isinstance(arg, type) and issubclass(arg, BaseHookEvent)):
+                raise ValueError(f"Invalid type in union: {arg} | must be a subclass of BaseHookEvent")
+            event_types.append(cast("type[TEvent]", arg))
+        return event_types
+
+    # Handle single type
+    if isinstance(type_hint, type) and issubclass(type_hint, BaseHookEvent):
+        return [cast("type[TEvent]", type_hint)]
+
+    raise ValueError(
+        f"parameter=<{first_param.name}>, type=<{type_hint}> | type hint must be a subclass of BaseHookEvent"
+    )

--- a/src/strands/hooks/_type_inference.py
+++ b/src/strands/hooks/_type_inference.py
@@ -44,9 +44,9 @@ def infer_event_types(callback: "HookCallback[TEvent]") -> "list[type[TEvent]]":
     if not params:
         raise ValueError("callback has no parameters | cannot infer event type, please provide event_type explicitly")
 
-    # Skip 'self' parameter for methods
+    # Skip 'self' and 'cls' parameters for methods
     first_param = params[0]
-    if first_param.name == "self" and len(params) > 1:
+    if first_param.name in ("self", "cls") and len(params) > 1:
         first_param = params[1]
 
     type_hint = hints.get(first_param.name)

--- a/src/strands/hooks/registry.py
+++ b/src/strands/hooks/registry.py
@@ -9,24 +9,12 @@ via hook provider objects.
 
 import inspect
 import logging
-import types
 from collections.abc import Awaitable, Generator
 from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    Protocol,
-    TypeVar,
-    Union,
-    cast,
-    get_args,
-    get_origin,
-    get_type_hints,
-    runtime_checkable,
-)
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, runtime_checkable
 
 from ..interrupt import Interrupt, InterruptException
+from ._type_inference import infer_event_types
 
 if TYPE_CHECKING:
     from ..agent import Agent
@@ -276,51 +264,7 @@ class HookRegistry:
             ValueError: If the event type cannot be inferred from the callback's type hints,
                 or if a union contains None or non-BaseHookEvent types.
         """
-        try:
-            hints = get_type_hints(callback)
-        except Exception as e:
-            logger.debug("callback=<%s>, error=<%s> | failed to get type hints", callback, e)
-            raise ValueError(
-                "failed to get type hints for callback | cannot infer event type, please provide event_type explicitly"
-            ) from e
-
-        # Get the first parameter's type hint
-        sig = inspect.signature(callback)
-        params = list(sig.parameters.values())
-
-        if not params:
-            raise ValueError(
-                "callback has no parameters | cannot infer event type, please provide event_type explicitly"
-            )
-
-        first_param = params[0]
-        type_hint = hints.get(first_param.name)
-
-        if type_hint is None:
-            raise ValueError(
-                f"parameter=<{first_param.name}> has no type hint | "
-                "cannot infer event type, please provide event_type explicitly"
-            )
-
-        # Check if it's a Union type (Union[A, B] or A | B)
-        origin = get_origin(type_hint)
-        if origin is Union or origin is types.UnionType:
-            event_types: list[type[TEvent]] = []
-            for arg in get_args(type_hint):
-                if arg is type(None):
-                    raise ValueError("None is not a valid event type in union")
-                if not (isinstance(arg, type) and issubclass(arg, BaseHookEvent)):
-                    raise ValueError(f"Invalid type in union: {arg} | must be a subclass of BaseHookEvent")
-                event_types.append(cast(type[TEvent], arg))
-            return event_types
-
-        # Handle single type
-        if isinstance(type_hint, type) and issubclass(type_hint, BaseHookEvent):
-            return [cast(type[TEvent], type_hint)]
-
-        raise ValueError(
-            f"parameter=<{first_param.name}>, type=<{type_hint}> | type hint must be a subclass of BaseHookEvent"
-        )
+        return infer_event_types(callback, skip_self=False)
 
     def add_hook(self, hook: HookProvider) -> None:
         """Register all callbacks from a hook provider.

--- a/src/strands/hooks/registry.py
+++ b/src/strands/hooks/registry.py
@@ -213,7 +213,7 @@ class HookRegistry:
             resolved_event_types = self._validate_event_type_list(event_type)
         elif event_type is None:
             # Infer event type(s) from callback type hints
-            resolved_event_types = self._infer_event_types(callback)
+            resolved_event_types = infer_event_types(callback)
         else:
             # Single event type provided explicitly
             resolved_event_types = [event_type]
@@ -248,23 +248,6 @@ class HookRegistry:
                 raise ValueError(f"Invalid event type: {et} | must be a subclass of BaseHookEvent")
             validated.append(et)
         return validated
-
-    def _infer_event_types(self, callback: HookCallback[TEvent]) -> list[type[TEvent]]:
-        """Infer the event type(s) from a callback's type hints.
-
-        Supports both single types and union types (A | B or Union[A, B]).
-
-        Args:
-            callback: The callback function to inspect.
-
-        Returns:
-            A list of event types inferred from the callback's first parameter type hint.
-
-        Raises:
-            ValueError: If the event type cannot be inferred from the callback's type hints,
-                or if a union contains None or non-BaseHookEvent types.
-        """
-        return infer_event_types(callback, skip_self=False)
 
     def add_hook(self, hook: HookProvider) -> None:
         """Register all callbacks from a hook provider.

--- a/src/strands/plugins/__init__.py
+++ b/src/strands/plugins/__init__.py
@@ -2,43 +2,6 @@
 
 This module provides a composable mechanism for building objects that can
 extend agent behavior through automatic hook and tool registration.
-
-Example Usage with Decorators (recommended):
-    ```python
-    from strands.plugins import Plugin, hook
-    from strands.hooks import BeforeModelCallEvent
-    from strands import tool
-
-    class LoggingPlugin(Plugin):
-        name = "logging"
-
-        @hook
-        def on_model_call(self, event: BeforeModelCallEvent) -> None:
-            print(f"Model called for {event.agent.name}")
-
-        @tool
-        def log_message(self, message: str) -> str:
-            '''Log a message.'''
-            print(message)
-            return "Logged"
-    ```
-
-Example Usage with Custom Initialization:
-    ```python
-    from strands.plugins import Plugin
-    from strands.hooks import BeforeModelCallEvent
-
-    class LoggingPlugin(Plugin):
-        name = "logging"
-
-        def init_agent(self, agent: Agent) -> None:
-            # Custom initialization - no super() needed
-            # Decorated hooks/tools are auto-registered by the registry
-            agent.hooks.add_callback(BeforeModelCallEvent, self.on_model_call)
-
-        def on_model_call(self, event: BeforeModelCallEvent) -> None:
-            print(f"Model called for {event.agent.name}")
-    ```
 """
 
 from .decorator import hook

--- a/src/strands/plugins/__init__.py
+++ b/src/strands/plugins/__init__.py
@@ -1,25 +1,49 @@
 """Plugin system for extending agent functionality.
 
 This module provides a composable mechanism for building objects that can
-extend agent behavior through a standardized initialization pattern.
+extend agent behavior through automatic hook and tool registration.
 
-Example Usage:
+Example Usage with Decorators (recommended):
+    ```python
+    from strands.plugins import Plugin, hook
+    from strands.hooks import BeforeModelCallEvent
+
+    class LoggingPlugin(Plugin):
+        name = "logging"
+
+        @hook
+        def on_model_call(self, event: BeforeModelCallEvent) -> None:
+            print(f"Model called for {event.agent.name}")
+
+        @tool
+        def log_message(self, message: str) -> str:
+            '''Log a message.'''
+            print(message)
+            return "Logged"
+    ```
+
+Example Usage with Manual Registration:
     ```python
     from strands.plugins import Plugin
+    from strands.hooks import BeforeModelCallEvent
 
     class LoggingPlugin(Plugin):
         name = "logging"
 
         def init_agent(self, agent: Agent) -> None:
-            agent.add_hook(self.on_model_call, BeforeModelCallEvent)
+            super().init_agent(agent)  # Register decorated methods
+            # Add additional manual hooks
+            agent.hooks.add_callback(BeforeModelCallEvent, self.on_model_call)
 
         def on_model_call(self, event: BeforeModelCallEvent) -> None:
             print(f"Model called for {event.agent.name}")
     ```
 """
 
+from .decorator import hook
 from .plugin import Plugin
 
 __all__ = [
     "Plugin",
+    "hook",
 ]

--- a/src/strands/plugins/__init__.py
+++ b/src/strands/plugins/__init__.py
@@ -7,6 +7,7 @@ Example Usage with Decorators (recommended):
     ```python
     from strands.plugins import Plugin, hook
     from strands.hooks import BeforeModelCallEvent
+    from strands import tool
 
     class LoggingPlugin(Plugin):
         name = "logging"
@@ -22,7 +23,7 @@ Example Usage with Decorators (recommended):
             return "Logged"
     ```
 
-Example Usage with Manual Registration:
+Example Usage with Custom Initialization:
     ```python
     from strands.plugins import Plugin
     from strands.hooks import BeforeModelCallEvent
@@ -31,8 +32,8 @@ Example Usage with Manual Registration:
         name = "logging"
 
         def init_agent(self, agent: Agent) -> None:
-            super().init_agent(agent)  # Register decorated methods
-            # Add additional manual hooks
+            # Custom initialization - no super() needed
+            # Decorated hooks/tools are auto-registered by the registry
             agent.hooks.add_callback(BeforeModelCallEvent, self.on_model_call)
 
         def on_model_call(self, event: BeforeModelCallEvent) -> None:

--- a/src/strands/plugins/decorator.py
+++ b/src/strands/plugins/decorator.py
@@ -1,0 +1,188 @@
+"""Hook decorator for Plugin methods.
+
+This module provides the @hook decorator that marks methods as hook callbacks
+for automatic registration when the plugin is attached to an agent.
+
+The @hook decorator performs several functions:
+
+1. Marks methods as hook callbacks for automatic discovery by Plugin base class
+2. Infers event types from the callback's type hints (consistent with HookRegistry.add_callback)
+3. Supports both @hook and @hook() syntax
+4. Supports union types for multiple event types (e.g., BeforeModelCallEvent | AfterModelCallEvent)
+5. Stores hook metadata on the decorated method for later discovery
+
+Example:
+    ```python
+    from strands.plugins import Plugin, hook
+    from strands.hooks import BeforeModelCallEvent, AfterModelCallEvent
+
+    class MyPlugin(Plugin):
+        name = "my-plugin"
+
+        @hook
+        def on_model_call(self, event: BeforeModelCallEvent):
+            print(event)
+
+        @hook
+        def on_any_model_event(self, event: BeforeModelCallEvent | AfterModelCallEvent):
+            print(event)
+    ```
+"""
+
+import functools
+import inspect
+import logging
+import types
+from collections.abc import Callable
+from typing import TypeVar, Union, cast, get_args, get_origin, get_type_hints, overload
+
+from ..hooks.registry import BaseHookEvent, HookCallback, TEvent
+
+logger = logging.getLogger(__name__)
+
+# Type for wrapped function
+T = TypeVar("T", bound=Callable[..., object])
+
+
+def _infer_event_types(callback: HookCallback[TEvent]) -> list[type[TEvent]]:
+    """Infer the event type(s) from a callback's type hints.
+
+    Supports both single types and union types (A | B or Union[A, B]).
+
+    This logic is adapted from HookRegistry._infer_event_types to provide
+    consistent behavior for event type inference.
+
+    Args:
+        callback: The callback function to inspect.
+
+    Returns:
+        A list of event types inferred from the callback's first parameter type hint.
+
+    Raises:
+        ValueError: If the event type cannot be inferred from the callback's type hints,
+            or if a union contains None or non-BaseHookEvent types.
+    """
+    try:
+        hints = get_type_hints(callback)
+    except Exception as e:
+        logger.debug("callback=<%s>, error=<%s> | failed to get type hints", callback, e)
+        raise ValueError(
+            "failed to get type hints for callback | cannot infer event type, please provide event_type explicitly"
+        ) from e
+
+    # Get the first parameter's type hint
+    sig = inspect.signature(callback)
+    params = list(sig.parameters.values())
+
+    if not params:
+        raise ValueError("callback has no parameters | cannot infer event type, please provide event_type explicitly")
+
+    # For methods, skip 'self' parameter
+    first_param = params[0]
+    if first_param.name == "self" and len(params) > 1:
+        first_param = params[1]
+
+    type_hint = hints.get(first_param.name)
+
+    if type_hint is None:
+        raise ValueError(
+            f"parameter=<{first_param.name}> has no type hint | "
+            "cannot infer event type, please provide event_type explicitly"
+        )
+
+    # Check if it's a Union type (Union[A, B] or A | B)
+    origin = get_origin(type_hint)
+    if origin is Union or origin is types.UnionType:
+        event_types: list[type[TEvent]] = []
+        for arg in get_args(type_hint):
+            if arg is type(None):
+                raise ValueError("None is not a valid event type in union")
+            if not (isinstance(arg, type) and issubclass(arg, BaseHookEvent)):
+                raise ValueError(f"Invalid type in union: {arg} | must be a subclass of BaseHookEvent")
+            event_types.append(cast(type[TEvent], arg))
+        return event_types
+
+    # Handle single type
+    if isinstance(type_hint, type) and issubclass(type_hint, BaseHookEvent):
+        return [cast(type[TEvent], type_hint)]
+
+    raise ValueError(
+        f"parameter=<{first_param.name}>, type=<{type_hint}> | type hint must be a subclass of BaseHookEvent"
+    )
+
+
+# Handle @hook
+@overload
+def hook(__func: T) -> T: ...
+
+
+# Handle @hook()
+@overload
+def hook() -> Callable[[T], T]: ...
+
+
+def hook(  # type: ignore[misc]
+    func: T | None = None,
+) -> T | Callable[[T], T]:
+    """Decorator that marks a method as a hook callback for automatic registration.
+
+    This decorator enables declarative hook registration in Plugin classes. When a
+    Plugin is attached to an agent, methods marked with @hook are automatically
+    discovered and registered with the agent's hook registry.
+
+    The event type is inferred from the callback's type hint on the first parameter
+    (after 'self' for instance methods). Union types are supported for registering
+    a single callback for multiple event types.
+
+    The decorator can be used in two ways:
+    - As a simple decorator: `@hook`
+    - With parentheses: `@hook()`
+
+    Args:
+        func: The function to decorate. When used as a simple decorator, this is
+            the function being decorated. When used with parentheses, this will be None.
+
+    Returns:
+        The decorated function with hook metadata attached.
+
+    Raises:
+        ValueError: If the event type cannot be inferred from type hints, or if
+            the type hint is not a valid HookEvent subclass.
+
+    Example:
+        ```python
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def on_model_call(self, event: BeforeModelCallEvent):
+                print(f"Model called: {event}")
+
+            @hook
+            def on_any_event(self, event: BeforeModelCallEvent | AfterModelCallEvent):
+                print(f"Event: {type(event).__name__}")
+        ```
+    """
+
+    def decorator(f: T) -> T:
+        # Infer event types from type hints
+        event_types = _infer_event_types(f)
+
+        # Store hook metadata on the function
+        f._hook_event_types = event_types
+
+        # Preserve original function metadata
+        @functools.wraps(f)
+        def wrapper(*args: object, **kwargs: object) -> object:
+            return f(*args, **kwargs)
+
+        # Copy hook metadata to wrapper
+        wrapper._hook_event_types = event_types
+
+        return cast(T, wrapper)
+
+    # Handle both @hook and @hook() syntax
+    if func is None:
+        return decorator
+
+    return decorator(func)

--- a/src/strands/plugins/decorator.py
+++ b/src/strands/plugins/decorator.py
@@ -21,9 +21,9 @@ from ..hooks.registry import HookCallback, TEvent
 
 
 class _WrappedHookCallable(HookCallback, Generic[TEvent]):
-    """Wrapped version of HookCallback that includes a `_hook_event_types` argument."""
+    """Wrapped version of HookCallback that includes a `_hook_event_types` attribute."""
 
-    _hook_event_types: list[TEvent]
+    _hook_event_types: list[type[TEvent]]
 
 
 # Handle @hook

--- a/src/strands/plugins/plugin.py
+++ b/src/strands/plugins/plugin.py
@@ -27,8 +27,8 @@ class Plugin(ABC):
 
     Attributes:
         name: A stable string identifier for the plugin (must be provided by subclass)
-        hooks: List of discovered @hook decorated methods (mutable for filtering)
-        tools: List of discovered @tool decorated methods (mutable for filtering)
+        hooks: List of hooks the plugin provides, auto-discovered from @hook decorated methods
+        tools: List of tools the plugin provides, auto-discovered from @tool decorated methods
 
     Example using decorators (recommended):
         ```python
@@ -82,22 +82,12 @@ class Plugin(ABC):
 
     @property
     def hooks(self) -> list[_WrappedHookCallable]:
-        """Discovered @hook decorated methods.
-
-        Returns the list of hook callbacks that will be auto-registered
-        when the plugin is attached to an agent. This list is mutable,
-        allowing users to filter or modify hooks before registration.
-        """
+        """List of hooks the plugin provides, auto-discovered from @hook decorated methods."""
         return self._hooks
 
     @property
     def tools(self) -> list[DecoratedFunctionTool]:
-        """Discovered @tool decorated methods.
-
-        Returns the list of tools that will be auto-registered
-        when the plugin is attached to an agent. This list is mutable,
-        allowing users to filter or modify tools before registration.
-        """
+        """List of tools the plugin provides, auto-discovered from @tool decorated methods."""
         return self._tools
 
     def _discover_decorated_methods(self) -> None:

--- a/src/strands/plugins/plugin.py
+++ b/src/strands/plugins/plugin.py
@@ -27,8 +27,8 @@ class Plugin(ABC):
 
     Attributes:
         name: A stable string identifier for the plugin (must be provided by subclass)
-        hooks: Tuple of discovered @hook decorated methods (read-only)
-        tools: Tuple of discovered @tool decorated methods (read-only)
+        hooks: List of discovered @hook decorated methods (mutable for filtering)
+        tools: List of discovered @tool decorated methods (mutable for filtering)
 
     Example using decorators (recommended):
         ```python

--- a/src/strands/plugins/plugin.py
+++ b/src/strands/plugins/plugin.py
@@ -4,9 +4,9 @@ This module defines the Plugin base class, which provides a composable way to
 add behavior changes to agents through a standardized initialization pattern.
 """
 
+import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable
-import logging
 from typing import TYPE_CHECKING
 
 from strands.tools.decorator import DecoratedFunctionTool
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from ..agent import Agent
 
 logger = logging.getLogger(__name__)
+
 
 class Plugin(ABC):
     """Base class for objects that extend agent functionality.
@@ -99,7 +100,6 @@ class Plugin(ABC):
             if isinstance(attr, DecoratedFunctionTool):
                 self._tools.append(attr)
                 logger.debug("plugin=<%s>, tool=<%s> | discovered tool method", self.name, name)
-
 
     def init_agent(self, agent: "Agent") -> None | Awaitable[None]:
         """Initialize the agent instance.

--- a/src/strands/plugins/plugin.py
+++ b/src/strands/plugins/plugin.py
@@ -6,29 +6,58 @@ add behavior changes to agents through a standardized initialization pattern.
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable
+import logging
 from typing import TYPE_CHECKING
+
+from strands.tools.decorator import DecoratedFunctionTool
 
 if TYPE_CHECKING:
     from ..agent import Agent
 
+logger = logging.getLogger(__name__)
 
 class Plugin(ABC):
     """Base class for objects that extend agent functionality.
 
     Plugins provide a composable way to add behavior changes to agents.
-    They can register hooks, modify agent attributes, or perform other 
-    setup tasks on an agent instance.
+    They support automatic discovery and registration of methods decorated
+    with @hook and @tool decorators.
 
     Attributes:
-        name: A stable string identifier for the plugin
+        name: A stable string identifier for the plugin (must be provided by subclass)
+        _hooks: List of discovered @hook decorated methods (populated in __init__)
+        _tools: List of discovered @tool decorated methods (populated in __init__)
 
-    Example:
+    Example using decorators (recommended):
+        ```python
+        from strands.plugins import Plugin, hook
+        from strands.hooks import BeforeModelCallEvent
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def on_model_call(self, event: BeforeModelCallEvent):
+                print(f"Model called: {event}")
+
+            @tool
+            def my_tool(self, param: str) -> str:
+                '''A tool that does something.'''
+                return f"Result: {param}"
+        ```
+
+    Example with manual registration:
         ```python
         class MyPlugin(Plugin):
             name = "my-plugin"
 
             def init_agent(self, agent: Agent) -> None:
-                agent.add_hook(self.on_model_call, BeforeModelCallEvent)
+                super().init_agent(agent)  # Register decorated methods
+                # Add additional manual hooks if needed
+                agent.hooks.add_callback(BeforeModelCallEvent, self.custom_hook)
+
+            def custom_hook(self, event: BeforeModelCallEvent):
+                print(event)
         ```
     """
 
@@ -38,11 +67,71 @@ class Plugin(ABC):
         """A stable string identifier for the plugin."""
         ...
 
-    @abstractmethod
+    def __init__(self) -> None:
+        """Initialize the plugin and discover decorated methods.
+
+        Scans the class for methods decorated with @hook and @tool and stores
+        references for later registration when init_agent is called.
+        """
+        self._hooks: list[object] = []
+        self._tools: list[DecoratedFunctionTool] = []
+        self._discover_decorated_methods()
+
+    def _discover_decorated_methods(self) -> None:
+        """Scan class for @hook and @tool decorated methods."""
+        for name in dir(self):
+            # Skip private and dunder methods
+            if name.startswith("_"):
+                continue
+
+            try:
+                attr = getattr(self, name)
+            except Exception:
+                # Skip attributes that can't be accessed
+                continue
+
+            # Check for @hook decorated methods
+            if hasattr(attr, "_hook_event_types") and callable(attr):
+                self._hooks.append(attr)
+                logger.debug("plugin=<%s>, hook=<%s> | discovered hook method", self.name, name)
+
+            # Check for @tool decorated methods (DecoratedFunctionTool instances)
+            if isinstance(attr, DecoratedFunctionTool):
+                self._tools.append(attr)
+                logger.debug("plugin=<%s>, tool=<%s> | discovered tool method", self.name, name)
+
+
     def init_agent(self, agent: "Agent") -> None | Awaitable[None]:
         """Initialize the agent instance.
+
+        Default implementation that registers all discovered @hook methods
+        with the agent's hook registry and adds all discovered @tool methods
+        to the agent's tools list.
+
+        Subclasses can override this method and call super().init_agent(agent)
+        to retain automatic registration while adding custom initialization logic.
 
         Args:
             agent: The agent instance to initialize.
         """
-        ...
+        # Register discovered hooks with the agent's hook registry
+        for hook_callback in self._hooks:
+            event_types = getattr(hook_callback, "_hook_event_types", [])
+            for event_type in event_types:
+                agent.hooks.add_callback(event_type, hook_callback)
+                logger.debug(
+                    "plugin=<%s>, hook=<%s>, event_type=<%s> | registered hook",
+                    self.name,
+                    getattr(hook_callback, "__name__", repr(hook_callback)),
+                    event_type.__name__,
+                )
+
+        # Register discovered tools with the agent's tool registry
+        if self._tools:
+            agent.tool_registry.process_tools(self._tools)
+            for tool in self._tools:
+                logger.debug(
+                    "plugin=<%s>, tool=<%s> | registered tool",
+                    self.name,
+                    tool.tool_name,
+                )

--- a/src/strands/plugins/plugin.py
+++ b/src/strands/plugins/plugin.py
@@ -135,3 +135,5 @@ class Plugin(ABC):
                     self.name,
                     tool.tool_name,
                 )
+
+        return None

--- a/src/strands/plugins/plugin.py
+++ b/src/strands/plugins/plugin.py
@@ -81,22 +81,24 @@ class Plugin(ABC):
         self._discover_decorated_methods()
 
     @property
-    def hooks(self) -> tuple[_WrappedHookCallable, ...]:
+    def hooks(self) -> list[_WrappedHookCallable]:
         """Discovered @hook decorated methods.
 
-        Returns a tuple of hook callbacks that will be auto-registered
-        when the plugin is attached to an agent.
+        Returns the list of hook callbacks that will be auto-registered
+        when the plugin is attached to an agent. This list is mutable,
+        allowing users to filter or modify hooks before registration.
         """
-        return tuple(self._hooks)
+        return self._hooks
 
     @property
-    def tools(self) -> tuple[DecoratedFunctionTool, ...]:
+    def tools(self) -> list[DecoratedFunctionTool]:
         """Discovered @tool decorated methods.
 
-        Returns a tuple of tools that will be auto-registered
-        when the plugin is attached to an agent.
+        Returns the list of tools that will be auto-registered
+        when the plugin is attached to an agent. This list is mutable,
+        allowing users to filter or modify tools before registration.
         """
-        return tuple(self._tools)
+        return self._tools
 
     def _discover_decorated_methods(self) -> None:
         """Scan class for @hook and @tool decorated methods."""

--- a/src/strands/plugins/plugin.py
+++ b/src/strands/plugins/plugin.py
@@ -9,7 +9,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Awaitable
 from typing import TYPE_CHECKING
 
-from strands.tools.decorator import DecoratedFunctionTool
+from ..tools.decorator import DecoratedFunctionTool
+from .decorator import _WrappedHookCallable
 
 if TYPE_CHECKING:
     from ..agent import Agent
@@ -74,17 +75,13 @@ class Plugin(ABC):
         Scans the class for methods decorated with @hook and @tool and stores
         references for later registration when init_agent is called.
         """
-        self._hooks: list[object] = []
+        self._hooks: list[_WrappedHookCallable] = []
         self._tools: list[DecoratedFunctionTool] = []
         self._discover_decorated_methods()
 
     def _discover_decorated_methods(self) -> None:
         """Scan class for @hook and @tool decorated methods."""
         for name in dir(self):
-            # Skip private and dunder methods
-            if name.startswith("_"):
-                continue
-
             try:
                 attr = getattr(self, name)
             except Exception:
@@ -118,7 +115,7 @@ class Plugin(ABC):
         for hook_callback in self._hooks:
             event_types = getattr(hook_callback, "_hook_event_types", [])
             for event_type in event_types:
-                agent.hooks.add_callback(event_type, hook_callback)
+                agent.add_hook(hook_callback, event_type)
                 logger.debug(
                     "plugin=<%s>, hook=<%s>, event_type=<%s> | registered hook",
                     self.name,

--- a/src/strands/plugins/registry.py
+++ b/src/strands/plugins/registry.py
@@ -24,6 +24,11 @@ class _PluginRegistry:
     The _PluginRegistry tracks plugins that have been initialized with an agent,
     providing methods to add plugins and invoke their initialization.
 
+    The registry handles:
+    1. Calling the plugin's init_agent() method for custom initialization
+    2. Auto-registering discovered @hook decorated methods with the agent
+    3. Auto-registering discovered @tool decorated methods with the agent
+
     Example:
         ```python
         registry = _PluginRegistry(agent)
@@ -31,7 +36,12 @@ class _PluginRegistry:
         class MyPlugin(Plugin):
             name = "my-plugin"
 
+            @hook
+            def on_event(self, event: BeforeModelCallEvent):
+                pass  # Auto-registered by registry
+
             def init_agent(self, agent: Agent) -> None:
+                # Custom logic only - no super() needed
                 pass
 
         plugin = MyPlugin()
@@ -51,7 +61,12 @@ class _PluginRegistry:
     def add_and_init(self, plugin: Plugin) -> None:
         """Add and initialize a plugin with the agent.
 
-        This method registers the plugin and calls its init_agent method.
+        This method:
+        1. Registers the plugin in the registry
+        2. Calls the plugin's init_agent method for custom initialization
+        3. Auto-registers all discovered @hook methods with the agent's hook registry
+        4. Auto-registers all discovered @tool methods with the agent's tool registry
+
         Handles both sync and async init_agent implementations automatically.
 
         Args:
@@ -66,8 +81,47 @@ class _PluginRegistry:
         logger.debug("plugin_name=<%s> | registering and initializing plugin", plugin.name)
         self._plugins[plugin.name] = plugin
 
+        # Call user's init_agent for custom initialization
         if inspect.iscoroutinefunction(plugin.init_agent):
             async_plugin_init = cast(Callable[..., Awaitable[None]], plugin.init_agent)
             run_async(lambda: async_plugin_init(self._agent))
         else:
             plugin.init_agent(self._agent)
+
+        # Auto-register discovered hooks with the agent's hook registry
+        self._register_hooks(plugin)
+
+        # Auto-register discovered tools with the agent's tool registry
+        self._register_tools(plugin)
+
+    def _register_hooks(self, plugin: Plugin) -> None:
+        """Register all discovered hooks from the plugin with the agent.
+
+        Args:
+            plugin: The plugin whose hooks should be registered.
+        """
+        for hook_callback in plugin.hooks:
+            event_types = getattr(hook_callback, "_hook_event_types", [])
+            for event_type in event_types:
+                self._agent.add_hook(hook_callback, event_type)
+                logger.debug(
+                    "plugin=<%s>, hook=<%s>, event_type=<%s> | registered hook",
+                    plugin.name,
+                    getattr(hook_callback, "__name__", repr(hook_callback)),
+                    event_type.__name__,
+                )
+
+    def _register_tools(self, plugin: Plugin) -> None:
+        """Register all discovered tools from the plugin with the agent.
+
+        Args:
+            plugin: The plugin whose tools should be registered.
+        """
+        if plugin.tools:
+            self._agent.tool_registry.process_tools(list(plugin.tools))
+            for tool in plugin.tools:
+                logger.debug(
+                    "plugin=<%s>, tool=<%s> | registered tool",
+                    plugin.name,
+                    tool.tool_name,
+                )

--- a/src/strands/plugins/registry.py
+++ b/src/strands/plugins/registry.py
@@ -97,6 +97,10 @@ class _PluginRegistry:
     def _register_hooks(self, plugin: Plugin) -> None:
         """Register all discovered hooks from the plugin with the agent.
 
+        Warns if a hook callback is already registered for an event type,
+        which can happen when init_agent() manually registers a hook that
+        is also decorated with @hook.
+
         Args:
             plugin: The plugin whose hooks should be registered.
         """

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -14,7 +14,7 @@ import pytest
 from pydantic import BaseModel
 
 import strands
-from strands import Agent, ToolContext
+from strands import Agent, Plugin, ToolContext
 from strands.agent import AgentResult
 from strands.agent.conversation_manager.null_conversation_manager import NullConversationManager
 from strands.agent.conversation_manager.sliding_window_conversation_manager import SlidingWindowConversationManager
@@ -2625,6 +2625,8 @@ def test_agent_plugins_sync_initialization():
     """Test that plugins with sync init_agent are initialized correctly."""
     plugin_mock = unittest.mock.Mock()
     plugin_mock.name = "test-plugin"
+    plugin_mock.hooks = []
+    plugin_mock.tools = []
     plugin_mock.init_agent = unittest.mock.Mock()
 
     agent = Agent(
@@ -2639,6 +2641,8 @@ def test_agent_plugins_async_initialization():
     """Test that plugins with async init_agent are initialized correctly."""
     plugin_mock = unittest.mock.Mock()
     plugin_mock.name = "async-plugin"
+    plugin_mock.hooks = []
+    plugin_mock.tools = []
     plugin_mock.init_agent = unittest.mock.AsyncMock()
 
     agent = Agent(
@@ -2655,10 +2659,14 @@ def test_agent_plugins_multiple_in_order():
 
     plugin1 = unittest.mock.Mock()
     plugin1.name = "plugin1"
+    plugin1.hooks = []
+    plugin1.tools = []
     plugin1.init_agent = unittest.mock.Mock(side_effect=lambda agent: call_order.append("plugin1"))
 
     plugin2 = unittest.mock.Mock()
     plugin2.name = "plugin2"
+    plugin2.hooks = []
+    plugin2.tools = []
     plugin2.init_agent = unittest.mock.Mock(side_effect=lambda agent: call_order.append("plugin2"))
 
     Agent(
@@ -2673,7 +2681,7 @@ def test_agent_plugins_can_register_hooks():
     """Test that plugins can register hooks during initialization."""
     hook_called = []
 
-    class TestPlugin:
+    class TestPlugin(Plugin):
         name = "hook-plugin"
 
         def init_agent(self, agent):

--- a/tests/strands/plugins/test_hook_decorator.py
+++ b/tests/strands/plugins/test_hook_decorator.py
@@ -1,0 +1,232 @@
+"""Tests for the @hook decorator."""
+
+import unittest.mock
+
+import pytest
+
+from strands.hooks import (
+    AfterInvocationEvent,
+    AfterModelCallEvent,
+    BeforeInvocationEvent,
+    BeforeModelCallEvent,
+)
+from strands.plugins.decorator import hook
+
+
+class TestHookDecoratorBasic:
+    """Tests for basic @hook decorator functionality."""
+
+    def test_hook_decorator_marks_method(self):
+        """Test that @hook marks a method with hook metadata."""
+
+        @hook
+        def on_before_model_call(event: BeforeModelCallEvent):
+            pass
+
+        assert hasattr(on_before_model_call, "_hook_event_types")
+        assert BeforeModelCallEvent in on_before_model_call._hook_event_types
+
+    def test_hook_decorator_with_parentheses(self):
+        """Test that @hook() syntax also works."""
+
+        @hook()
+        def on_before_model_call(event: BeforeModelCallEvent):
+            pass
+
+        assert hasattr(on_before_model_call, "_hook_event_types")
+        assert BeforeModelCallEvent in on_before_model_call._hook_event_types
+
+    def test_hook_decorator_preserves_function_metadata(self):
+        """Test that @hook preserves the original function's metadata."""
+
+        @hook
+        def on_before_model_call(event: BeforeModelCallEvent):
+            """Docstring for the hook."""
+            pass
+
+        assert on_before_model_call.__name__ == "on_before_model_call"
+        assert on_before_model_call.__doc__ == "Docstring for the hook."
+
+    def test_hook_decorator_function_still_callable(self):
+        """Test that decorated function can still be called normally."""
+        call_count = 0
+
+        @hook
+        def on_before_model_call(event: BeforeModelCallEvent):
+            nonlocal call_count
+            call_count += 1
+
+        mock_event = unittest.mock.MagicMock(spec=BeforeModelCallEvent)
+        on_before_model_call(mock_event)
+        assert call_count == 1
+
+
+class TestHookDecoratorEventTypeInference:
+    """Tests for event type inference from type hints."""
+
+    def test_hook_infers_event_type_from_type_hint(self):
+        """Test that @hook infers event type from the first parameter's type hint."""
+
+        @hook
+        def handler(event: BeforeInvocationEvent):
+            pass
+
+        assert BeforeInvocationEvent in handler._hook_event_types
+
+    def test_hook_infers_different_event_types(self):
+        """Test that different event types are correctly inferred."""
+
+        @hook
+        def handler1(event: BeforeModelCallEvent):
+            pass
+
+        @hook
+        def handler2(event: AfterModelCallEvent):
+            pass
+
+        @hook
+        def handler3(event: AfterInvocationEvent):
+            pass
+
+        assert BeforeModelCallEvent in handler1._hook_event_types
+        assert AfterModelCallEvent in handler2._hook_event_types
+        assert AfterInvocationEvent in handler3._hook_event_types
+
+
+class TestHookDecoratorUnionTypes:
+    """Tests for union type support in @hook decorator."""
+
+    def test_hook_supports_union_types_with_pipe(self):
+        """Test that @hook supports union types using | syntax."""
+
+        @hook
+        def handler(event: BeforeModelCallEvent | AfterModelCallEvent):
+            pass
+
+        assert BeforeModelCallEvent in handler._hook_event_types
+        assert AfterModelCallEvent in handler._hook_event_types
+
+    def test_hook_supports_union_types_with_typing_union(self):
+        """Test that @hook supports Union[] syntax."""
+
+        @hook
+        def handler(event: BeforeModelCallEvent | AfterModelCallEvent):
+            pass
+
+        assert BeforeModelCallEvent in handler._hook_event_types
+        assert AfterModelCallEvent in handler._hook_event_types
+
+    def test_hook_supports_multiple_union_types(self):
+        """Test that @hook supports unions with more than two types."""
+
+        @hook
+        def handler(event: BeforeModelCallEvent | AfterModelCallEvent | BeforeInvocationEvent):
+            pass
+
+        assert BeforeModelCallEvent in handler._hook_event_types
+        assert AfterModelCallEvent in handler._hook_event_types
+        assert BeforeInvocationEvent in handler._hook_event_types
+
+
+class TestHookDecoratorErrorHandling:
+    """Tests for error handling in @hook decorator."""
+
+    def test_hook_raises_error_without_type_hint(self):
+        """Test that @hook raises error when no type hint is provided."""
+        with pytest.raises(ValueError, match="cannot infer event type"):
+
+            @hook
+            def handler(event):
+                pass
+
+    def test_hook_raises_error_with_non_hook_event_type(self):
+        """Test that @hook raises error when type hint is not a HookEvent subclass."""
+        with pytest.raises(ValueError, match="must be a subclass of BaseHookEvent"):
+
+            @hook
+            def handler(event: str):
+                pass
+
+    def test_hook_raises_error_with_none_in_union(self):
+        """Test that @hook raises error when union contains None."""
+        with pytest.raises(ValueError, match="None is not a valid event type"):
+
+            @hook
+            def handler(event: BeforeModelCallEvent | None):
+                pass
+
+
+class TestHookDecoratorWithMethods:
+    """Tests for @hook decorator on class methods."""
+
+    def test_hook_works_on_instance_method(self):
+        """Test that @hook works correctly on instance methods."""
+
+        class MyClass:
+            @hook
+            def handler(self, event: BeforeModelCallEvent):
+                pass
+
+        instance = MyClass()
+        assert hasattr(instance.handler, "_hook_event_types")
+        assert BeforeModelCallEvent in instance.handler._hook_event_types
+
+    def test_hook_instance_method_is_callable(self):
+        """Test that decorated instance method can be called."""
+        call_count = 0
+
+        class MyClass:
+            @hook
+            def handler(self, event: BeforeModelCallEvent):
+                nonlocal call_count
+                call_count += 1
+
+        instance = MyClass()
+        mock_event = unittest.mock.MagicMock(spec=BeforeModelCallEvent)
+        instance.handler(mock_event)
+        assert call_count == 1
+
+    def test_hook_method_accesses_self(self):
+        """Test that decorated method can access self."""
+
+        class MyClass:
+            def __init__(self):
+                self.events_received = []
+
+            @hook
+            def handler(self, event: BeforeModelCallEvent):
+                self.events_received.append(event)
+
+        instance = MyClass()
+        mock_event = unittest.mock.MagicMock(spec=BeforeModelCallEvent)
+        instance.handler(mock_event)
+        assert len(instance.events_received) == 1
+        assert instance.events_received[0] is mock_event
+
+
+class TestHookDecoratorAsync:
+    """Tests for async functions with @hook decorator."""
+
+    def test_hook_works_on_async_function(self):
+        """Test that @hook works on async functions."""
+
+        @hook
+        async def handler(event: BeforeModelCallEvent):
+            pass
+
+        assert hasattr(handler, "_hook_event_types")
+        assert BeforeModelCallEvent in handler._hook_event_types
+
+    @pytest.mark.asyncio
+    async def test_hook_async_function_is_callable(self):
+        """Test that decorated async function can be awaited."""
+        call_count = 0
+
+        @hook
+        async def handler(event: BeforeModelCallEvent):
+            nonlocal call_count
+            call_count += 1
+
+        mock_event = unittest.mock.MagicMock(spec=BeforeModelCallEvent)
+        await handler(mock_event)
+        assert call_count == 1

--- a/tests/strands/plugins/test_hook_decorator.py
+++ b/tests/strands/plugins/test_hook_decorator.py
@@ -92,6 +92,17 @@ class TestHookDecoratorEventTypeInference:
         assert AfterModelCallEvent in handler2._hook_event_types
         assert AfterInvocationEvent in handler3._hook_event_types
 
+    def test_hook_skips_cls_parameter(self):
+        """Test that @hook skips 'cls' parameter for classmethods."""
+
+        class MyClass:
+            @classmethod
+            @hook
+            def handler(cls, event: BeforeModelCallEvent):
+                pass
+
+        assert BeforeModelCallEvent in MyClass.handler._hook_event_types
+
 
 class TestHookDecoratorUnionTypes:
     """Tests for union type support in @hook decorator."""

--- a/tests/strands/plugins/test_plugin_base_class.py
+++ b/tests/strands/plugins/test_plugin_base_class.py
@@ -90,6 +90,31 @@ class TestPluginAutoDiscovery:
         assert "hook1" in hook_names
         assert "hook2" in hook_names
 
+    def test_hooks_preserve_definition_order(self):
+        """Test that hooks are discovered in definition order, not alphabetical."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def z_last_alphabetically(self, event: BeforeModelCallEvent):
+                pass
+
+            @hook
+            def a_first_alphabetically(self, event: BeforeModelCallEvent):
+                pass
+
+            @hook
+            def m_middle_alphabetically(self, event: BeforeModelCallEvent):
+                pass
+
+        plugin = MyPlugin()
+        assert len(plugin.hooks) == 3
+        # Should be in definition order, not alphabetical
+        assert plugin.hooks[0].__name__ == "z_last_alphabetically"
+        assert plugin.hooks[1].__name__ == "a_first_alphabetically"
+        assert plugin.hooks[2].__name__ == "m_middle_alphabetically"
+
     def test_plugin_discovers_tool_decorated_methods(self):
         """Test that Plugin.__init__ discovers @tool decorated methods."""
 

--- a/tests/strands/plugins/test_plugin_base_class.py
+++ b/tests/strands/plugins/test_plugin_base_class.py
@@ -9,6 +9,16 @@ from strands.plugins import Plugin, hook
 from strands.tools.decorator import tool
 
 
+def _configure_mock_agent_with_hooks():
+    """Helper to create a mock agent with working add_hook."""
+    mock_agent = unittest.mock.MagicMock()
+    mock_agent.hooks = HookRegistry()
+    mock_agent.add_hook.side_effect = lambda callback, event_type=None: mock_agent.hooks.add_callback(
+        event_type, callback
+    )
+    return mock_agent
+
+
 class TestPluginBaseClass:
     """Tests for Plugin base class basics."""
 
@@ -145,8 +155,7 @@ class TestPluginInitPlugin:
                 pass
 
         plugin = MyPlugin()
-        mock_agent = unittest.mock.MagicMock()
-        mock_agent.hooks = HookRegistry()
+        mock_agent = _configure_mock_agent_with_hooks()
 
         plugin.init_agent(mock_agent)
 
@@ -190,8 +199,7 @@ class TestPluginInitPlugin:
                 return param
 
         plugin = MyPlugin()
-        mock_agent = unittest.mock.MagicMock()
-        mock_agent.hooks = HookRegistry()
+        mock_agent = _configure_mock_agent_with_hooks()
         mock_agent.tool_registry = unittest.mock.MagicMock()
 
         plugin.init_agent(mock_agent)
@@ -215,8 +223,7 @@ class TestPluginHookWithUnionTypes:
                 pass
 
         plugin = MyPlugin()
-        mock_agent = unittest.mock.MagicMock()
-        mock_agent.hooks = HookRegistry()
+        mock_agent = _configure_mock_agent_with_hooks()
 
         plugin.init_agent(mock_agent)
 
@@ -240,10 +247,8 @@ class TestPluginMultipleAgents:
 
         plugin = MyPlugin()
 
-        mock_agent1 = unittest.mock.MagicMock()
-        mock_agent1.hooks = HookRegistry()
-        mock_agent2 = unittest.mock.MagicMock()
-        mock_agent2.hooks = HookRegistry()
+        mock_agent1 = _configure_mock_agent_with_hooks()
+        mock_agent2 = _configure_mock_agent_with_hooks()
 
         plugin.init_agent(mock_agent1)
         plugin.init_agent(mock_agent2)
@@ -273,8 +278,7 @@ class TestPluginSubclassOverride:
                 super().init_agent(agent)
 
         plugin = MyPlugin()
-        mock_agent = unittest.mock.MagicMock()
-        mock_agent.hooks = HookRegistry()
+        mock_agent = _configure_mock_agent_with_hooks()
 
         plugin.init_agent(mock_agent)
 
@@ -304,8 +308,7 @@ class TestPluginSubclassOverride:
                 manual_hook_added = True
 
         plugin = MyPlugin()
-        mock_agent = unittest.mock.MagicMock()
-        mock_agent.hooks = HookRegistry()
+        mock_agent = _configure_mock_agent_with_hooks()
 
         plugin.init_agent(mock_agent)
 
@@ -334,8 +337,7 @@ class TestPluginAsyncInitPlugin:
                 super().init_agent(agent)
 
         plugin = MyPlugin()
-        mock_agent = unittest.mock.MagicMock()
-        mock_agent.hooks = HookRegistry()
+        mock_agent = _configure_mock_agent_with_hooks()
 
         await plugin.init_agent(mock_agent)
 
@@ -361,8 +363,7 @@ class TestPluginBoundMethods:
                 self.events_received.append(event)
 
         plugin = MyPlugin()
-        mock_agent = unittest.mock.MagicMock()
-        mock_agent.hooks = HookRegistry()
+        mock_agent = _configure_mock_agent_with_hooks()
 
         plugin.init_agent(mock_agent)
 

--- a/tests/strands/plugins/test_plugin_base_class.py
+++ b/tests/strands/plugins/test_plugin_base_class.py
@@ -1,0 +1,408 @@
+"""Tests for the Plugin base class with auto-discovery."""
+
+import unittest.mock
+
+import pytest
+
+from strands.hooks import BeforeInvocationEvent, BeforeModelCallEvent, HookRegistry
+from strands.plugins import Plugin, hook
+from strands.tools.decorator import tool
+
+
+class TestPluginBaseClass:
+    """Tests for Plugin base class basics."""
+
+    def test_plugin_is_class_not_protocol(self):
+        """Test that Plugin is now a class, not a Protocol."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+        plugin = MyPlugin()
+        assert isinstance(plugin, Plugin)
+
+    def test_plugin_requires_name_attribute(self):
+        """Test that Plugin subclass must have name attribute."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+        plugin = MyPlugin()
+        assert plugin.name == "my-plugin"
+
+    def test_plugin_name_as_property(self):
+        """Test that Plugin name can be a property."""
+
+        class MyPlugin(Plugin):
+            @property
+            def name(self) -> str:
+                return "property-plugin"
+
+        plugin = MyPlugin()
+        assert plugin.name == "property-plugin"
+
+
+class TestPluginAutoDiscovery:
+    """Tests for automatic discovery of decorated methods."""
+
+    def test_plugin_discovers_hook_decorated_methods(self):
+        """Test that Plugin.__init__ discovers @hook decorated methods."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def on_before_model(self, event: BeforeModelCallEvent):
+                pass
+
+        plugin = MyPlugin()
+        assert len(plugin._hooks) == 1
+        assert plugin._hooks[0].__name__ == "on_before_model"
+
+    def test_plugin_discovers_multiple_hooks(self):
+        """Test that Plugin discovers multiple @hook decorated methods."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def hook1(self, event: BeforeModelCallEvent):
+                pass
+
+            @hook
+            def hook2(self, event: BeforeInvocationEvent):
+                pass
+
+        plugin = MyPlugin()
+        assert len(plugin._hooks) == 2
+        hook_names = {h.__name__ for h in plugin._hooks}
+        assert "hook1" in hook_names
+        assert "hook2" in hook_names
+
+    def test_plugin_discovers_tool_decorated_methods(self):
+        """Test that Plugin.__init__ discovers @tool decorated methods."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @tool
+            def my_tool(self, param: str) -> str:
+                """A test tool."""
+                return param
+
+        plugin = MyPlugin()
+        assert len(plugin._tools) == 1
+        assert plugin._tools[0].tool_name == "my_tool"
+
+    def test_plugin_discovers_both_hooks_and_tools(self):
+        """Test that Plugin discovers both @hook and @tool decorated methods."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def my_hook(self, event: BeforeModelCallEvent):
+                pass
+
+            @tool
+            def my_tool(self, param: str) -> str:
+                """A test tool."""
+                return param
+
+        plugin = MyPlugin()
+        assert len(plugin._hooks) == 1
+        assert len(plugin._tools) == 1
+
+    def test_plugin_ignores_non_decorated_methods(self):
+        """Test that Plugin doesn't discover non-decorated methods."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            def regular_method(self):
+                pass
+
+            @hook
+            def decorated_hook(self, event: BeforeModelCallEvent):
+                pass
+
+        plugin = MyPlugin()
+        assert len(plugin._hooks) == 1
+        assert plugin._hooks[0].__name__ == "decorated_hook"
+
+
+class TestPluginInitPlugin:
+    """Tests for Plugin.init_agent() auto-registration."""
+
+    def test_init_agent_registers_hooks_with_agent(self):
+        """Test that init_agent registers discovered hooks with agent."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def on_before_model(self, event: BeforeModelCallEvent):
+                pass
+
+        plugin = MyPlugin()
+        mock_agent = unittest.mock.MagicMock()
+        mock_agent.hooks = HookRegistry()
+
+        plugin.init_agent(mock_agent)
+
+        # Verify hook was registered
+        assert len(mock_agent.hooks._registered_callbacks.get(BeforeModelCallEvent, [])) == 1
+
+    def test_init_agent_registers_tools_with_agent(self):
+        """Test that init_agent adds discovered tools to agent's tools."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @tool
+            def my_tool(self, param: str) -> str:
+                """A test tool."""
+                return param
+
+        plugin = MyPlugin()
+        mock_agent = unittest.mock.MagicMock()
+        mock_agent.hooks = HookRegistry()
+        mock_agent.tool_registry = unittest.mock.MagicMock()
+
+        plugin.init_agent(mock_agent)
+
+        # Verify tool was added to agent
+        mock_agent.tool_registry.process_tools.assert_called_once()
+
+    def test_init_agent_registers_both_hooks_and_tools(self):
+        """Test that init_agent registers both hooks and tools."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def my_hook(self, event: BeforeModelCallEvent):
+                pass
+
+            @tool
+            def my_tool(self, param: str) -> str:
+                """A test tool."""
+                return param
+
+        plugin = MyPlugin()
+        mock_agent = unittest.mock.MagicMock()
+        mock_agent.hooks = HookRegistry()
+        mock_agent.tool_registry = unittest.mock.MagicMock()
+
+        plugin.init_agent(mock_agent)
+
+        # Verify both registered
+        assert len(mock_agent.hooks._registered_callbacks.get(BeforeModelCallEvent, [])) == 1
+        mock_agent.tool_registry.process_tools.assert_called_once()
+
+
+class TestPluginHookWithUnionTypes:
+    """Tests for Plugin hooks with union types."""
+
+    def test_init_agent_registers_hook_for_union_types(self):
+        """Test that hooks with union types are registered for all event types."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def on_model_events(self, event: BeforeModelCallEvent | BeforeInvocationEvent):
+                pass
+
+        plugin = MyPlugin()
+        mock_agent = unittest.mock.MagicMock()
+        mock_agent.hooks = HookRegistry()
+
+        plugin.init_agent(mock_agent)
+
+        # Verify hook was registered for both event types
+        assert len(mock_agent.hooks._registered_callbacks.get(BeforeModelCallEvent, [])) == 1
+        assert len(mock_agent.hooks._registered_callbacks.get(BeforeInvocationEvent, [])) == 1
+
+
+class TestPluginMultipleAgents:
+    """Tests for plugin reuse with multiple agents."""
+
+    def test_plugin_can_be_attached_to_multiple_agents(self):
+        """Test that the same plugin instance can be used with multiple agents."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def on_before_model(self, event: BeforeModelCallEvent):
+                pass
+
+        plugin = MyPlugin()
+
+        mock_agent1 = unittest.mock.MagicMock()
+        mock_agent1.hooks = HookRegistry()
+        mock_agent2 = unittest.mock.MagicMock()
+        mock_agent2.hooks = HookRegistry()
+
+        plugin.init_agent(mock_agent1)
+        plugin.init_agent(mock_agent2)
+
+        # Verify both agents have the hook registered
+        assert len(mock_agent1.hooks._registered_callbacks.get(BeforeModelCallEvent, [])) == 1
+        assert len(mock_agent2.hooks._registered_callbacks.get(BeforeModelCallEvent, [])) == 1
+
+
+class TestPluginSubclassOverride:
+    """Tests for subclass overriding init_agent."""
+
+    def test_subclass_can_override_init_agent(self):
+        """Test that subclass can override init_agent and call super()."""
+        custom_init_called = False
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def on_before_model(self, event: BeforeModelCallEvent):
+                pass
+
+            def init_agent(self, agent):
+                nonlocal custom_init_called
+                custom_init_called = True
+                super().init_agent(agent)
+
+        plugin = MyPlugin()
+        mock_agent = unittest.mock.MagicMock()
+        mock_agent.hooks = HookRegistry()
+
+        plugin.init_agent(mock_agent)
+
+        assert custom_init_called
+        # Verify auto-registration still happened via super()
+        assert len(mock_agent.hooks._registered_callbacks.get(BeforeModelCallEvent, [])) == 1
+
+    def test_subclass_can_add_manual_hooks(self):
+        """Test that subclass can manually add hooks in addition to decorated ones."""
+        manual_hook_added = False
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def auto_hook(self, event: BeforeModelCallEvent):
+                pass
+
+            def manual_hook(self, event: BeforeInvocationEvent):
+                pass
+
+            def init_agent(self, agent):
+                nonlocal manual_hook_added
+                super().init_agent(agent)
+                # Add manual hook
+                agent.hooks.add_callback(BeforeInvocationEvent, self.manual_hook)
+                manual_hook_added = True
+
+        plugin = MyPlugin()
+        mock_agent = unittest.mock.MagicMock()
+        mock_agent.hooks = HookRegistry()
+
+        plugin.init_agent(mock_agent)
+
+        assert manual_hook_added
+        # Verify both hooks registered
+        assert len(mock_agent.hooks._registered_callbacks.get(BeforeModelCallEvent, [])) == 1
+        assert len(mock_agent.hooks._registered_callbacks.get(BeforeInvocationEvent, [])) == 1
+
+
+class TestPluginAsyncInitPlugin:
+    """Tests for async init_agent support."""
+
+    @pytest.mark.asyncio
+    async def test_async_init_agent_supported(self):
+        """Test that async init_agent is supported."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def on_before_model(self, event: BeforeModelCallEvent):
+                pass
+
+            async def init_agent(self, agent):
+                # Just call super synchronously - async is for custom logic
+                super().init_agent(agent)
+
+        plugin = MyPlugin()
+        mock_agent = unittest.mock.MagicMock()
+        mock_agent.hooks = HookRegistry()
+
+        await plugin.init_agent(mock_agent)
+
+        # Verify hook was registered
+        assert len(mock_agent.hooks._registered_callbacks.get(BeforeModelCallEvent, [])) == 1
+
+
+class TestPluginBoundMethods:
+    """Tests for bound method registration."""
+
+    def test_hooks_are_bound_to_instance(self):
+        """Test that registered hooks are bound to the plugin instance."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            def __init__(self):
+                super().__init__()
+                self.events_received = []
+
+            @hook
+            def on_before_model(self, event: BeforeModelCallEvent):
+                self.events_received.append(event)
+
+        plugin = MyPlugin()
+        mock_agent = unittest.mock.MagicMock()
+        mock_agent.hooks = HookRegistry()
+
+        plugin.init_agent(mock_agent)
+
+        # Call the registered hook and verify it accesses the correct instance
+        mock_event = unittest.mock.MagicMock(spec=BeforeModelCallEvent)
+        callbacks = list(mock_agent.hooks._registered_callbacks.get(BeforeModelCallEvent, []))
+        callbacks[0](mock_event)
+
+        assert len(plugin.events_received) == 1
+        assert plugin.events_received[0] is mock_event
+
+    def test_tools_are_bound_to_instance(self):
+        """Test that registered tools are bound to the plugin instance."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            def __init__(self):
+                super().__init__()
+                self.tool_called = False
+
+            @tool
+            def my_tool(self, param: str) -> str:
+                """A test tool."""
+                self.tool_called = True
+                return param
+
+        plugin = MyPlugin()
+        mock_agent = unittest.mock.MagicMock()
+        mock_agent.hooks = HookRegistry()
+        mock_agent.tool_registry = unittest.mock.MagicMock()
+
+        plugin.init_agent(mock_agent)
+
+        # Get the tool that was registered and call it
+        call_args = mock_agent.tool_registry.process_tools.call_args
+        registered_tools = call_args[0][0]
+        assert len(registered_tools) == 1
+
+        # Call the tool - it should be bound to the instance
+        result = registered_tools[0]("test")
+        assert plugin.tool_called
+        assert result == "test"

--- a/tests/strands/plugins/test_plugin_base_class.py
+++ b/tests/strands/plugins/test_plugin_base_class.py
@@ -141,8 +141,8 @@ class TestPluginAutoDiscovery:
         assert len(plugin.hooks) == 1
         assert plugin.hooks[0].__name__ == "decorated_hook"
 
-    def test_hooks_property_returns_tuple(self):
-        """Test that hooks property returns an immutable tuple."""
+    def test_hooks_property_returns_list(self):
+        """Test that hooks property returns a mutable list."""
 
         class MyPlugin(Plugin):
             name = "my-plugin"
@@ -152,10 +152,10 @@ class TestPluginAutoDiscovery:
                 pass
 
         plugin = MyPlugin()
-        assert isinstance(plugin.hooks, tuple)
+        assert isinstance(plugin.hooks, list)
 
-    def test_tools_property_returns_tuple(self):
-        """Test that tools property returns an immutable tuple."""
+    def test_tools_property_returns_list(self):
+        """Test that tools property returns a mutable list."""
 
         class MyPlugin(Plugin):
             name = "my-plugin"
@@ -166,7 +166,53 @@ class TestPluginAutoDiscovery:
                 return param
 
         plugin = MyPlugin()
-        assert isinstance(plugin.tools, tuple)
+        assert isinstance(plugin.tools, list)
+
+    def test_hooks_can_be_filtered(self):
+        """Test that hooks list can be modified before registration."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @hook
+            def hook1(self, event: BeforeModelCallEvent):
+                pass
+
+            @hook
+            def hook2(self, event: BeforeInvocationEvent):
+                pass
+
+        plugin = MyPlugin()
+        assert len(plugin.hooks) == 2
+
+        # Filter out hook1
+        plugin.hooks[:] = [h for h in plugin.hooks if h.__name__ != "hook1"]
+        assert len(plugin.hooks) == 1
+        assert plugin.hooks[0].__name__ == "hook2"
+
+    def test_tools_can_be_filtered(self):
+        """Test that tools list can be modified before registration."""
+
+        class MyPlugin(Plugin):
+            name = "my-plugin"
+
+            @tool
+            def tool1(self, param: str) -> str:
+                """Tool 1."""
+                return param
+
+            @tool
+            def tool2(self, param: str) -> str:
+                """Tool 2."""
+                return param
+
+        plugin = MyPlugin()
+        assert len(plugin.tools) == 2
+
+        # Filter out tool1
+        plugin.tools[:] = [t for t in plugin.tools if t.tool_name != "tool1"]
+        assert len(plugin.tools) == 1
+        assert plugin.tools[0].tool_name == "tool2"
 
 
 class TestPluginRegistryAutoRegistration:

--- a/tests/strands/plugins/test_plugins.py
+++ b/tests/strands/plugins/test_plugins.py
@@ -4,38 +4,39 @@ import unittest.mock
 
 import pytest
 
+from strands.hooks import HookRegistry
 from strands.plugins import Plugin
 from strands.plugins.registry import _PluginRegistry
 
-# Plugin Tests
+# Plugin Base Class Tests
 
 
-def test_plugin_class_requires_inheritance():
-    """Test that Plugin class requires inheritance."""
+def test_plugin_base_class_isinstance_check():
+    """Test that Plugin subclass passes isinstance check."""
 
     class MyPlugin(Plugin):
         name = "my-plugin"
-
-        def init_agent(self, agent):
-            pass
 
     plugin = MyPlugin()
     assert isinstance(plugin, Plugin)
 
 
-def test_plugin_class_sync_implementation():
-    """Test Plugin class works with synchronous init_agent."""
+def test_plugin_base_class_sync_implementation():
+    """Test Plugin base class works with synchronous init_agent."""
 
     class SyncPlugin(Plugin):
         name = "sync-plugin"
 
         def init_agent(self, agent):
+            super().init_agent(agent)
             agent.custom_attribute = "initialized by plugin"
 
     plugin = SyncPlugin()
     mock_agent = unittest.mock.Mock()
+    mock_agent.hooks = HookRegistry()
+    mock_agent.tool_registry = unittest.mock.MagicMock()
 
-    # Verify the plugin is an instance of Plugin
+    # Verify the plugin is an instance
     assert isinstance(plugin, Plugin)
     assert plugin.name == "sync-plugin"
 
@@ -45,19 +46,22 @@ def test_plugin_class_sync_implementation():
 
 
 @pytest.mark.asyncio
-async def test_plugin_class_async_implementation():
-    """Test Plugin class works with asynchronous init_agent."""
+async def test_plugin_base_class_async_implementation():
+    """Test Plugin base class works with asynchronous init_agent."""
 
     class AsyncPlugin(Plugin):
         name = "async-plugin"
 
         async def init_agent(self, agent):
+            super().init_agent(agent)
             agent.custom_attribute = "initialized by async plugin"
 
     plugin = AsyncPlugin()
     mock_agent = unittest.mock.Mock()
+    mock_agent.hooks = HookRegistry()
+    mock_agent.tool_registry = unittest.mock.MagicMock()
 
-    # Verify the plugin is an instance of Plugin
+    # Verify the plugin is an instance
     assert isinstance(plugin, Plugin)
     assert plugin.name == "async-plugin"
 
@@ -78,41 +82,36 @@ def test_plugin_class_requires_name():
         PluginWithoutName()
 
 
-def test_plugin_class_requires_init_agent_method():
-    """Test that Plugin class requires an init_agent method."""
+def test_plugin_base_class_requires_init_agent_method():
+    """Test that Plugin base class provides default init_agent."""
 
-    with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+    class PluginWithoutOverride(Plugin):
+        name = "no-override-plugin"
 
-        class PluginWithoutInitPlugin(Plugin):
-            name = "incomplete-plugin"
+    plugin = PluginWithoutOverride()
+    # Plugin base class provides default init_agent
+    assert hasattr(plugin, "init_agent")
+    assert callable(plugin.init_agent)
 
-        PluginWithoutInitPlugin()
 
-
-def test_plugin_class_with_class_attribute_name():
-    """Test Plugin class works when name is a class attribute."""
+def test_plugin_base_class_with_class_attribute_name():
+    """Test Plugin base class works when name is a class attribute."""
 
     class PluginWithClassAttribute(Plugin):
         name: str = "class-attr-plugin"
-
-        def init_agent(self, agent):
-            pass
 
     plugin = PluginWithClassAttribute()
     assert isinstance(plugin, Plugin)
     assert plugin.name == "class-attr-plugin"
 
 
-def test_plugin_class_with_property_name():
-    """Test Plugin class works when name is a property."""
+def test_plugin_base_class_with_property_name():
+    """Test Plugin base class works when name is a property."""
 
     class PluginWithProperty(Plugin):
         @property
-        def name(self):
+        def name(self) -> str:
             return "property-plugin"
-
-        def init_agent(self, agent):
-            pass
 
     plugin = PluginWithProperty()
     assert isinstance(plugin, Plugin)
@@ -125,7 +124,10 @@ def test_plugin_class_with_property_name():
 @pytest.fixture
 def mock_agent():
     """Create a mock agent for testing."""
-    return unittest.mock.Mock()
+    agent = unittest.mock.Mock()
+    agent.hooks = HookRegistry()
+    agent.tool_registry = unittest.mock.MagicMock()
+    return agent
 
 
 @pytest.fixture
@@ -141,9 +143,11 @@ def test_plugin_registry_add_and_init_calls_init_agent(registry, mock_agent):
         name = "test-plugin"
 
         def __init__(self):
+            super().__init__()
             self.initialized = False
 
         def init_agent(self, agent):
+            super().init_agent(agent)
             self.initialized = True
             agent.plugin_initialized = True
 
@@ -159,9 +163,6 @@ def test_plugin_registry_add_duplicate_raises_error(registry, mock_agent):
 
     class TestPlugin(Plugin):
         name = "test-plugin"
-
-        def init_agent(self, agent):
-            pass
 
     plugin1 = TestPlugin()
     plugin2 = TestPlugin()
@@ -179,9 +180,11 @@ def test_plugin_registry_add_and_init_with_async_plugin(registry, mock_agent):
         name = "async-plugin"
 
         def __init__(self):
+            super().__init__()
             self.initialized = False
 
         async def init_agent(self, agent):
+            super().init_agent(agent)
             self.initialized = True
             agent.async_plugin_initialized = True
 

--- a/tests/strands/plugins/test_plugins.py
+++ b/tests/strands/plugins/test_plugins.py
@@ -28,7 +28,7 @@ def test_plugin_base_class_sync_implementation():
         name = "sync-plugin"
 
         def init_agent(self, agent):
-            super().init_agent(agent)
+            # No super() needed - registry handles auto-registration
             agent.custom_attribute = "initialized by plugin"
 
     plugin = SyncPlugin()
@@ -53,7 +53,7 @@ async def test_plugin_base_class_async_implementation():
         name = "async-plugin"
 
         async def init_agent(self, agent):
-            super().init_agent(agent)
+            # No super() needed - registry handles auto-registration
             agent.custom_attribute = "initialized by async plugin"
 
     plugin = AsyncPlugin()
@@ -127,6 +127,7 @@ def mock_agent():
     agent = unittest.mock.Mock()
     agent.hooks = HookRegistry()
     agent.tool_registry = unittest.mock.MagicMock()
+    agent.add_hook = unittest.mock.Mock()
     return agent
 
 
@@ -147,7 +148,7 @@ def test_plugin_registry_add_and_init_calls_init_agent(registry, mock_agent):
             self.initialized = False
 
         def init_agent(self, agent):
-            super().init_agent(agent)
+            # No super() needed - registry handles auto-registration
             self.initialized = True
             agent.plugin_initialized = True
 
@@ -184,7 +185,7 @@ def test_plugin_registry_add_and_init_with_async_plugin(registry, mock_agent):
             self.initialized = False
 
         async def init_agent(self, agent):
-            super().init_agent(agent)
+            # No super() needed - registry handles auto-registration
             self.initialized = True
             agent.async_plugin_initialized = True
 


### PR DESCRIPTION
## Motivation

Currently, plugin authors must manually register hooks in their `init_plugin()` method, which is verbose and error-prone:

```python
class MyPlugin:
    name = "my-plugin"
    
    def init_plugin(self, agent: Agent) -> None:
        agent.add_hook(self.log_call, BeforeModelCallEvent)
```

This PR enables declarative hook registration using a `@hook` decorator, making plugin development more intuitive and reducing boilerplate:

```python
class MyPlugin(Plugin):
    name = "my-plugin"

    @hook
    def log_call(self, event: BeforeModelCallEvent):
        print(event)

    @tool
    def printer(self, log: str):
        print(log)
        return "Printed log"
```

Resolves: #1739

## Public API Changes

### New `@hook` decorator

The `@hook` decorator marks methods for automatic registration:

```python
from strands.plugins import Plugin, hook
from strands.hooks import BeforeModelCallEvent, AfterModelCallEvent

class MyPlugin(Plugin):
    name = "my-plugin"

    # Single event type - inferred from type hint
    @hook
    def on_model_call(self, event: BeforeModelCallEvent):
        print(event)

    # Union types - registers for multiple events
    @hook
    def on_any_model_event(self, event: BeforeModelCallEvent | AfterModelCallEvent):
        print(event)
``
