### PR TITLE
feat(mcp): add support for MCP elicitation -32042 error handling

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -672,11 +672,11 @@ class MCPClient(ToolProvider):
 
     def _handle_tool_execution_error(self, tool_use_id: str, exception: Exception) -> MCPToolResult:
         """Create error ToolResult with consistent logging and elicitation callback support.
-    
+
         Args:
             tool_use_id: Unique identifier for this tool use.
             exception: The exception that occurred during tool execution.
-    
+
         Returns:
             MCPToolResult: Error result containing either the elicitation data or the
                 original exception message.
@@ -685,22 +685,17 @@ class MCPClient(ToolProvider):
             try:
                 error_data = ElicitationRequiredErrorData.model_validate(exception.error.data)
                 elicitations = [e.model_dump(exclude_none=True) for e in error_data.elicitations]
-    
+
                 return MCPToolResult(
                     status="error",
                     toolUseId=tool_use_id,
                     content=[
-                        {
-                            "text": (
-                                f"MCP Elicitation required: [{str(exception)}] "
-                                f"with data {json.dumps(elicitations)}"
-                            )
-                        }
+                        {"text": (f"MCP Elicitation required: [{str(exception)}] with data {json.dumps(elicitations)}")}
                     ],
                 )
             except Exception:
                 logger.debug("Failed to parse ElicitationRequiredErrorData from -32042 error", exc_info=True)
-    
+
         return MCPToolResult(
             status="error",
             toolUseId=tool_use_id,

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -935,7 +935,6 @@ def test_call_tool_sync_elicitation_error(mock_transport, mock_session):
     from mcp.shared.exceptions import McpError
     from mcp.types import ElicitationRequiredErrorData, ElicitRequestURLParams
 
-    # Create an elicitation error (code -32042)
     elicitation_data = ElicitationRequiredErrorData(
         elicitations=[
             ElicitRequestURLParams(
@@ -945,7 +944,6 @@ def test_call_tool_sync_elicitation_error(mock_transport, mock_session):
     )
 
     error = McpError(error=MagicMock(code=-32042, data=elicitation_data.model_dump()))
-
     mock_session.call_tool.side_effect = error
 
     with MCPClient(mock_transport["transport_callable"]) as client:
@@ -954,18 +952,17 @@ def test_call_tool_sync_elicitation_error(mock_transport, mock_session):
         assert result["status"] == "error"
         assert result["toolUseId"] == "test-123"
         assert len(result["content"]) == 1
-        assert "URL_ELICITATION_REQUIRED" in result["content"][0]["text"]
+        assert "MCP Elicitation required" in result["content"][0]["text"]
         assert "https://example.com/auth" in result["content"][0]["text"]
         assert "Please authorize the application" in result["content"][0]["text"]
-        assert "retry this tool call" in result["content"][0]["text"]
+        assert "elicit-123" in result["content"][0]["text"]
 
 
 def test_call_tool_sync_elicitation_error_multiple_urls(mock_transport, mock_session):
-    """Test that call_tool_sync correctly handles elicitation errors with multiple URLs."""
+    """Test that call_tool_sync correctly handles elicitation errors with multiple elicitations."""
     from mcp.shared.exceptions import McpError
     from mcp.types import ElicitationRequiredErrorData, ElicitRequestURLParams
 
-    # Create an elicitation error with multiple URLs
     elicitation_data = ElicitationRequiredErrorData(
         elicitations=[
             ElicitRequestURLParams(
@@ -978,7 +975,6 @@ def test_call_tool_sync_elicitation_error_multiple_urls(mock_transport, mock_ses
     )
 
     error = McpError(error=MagicMock(code=-32042, data=elicitation_data.model_dump()))
-
     mock_session.call_tool.side_effect = error
 
     with MCPClient(mock_transport["transport_callable"]) as client:
@@ -987,40 +983,22 @@ def test_call_tool_sync_elicitation_error_multiple_urls(mock_transport, mock_ses
         assert result["status"] == "error"
         assert result["toolUseId"] == "test-123"
         assert len(result["content"]) == 1
-        assert "URL_ELICITATION_REQUIRED" in result["content"][0]["text"]
+        assert "MCP Elicitation required" in result["content"][0]["text"]
         assert "https://example.com/auth1" in result["content"][0]["text"]
         assert "https://example.com/auth2" in result["content"][0]["text"]
         assert "First authorization" in result["content"][0]["text"]
-
-
-def test_call_tool_sync_elicitation_error_invalid_data(mock_transport, mock_session):
-    """Test that call_tool_sync handles malformed elicitation error data gracefully."""
-    from mcp.shared.exceptions import McpError
-
-    # Create an elicitation error with invalid data that can't be parsed
-    error = McpError(error=MagicMock(code=-32042, data={"invalid": "data structure"}))
-
-    mock_session.call_tool.side_effect = error
-
-    with MCPClient(mock_transport["transport_callable"]) as client:
-        result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={"param": "value"})
-
-        # Should fall back to generic error message when parsing fails
-        assert result["status"] == "error"
-        assert result["toolUseId"] == "test-123"
-        assert len(result["content"]) == 1
-        assert "Tool execution failed" in result["content"][0]["text"]
+        assert "Second authorization" in result["content"][0]["text"]
+        assert "elicit-1" in result["content"][0]["text"]
+        assert "elicit-2" in result["content"][0]["text"]
 
 
 def test_call_tool_sync_elicitation_error_no_urls(mock_transport, mock_session):
-    """Test that -32042 error with elicitation data returns elicitation result."""
+    """Test that -32042 error with empty URL still returns generic elicitation result."""
     from mcp.shared.exceptions import McpError
     from mcp.types import ElicitationRequiredErrorData, ElicitRequestURLParams
 
     elicitation_data = ElicitationRequiredErrorData(
-        elicitations=[
-            ElicitRequestURLParams(url=None, message="No URL provided", elicitationId="elicit-1")
-        ]
+        elicitations=[ElicitRequestURLParams(url="", message="No URL provided", elicitationId="elicit-1")]
     )
     error = McpError(error=MagicMock(code=-32042, data=elicitation_data.model_dump()))
     mock_session.call_tool.side_effect = error
@@ -1030,6 +1008,7 @@ def test_call_tool_sync_elicitation_error_no_urls(mock_transport, mock_session):
         assert result["status"] == "error"
         assert "MCP Elicitation required" in result["content"][0]["text"]
         assert "elicit-1" in result["content"][0]["text"]
+        assert "No URL provided" in result["content"][0]["text"]
 
 
 def test_call_tool_sync_other_mcp_error_code(mock_transport, mock_session):
@@ -1043,7 +1022,7 @@ def test_call_tool_sync_other_mcp_error_code(mock_transport, mock_session):
         result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={})
         assert result["status"] == "error"
         assert "Tool execution failed" in result["content"][0]["text"]
-        
+
 
 def test_call_tool_sync_elicitation_error_malformed_data(mock_transport, mock_session):
     """Test that -32042 with unparseable data falls through to generic error."""
@@ -1064,7 +1043,6 @@ async def test_call_tool_async_elicitation_error(mock_transport, mock_session):
     from mcp.shared.exceptions import McpError
     from mcp.types import ElicitationRequiredErrorData, ElicitRequestURLParams
 
-    # Create an elicitation error (code -32042)
     elicitation_data = ElicitationRequiredErrorData(
         elicitations=[
             ElicitRequestURLParams(
@@ -1083,7 +1061,6 @@ async def test_call_tool_async_elicitation_error(mock_transport, mock_session):
             mock_future = MagicMock()
             mock_run_coroutine_threadsafe.return_value = mock_future
 
-            # Create an async mock that raises the elicitation error
             async def mock_awaitable():
                 raise error
 
@@ -1096,6 +1073,7 @@ async def test_call_tool_async_elicitation_error(mock_transport, mock_session):
         assert result["status"] == "error"
         assert result["toolUseId"] == "test-123"
         assert len(result["content"]) == 1
-        assert "URL_ELICITATION_REQUIRED" in result["content"][0]["text"]
+        assert "MCP Elicitation required" in result["content"][0]["text"]
         assert "https://example.com/auth" in result["content"][0]["text"]
         assert "Please authorize the application" in result["content"][0]["text"]
+        assert "elicit-123" in result["content"][0]["text"]


### PR DESCRIPTION
## Description

When an MCP server like AgentCore Gateway returns a `-32042` (URLElicitationRequiredError) on `tools/call`, the
MCP Python SDK raises `McpError`. The current `MCPClient._handle_tool_execution_error`
catches it and returns a generic error string, losing the authorization URL(s) embedded in
`error.data.elicitations`. This breaks OAuth consent flows that rely on URL mode elicitation
(e.g., AgentCore Gateway 3LO, or any MCP server using the 2025-11-25 spec).

This PR modifies `_handle_tool_execution_error` to detect `McpError` with code `-32042`,
parse the error data using the MCP SDK's `ElicitationRequiredErrorData` model, and include
the authorization URL(s) in the tool result text with a `URL_ELICITATION_REQUIRED` prefix.
The LLM can then present the URL to the user and retry the tool call after consent completes.

### Changes

**File: `strands/tools/mcp/mcp_client.py`**

- Added imports: `McpError` from `mcp.shared.exceptions`, `ElicitationRequiredErrorData` from `mcp.types`
- Modified `MCPClient._handle_tool_execution_error`: added a check at the top of the method for `-32042` errors, parses `ElicitationRequiredErrorData`, extracts URL(s) and message(s), and returns them in the tool result. Falls through to original behavior for all non-32042 errors.

### How the two elicitation paths work together

The MCP 2025-11-25 spec defines two ways a server can request user authorization:

| Path | Mechanism | Handled by |
|------|-----------|------------|
| Server-initiated | Server sends `elicitation/create` request to client | `elicitation_callback` on `MCPClient` (existing, unchanged) |
| Error-based | Server returns `-32042` error on `tools/call` | `_handle_tool_execution_error` (this PR) |

Both paths can coexist. The `elicitation_callback` handles case 1 via the MCP Python SDK's
`ClientSession`. This PR handles case 2, where the error is raised as `McpError` and caught
by `call_tool_async`/`call_tool_sync`.

## Related Issues

Closes #1742

Specifically addresses the "URL Mode Elicitation" item under Major Changes in the MCP 2025-11-25 spec:
- [URL Mode Elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation)
- [URLElicitationRequiredError](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-elicitation-required-error) (code `-32042`)
- [MCP 2025-11-25 Changelog](https://modelcontextprotocol.io/specification/2025-11-25/changelog)

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->
N/A

## Type of Change

New feature

## Testing

### Unit tests

| Test case | Input | Expected output |
|-----------|-------|-----------------|
| `-32042` with valid `ElicitationRequiredErrorData` | `McpError(ErrorData(code=-32042, data={"elicitations": [{"mode": "url", "url": "https://...", "message": "Please authorize"}]}))` | `MCPToolResult` with `URL_ELICITATION_REQUIRED` and the URL |
| `-32042` with multiple URLs | Same as above with 2+ elicitations | All URLs included, newline-separated |
| `-32042` with malformed data | `McpError(ErrorData(code=-32042, data="invalid"))` | Falls through to `"Tool execution failed: ..."` |
| `-32042` with no URLs in elicitations | `McpError(ErrorData(code=-32042, data={"elicitations": [{"mode": "url"}]}))` | Falls through to `"Tool execution failed: ..."` |
| Different McpError code | `McpError(ErrorData(code=-32600, ...))` | Falls through to `"Tool execution failed: ..."` (no change) |
| Non-McpError exception | `RuntimeError("connection lost")` | Falls through to `"Tool execution failed: ..."` (no change) |

### Integration test

Tested with AgentCore Gateway using LinkedIn as a 3LO OAuth target:
1. Agent calls `LinkedInAuthCode___getUserInfo`
2. Gateway returns `-32042` with authorization URL
3. LLM receives the URL in the tool result and presents it to the user
4. User completes OAuth consent in browser
5. Agent retries the tool call — succeeds and returns LinkedIn user data

- [X] I ran `hatch run prepare`

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.