### PR TITLE
fix(anthropic): suppress Pydantic serialization warnings from ParsedTextBlock

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -407,7 +407,7 @@ class AnthropicModel(Model):
                 logger.debug("got response from model")
                 async for event in stream:
                     if event.type in AnthropicModel.EVENT_TYPES:
-                        yield self.format_chunk(event.model_dump())
+                        yield self.format_chunk(event.model_dump(warnings=False))
 
                 usage = event.message.usage  # type: ignore
                 yield self.format_chunk({"type": "metadata", "usage": usage.model_dump()})

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -696,19 +696,19 @@ async def test_stream(anthropic_client, model, agenerator, alist):
     mock_event_1 = unittest.mock.Mock(
         type="message_start",
         dict=lambda: {"type": "message_start"},
-        model_dump=lambda: {"type": "message_start"},
+        model_dump=lambda **kwargs: {"type": "message_start"},
     )
     mock_event_2 = unittest.mock.Mock(
         type="unknown",
         dict=lambda: {"type": "unknown"},
-        model_dump=lambda: {"type": "unknown"},
+        model_dump=lambda **kwargs: {"type": "unknown"},
     )
     mock_event_3 = unittest.mock.Mock(
         type="metadata",
         message=unittest.mock.Mock(
             usage=unittest.mock.Mock(
                 dict=lambda: {"input_tokens": 1, "output_tokens": 2},
-                model_dump=lambda: {"input_tokens": 1, "output_tokens": 2},
+                model_dump=lambda **kwargs: {"input_tokens": 1, "output_tokens": 2},
             )
         ),
     )


### PR DESCRIPTION
## Bug

When using Anthropic SDK >= 0.83.0, every streaming call produces `PydanticSerializationUnexpectedValue` warnings for each content block. These are harmless but noisy, cluttering logs and alarming users.

**Reported in:** #1746

### Root cause

Anthropic SDK returns `ParsedTextBlock` (a Pydantic `BaseModel` subclass) in streaming events. When `event.model_dump()` serializes these objects, Pydantic tries to match them against each variant in the union type (`ThinkingBlock`, `ToolUseBlock`, etc.) and emits a warning for each non-matching variant before finding the correct one.

### Fix

Pass `warnings=False` to `model_dump()` in the streaming event handler. This suppresses the serialization warnings without affecting the output — the data is serialized correctly regardless.

### Testing

- Updated mock `model_dump` lambdas in `test_stream` to accept `**kwargs` (matching the new signature)
- All 42 Anthropic model tests pass
- All lint checks pass

Fixes #1746