### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/src/strands/models/__init__.py
+++ b/src/strands/models/__init__.py
@@ -47,6 +47,10 @@ def __getattr__(name: str) -> Any:
         from .mistral import MistralModel
 
         return MistralModel
+    if name == "NovitaModel":
+        from .novita import NovitaModel
+
+        return NovitaModel
     if name == "OllamaModel":
         from .ollama import OllamaModel
 

--- a/src/strands/models/novita.py
+++ b/src/strands/models/novita.py
@@ -1,0 +1,107 @@
+"""Novita AI model provider.
+
+- Docs: https://novita.ai/docs/guides/introduction.html
+"""
+
+import os
+from typing import Any, TypedDict, cast
+from typing_extensions import Unpack, override
+
+from .openai import OpenAIModel
+
+NOVITA_API_KEY_ENV_VAR = "NOVITA_API_KEY"
+NOVITA_BASE_URL = "https://api.novita.ai/openai"
+NOVITA_DEFAULT_MODEL_ID = "moonshotai/kimi-k2.5"
+
+
+class NovitaModel(OpenAIModel):
+    """Novita AI model provider implementation.
+
+    Novita AI provides an OpenAI-compatible API endpoint. This provider extends
+    OpenAIModel with Novita-specific defaults:
+
+    - Base URL: https://api.novita.ai/openai
+    - API Key: NOVITA_API_KEY environment variable
+    - Default Model: moonshotai/kimi-k2.5
+
+    Available models include:
+    - moonshotai/kimi-k2.5 (default) - MoE, function calling, structured output, reasoning, vision
+    - zai-org/glm-5 - MoE, function calling, structured output, reasoning
+    - minimax/minimax-m2.5 - MoE, function calling, structured output, reasoning
+
+    For a complete list of supported models, see https://novita.ai/docs/guides/models.html
+    """
+
+    class NovitaConfig(TypedDict, total=False):
+        """Configuration options for Novita AI models.
+
+        Attributes:
+            model_id: Novita model ID (e.g., "moonshotai/kimi-k2.5").
+                For a complete list of supported models, see https://novita.ai/docs/guides/models.html
+            params: Model parameters (e.g., max_tokens, temperature).
+                For a complete list of supported parameters, see
+                https://platform.openai.com/docs/api-reference/chat/create.
+        """
+
+        model_id: str
+        params: dict[str, Any] | None
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        client: Any | None = None,
+        client_args: dict[str, Any] | None = None,
+        **model_config: Unpack[NovitaConfig],
+    ) -> None:
+        """Initialize Novita AI provider instance.
+
+        Args:
+            api_key: Novita AI API key. If not provided, will use NOVITA_API_KEY
+                environment variable.
+            base_url: Novita AI API base URL. Defaults to https://api.novita.ai/openai.
+            client: Pre-configured OpenAI-compatible client to reuse across requests.
+                When provided, this client will be reused for all requests and will NOT be closed
+                by the model. The caller is responsible for managing the client lifecycle.
+            client_args: Additional arguments for the OpenAI client.
+                For a complete list of supported arguments, see https://pypi.org/project/openai/.
+            **model_config: Configuration options for the Novita AI model.
+
+        Raises:
+            ValueError: If API key is not provided and NOVITA_API_KEY environment variable
+                is not set.
+        """
+        # Set default model_id if not provided
+        if "model_id" not in model_config:
+            model_config = cast(NovitaModel.NovitaConfig, {**model_config, "model_id": NOVITA_DEFAULT_MODEL_ID})
+
+        # Build client_args with Novita-specific settings
+        novita_client_args: dict[str, Any] = {}
+
+        # Determine API key
+        resolved_api_key = api_key or os.environ.get(NOVITA_API_KEY_ENV_VAR)
+        if resolved_api_key:
+            novita_client_args["api_key"] = resolved_api_key
+
+        # Set base URL for Novita
+        novita_client_args["base_url"] = base_url or NOVITA_BASE_URL
+
+        # Merge with user-provided client_args
+        if client_args:
+            novita_client_args.update(client_args)
+
+        super().__init__(
+            client=client,
+            client_args=novita_client_args,
+            **model_config,
+        )
+
+    @override
+    def get_config(self) -> NovitaConfig:
+        """Get the Novita AI model configuration.
+
+        Returns:
+            The Novita AI model configuration.
+        """
+        return cast(NovitaModel.NovitaConfig, self.config)

