### PR TITLE
fix: CRITICAL: Hard pin `litellm<=1.82.6` to mitigate supply chain attack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.21.0,<1.0.0"]
 gemini = ["google-genai>=1.32.0,<2.0.0"]
-litellm = ["litellm>=1.75.9,<2.0.0", "openai>=1.68.0,<3.0.0"]
+litellm = ["litellm>=1.75.9,<=1.82.6", "openai>=1.68.0,<3.0.0"]
 llamaapi = ["llama-api-client>=0.1.0,<1.0.0"]
 mistral = ["mistralai>=1.8.2,<2.0.0"]
 ollama = ["ollama>=0.4.8,<1.0.0"]


### PR DESCRIPTION
## Description
There seems to be a vulnerability issue in the newer version of `litellm` (Malicious file is `litellm_init.pth`) and the owner's account is compromised, you can check the issue below.

## Related Issues

Relates to https://github.com/BerriAI/litellm/issues/24512

https://futuresearch.ai/blog/litellm-pypi-supply-chain-attack/
