### PR TITLE
fix: openai repsonses api error handling

### DIFF
--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -294,14 +294,14 @@ class OpenAIResponsesModel(Model):
                             if hasattr(event, "response") and hasattr(event.response, "usage"):
                                 final_usage = event.response.usage
                             break
-            except openai.BadRequestError as e:
+            except openai.APIError as e:
                 if hasattr(e, "code") and e.code == "context_length_exceeded":
                     logger.warning(_CONTEXT_WINDOW_OVERFLOW_MSG)
                     raise ContextWindowOverflowException(str(e)) from e
+                if isinstance(e, openai.RateLimitError):
+                    logger.warning(_RATE_LIMIT_MSG)
+                    raise ModelThrottledException(str(e)) from e
                 raise
-            except openai.RateLimitError as e:
-                logger.warning(_RATE_LIMIT_MSG)
-                raise ModelThrottledException(str(e)) from e
 
             # Close current content block if we had any
             if data_type:

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -654,6 +654,26 @@ async def test_stream_context_overflow_exception(openai_client, model, messages)
 
 
 @pytest.mark.asyncio
+async def test_stream_context_overflow_exception_api_error_type(openai_client, model, messages):
+    """Test that OpenAI context overflow errors are properly converted to ContextWindowOverflowException."""
+    mock_error = openai.APIError(
+        message="This model's maximum context length is 4096 tokens.",
+        request=unittest.mock.MagicMock(),
+        body={"error": {"code": "context_length_exceeded"}},
+    )
+    mock_error.code = "context_length_exceeded"
+
+    openai_client.responses.create.side_effect = mock_error
+
+    with pytest.raises(ContextWindowOverflowException) as exc_info:
+        async for _ in model.stream(messages):
+            pass
+
+    assert "maximum context length" in str(exc_info.value)
+    assert exc_info.value.__cause__ == mock_error
+
+
+@pytest.mark.asyncio
 async def test_stream_rate_limit_as_throttle(openai_client, model, messages):
     """Test that rate limit errors are converted to ModelThrottledException."""
     mock_error = openai.RateLimitError(

--- a/tests_integ/models/test_model_openai.py
+++ b/tests_integ/models/test_model_openai.py
@@ -225,16 +225,15 @@ def _rate_limit_params():
     return params
 
 
-@pytest.mark.parametrize("model_class,model_id", _rate_limit_params())
-def test_rate_limit_throttling_integration_no_retries(model_class, model_id):
+def test_rate_limit_throttling_integration_no_retries():
     """Integration test for rate limit handling with retries disabled.
 
     This test verifies that when a request exceeds OpenAI's rate limits,
     the model properly raises a ModelThrottledException. We disable retries
     to avoid waiting for the exponential backoff during testing.
     """
-    model = model_class(
-        model_id=model_id,
+    model = OpenAIModel(
+        model_id="gpt-4o",
         client_args={
             "api_key": os.getenv("OPENAI_API_KEY"),
         },


### PR DESCRIPTION
## Description
Fix failing openai responses api integ test:
```
FAILED tests_integ/models/test_model_openai.py::test_context_window_overflow_integration[OpenAIResponsesModel-gpt-4o-mini-2024-07-18] - Failed: DID NOT RAISE <class 'strands.types.exceptions.ContextWindowOverflowException'>
```

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
