### PR TITLE
chore: switch to Sonnet 4.6 for Anthropic provider integ tests

### DIFF
--- a/tests_integ/models/providers.py
+++ b/tests_integ/models/providers.py
@@ -66,7 +66,7 @@ anthropic = ProviderInfo(
         client_args={
             "api_key": os.getenv("ANTHROPIC_API_KEY"),
         },
-        model_id="claude-3-7-sonnet-20250219",
+        model_id="claude-sonnet-4-6",
         max_tokens=512,
     ),
 )

--- a/tests_integ/models/test_model_anthropic.py
+++ b/tests_integ/models/test_model_anthropic.py
@@ -28,7 +28,7 @@ def model():
         client_args={
             "api_key": os.getenv("ANTHROPIC_API_KEY"),
         },
-        model_id="claude-3-7-sonnet-20250219",
+        model_id="claude-sonnet-4-6",
         max_tokens=512,
     )
 


### PR DESCRIPTION
## Description
The integ tests currently use Sonnet 3.7, which was retired on Feb 19 from Anthropic 1P.
https://platform.claude.com/docs/en/about-claude/model-deprecations

Integ tests currently fail with:
```
anthropic.NotFoundError: Error code: 404 - {'type': 'error', 'error': {'type': 'not_found_error', 'message': 'model: claude-3-7-sonnet-20250219'}
```

This change switches to Sonnet 4.6, which will retire no sooner than February 17, 2027

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
