### PR TITLE
feat: add endpoint_url parameter to S3SessionManager

### DIFF
--- a/strands-py/src/strands/session/s3_session_manager.py
+++ b/strands-py/src/strands/session/s3_session_manager.py
@@ -51,6 +51,7 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
         boto_session: boto3.Session | None = None,
         boto_client_config: BotocoreConfig | None = None,
         region_name: str | None = None,
+        endpoint_url: str | None = None,
         **kwargs: Any,
     ):
         """Initialize S3SessionManager with S3 storage.
@@ -63,6 +64,8 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             boto_session: Optional boto3 session
             boto_client_config: Optional boto3 client configuration
             region_name: AWS region for S3 storage
+            endpoint_url: Custom endpoint URL for S3-compatible storage backends (e.g., MinIO, LocalStack)
+                or VPC endpoints (PrivateLink)
             **kwargs: Additional keyword arguments for future extensibility.
         """
         self.bucket = bucket
@@ -82,7 +85,7 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
         else:
             client_config = BotocoreConfig(user_agent_extra="strands-agents")
 
-        self.client = session.client(service_name="s3", config=client_config)
+        self.client = session.client(service_name="s3", config=client_config, endpoint_url=endpoint_url)
         super().__init__(session_id=session_id, session_repository=self)
 
     def _get_session_path(self, session_id: str) -> str:

--- a/strands-py/tests/strands/session/test_s3_session_manager.py
+++ b/strands-py/tests/strands/session/test_s3_session_manager.py
@@ -89,6 +89,13 @@ def test_init_s3_session_manager_with_existing_user_agent(mocked_aws, s3_bucket)
     assert "strands-agents" in session_manager.client.meta.config.user_agent_extra
 
 
+def test_init_s3_session_manager_with_endpoint_url(mocked_aws, s3_bucket, monkeypatch):
+    custom_endpoint = "http://localhost:9000"
+    monkeypatch.setenv("MOTO_S3_CUSTOM_ENDPOINTS", custom_endpoint)
+    session_manager = S3SessionManager(session_id="test", bucket=s3_bucket, endpoint_url=custom_endpoint)
+    assert session_manager.client.meta.endpoint_url == custom_endpoint
+
+
 def test_empty_prefix_session_roundtrip(mocked_aws, s3_bucket, sample_session, sample_agent):
     """Test that session data can be written and read back with default empty prefix."""
     manager = S3SessionManager(session_id="test", bucket=s3_bucket, prefix="", region_name="us-west-2")


### PR DESCRIPTION
## Description

Add `endpoint_url` parameter to `S3SessionManager`, enabling use with S3-compatible storage backends (e.g., MinIO, LocalStack) and VPC endpoints. This aligns with the existing `BedrockModel` pattern.

```python
session_manager = S3SessionManager(
    session_id="my-session",
    bucket="my-bucket",
    endpoint_url="http://localhost:9000",
)
```

Resolves: #1794

## Related Issues

#1794

## Documentation PR

N/A

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.