### PR TITLE
fix(metrics): preserve all tool invocation inputs in ToolMetrics

### DIFF
--- a/src/strands/telemetry/metrics.py
+++ b/src/strands/telemetry/metrics.py
@@ -109,11 +109,12 @@ class ToolMetrics:
     """Metrics for a specific tool's usage.
 
     Attributes:
-        tool: The tool being tracked.
+        tool: The most recent tool invocation being tracked.
         call_count: Number of times the tool has been called.
         success_count: Number of successful tool calls.
         error_count: Number of failed tool calls.
         total_time: Total execution time across all calls in seconds.
+        calls: History of all individual tool invocations with their inputs.
     """
 
     tool: ToolUse
@@ -121,6 +122,7 @@ class ToolMetrics:
     success_count: int = 0
     error_count: int = 0
     total_time: float = 0.0
+    calls: list[ToolUse] = field(default_factory=list)
 
     def add_call(
         self,
@@ -140,6 +142,7 @@ class ToolMetrics:
             attributes: attributes of the metrics.
         """
         self.tool = tool  # Update with latest tool state
+        self.calls.append(tool)
         self.call_count += 1
         self.total_time += duration
         metrics_client.tool_call_count.add(1, attributes=attributes)

--- a/tests/strands/telemetry/test_metrics.py
+++ b/tests/strands/telemetry/test_metrics.py
@@ -226,6 +226,7 @@ def test_tool_metrics_add_call(success, tool, tool_metrics, mock_get_meter_provi
         "success_count": success,
         "error_count": not success,
         "total_time": duration,
+        "calls": [tool],
     }
 
     mock_get_meter_provider.return_value.get_meter.assert_called()
@@ -313,6 +314,7 @@ def test_event_loop_metrics_add_tool_usage(mock_time, trace, tool, event_loop_me
                 success_count=1,
                 error_count=0,
                 total_time=duration,
+                calls=[tool],
             ),
         }
     }
@@ -566,3 +568,35 @@ def test_reset_usage_metrics(usage, event_loop_metrics, mock_get_meter_provider)
 
     # Verify accumulated_usage is NOT cleared
     assert event_loop_metrics.accumulated_usage["inputTokens"] == 11
+
+
+@unittest.mock.patch("opentelemetry.metrics.get_meter_provider")
+def test_tool_metrics_calls_preserves_all_invocations(mock_get_meter_provider):
+    """Regression: tool_metrics.calls should track all invocations, not just the latest.
+
+    Previously, ToolMetrics.tool was overwritten on each add_call(), losing
+    the inputs from earlier invocations of the same tool.
+
+    See: https://github.com/strands-agents/sdk-python/issues/301
+    """
+    tool1 = {"toolUseId": "id1", "name": "weather", "input": {"city": "Berlin"}}
+    tool2 = {"toolUseId": "id2", "name": "weather", "input": {"city": "Paris"}}
+    tool3 = {"toolUseId": "id3", "name": "weather", "input": {"city": "Rome"}}
+
+    metrics = strands.telemetry.metrics.ToolMetrics(tool=tool1)
+    metrics_client = MetricsClient()
+
+    metrics.add_call(tool1, 0.1, True, metrics_client)
+    metrics.add_call(tool2, 0.2, True, metrics_client)
+    metrics.add_call(tool3, 0.3, True, metrics_client)
+
+    assert metrics.call_count == 3
+    assert len(metrics.calls) == 3
+
+    # All inputs are preserved in order
+    assert metrics.calls[0]["input"]["city"] == "Berlin"
+    assert metrics.calls[1]["input"]["city"] == "Paris"
+    assert metrics.calls[2]["input"]["city"] == "Rome"
+
+    # .tool still points to the latest (backward compatible)
+    assert metrics.tool["input"]["city"] == "Rome"


### PR DESCRIPTION
## Bug

`AgentResult.metrics.tool_metrics` only stores the inputs from the **last** invocation of each tool. When a tool is called multiple times (e.g., weather forecast for 3 cities), the `tool` field is overwritten on each `add_call()`, losing all earlier inputs.

**Reported in:** #301

### Root cause

`ToolMetrics.add_call()` unconditionally overwrites `self.tool = tool` (line 142), discarding the previous tool invocation data.

### Fix

Add a `calls: list[ToolUse]` field to `ToolMetrics` that appends every tool invocation in order. The existing `tool` field remains for backward compatibility (always points to the latest invocation).

Users can now access all invocations via `metrics.tool_metrics["tool_name"].calls` to see each invocation's inputs.

### Testing

- Added `test_tool_metrics_calls_preserves_all_invocations`: creates 3 calls with different city inputs, verifies all 3 are preserved in `calls` list with correct order and that `tool` still points to latest
- Updated existing tests to include `calls` field in expected attributes
- All 21 metrics tests pass

Fixes #301