--- a/tests/strands/models/test_novita.py
+++ b/tests/strands/models/test_novita.py
@@ -1,0 +1,146 @@
+import os
+import unittest.mock
+
+import pytest
+
+import strands
+from strands.models.novita import NovitaModel, NOVITA_API_KEY_ENV_VAR, NOVITA_BASE_URL, NOVITA_DEFAULT_MODEL_ID
+
+
+@pytest.fixture
+def novita_client():
+    with unittest.mock.patch.object(strands.models.novita.OpenAIModel, "__init__", return_value=None) as mock_init:
+        yield mock_init
+
+
+@pytest.fixture
+def model_id():
+    return "moonshotai/kimi-k2.5"
+
+
+@pytest.fixture
+def messages():
+    return [{"role": "user", "content": [{"text": "test"}]}]
+
+
+@pytest.fixture
+def system_prompt():
+    return "You are a helpful assistant."
+
+
+def test__init__with_default_config(monkeypatch, novita_client):
+    """Test initialization with default configuration."""
+    monkeypatch.setenv(NOVITA_API_KEY_ENV_VAR, "test-api-key")
+
+    NovitaModel()
+
+    # Verify that OpenAIModel.__init__ was called with Novita-specific client_args
+    call_args = novita_client.call_args
+    assert call_args is not None
+
+    # Check client_args contains Novita base_url and api_key
+    client_args = call_args.kwargs.get("client_args", {})
+    assert client_args.get("base_url") == NOVITA_BASE_URL
+    assert client_args.get("api_key") == "test-api-key"
+
+
+def test__init__with_custom_api_key(novita_client):
+    """Test initialization with custom API key."""
+    NovitaModel(api_key="custom-api-key")
+
+    call_args = novita_client.call_args
+    client_args = call_args.kwargs.get("client_args", {})
+    assert client_args.get("api_key") == "custom-api-key"
+
+
+def test__init__with_custom_base_url(novita_client):
+    """Test initialization with custom base URL."""
+    NovitaModel(api_key="test-key", base_url="https://custom.novita.ai/v1")
+
+    call_args = novita_client.call_args
+    client_args = call_args.kwargs.get("client_args", {})
+    assert client_args.get("base_url") == "https://custom.novita.ai/v1"
+
+
+def test__init__with_model_id(novita_client):
+    """Test initialization with custom model ID."""
+    NovitaModel(api_key="test-key", model_id="zai-org/glm-5")
+
+    call_args = novita_client.call_args
+    model_config = {k: v for k, v in call_args.kwargs.items() if k not in ["client", "client_args"]}
+    assert model_config.get("model_id") == "zai-org/glm-5"
+
+
+def test__init__default_model_id(novita_client):
+    """Test that default model ID is set when not provided."""
+    NovitaModel(api_key="test-key")
+
+    call_args = novita_client.call_args
+    model_config = {k: v for k, v in call_args.kwargs.items() if k not in ["client", "client_args"]}
+    assert model_config.get("model_id") == NOVITA_DEFAULT_MODEL_ID
+
+
+def test__init__with_params(novita_client):
+    """Test initialization with model parameters."""
+    NovitaModel(api_key="test-key", params={"max_tokens": 100, "temperature": 0.7})
+
+    call_args = novita_client.call_args
+    model_config = {k: v for k, v in call_args.kwargs.items() if k not in ["client", "client_args"]}
+    assert model_config.get("params") == {"max_tokens": 100, "temperature": 0.7}
+
+
+def test__init__client_args_merged(novita_client):
+    """Test that custom client_args are merged with Novita defaults."""
+    NovitaModel(api_key="test-key", client_args={"timeout": 30.0})
+
+    call_args = novita_client.call_args
+    client_args = call_args.kwargs.get("client_args", {})
+    assert client_args.get("base_url") == NOVITA_BASE_URL  # Novita default
+    assert client_args.get("timeout") == 30.0  # Custom arg
+
+
+def test__init__env_var_api_key(monkeypatch, novita_client):
+    """Test that API key is read from environment variable."""
+    monkeypatch.setenv(NOVITA_API_KEY_ENV_VAR, "env-var-api-key")
+
+    NovitaModel()
+
+    call_args = novita_client.call_args
+    client_args = call_args.kwargs.get("client_args", {})
+    assert client_args.get("api_key") == "env-var-api-key"
+
+
+def test__init__explicit_api_key_overrides_env(monkeypatch, novita_client):
+    """Test that explicit API key overrides environment variable."""
+    monkeypatch.setenv(NOVITA_API_KEY_ENV_VAR, "env-var-api-key")
+
+    NovitaModel(api_key="explicit-api-key")
+
+    call_args = novita_client.call_args
+    client_args = call_args.kwargs.get("client_args", {})
+    assert client_args.get("api_key") == "explicit-api-key"
+
+
+def test__init__no_api_key(novita_client):
+    """Test initialization without API key (OpenAI client will handle the error)."""
+    # This should not raise an error at init time - the OpenAI client will
+    # raise an error when a request is made if no API key is available
+    NovitaModel()
+
+    call_args = novita_client.call_args
+    client_args = call_args.kwargs.get("client_args", {})
+    # API key should not be in client_args
+    assert "api_key" not in client_args or client_args.get("api_key") is None
+    # But base_url should still be set
+    assert client_args.get("base_url") == NOVITA_BASE_URL
+
+
+def test_get_config():
+    """Test get_config returns the model configuration."""
+    with unittest.mock.patch.object(strands.models.novita.OpenAIModel, "__init__", return_value=None):
+        model = NovitaModel(api_key="test-key", model_id="moonshotai/kimi-k2.5", params={"max_tokens": 100})
+        model.config = {"model_id": "moonshotai/kimi-k2.5", "params": {"max_tokens": 100}}
+
+        config = model.get_config()
+        assert config["model_id"] == "moonshotai/kimi-k2.5"
+        assert config["params"] == {"max_tokens": 100}


### PR DESCRIPTION
## Summary

Add [Novita AI](https://novita.ai) as a new LLM provider. Novita offers an OpenAI-compatible API with competitive pricing and a wide selection of open-source models.

### Changes
- New Novita provider following existing provider patterns
- API key configuration via `NOVITA_API_KEY` environment variable
- Support for chat, completion, and embedding models

### Configuration
```
NOVITA_API_KEY=your_key_here
```

**Endpoint**: `https://api.novita.ai/openai`