### PR TITLE
feat: add put_object_kwargs support to S3SessionManager

### DIFF
--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -64,9 +64,20 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             boto_client_config: Optional boto3 client configuration
             region_name: AWS region for S3 storage
             **kwargs: Additional keyword arguments for future extensibility.
+                put_object_kwargs: Optional dict of additional parameters to pass to S3 put_object calls
+                    (e.g., ServerSideEncryption, SSEKMSKeyId, etc.)
         """
         self.bucket = bucket
         self.prefix = prefix
+        put_object_kwargs = kwargs.pop("put_object_kwargs", None) or {}
+
+        # Validate that reserved parameters are not being overridden
+        reserved_params = {"Bucket", "Key", "Body", "ContentType"}
+        invalid_params = reserved_params.intersection(put_object_kwargs.keys())
+        if invalid_params:
+            raise ValueError(f"put_object_kwargs cannot contain reserved parameters: {invalid_params}")
+
+        self.put_object_kwargs: dict[str, Any] = put_object_kwargs
 
         session = boto_session or boto3.Session(region_name=region_name)
 
@@ -149,9 +160,14 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
         """Write JSON object to S3."""
         try:
             content = json.dumps(data, indent=2, ensure_ascii=False)
-            self.client.put_object(
-                Bucket=self.bucket, Key=key, Body=content.encode("utf-8"), ContentType="application/json"
-            )
+            put_params = {
+                "Bucket": self.bucket,
+                "Key": key,
+                "Body": content.encode("utf-8"),
+                "ContentType": "application/json",
+                **self.put_object_kwargs,
+            }
+            self.client.put_object(**put_params)
         except ClientError as e:
             raise SessionException(f"Failed to write S3 object {key}: {e}") from e
 

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -82,11 +82,42 @@ def test_init_s3_session_manager_with_config(mocked_aws, s3_bucket):
     assert "strands-agents" in session_manager.client.meta.config.user_agent_extra
 
 
-def test_init_s3_session_manager_with_existing_user_agent(mocked_aws, s3_bucket):
+def test_init_s3_session_manager_with_existing_user_agent(s3_bucket):
     session_manager = S3SessionManager(
         session_id="test", bucket=s3_bucket, boto_client_config=BotocoreConfig(user_agent_extra="test")
     )
     assert "strands-agents" in session_manager.client.meta.config.user_agent_extra
+
+
+def test_init_s3_session_manager_with_put_object_kwargs(s3_bucket):
+    """Test initializing S3SessionManager with put_object_kwargs."""
+    put_object_kwargs = {
+        "ServerSideEncryption": "aws:kms",
+        "SSEKMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+    }
+    session_manager = S3SessionManager(session_id="test", bucket=s3_bucket, put_object_kwargs=put_object_kwargs)
+    assert session_manager.put_object_kwargs == put_object_kwargs
+
+
+def test_init_s3_session_manager_without_put_object_kwargs(s3_bucket):
+    """Test initializing S3SessionManager without put_object_kwargs defaults to empty dict."""
+    session_manager = S3SessionManager(session_id="test", bucket=s3_bucket)
+    assert session_manager.put_object_kwargs == {}
+
+
+def test_init_s3_session_manager_with_reserved_params_in_put_object_kwargs(s3_bucket):
+    """Test that reserved parameters in put_object_kwargs raise ValueError."""
+    with pytest.raises(ValueError, match="put_object_kwargs cannot contain reserved parameters"):
+        S3SessionManager(session_id="test", bucket=s3_bucket, put_object_kwargs={"Bucket": "other-bucket"})
+
+    with pytest.raises(ValueError, match="put_object_kwargs cannot contain reserved parameters"):
+        S3SessionManager(session_id="test", bucket=s3_bucket, put_object_kwargs={"Key": "some-key"})
+
+    with pytest.raises(ValueError, match="put_object_kwargs cannot contain reserved parameters"):
+        S3SessionManager(session_id="test", bucket=s3_bucket, put_object_kwargs={"Body": "data"})
+
+    with pytest.raises(ValueError, match="put_object_kwargs cannot contain reserved parameters"):
+        S3SessionManager(session_id="test", bucket=s3_bucket, put_object_kwargs={"ContentType": "text/plain"})
 
 
 def test_create_session(s3_manager, sample_session):
@@ -102,6 +133,18 @@ def test_create_session(s3_manager, sample_session):
 
     assert data["session_id"] == sample_session.session_id
     assert data["session_type"] == sample_session.session_type
+
+
+def test_create_session_with_put_object_kwargs(s3_bucket, sample_session):
+    """Test creating a session with put_object_kwargs applies encryption."""
+    put_object_kwargs = {"ServerSideEncryption": "AES256"}
+    manager_with_encryption = S3SessionManager(session_id="test", bucket=s3_bucket, put_object_kwargs=put_object_kwargs)
+    manager_with_encryption.create_session(sample_session)
+
+    # Verify S3 object has encryption
+    key = f"{manager_with_encryption._get_session_path(sample_session.session_id)}session.json"
+    response = manager_with_encryption.client.head_object(Bucket=manager_with_encryption.bucket, Key=key)
+    assert response["ServerSideEncryption"] == "AES256"
 
 
 def test_create_session_already_exists(s3_manager, sample_session):

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -93,7 +93,6 @@ def test_init_s3_session_manager_with_put_object_kwargs(s3_bucket):
     """Test initializing S3SessionManager with put_object_kwargs."""
     put_object_kwargs = {
         "ServerSideEncryption": "aws:kms",
-        "SSEKMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
     }
     session_manager = S3SessionManager(session_id="test", bucket=s3_bucket, put_object_kwargs=put_object_kwargs)
     assert session_manager.put_object_kwargs == put_object_kwargs


### PR DESCRIPTION
## Description

This PR adds support for passing custom S3 parameters to `S3SessionManager` to enable encryption configuration and other S3-specific options when storing session data.

### Changes:
- Added `put_object_kwargs` parameter support in `S3SessionManager.__init__()` that accepts a dictionary of additional keyword arguments
- Modified `_write_s3_object()` to merge `put_object_kwargs` with default S3 put_object parameters
- Added validation to prevent reserved parameters (`Bucket`, `Key`, `Body`, `ContentType`) from being overridden
- Added comprehensive test coverage for the new functionality

### Implementation Details:
- `put_object_kwargs` is extracted from `**kwargs` in `__init__` and stored as an instance variable
- Reserved parameters are validated at initialization time to fail fast
- All S3 write operations now include the custom parameters, enabling features like server-side encryption (SSE-KMS)

### Example Usage:
```python
from strands.session import S3SessionManager

session_manager = S3SessionManager(
    session_id="my-session",
    bucket="my-bucket",
    put_object_kwargs={
        "ServerSideEncryption": "aws:kms",
        "SSEKMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
    }
)
```


## Related Issues

#1247 

## Documentation PR

None necessary/applicable

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
