### PR TITLE
feat: add prompt caching support for nova models in bedrock

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -52,6 +52,14 @@ _MODELS_INCLUDE_STATUS = [
     "anthropic.claude",
 ]
 
+# Models that support prompt caching
+# Anthropic Claude and Amazon Nova models on Bedrock support prompt caching
+_MODELS_SUPPORTING_CACHING = [
+    "anthropic",
+    "claude",
+    "nova",
+]
+
 T = TypeVar("T", bound=BaseModel)
 
 DEFAULT_READ_TIMEOUT = 120
@@ -78,6 +86,7 @@ class BedrockModel(Model):
             additional_response_field_paths: Additional response field paths to extract
             cache_prompt: Cache point type for the system prompt (deprecated, use cache_config)
             cache_config: Configuration for prompt caching. Use CacheConfig(strategy="auto") for automatic caching.
+                Supports Anthropic Claude and Amazon Nova models.
             cache_tools: Cache point type for tools
             guardrail_id: ID of the guardrail to apply
             guardrail_trace: Guardrail trace mode. Defaults to enabled.
@@ -184,7 +193,7 @@ class BedrockModel(Model):
         Returns the appropriate cache strategy name, or None if automatic caching is not supported for this model.
         """
         model_id = self.config.get("model_id", "").lower()
-        if "claude" in model_id or "anthropic" in model_id:
+        if any(pattern in model_id for pattern in _MODELS_SUPPORTING_CACHING):
             return "anthropic"
         return None
 

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2591,9 +2591,18 @@ def test_cache_strategy_anthropic_for_claude(bedrock_client):
     assert model2._cache_strategy == "anthropic"
 
 
+def test_cache_strategy_anthropic_for_nova(bedrock_client):
+    """Test that _cache_strategy returns 'anthropic' for Nova models."""
+    model = BedrockModel(model_id="us.amazon.nova-pro-v1:0")
+    assert model._cache_strategy == "anthropic"
+
+    model2 = BedrockModel(model_id="amazon.nova-lite-v1:0")
+    assert model2._cache_strategy == "anthropic"
+
+
 def test_cache_strategy_none_for_non_claude(bedrock_client):
     """Test that _cache_strategy returns None for unsupported models."""
-    model = BedrockModel(model_id="amazon.nova-pro-v1:0")
+    model = BedrockModel(model_id="amazon.titan-text-express-v1")
     assert model._cache_strategy is None
 
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Extends automatic prompt caching to Amazon Nova models in the Bedrock provider. Previously, only Anthropic Claude models supported automatic cache point injection when using CacheConfig(strategy="auto"). This is consistent with the docs https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/1817

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
