### PR TITLE
fix(bedrock): track tool_use via contentBlockDelta for stop reason override

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -836,8 +836,10 @@ class BedrockModel(Model):
                             for event in self._generate_redaction_events():
                                 callback(event)
 
-                    # Track if we see tool use events
+                    # Track if we see tool use events (check both start and delta as fallback)
                     if "contentBlockStart" in chunk and chunk["contentBlockStart"].get("start", {}).get("toolUse"):
+                        has_tool_use = True
+                    if "contentBlockDelta" in chunk and chunk["contentBlockDelta"].get("delta", {}).get("toolUse"):
                         has_tool_use = True
 
                     # Fix stopReason for streaming responses that contain tool use

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1589,6 +1589,35 @@ async def test_stream_stop_reason_override_streaming(bedrock_client, model, mess
 
 
 @pytest.mark.asyncio
+async def test_stream_stop_reason_override_via_delta_only(bedrock_client, model, messages, alist):
+    """Test stopReason override when toolUse is only signalled via contentBlockDelta, not contentBlockStart.
+
+    Regression test for https://github.com/strands-agents/sdk-python/issues/1810:
+    Some Bedrock streaming responses only include toolUse in contentBlockDelta events
+    without a corresponding contentBlockStart toolUse entry. The has_tool_use flag must
+    still be set so the end_turn → tool_use override fires.
+    """
+    bedrock_client.converse_stream.return_value = {
+        "stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"start": {"text": ""}}},
+            {"contentBlockDelta": {"delta": {"text": "Let me call a tool."}}},
+            {"contentBlockStop": {}},
+            {"contentBlockStart": {"start": {}}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"param": "value"}'}}}},
+            {"contentBlockStop": {}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+    }
+
+    response = model.stream(messages)
+    events = await alist(response)
+
+    message_stop_event = next(event for event in events if "messageStop" in event)
+    assert message_stop_event["messageStop"]["stopReason"] == "tool_use"
+
+
+@pytest.mark.asyncio
 async def test_stream_stop_reason_override_non_streaming(bedrock_client, alist, messages):
     """Test that stopReason is overridden from end_turn to tool_use in non-streaming mode when tool use is detected."""
     bedrock_client.converse.return_value = {


### PR DESCRIPTION
## Bug

`BedrockModel._stream()` only tracks tool use via `contentBlockStart` events. In edge cases where Bedrock sends tool calls fragmented across chunks (or `contentBlockStart` doesn't include a `toolUse` entry), the `has_tool_use` flag is never set. This causes the `end_turn` → `tool_use` stop reason override to miss, leading to premature agent loop termination.

**Reported in:** #1810

### Root cause

The `has_tool_use` flag was only set when processing `contentBlockStart` chunks containing `toolUse`. Some Bedrock streaming responses only signal tool use via `contentBlockDelta` events, bypassing the existing check entirely.

### Fix

Add `contentBlockDelta` as a secondary signal for tool use detection. If any chunk contains `contentBlockDelta.delta.toolUse`, the `has_tool_use` flag is set, ensuring the stop reason override fires correctly.

### Testing

- Added regression test `test_stream_stop_reason_override_via_delta_only` simulating a stream where tool use is only signalled via `contentBlockDelta`
- Existing `test_stream_stop_reason_override_streaming` still passes
- All 122 Bedrock model tests pass

Fixes #1810