### PR TITLE
fix: lowercase the python language in code snippet

### DIFF
--- a/src/strands/types/interrupt.py
+++ b/src/strands/types/interrupt.py
@@ -16,7 +16,7 @@ Interrupt Flow:
     ```
 
 Example:
-    ```Python
+    ```python
     from typing import Any
 
     from strands import Agent, tool


### PR DESCRIPTION


## Description
Lowercase the python language in code snippet - the docs build keeps complaining about it

## Type of Change


Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
