### PR TITLE
fix(anthropic): suppress Pydantic serialization warnings from ParsedTextBlock

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -407,10 +407,10 @@ class AnthropicModel(Model):
                 logger.debug("got response from model")
                 async for event in stream:
                     if event.type in AnthropicModel.EVENT_TYPES:
-                        yield self.format_chunk(event.model_dump())
+                        yield self.format_chunk(event.model_dump(warnings=False))
 
                 usage = event.message.usage  # type: ignore
-                yield self.format_chunk({"type": "metadata", "usage": usage.model_dump()})
+                yield self.format_chunk({"type": "metadata", "usage": usage.model_dump(warnings=False)})
 
         except anthropic.RateLimitError as error:
             raise ModelThrottledException(str(error)) from error


### PR DESCRIPTION
## Summary
- Passes `warnings=False` to `model_dump()` calls in `AnthropicModel.stream()` to suppress `PydanticSerializationUnexpectedValue` warnings
- Anthropic SDK >= 0.84.0 returns `ParsedTextBlock` objects that don't match Pydantic's expected union discriminator, producing 6+ warning lines per agent invocation on stderr
- The serialization still works correctly — this only suppresses the noisy warnings

Fixes #1865

## Test plan
- [ ] Run agent with `AnthropicModel` using `anthropic>=0.84.0` and verify no `PydanticSerializationUnexpectedValue` warnings on stderr
- [ ] Verify agent tool calls and responses still work correctly
- [ ] Run existing test suite

https://claude.ai/code/session_011TWMvnjeLgAJg9XtxoLfZT