### PR TITLE
feat: add "anthropic" cache strategy to bypass model ID check

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -178,8 +178,8 @@ class BedrockModel(Model):
         logger.debug("region=<%s> | bedrock client created", self.client.meta.region_name)
 
     @property
-    def _resolve_cache_strategy(self) -> str | None:
-        """Resolve the cache strategy for this model based on its model ID.
+    def _cache_strategy(self) -> str | None:
+        """The cache strategy for this model based on its model ID.
 
         Returns the appropriate cache strategy name, or None if automatic caching is not supported for this model.
         """
@@ -464,7 +464,7 @@ class BedrockModel(Model):
         if cache_config:
             strategy: str | None = cache_config.strategy
             if strategy == "auto":
-                strategy = self._resolve_cache_strategy
+                strategy = self._cache_strategy
                 if not strategy:
                     logger.warning(
                         "model_id=<%s> | cache_config is enabled but this model does not support automatic caching",

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -178,13 +178,15 @@ class BedrockModel(Model):
         logger.debug("region=<%s> | bedrock client created", self.client.meta.region_name)
 
     @property
-    def _supports_caching(self) -> bool:
-        """Whether this model supports prompt caching.
+    def _resolve_cache_strategy(self) -> str | None:
+        """Resolve the cache strategy for this model based on its model ID.
 
-        Returns True for Claude models on Bedrock.
+        Returns the appropriate cache strategy name, or None if automatic caching is not supported for this model.
         """
         model_id = self.config.get("model_id", "").lower()
-        return "claude" in model_id or "anthropic" in model_id
+        if "claude" in model_id or "anthropic" in model_id:
+            return "anthropic"
+        return None
 
     @override
     def update_config(self, **model_config: Unpack[BedrockConfig]) -> None:  # type: ignore
@@ -459,14 +461,17 @@ class BedrockModel(Model):
 
         # Inject cache point into cleaned_messages (not original messages) if cache_config is set
         cache_config = self.config.get("cache_config")
-        if cache_config and cache_config.strategy == "auto":
-            if self._supports_caching:
+        if cache_config:
+            strategy: str | None = cache_config.strategy
+            if strategy == "auto":
+                strategy = self._resolve_cache_strategy
+                if not strategy:
+                    logger.warning(
+                        "model_id=<%s> | cache_config is enabled but this model does not support automatic caching",
+                        self.config.get("model_id"),
+                    )
+            if strategy == "anthropic":
                 self._inject_cache_point(cleaned_messages)
-            else:
-                logger.warning(
-                    "model_id=<%s> | cache_config is enabled but this model does not support caching",
-                    self.config.get("model_id"),
-                )
 
         return cleaned_messages
 

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -23,10 +23,11 @@ class CacheConfig:
 
     Attributes:
         strategy: Caching strategy to use.
