### PR TITLE
fix(bedrock): insert cache point before reasoning blocks to avoid API error

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -360,7 +360,13 @@ class BedrockModel(Model):
                 last_assistant_idx = msg_idx
 
         if last_assistant_idx is not None and messages[last_assistant_idx].get("content"):
-            messages[last_assistant_idx]["content"].append({"cachePoint": {"type": "default"}})
+            content = messages[last_assistant_idx]["content"]
+            # Insert cache point before any trailing reasoning blocks, since Bedrock's API
+            # does not allow cache points after reasoningContent blocks.
+            insert_pos = len(content)
+            while insert_pos > 0 and "reasoningContent" in content[insert_pos - 1]:
+                insert_pos -= 1
+            content.insert(insert_pos, {"cachePoint": {"type": "default"}})
             logger.debug("msg_idx=<%s> | added cache point to last assistant message", last_assistant_idx)
 
     def _find_last_user_text_message_index(self, messages: Messages) -> int | None:

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2693,6 +2693,33 @@ def test_inject_cache_point_strips_existing_cache_points(bedrock_client):
     assert "cachePoint" in cleaned_messages[3]["content"][-1]
 
 
+def test_inject_cache_point_before_reasoning_content(bedrock_client):
+    """Test that cache point is inserted before trailing reasoningContent blocks."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=CacheConfig(strategy="auto")
+    )
+
+    cleaned_messages = [
+        {"role": "user", "content": [{"text": "Hello"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {"text": "Here is my answer."},
+                {"reasoningContent": {"reasoningText": {"text": "Let me think..."}}},
+            ],
+        },
+    ]
+
+    model._inject_cache_point(cleaned_messages)
+
+    content = cleaned_messages[1]["content"]
+    # Cache point should be before the reasoning block, not after
+    assert len(content) == 3
+    assert content[0] == {"text": "Here is my answer."}
+    assert "cachePoint" in content[1]
+    assert "reasoningContent" in content[2]
+
+
 def test_find_last_user_text_message_index_no_user_messages(bedrock_client):
     """Test _find_last_user_text_message_index returns None when no user text messages exist."""
     model = BedrockModel(model_id="test-model")


### PR DESCRIPTION
## Summary

Fixes #1820

When `cache_config=CacheConfig(strategy="auto")` is used with extended thinking models (e.g. `us.anthropic.claude-sonnet-4-6`), the `_inject_cache_point()` method unconditionally appended cache points to the **end** of assistant message content. If the last content block was a `reasoningContent` block, Bedrock's API returned:

```
ValidationException: Cache point cannot be inserted after reasoning block
```

## Root Cause

`_inject_cache_point()` used `content.append()` to add the cache point at the end of the content list without checking what the last block is:

```python
# Before (broken)
messages[last_assistant_idx]["content"].append({"cachePoint": {"type": "default"}})
# Result: [..., text, reasoningContent, cachePoint] ← API error
```

## Fix

The method now walks backward over trailing `reasoningContent` blocks and inserts the cache point before them:

```python
# After (fixed)
insert_pos = len(content)
while insert_pos > 0 and "reasoningContent" in content[insert_pos - 1]:
    insert_pos -= 1
content.insert(insert_pos, {"cachePoint": {"type": "default"}})
# Result: [..., text, cachePoint, reasoningContent] ← Valid
```

## Tests

Added `test_inject_cache_point_before_reasoning_content` — verifies cache point is inserted before trailing reasoning blocks.

```
122 passed in 0.21s
```

All Bedrock model tests pass. No regressions.