### PR TITLE
feat(a2a): add `agent_card_url` property to `A2AServer` for customizable `url` in `AgentCard`

### DIFF
--- a/strands-py/src/strands/multiagent/a2a/server.py
+++ b/strands-py/src/strands/multiagent/a2a/server.py
@@ -105,6 +105,7 @@ class A2AServer:
             push_sender=push_sender,
         )
         self._agent_skills = skills
+        self._agent_card_url: str | None = None
         logger.info("Strands' integration with A2A is experimental. Be aware of frequent breaking changes.")
 
     def _parse_public_url(self, url: str) -> tuple[str, str]:
@@ -148,7 +149,7 @@ class A2AServer:
         return AgentCard(
             name=self.name,
             description=self.description,
-            url=self.http_url,
+            url=self.agent_card_url,
             version=self.version,
             skills=self.agent_skills,
             default_input_modes=["text"],
@@ -169,6 +170,24 @@ class A2AServer:
             AgentSkill(name=config["name"], id=config["name"], description=config["description"], tags=[])
             for config in self.strands_agent.tool_registry.get_all_tools_config().values()
         ]
+
+    @property
+    def agent_card_url(self) -> str:
+        """Get the URL advertised in the AgentCard.
+
+        Defaults to http_url. Can be overridden to advertise a custom URL
+        (e.g., without trailing slash or with a different base).
+        """
+        return self._agent_card_url if self._agent_card_url is not None else self.http_url
+
+    @agent_card_url.setter
+    def agent_card_url(self, url: str) -> None:
+        """Override the URL advertised in the AgentCard.
+
+        Args:
+            url: The URL to advertise in the AgentCard.
+        """
+        self._agent_card_url = url
 
     @property
     def agent_skills(self) -> list[AgentSkill]:

--- a/strands-py/tests/strands/multiagent/a2a/test_server.py
+++ b/strands-py/tests/strands/multiagent/a2a/test_server.py
@@ -600,6 +600,26 @@ def test_public_agent_card_with_http_url(mock_strands_agent):
     assert card.description == "A test agent for unit testing"
 
 
+def test_agent_card_url_defaults_to_http_url(mock_strands_agent):
+    """Test that agent_card_url defaults to http_url."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="https://my-alb.amazonaws.com/agent1", skills=[])
+    assert a2a_agent.agent_card_url == "https://my-alb.amazonaws.com/agent1/"  # Adds trailing slash at the end
+
+
+def test_agent_card_url_override(mock_strands_agent):
+    """Test that agent_card_url can be overridden to a custom value."""
+    mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}
+
+    a2a_agent = A2AServer(mock_strands_agent, http_url="https://my-alb.amazonaws.com/agent1", skills=[])
+    a2a_agent.agent_card_url = "https://my-alb.amazonaws.com/agent1"  # Override to URL without trailing slash
+
+    assert a2a_agent.agent_card_url == "https://my-alb.amazonaws.com/agent1"
+    card = a2a_agent.public_agent_card
+    assert card.url == "https://my-alb.amazonaws.com/agent1"
+
+
 def test_to_starlette_app_with_mounting(mock_strands_agent):
     """Test that to_starlette_app creates mounted app when mount_path exists."""
     mock_strands_agent.tool_registry.get_all_tools_config.return_value = {}


### PR DESCRIPTION
## Description
`A2AServer` currently sets the `url` field in the `AgentCard` to `http_url`, which always [appends a trailing slash](https://github.com/strands-agents/sdk-python/blob/main/src/strands/multiagent/a2a/server.py#L81). In load-balanced or reverse-proxy deployments, the advertised URL may need to differ from the internal `http_url` - for example, to omit the trailing slash or use a completely different base URL.

This PR adds an `agent_card_url` property to `A2AServer` that defaults to `http_url` but can be overridden via a setter, giving users control over the URL advertised in the `AgentCard`.

## Related Issues

No related issues.

## Documentation PR

To be created after approval

## Type of Change

New feature

## Testing

Yes, I have tested the change and verified it doesn't break functionality.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Use Cases

1. Trailing slashes are not preferred.

```python
# The agent will be accessible at http://my-alb.amazonaws.com/calculator/
a2a_server = A2AServer(
    agent=agent,
    http_url="http://my-alb.amazonaws.com/calculator"
)
```

```python
# The agent will be accessible at http://my-alb.amazonaws.com/calculator
a2a_server = A2AServer(
    agent=agent,
    http_url="http://my-alb.amazonaws.com/calculator"
)
a2a_server.agent_card_url("http://my-alb.amazonaws.com/calculator")
```

2. In load-balanced or reverse-proxy deployments, the advertised URL may need to differ.

```python
from unittest.mock import MagicMock
from strands import Agent
from strands.models.model import Model
from strands.multiagent.a2a import A2AServer
from a2a.types import AgentSkill


INTERNAL_HOST = "0.0.0.0"
INTERNAL_PORT = 8001
INTERNAL_URL = f"http://{INTERNAL_HOST}:{INTERNAL_PORT}/chat"
PUBLIC_URL = "https://api.example.com"

SKILLS = [
    AgentSkill(
        id="skill-id",
        name="Agent Name",
        description="Agent Description",
        tags=["tag"],
        examples=["Example."],
    )
]

mock_model = MagicMock(spec=Model)

agent = Agent(
    model=mock_model,
    name="Agent Name",
    description="Agent Description",
    tools=[],
    callback_handler=None,
)


# Without agent_card_url
server = A2AServer(
    agent=agent,
    http_url=INTERNAL_URL,
    skills=SKILLS,
)

# The agent card advertises `http://0.0.0.0:8001/chat/`. External clients cannot reach this address.
# Any orchestrator or peer agent that reads the card will fail to connect.
card = server.public_agent_card
```

```python
"""
One workaround could be to pass public url as `http_url`. The card.url would be correct, but
- The server derives its internal mount_path from http_url.
- Starlette routes are built around that external hostname / path.
- In the container, the process still binds to {INTERNAL_HOST}:{INTERNAL_PORT}.
- The mismatch between what A2AServer thinks is its base URL and
  what uvicorn actually serves on leads to routing confusion.
- You'd also have to manually reconcile the  /agent-card mount that live outside the A2A server.
"""

A2AServer(agent=agent, http_url="{PUBLIC_URL}/chat")
```

```python
# With agent_card_url
server_with = A2AServer(
    agent=agent,
    http_url=INTERNAL_HTTP_URL,  # container-internal address
    skills=SKILLS,
)

# One-liner override - the card now advertises the gateway URL
server.agent_card_url = f"{PUBLIC_URL}/chat"

card = server.public_agent_card
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.