### PR TITLE
fix: Fix has_tool_use tracking in streaming to also check contentBlockDelta for tool use events

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -835,6 +835,9 @@ class BedrockModel(Model):
                     if "contentBlockStart" in chunk and chunk["contentBlockStart"].get("start", {}).get("toolUse"):
                         has_tool_use = True
 
+                    if "contentBlockDelta" in chunk and chunk["contentBlockDelta"].get("delta", {}).get("toolUse"):
+                        has_tool_use = True
+
                     # Fix stopReason for streaming responses that contain tool use
                     if (
                         has_tool_use


### PR DESCRIPTION

## Description
Adding redundant tracking via contentBlockDelta as a fallback:

# Track if we see tool use events - check both start and delta
if "contentBlockStart" in chunk and chunk["contentBlockStart"].get("start", {}).get("toolUse"):
    has_tool_use = True
if "contentBlockDelta" in chunk and chunk["contentBlockDelta"].get("delta", {}).get("toolUse"):
    has_tool_use = True]
Please check bug for more issue details.

## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/1810

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix 


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

Yes, all tests passed.
========================= 2102 passed, 4 skipped, 33 warnings in 71.65s (0:01:11) =========

- [y ] I ran `hatch run prepare`

## Checklist
- [y] I have read the CONTRIBUTING document
- [y] I have added any necessary tests that prove my fix is effective or my feature works
- [y] I have updated the documentation accordingly
- [y ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [y] My changes generate no new warnings
- [y] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
