### PR TITLE
fix: summary manager using structured output

### DIFF
--- a/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
+++ b/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
@@ -220,8 +220,14 @@ class SummarizingConversationManager(ConversationManager):
         original_system_prompt = summarization_agent.system_prompt
         original_messages = summarization_agent.messages.copy()
         original_tool_registry = summarization_agent.tool_registry
+        original_structured_output_model = getattr(summarization_agent, "_default_structured_output_model", None)
 
         try:
+            # Disable structured output for summarization. Summaries are plain text and
+            # structured output adds toolUse blocks that are invalid in user messages.
+            if hasattr(summarization_agent, "_default_structured_output_model"):
+                summarization_agent._default_structured_output_model = None
+
             # Add no-op tool if agent has no tools to satisfy tool spec requirement
             if not summarization_agent.tool_names:
                 tool_registry = ToolRegistry()
@@ -237,6 +243,8 @@ class SummarizingConversationManager(ConversationManager):
             summarization_agent.system_prompt = original_system_prompt
             summarization_agent.messages = original_messages
             summarization_agent.tool_registry = original_tool_registry
+            if hasattr(summarization_agent, "_default_structured_output_model"):
+                summarization_agent._default_structured_output_model = original_structured_output_model
 
     # ------------------------------------------------------------------
     # Path 2 – default case: call model.stream() directly

--- a/tests/strands/agent/test_summarizing_conversation_manager.py
+++ b/tests/strands/agent/test_summarizing_conversation_manager.py
@@ -50,6 +50,7 @@ class MockAgent:
         self.call_tracker = Mock()
         self.tool_registry = Mock()
         self.tool_names = []
+        self._default_structured_output_model = None
 
     def __call__(self, prompt):
         """Mock agent call that returns a summary."""
@@ -769,3 +770,35 @@ def test_summarizing_conversation_manager_generate_summary_with_tools_agent_path
     manager._generate_summary(messages, parent_agent)
 
     mock_registry.register_tool.assert_not_called()
+
+
+def test_generate_summary_disables_structured_output_on_summarization_agent():
+    """Test that structured output is disabled during summarization to avoid toolUse in user messages.
+
+    When a summarization agent has structured_output_model configured, the response contains toolUse blocks.
+    Since the summary is converted to a user message, toolUse blocks would violate the model API constraint
+    that user messages cannot contain tool uses. The fix disables structured output during summarization.
+    """
+    summary_agent = create_mock_agent()
+    structured_output_model = Mock()
+    summary_agent._default_structured_output_model = structured_output_model
+
+    original_call = summary_agent.__class__.__call__
+    observed_values = []
+
+    def tracking_call(self, prompt):
+        observed_values.append(self._default_structured_output_model)
+        return original_call(self, prompt)
+
+    messages: Messages = [
+        {"role": "user", "content": [{"text": "Hello"}]},
+        {"role": "assistant", "content": [{"text": "Hi there"}]},
+    ]
+
+    manager = SummarizingConversationManager(summarization_agent=summary_agent)
+
+    with patch.object(MockAgent, "__call__", tracking_call):
+        manager._generate_summary(messages, create_mock_agent())
+
+    assert observed_values == [None], "structured output should be disabled during summarization"
+    assert summary_agent._default_structured_output_model is structured_output_model, "should be restored after"

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -148,14 +148,16 @@ def test_start_model_invoke_span(mock_tracer):
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "chat"
         assert mock_tracer.start_span.call_args[1]["kind"] == SpanKind.INTERNAL
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.operation.name": "chat",
-            "gen_ai.system": "strands-agents",
-            "custom_key": "custom_value",
-            "user_id": "12345",
-            "gen_ai.request.model": model_id,
-            "agent_name": "TestAgent",
-        })
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.system": "strands-agents",
+                "custom_key": "custom_value",
+                "user_id": "12345",
+                "gen_ai.request.model": model_id,
+                "agent_name": "TestAgent",
+            }
+        )
         mock_span.add_event.assert_called_with(
             "gen_ai.user.message", attributes={"content": json.dumps(messages[0]["content"])}
         )
