### PR TITLE
fix: update README documentation links from /latest/ to /docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <div>
     <a href="https://strandsagents.com">
-      <img src="https://strandsagents.com/latest/assets/logo-github.svg" alt="Strands Agents" width="55px" height="105px">
+      <img src="https://strandsagents.com/docs/assets/logo-github.svg" alt="Strands Agents" width="55px" height="105px">
     </a>
   </div>
 
@@ -169,21 +169,21 @@ response = agent("Tell me about Agentic AI")
 ```
 
 Built-in providers:
- - [Amazon Bedrock](https://strandsagents.com/latest/user-guide/concepts/model-providers/amazon-bedrock/)
- - [Anthropic](https://strandsagents.com/latest/user-guide/concepts/model-providers/anthropic/)
- - [Gemini](https://strandsagents.com/latest/user-guide/concepts/model-providers/gemini/)
- - [Cohere](https://strandsagents.com/latest/user-guide/concepts/model-providers/cohere/)
- - [LiteLLM](https://strandsagents.com/latest/user-guide/concepts/model-providers/litellm/)
- - [llama.cpp](https://strandsagents.com/latest/user-guide/concepts/model-providers/llamacpp/)
- - [LlamaAPI](https://strandsagents.com/latest/user-guide/concepts/model-providers/llamaapi/)
- - [MistralAI](https://strandsagents.com/latest/user-guide/concepts/model-providers/mistral/)
- - [Ollama](https://strandsagents.com/latest/user-guide/concepts/model-providers/ollama/)
- - [OpenAI](https://strandsagents.com/latest/user-guide/concepts/model-providers/openai/)
- - [OpenAI Responses API](https://strandsagents.com/latest/user-guide/concepts/model-providers/openai/)
- - [SageMaker](https://strandsagents.com/latest/user-guide/concepts/model-providers/sagemaker/)
- - [Writer](https://strandsagents.com/latest/user-guide/concepts/model-providers/writer/)
+ - [Amazon Bedrock](https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/)
+ - [Anthropic](https://strandsagents.com/docs/user-guide/concepts/model-providers/anthropic/)
+ - [Gemini](https://strandsagents.com/docs/user-guide/concepts/model-providers/gemini/)
+ - [Cohere](https://strandsagents.com/docs/user-guide/concepts/model-providers/cohere/)
+ - [LiteLLM](https://strandsagents.com/docs/user-guide/concepts/model-providers/litellm/)
+ - [llama.cpp](https://strandsagents.com/docs/user-guide/concepts/model-providers/llamacpp/)
+ - [LlamaAPI](https://strandsagents.com/docs/user-guide/concepts/model-providers/llamaapi/)
+ - [MistralAI](https://strandsagents.com/docs/user-guide/concepts/model-providers/mistral/)
+ - [Ollama](https://strandsagents.com/docs/user-guide/concepts/model-providers/ollama/)
+ - [OpenAI](https://strandsagents.com/docs/user-guide/concepts/model-providers/openai/)
+ - [OpenAI Responses API](https://strandsagents.com/docs/user-guide/concepts/model-providers/openai/)
+ - [SageMaker](https://strandsagents.com/docs/user-guide/concepts/model-providers/sagemaker/)
+ - [Writer](https://strandsagents.com/docs/user-guide/concepts/model-providers/writer/)
 
-Custom providers can be implemented using [Custom Providers](https://strandsagents.com/latest/user-guide/concepts/model-providers/custom_model_provider/)
+Custom providers can be implemented using [Custom Providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/custom_model_provider/)
 
 ### Example tools
 
@@ -202,7 +202,7 @@ It's also available on GitHub via [strands-agents/tools](https://github.com/stra
 
 > **⚠️ Experimental Feature**: Bidirectional streaming is currently in experimental status. APIs may change in future releases as we refine the feature based on user feedback and evolving model capabilities.
 
-Build real-time voice and audio conversations with persistent streaming connections. Unlike traditional request-response patterns, bidirectional streaming maintains long-running conversations where users can interrupt, provide continuous input, and receive real-time audio responses. Get started with your first BidiAgent by following the [Quickstart](https://strandsagents.com/latest/documentation/docs/user-guide/concepts/experimental/bidirectional-streaming/quickstart) guide. 
+Build real-time voice and audio conversations with persistent streaming connections. Unlike traditional request-response patterns, bidirectional streaming maintains long-running conversations where users can interrupt, provide continuous input, and receive real-time audio responses. Get started with your first BidiAgent by following the [Quickstart](https://strandsagents.com/docs/user-guide/quickstart/) guide. 
 
 **Supported Model Providers:**
 - Amazon Nova Sonic (v1, v2)
@@ -301,11 +301,11 @@ await agent.run(
 For detailed guidance & examples, explore our documentation:
 
 - [User Guide](https://strandsagents.com/)
-- [Quick Start Guide](https://strandsagents.com/latest/user-guide/quickstart/)
-- [Agent Loop](https://strandsagents.com/latest/user-guide/concepts/agents/agent-loop/)
-- [Examples](https://strandsagents.com/latest/examples/)
-- [API Reference](https://strandsagents.com/latest/api-reference/agent/)
-- [Production & Deployment Guide](https://strandsagents.com/latest/user-guide/deploy/operating-agents-in-production/)
+- [Quick Start Guide](https://strandsagents.com/docs/user-guide/quickstart/)
+- [Agent Loop](https://strandsagents.com/docs/user-guide/concepts/agents/agent-loop/)
+- [Examples](https://strandsagents.com/docs/examples/)
+- [API Reference](https://strandsagents.com/docs/api/python/)
+- [Production & Deployment Guide](https://strandsagents.com/docs/user-guide/deploy/operating-agents-in-production/)
 
 ## Contributing ❤️
 


### PR DESCRIPTION
## Summary

Fixes #1905.

The `strandsagents.com` docs site URL structure changed from `/latest/...` to `/docs/...`, causing all documentation links in README.md to return 404.

## Changes

- Replace `/latest/` with `/docs/` across all 19 provider and guide links
- Fix doubled path in bidirectional streaming quickstart link (`/docs/documentation/docs/...` → `/docs/user-guide/quickstart/`)
- Update API Reference link to correct `/docs/api/python/` path

## Verification

All updated links verified as returning HTTP 200:
- All 12 model provider links ✅
- Quickstart, Agent Loop, Examples, Production Guide ✅
- API Reference ✅
- Custom provider link ✅