### PR TITLE
fix(graph): prevent reset_executor_state from corrupting MultiAgentBase state

### DIFF
--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -188,7 +188,7 @@ class GraphNode:
         if hasattr(self.executor, "messages"):
             self.executor.messages = copy.deepcopy(self._initial_messages)
 
-        if hasattr(self.executor, "state"):
+        if hasattr(self.executor, "state") and hasattr(self.executor.state, "get"):
             self.executor.state = AgentState(self._initial_state.get())
 
         # Reset execution status


### PR DESCRIPTION
## Problem

`GraphNode.reset_executor_state()` corrupts the executor state when the executor is a `MultiAgentBase` (e.g. a nested `Graph`).

The method checks `hasattr(self.executor, "state")` without distinguishing executor type, then unconditionally assigns `AgentState(...)`. For `MultiAgentBase` executors whose `.state` is a `GraphState`, this overwrites it with the wrong type — breaking the nested executor.

Two call sites are affected:
- `_execute_node`: guarded by `reset_on_revisit` (triggers when revisiting a nested graph node in a cycle)
- `deserialize_state`: unguarded (triggers when restoring a completed run with no `next_nodes_to_execute`)

## Root Cause

`__post_init__` already has the correct guard:
```python
if hasattr(self.executor, "state") and hasattr(self.executor.state, "get"):
    self._initial_state = AgentState(self.executor.state.get())
```

But `reset_executor_state()` was missing the `hasattr(self.executor.state, "get")` check:
```python
if hasattr(self.executor, "state"):
    self.executor.state = AgentState(self._initial_state.get())  # Wrong for MultiAgentBase
```

`GraphState` doesn't have a `.get()` method, so the guard correctly skips it.

## Fix

Add the same `hasattr(self.executor.state, "get")` guard to `reset_executor_state()`, matching the existing pattern in `__post_init__`.

## Test

Added `test_reset_executor_state_preserves_multiagent_graph_state` — verifies that a `GraphNode` wrapping a `MultiAgentBase` with `GraphState` preserves the state type after `reset_executor_state()`.

Fixes #1775