### PR TITLE
fix: run mymp typecheck in ci

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -130,3 +130,6 @@ jobs:
         run: hatch fmt --linter --check
         continue-on-error: false
 
+      - name: Run type check
+        run: hatch run hatch-static-analysis:lint-check
+


### PR DESCRIPTION
## Description
The lint-check script in `pyproject.toml` defines both `ruff check` and `mypy ./src`, but the CI lint job only runs `hatch fmt --linter --check`, which only invokes ruff. This means `mypy` is configured but never actually executed in CI, allowing type errors to slip through PRs undetected.

This adds a dedicated “Run type check” step that calls `hatch run hatch-static-analysis:lint-check` to ensure `mypy` runs as part of the CI pipeline.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
