### PR TITLE
fix: bedrock cachepoint skips supported models

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -177,15 +177,6 @@ class BedrockModel(Model):
 
         logger.debug("region=<%s> | bedrock client created", self.client.meta.region_name)
 
-    @property
-    def _supports_caching(self) -> bool:
-        """Whether this model supports prompt caching.
-
-        Returns True for Claude models on Bedrock.
-        """
-        model_id = self.config.get("model_id", "").lower()
-        return "claude" in model_id or "anthropic" in model_id
-
     @override
     def update_config(self, **model_config: Unpack[BedrockConfig]) -> None:  # type: ignore
         """Update the Bedrock Model configuration with the provided arguments.
@@ -460,13 +451,7 @@ class BedrockModel(Model):
         # Inject cache point into cleaned_messages (not original messages) if cache_config is set
         cache_config = self.config.get("cache_config")
         if cache_config and cache_config.strategy == "auto":
-            if self._supports_caching:
-                self._inject_cache_point(cleaned_messages)
-            else:
-                logger.warning(
-                    "model_id=<%s> | cache_config is enabled but this model does not support caching",
-                    self.config.get("model_id"),
-                )
+            self._inject_cache_point(cleaned_messages)
 
         return cleaned_messages
 

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2582,21 +2582,6 @@ async def test_format_request_with_guardrail_multiple_tool_results_same_message(
     assert formatted_messages[0]["content"][0]["guardContent"]["text"]["text"] == "Question requiring multiple tools"
 
 
-def test_supports_caching_true_for_claude(bedrock_client):
-    """Test that supports_caching returns True for Claude models."""
-    model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
-    assert model._supports_caching is True
-
-    model2 = BedrockModel(model_id="anthropic.claude-3-haiku-20240307-v1:0")
-    assert model2._supports_caching is True
-
-
-def test_supports_caching_false_for_non_claude(bedrock_client):
-    """Test that supports_caching returns False for non-Claude models."""
-    model = BedrockModel(model_id="amazon.nova-pro-v1:0")
-    assert model._supports_caching is False
-
-
 def test_inject_cache_point_adds_to_last_assistant(bedrock_client):
     """Test that _inject_cache_point adds cache point to last assistant message."""
     model = BedrockModel(
@@ -2630,21 +2615,6 @@ def test_inject_cache_point_no_assistant_message(bedrock_client):
 
     assert len(cleaned_messages) == 1
     assert len(cleaned_messages[0]["content"]) == 1
-
-
-def test_inject_cache_point_skipped_for_non_claude(bedrock_client):
-    """Test that cache point injection is skipped for non-Claude models."""
-    model = BedrockModel(model_id="amazon.nova-pro-v1:0", cache_config=CacheConfig(strategy="auto"))
-
-    messages = [
-        {"role": "user", "content": [{"text": "Hello"}]},
-        {"role": "assistant", "content": [{"text": "Response"}]},
-    ]
-
-    formatted = model._format_bedrock_messages(messages)
-
-    assert len(formatted[1]["content"]) == 1
-    assert "cachePoint" not in formatted[1]["content"][0]
 
 
 def test_format_bedrock_messages_does_not_mutate_original(bedrock_client):


### PR DESCRIPTION
## Description

Users with Bedrock application inference profile ARNs (e.g., `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdefghijk2`) cannot use prompt caching even when they explicitly enable it via `cache_config`. The `_supports_caching` check only recognizes model IDs containing "claude" or "anthropic", so it silently disables caching for application inference profiles with a warning log that's easy to miss.

This removes the `_supports_caching` guard so that when a user explicitly opts into caching by passing `cache_config`, we respect that configuration. If the underlying model doesn't support caching, Bedrock returns an error: "You invoked an unsupported model or your request did not allow prompt caching."

## Related Issues

#1705

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`
- [x] Verified with unit tests that cache point injection works when `cache_config` is set. Manually tested against Bedrock with both supported (Claude, Nova) and unsupported (Llama) models to confirm behavior:
    - Claude: caching works as expected
    - Nova: caching works as expected
    - Llama: returns a clear `AccessDeniedException` with an actionable error message

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.