@@ -188,13 +190,15 @@ def test_start_model_invoke_span_latest_conventions(mock_tracer, monkeypatch):
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "chat"
         assert mock_tracer.start_span.call_args[1]["kind"] == SpanKind.INTERNAL
-        
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.operation.name": "chat",
-            "gen_ai.provider.name": "strands-agents",
-            "gen_ai.request.model": model_id,
-            "agent_name": "TestAgent",
-        })
+
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "strands-agents",
+                "gen_ai.request.model": model_id,
+                "agent_name": "TestAgent",
+            }
+        )
         mock_span.add_event.assert_called_with(
             "gen_ai.client.inference.operation.details",
             attributes={
@@ -232,15 +236,17 @@ def test_end_model_invoke_span(mock_span):
 
     tracer.end_model_invoke_span(mock_span, message, usage, metrics, stop_reason)
 
-    mock_span.set_attributes.assert_called_once_with({
-        "gen_ai.usage.prompt_tokens": 10,
-        "gen_ai.usage.input_tokens": 10,
-        "gen_ai.usage.completion_tokens": 20,
-        "gen_ai.usage.output_tokens": 20,
-        "gen_ai.usage.total_tokens": 30,
-        "gen_ai.server.time_to_first_token": 10,
-        "gen_ai.server.request.duration": 20,
-    })
+    mock_span.set_attributes.assert_called_once_with(
+        {
+            "gen_ai.usage.prompt_tokens": 10,
+            "gen_ai.usage.input_tokens": 10,
+            "gen_ai.usage.completion_tokens": 20,
+            "gen_ai.usage.output_tokens": 20,
+            "gen_ai.usage.total_tokens": 30,
+            "gen_ai.server.time_to_first_token": 10,
+            "gen_ai.server.request.duration": 20,
+        }
+    )
     mock_span.add_event.assert_called_with(
         "gen_ai.choice",
         attributes={"message": json.dumps(message["content"]), "finish_reason": "end_turn"},
@@ -259,15 +265,17 @@ def test_end_model_invoke_span_latest_conventions(mock_span, monkeypatch):
 
         tracer.end_model_invoke_span(mock_span, message, usage, metrics, stop_reason)
 
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.usage.prompt_tokens": 10,
-            "gen_ai.usage.input_tokens": 10,
-            "gen_ai.usage.completion_tokens": 20,
-            "gen_ai.usage.output_tokens": 20,
-            "gen_ai.usage.total_tokens": 30,
-            "gen_ai.server.time_to_first_token": 10,
-            "gen_ai.server.request.duration": 20,
-        })
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.usage.prompt_tokens": 10,
+                "gen_ai.usage.input_tokens": 10,
+                "gen_ai.usage.completion_tokens": 20,
+                "gen_ai.usage.output_tokens": 20,
+                "gen_ai.usage.total_tokens": 30,
+                "gen_ai.server.time_to_first_token": 10,
+                "gen_ai.server.request.duration": 20,
+            }
+        )
         mock_span.add_event.assert_called_with(
             "gen_ai.client.inference.operation.details",
             attributes={
@@ -300,15 +308,17 @@ def test_start_tool_call_span(mock_tracer):
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "execute_tool test-tool"
-        
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.tool.name": "test-tool",
-            "gen_ai.system": "strands-agents",
-            "gen_ai.operation.name": "execute_tool",
-            "gen_ai.tool.call.id": "123",
-            "session_id": "abc123",
-            "environment": "production",
-        })
+
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.tool.name": "test-tool",
+                "gen_ai.system": "strands-agents",
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.call.id": "123",
+                "session_id": "abc123",
+                "environment": "production",
+            }
+        )
         mock_span.add_event.assert_any_call(
             "gen_ai.tool.message", attributes={"role": "tool", "content": json.dumps({"param": "value"}), "id": "123"}
         )
