### PR TITLE
fix: prevent leading slash in S3 keys when prefix is empty

### DIFF
--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -95,7 +95,9 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             ValueError: If session id contains a path separator.
         """
         session_id = _identifier.validate(session_id, _identifier.Identifier.SESSION)
-        return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
+        if self.prefix:
+            return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
+        return f"{SESSION_PREFIX}{session_id}/"
 
     def _get_agent_path(self, session_id: str, agent_id: str) -> str:
         """Get agent S3 prefix.

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -89,6 +89,21 @@ def test_init_s3_session_manager_with_existing_user_agent(mocked_aws, s3_bucket)
     assert "strands-agents" in session_manager.client.meta.config.user_agent_extra
 
 
+def test_get_session_path_empty_prefix(mocked_aws, s3_bucket):
+    """Test that empty prefix does not produce a leading slash in S3 keys."""
+    manager = S3SessionManager(session_id="test", bucket=s3_bucket, prefix="", region_name="us-west-2")
+    path = manager._get_session_path("my-session")
+    assert not path.startswith("/"), f"Path should not start with '/': {path}"
+    assert path == "session_my-session/"
+
+
+def test_get_session_path_with_prefix(mocked_aws, s3_bucket):
+    """Test that non-empty prefix is included in S3 keys."""
+    manager = S3SessionManager(session_id="test", bucket=s3_bucket, prefix="data", region_name="us-west-2")
+    path = manager._get_session_path("my-session")
+    assert path == "data/session_my-session/"
+
+
 def test_create_session(s3_manager, sample_session):
     """Test creating a session in S3."""
     result = s3_manager.create_session(sample_session)


### PR DESCRIPTION
## Summary
- Fixes `_get_session_path` to not produce a leading `/` when `prefix` is empty
- Adds tests for both empty and non-empty prefix cases

## Problem
When `S3SessionManager` is created with the default `prefix=""`, `_get_session_path` returns `"/session_<id>/"` (leading slash) due to the f-string `f"{self.prefix}/{SESSION_PREFIX}{session_id}/"`.

MinIO and some S3-compatible backends strip the leading slash on write but not on read, so:
- **Write**: stores at `session_<id>/...` (no leading slash)
- **Read**: looks for `/session_<id>/...` (with leading slash)
- **Result**: session restore always fails silently, agent starts fresh every time

## Changes
- `s3_session_manager.py`: Conditionally omit the prefix separator when `self.prefix` is empty
- `test_s3_session_manager.py`: Added `test_get_session_path_empty_prefix` and `test_get_session_path_with_prefix`

## Test plan
- [ ] Verify S3 keys have no leading slash when prefix is empty
- [ ] Verify S3 keys include prefix correctly when prefix is non-empty
- [ ] Verify session create/read round-trip works with empty prefix on MinIO

Fixes #1863

https://claude.ai/code/session_011TWMvnjeLgAJg9XtxoLfZT