### PR TITLE
fix: handle bytes serialization in session managers for binary content

### DIFF
--- a/src/strands/session/file_session_manager.py
+++ b/src/strands/session/file_session_manager.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from .. import _identifier
 from ..types.exceptions import SessionException
-from ..types.session import Session, SessionAgent, SessionMessage
+from ..types.session import Session, SessionAgent, SessionMessage, decode_bytes_values, encode_bytes_values
 from .repository_session_manager import RepositorySessionManager
 from .session_repository import SessionRepository
 
@@ -106,20 +106,30 @@ class FileSessionManager(RepositorySessionManager, SessionRepository):
         return os.path.join(agent_path, "messages", f"{MESSAGE_PREFIX}{message_id}.json")
 
     def _read_file(self, path: str) -> dict[str, Any]:
-        """Read JSON file."""
+        """Read JSON file.
+
+        Automatically decodes any base64-encoded bytes values that were encoded
+        during write operations.
+        """
         try:
             with open(path, encoding="utf-8") as f:
-                return cast(dict[str, Any], json.load(f))
+                data = json.load(f)
+                return cast(dict[str, Any], decode_bytes_values(data))
         except json.JSONDecodeError as e:
             raise SessionException(f"Invalid JSON in file {path}: {str(e)}") from e
 
     def _write_file(self, path: str, data: dict[str, Any]) -> None:
-        """Write JSON file."""
+        """Write JSON file.
+
+        Automatically encodes any bytes values to base64 before JSON serialization
+        to handle binary content like images and documents.
+        """
         os.makedirs(os.path.dirname(path), exist_ok=True)
         # This automic write ensure the completeness of session files in both single agent/ multi agents
         tmp = f"{path}.tmp"
+        encoded_data = encode_bytes_values(data)
         with open(tmp, "w", encoding="utf-8", newline="\n") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
+            json.dump(encoded_data, f, indent=2, ensure_ascii=False)
         os.replace(tmp, path)
 
     def create_session(self, session: Session, **kwargs: Any) -> Session:

--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -11,7 +11,7 @@ from botocore.exceptions import ClientError
 
 from .. import _identifier
 from ..types.exceptions import SessionException
-from ..types.session import Session, SessionAgent, SessionMessage
+from ..types.session import Session, SessionAgent, SessionMessage, decode_bytes_values, encode_bytes_values
 from .repository_session_manager import RepositorySessionManager
 from .session_repository import SessionRepository
 
@@ -132,11 +132,16 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
         return f"{agent_path}messages/{MESSAGE_PREFIX}{message_id}.json"
 
     def _read_s3_object(self, key: str) -> dict[str, Any] | None:
-        """Read JSON object from S3."""
+        """Read JSON object from S3.
+
+        Automatically decodes any base64-encoded bytes values that were encoded
+        during write operations.
+        """
         try:
             response = self.client.get_object(Bucket=self.bucket, Key=key)
             content = response["Body"].read().decode("utf-8")
-            return cast(dict[str, Any], json.loads(content))
+            data = json.loads(content)
+            return cast(dict[str, Any], decode_bytes_values(data))
         except ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
                 return None
@@ -146,9 +151,14 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             raise SessionException(f"Invalid JSON in S3 object {key}: {e}") from e
 
     def _write_s3_object(self, key: str, data: dict[str, Any]) -> None:
-        """Write JSON object to S3."""
+        """Write JSON object to S3.
+
+        Automatically encodes any bytes values to base64 before JSON serialization
+        to handle binary content like images and documents.
+        """
         try:
-            content = json.dumps(data, indent=2, ensure_ascii=False)
+            encoded_data = encode_bytes_values(data)
+            content = json.dumps(encoded_data, indent=2, ensure_ascii=False)
             self.client.put_object(
                 Bucket=self.bucket, Key=key, Body=content.encode("utf-8"), ContentType="application/json"
             )

