### PR TITLE
fix(session): prevent leading slash in S3 keys when prefix is empty

### DIFF
--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -95,7 +95,9 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             ValueError: If session id contains a path separator.
         """
         session_id = _identifier.validate(session_id, _identifier.Identifier.SESSION)
-        return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
+        if self.prefix:
+            return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
+        return f"{SESSION_PREFIX}{session_id}/"
 
     def _get_agent_path(self, session_id: str, agent_id: str) -> str:
         """Get agent S3 prefix.

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -481,3 +481,28 @@ def test_update_nonexistent_multi_agent(s3_manager, sample_session):
     nonexistent_mock.id = "nonexistent"
     with pytest.raises(SessionException):
         s3_manager.update_multi_agent(sample_session.session_id, nonexistent_mock)
+
+
+def test_empty_prefix_no_leading_slash(mocked_aws, s3_bucket):
+    """Regression test for #1863: empty prefix must not produce leading slash in S3 keys."""
+    manager = S3SessionManager(session_id="test", bucket=s3_bucket, prefix="", region_name="us-west-2")
+    path = manager._get_session_path("my-session")
+    assert not path.startswith("/"), f"Path should not start with '/' but got: {path}"
+    assert path == "session_my-session/"
+
+
+def test_nonempty_prefix_preserves_structure(mocked_aws, s3_bucket):
+    """Ensure non-empty prefix still produces correct paths."""
+    manager = S3SessionManager(session_id="test", bucket=s3_bucket, prefix="my-prefix", region_name="us-west-2")
+    path = manager._get_session_path("my-session")
+    assert path == "my-prefix/session_my-session/"
+
+
+def test_empty_prefix_session_roundtrip(mocked_aws, s3_bucket):
+    """Verify sessions can be created and read back with empty prefix."""
+    manager = S3SessionManager(session_id="test", bucket=s3_bucket, prefix="", region_name="us-west-2")
+    session = Session(session_id="roundtrip-123", session_type=SessionType.AGENT)
+    manager.create_session(session)
+    restored = manager.read_session("roundtrip-123")
+    assert restored is not None
+    assert restored.session_id == "roundtrip-123"


### PR DESCRIPTION
## Summary

Fixes #1863 — S3SessionManager with empty prefix produces leading slash in S3 keys, causing session restore failure on MinIO and S3-compatible backends.

## Root Cause

`_get_session_path` always uses `f"{self.prefix}/{SESSION_PREFIX}{session_id}/"`, which produces `/session_<id>/...` when `prefix=""` (the default).

MinIO and some S3-compatible backends strip the leading slash on write, storing as `session_<id>/...`, but reads use `/session_<id>/...` which never matches. `read_agent()` returns `None`, `initialize()` takes the new-session branch, and the agent starts fresh every time.

## Fix

```python
# Before
return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"

# After
if self.prefix:
    return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
return f"{SESSION_PREFIX}{session_id}/"
```

## Tests

Added 3 regression tests:
- `test_empty_prefix_no_leading_slash` — verifies no leading `/` in path
- `test_nonempty_prefix_preserves_structure` — ensures non-empty prefix still works correctly
- `test_empty_prefix_session_roundtrip` — full create/read cycle with empty prefix

All 41 tests pass:
```
41 passed in 4.88s
```