### PR TITLE
fix: ollama input/output token count

### DIFF
--- a/src/strands/models/ollama.py
+++ b/src/strands/models/ollama.py
@@ -273,8 +273,8 @@ class OllamaModel(Model):
                 return {
                     "metadata": {
                         "usage": {
-                            "inputTokens": event["data"].eval_count,
-                            "outputTokens": event["data"].prompt_eval_count,
+                            "inputTokens": event["data"].prompt_eval_count,
+                            "outputTokens": event["data"].eval_count,
                             "totalTokens": event["data"].eval_count + event["data"].prompt_eval_count,
                         },
                         "metrics": {

--- a/tests/strands/models/test_ollama.py
+++ b/tests/strands/models/test_ollama.py
@@ -394,8 +394,8 @@ def test_format_chunk_metadata(model):
     exp_chunk = {
         "metadata": {
             "usage": {
-                "inputTokens": 100,
-                "outputTokens": 50,
+                "inputTokens": 50,
+                "outputTokens": 100,
                 "totalTokens": 150,
             },
             "metrics": {
@@ -438,7 +438,7 @@ async def test_stream(ollama_client, model, agenerator, alist, captured_warnings
         {"messageStop": {"stopReason": "end_turn"}},
         {
             "metadata": {
-                "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+                "usage": {"inputTokens": 5, "outputTokens": 10, "totalTokens": 15},
                 "metrics": {"latencyMs": 1.0},
             }
         },
@@ -510,7 +510,7 @@ async def test_stream_with_tool_calls(ollama_client, model, agenerator, alist):
         {"messageStop": {"stopReason": "tool_use"}},
         {
             "metadata": {
-                "usage": {"inputTokens": 15, "outputTokens": 8, "totalTokens": 23},
+                "usage": {"inputTokens": 8, "outputTokens": 15, "totalTokens": 23},
                 "metrics": {"latencyMs": 2.0},
             }
         },


### PR DESCRIPTION
## Description
Fixes https://github.com/strands-agents/sdk-python/issues/2007

>`inputTokens` and `outputTokens` are swapped. At `src/strands/models/ollama.py:276-277`, `eval_count` (output) is mapped to `inputTokens` and `prompt_eval_count` (input) is mapped to `outputTokens`:
>```python
>"inputTokens": event["data"].eval_count,        # wrong — this is output
>"outputTokens": event["data"].prompt_eval_count, # wrong — this is input
>```
>`totalTokens` is coincidentally correct since addition is commutative.

## Related Issues

#2007 

## Documentation PR

NA

## Type of Change
Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
