### PR TITLE
fix(telemetry): add common gen_ai attributes to event_loop_cycle spans

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -521,9 +521,10 @@ class Tracer:
         event_loop_cycle_id = str(invocation_state.get("event_loop_cycle_id"))
         parent_span = parent_span if parent_span else invocation_state.get("event_loop_parent_span")
 
-        attributes: dict[str, AttributeValue] = {
-            "event_loop.cycle_id": event_loop_cycle_id,
-        }
+        attributes: dict[str, AttributeValue] = self._get_common_attributes(
+            operation_name="execute_event_loop_cycle"
+        )
+        attributes["event_loop.cycle_id"] = event_loop_cycle_id
 
         if custom_trace_attributes:
             attributes.update(custom_trace_attributes)

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -631,6 +631,8 @@ def test_start_event_loop_cycle_span(mock_tracer):
 
         mock_span.set_attributes.assert_called_once_with(
             {
+                "gen_ai.operation.name": "execute_event_loop_cycle",
+                "gen_ai.system": "strands-agents",
                 "event_loop.cycle_id": "cycle-123",
                 "request_id": "req-456",
                 "trace_level": "debug",
@@ -660,7 +662,13 @@ def test_start_event_loop_cycle_span_latest_conventions(mock_tracer, monkeypatch
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "execute_event_loop_cycle"
 
-        mock_span.set_attributes.assert_called_once_with({"event_loop.cycle_id": "cycle-123"})
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "execute_event_loop_cycle",
+                "gen_ai.provider.name": "strands-agents",
+                "event_loop.cycle_id": "cycle-123",
+            }
+        )
         mock_span.add_event.assert_any_call(
             "gen_ai.client.inference.operation.details",
             attributes={


### PR DESCRIPTION
## Summary

Fixes #1876 — `execute_event_loop_cycle` spans are missing `gen_ai.system`/`gen_ai.provider.name` and `gen_ai.operation.name` common attributes.

## Root Cause

`start_event_loop_cycle_span()` was the only span start method that did not call `_get_common_attributes()`:

| Method | Calls `_get_common_attributes()` |
|---|---|
| `start_model_invoke_span` | ✅ |
| `start_tool_call_span` | ✅ |
| `start_agent_span` | ✅ |
| `start_multiagent_span` | ✅ |
| `start_event_loop_cycle_span` | ❌ (before this fix) |

This caused `execute_event_loop_cycle` spans to carry `gen_ai.input.messages` (added by `_add_event_messages()` since #1768) but lack the identification attributes that downstream OTEL tooling relies on.

## Fix

Added `_get_common_attributes('execute_event_loop_cycle')` to the span attributes initialization, producing:

**Standard conventions:**
- `gen_ai.system: strands-agents`
- `gen_ai.operation.name: execute_event_loop_cycle`

**Latest conventions** (`OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`):
- `gen_ai.provider.name: strands-agents`
- `gen_ai.operation.name: execute_event_loop_cycle`

## Tests

Updated both existing event loop cycle span tests to verify the common attributes are present. All 74 tracer tests pass.