### PR TITLE
fix(graph): prevent reset_executor_state from corrupting MultiAgentBase state

### DIFF
--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -240,7 +240,7 @@ class GraphNode:
         if hasattr(self.executor, "messages"):
             self._initial_messages = copy.deepcopy(self.executor.messages)
 
-        if hasattr(self.executor, "state") and hasattr(self.executor.state, "get"):
+        if hasattr(self.executor, "state") and isinstance(self.executor.state, AgentState):
             self._initial_state = AgentState(self.executor.state.get())
 
         if hasattr(self.executor, "_model_state"):
@@ -255,7 +255,7 @@ class GraphNode:
         if hasattr(self.executor, "messages"):
             self.executor.messages = copy.deepcopy(self._initial_messages)
 
-        if hasattr(self.executor, "state") and hasattr(self.executor.state, "get"):
+        if hasattr(self.executor, "state") and isinstance(self.executor.state, AgentState):
             self.executor.state = AgentState(self._initial_state.get())
 
         if hasattr(self.executor, "_model_state"):

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -255,7 +255,7 @@ class GraphNode:
         if hasattr(self.executor, "messages"):
             self.executor.messages = copy.deepcopy(self._initial_messages)
 
-        if hasattr(self.executor, "state"):
+        if hasattr(self.executor, "state") and hasattr(self.executor.state, "get"):
             self.executor.state = AgentState(self._initial_state.get())
 
         if hasattr(self.executor, "_model_state"):

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2767,3 +2767,37 @@ class TestConditionSignatureDetection:
 
         cond = lambda state: len(state.completed_nodes) > 0  # noqa: E731
         assert not _is_context_condition(cond)
+
+
+@pytest.mark.asyncio
+async def test_reset_executor_state_preserves_graph_state_for_nested_graph():
+    """Verify reset_executor_state does not corrupt MultiAgentBase state.
+
+    When a GraphNode wraps a MultiAgentBase executor (e.g. a nested Graph),
+    reset_executor_state() must not overwrite GraphState with AgentState.
+    Regression test for #1775.
+    """
+    inner_agent = create_mock_agent("inner", "inner response")
+    inner_builder = GraphBuilder()
+    inner_builder.add_node(inner_agent, "inner_node")
+    inner_builder.set_entry_point("inner_node")
+    inner_graph = inner_builder.build()
+
+    # inner_graph.state is a GraphState, not AgentState
+    assert isinstance(inner_graph.state, GraphState)
+
+    node = GraphNode(node_id="nested", executor=inner_graph)
+
+    # Simulate a completed execution
+    node.execution_status = Status.COMPLETED
+    node.result = NodeResult(result=MagicMock(), status=Status.COMPLETED)
+
+    # Reset should NOT corrupt the nested graph's state
+    node.reset_executor_state()
+
+    # After reset, the executor's state must still be GraphState
+    assert isinstance(inner_graph.state, GraphState), (
+        "reset_executor_state overwrote GraphState with AgentState"
+    )
+    assert node.execution_status == Status.PENDING
+    assert node.result is None

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2796,8 +2796,6 @@ async def test_reset_executor_state_preserves_graph_state_for_nested_graph():
     node.reset_executor_state()
 
     # After reset, the executor's state must still be GraphState
-    assert isinstance(inner_graph.state, GraphState), (
-        "reset_executor_state overwrote GraphState with AgentState"
-    )
+    assert isinstance(inner_graph.state, GraphState), "reset_executor_state overwrote GraphState with AgentState"
     assert node.execution_status == Status.PENDING
     assert node.result is None


### PR DESCRIPTION
## Summary

Fixes #1775 — `GraphNode.reset_executor_state()` corrupts `MultiAgentBase` executor state by overwriting `GraphState` with `AgentState`.

## Root Cause

`reset_executor_state()` checks `hasattr(self.executor, 'state')` without verifying the state type:

```python
# Before (broken)
if hasattr(self.executor, 'state'):
    self.executor.state = AgentState(self._initial_state.get())  # Overwrites GraphState!
```

`__post_init__` already had the correct guard (`hasattr(self.executor.state, 'get')`), but `reset_executor_state()` was missing it.

## Impact

Two call sites affected:
| Call site | Trigger |
|---|---|
| `_execute_node` | `reset_on_revisit=True` with nested graph in a cycle |
| `deserialize_state` | **Always** — iterates all nodes when restoring a completed run |

## Fix

Mirror the `__post_init__` guard:

```python
# After (fixed)
if hasattr(self.executor, 'state') and hasattr(self.executor.state, 'get'):
    self.executor.state = AgentState(self._initial_state.get())
```

## Test

Added `test_reset_executor_state_preserves_graph_state_for_nested_graph` — creates a `GraphNode` with a nested `Graph` executor and verifies `reset_executor_state()` preserves the `GraphState` type.

All 49 graph tests pass.

> ⚠️ This reopens #1896 which was accidentally closed due to fork deletion.