### PR TITLE
fix: isolate langfuse env vars

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,9 @@ def moto_env(monkeypatch):
     monkeypatch.setenv("AWS_SECURITY_TOKEN", "test")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
 
 
 @pytest.fixture


### PR DESCRIPTION


## Description

Fix tracer tests failing when developers have Langfuse environment variables set locally introduced in https://github.com/strands-agents/sdk-python/pull/1768

The `is_langfuse` property checks three env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `LANGFUSE_BASE_URL`), but the `moto_env` test fixture only cleared the first one. When a developer has Langfuse configured locally, the remaining env vars leak into tests, causing `is_langfuse` to unexpectedly return `True`. This triggers extra `span.set_attributes()` calls that break `assert_called_once_with` assertions.

The fix adds `monkeypatch.delenv` calls for `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and `LANGFUSE_BASE_URL` to the `moto_env` fixture, ensuring all three langfuse-related env vars are cleared for tests.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `hatch run prepare`
- Verified all 76 tracer tests pass with Langfuse env vars set locally

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.