### PR TITLE
Fix: preventing leading slash in S3/MinIO keys when prefix is empty

### DIFF
--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -95,7 +95,9 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             ValueError: If session id contains a path separator.
         """
         session_id = _identifier.validate(session_id, _identifier.Identifier.SESSION)
-        return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
+        if self.prefix:
+            return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
+        return f"{SESSION_PREFIX}{session_id}/"
 
     def _get_agent_path(self, session_id: str, agent_id: str) -> str:
         """Get agent S3 prefix.


### PR DESCRIPTION
## Description
Fixes an issue where the S3 session manager fails when the prefix is empty.

Previously, an empty prefix caused incorrect handling during S3 session initialization.  
This change ensures that empty prefixes are handled safely while maintaining existing behavior for valid prefixes.

## Related Issues
Fixes #1863

## Documentation PR
N/A

## Type of Change
Bug fix

## Testing
Tested locally by running the S3 session flow with:
- empty prefix
- valid prefix

Both scenarios now behave as expected.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

This change is backward compatible and does not affect existing S3 prefix behavior.