### PR TITLE
test: revert pinning virtualenv now that hatch 1.16.5 is out

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install --no-cache-dir hatch 'virtualenv<21'
+          pip install --no-cache-dir hatch
       - name: Run integration tests
         env:
           AWS_REGION: us-east-1

--- a/.github/workflows/python-pypi-publish-on-release.yml
+++ b/.github/workflows/python-pypi-publish-on-release.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install hatch twine 'virtualenv<21'
+        pip install hatch twine
 
     - name: Validate version
       run: |

--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -118,7 +118,7 @@ jobs:
           echo "Windows audio dependencies handled by PyAudio wheels"
       - name: Install dependencies
         run: |
-          pip install --no-cache-dir hatch 'virtualenv<21'
+          pip install --no-cache-dir hatch
       - name: Run Unit tests
         id: tests
         run: hatch test tests --cover
@@ -173,7 +173,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --no-cache-dir hatch 'virtualenv<21'
+          pip install --no-cache-dir hatch
 
       - name: Run lint
         id: lint


### PR DESCRIPTION
https://pypi.org/project/hatch/1.16.5/

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
