### PR TITLE
chore: remove Cohere from required integ test providers

### DIFF
--- a/tests_integ/conftest.py
+++ b/tests_integ/conftest.py
@@ -202,7 +202,6 @@ def _load_api_keys_from_secrets_manager():
 
     required_providers = {
         "ANTHROPIC_API_KEY",
-        "COHERE_API_KEY",
         "MISTRAL_API_KEY",
         "OPENAI_API_KEY",
         "WRITER_API_KEY",


### PR DESCRIPTION
## Description

The Cohere API key used in CI is being revoked out of an abundance of safety after the LiteLLM dependency chain issue. While we sort out a proper key, removing it from the required providers list prevents the entire integration test session from failing when the key is absent.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Verified the required_providers set no longer includes `COHERE_API_KEY`, so a missing key results in skipped tests rather than a session-level failure.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
