### PR TITLE
fix: fix type imcompatible

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -839,7 +839,9 @@ class Tracer:
         if system_prompt is None and system_prompt_content is None:
             return
 
-        content_blocks = system_prompt_content if system_prompt_content else [{"text": system_prompt}]
+        content_blocks: list[ContentBlock] = (
+            system_prompt_content if system_prompt_content else [{"text": system_prompt or ""}]
+        )
 
         if self.use_latest_genai_conventions:
             parts = self._map_content_blocks_to_otel_parts(content_blocks)

--- a/tests_integ/models/test_model_mantle.py
+++ b/tests_integ/models/test_model_mantle.py
@@ -88,10 +88,7 @@ def test_reasoning_content_multi_turn(client_args):
 
     # Verify reasoning content was produced
     has_reasoning = any(
-        "reasoningContent" in block
-        for msg in agent.messages
-        if msg["role"] == "assistant"
-        for block in msg["content"]
+        "reasoningContent" in block for msg in agent.messages if msg["role"] == "assistant" for block in msg["content"]
     )
     assert has_reasoning
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Fixes a mypy type error in Tracer._add_system_prompt_event where the content_blocks variable passed to _map_content_blocks_to_otel_parts had an inferred type of list[Any] | list[dict[str, str | None] | Any], which is incompatible with the expected list[ContentBlock] | list[InterruptResponseContent].

Added an explicit list[ContentBlock] type annotation to content_blocks and used system_prompt or "" to ensure the text value is always str (satisfying the ContentBlock TypedDict contract, since mypy cannot narrow system_prompt through the early return guard).


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
