### PR TITLE
fix: Set _is_new_session = False at the end of each initialize_* method

### DIFF
--- a/src/strands/session/repository_session_manager.py
+++ b/src/strands/session/repository_session_manager.py
@@ -226,6 +226,8 @@ class RepositorySessionManager(SessionManager):
             # Fix broken session histories: https://github.com/strands-agents/sdk-python/issues/859
             agent.messages = self._fix_broken_tool_use(agent.messages)
 
+        self._is_new_session = False
+
     def _fix_broken_tool_use(self, messages: list[Message]) -> list[Message]:
         """Fix broken tool use/result pairs in message history.
 
@@ -318,6 +320,8 @@ class RepositorySessionManager(SessionManager):
             logger.debug("session_id=<%s> | restoring multi-agent state", self.session_id)
             source.deserialize_state(state)
 
+        self._is_new_session = False
+
     def initialize_bidi_agent(self, agent: "BidiAgent", **kwargs: Any) -> None:
         """Initialize a bidirectional agent with a session.
 
@@ -374,6 +378,8 @@ class RepositorySessionManager(SessionManager):
 
             # Fix broken session histories: https://github.com/strands-agents/sdk-python/issues/859
             agent.messages = self._fix_broken_tool_use(agent.messages)
+
+        self._is_new_session = False
 
     def append_bidi_message(self, message: Message, agent: "BidiAgent", **kwargs: Any) -> None:
         """Append a message to the bidirectional agent's session.


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

PR #1829 added _is_new_session = True in RepositorySessionManager.__init__ when a session is first created. In this PR we set  `_is_new_session = False` at the end of each initialize_* method.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
