### PR TITLE
fix: pass config params to structured_output in OpenAIResponsesModel

### DIFF
--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -16,6 +16,7 @@ The Responses API is OpenAI's newer API that differs from the Chat Completions A
 """
 
 import base64
+import copy
 import json
 import logging
 import mimetypes
@@ -412,7 +413,7 @@ class OpenAIResponsesModel(Model):
             "model": self.config["model_id"],
             "input": input_items,
             "stream": True,
-            **cast(dict[str, Any], self.config.get("params", {})),
+            **copy.deepcopy(cast(dict[str, Any], self.config.get("params", {}))),
         }
 
         if system_prompt:

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -356,13 +356,21 @@ class OpenAIResponsesModel(Model):
             ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: If the request is throttled by OpenAI (rate limits).
         """
+        request = self._format_request(prompt, system_prompt=system_prompt)
+
+        excluded_keys = {"model", "input", "stream"}
+        parse_kwargs: dict[str, Any] = {
+            "model": request["model"],
+            "input": request["input"],
+            "text_format": output_model,
+        }
+        for key, value in request.items():
+            if key not in excluded_keys:
+                parse_kwargs.setdefault(key, value)
+
         async with openai.AsyncOpenAI(**self.client_args) as client:
             try:
-                response = await client.responses.parse(
-                    model=self.get_config()["model_id"],
-                    input=self._format_request(prompt, system_prompt=system_prompt)["input"],
-                    text_format=output_model,
-                )
+                response = await client.responses.parse(**parse_kwargs)
             except openai.BadRequestError as e:
                 if hasattr(e, "code") and e.code == "context_length_exceeded":
                     logger.warning(_CONTEXT_WINDOW_OVERFLOW_MSG)

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -634,6 +634,54 @@ async def test_structured_output(openai_client, model, test_output_model_cls, al
 
 
 @pytest.mark.asyncio
+async def test_structured_output_passes_config_params(openai_client, test_output_model_cls, alist):
+    """Test that structured_output passes config params (max_output_tokens, reasoning, etc.) to responses.parse."""
+    model = OpenAIResponsesModel(
+        model_id="gpt-5.4",
+        params={
+            "max_output_tokens": 500,
+            "reasoning": {"effort": "high"},
+        },
+    )
+
+    messages = [{"role": "user", "content": [{"text": "Generate a person"}]}]
+
+    mock_parsed_instance = test_output_model_cls(name="Alice", age=25)
+    mock_response = unittest.mock.Mock(output_parsed=mock_parsed_instance)
+    openai_client.responses.parse = unittest.mock.AsyncMock(return_value=mock_response)
+
+    events = await alist(model.structured_output(test_output_model_cls, messages))
+
+    assert events[-1] == {"output": test_output_model_cls(name="Alice", age=25)}
+
+    call_kwargs = openai_client.responses.parse.call_args.kwargs
+    assert call_kwargs["model"] == "gpt-5.4"
+    assert call_kwargs["text_format"] == test_output_model_cls
+    assert call_kwargs["max_output_tokens"] == 500
+    assert call_kwargs["reasoning"] == {"effort": "high"}
+    assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_structured_output_passes_instructions(openai_client, test_output_model_cls, alist):
+    """Test that structured_output passes system_prompt as instructions to responses.parse."""
+    model = OpenAIResponsesModel(model_id="gpt-4o")
+
+    messages = [{"role": "user", "content": [{"text": "Generate a person"}]}]
+
+    mock_parsed_instance = test_output_model_cls(name="Bob", age=40)
+    mock_response = unittest.mock.Mock(output_parsed=mock_parsed_instance)
+    openai_client.responses.parse = unittest.mock.AsyncMock(return_value=mock_response)
+
+    events = await alist(model.structured_output(test_output_model_cls, messages, system_prompt="Be helpful"))
+
+    assert events[-1] == {"output": test_output_model_cls(name="Bob", age=40)}
+
+    call_kwargs = openai_client.responses.parse.call_args.kwargs
+    assert call_kwargs["instructions"] == "Be helpful"
+
+
+@pytest.mark.asyncio
 async def test_stream_context_overflow_exception(openai_client, model, messages):
     """Test that OpenAI context overflow errors are properly converted to ContextWindowOverflowException."""
     mock_error = openai.BadRequestError(


### PR DESCRIPTION
## Description

`OpenAIResponsesModel.structured_output()` silently drops all config params (`max_output_tokens`, `reasoning`, `instructions`, etc.) because it only extracts `["input"]` from the `_format_request()` result.

This fix builds `parse_kwargs` from the full `_format_request()` output, excluding `model`/`input` (already handled explicitly) and `stream` (hardcoded as `True` by `_format_request()`, incompatible with `parse()`). Other params pass through directly, letting the API/SDK validate incompatible combinations.

Resolves: #1908

## Related Issues

#1908

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- `test_structured_output_passes_config_params` — verifies `max_output_tokens` and `reasoning` are forwarded, `stream` is excluded
- `test_structured_output_passes_instructions` — verifies `system_prompt` is forwarded as `instructions`
- Verified with live API calls against `gpt-5.4` that `responses.parse()` correctly accepts `max_output_tokens`, `reasoning`, and `instructions`

---

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
