### PR TITLE
fix: recognize Bedrock application inference profile ARNs for caching (#1705)

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -186,6 +186,11 @@ class BedrockModel(Model):
         model_id = self.config.get("model_id", "").lower()
         if "claude" in model_id or "anthropic" in model_id:
             return "anthropic"
+        # Application inference profile ARNs don't contain model names.
+        # When the user explicitly enables caching via cache_config, assume Anthropic
+        # strategy for Bedrock ARNs since only Anthropic models currently support it.
+        if model_id.startswith("arn:") and "bedrock" in model_id:
+            return "anthropic"
         return None
 
     @override


### PR DESCRIPTION
## Summary

Fix `_cache_strategy` to recognize Bedrock application inference profile ARNs, which don't contain "claude" or "anthropic" in the model ID string.

## Root cause

Application inference profile ARNs look like:
```
arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123
```

`_cache_strategy` only checked `"claude" in model_id or "anthropic" in model_id`, which fails for these ARNs. This caused a warning on every API call and silently disabled caching even when the user explicitly set `cache_config=CacheConfig(strategy="auto")`.

## Fix

Also return `"anthropic"` strategy when the model_id is a Bedrock ARN (`arn:...bedrock...`), since only Anthropic models currently support prompt caching on Bedrock.

Fixes #1705