### PR TITLE
fix: handle None text in message content sanitization

### DIFF
--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -82,15 +82,19 @@ def _normalize_messages(messages: Messages) -> Messages:
                         replaced_tool_names = True
 
             if has_tool_use:
-                # Remove blank 'text' items for assistant messages
+                # Remove blank or None 'text' items for assistant messages
                 before_len = len(content)
-                content[:] = [item for item in content if "text" not in item or item["text"].strip()]
+                content[:] = [
+                    item
+                    for item in content
+                    if "text" not in item or (item["text"] is not None and item["text"].strip())
+                ]
                 if not removed_blank_message_content_text and before_len != len(content):
                     removed_blank_message_content_text = True
             else:
-                # Replace blank 'text' with '[blank text]' for assistant messages
+                # Replace blank or None 'text' with '[blank text]' for assistant messages
                 for item in content:
-                    if "text" in item and not item["text"].strip():
+                    if "text" in item and (item["text"] is None or not item["text"].strip()):
                         replaced_blank_message_content_text = True
                         item["text"] = "[blank text]"
 
@@ -136,15 +140,19 @@ def remove_blank_messages_content_text(messages: Messages) -> Messages:
                 continue
 
             if has_tool_use:
-                # Remove blank 'text' items for assistant messages
+                # Remove blank or None 'text' items for assistant messages
                 before_len = len(content)
-                content[:] = [item for item in content if "text" not in item or item["text"].strip()]
+                content[:] = [
+                    item
+                    for item in content
+                    if "text" not in item or (item["text"] is not None and item["text"].strip())
+                ]
                 if not removed_blank_message_content_text and before_len != len(content):
                     removed_blank_message_content_text = True
             else:
-                # Replace blank 'text' with '[blank text]' for assistant messages
+                # Replace blank or None 'text' with '[blank text]' for assistant messages
                 for item in content:
-                    if "text" in item and not item["text"].strip():
+                    if "text" in item and (item["text"] is None or not item["text"].strip()):
                         replaced_blank_message_content_text = True
                         item["text"] = "[blank text]"
 

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -100,6 +100,24 @@ def test_remove_blank_messages_content_text(messages, exp_result):
             ],
             id="missing tool name",
         ),
+        pytest.param(
+            [
+                {"role": "assistant", "content": [{"text": None}, {"toolUse": {"name": "a_name"}}]},
+            ],
+            [
+                {"role": "assistant", "content": [{"toolUse": {"name": "a_name"}}]},
+            ],
+            id="none text with tool use",
+        ),
+        pytest.param(
+            [
+                {"role": "assistant", "content": [{"text": None}]},
+            ],
+            [
+                {"role": "assistant", "content": [{"text": "[blank text]"}]},
+            ],
+            id="none text without tool use",
+        ),
     ],
 )
 def test_normalize_blank_messages_content_text(messages, exp_result):


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
`_normalize_messages` and `remove_blank_messages_content_text` call `.strip()` on `item["text"]` without guarding against `None`. When a model provider (e.g. Gemini) returns a content block with `{"text": None}`, this causes `TypeError: expected string or bytes-like object, got 'NoneType'`.

Add explicit `None` checks before calling `.strip()`:
- With tool_use: None text items are removed (same as blank text)
- Without tool_use: None text is replaced with "[blank text]" (same as blank)

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->
Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
