### PR TITLE
test: pin virtualenv to <21 for hatch bug

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,8 +48,10 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install dependencies
+        # Pin virtualenv until hatch is fixed.
+        # See https://github.com/pypa/hatch/issues/2193
         run: |
-          pip install --no-cache-dir hatch
+          pip install --no-cache-dir hatch 'virtualenv<21'
       - name: Run integration tests
         env:
           AWS_REGION: us-east-1

--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -34,9 +34,11 @@ jobs:
         python-version: '3.10'
 
     - name: Install dependencies
+      # Pin virtualenv until hatch is fixed.
+      # See https://github.com/pypa/hatch/issues/2193
       run: |
         python -m pip install --upgrade pip
-        pip install hatch twine
+        pip install hatch twine 'virtualenv<21'
 
     - name: Validate version
       run: |

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -83,8 +83,10 @@ jobs:
           # Windows typically has audio libraries available by default
           echo "Windows audio dependencies handled by PyAudio wheels"
       - name: Install dependencies
+        # Pin virtualenv until hatch is fixed.
+        # See https://github.com/pypa/hatch/issues/2193
         run: |
-          pip install --no-cache-dir hatch
+          pip install --no-cache-dir hatch 'virtualenv<21'
       - name: Run Unit tests
         id: tests
         run: hatch test tests --cover
@@ -118,8 +120,10 @@ jobs:
           sudo apt-get install -y portaudio19-dev libasound2-dev
 
       - name: Install dependencies
+        # Pin virtualenv until hatch is fixed.
+        # See https://github.com/pypa/hatch/issues/2193
         run: |
-          pip install --no-cache-dir hatch
+          pip install --no-cache-dir hatch 'virtualenv<21'
 
       - name: Run lint
         id: lint


### PR DESCRIPTION
See https://github.com/pypa/hatch/issues/2193
Hopefully it will just be a day or two before hatch releases the fix, and we can revert this change

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
