### PR TITLE
feat: add public tool_spec setter 

### DIFF
--- a/src/strands/tools/decorator.py
+++ b/src/strands/tools/decorator.py
@@ -552,8 +552,8 @@ class DecoratedFunctionTool(AgentTool, Generic[P, R]):
             value: The new tool specification.
 
         Raises:
-            ValueError: If the spec fails structural validation (wrong name,
-                missing description, missing inputSchema, or missing json key).
+            ValueError: If the spec fails structural validation (wrong name or
+                missing required field).
         """
         if value.get("name") != self._tool_name:
             raise ValueError(
@@ -563,9 +563,6 @@ class DecoratedFunctionTool(AgentTool, Generic[P, R]):
         for field in ("description", "inputSchema"):
             if field not in value:
                 raise ValueError(f"tool_spec must contain '{field}'")
-
-        if "json" not in value["inputSchema"]:
-            raise ValueError("tool_spec 'inputSchema' must contain a 'json' key")
 
         self._tool_spec = value
 

--- a/src/strands/tools/tools.py
+++ b/src/strands/tools/tools.py
@@ -208,8 +208,8 @@ class PythonAgentTool(AgentTool):
             value: The new tool specification.
 
         Raises:
-            ValueError: If the spec fails structural validation (wrong name,
-                missing description, missing inputSchema, or missing json key).
+            ValueError: If the spec fails structural validation (wrong name or
+                missing required field).
         """
         if value.get("name") != self._tool_name:
             raise ValueError(
@@ -219,9 +219,6 @@ class PythonAgentTool(AgentTool):
         for field in ("description", "inputSchema"):
             if field not in value:
                 raise ValueError(f"tool_spec must contain '{field}'")
-
-        if "json" not in value["inputSchema"]:
-            raise ValueError("tool_spec 'inputSchema' must contain a 'json' key")
 
         self._tool_spec = value
 

--- a/tests/strands/tools/test_tool_spec_setter.py
+++ b/tests/strands/tools/test_tool_spec_setter.py
@@ -112,19 +112,19 @@ class TestDecoratedFunctionToolSpecSetter:
         with pytest.raises(ValueError, match="tool_spec must contain 'inputSchema'"):
             my_tool.tool_spec = bad_spec
 
-    def test_set_tool_spec_rejects_missing_json_key(self):
+    def test_set_tool_spec_accepts_bare_input_schema(self):
         @tool
         def my_tool(query: str) -> str:
             """A test tool."""
             return query
 
-        bad_spec: ToolSpec = {
+        bare_spec: ToolSpec = {
             "name": "my_tool",
-            "description": "Updated tool",
-            "inputSchema": {"not_json": {}},
+            "description": "Bare schema",
+            "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
         }
-        with pytest.raises(ValueError, match="tool_spec 'inputSchema' must contain a 'json' key"):
-            my_tool.tool_spec = bad_spec
+        my_tool.tool_spec = bare_spec
+        assert my_tool.tool_spec is bare_spec
 
     def test_set_tool_spec_accepts_valid_spec(self):
         @tool
@@ -226,15 +226,15 @@ class TestPythonAgentToolSpecSetter:
         with pytest.raises(ValueError, match="tool_spec must contain 'inputSchema'"):
             t.tool_spec = bad_spec
 
-    def test_set_tool_spec_rejects_missing_json_key(self):
+    def test_set_tool_spec_accepts_bare_input_schema(self):
         t = self._make_tool()
-        bad_spec: ToolSpec = {
+        bare_spec: ToolSpec = {
             "name": "test_tool",
-            "description": "Updated",
-            "inputSchema": {"not_json": {}},
+            "description": "Bare schema",
+            "inputSchema": {"type": "object", "properties": {"input": {"type": "string"}}, "required": ["input"]},
         }
-        with pytest.raises(ValueError, match="tool_spec 'inputSchema' must contain a 'json' key"):
-            t.tool_spec = bad_spec
+        t.tool_spec = bare_spec
+        assert t.tool_spec is bare_spec
 
     def test_set_tool_spec_accepts_valid_spec(self):
         t = self._make_tool()


### PR DESCRIPTION
## Description

Add a public `tool_spec` setter property to `DecoratedFunctionTool` and `PythonAgentTool`, enabling runtime modification of a tool's schema after construction.

This is useful for dynamically adjusting tool configurations based on feature flags, user permissions, or other runtime conditions — for example, adding or removing parameters from a tool's input schema without recreating the tool instance.

**Changes:**
- `src/strands/tools/decorator.py` — Added `@tool_spec.setter` on `DecoratedFunctionTool`
- `src/strands/tools/tools.py` — Added `@tool_spec.setter` on `PythonAgentTool`
- `tests/strands/tools/test_tool_spec_setter.py` — 5 unit tests covering both classes

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New feature

## Testing

Added `tests/strands/tools/test_tool_spec_setter.py` with 5 tests:

- **`TestDecoratedFunctionToolSpecSetter`** (3 tests): verifies spec replacement, persistence across reads, and adding properties via setter
- **`TestPythonAgentToolSpecSetter`** (2 tests): verifies spec replacement and persistence across reads

All tests pass:

```
tests/strands/tools/test_tool_spec_setter.py::TestDecoratedFunctionToolSpecSetter::test_set_tool_spec_replaces_spec PASSED
tests/strands/tools/test_tool_spec_setter.py::TestDecoratedFunctionToolSpecSetter::test_set_tool_spec_persists_across_reads PASSED
tests/strands/tools/test_tool_spec_setter.py::TestDecoratedFunctionToolSpecSetter::test_add_property_via_setter PASSED
tests/strands/tools/test_tool_spec_setter.py::TestPythonAgentToolSpecSetter::test_set_tool_spec PASSED
tests/strands/tools/test_tool_spec_setter.py::TestPythonAgentToolSpecSetter::test_set_tool_spec_persists PASSED
```

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.