### PR TITLE
fix: suppress PydanticSerializationUnexpectedValue warnings for Anthropic streaming

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -407,7 +407,7 @@ class AnthropicModel(Model):
                 logger.debug("got response from model")
                 async for event in stream:
                     if event.type in AnthropicModel.EVENT_TYPES:
-                        yield self.format_chunk(event.model_dump())
+                        yield self.format_chunk(event.model_dump(warnings=False))
 
                 usage = event.message.usage  # type: ignore
                 yield self.format_chunk({"type": "metadata", "usage": usage.model_dump()})

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -696,19 +696,19 @@ async def test_stream(anthropic_client, model, agenerator, alist):
     mock_event_1 = unittest.mock.Mock(
         type="message_start",
         dict=lambda: {"type": "message_start"},
-        model_dump=lambda: {"type": "message_start"},
+        model_dump=lambda **_: {"type": "message_start"},
     )
     mock_event_2 = unittest.mock.Mock(
         type="unknown",
         dict=lambda: {"type": "unknown"},
-        model_dump=lambda: {"type": "unknown"},
+        model_dump=lambda **_: {"type": "unknown"},
     )
     mock_event_3 = unittest.mock.Mock(
         type="metadata",
         message=unittest.mock.Mock(
             usage=unittest.mock.Mock(
                 dict=lambda: {"input_tokens": 1, "output_tokens": 2},
-                model_dump=lambda: {"input_tokens": 1, "output_tokens": 2},
+                model_dump=lambda **_: {"input_tokens": 1, "output_tokens": 2},
             )
         ),
     )


### PR DESCRIPTION
## Summary

Fixes #1746

When using Anthropic SDK >= 0.83.0, `message_stop` events contain `ParsedTextBlock` objects (a generic BaseModel subclass of `TextBlock`) in the `Message.content` field. Pydantic's serializer cannot match `ParsedTextBlock` against the `ContentBlock` TypedDict union variants, producing noisy warnings for each failed match attempt:

```
PydanticSerializationUnexpectedValue(Expected `ThinkingBlock` - serialized value may not be as expected ...)
PydanticSerializationUnexpectedValue(Expected `ToolUseBlock` - serialized value may not be as expected ...)
...
```

## Root Cause

`ParsedTextBlock` is a generic Pydantic BaseModel (`ParsedTextBlock[TypeVar]`) that inherits from `TextBlock`. When `model_dump()` is called on the streaming event, Pydantic tries each variant in the `ContentBlock` union and warns for every non-match. The serialization still produces correct output — `ParsedTextBlock` serializes identically to `TextBlock` — but the warnings confuse users.

## Fix

Added `warnings=False` to `event.model_dump()` call in the streaming loop. This suppresses the non-critical serialization warnings while preserving correct serialization behavior.

The `format_chunk()` method only extracts specific fields from each event type (e.g., `stop_reason` from `message_stop`, `delta` from `content_block_delta`), so the serialization of unused `ParsedTextBlock` content is irrelevant to the output.

## Tests

All 42 Anthropic model tests pass.