### PR TITLE
fix: set StatusCode.ERROR on tool spans when tool result status is error

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -501,6 +501,12 @@ class Tracer:
                     },
                 )
 
+        # If no explicit error but tool_result indicates an error, synthesize one so the span gets StatusCode.ERROR
+        if error is None and tool_result is not None and tool_result.get("status") == "error":
+            content = tool_result.get("content", [])
+            error_message = content[0].get("text", "Tool call failed") if content else "Tool call failed"
+            error = Exception(error_message)
+
         self._end_span(span, attributes, error)
 
     def start_event_loop_cycle_span(


### PR DESCRIPTION
## Problem

When a tool raises an exception, Strands catches it in `_stream()` and converts it to a `ToolResult` dict with `status='error'`. The original exception object is lost before `end_tool_call_span` is called, so `_end_span()` always falls into the `else` branch and marks the span as `StatusCode.OK`.

The `gen_ai.tool.status: "error"` attribute IS correctly set, but the span `StatusCode` remains `OK`. This is critical because observability backends like Langfuse rely on `StatusCode.ERROR` to raise alarms/statistics on failed tool calls.

## Solution

In `end_tool_call_span()`, before calling `_end_span()`, check if `tool_result["status"] == "error"` and synthesize an `Exception` from the error content. This ensures the span correctly gets `StatusCode.ERROR` and `record_exception()` is called.

## Testing

- All 76 tracer tests pass ✅
- All 30 executor tests pass ✅

Fixes #2016