### PR TITLE
feat(openai): pass extra_headers through to OpenAI client

### DIFF
--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -596,6 +596,10 @@ class OpenAIModel(Model):
             ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: If the request is throttled by OpenAI (rate limits).
         """
+        # Extract extra_headers from kwargs so adapters (e.g. aws_rft_sdk.wrap_model) can inject
+        # per-request HTTP headers that get forwarded to the OpenAI-compatible endpoint.
+        extra_headers = kwargs.pop("extra_headers", None)
+
         logger.debug("formatting request")
         request = self.format_request(messages, tool_specs, system_prompt, tool_choice)
         logger.debug("formatted request=<%s>", request)
@@ -607,7 +611,10 @@ class OpenAIModel(Model):
         # https://github.com/encode/httpx/discussions/2959.
         async with self._get_client() as client:
             try:
-                response = await client.chat.completions.create(**request)
+                response = await client.chat.completions.create(
+                    **request,
+                    **({"extra_headers": extra_headers} if extra_headers else {}),
+                )
             except openai.BadRequestError as e:
                 # Check if this is a context length exceeded error
                 if hasattr(e, "code") and e.code == "context_length_exceeded":


### PR DESCRIPTION
## Summary
- Extract `extra_headers` from `**kwargs` in `OpenAIModel.stream()` and pass it through to `client.chat.completions.create()`
- Enables adapters to inject per-request HTTP headers that get forwarded to the OpenAI-compatible endpoint
- Use case: RFT (Reinforcement Fine-Tuning) where training metadata headers (`X-Rft-Job-Arn`, `X-Trajectory-Id`, `X-Span-Id`) need to be forwarded to the inference endpoint via the `POST /sample` API

## How it works
```python
# In OpenAIModel.stream():
extra_headers = kwargs.pop("extra_headers", None)
# ...
response = await client.chat.completions.create(
    **request,
    **({"extra_headers": extra_headers} if extra_headers else {}),
)
```

Adapters like `aws_rft_sdk.wrap_model` intercept `stream()` and pass `extra_headers={"X-Rft-Job-Arn": ..., "X-Trajectory-Id": ..., "X-Span-Id": ...}` which are then forwarded to the OpenAI-compatible endpoint.

## Test Results
- [x] All 72 existing OpenAI model tests pass (no regressions)
- [x] Integration tested with `aws_rft_sdk.wrap_model` adapter end-to-end
- [x] Verified headers reach `client.chat.completions.create()` via mock tests
- [x] No headers injected when `extra_headers` kwarg is absent (backward compatible)
- [x] Tested against alpha endpoint (`finetuning-job-runtime.alpha.sagemaker.us-west-2.api.aws`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)