@@ -331,13 +341,15 @@ def test_start_tool_call_span_latest_conventions(mock_tracer, monkeypatch):
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "execute_tool test-tool"
-        
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.tool.name": "test-tool",
-            "gen_ai.provider.name": "strands-agents",
-            "gen_ai.operation.name": "execute_tool",
-            "gen_ai.tool.call.id": "123",
-        })
+
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.tool.name": "test-tool",
+                "gen_ai.provider.name": "strands-agents",
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.call.id": "123",
+            }
+        )
         mock_span.add_event.assert_called_with(
             "gen_ai.client.inference.operation.details",
             attributes={
@@ -377,14 +389,16 @@ def test_start_swarm_call_span_with_string_task(mock_tracer):
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "invoke_swarm"
-        
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.operation.name": "invoke_swarm",
-            "gen_ai.system": "strands-agents",
-            "gen_ai.agent.name": "swarm",
-            "workflow_id": "wf-789",
-            "priority": "high",
-        })
+
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "invoke_swarm",
+                "gen_ai.system": "strands-agents",
+                "gen_ai.agent.name": "swarm",
+                "workflow_id": "wf-789",
+                "priority": "high",
+            }
+        )
         mock_span.add_event.assert_any_call("gen_ai.user.message", attributes={"content": "Design foo bar"})
         assert span is not None
 
@@ -404,12 +418,14 @@ def test_start_swarm_span_with_contentblock_task(mock_tracer):
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "invoke_swarm"
-        
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.operation.name": "invoke_swarm",
-            "gen_ai.system": "strands-agents",
-            "gen_ai.agent.name": "swarm",
-        })
+
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "invoke_swarm",
+                "gen_ai.system": "strands-agents",
+                "gen_ai.agent.name": "swarm",
+            }
+        )
         mock_span.add_event.assert_any_call(
             "gen_ai.user.message", attributes={"content": '[{"text": "Original Task: foo bar"}]'}
         )
@@ -460,12 +476,14 @@ def test_start_swarm_span_with_contentblock_task_latest_conventions(mock_tracer,
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "invoke_swarm"
-        
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.operation.name": "invoke_swarm",
-            "gen_ai.provider.name": "strands-agents",
-            "gen_ai.agent.name": "swarm",
-        })
+
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "invoke_swarm",
+                "gen_ai.provider.name": "strands-agents",
+                "gen_ai.agent.name": "swarm",
+            }
+        )
         mock_span.add_event.assert_any_call(
             "gen_ai.client.inference.operation.details",
             attributes={
@@ -528,13 +546,15 @@ def test_start_graph_call_span(mock_tracer):
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "execute_tool test-tool"
-        
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.operation.name": "execute_tool",
-            "gen_ai.system": "strands-agents",
-            "gen_ai.tool.name": "test-tool",
-            "gen_ai.tool.call.id": "123",
-        })
+
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.system": "strands-agents",
+                "gen_ai.tool.name": "test-tool",
+                "gen_ai.tool.call.id": "123",
+            }
+        )
         mock_span.add_event.assert_any_call(
             "gen_ai.tool.message", attributes={"role": "tool", "content": json.dumps({"param": "value"}), "id": "123"}
         )
@@ -608,12 +628,14 @@ def test_start_event_loop_cycle_span(mock_tracer):
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "execute_event_loop_cycle"
-        
-        mock_span.set_attributes.assert_called_once_with({
-            "event_loop.cycle_id": "cycle-123",
-            "request_id": "req-456",
-            "trace_level": "debug",
-        })
+
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "event_loop.cycle_id": "cycle-123",
+                "request_id": "req-456",
+                "trace_level": "debug",
+            }
+        )
         mock_span.add_event.assert_any_call(
             "gen_ai.user.message", attributes={"content": json.dumps([{"text": "Hello"}])}
         )
