### PR TITLE
feat: handle reasoning summary events from OpenAI Responses API

### DIFF
--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -219,8 +219,14 @@ class OpenAIResponsesModel(Model):
 
                 async for event in response:
                     if hasattr(event, "type"):
-                        if event.type == "response.reasoning_text.delta":
-                            # Reasoning content streaming (for o1/o3 reasoning models)
+                        if event.type in (
+                            "response.reasoning_text.delta",
+                            "response.reasoning_summary_text.delta",
+                        ):
+                            # Reasoning content streaming:
+                            # - response.reasoning_text.delta: encrypted reasoning (o1/o3 models)
+                            # - response.reasoning_summary_text.delta: readable reasoning summaries
+                            #   (GPT-5.x+ models with reasoning.summary="auto"|"concise"|"detailed")
                             chunks, data_type = self._stream_switch_content("reasoning_content", data_type)
                             for chunk in chunks:
                                 yield chunk
@@ -232,6 +238,15 @@ class OpenAIResponsesModel(Model):
                                         "data": event.delta,
                                     }
                                 )
+
+                        elif event.type in (
+                            "response.reasoning_summary_part.added",
+                            "response.reasoning_summary_part.done",
+                            "response.reasoning_summary_text.done",
+                        ):
+                            # Metadata events for reasoning summaries — content is already
+                            # handled via the delta events above
+                            pass
 
                         elif event.type == "response.output_text.delta":
                             # Text content streaming

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -484,7 +484,9 @@ class OpenAIResponsesModel(Model):
             formatted_contents = [
                 cls._format_request_message_content(content, role=role)
                 for content in contents
-                if not any(block_type in content for block_type in ["toolResult", "toolUse"])
+                if not any(
+                    block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent"]
+                )
             ]
 
             formatted_tool_calls = [


### PR DESCRIPTION
## Summary

GPT-5.x models with `reasoning.summary="auto"|"concise"|"detailed"` emit `response.reasoning_summary_text.delta` events for readable reasoning summaries. The existing handler only covers `response.reasoning_text.delta` (used by o1/o3 for encrypted reasoning), so reasoning summary content is silently dropped during streaming.

This PR adds:
- Handling for `response.reasoning_summary_text.delta` — treated identically to `response.reasoning_text.delta`, emitting `reasoningContent` content blocks
- Pass-through for associated metadata events (`response.reasoning_summary_part.added/done`, `response.reasoning_summary_text.done`)

## Motivation

When using GPT-5.4 with `reasoning={"effort": "low", "summary": "auto"}` through `OpenAIResponsesModel`, the API returns reasoning summaries as `response.reasoning_summary_text.delta` events. Without this fix, those events are ignored and no `reasoningContent` blocks appear in the stream — even though the model is actively reasoning.

Tested by comparing `stream_async()` output with and without this change:
- **Before**: 0 reasoning events in the stream
- **After**: reasoning content blocks stream correctly with `delta.keys: ['reasoningContent']`

## Test plan
- [x] All 2395 existing unit tests pass (`hatch test`)
- [x] Formatter passes (`hatch fmt --formatter`)  
- [x] Linter passes (`hatch fmt --linter`)
- [ ] Manual verification: `stream_async()` with GPT-5.4-mini + `reasoning.summary="auto"` produces `reasoningContent` content blocks