### PR TITLE
fix(watcher): handle on_created events for new tool files

### DIFF
--- a/src/strands/tools/watcher.py
+++ b/src/strands/tools/watcher.py
@@ -49,8 +49,8 @@ class ToolWatcher:
             """
             self.tool_registry = tool_registry
 
-        def on_modified(self, event: Any) -> None:
-            """Reload tool if file modification detected.
+        def _handle_tool_event(self, event: Any) -> None:
+            """Process a tool file event (created or modified).
 
             Args:
                 event: The file system event that triggered this handler.
@@ -66,6 +66,22 @@ class ToolWatcher:
                     except Exception as e:
                         logger.error("tool_name=<%s>, exception=<%s> | failed to reload tool", tool_name, str(e))
 
+        def on_modified(self, event: Any) -> None:
+            """Reload tool if file modification detected.
+
+            Args:
+                event: The file system event that triggered this handler.
+            """
+            self._handle_tool_event(event)
+
+        def on_created(self, event: Any) -> None:
+            """Reload tool if new file created.
+
+            Args:
+                event: The file system event that triggered this handler.
+            """
+            self._handle_tool_event(event)
+
     class MasterChangeHandler(FileSystemEventHandler):
         """Master handler that delegates to all registered handlers."""
 
@@ -77,23 +93,39 @@ class ToolWatcher:
             """
             self.dir_path = dir_path
 
-        def on_modified(self, event: Any) -> None:
-            """Delegate file modification events to all registered handlers.
+        def _delegate_event(self, event: Any, method_name: str) -> None:
+            """Delegate file events to all registered handlers.
 
             Args:
                 event: The file system event that triggered this handler.
+                method_name: The handler method to call (e.g., 'on_modified', 'on_created').
             """
             if event.src_path.endswith(".py"):
                 tool_path = Path(event.src_path)
                 tool_name = tool_path.stem
 
                 if tool_name not in ["__init__"]:
-                    # Delegate to all registered handlers for this directory
                     for handler in ToolWatcher._registry_handlers.get(self.dir_path, {}).values():
                         try:
-                            handler.on_modified(event)
+                            getattr(handler, method_name)(event)
                         except Exception as e:
                             logger.error("exception=<%s> | handler error", str(e))
+
+        def on_modified(self, event: Any) -> None:
+            """Delegate file modification events to all registered handlers.
+
+            Args:
+                event: The file system event that triggered this handler.
+            """
+            self._delegate_event(event, "on_modified")
+
+        def on_created(self, event: Any) -> None:
+            """Delegate file creation events to all registered handlers.
+
+            Args:
+                event: The file system event that triggered this handler.
+            """
+            self._delegate_event(event, "on_created")
 
     def start(self) -> None:
         """Start watching all tools directories for changes."""

--- a/tests/strands/tools/test_watcher.py
+++ b/tests/strands/tools/test_watcher.py
@@ -96,3 +96,42 @@ def test_on_modified_error_handling(mock_reload_tool):
 
     # Verify that reload_tool was called
     mock_reload_tool.assert_called_once_with("test_tool")
+
+
+@patch.object(ToolRegistry, "reload_tool")
+def test_on_created_reloads_new_tool(mock_reload_tool):
+    """Regression: on_created must trigger tool reload for newly added files.
+
+    Previously, only on_modified was handled, so the first tool file added
+    to an empty directory was never detected by the watcher.
+
+    See: https://github.com/strands-agents/sdk-python/issues/264
+    """
+    tool_registry = ToolRegistry()
+    watcher = ToolWatcher(tool_registry)
+
+    event = MagicMock()
+    event.src_path = "/path/to/tools/my_new_tool.py"
+
+    watcher.tool_change_handler.on_created(event)
+
+    mock_reload_tool.assert_called_once_with("my_new_tool")
+
+
+@patch.object(ToolRegistry, "reload_tool")
+def test_master_handler_delegates_on_created(mock_reload_tool):
+    """Verify MasterChangeHandler delegates on_created events."""
+    tool_registry = ToolRegistry()
+    watcher = ToolWatcher(tool_registry)
+
+    dir_path = "/path/to/tools"
+    master = ToolWatcher.MasterChangeHandler(dir_path)
+
+    ToolWatcher._registry_handlers[dir_path] = {id(tool_registry): watcher.tool_change_handler}
+
+    event = MagicMock()
+    event.src_path = "/path/to/tools/new_tool.py"
+
+    master.on_created(event)
+
+    mock_reload_tool.assert_called_once_with("new_tool")


### PR DESCRIPTION
## Bug

When the `./tools/` directory is empty at Agent initialization, the first tool file added to the directory is not hot-reloaded. Subsequent tool file modifications work fine. Users have to restart Python to pick up the first tool.

**Reported in:** #264

### Root cause

`ToolChangeHandler` and `MasterChangeHandler` only implement `on_modified()`. When a **new** file is created in the watched directory, the filesystem fires an `on_created` event — not `on_modified`. Since there's no handler for creation events, the first file goes undetected.

Subsequent edits to existing files fire `on_modified`, which is why they work.

### Fix

- Add `on_created()` handlers to both `ToolChangeHandler` and `MasterChangeHandler`
- Extract shared logic into `_handle_tool_event()` and `_delegate_event()` helper methods
- Both creation and modification events now trigger tool reload

### Testing

- Added `test_on_created_reloads_new_tool`: verifies `on_created` triggers `reload_tool`
- Added `test_master_handler_delegates_on_created`: verifies `MasterChangeHandler` delegates creation events
- All 9 watcher tests pass

Fixes #264