### PR TITLE
fix: guardrail redaction targets last user message instead of last message

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -804,11 +804,21 @@ class Agent(AgentBase):
                     and event.chunk.get("redactContent")
                     and event.chunk["redactContent"].get("redactUserContentMessage")
                 ):
-                    self.messages[-1]["content"] = self._redact_user_content(
-                        self.messages[-1]["content"], str(event.chunk["redactContent"]["redactUserContentMessage"])
-                    )
-                    if self._session_manager:
-                        self._session_manager.redact_latest_message(self.messages[-1], self)
+                    # Find the last user message for redaction (not just messages[-1],
+                    # which may be a non-user message appended by session managers)
+                    last_user_msg = None
+                    for msg in reversed(self.messages):
+                        if msg.get("role") == "user":
+                            last_user_msg = msg
+                            break
+
+                    if last_user_msg is not None:
+                        last_user_msg["content"] = self._redact_user_content(
+                            last_user_msg["content"],
+                            str(event.chunk["redactContent"]["redactUserContentMessage"]),
+                        )
+                        if self._session_manager:
+                            self._session_manager.redact_latest_message(last_user_msg, self)
                 yield event
 
             # Capture the result from the final event if available

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -2689,3 +2689,47 @@ def test_agent_plugins_can_register_hooks():
 
     agent("test")
     assert len(hook_called) == 1
+
+
+def test_guardrail_redact_targets_last_user_message_not_last_message(mock_model, agenerator):
+    """Test that guardrail redaction targets the last user message, not the last message overall.
+
+    Regression test for https://github.com/strands-agents/sdk-python/issues/1639:
+    When a session manager appends a non-user message (e.g., LTM context) after the
+    user's input, self.messages[-1] is no longer the user message. The redaction
+    should find and redact the last user message instead.
+    """
+    from strands.hooks.events import BeforeInvocationEvent
+
+    mock_model.mock_stream.return_value = agenerator(
+        [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"start": {"text": ""}}},
+            {"contentBlockDelta": {"delta": {"text": "Response"}}},
+            {"contentBlockStop": {}},
+            {"redactContent": {"redactUserContentMessage": "BLOCKED"}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15}}},
+        ]
+    )
+
+    agent = Agent(model=mock_model)
+
+    # Simulate what a session manager with LTM does: after the user message is added,
+    # append an assistant message with memory context before the model call
+    def inject_ltm(event: BeforeInvocationEvent) -> None:
+        event.agent.messages.append(
+            {"role": "assistant", "content": [{"text": "<user_context>Some LTM context</user_context>"}]}
+        )
+
+    agent.hooks.add_callback(BeforeInvocationEvent, inject_ltm)
+
+    agent("Tell me something dangerous")
+
+    # The user message should be redacted
+    user_msgs = [m for m in agent.messages if m["role"] == "user"]
+    assert len(user_msgs) >= 1
+    last_user_msg = user_msgs[-1]
+    assert last_user_msg["content"] == [{"text": "BLOCKED"}], (
+        "Guardrail should redact the last user message, not the last message in the list"
+    )


### PR DESCRIPTION
## Problem

When `guardrail_redact_input` is enabled and a session manager appends non-user messages (e.g., LTM context) after the user's input, the guardrail redaction logic used `self.messages[-1]` to find the message to redact. However, `self.messages[-1]` was the LTM assistant message instead of the user message that triggered the guardrail.

This caused the LTM context to be overwritten with the redacted content ("BLOCKED"), while the actual user message containing the unsafe content remained unchanged.

Reported in #1639.

## Root Cause

In `agent.py`, the redaction handler at line 807 used `self.messages[-1]` directly. When a session manager (like AgentCoreMemorySessionManager) injects an assistant message with `<user_context>` after the user's input is appended, the last message in the list is no longer the user message — it's the LTM context.

## Fix

Replace `self.messages[-1]` with a reverse iteration through `self.messages` to find the last message with `role == "user"`. This correctly targets the user's input for redaction regardless of what other messages have been appended afterward.

## Testing

- Added `test_guardrail_redact_targets_last_user_message_not_last_message`: simulates a `BeforeInvocationEvent` hook that injects an LTM assistant message (as session managers do), then verifies that the guardrail redaction targets the user message, not the injected assistant message.
- All 8 existing redact-related tests continue to pass.

## Changes

- `src/strands/agent/agent.py`: Changed guardrail redaction to iterate backward through messages to find the last user message
- `tests/strands/agent/test_agent.py`: Added regression test