### PR TITLE
fix: SlidingWindowConversationManager no longer falsely truncates tool results in window

### DIFF
--- a/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
+++ b/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
@@ -139,6 +139,10 @@ class SlidingWindowConversationManager(ConversationManager):
         This method is called after every event loop cycle to apply a sliding window if the message count
         exceeds the window size.
 
+        Unlike reduce_context (which prioritizes content truncation for context overflow recovery),
+        this method prioritizes sliding window trimming to remove old messages. This prevents false
+        positives where tool results inside the kept window are unnecessarily truncated.
+
         Args:
             agent: The agent whose messages will be managed.
                 This list is modified in-place.
@@ -151,7 +155,7 @@ class SlidingWindowConversationManager(ConversationManager):
                 "message_count=<%s>, window_size=<%s> | skipping context reduction", len(messages), self.window_size
             )
             return
-        self.reduce_context(agent)
+        self._slide_window(messages)
 
     def reduce_context(self, agent: "Agent", e: Exception | None = None, **kwargs: Any) -> None:
         """Trim the oldest messages to reduce the conversation context size.
@@ -184,7 +188,22 @@ class SlidingWindowConversationManager(ConversationManager):
                 logger.debug("message_index=<%s> | tool results truncated", oldest_message_idx_with_tool_results)
                 return
 
-        # Try to trim index id when tool result cannot be truncated anymore
+        # Try to trim messages when tool result cannot be truncated anymore
+        self._slide_window(messages, e)
+
+    def _slide_window(self, messages: Messages, e: Exception | None = None) -> None:
+        """Remove the oldest messages using a sliding window.
+
+        Handles special cases where trimming the messages leads to toolResult
+        with no corresponding toolUse or toolUse with no corresponding toolResult.
+
+        Args:
+            messages: The conversation message history (modified in-place).
+            e: The exception that triggered the context reduction, if any.
+
+        Raises:
+            ContextWindowOverflowException: If no valid trim index can be found.
+        """
         # If the number of messages is less than the window_size, then we default to 2, otherwise, trim to window size
         trim_index = 2 if len(messages) <= self.window_size else len(messages) - self.window_size
 

--- a/tests/strands/agent/test_conversation_manager.py
+++ b/tests/strands/agent/test_conversation_manager.py
@@ -591,3 +591,51 @@ def test_boundary_text_in_tool_result_not_truncated():
 
     assert not changed
     assert messages[0]["content"][0]["toolResult"]["content"][0]["text"] == boundary_text
+
+
+def test_apply_management_does_not_falsely_truncate_tool_results_in_window():
+    """apply_management should slide the window, not truncate tool results that would be kept.
+
+    Regression test for https://github.com/strands-agents/sdk-python/issues/702:
+    With window_size=5 and 8 messages, apply_management should remove the 3 oldest
+    messages via sliding window, NOT truncate tool results that fall inside the
+    kept window.
+    """
+    manager = SlidingWindowConversationManager(window_size=5)
+    messages = [
+        {"role": "user", "content": [{"text": "Hello, my name is Strands!"}]},
+        {"role": "assistant", "content": [{"text": "Hi there!"}]},
+        {"role": "user", "content": [{"text": "What's my name?"}]},
+        {"role": "assistant", "content": [{"text": "Your name is Strands!"}]},
+        {"role": "user", "content": [{"text": "direct tool call"}]},
+        {"role": "assistant", "content": [{"toolUse": {"toolUseId": "calc1", "name": "calculator", "input": {}}}]},
+        {
+            "role": "user",
+            "content": [
+                {"toolResult": {"toolUseId": "calc1", "content": [{"text": "Result: 56088"}], "status": "success"}}
+            ],
+        },
+        {"role": "assistant", "content": [{"text": "calculator was called."}]},
+    ]
+    test_agent = Agent(messages=messages)
+
+    manager.apply_management(test_agent)
+
+    # Should have trimmed to window_size (5 messages kept)
+    assert len(test_agent.messages) <= 5
+
+    # The tool result inside the window must NOT be truncated or marked as error
+    tool_result_msgs = [
+        m for m in test_agent.messages
+        if any("toolResult" in c for c in m.get("content", []))
+    ]
+    for msg in tool_result_msgs:
+        for content in msg["content"]:
+            if "toolResult" in content:
+                assert content["toolResult"]["status"] == "success", (
+                    "Tool result status should remain 'success', not changed to 'error'"
+                )
+                result_text = content["toolResult"]["content"][0]["text"]
+                assert "truncated" not in result_text.lower(), (
+                    "Tool result should not be truncated when it falls inside the window"
+                )


### PR DESCRIPTION
## Problem

When the message count exceeds `window_size`, `apply_management()` calls `reduce_context()` which prioritizes tool result truncation over sliding window trimming. This causes tool results **inside the kept window** to be unnecessarily truncated or marked as errors, even though they would be retained after the sliding window trims old messages.

For example, with `window_size=5` and 8 messages, the manager should remove the 3 oldest messages via sliding. Instead, it finds the oldest tool result (which may be at index 6 — inside the window) and truncates its content first.

Reported in #702.

## Root Cause

`apply_management()` delegates entirely to `reduce_context()`, which has a truncation-first strategy designed for **context overflow recovery** (when the model reports the context is too large). This strategy is correct for context overflow, but wrong for routine window size management where the goal is to remove old messages, not reduce content size.

## Fix

1. **`apply_management()`** now calls `_slide_window()` directly to remove old messages. Tool results inside the kept window are never touched.

2. **`reduce_context()`** retains its original truncation-first strategy for context overflow recovery (called by the agent when the model raises `ContextWindowOverflowException`).

3. **Extracted `_slide_window()`** as a shared method that encapsulates the sliding window trim logic (finding a valid trim index that preserves toolUse/toolResult pairs).

## Testing

- Added `test_apply_management_does_not_falsely_truncate_tool_results_in_window`: verifies that with `window_size=5` and 8 messages, tool results inside the window remain untouched with `status='success'`
- All 36 existing conversation manager tests continue to pass

## Changes

- `src/strands/agent/conversation_manager/sliding_window_conversation_manager.py`: Refactored `apply_management()` and extracted `_slide_window()`
- `tests/strands/agent/test_conversation_manager.py`: Added regression test