### PR TITLE
fix: s3session manager bug

### DIFF
--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -95,7 +95,10 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             ValueError: If session id contains a path separator.
         """
         session_id = _identifier.validate(session_id, _identifier.Identifier.SESSION)
-        return f"{self.prefix}/{SESSION_PREFIX}{session_id}/"
+        prefix = self.prefix.strip("/")
+        if prefix:
+            return f"{prefix}/{SESSION_PREFIX}{session_id}/"
+        return f"{SESSION_PREFIX}{session_id}/"
 
     def _get_agent_path(self, session_id: str, agent_id: str) -> str:
         """Get agent S3 prefix.

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -89,6 +89,17 @@ def test_init_s3_session_manager_with_existing_user_agent(mocked_aws, s3_bucket)
     assert "strands-agents" in session_manager.client.meta.config.user_agent_extra
 
 
+def test_empty_prefix_session_roundtrip(mocked_aws, s3_bucket, sample_session, sample_agent):
+    """Test that session data can be written and read back with default empty prefix."""
+    manager = S3SessionManager(session_id="test", bucket=s3_bucket, prefix="", region_name="us-west-2")
+    manager.create_session(sample_session)
+    manager.create_agent(sample_session.session_id, sample_agent)
+
+    result = manager.read_agent(sample_session.session_id, sample_agent.agent_id)
+    assert result is not None
+    assert result.agent_id == sample_agent.agent_id
+
+
 def test_create_session(s3_manager, sample_session):
     """Test creating a session in S3."""
     result = s3_manager.create_session(sample_session)
@@ -367,6 +378,24 @@ def test_update_nonexistent_message(s3_manager, sample_session, sample_agent, sa
     # Update message
     with pytest.raises(SessionException):
         s3_manager.update_message(sample_session.session_id, sample_agent.agent_id, sample_message)
+
+
+@pytest.mark.parametrize(
+    "prefix, expected_path",
+    [
+        ("", "session_test-id/"),
+        ("sessions", "sessions/session_test-id/"),
+        ("sessions/", "sessions/session_test-id/"),
+        ("/sessions", "sessions/session_test-id/"),
+        ("/sessions/", "sessions/session_test-id/"),
+        ("a/b/c", "a/b/c/session_test-id/"),
+        ("a/b/c/", "a/b/c/session_test-id/"),
+    ],
+)
+def test__get_session_path_prefix_normalization(mocked_aws, s3_bucket, prefix, expected_path):
+    """Test that _get_session_path normalizes prefix to avoid leading or double slashes."""
+    manager = S3SessionManager(session_id="test", bucket=s3_bucket, prefix=prefix, region_name="us-west-2")
+    assert manager._get_session_path("test-id") == expected_path
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

S3SessionManager with the default empty prefix (prefix="") produces S3 keys with a leading slash (e.g., /session_abc/agents/agent_default/agent.json). S3-compatible backends like MinIO normalize keys by stripping leading slashes on write, but the SDK reads using the original key with the leading slash. This mismatch causes read_agent() to return None, so the agent always takes the new-session branch on restore — silently discarding previous conversation history.

A related issue exists when users pass a prefix with a trailing slash (e.g., prefix="sessions/"), which produces double slashes in keys (sessions//session_abc/...).

```python
# All of these now produce consistent, correct keys:
S3SessionManager(session_id="s1", bucket="b", prefix="")           # session_s1/...
S3SessionManager(session_id="s1", bucket="b", prefix="sessions")   # sessions/session_s1/...
S3SessionManager(session_id="s1", bucket="b", prefix="sessions/")  # sessions/session_s1/...
S3SessionManager(session_id="s1", bucket="b", prefix="/sessions/") # sessions/session_s1/...
```

## Related Issues

<!-- Link to related issues using #issue-number format -->
#1863 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
