### PR TITLE
fix: handle missing usage metadata on premature Anthropic stream termination

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -396,6 +396,7 @@ class AnthropicModel(Model):
         Raises:
             ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: If the request is throttled by Anthropic.
+            RuntimeError: If the stream ends before final usage metadata is available.
         """
         logger.debug("formatting request")
         request = self.format_request(messages, tool_specs, system_prompt, tool_choice)
@@ -410,17 +411,14 @@ class AnthropicModel(Model):
                     if event.type in AnthropicModel.EVENT_TYPES:
                         yield self.format_chunk(event.model_dump())
 
-                usage = getattr(getattr(event, "message", None), "usage", None) if event else None
-                if usage is not None:
-                    yield self.format_chunk({"type": "metadata", "usage": usage.model_dump()})
-                else:
-                    logger.warning("stream ended without usage metadata (possible premature termination)")
-                    yield self.format_chunk(
-                        {
-                            "type": "metadata",
-                            "usage": {"input_tokens": 0, "output_tokens": 0},
-                        }
-                    )
+                if event is None:
+                    raise RuntimeError("Anthropic stream terminated before receiving any events")
+
+                usage = getattr(getattr(event, "message", None), "usage", None)
+                if usage is None:
+                    raise RuntimeError("Anthropic stream ended without usage metadata")
+
+                yield self.format_chunk({"type": "metadata", "usage": usage.model_dump()})
 
         except anthropic.RateLimitError as error:
             raise ModelThrottledException(str(error)) from error

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -740,10 +740,10 @@ async def test_stream(anthropic_client, model, agenerator, alist):
 
 @pytest.mark.asyncio
 async def test_stream_premature_termination(anthropic_client, model, agenerator, alist):
-    """Test that stream handles premature termination without crashing.
+    """Test that stream fails clearly on premature termination.
 
     When the Anthropic API stream ends before message_stop (e.g. network
-    timeout), event.message.usage may be None. The code must not crash
+    timeout), the request should fail with a clear error instead of crashing
     with AttributeError.
 
     Regression test for #1868.
@@ -766,16 +766,13 @@ async def test_stream_premature_termination(anthropic_client, model, agenerator,
     messages = [{"role": "user", "content": [{"text": "hello"}]}]
     response = model.stream(messages, None, None)
 
-    # Should not raise AttributeError
-    tru_events = await alist(response)
-
-    # Should still yield a metadata event with zero usage
-    assert any("metadata" in str(e) for e in tru_events)
+    with pytest.raises(RuntimeError, match="without usage metadata"):
+        await alist(response)
 
 
 @pytest.mark.asyncio
 async def test_stream_empty_no_events(anthropic_client, model, agenerator, alist):
-    """Test that stream handles an empty event sequence without crashing."""
+    """Test that an empty stream fails clearly."""
     mock_context = unittest.mock.AsyncMock()
     mock_context.__aenter__.return_value = agenerator([])
     anthropic_client.messages.stream.return_value = mock_context
@@ -783,11 +780,12 @@ async def test_stream_empty_no_events(anthropic_client, model, agenerator, alist
     messages = [{"role": "user", "content": [{"text": "hello"}]}]
     response = model.stream(messages, None, None)
 
-    # Should not raise UnboundLocalError or AttributeError
-    tru_events = await alist(response)
+    with pytest.raises(RuntimeError, match="before receiving any events"):
+        await alist(response)
 
-    # Should still yield a metadata event with zero usage
-    assert any("metadata" in str(e) for e in tru_events)
+
+@pytest.mark.asyncio
+async def test_stream_rate_limit_error(anthropic_client, model, alist):
     anthropic_client.messages.stream.side_effect = anthropic.RateLimitError(
         "rate limit", response=unittest.mock.Mock(), body=None
     )


### PR DESCRIPTION
## Problem

When the Anthropic API stream terminates before sending the `message_stop` event (e.g., network timeout, connection reset, server error mid-stream), `AnthropicModel.stream()` crashes with `AttributeError`.

**Crash site**:
```python
usage = event.message.usage  # type: ignore
yield self.format_chunk({"type": "metadata", "usage": usage.model_dump()})
```

Two failure modes:
1. **Empty stream**: the `event` variable is never assigned by the `async for` loop → `UnboundLocalError`
2. **Premature termination**: the last `event` lacks a `.message` attribute or `.message.usage` is `None` → `AttributeError`

## Root Cause

The code unconditionally accesses `event.message.usage` after the async iteration loop, assuming the Anthropic stream always completes normally with usage metadata. That assumption fails when the connection drops before the final usage-bearing event arrives.

## Fix

1. Initialize `event = None` before the loop
2. Keep the safe post-loop access pattern, but **fail clearly** instead of silently synthesizing zero-usage metadata
3. Raise explicit `RuntimeError`s for:
   - empty stream: `Anthropic stream terminated before receiving any events`
   - incomplete stream: `Anthropic stream ended without usage metadata`
4. Split the stray rate-limit assertions back into their own regression test

This keeps normal successful streams unchanged, but ensures interrupted requests fail clearly instead of masking a broken connection.

## Tests

Added / updated regression coverage for:
- `test_stream_premature_termination`
- `test_stream_empty_no_events`
- `test_stream_rate_limit_error`

Local validation:
- `ruff check src/strands/models/anthropic.py tests/strands/models/test_anthropic.py`
- `ruff format --check src/strands/models/anthropic.py tests/strands/models/test_anthropic.py`
- `pytest -q tests/strands/models/test_anthropic.py` → `44 passed`
- runtime proof script covering:
  - normal completion still yielding metadata
  - premature termination raising a clear error
  - empty stream raising a clear error

Fixes #1868
