### PR TITLE
fix(telemetry): add common gen_ai attributes to event loop cycle spans

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -521,9 +521,10 @@ class Tracer:
         event_loop_cycle_id = str(invocation_state.get("event_loop_cycle_id"))
         parent_span = parent_span if parent_span else invocation_state.get("event_loop_parent_span")
 
-        attributes: dict[str, AttributeValue] = {
-            "event_loop.cycle_id": event_loop_cycle_id,
-        }
+        attributes: dict[str, AttributeValue] = self._get_common_attributes(
+            operation_name="execute_event_loop_cycle"
+        )
+        attributes["event_loop.cycle_id"] = event_loop_cycle_id
 
         if custom_trace_attributes:
             attributes.update(custom_trace_attributes)

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -631,6 +631,8 @@ def test_start_event_loop_cycle_span(mock_tracer):
 
         mock_span.set_attributes.assert_called_once_with(
             {
+                "gen_ai.operation.name": "execute_event_loop_cycle",
+                "gen_ai.system": "strands-agents",
                 "event_loop.cycle_id": "cycle-123",
                 "request_id": "req-456",
                 "trace_level": "debug",
@@ -660,7 +662,13 @@ def test_start_event_loop_cycle_span_latest_conventions(mock_tracer, monkeypatch
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "execute_event_loop_cycle"
 
-        mock_span.set_attributes.assert_called_once_with({"event_loop.cycle_id": "cycle-123"})
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "execute_event_loop_cycle",
+                "gen_ai.provider.name": "strands-agents",
+                "event_loop.cycle_id": "cycle-123",
+            }
+        )
         mock_span.add_event.assert_any_call(
             "gen_ai.client.inference.operation.details",
             attributes={


### PR DESCRIPTION
## Summary

`start_event_loop_cycle_span()` was the only span start method that did not call `_get_common_attributes()`, causing event loop cycle spans to lack `gen_ai.system` / `gen_ai.provider.name` and `gen_ai.operation.name` attributes.

This is inconsistent with `start_model_invoke_span`, `start_tool_call_span`, `start_agent_span`, and `start_multiagent_span`, all of which include these common attributes. Downstream OTEL tooling (collectors, exporters, redaction processors) may rely on these attributes for filtering or policy decisions.

## Changes

- Added `_get_common_attributes(operation_name="execute_event_loop_cycle")` call in `start_event_loop_cycle_span()`
- Updated existing tests to expect the new common attributes in both legacy and latest convention modes

## Testing

All 74 tracer tests pass (including 5 event_loop_cycle-specific tests).

Closes #1876