### PR TITLE
fix: raise specific error for interrupt responses without active interrupt state

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -962,6 +962,14 @@ class Agent(AgentBase):
                         # Treat as List[ContentBlock] input - convert to user message
                         # This allows invalid structures to be passed through to the model
                         messages = [{"role": "user", "content": cast(list[ContentBlock], prompt)}]
+
+                    # Check if all items are interrupt responses
+                    elif all("interruptResponse" in item for item in prompt):
+                        raise ValueError(
+                            "Received interrupt responses but agent is not in interrupt state. "
+                            "Ensure the agent instance is preserved between calls, or use session "
+                            "management to persist interrupt state across requests."
+                        )
         else:
             messages = []
         if messages is None:

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -1866,6 +1866,15 @@ def test_agent__call__resume_interrupt_invalid_id():
         agent([{"interruptResponse": {"interruptId": "invalid", "response": None}}])
 
 
+def test_agent__call__resume_interrupt_not_activated():
+    """Passing interrupt responses to an agent not in interrupt state should raise a clear error."""
+    agent = Agent()
+
+    exp_message = r"Received interrupt responses but agent is not in interrupt state"
+    with pytest.raises(ValueError, match=exp_message):
+        agent([{"interruptResponse": {"interruptId": "test-id", "response": "yes"}}])
+
+
 def test_agent_structured_output_interrupt(user):
     agent = Agent()
     agent._interrupt_state.activated = True


### PR DESCRIPTION
## Summary

Fixes #1644

When interrupt responses (`list[InterruptResponseContent]`) are passed to an agent that is **not** in interrupt state (e.g. fresh instance, serverless handler without session management), `_convert_prompt_to_messages` now raises a clear `ValueError` instead of the generic:

```
ValueError: Input prompt must be of type: `str | list[Contentblock] | Messages | None`.
```

## Root Cause

`_convert_prompt_to_messages` validates the input prompt but did not recognize interrupt response payloads (`[{"interruptResponse": {...}}]`) as a valid input type. These dicts don't match `Message` (no `role`/`content` keys) or `ContentBlock` (no `text`/`image`/etc. keys), so the method fell through to `messages is None` and raised a generic `ValueError`.

When the interrupt state IS activated, this code path is never reached because line 926-927 returns `[]` early. The bug only surfaces when the agent is not in interrupt state — typically in stateless/serverless setups where the agent is reconstructed per request.

## Fix

Added a detection branch in `_convert_prompt_to_messages` that recognizes `interruptResponse` payloads and raises a specific, actionable error message guiding users to preserve the agent instance or use session management.

## Test

Added `test_agent__call__resume_interrupt_not_activated` — verifies that passing interrupt responses to a non-interrupt agent raises the new specific `ValueError` instead of the generic one.

**All 114 agent tests + 16 interrupt tests pass.**

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.