### PR TITLE
fix: override end_turn stop reason when message contains tool use blocks

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -436,6 +436,19 @@ async def process_stream(
         elif "redactContent" in chunk:
             handle_redact_content(chunk["redactContent"], state)
 
+    # Override stop_reason from "end_turn" to "tool_use" if the message contains
+    # toolUse content blocks. Some models (e.g., Sonnet 4.x via Bedrock) may
+    # send stopReason: "end_turn" in messageStop even when the response includes
+    # tool use requests. This can happen when contentBlockDelta events carry
+    # toolUse deltas without a prior contentBlockStart, or when the model
+    # inconsistently reports the stop reason. Without this override, the event
+    # loop would treat the response as a final answer and skip tool execution.
+    if stop_reason == "end_turn":
+        for block in state["message"].get("content", []):
+            if "toolUse" in block:
+                stop_reason = "tool_use"
+                break
+
     yield ModelStopReason(stop_reason=stop_reason, message=state["message"], usage=usage, metrics=metrics)
 
 

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -1334,3 +1334,55 @@ async def test_stream_messages_normalizes_messages(agenerator, alist):
         {"content": [{"toolUse": {"name": "INVALID_TOOL_NAME"}}], "role": "assistant"},
         {"content": [{"toolUse": {"name": "INVALID_TOOL_NAME"}}], "role": "assistant"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_process_stream_overrides_end_turn_when_tool_use_present(agenerator, alist):
+    """Test that stop_reason is overridden from end_turn to tool_use when message contains toolUse blocks.
+
+    Some models (e.g., Sonnet 4.x via Bedrock) may send stopReason: "end_turn" in messageStop
+    even when the response includes tool use requests. The SDK must detect this mismatch and
+    override the stop reason to ensure tool execution proceeds.
+
+    Reproduces: https://github.com/strands-agents/sdk-python/issues/1810
+    """
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        # Text block first
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": "Let me call a tool."}}},
+        {"contentBlockStop": {}},
+        # Tool use block
+        {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "tool_1", "name": "my_tool"}}}},
+        {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"arg": "val"}'}}}},
+        {"contentBlockStop": {}},
+        # Model incorrectly reports end_turn
+        {"messageStop": {"stopReason": "end_turn"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                "metrics": {"latencyMs": 100},
+            }
+        },
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+    events = await alist(stream)
+
+    # The final event should be a ModelStopReason with the overridden stop reason
+    stop_event = events[-1]
+    assert "stop" in stop_event
+    stop_reason, message, usage, metrics = stop_event["stop"]
+
+    # Critical assertion: stop_reason must be overridden to "tool_use"
+    assert stop_reason == "tool_use", f"Expected 'tool_use' but got '{stop_reason}'"
+
+    # Verify the message content is correct
+    assert message["role"] == "assistant"
+    content = message["content"]
+    assert len(content) == 2
+    assert "text" in content[0]
+    assert content[0]["text"] == "Let me call a tool."
+    assert "toolUse" in content[1]
+    assert content[1]["toolUse"]["name"] == "my_tool"
+    assert content[1]["toolUse"]["input"] == {"arg": "val"}


### PR DESCRIPTION
## Issue

Closes #1810

## Problem

Some models (e.g., Sonnet 4.x via Bedrock) may send `stopReason: "end_turn"` in the `messageStop` event even when the response content includes `toolUse` blocks. This happens because:

1. The `contentBlockDelta` events carry `toolUse` deltas, but the model's stop reason doesn't reflect the tool use intent
2. Certain model versions inconsistently report the stop reason in edge cases with mixed text + tool call responses

When this mismatch occurs, the event loop treats the response as a final answer and skips tool execution, causing the agent to silently ignore pending tool calls.

## Root Cause

In `process_stream()`, the `stop_reason` is taken directly from `handle_message_stop()` without validating it against the actual message content. The post-stream function `_has_tool_use_in_latest_message()` in `event_loop.py` catches some cases, but only when checking previously accumulated messages — it doesn't catch the mismatch within the current streaming cycle.

## Solution

Added a post-stream validation step in `process_stream()` that:
1. Checks if `stop_reason` is `"end_turn"`
2. Inspects the accumulated message content blocks for `toolUse` entries  
3. Overrides the stop reason to `"tool_use"` when a mismatch is detected

This ensures tool calls are always executed regardless of the model's reported stop reason, while maintaining backward compatibility for responses that genuinely end without tool calls.

## Testing

- Added `test_process_stream_overrides_end_turn_when_tool_use_present` test that verifies:
  - Stop reason is correctly overridden from `end_turn` to `tool_use`
  - Message content (text + toolUse blocks) is preserved correctly
- All 53 streaming tests pass
- No regressions in existing test cases

## Changes

- `src/strands/event_loop/streaming.py`: Added stop_reason override check before final `ModelStopReason` yield
- `tests/strands/event_loop/test_streaming.py`: Added test case for the override behavior