### PR TITLE
fix(anthropic): normalize ParsedTextBlock to avoid Pydantic serialization warnings

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -11,6 +11,7 @@ from collections.abc import AsyncGenerator
 from typing import Any, TypedDict, TypeVar, cast
 
 import anthropic
+from anthropic.types import TextBlock
 from pydantic import BaseModel
 from typing_extensions import Required, Unpack, override
 
@@ -254,6 +255,33 @@ class AnthropicModel(Model):
         else:
             return {}
 
+    @staticmethod
+    def _normalize_event(event: Any) -> Any:
+        """Normalize Anthropic stream event to avoid Pydantic serialization warnings.
+
+        The Anthropic SDK returns ParsedTextBlock (a TextBlock subclass with an extra
+        ``parsed_output`` field) in ``content_block_start`` events.  Because the event's
+        ``content_block`` field is typed as a discriminated union of known block types,
+        calling ``model_dump()`` on the event triggers PydanticSerializationUnexpectedValue
+        warnings — even though serialization succeeds.
+
+        This method converts any ParsedTextBlock back to a plain TextBlock so that the
+        discriminated union matches cleanly and no warnings are emitted.
+        """
+        try:
+            from anthropic.types.parsed_message import ParsedTextBlock
+        except ImportError:
+            return event
+
+        if event.type == "content_block_start" and isinstance(event.content_block, ParsedTextBlock):
+            event.content_block = TextBlock(
+                text=event.content_block.text,
+                type=event.content_block.type,
+                citations=event.content_block.citations,
+            )
+
+        return event
+
     def format_chunk(self, event: dict[str, Any]) -> StreamEvent:
         """Format the Anthropic response events into standardized message chunks.
 
@@ -407,7 +435,7 @@ class AnthropicModel(Model):
                 logger.debug("got response from model")
                 async for event in stream:
                     if event.type in AnthropicModel.EVENT_TYPES:
-                        yield self.format_chunk(event.model_dump())
+                        yield self.format_chunk(self._normalize_event(event).model_dump())
 
                 usage = event.message.usage  # type: ignore
                 yield self.format_chunk({"type": "metadata", "usage": usage.model_dump()})

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -933,3 +933,58 @@ def test_format_request_filters_location_source_document(model, model_id, max_to
     ]
     assert tru_request["messages"] == exp_messages
     assert "Location sources are not supported by Anthropic" in caplog.text
+
+
+def test_normalize_event_converts_parsed_text_block(model):
+    """Test that _normalize_event converts ParsedTextBlock to TextBlock.
+
+    When the Anthropic SDK returns ParsedTextBlock objects in content_block_start events,
+    calling model_dump() on the event triggers PydanticSerializationUnexpectedValue warnings
+    because ParsedTextBlock doesn't match the discriminated union. The _normalize_event method
+    should convert ParsedTextBlock to plain TextBlock to avoid these warnings.
+    """
+    from anthropic.types import TextBlock
+    from anthropic.types.parsed_message import ParsedTextBlock
+
+    parsed_block = ParsedTextBlock(text="Hello, world!", type="text", citations=None, parsed_output=None)
+
+    # Create a mock event that looks like a content_block_start event
+    mock_event = unittest.mock.MagicMock()
+    mock_event.type = "content_block_start"
+    mock_event.content_block = parsed_block
+
+    normalized = AnthropicModel._normalize_event(mock_event)
+
+    # content_block should now be a plain TextBlock, not ParsedTextBlock
+    assert type(normalized.content_block) is TextBlock
+    assert not isinstance(normalized.content_block, ParsedTextBlock)
+    assert normalized.content_block.text == "Hello, world!"
+    assert normalized.content_block.type == "text"
+    assert normalized.content_block.citations is None
+
+
+def test_normalize_event_preserves_non_parsed_blocks(model):
+    """Test that _normalize_event leaves non-ParsedTextBlock events unchanged."""
+    from anthropic.types import TextBlock
+
+    text_block = TextBlock(text="Normal text", type="text", citations=None)
+
+    mock_event = unittest.mock.MagicMock()
+    mock_event.type = "content_block_start"
+    mock_event.content_block = text_block
+
+    normalized = AnthropicModel._normalize_event(mock_event)
+
+    # Should be left untouched — same object
+    assert normalized.content_block is text_block
+
+
+def test_normalize_event_ignores_non_content_block_events(model):
+    """Test that _normalize_event ignores events that aren't content_block_start."""
+    mock_event = unittest.mock.MagicMock()
+    mock_event.type = "message_start"
+
+    normalized = AnthropicModel._normalize_event(mock_event)
+
+    # Should pass through unchanged
+    assert normalized is mock_event


### PR DESCRIPTION
## Issue

Closes #1865

## Description

When using strands-agents with Anthropic SDK >= v0.84.0, every agent invocation emits 6+ `PydanticSerializationUnexpectedValue` warnings on stderr:

```
PydanticSerializationUnexpectedValue(Expected `ParsedTextBlock[TypeVar]` - serialized value may not be as expected ...)
PydanticSerializationUnexpectedValue(Expected `ThinkingBlock` - serialized value may not be as expected ...)
PydanticSerializationUnexpectedValue(Expected `RedactedThinkingBlock` - serialized value may not be as expected ...)
...
```

### Root Cause

The Anthropic SDK returns `ParsedTextBlock` objects (a `TextBlock` subclass with an extra `parsed_output` field) in `content_block_start` events. The event's `content_block` field is typed as a Pydantic discriminated union of known block types. `ParsedTextBlock` is not in that union, so `model_dump()` triggers warnings — even though serialization succeeds.

### Fix

Add a `_normalize_event()` static method that converts `ParsedTextBlock` back to a plain `TextBlock` before calling `model_dump()`. This preserves all content data (text, type, citations) while removing the spurious `parsed_output` field that triggers the discriminated union mismatch.

**Key details:**
- The import of `ParsedTextBlock` is guarded with try/except for forward compatibility
- Non-`content_block_start` events pass through unchanged (zero overhead)
- Events with normal `TextBlock` (not `ParsedTextBlock`) are also passed through unchanged

## Testing

Added 3 unit tests:
- `test_normalize_event_converts_parsed_text_block`: Verifies ParsedTextBlock → TextBlock conversion
- `test_normalize_event_preserves_non_parsed_blocks`: Verifies normal TextBlock left untouched
- `test_normalize_event_ignores_non_content_block_events`: Verifies non-content events pass through

All 45 existing tests pass (1 pre-existing failure in `test_structured_output` unrelated to this change).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

> ⚠️ This reopens #1875 which was accidentally closed due to fork deletion.