### PR TITLE
fix: handle reasoning content in OpenAIResponsesModel request formatting

### DIFF
--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -240,8 +240,13 @@ class OpenAIResponsesModel(Model):
                                 if model_state is not None and response_id:
                                     model_state["response_id"] = response_id
 
-                        elif event.type == "response.reasoning_text.delta":
-                            # Reasoning content streaming (for o1/o3 reasoning models)
+                        elif event.type in (
+                            "response.reasoning_text.delta",
+                            "response.reasoning_summary_text.delta",
+                        ):
+                            # Reasoning content streaming:
+                            # - reasoning_text: full chain-of-thought (gpt-oss models)
+                            # - reasoning_summary_text: condensed summary (o-series models)
                             chunks, data_type = self._stream_switch_content("reasoning_content", data_type)
                             for chunk in chunks:
                                 yield chunk
@@ -510,10 +515,15 @@ class OpenAIResponsesModel(Model):
             role = message["role"]
             contents = message["content"]
 
+            if any("reasoningContent" in content for content in contents):
+                logger.warning(
+                    "reasoningContent is not yet supported in multi-turn conversations with the Responses API"
+                )
+
             formatted_contents = [
                 cls._format_request_message_content(content, role=role)
                 for content in contents
-                if not any(block_type in content for block_type in ["toolResult", "toolUse"])
+                if not any(block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent"])
             ]
 
             formatted_tool_calls = [

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -596,9 +596,16 @@ async def test_stream_response_incomplete(openai_client, model, agenerator, alis
 
 
 @pytest.mark.asyncio
-async def test_stream_reasoning_content(openai_client, model, agenerator, alist):
-    """Test that reasoning content (o1/o3 models) is streamed correctly."""
-    mock_reasoning_event = unittest.mock.Mock(type="response.reasoning_text.delta", delta="Let me think...")
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        "response.reasoning_text.delta",
+        "response.reasoning_summary_text.delta",
+    ],
+)
+async def test_stream_reasoning_content(openai_client, model, agenerator, alist, event_type):
+    """Test that reasoning content is streamed correctly for both full and summary reasoning events."""
+    mock_reasoning_event = unittest.mock.Mock(type=event_type, delta="Let me think...")
     mock_text_event = unittest.mock.Mock(type="response.output_text.delta", delta="The answer is 42")
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
@@ -1152,3 +1159,34 @@ async def test_stream_stateful(openai_client, model_id, agenerator, alist):
         "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
         "metrics": {"latencyMs": 0},
     }
+
+
+def test_format_request_messages_excludes_reasoning_content(caplog):
+    """Test that reasoningContent blocks are filtered from messages with a warning."""
+    messages = [
+        {
+            "content": [{"text": "Hello"}],
+            "role": "user",
+        },
+        {
+            "content": [
+                {"reasoningContent": {"reasoningText": {"text": "Let me think..."}}},
+                {"text": "The answer is 42"},
+            ],
+            "role": "assistant",
+        },
+        {
+            "content": [{"text": "Thanks"}],
+            "role": "user",
+        },
+    ]
+
+    with caplog.at_level("WARNING"):
+        result = OpenAIResponsesModel._format_request_messages(messages)
+
+    assert result == [
+        {"role": "user", "content": [{"type": "input_text", "text": "Hello"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "The answer is 42"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "Thanks"}]},
+    ]
+    assert "reasoningContent is not yet supported" in caplog.text

--- a/tests_integ/models/test_model_mantle.py
+++ b/tests_integ/models/test_model_mantle.py
@@ -72,3 +72,28 @@ def test_responses_server_side_conversation(stateful_model):
 
     result = agent("What is my name?")
     assert "alice" in str(result).lower()
+
+
+def test_reasoning_content_multi_turn(client_args):
+    """Test that reasoning content from gpt-oss models doesn't break multi-turn conversations."""
+    model = OpenAIResponsesModel(
+        model_id="openai.gpt-oss-120b",
+        client_args=client_args,
+        params={"reasoning": {"effort": "low"}},
+    )
+    agent = Agent(model=model, system_prompt="Reply in one short sentence.", callback_handler=None)
+
+    result1 = agent("What is 2+2?")
+    assert "4" in str(result1)
+
+    # Verify reasoning content was produced
+    has_reasoning = any(
+        "reasoningContent" in block
+        for msg in agent.messages
+        if msg["role"] == "assistant"
+        for block in msg["content"]
+    )
+    assert has_reasoning
+
+    # Second turn should not raise despite reasoningContent in message history
+    agent("What about 3+3?")


### PR DESCRIPTION
## Description

Multi-turn conversations with reasoning models (gpt-oss, o-series) crash with a `TypeError` on the second turn because `reasoningContent` blocks in the message history are not handled during request formatting. The Responses API also has a separate streaming event for reasoning summaries (`response.reasoning_summary_text.delta`) that was not being captured.

## Motivation

When using `OpenAIResponsesModel` with models that produce reasoning content (e.g., `gpt-oss-120b` via Bedrock Mantle), the first turn succeeds and stores a `reasoningContent` block in the assistant message. On the next turn, `_format_request_messages` passes this block to `_format_request_message_content`, which has no handler for it and raises `TypeError: content_type=<reasoningContent> | unsupported type`.

The Responses API expects reasoning as a top-level input item with a specific structure (`id`, `summary`, `type`) that differs from the Strands `ReasoningContentBlock` format. Properly passing reasoning back requires storing additional metadata (reasoning item ID, structured summary) that the content block type does not currently support. For now, we filter reasoning content from the request with a warning, matching the approach used by the Chat Completions model (`openai.py`).

Additionally, proprietary reasoning models (o3, o4-mini) stream reasoning summaries via `response.reasoning_summary_text.delta` events, which were not being captured. These are now handled alongside the existing `response.reasoning_text.delta` events from gpt-oss models.

Resolves: #1957

## Public API Changes

No public API changes.

## Follow-ups

To properly pass reasoning content back to the Responses API on subsequent turns, we need the reasoning item `id`, structured `summary` list, and optionally `encrypted_content`. These fields are available during streaming (via `response.output_item.done`) but have no place to live in the current `ReasoningContentBlock` type, which was designed around the Bedrock API format. We should explore providing a means to support provider-specific content in our message content block types so that model providers can round-trip metadata that does not fit the shared schema. This would allow `OpenAIResponsesModel` to store and retrieve the reasoning item metadata alongside the message it belongs to, keeping it in sync with conversation manager trimming and session persistence.

Tracked in #2014.

## Type of Change

Bug fix

## Testing

- Unit tests for reasoning content filtering and warning emission
- Parametrized streaming test covering both `response.reasoning_text.delta` (gpt-oss) and `response.reasoning_summary_text.delta` (o-series) event types
- Integration test with `gpt-oss-120b` via Bedrock Mantle verifying multi-turn conversations with reasoning content do not crash

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.