### PR TITLE
fix(mcp): add timeout to background thread join in stop() to prevent hangs

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -353,7 +353,9 @@ class MCPClient(ToolProvider):
                 asyncio.run_coroutine_threadsafe(coro=_set_close_event(), loop=self._background_thread_event_loop)
 
             self._log_debug_with_thread("waiting for background thread to join")
-            self._background_thread.join()
+            self._background_thread.join(timeout=self._startup_timeout)
+            if self._background_thread.is_alive():
+                logger.warning("background thread did not exit within %d seconds, continuing cleanup", self._startup_timeout)
 
         if self._background_thread_event_loop is not None:
             self._background_thread_event_loop.close()

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -495,14 +495,15 @@ def test_stop_with_background_thread_but_no_event_loop():
     # Mock a background thread without event loop
     mock_thread = MagicMock()
     mock_thread.join = MagicMock()
+    mock_thread.is_alive = MagicMock(return_value=False)
     client._background_thread = mock_thread
     client._background_thread_event_loop = None
 
     # Should not raise any exceptions and should join the thread
     client.stop(None, None, None)
 
-    # Verify thread was joined
-    mock_thread.join.assert_called_once()
+    # Verify thread was joined with timeout
+    mock_thread.join.assert_called_once_with(timeout=client._startup_timeout)
 
     # Verify cleanup occurred
     assert client._background_thread is None
@@ -515,6 +516,7 @@ def test_stop_closes_event_loop():
     # Mock a background thread with event loop
     mock_thread = MagicMock()
     mock_thread.join = MagicMock()
+    mock_thread.is_alive = MagicMock(return_value=False)
     mock_event_loop = MagicMock()
     mock_event_loop.close = MagicMock()
 
@@ -524,13 +526,35 @@ def test_stop_closes_event_loop():
     # Should close the event loop and join the thread
     client.stop(None, None, None)
 
-    # Verify thread was joined
-    mock_thread.join.assert_called_once()
+    # Verify thread was joined with timeout
+    mock_thread.join.assert_called_once_with(timeout=client._startup_timeout)
 
     # Verify event loop was closed
     mock_event_loop.close.assert_called_once()
 
     # Verify cleanup occurred
+    assert client._background_thread is None
+    assert client._background_thread_event_loop is None
+
+
+def test_stop_does_not_hang_when_join_times_out():
+    """Test that stop() completes even if the background thread doesn't exit in time."""
+    client = MCPClient(MagicMock())
+
+    mock_thread = MagicMock()
+    # Simulate thread still alive after join (timed out)
+    mock_thread.is_alive = MagicMock(return_value=True)
+    mock_event_loop = MagicMock()
+    mock_event_loop.close = MagicMock()
+
+    client._background_thread = mock_thread
+    client._background_thread_event_loop = mock_event_loop
+
+    client.stop(None, None, None)
+
+    # join should have been called with timeout
+    mock_thread.join.assert_called_once_with(timeout=client._startup_timeout)
+    # Cleanup should still proceed even though thread is alive
     assert client._background_thread is None
     assert client._background_thread_event_loop is None
 


### PR DESCRIPTION
## Summary

Fixes #1732

When an `Agent` holding an `MCPClient` goes out of scope inside a function, the `Agent.__del__` finalizer calls `MCPClient.stop()` which calls `_background_thread.join()`. If the background thread cannot exit promptly (e.g. transport subprocess teardown is slow), `join()` blocks indefinitely, causing the entire process to hang on exit.

## Root Cause

`_background_thread.join()` at line 356 of `mcp_client.py` has no timeout. When called from the GC finalizer (`Agent.__del__` → `ToolRegistry.cleanup()` → `MCPClient.remove_consumer()` → `MCPClient.stop()`), the transport subprocess may not shut down quickly, causing the join to block forever.

## Fix

Add `timeout=self._startup_timeout` (default 30s) to the `join()` call. If the thread does not exit within the timeout, log a warning and continue cleanup. The thread is already a daemon thread (`daemon=True`), so it will be cleaned up by the interpreter on process exit.

## Changes

### `src/strands/tools/mcp/mcp_client.py`
- Changed `self._background_thread.join()` to `self._background_thread.join(timeout=self._startup_timeout)`
- Added `is_alive()` check after join to log a warning if the thread didn't exit

### `tests/strands/tools/mcp/test_mcp_client.py`
- Updated existing tests to expect `join(timeout=...)`
- Added `test_stop_does_not_hang_when_join_times_out` — verifies cleanup proceeds even when thread is still alive after join timeout

## Test Results

```
127 passed (all MCP tests), 0 failures
```