### PR TITLE
feat(mcp): expose server instructions from InitializeResult on MCPClient

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -153,6 +153,7 @@ class MCPClient(ToolProvider):
         self._background_thread_event_loop: AbstractEventLoop | None = None
         self._loaded_tools: list[MCPAgentTool] | None = None
         self._tool_provider_started = False
+        self.server_instructions: str | None = None
         self._consumers: set[Any] = set()
 
         # Task support configuration and caching
@@ -732,9 +733,11 @@ class MCPClient(ToolProvider):
                     elicitation_callback=self._elicitation_callback,
                 ) as session:
                     self._log_debug_with_thread("initializing MCP session")
-                    await session.initialize()
+                    init_result = await session.initialize()
 
                     self._log_debug_with_thread("session initialized successfully")
+                    # Store server instructions from InitializeResult for Host applications
+                    self.server_instructions = init_result.instructions
                     # Store the session for use while we await the close event
                     self._background_thread_session = session
 

--- a/tests/strands/tools/mcp/conftest.py
+++ b/tests/strands/tools/mcp/conftest.py
@@ -26,7 +26,9 @@ def mock_transport():
 def mock_session():
     """Create a mock MCP session."""
     mock_session = AsyncMock()
-    mock_session.initialize = AsyncMock()
+    mock_init_result = MagicMock()
+    mock_init_result.instructions = None
+    mock_session.initialize = AsyncMock(return_value=mock_init_result)
     # Default: no task support (get_server_capabilities is sync, not async!)
     mock_session.get_server_capabilities = MagicMock(return_value=None)
 

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -50,6 +50,20 @@ def test_mcp_client_context_manager(mock_transport, mock_session):
     assert client._background_thread is None
 
 
+def test_server_instructions_default(mock_transport, mock_session):
+    """Test that server_instructions defaults to None when server returns None."""
+    mock_session.initialize.return_value.instructions = None
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        assert client.server_instructions is None
+
+
+def test_server_instructions_from_server(mock_transport, mock_session):
+    """Test that server_instructions is populated from InitializeResult."""
+    mock_session.initialize.return_value.instructions = "Use tool A before tool B."
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        assert client.server_instructions == "Use tool A before tool B."
+
+
 def test_list_tools_sync(mock_transport, mock_session):
     """Test that list_tools_sync correctly retrieves and adapts tools."""
     mock_tool = MCPTool(name="test_tool", description="A test tool", inputSchema={"type": "object", "properties": {}})


### PR DESCRIPTION
## Description

Store `InitializeResult.instructions` on `MCPClient.server_instructions` so Host applications can access MCP server instructions and inject them into the LLM's system prompt.

The [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle) defines `instructions` in `InitializeResult` for servers to provide LLMs with contextual knowledge about tool interdependencies and operational constraints. Currently `MCPClient` discards the `InitializeResult`, making instructions inaccessible to Host applications.

Changes:
- `mcp_client.py`: Store `init_result.instructions` after `session.initialize()` (3 lines added)
- `conftest.py`: Fix mock to return proper `InitializeResult` with `instructions` field
- `test_mcp_client.py`: Add 2 tests (default empty string, populated from server)

The SDK's responsibility is only to make the data accessible — how/whether to inject into the system prompt remains the Host's decision.

## Related Issues

Closes #1813

## Documentation PR

N/A — Public attribute `server_instructions` is self-documenting. Docs update can follow if needed.

## Type of Change

New feature

## Testing

- 2106 passed, 2 failed (pre-existing failures unrelated to this PR — region-dependent default model prefix `apac` vs `us`)
- 128 MCP tests all pass
- 2 new tests added

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published