### PR TITLE
test: pin integ tests to Python 3.10

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -57,7 +57,7 @@ jobs:
           STRANDS_TEST_API_KEYS_SECRET_NAME: ${{ secrets.STRANDS_TEST_API_KEYS_SECRET_NAME }}
         id: tests
         run: |
-          hatch test tests_integ
+          hatch test --python 3.10 tests_integ
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Description
Something seems to have changed in hatch maybe, I'm now seeing this in integ tests:

```
2026-02-25T22:32:03.4790361Z ##[group]Run hatch test tests_integ
2026-02-25T22:32:03.4790955Z [36;1mhatch test tests_integ[0m
....
2026-02-25T22:32:03.7458904Z No compatible environments found: [<hatch.env.virtual.VirtualEnvironment object at 0x7f314f7e1ea0>, <hatch.env.virtual.VirtualEnvironment object at 0x7f314f61bca0>, <hatch.env.virtual.VirtualEnvironment object at 0x7f314f658370>, <hatch.env.virtual.VirtualEnvironment object at 0x7f314f658520>, <hatch.env.virtual.VirtualEnvironment object at 0x7f314f6586d0>]
2026-02-25T22:32:03.7829803Z ##[error]Process completed with exit code 1.
```

It seems to be trying to set up a venv for each Python version, instead for just the one found in the environment (Python 3.10 via setup-python step)

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
