### PR TITLE
fix: prevent leading slash in S3 keys when prefix is empty (#1863)

### DIFF
--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -95,7 +95,10 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             ValueError: If session id contains a path separator.
         """
         session_id = _identifier.validate(session_id, _identifier.Identifier.SESSION)
-        return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
+        session_key = f"{SESSION_PREFIX}{session_id}/"
+        if self.prefix:
+            return f"{self.prefix}/{session_key}"
+        return session_key
 
     def _get_agent_path(self, session_id: str, agent_id: str) -> str:
         """Get agent S3 prefix.


### PR DESCRIPTION
## Summary

Fix `S3SessionManager._get_session_path()` producing S3 keys with a leading slash when `prefix=""` (the default), causing session restore to silently fail on MinIO and S3-compatible backends.

## Root cause

```python
# Before: prefix="" produces "/session_<id>/..."
return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
```

MinIO strips the leading `/` on write, storing `session_<id>/...`, but reads use `/session_<id>/...` which never matches. `read_agent()` returns `None`, `initialize()` takes the new-session branch, and the agent starts fresh every time.

## Fix

```python
session_key = f"{SESSION_PREFIX}{session_id}/"
if self.prefix:
    return f"{self.prefix}/{session_key}"
return session_key
```

Only prepend `prefix/` when prefix is non-empty. All downstream methods (`_get_agent_path`, `_get_message_path`) call `_get_session_path`, so they are all fixed.

Fixes #1863

## Test plan

- [ ] `S3SessionManager(prefix="")` → keys have no leading slash
- [ ] `S3SessionManager(prefix="my-prefix")` → keys are `my-prefix/session_<id>/...`
- [ ] Session restore works on MinIO with empty prefix