### PR TITLE
fix(mcp): add timeout to background thread join in stop() to prevent hangs

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -357,9 +357,10 @@ class MCPClient(ToolProvider):
             if self._background_thread.is_alive():
                 logger.warning(
                     "background thread did not exit within %d seconds; "
-                    "skipping event loop close to avoid interfering with running thread",
+                    "skipping event loop close and state reset to avoid interfering with running thread",
                     self._startup_timeout,
                 )
+                return
             elif self._background_thread_event_loop is not None:
                 self._background_thread_event_loop.close()
         elif self._background_thread_event_loop is not None:

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -557,11 +557,11 @@ def test_stop_closes_event_loop():
 
 
 def test_stop_does_not_hang_when_join_times_out():
-    """Test that stop() skips event loop close when the background thread doesn't exit within timeout.
+    """Test that stop() returns early when the background thread doesn't exit within timeout.
 
     When join() times out (is_alive() returns True), stop() must skip event loop
-    close to avoid interfering with the still-running thread, but still reset
-    state so the client can be reused.
+    close AND state reset to avoid interfering with the still-running thread and
+    prevent a second background thread from being spawned via start().
     """
     client = MCPClient(MagicMock())
 
@@ -578,10 +578,11 @@ def test_stop_does_not_hang_when_join_times_out():
 
     # join should have been called with timeout, and stop() should return promptly
     mock_thread.join.assert_called_once_with(timeout=client._startup_timeout)
-    # When thread is still alive, stop() skips event loop close but still resets state
+    # When thread is still alive, stop() skips event loop close AND state reset
     mock_event_loop.close.assert_not_called()
-    assert client._background_thread is None
-    assert client._background_thread_event_loop is None
+    # State is NOT reset — references kept to prevent reuse while thread is still alive
+    assert client._background_thread is mock_thread
+    assert client._background_thread_event_loop is mock_event_loop
 
 
 def test_mcp_client_state_reset_after_timeout():


### PR DESCRIPTION
## Summary

When an `Agent` holding an `MCPClient` is created inside a function and goes out of scope, the `Agent.__del__` finalizer calls `MCPClient.stop()` which invokes `_background_thread.join()`. If the background thread cannot exit promptly (e.g. transport subprocess teardown is slow), `join()` blocks indefinitely, causing the entire process to hang on exit.

## Changes

- Add a timeout (equal to `startup_timeout`, default 30s) to the `join()` call in `stop()`
- If the thread does not exit within the timeout, log a warning and proceed with cleanup
- The thread is already a daemon thread (`daemon=True`), so it will be cleaned up by the interpreter on process exit

## Testing

- Updated existing tests to verify `join()` is called with timeout
- Added new test `test_stop_does_not_hang_when_join_times_out` covering the timeout path

Fixes #1732