### PR TITLE
fix: added LANGFUSE_BASE_URL check for additinoal attribute

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -117,8 +117,9 @@ class Tracer:
         Returns:
             True if Langfuse is the OTLP endpoint, False otherwise.
         """
-        return "langfuse" in os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "") or "langfuse" in os.getenv(
-            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""
+        return any(
+            "langfuse" in os.getenv(var, "")
+            for var in ("OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "LANGFUSE_BASE_URL")
         )
 
     def _start_span(

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -1604,3 +1604,50 @@ def test_end_model_invoke_span_non_langfuse_no_extra_attributes(mock_span, monke
         "gen_ai.client.inference.operation.details",
         attributes={"gen_ai.output.messages": expected_output},
     )
+
+
+class TestIsLangfuse:
+    """Tests for the is_langfuse property."""
+
+    def test_is_langfuse_with_otel_exporter_otlp_endpoint(self, monkeypatch):
+        """Test is_langfuse returns True when OTEL_EXPORTER_OTLP_ENDPOINT contains langfuse."""
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://us.cloud.langfuse.com")
+        tracer = Tracer()
+        assert tracer.is_langfuse is True
+
+    def test_is_langfuse_with_otel_exporter_otlp_traces_endpoint(self, monkeypatch):
+        """Test is_langfuse returns True when OTEL_EXPORTER_OTLP_TRACES_ENDPOINT contains langfuse."""
+        monkeypatch.setenv(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://us.cloud.langfuse.com/api/public/otel/v1/traces"
+        )
+        tracer = Tracer()
+        assert tracer.is_langfuse is True
+
+    def test_is_langfuse_with_langfuse_base_url(self, monkeypatch):
+        """Test is_langfuse returns True when LANGFUSE_BASE_URL contains langfuse."""
+        monkeypatch.setenv("LANGFUSE_BASE_URL", "https://us.cloud.langfuse.com")
+        tracer = Tracer()
+        assert tracer.is_langfuse is True
+
+    def test_is_langfuse_false_when_no_langfuse_env_vars(self, monkeypatch):
+        """Test is_langfuse returns False when no Langfuse-related env vars are set."""
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+        monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
+        tracer = Tracer()
+        assert tracer.is_langfuse is False
+
+    def test_is_langfuse_false_with_non_langfuse_endpoint(self, monkeypatch):
+        """Test is_langfuse returns False when endpoint is not Langfuse."""
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://api.honeycomb.io")
+        monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
+        tracer = Tracer()
+        assert tracer.is_langfuse is False
+
+    def test_is_langfuse_false_with_non_langfuse_base_url(self, monkeypatch):
+        """Test is_langfuse returns False when LANGFUSE_BASE_URL doesn't contain langfuse."""
+        monkeypatch.setenv("LANGFUSE_BASE_URL", "https://some-other-service.com")
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+        tracer = Tracer()
+        assert tracer.is_langfuse is False


### PR DESCRIPTION
## Description
Add additional env var check (`LANGFUSE_BASE_URL`) to prevent double token count in langfuse.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1267#issuecomment-4010154757

## Documentation PR

N/A

## Type of Change
Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