--- a/tests/strands/session/test_file_session_manager.py
+++ b/tests/strands/session/test_file_session_manager.py
@@ -501,3 +501,108 @@ def test_create_session_multi_agent_directory_structure(multi_agent_manager, sam
 
     assert os.path.exists(session_dir)
     assert os.path.exists(multi_agents_dir)
+
+
+def test_create_message_with_image_bytes(file_manager, sample_session, sample_agent):
+    """Test creating a message containing image bytes."""
+    file_manager.create_session(sample_session)
+    file_manager.create_agent(sample_session.session_id, sample_agent)
+
+    # Create a message with image bytes
+    image_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"  # PNG header bytes
+    message_with_image = SessionMessage.from_message(
+        message={
+            "role": "user",
+            "content": [
+                ContentBlock(text="Analyze this image"),
+                ContentBlock(image={"format": "png", "source": {"bytes": image_bytes}}),
+            ],
+        },
+        index=0,
+    )
+
+    # This should not raise TypeError: Object of type bytes is not JSON serializable
+    file_manager.create_message(sample_session.session_id, sample_agent.agent_id, message_with_image)
+
+    # Read the message back and verify bytes are preserved
+    result = file_manager.read_message(sample_session.session_id, sample_agent.agent_id, 0)
+    assert result is not None
+    assert result.message["content"][0]["text"] == "Analyze this image"
+    assert result.message["content"][1]["image"]["source"]["bytes"] == image_bytes
+
+
+def test_create_message_with_document_bytes(file_manager, sample_session, sample_agent):
+    """Test creating a message containing document bytes."""
+    file_manager.create_session(sample_session)
+    file_manager.create_agent(sample_session.session_id, sample_agent)
+
+    # Create a message with PDF bytes
+    pdf_bytes = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3"  # PDF header bytes
+    message_with_doc = SessionMessage.from_message(
+        message={
+            "role": "user",
+            "content": [
+                ContentBlock(text="Analyze this PDF"),
+                ContentBlock(document={"format": "pdf", "name": "test.pdf", "source": {"bytes": pdf_bytes}}),
+            ],
+        },
+        index=0,
+    )
+
+    # This should not raise TypeError
+    file_manager.create_message(sample_session.session_id, sample_agent.agent_id, message_with_doc)
+
+    # Read the message back and verify bytes are preserved
+    result = file_manager.read_message(sample_session.session_id, sample_agent.agent_id, 0)
+    assert result is not None
+    assert result.message["content"][1]["document"]["source"]["bytes"] == pdf_bytes
+
+
+def test_create_multi_agent_with_bytes_in_state(multi_agent_manager, sample_session):
+    """Test creating multi-agent state containing bytes."""
+    multi_agent_manager.create_session(sample_session)
+
+    # Create mock multi-agent with bytes in the serialized state
+    image_bytes = b"\x89PNG\r\n\x1a\n"
+    mock_multi_agent = Mock()
+    mock_multi_agent.id = "test-multi-agent"
+    mock_multi_agent.serialize_state.return_value = {
+        "id": "test-multi-agent",
+        "current_task": [
+            {"text": "Analyze this image"},
+            {"image": {"format": "png", "source": {"bytes": image_bytes}}},
+        ],
+    }
+
+    # This should not raise TypeError
+    multi_agent_manager.create_multi_agent(sample_session.session_id, mock_multi_agent)
+
+    # Read the state back and verify bytes are preserved
+    result = multi_agent_manager.read_multi_agent(sample_session.session_id, mock_multi_agent.id)
+    assert result is not None
+    assert result["current_task"][1]["image"]["source"]["bytes"] == image_bytes
+
+
+def test_update_multi_agent_with_bytes_in_state(multi_agent_manager, sample_session, mock_multi_agent):
+    """Test updating multi-agent state containing bytes."""
+    multi_agent_manager.create_session(sample_session)
+
+    # Create initial multi-agent state
+    multi_agent_manager.create_multi_agent(sample_session.session_id, mock_multi_agent)
+
+    # Update with bytes in state
+    pdf_bytes = b"%PDF-1.4\n"
+    updated_mock = Mock()
+    updated_mock.id = mock_multi_agent.id
+    updated_mock.serialize_state.return_value = {
+        "id": mock_multi_agent.id,
+        "current_task": [
+            {"document": {"format": "pdf", "name": "doc.pdf", "source": {"bytes": pdf_bytes}}},
+        ],
+    }
+
+    multi_agent_manager.update_multi_agent(sample_session.session_id, updated_mock)
+
+    # Verify bytes are preserved
+    result = multi_agent_manager.read_multi_agent(sample_session.session_id, mock_multi_agent.id)
+    assert result["current_task"][0]["document"]["source"]["bytes"] == pdf_bytes

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -481,3 +481,111 @@ def test_update_nonexistent_multi_agent(s3_manager, sample_session):
     nonexistent_mock.id = "nonexistent"
     with pytest.raises(SessionException):
         s3_manager.update_multi_agent(sample_session.session_id, nonexistent_mock)
+
+
+def test_create_message_with_image_bytes(s3_manager, sample_session, sample_agent):
+    """Test creating a message containing image bytes in S3."""
+    s3_manager.create_session(sample_session)
+    s3_manager.create_agent(sample_session.session_id, sample_agent)
+
+    # Create a message with image bytes
+    image_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"  # PNG header bytes
+    message_with_image = SessionMessage.from_message(
+        message={
+            "role": "user",
+            "content": [
+                ContentBlock(text="Analyze this image"),
+                ContentBlock(image={"format": "png", "source": {"bytes": image_bytes}}),
+            ],
+        },
+        index=0,
+    )
+
+    # This should not raise TypeError: Object of type bytes is not JSON serializable
+    s3_manager.create_message(sample_session.session_id, sample_agent.agent_id, message_with_image)
+
+    # Read the message back and verify bytes are preserved
+    result = s3_manager.read_message(sample_session.session_id, sample_agent.agent_id, 0)
+    assert result is not None
+    assert result.message["content"][0]["text"] == "Analyze this image"
+    assert result.message["content"][1]["image"]["source"]["bytes"] == image_bytes
+
+
+def test_create_message_with_document_bytes(s3_manager, sample_session, sample_agent):
+    """Test creating a message containing document bytes in S3."""
+    s3_manager.create_session(sample_session)
+    s3_manager.create_agent(sample_session.session_id, sample_agent)
+
+    # Create a message with PDF bytes
+    pdf_bytes = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3"  # PDF header bytes
+    message_with_doc = SessionMessage.from_message(
+        message={
+            "role": "user",
+            "content": [
+                ContentBlock(text="Analyze this PDF"),
+                ContentBlock(document={"format": "pdf", "name": "test.pdf", "source": {"bytes": pdf_bytes}}),
+            ],
+        },
+        index=0,
+    )
+
+    # This should not raise TypeError
+    s3_manager.create_message(sample_session.session_id, sample_agent.agent_id, message_with_doc)
+
+    # Read the message back and verify bytes are preserved
+    result = s3_manager.read_message(sample_session.session_id, sample_agent.agent_id, 0)
+    assert result is not None
+    assert result.message["content"][1]["document"]["source"]["bytes"] == pdf_bytes
+
+
+def test_create_multi_agent_with_bytes_in_state(s3_manager, sample_session):
+    """Test creating multi-agent state containing bytes in S3."""
+    s3_manager.create_session(sample_session)
+
+    # Create mock multi-agent with bytes in the serialized state
+    image_bytes = b"\x89PNG\r\n\x1a\n"
+    mock_multi_agent = Mock()
+    mock_multi_agent.id = "test-multi-agent"
+    mock_multi_agent.serialize_state.return_value = {
+        "id": "test-multi-agent",
+        "current_task": [
+            {"text": "Analyze this image"},
+            {"image": {"format": "png", "source": {"bytes": image_bytes}}},
+        ],
+    }
+
+    # This should not raise TypeError
+    s3_manager.create_multi_agent(sample_session.session_id, mock_multi_agent)
+
+    # Read the state back and verify bytes are preserved
+    result = s3_manager.read_multi_agent(sample_session.session_id, mock_multi_agent.id)
+    assert result is not None
+    assert result["current_task"][1]["image"]["source"]["bytes"] == image_bytes
+
+
+def test_update_multi_agent_with_bytes_in_state(s3_manager, sample_session):
+    """Test updating multi-agent state containing bytes in S3."""
+    s3_manager.create_session(sample_session)
+
+    # Create initial multi-agent state
+    mock_multi_agent = Mock()
+    mock_multi_agent.id = "test-multi-agent"
+    mock_multi_agent.serialize_state.return_value = {"id": "test-multi-agent", "state": {"key": "value"}}
+    s3_manager.create_multi_agent(sample_session.session_id, mock_multi_agent)
+
+    # Update with bytes in state
+    pdf_bytes = b"%PDF-1.4\n"
+    updated_mock = Mock()
+    updated_mock.id = mock_multi_agent.id
+    updated_mock.serialize_state.return_value = {
+        "id": mock_multi_agent.id,
+        "current_task": [
+            {"document": {"format": "pdf", "name": "doc.pdf", "source": {"bytes": pdf_bytes}}},
+        ],
+    }
+
+    s3_manager.update_multi_agent(sample_session.session_id, updated_mock)
+
+    # Verify bytes are preserved
+    result = s3_manager.read_multi_agent(sample_session.session_id, mock_multi_agent.id)
+    assert result["current_task"][0]["document"]["source"]["bytes"] == pdf_bytes


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
Fixes the TypeError: Object of type bytes is not JSON serializable issue that occurs when persisting multi-agent state containing binary content (images, PDFs) via S3SessionManager or FileSessionManager.

- Add encode_bytes_values() in _write_s3_object() and _write_file() to convert bytes to base64 before JSON serialization
- Add decode_bytes_values() in _read_s3_object() and _read_file() to restore bytes from base64 after JSON deserialization
- Add tests for serializing messages and multi-agent state with binary content (images, documents)

## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/1864


## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
