### PR TITLE
fix(event-loop): ensure all cycle metrics include end time and duration

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -560,8 +560,9 @@ async def _handle_tool_execution(
     if cycle_span:
         tracer.end_event_loop_cycle_span(span=cycle_span, message=message, tool_result_message=tool_result_message)
 
+    agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
+
     if invocation_state["request_state"].get("stop_event_loop", False) or structured_output_context.stop_loop:
-        agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
         yield EventLoopStopEvent(
             stop_reason,
             message,

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -1084,3 +1084,51 @@ async def test_invalid_tool_names_adds_tool_uses(agent, model, alist):
         ],
         "role": "user",
     }
+
+
+@pytest.mark.asyncio
+async def test_event_loop_metrics_recorded_before_recursion(
+    agent,
+    model,
+    tool,
+    agenerator,
+    alist,
+):
+    model.stream.side_effect = [
+        agenerator(
+            [
+                {
+                    "contentBlockStart": {
+                        "start": {
+                            "toolUse": {
+                                "toolUseId": "t1",
+                                "name": tool.tool_spec["name"],
+                            },
+                        },
+                    },
+                },
+                {"contentBlockStop": {}},
+                {"messageStop": {"stopReason": "tool_use"}},
+            ]
+        ),
+        agenerator(
+            [
+                {"contentBlockDelta": {"delta": {"text": "test text"}}},
+                {"contentBlockStop": {}},
+            ]
+        ),
+    ]
+
+    with unittest.mock.patch.object(agent.event_loop_metrics, "end_cycle") as mock_end_cycle:
+        stream = strands.event_loop.event_loop.event_loop_cycle(
+            agent=agent,
+            invocation_state={"request_state": {}},
+        )
+        events = await alist(stream)
+
+        # Verify end_cycle was called once for tool cycle, once for text cycle
+        assert mock_end_cycle.call_count == 2
+
+        # Verify the event loop completed successfully
+        tru_stop_reason, _, _, _, _, _ = events[-1]["stop"]
+        assert tru_stop_reason == "end_turn"


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Event loop cycle metrics (`end_time` and `duration`) were not being recorded for cycles that ended with a recursive call. This caused `total_duration` and `average_cycle_time` in the response metrics to be inaccurate, making it difficult to monitor agent performance in multi-cycle invocations.

Response metric traces would like like this, where `total_duration` is only including the Cycle 2 duration:
```json
{
  "total_cycles": 2,
  "total_duration": 2.97,
  "traces": [
    {
      "name": "Cycle 1",
      "start_time": 1772822921.485906,
      "end_time": null,
      "duration": null,
      "children": [
        {
          "name": "stream_messages",
          "start_time": 1772822921.486195,
          "end_time": 1772822924.446701,
          "duration": 2.96
        },
        {
          "name": "Tool: tool_name",
          "start_time": 1772822924.447283,
          "end_time": 1772822931.842052,
          "duration": 7.39
        },
        {
          "name": "Recursive call",
          "start_time": 1772822931.842254,
          "end_time": 1772822934.810739,
          "duration": 2.97
        }
      ]
    },
    {
      "name": "Cycle 2",
      "start_time": 1772822931.842278,
      "end_time": 1772822934.810579,
      "duration": 2.97,
      "children": [
        {
          "name": "stream_messages",
          "start_time": 1772822931.842385,
          "end_time": 1772822934.810402,
          "duration": 2.97
        }
      ]
    }
  ]
}
```


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

Tested locally with recursive call scenarios, verified cycle metrics now include accurate `end_time` and `duration` values

Cycle 1 duration includes all child durations except the recursive call.
```json
{
  "total_cycles": 2,
  "total_duration": 14.80,
  "traces": [
    {
      "name": "Cycle 1",
      "start_time": 1772825264.482746,
      "end_time": 1772825275.644092,
      "duration": 11.16,
      "children": [
        {
          "name": "stream_messages",
          "start_time": 1772825264.483011,
          "end_time": 1772825267.999054,
          "duration": 3.52
        },
        {
          "name": "Tool: tool_name",
          "start_time": 1772825268.000930,
          "end_time": 1772825275.643905,
          "duration": 7.64
        },
        {
          "name": "Recursive call",
          "start_time": 1772825275.644141,
          "end_time": 1772825279.281506,
          "duration": 3.64
        }
      ]
    },
    {
      "name": "Cycle 2",
      "start_time": 1772825275.644161,
      "end_time": 1772825279.281480,
      "duration": 3.64,
      "children": [
        {
          "name": "stream_messages",
          "start_time": 1772825275.644274,
          "end_time": 1772825279.281442,
          "duration": 3.64
        }
      ]
    }
  ]
}
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
