### PR TITLE
test: pinned virtualenv version in hatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,10 @@ dependencies = [
     "pre-commit>=3.2.0,<4.6.0",
 ]
 
+[tool.hatch.env]
+requires = [
+    "virtualenv==20.26.6",
+]
 
 [tool.hatch.envs.default.scripts]
 list = "echo 'Scripts commands available for default env:'; hatch env show --json | jq --raw-output '.default.scripts | keys[]'"


### PR DESCRIPTION
## Description
See https://github.com/pypa/hatch/issues/2193

Pinning the virtualenv version in hatch too so the commands won't fail.

## Documentation PR

N/A

## Type of Change
Other (please describe):
Downstream dependency issue

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