@@ -637,7 +659,7 @@ def test_start_event_loop_cycle_span_latest_conventions(mock_tracer, monkeypatch
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "execute_event_loop_cycle"
-        
+
         mock_span.set_attributes.assert_called_once_with({"event_loop.cycle_id": "cycle-123"})
         mock_span.add_event.assert_any_call(
             "gen_ai.client.inference.operation.details",
@@ -731,14 +753,16 @@ def test_start_agent_span(mock_tracer):
         assert mock_tracer.start_span.call_args[1]["name"] == "invoke_agent WeatherAgent"
         assert mock_tracer.start_span.call_args[1]["kind"] == SpanKind.INTERNAL
 
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.operation.name": "invoke_agent",
-            "gen_ai.system": "strands-agents",
-            "gen_ai.agent.name": "WeatherAgent",
-            "gen_ai.request.model": model_id,
-            "gen_ai.agent.tools": json.dumps(tools),
-            "custom_attr": "value",
-        })
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "invoke_agent",
+                "gen_ai.system": "strands-agents",
+                "gen_ai.agent.name": "WeatherAgent",
+                "gen_ai.request.model": model_id,
+                "gen_ai.agent.tools": json.dumps(tools),
+                "custom_attr": "value",
+            }
+        )
         mock_span.add_event.assert_any_call("gen_ai.user.message", attributes={"content": json.dumps(content)})
         assert span is not None
 
@@ -768,15 +792,17 @@ def test_start_agent_span_latest_conventions(mock_tracer, monkeypatch):
 
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "invoke_agent WeatherAgent"
-        
-        mock_span.set_attributes.assert_called_once_with({
-            "gen_ai.operation.name": "invoke_agent",
-            "gen_ai.provider.name": "strands-agents",
-            "gen_ai.agent.name": "WeatherAgent",
-            "gen_ai.request.model": model_id,
-            "gen_ai.agent.tools": json.dumps(tools),
-            "custom_attr": "value",
-        })
+
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "invoke_agent",
+                "gen_ai.provider.name": "strands-agents",
+                "gen_ai.agent.name": "WeatherAgent",
+                "gen_ai.request.model": model_id,
+                "gen_ai.agent.tools": json.dumps(tools),
+                "custom_attr": "value",
+            }
+        )
         mock_span.add_event.assert_any_call(
             "gen_ai.client.inference.operation.details",
             attributes={
@@ -919,17 +945,19 @@ def test_end_model_invoke_span_with_cache_metrics(mock_span):
 
     tracer.end_model_invoke_span(mock_span, message, usage, metrics, stop_reason)
 
-    mock_span.set_attributes.assert_called_once_with({
-        "gen_ai.usage.prompt_tokens": 10,
-        "gen_ai.usage.input_tokens": 10,
-        "gen_ai.usage.completion_tokens": 20,
-        "gen_ai.usage.output_tokens": 20,
-        "gen_ai.usage.total_tokens": 30,
-        "gen_ai.usage.cache_read_input_tokens": 5,
-        "gen_ai.usage.cache_write_input_tokens": 3,
-        "gen_ai.server.request.duration": 10,
-        "gen_ai.server.time_to_first_token": 5,
-    })
+    mock_span.set_attributes.assert_called_once_with(
+        {
+            "gen_ai.usage.prompt_tokens": 10,
+            "gen_ai.usage.input_tokens": 10,
+            "gen_ai.usage.completion_tokens": 20,
+            "gen_ai.usage.output_tokens": 20,
+            "gen_ai.usage.total_tokens": 30,
+            "gen_ai.usage.cache_read_input_tokens": 5,
+            "gen_ai.usage.cache_write_input_tokens": 3,
+            "gen_ai.server.request.duration": 10,
+            "gen_ai.server.time_to_first_token": 5,
+        }
+    )
 
 
 def test_end_agent_span_with_cache_metrics(mock_span):
@@ -953,15 +981,17 @@ def test_end_agent_span_with_cache_metrics(mock_span):
 
     tracer.end_agent_span(mock_span, mock_response)
 
-    mock_span.set_attributes.assert_called_once_with({
-        "gen_ai.usage.prompt_tokens": 50,
-        "gen_ai.usage.input_tokens": 50,
-        "gen_ai.usage.completion_tokens": 100,
-        "gen_ai.usage.output_tokens": 100,
-        "gen_ai.usage.total_tokens": 150,
-        "gen_ai.usage.cache_read_input_tokens": 25,
-        "gen_ai.usage.cache_write_input_tokens": 10,
-    })
+    mock_span.set_attributes.assert_called_once_with(
+        {
+            "gen_ai.usage.prompt_tokens": 50,
+            "gen_ai.usage.input_tokens": 50,
+            "gen_ai.usage.completion_tokens": 100,
+            "gen_ai.usage.output_tokens": 100,
+            "gen_ai.usage.total_tokens": 150,
+            "gen_ai.usage.cache_read_input_tokens": 25,
+            "gen_ai.usage.cache_write_input_tokens": 10,
+        }
+    )
     mock_span.set_status.assert_called_once_with(StatusCode.OK)
     mock_span.end.assert_called_once()
 
@@ -1519,18 +1549,20 @@ def test_end_model_invoke_span_langfuse_adds_attributes(mock_span, monkeypatch):
             }
         ]
     )
