### PR TITLE
fix: suppress Pydantic serialization warnings from ParsedTextBlock

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -7,6 +7,7 @@ import base64
 import json
 import logging
 import mimetypes
+import warnings
 from collections.abc import AsyncGenerator
 from typing import Any, TypedDict, TypeVar, cast
 
@@ -407,7 +408,19 @@ class AnthropicModel(Model):
                 logger.debug("got response from model")
                 async for event in stream:
                     if event.type in AnthropicModel.EVENT_TYPES:
-                        yield self.format_chunk(event.model_dump())
+                        # Suppress Pydantic serialization warnings from ParsedTextBlock.
+                        # Anthropic SDK >= 0.84.0 returns ParsedTextBlock objects that have
+                        # extra fields (parsed, parsed_output) not in the Message.content
+                        # union type, triggering PydanticSerializationUnexpectedValue warnings
+                        # during model_dump(). The serialized dict is correct regardless.
+                        with warnings.catch_warnings():
+                            warnings.filterwarnings(
+                                "ignore",
+                                message="Expected `.*` - serialized value may not be as expected",
+                                category=UserWarning,
+                            )
+                            event_dict = event.model_dump()
+                        yield self.format_chunk(event_dict)
 
                 usage = event.message.usage  # type: ignore
                 yield self.format_chunk({"type": "metadata", "usage": usage.model_dump()})

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -739,6 +739,48 @@ async def test_stream(anthropic_client, model, agenerator, alist):
 
 
 @pytest.mark.asyncio
+async def test_stream_suppresses_pydantic_serialization_warnings(anthropic_client, model, agenerator, alist):
+    """Verify that Pydantic serialization warnings from ParsedTextBlock are suppressed.
+
+    Anthropic SDK >= 0.84.0 returns ParsedTextBlock objects whose extra fields
+    trigger PydanticSerializationUnexpectedValue warnings during model_dump().
+    These warnings should not propagate to stderr.
+    """
+    import warnings as _warnings
+
+    def model_dump_with_warning():
+        _warnings.warn(
+            "Expected `ParsedTextBlock[TypeVar]` - serialized value may not be as expected",
+            UserWarning,
+            stacklevel=1,
+        )
+        return {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": "hello"}}
+
+    mock_event_1 = unittest.mock.Mock(type="content_block_start", model_dump=model_dump_with_warning)
+    mock_event_2 = unittest.mock.Mock(
+        type="done",
+        message=unittest.mock.Mock(
+            usage=unittest.mock.Mock(
+                model_dump=lambda: {"input_tokens": 1, "output_tokens": 2},
+            )
+        ),
+    )
+
+    mock_context = unittest.mock.AsyncMock()
+    mock_context.__aenter__.return_value = agenerator([mock_event_1, mock_event_2])
+    anthropic_client.messages.stream.return_value = mock_context
+
+    messages = [{"role": "user", "content": [{"text": "hello"}]}]
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        await alist(model.stream(messages, None, None))
+
+    pydantic_warnings = [w for w in caught if "serialized value may not be as expected" in str(w.message)]
+    assert len(pydantic_warnings) == 0, f"Pydantic warnings leaked: {pydantic_warnings}"
+
+
+@pytest.mark.asyncio
 async def test_stream_rate_limit_error(anthropic_client, model, alist):
     anthropic_client.messages.stream.side_effect = anthropic.RateLimitError(
         "rate limit", response=unittest.mock.Mock(), body=None


### PR DESCRIPTION
## Problem

Every agent invocation using `AnthropicModel` with Anthropic SDK >= 0.84.0 produces 6+ Pydantic serialization warnings on stderr:

```
PydanticSerializationUnexpectedValue(Expected `ParsedTextBlock[TypeVar]` - serialized value may not be as expected ...)
PydanticSerializationUnexpectedValue(Expected `ThinkingBlock` - serialized value may not be as expected ...)
PydanticSerializationUnexpectedValue(Expected `RedactedThinkingBlock` - serialized value may not be as expected ...)
PydanticSerializationUnexpectedValue(Expected `ToolUseBlock` - serialized value may not be as expected ...)
PydanticSerializationUnexpectedValue(Expected `ServerToolUseBlock` - serialized value may not be as expected ...)
PydanticSerializationUnexpectedValue(Expected `WebSearchToolResultBlock` - serialized value may not be as expected ...)
```

The agent functions correctly — results, tool calls, and metrics are all accurate — but stderr is cluttered with noisy warnings on every call.

## Root Cause

Anthropic SDK >= 0.84.0 returns `ParsedTextBlock` objects in streaming responses. `ParsedTextBlock` has extra fields (`parsed`, `parsed_output`) that are not part of the `Message.content` discriminated union type. When `event.model_dump()` is called in the `stream()` method, Pydantic's serializer fails to match `ParsedTextBlock` against any variant in the union and emits a warning for each variant it tries.

## Fix

Wrap `event.model_dump()` in `warnings.catch_warnings()` to suppress the specific `PydanticSerializationUnexpectedValue` warning pattern. This is safe because:

1. The serialized dict is functionally correct — `ParsedTextBlock` dumps to the same structure as `TextBlock` (with optional extra fields that `format_chunk()` ignores)
2. The warning is purely cosmetic (Pydantic still produces the correct output)
3. The filter is scoped: only suppresses the specific "serialized value may not be as expected" pattern during `model_dump()`, not globally

## Tests

Added `test_stream_suppresses_pydantic_serialization_warnings` — creates a mock event whose `model_dump()` emits the warning, then verifies the warning doesn't propagate.

All 43 existing tests continue to pass.

Fixes #1865