### PR TITLE
fix(openai): preserve user-provided http_client across requests

### DIFF
--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -562,6 +562,12 @@ class OpenAIModel(Model):
         if self._custom_client is not None:
             # Use the injected client (caller manages lifecycle)
             yield self._custom_client
+        elif "http_client" in self.client_args:
+            # User provided a custom httpx client via client_args.
+            # Do NOT use `async with` because that closes the underlying httpx client,
+            # which breaks subsequent requests when the same http_client is reused.
+            client = openai.AsyncOpenAI(**self.client_args)
+            yield client
         else:
             # Create a new client from client_args
             # We initialize an OpenAI context on every request so as to avoid connection sharing in the underlying

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -1533,3 +1533,42 @@ def test_format_request_messages_multiple_tool_calls_with_images():
         },
     ]
     assert tru_result == exp_result
+
+
+@pytest.mark.asyncio
+async def test_get_client_does_not_close_user_http_client():
+    """Verify that a user-provided http_client is not closed between requests.
+
+    When client_args includes http_client, the model should not use `async with`
+    on the AsyncOpenAI instance, because that closes the underlying httpx client,
+    breaking subsequent requests.
+
+    See: https://github.com/strands-agents/sdk-python/issues/906
+    """
+    import httpx
+
+    http_client = httpx.AsyncClient()
+    original_aclose = http_client.aclose
+    close_called = []
+    http_client.aclose = lambda: close_called.append(True) or original_aclose()
+
+    model = OpenAIModel(
+        client_args={"api_key": "test-key", "http_client": http_client},
+        model_id="test-model",
+    )
+
+    # First request
+    async with model._get_client() as client1:
+        assert client1 is not None
+
+    # http_client should NOT have been closed
+    assert len(close_called) == 0
+
+    # Second request should work without error
+    async with model._get_client() as client2:
+        assert client2 is not None
+
+    assert len(close_called) == 0
+
+    # Cleanup
+    await original_aclose()


### PR DESCRIPTION
## Bug

When passing a custom `httpx.AsyncClient` via `client_args["http_client"]`, the second agent call fails with a connection-closed error. Only the first call succeeds.

**Reported in:** #906

### Root cause

`_get_client()` creates a new `AsyncOpenAI` instance per request using `async with openai.AsyncOpenAI(**self.client_args)`. The `async with` context manager calls `aclose()` on exit, which closes the underlying httpx client. Since the same `http_client` instance is reused in subsequent `AsyncOpenAI` creations, the second request finds a closed connection.

### Fix

When `http_client` is present in `client_args`, skip the `async with` lifecycle management. The caller owns the `http_client` and is responsible for its lifecycle, just like with the `client` parameter.

### Testing

- Added `test_get_client_does_not_close_user_http_client`: creates a real `httpx.AsyncClient`, verifies `aclose()` is never called by the model between two consecutive `_get_client()` calls
- All 73 OpenAI model tests pass

Fixes #906