### PR TITLE
fix(openai): serialize all-text tool message content as string for broader compatibility

### DIFF
--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -206,9 +206,11 @@ class OpenAIModel(Model):
 
         formatted_contents = [cls.format_request_message_content(content) for content in contents]
 
-        # If single text content, use string format for better model compatibility
-        if len(formatted_contents) == 1 and formatted_contents[0].get("type") == "text":
-            content: str | list[dict[str, Any]] = formatted_contents[0]["text"]
+        # Use string format when all content blocks are text for broader model compatibility.
+        # Many OpenAI-compatible endpoints (e.g. Kimi K2.5) only accept string content
+        # for tool messages, not the array-of-dicts format.
+        if formatted_contents and all(fc.get("type") == "text" for fc in formatted_contents):
+            content: str | list[dict[str, Any]] = "\n".join(fc["text"] for fc in formatted_contents)
         else:
             content = formatted_contents
 

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -173,7 +173,7 @@ def test_format_request_tool_message():
 
     tru_result = OpenAIModel.format_request_tool_message(tool_result)
     exp_result = {
-        "content": [{"text": "4", "type": "text"}, {"text": '["4"]', "type": "text"}],
+        "content": '4\n["4"]',
         "role": "tool",
         "tool_call_id": "c1",
     }
@@ -197,7 +197,24 @@ def test_format_request_tool_message_single_text_returns_string():
     assert tru_result == exp_result
 
 
-def test_split_tool_message_images_with_image():
+def test_format_request_tool_message_mixed_content_keeps_array():
+    """Test that mixed text+image tool content keeps array format."""
+    tool_result = {
+        "content": [
+            {"text": "Result text"},
+            {"image": {"format": "png", "source": {"bytes": b"\x89PNG"}}},
+        ],
+        "status": "success",
+        "toolUseId": "c1",
+    }
+
+    result = OpenAIModel.format_request_tool_message(tool_result)
+    # Mixed content should remain as array since image can't be stringified
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) == 2
+
+
+
     """Test that images are extracted from tool messages."""
     tool_message = {
         "role": "tool",


### PR DESCRIPTION
## Summary

Fixes #1696

When a tool result contains multiple text content blocks, `format_request_tool_message()` was sending `content` as an array of dict objects:

```python
{"content": [{"text": "4", "type": "text"}, {"text": "[\"4\"]", "type": "text"}], ...}
```

While OpenAI's API accepts both array and string formats, many OpenAI-compatible endpoints (e.g. Kimi K2.5 via Moonshot API) only correctly process the **string** format for tool messages. When receiving the array format, these models fail to parse the tool result and fall back to hallucinating the answer.

## Changes

**`src/strands/models/openai.py`:**
- Modified `format_request_tool_message()` to always serialize as a joined string when all content blocks are text
- Mixed content (text + images/files) still uses array format since those types can't be stringified
- This subsumes the existing single-text optimization (which was the special case of this general rule)

**`tests/strands/models/test_openai.py`:**
- Updated `test_format_request_tool_message` to expect joined string for multi-text content
- Added `test_format_request_tool_message_mixed_content_keeps_array` to verify mixed content preserves array format
- Existing `test_format_request_tool_message_single_text_returns_string` still passes (no behavior change)

## Test Results

```
72 passed in 0.30s
```

All OpenAI model tests pass. No regressions.

## Compatibility

- ✅ OpenAI API: accepts both string and array — no change in behavior
- ✅ OpenAI-compatible endpoints (Kimi K2.5, etc.): now works correctly
- ✅ Mixed content (text + images): still uses array format (required for images)
- ✅ Backward compatible: string format is a valid superset of the previous single-text optimization