### PR TITLE
fix: pin upper bound for mistralai dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,8 @@ a2a = [
 ]
 
 bidi = [
-    "aws_sdk_bedrock_runtime; python_version>='3.12'",
-    "smithy-aws-core>=0.0.1; python_version>='3.12'",
+    "aws_sdk_bedrock_runtime>=0.4.0,<1.0.0; python_version>='3.12'",
+    "smithy-aws-core>=0.4.0,<1.0.0; python_version>='3.12'",
 ]
 bidi-io = [
     "prompt_toolkit>=3.0.0,<4.0.0",


### PR DESCRIPTION
## Description

Currently Mistral model provider is broken, because we do not have an upper bound in our deps, and they just released 2.0 

This pins the upper version of mistralai

Also pins versions for Bedrock Bidi clients, so we don't run into the same issue. We should have upper bounds for everything

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1924

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
