### PR TITLE
feat: expose usage and metrics in AfterModelCallEvent

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -346,8 +346,7 @@ async def _handle_model_execution(
                     agent=agent,
                     invocation_state=invocation_state,
                     stop_response=AfterModelCallEvent.ModelStopResponse(
-                        stop_reason=stop_reason,
-                        message=message,
+                        stop_reason=stop_reason, message=message, usage=usage, metrics=metrics
                     ),
                 )
 

--- a/src/strands/hooks/events.py
+++ b/src/strands/hooks/events.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from ..agent.agent_result import AgentResult
 
 from ..types.content import Message, Messages
+from ..types.event_loop import Metrics, Usage
 from ..types.interrupt import _Interruptible
 from ..types.streaming import StopReason
 from ..types.tools import AgentTool, ToolResult, ToolUse
@@ -269,10 +270,14 @@ class AfterModelCallEvent(HookEvent):
         Attributes:
             stop_reason: The reason the model stopped generating.
             message: The generated message from the model.
+            usage: Token usage information for model interactions.
+            metrics: Performance metrics for model interactions.
         """
 
         message: Message
         stop_reason: StopReason
+        usage: Usage | None = None
+        metrics: Metrics | None = None
 
     invocation_state: dict[str, Any] = field(default_factory=dict)
     stop_response: ModelStopResponse | None = None

--- a/tests/fixtures/mocked_model_provider.py
+++ b/tests/fixtures/mocked_model_provider.py
@@ -106,3 +106,9 @@ class MockedModelProvider(Model):
                     yield {"contentBlockStop": {}}
 
         yield {"messageStop": {"stopReason": stop_reason}}
+        yield {
+            "metadata": {
+                "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                "metrics": {"latencyMs": 100},
+            }
+        }

--- a/tests/strands/agent/hooks/test_agent_events.py
+++ b/tests/strands/agent/hooks/test_agent_events.py
@@ -141,6 +141,14 @@ async def test_stream_e2e_success(alist):
         {"event": {"contentBlockStop": {}}},
         {"event": {"messageStop": {"stopReason": "tool_use"}}},
         {
+            "event": {
+                "metadata": {
+                    "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                    "metrics": {"latencyMs": 100},
+                }
+            }
+        },
+        {
             "message": {
                 "content": [
                     {"text": "Okay invoking normal tool"},
@@ -198,6 +206,14 @@ async def test_stream_e2e_success(alist):
         },
         {"event": {"contentBlockStop": {}}},
         {"event": {"messageStop": {"stopReason": "tool_use"}}},
+        {
+            "event": {
+                "metadata": {
+                    "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                    "metrics": {"latencyMs": 100},
+                }
+            }
+        },
         {
             "message": {
                 "content": [
@@ -257,6 +273,14 @@ async def test_stream_e2e_success(alist):
         {"event": {"contentBlockStop": {}}},
         {"event": {"messageStop": {"stopReason": "tool_use"}}},
         {
+            "event": {
+                "metadata": {
+                    "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                    "metrics": {"latencyMs": 100},
+                }
+            }
+        },
+        {
             "message": {
                 "content": [
                     {"text": "Invoking streaming tool"},
@@ -307,6 +331,14 @@ async def test_stream_e2e_success(alist):
         },
         {"event": {"contentBlockStop": {}}},
         {"event": {"messageStop": {"stopReason": "end_turn"}}},
+        {
+            "event": {
+                "metadata": {
+                    "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                    "metrics": {"latencyMs": 100},
+                }
+            }
+        },
         {"message": {"content": [{"text": "I invoked the tools!"}], "role": "assistant"}},
         {
             "result": AgentResult(
@@ -371,6 +403,14 @@ async def test_stream_e2e_throttle_and_redact(alist, mock_sleep):
         },
         {"event": {"contentBlockStop": {}}},
         {"event": {"messageStop": {"stopReason": "guardrail_intervened"}}},
+        {
+            "event": {
+                "metadata": {
+                    "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                    "metrics": {"latencyMs": 100},
+                }
+            }
+        },
         {"message": {"content": [{"text": "INPUT BLOCKED!"}], "role": "assistant"}},
         {
             "result": AgentResult(
@@ -435,6 +475,14 @@ async def test_stream_e2e_reasoning_redacted_content(alist):
         },
         {"event": {"contentBlockStop": {}}},
         {"event": {"messageStop": {"stopReason": "end_turn"}}},
+        {
+            "event": {
+                "metadata": {
+                    "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                    "metrics": {"latencyMs": 100},
+                }
+            }
+        },
         {
             "message": {
                 "content": [

--- a/tests/strands/agent/test_agent_hooks.py
+++ b/tests/strands/agent/test_agent_hooks.py
@@ -175,6 +175,8 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, mock_model, tool_u
                 "role": "assistant",
             },
             stop_reason="tool_use",
+            usage={"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+            metrics={"latencyMs": 100},
         ),
         exception=None,
     )
@@ -201,6 +203,8 @@ def test_agent__call__hooks(agent, hook_provider, agent_tool, mock_model, tool_u
         stop_response=AfterModelCallEvent.ModelStopResponse(
             message=mock_model.agent_responses[1],
             stop_reason="end_turn",
+            usage={"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+            metrics={"latencyMs": 100},
         ),
         exception=None,
     )
@@ -248,6 +252,8 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, mock_m
                 "role": "assistant",
             },
             stop_reason="tool_use",
+            usage={"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+            metrics={"latencyMs": 100},
         ),
         exception=None,
     )
@@ -274,6 +280,8 @@ async def test_agent_stream_async_hooks(agent, hook_provider, agent_tool, mock_m
         stop_response=AfterModelCallEvent.ModelStopResponse(
             message=mock_model.agent_responses[1],
             stop_reason="end_turn",
+            usage={"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+            metrics={"latencyMs": 100},
         ),
         exception=None,
     )

--- a/tests/strands/agent/test_retry.py
+++ b/tests/strands/agent/test_retry.py
@@ -170,6 +170,8 @@ async def test_model_retry_strategy_no_retry_on_success():
         stop_response=AfterModelCallEvent.ModelStopResponse(
             message={"role": "assistant", "content": [{"text": "Success"}]},
             stop_reason="end_turn",
+            usage={"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+            metrics={"latencyMs": 100},
         ),
     )
 
@@ -203,6 +205,8 @@ async def test_model_retry_strategy_reset_on_success(mock_sleep):
         stop_response=AfterModelCallEvent.ModelStopResponse(
             message={"role": "assistant", "content": [{"text": "Success"}]},
             stop_reason="end_turn",
+            usage={"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+            metrics={"latencyMs": 100},
         ),
     )
     await strategy._handle_after_model_call(event2)
@@ -281,6 +285,8 @@ async def test_model_retry_strategy_backwards_compatible_event_cleared_on_succes
         stop_response=AfterModelCallEvent.ModelStopResponse(
             message={"role": "assistant", "content": [{"text": "Success"}]},
             stop_reason="end_turn",
+            usage={"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+            metrics={"latencyMs": 100},
         ),
     )
 

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -840,6 +840,12 @@ async def test_event_loop_cycle_exception_model_hooks(mock_sleep, agent, model, 
             [
                 {"contentBlockDelta": {"delta": {"text": "test text"}}},
                 {"contentBlockStop": {}},
+                {
+                    "metadata": {
+                        "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                        "metrics": {"latencyMs": 100},
+                    }
+                },
             ]
         ),
     ]
@@ -878,7 +884,10 @@ async def test_event_loop_cycle_exception_model_hooks(mock_sleep, agent, model, 
         agent=agent,
         invocation_state=ANY,
         stop_response=AfterModelCallEvent.ModelStopResponse(
-            message={"content": [{"text": "test text"}], "role": "assistant"}, stop_reason="end_turn"
+            message={"content": [{"text": "test text"}], "role": "assistant"},
+            stop_reason="end_turn",
+            usage={"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+            metrics={"latencyMs": 100},
         ),
         exception=None,
     )


### PR DESCRIPTION
## Description
Currently, per-call model invocation metrics are not exposed unless OpenTelemetry tracing is enabled. Instead, aggregated metrics are available at the end of agent invocation. This PR exposes `usage` and `metrics` through the `ModelStopResponse` class. Adding these metrics for each model call rather than the aggregation is valuable for SDK users as it enables improved cost optimization.

The fields have been implemented as optional for backwards compatibility.

## Related Issues
#1503 
#1532
#1575 <- adds these fields to `MessageAddedEvent`; I would argue that they're more appropriate on the `AfterModelCallEvent` but I'd be happy to see that PR merged too
## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