-            - "auto": Automatically inject cachePoint at optimal positions
+            - "auto": Automatically detect model support and inject cachePoint to maximize cache coverage
+            - "anthropic": Inject cachePoint in Anthropic-compatible format without model support check
     """
 
-    strategy: Literal["auto"] = "auto"
+    strategy: Literal["auto", "anthropic"] = "auto"
 
 
 class Model(abc.ABC):

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2582,19 +2582,19 @@ async def test_format_request_with_guardrail_multiple_tool_results_same_message(
     assert formatted_messages[0]["content"][0]["guardContent"]["text"]["text"] == "Question requiring multiple tools"
 
 
-def test_resolve_cache_strategy_anthropic_for_claude(bedrock_client):
-    """Test that _resolve_cache_strategy returns 'anthropic' for Claude models."""
+def test_cache_strategy_anthropic_for_claude(bedrock_client):
+    """Test that _cache_strategy returns 'anthropic' for Claude models."""
     model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
-    assert model._resolve_cache_strategy == "anthropic"
+    assert model._cache_strategy == "anthropic"
 
     model2 = BedrockModel(model_id="anthropic.claude-3-haiku-20240307-v1:0")
-    assert model2._resolve_cache_strategy == "anthropic"
+    assert model2._cache_strategy == "anthropic"
 
 
-def test_resolve_cache_strategy_none_for_non_claude(bedrock_client):
-    """Test that _resolve_cache_strategy returns None for unsupported models."""
+def test_cache_strategy_none_for_non_claude(bedrock_client):
+    """Test that _cache_strategy returns None for unsupported models."""
     model = BedrockModel(model_id="amazon.nova-pro-v1:0")
-    assert model._resolve_cache_strategy is None
+    assert model._cache_strategy is None
 
 
 def test_inject_cache_point_adds_to_last_assistant(bedrock_client):
@@ -2695,7 +2695,10 @@ def test_inject_cache_point_strips_existing_cache_points(bedrock_client):
 
 def test_inject_cache_point_anthropic_strategy_skips_model_check(bedrock_client):
     """Test that anthropic strategy injects cache point without model support check."""
-    model = BedrockModel(model_id="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/a1b2c3d4e5f6", cache_config=CacheConfig(strategy="anthropic"))
+    model = BedrockModel(
+        model_id="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/a1b2c3d4e5f6",
+        cache_config=CacheConfig(strategy="anthropic"),
+    )
 
     messages = [
         {"role": "user", "content": [{"text": "Hello"}]},

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2582,19 +2582,19 @@ async def test_format_request_with_guardrail_multiple_tool_results_same_message(
     assert formatted_messages[0]["content"][0]["guardContent"]["text"]["text"] == "Question requiring multiple tools"
 
 
-def test_supports_caching_true_for_claude(bedrock_client):
-    """Test that supports_caching returns True for Claude models."""
+def test_resolve_cache_strategy_anthropic_for_claude(bedrock_client):
+    """Test that _resolve_cache_strategy returns 'anthropic' for Claude models."""
     model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
-    assert model._supports_caching is True
+    assert model._resolve_cache_strategy == "anthropic"
 
     model2 = BedrockModel(model_id="anthropic.claude-3-haiku-20240307-v1:0")
-    assert model2._supports_caching is True
+    assert model2._resolve_cache_strategy == "anthropic"
 
 
-def test_supports_caching_false_for_non_claude(bedrock_client):
-    """Test that supports_caching returns False for non-Claude models."""
+def test_resolve_cache_strategy_none_for_non_claude(bedrock_client):
+    """Test that _resolve_cache_strategy returns None for unsupported models."""
     model = BedrockModel(model_id="amazon.nova-pro-v1:0")
-    assert model._supports_caching is False
+    assert model._resolve_cache_strategy is None
 
 
 def test_inject_cache_point_adds_to_last_assistant(bedrock_client):
@@ -2691,6 +2691,39 @@ def test_inject_cache_point_strips_existing_cache_points(bedrock_client):
     # New cache point should be at end of last assistant message
     assert len(cleaned_messages[3]["content"]) == 2
     assert "cachePoint" in cleaned_messages[3]["content"][-1]
+
+
+def test_inject_cache_point_anthropic_strategy_skips_model_check(bedrock_client):
+    """Test that anthropic strategy injects cache point without model support check."""
+    model = BedrockModel(model_id="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/a1b2c3d4e5f6", cache_config=CacheConfig(strategy="anthropic"))
+
+    messages = [
+        {"role": "user", "content": [{"text": "Hello"}]},
+        {"role": "assistant", "content": [{"text": "Response"}]},
+    ]
+
+    formatted = model._format_bedrock_messages(messages)
+
+    assert len(formatted[1]["content"]) == 2
+    assert "cachePoint" in formatted[1]["content"][-1]
+    assert formatted[1]["content"][-1]["cachePoint"]["type"] == "default"
+
+
+def test_inject_cache_point_auto_strategy_resolves_to_anthropic_for_claude(bedrock_client):
+    """Test that auto strategy resolves to anthropic strategy for Claude models."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=CacheConfig(strategy="auto")
+    )
+
+    messages = [
+        {"role": "user", "content": [{"text": "Hello"}]},
+        {"role": "assistant", "content": [{"text": "Response"}]},
+    ]
+
+    formatted = model._format_bedrock_messages(messages)
+
+    assert len(formatted[1]["content"]) == 2
+    assert "cachePoint" in formatted[1]["content"][-1]
 
 
 def test_find_last_user_text_message_index_no_user_messages(bedrock_client):


### PR DESCRIPTION
Add "anthropic" strategy that injects cache points without model ID validation, fixing cache support for Bedrock application inference profile ARNs. Closes #1705

## Description

The `auto` cache strategy relies on model ID string matching to detect cache support, which fails for Bedrock application inference profile ARNs that don't contain "claude" or "anthropic".

This PR:
- Adds `"anthropic"` strategy to `CacheConfig` that injects cache points in Anthropic-compatible format without model ID check
- Refactors `_supports_caching` into `_resolve_cache_strategy` which returns the appropriate strategy name (e.g., `"anthropic"`) or `None` for unsupported models
- `"auto"` strategy now delegates to `_resolve_cache_strategy` for model detection, making it extensible for future cache strategies

## Related Issues

#1705

## Type of Change

New feature

## Testing

- `test_resolve_cache_strategy_anthropic_for_claude` — verifies Claude models resolve to "anthropic" strategy
- `test_resolve_cache_strategy_none_for_non_claude` — verifies unsupported models resolve to None
- `test_inject_cache_point_anthropic_strategy_skips_model_check` — verifies cache point injection with application inference profile ARN using "anthropic" strategy
- `test_inject_cache_point_auto_strategy_resolves_to_anthropic_for_claude` — verifies "auto" resolves correctly for Claude models
- All existing cache tests pass (11 passed)
- `hatch run prepare` passed (mypy, ruff, 2104 tests)

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published