-    
+
     assert mock_span.set_attributes.call_count == 2
     mock_span.set_attributes.assert_any_call({"gen_ai.output.messages": expected_output})
-    mock_span.set_attributes.assert_any_call({
-        "gen_ai.usage.prompt_tokens": 10,
-        "gen_ai.usage.input_tokens": 10,
-        "gen_ai.usage.completion_tokens": 20,
-        "gen_ai.usage.output_tokens": 20,
-        "gen_ai.usage.total_tokens": 30,
-        "gen_ai.server.time_to_first_token": 10,
-        "gen_ai.server.request.duration": 20,
-    })
+    mock_span.set_attributes.assert_any_call(
+        {
+            "gen_ai.usage.prompt_tokens": 10,
+            "gen_ai.usage.input_tokens": 10,
+            "gen_ai.usage.completion_tokens": 20,
+            "gen_ai.usage.output_tokens": 20,
+            "gen_ai.usage.total_tokens": 30,
+            "gen_ai.server.time_to_first_token": 10,
+            "gen_ai.server.request.duration": 20,
+        }
+    )
 
     mock_span.add_event.assert_called_with(
         "gen_ai.client.inference.operation.details",

--- a/tests_integ/test_summarizing_conversation_manager_integration.py
+++ b/tests_integ/test_summarizing_conversation_manager_integration.py
@@ -443,16 +443,18 @@ def test_dedicated_summarization_agent_with_structured_output(model, summarizati
     )
 
     # Build conversation history
-    agent.messages.extend([
-        {"role": "user", "content": [{"text": "Tell me about Python programming."}]},
-        {"role": "assistant", "content": [{"text": "Python is a high-level programming language."}]},
-        {"role": "user", "content": [{"text": "What about its type system?"}]},
-        {"role": "assistant", "content": [{"text": "Python uses dynamic typing with optional type hints."}]},
-        {"role": "user", "content": [{"text": "How does async work in Python?"}]},
-        {"role": "assistant", "content": [{"text": "Python uses asyncio with async/await syntax."}]},
-        {"role": "user", "content": [{"text": "What about decorators?"}]},
-        {"role": "assistant", "content": [{"text": "Decorators are functions that modify other functions."}]},
-    ])
+    agent.messages.extend(
+        [
+            {"role": "user", "content": [{"text": "Tell me about Python programming."}]},
+            {"role": "assistant", "content": [{"text": "Python is a high-level programming language."}]},
+            {"role": "user", "content": [{"text": "What about its type system?"}]},
+            {"role": "assistant", "content": [{"text": "Python uses dynamic typing with optional type hints."}]},
+            {"role": "user", "content": [{"text": "How does async work in Python?"}]},
+            {"role": "assistant", "content": [{"text": "Python uses asyncio with async/await syntax."}]},
+            {"role": "user", "content": [{"text": "What about decorators?"}]},
+            {"role": "assistant", "content": [{"text": "Decorators are functions that modify other functions."}]},
+        ]
+    )
 
     original_length = len(agent.messages)
     agent.conversation_manager.reduce_context(agent)

--- a/tests_integ/test_summarizing_conversation_manager_integration.py
+++ b/tests_integ/test_summarizing_conversation_manager_integration.py
@@ -16,6 +16,7 @@ and may be skipped in CI environments without proper credentials.
 import os
 
 import pytest
+from pydantic import BaseModel
 
 import strands
 from strands import Agent
@@ -408,3 +409,66 @@ def test_summarization_with_tool_messages_and_no_tools():
 
     summary = str(agent.messages[0]).lower()
     assert "12:00" in summary
+
+
+def test_dedicated_summarization_agent_with_structured_output(model, summarization_model):
+    """Test that summarization works when the summarization agent has structured_output_model configured.
+
+    When structured_output_model is set on the summarization agent, the response would contain toolUse
+    blocks. Since the summary is converted to a user message, those blocks would cause a
+    ValidationException. This test verifies that structured output is properly disabled during
+    summarization.
+    """
+
+    class SummaryOutput(BaseModel):
+        topics: list[str]
+        key_points: list[str]
+
+    # Create a summarization agent with structured_output_model configured
+    summarization_agent = Agent(
+        model=summarization_model,
+        system_prompt="You are a conversation summarizer. Create concise, structured summaries.",
+        structured_output_model=SummaryOutput,
+        load_tools_from_directory=False,
+    )
+
+    agent = Agent(
+        model=model,
+        conversation_manager=SummarizingConversationManager(
+            summary_ratio=0.5,
+            preserve_recent_messages=2,
+            summarization_agent=summarization_agent,
+        ),
+        load_tools_from_directory=False,
+    )
+
+    # Build conversation history
+    agent.messages.extend([
+        {"role": "user", "content": [{"text": "Tell me about Python programming."}]},
+        {"role": "assistant", "content": [{"text": "Python is a high-level programming language."}]},
+        {"role": "user", "content": [{"text": "What about its type system?"}]},
+        {"role": "assistant", "content": [{"text": "Python uses dynamic typing with optional type hints."}]},
+        {"role": "user", "content": [{"text": "How does async work in Python?"}]},
+        {"role": "assistant", "content": [{"text": "Python uses asyncio with async/await syntax."}]},
+        {"role": "user", "content": [{"text": "What about decorators?"}]},
+        {"role": "assistant", "content": [{"text": "Decorators are functions that modify other functions."}]},
+    ])
+
+    original_length = len(agent.messages)
+    agent.conversation_manager.reduce_context(agent)
+
+    assert len(agent.messages) < original_length
+
+    summary_message = agent.messages[0]
+    assert summary_message["role"] == "user"
+
+    # Summary should contain only valid user message content (no toolUse blocks)
+    for content_block in summary_message["content"]:
+        assert "toolUse" not in content_block, "Summary user message should not contain toolUse blocks"
+
+    # Should have text content
+    assert any("text" in cb for cb in summary_message["content"])
+
+    # Invoke the agent with the summarized messages to verify the provider accepts them
+    result = agent("Thanks for the overview!")
+    assert result.message["role"] == "assistant"


### PR DESCRIPTION
## Description

When a `SummarizingConversationManager` is configured with a dedicated `summarization_agent` that has `structured_output_model` set, every summarization response includes `toolUse` blocks for the structured output tool. The `_generate_summary_with_agent` method converts this response to a user message (`"role": "user"`), but model providers reject `toolUse` blocks in user messages:

- Bedrock: `ValidationException: User messages cannot contain tool uses`
- Anthropic: `invalid_request_error: tool_use blocks can only be in assistant messages`

The summarization agent doesn't need structured output — its job is to produce a plain text summary. This fix temporarily disables `_default_structured_output_model` on the summarization agent during the summarization call, following the same save/restore pattern already used for `system_prompt`, `messages`, and `tool_registry` in that method. The value is always restored in the `finally` block.

No public API changes.

## Related Issues

Resolves #1160

## Documentation PR

No documentation changes required.

## Type of Change

Bug fix

## Testing

- [x] Added unit test verifying `_default_structured_output_model` is `None` during summarization and restored after
- [x] Added integration test with a real model confirming summarization succeeds and the agent can be invoked with the resulting messages
- [x] Verified without the fix: Anthropic returns `400 - tool_use blocks can only be in assistant messages`
- [x] All existing 35 unit tests pass

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
