### PR TITLE
feat: add `count_token` method to model with naive estimation using tiktoken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ sagemaker = [
     "openai>=1.68.0,<3.0.0",  # SageMaker uses OpenAI-compatible interface
 ]
 otel = ["opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0"]
+# Rename this extra once compression/context management features land #555
+token-estimation = ["tiktoken>=0.7.0,<1.0.0"]
 docs = [
     "sphinx>=5.0.0,<10.0.0",
     "sphinx-rtd-theme>=1.0.0,<4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,6 @@ sagemaker = [
     "openai>=1.68.0,<3.0.0",  # SageMaker uses OpenAI-compatible interface
 ]
 otel = ["opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0"]
-# Rename this extra once compression/context management features land #555
-token-estimation = ["tiktoken>=0.7.0,<1.0.0"]
 docs = [
     "sphinx>=5.0.0,<10.0.0",
     "sphinx-rtd-theme>=1.0.0,<4.0.0",

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -1,6 +1,7 @@
 """Abstract base class for Agent model providers."""
 
 import abc
+import functools
 import json
 import logging
 import math
@@ -24,8 +25,6 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 _DEFAULT_ENCODING = "cl100k_base"
-_cached_encoding: Any = None
-_tiktoken_available: bool | None = None
 
 
 def _heuristic_estimate_text(text: str) -> int:
@@ -41,26 +40,20 @@ def _heuristic_estimate_json(obj: Any) -> int:
         return 0
 
 
+@functools.lru_cache(maxsize=1)
 def _get_encoding() -> Any:
     """Get the default tiktoken encoding, caching to avoid repeated lookups.
 
     Returns:
         The tiktoken encoding, or None if tiktoken is not installed.
     """
-    global _cached_encoding, _tiktoken_available
-    if _tiktoken_available is False:
-        return None
-    if _cached_encoding is None:
-        try:
-            import tiktoken
+    try:
+        import tiktoken
 
-            _cached_encoding = tiktoken.get_encoding(_DEFAULT_ENCODING)
-            _tiktoken_available = True
-        except ImportError:
-            logger.debug("tiktoken not available, falling back to heuristic token estimation")
-            _tiktoken_available = False
-            return None
-    return _cached_encoding
+        return tiktoken.get_encoding(_DEFAULT_ENCODING)
+    except ImportError:
+        logger.debug("tiktoken not available, falling back to heuristic token estimation")
+        return None
 
 
 def _count_content_block_tokens(

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -291,7 +291,7 @@ class Model(abc.ABC):
         """
         pass
 
-    async def _estimate_tokens(
+    async def count_tokens(
         self,
         messages: Messages,
         tool_specs: list[ToolSpec] | None = None,

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -298,7 +298,7 @@ class Model(abc.ABC):
         """
         pass
 
-    def _estimate_tokens(
+    async def _estimate_tokens(
         self,
         messages: Messages,
         tool_specs: list[ToolSpec] | None = None,

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -1,6 +1,7 @@
 """Abstract base class for Agent model providers."""
 
 import abc
+import json
 import logging
 from collections.abc import AsyncGenerator, AsyncIterable
 from dataclasses import dataclass
@@ -10,7 +11,7 @@ from pydantic import BaseModel
 
 from ..hooks.events import AfterInvocationEvent
 from ..plugins.plugin import Plugin
-from ..types.content import Messages, SystemContentBlock
+from ..types.content import ContentBlock, Messages, SystemContentBlock
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 
@@ -20,6 +21,110 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
+
+_DEFAULT_ENCODING = "cl100k_base"
+_cached_encoding: Any = None
+
+
+def _get_encoding() -> Any:
+    """Get the default tiktoken encoding, caching to avoid repeated lookups."""
+    global _cached_encoding
+    if _cached_encoding is None:
+        try:
+            import tiktoken
+        except ImportError as err:
+            raise ImportError(
+                "tiktoken is required for token estimation. "
+                "Install it with: pip install strands-agents[token-estimation]"
+            ) from err
+        _cached_encoding = tiktoken.get_encoding(_DEFAULT_ENCODING)
+    return _cached_encoding
+
+
+def _count_content_block_tokens(block: ContentBlock, encoding: Any) -> int:
+    """Count tokens for a single content block."""
+    total = 0
+
+    if "text" in block:
+        total += len(encoding.encode(block["text"]))
+
+    if "toolUse" in block:
+        tool_use = block["toolUse"]
+        total += len(encoding.encode(tool_use.get("name", "")))
+        try:
+            total += len(encoding.encode(json.dumps(tool_use.get("input", {}))))
+        except (TypeError, ValueError):
+            logger.debug(
+                "tool_name=<%s> | skipping non-serializable toolUse input for token estimation",
+                tool_use.get("name", "unknown"),
+            )
+
+    if "toolResult" in block:
+        tool_result = block["toolResult"]
+        for item in tool_result.get("content", []):
+            if "text" in item:
+                total += len(encoding.encode(item["text"]))
+
+    if "reasoningContent" in block:
+        reasoning = block["reasoningContent"]
+        if "reasoningText" in reasoning:
+            reasoning_text = reasoning["reasoningText"]
+            if "text" in reasoning_text:
+                total += len(encoding.encode(reasoning_text["text"]))
+
+    if "guardContent" in block:
+        guard = block["guardContent"]
+        if "text" in guard:
+            total += len(encoding.encode(guard["text"]["text"]))
+
+    if "citationsContent" in block:
+        citations = block["citationsContent"]
+        if "content" in citations:
+            for citation_item in citations["content"]:
+                if "text" in citation_item:
+                    total += len(encoding.encode(citation_item["text"]))
+
+    return total
+
+
+def _estimate_tokens_with_tiktoken(
+    messages: Messages,
+    tool_specs: list[ToolSpec] | None = None,
+    system_prompt: str | None = None,
+    system_prompt_content: list[SystemContentBlock] | None = None,
+) -> int:
+    """Estimate tokens by serializing messages/tools to text and counting with tiktoken.
+
+    This is a best-effort fallback for providers that don't expose native counting.
+    Accuracy varies by model but is sufficient for threshold-based decisions.
+    """
+    encoding = _get_encoding()
+    total = 0
+
+    # Prefer system_prompt_content (structured) over system_prompt (plain string) to avoid double-counting,
+    # since providers wrap system_prompt into system_prompt_content when both are provided.
+    if system_prompt_content:
+        for block in system_prompt_content:
+            if "text" in block:
+                total += len(encoding.encode(block["text"]))
+    elif system_prompt:
+        total += len(encoding.encode(system_prompt))
+
+    for message in messages:
+        for block in message["content"]:
+            total += _count_content_block_tokens(block, encoding)
+
+    if tool_specs:
+        for spec in tool_specs:
+            try:
+                total += len(encoding.encode(json.dumps(spec)))
+            except (TypeError, ValueError):
+                logger.debug(
+                    "tool_name=<%s> | skipping non-serializable tool spec for token estimation",
+                    spec.get("name", "unknown"),
+                )
+
+    return total
 
 
 @dataclass
@@ -129,6 +234,34 @@ class Model(abc.ABC):
             ModelThrottledException: When the model service is throttling requests from the client.
         """
         pass
+
+    def _estimate_tokens(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+    ) -> int:
+        """Estimate token count for the given input before sending to the model.
+
+        Used for proactive context management (e.g., triggering compression at a
+        threshold). This is a naive approximation using tiktoken's cl100k_base encoding.
+        Accuracy varies by model provider but is typically within 5-10% for most providers.
+        Not intended for billing or precise quota calculations.
+
+        Subclasses may override this method to provide model-specific token counting
+        using native APIs for improved accuracy.
+
+        Args:
+            messages: List of message objects to estimate tokens for.
+            tool_specs: List of tool specifications to include in the estimate.
+            system_prompt: Plain string system prompt. Ignored if system_prompt_content is provided.
+            system_prompt_content: Structured system prompt content blocks. Takes priority over system_prompt.
+
+        Returns:
+            Estimated total input tokens.
+        """
+        return _estimate_tokens_with_tiktoken(messages, tool_specs, system_prompt, system_prompt_content)
 
 
 class _ModelPlugin(Plugin):

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -74,7 +74,7 @@ def _count_content_block_tokens(block: ContentBlock, encoding: Any) -> int:
 
     if "guardContent" in block:
         guard = block["guardContent"]
-        if "text" in guard:
+        if "text" in guard and "text" in guard["text"]:
             total += len(encoding.encode(guard["text"]["text"]))
 
     if "citationsContent" in block:
@@ -246,7 +246,7 @@ class Model(abc.ABC):
 
         Used for proactive context management (e.g., triggering compression at a
         threshold). This is a naive approximation using tiktoken's cl100k_base encoding.
-        Accuracy varies by model provider but is typically within 5-10% for most providers.
+        Accuracy varies by model provider but is estimated to be within 5-15% for most providers.
         Not intended for billing or precise quota calculations.
 
         Subclasses may override this method to provide model-specific token counting

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -3,7 +3,8 @@
 import abc
 import json
 import logging
-from collections.abc import AsyncGenerator, AsyncIterable
+import math
+from collections.abc import AsyncGenerator, AsyncIterable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
@@ -24,65 +25,88 @@ T = TypeVar("T", bound=BaseModel)
 
 _DEFAULT_ENCODING = "cl100k_base"
 _cached_encoding: Any = None
+_tiktoken_available: bool | None = None
+
+
+def _heuristic_estimate_text(text: str) -> int:
+    """Estimate token count from text using characters / 4 heuristic."""
+    return math.ceil(len(text) / 4)
+
+
+def _heuristic_estimate_json(obj: Any) -> int:
+    """Estimate token count from a JSON-serializable object using characters / 2 heuristic."""
+    try:
+        return math.ceil(len(json.dumps(obj)) / 2)
+    except (TypeError, ValueError):
+        return 0
 
 
 def _get_encoding() -> Any:
-    """Get the default tiktoken encoding, caching to avoid repeated lookups."""
-    global _cached_encoding
+    """Get the default tiktoken encoding, caching to avoid repeated lookups.
+
+    Returns:
+        The tiktoken encoding, or None if tiktoken is not installed.
+    """
+    global _cached_encoding, _tiktoken_available
+    if _tiktoken_available is False:
+        return None
     if _cached_encoding is None:
         try:
             import tiktoken
-        except ImportError as err:
-            raise ImportError(
-                "tiktoken is required for token estimation. "
-                "Install it with: pip install strands-agents[token-estimation]"
-            ) from err
-        _cached_encoding = tiktoken.get_encoding(_DEFAULT_ENCODING)
+
+            _cached_encoding = tiktoken.get_encoding(_DEFAULT_ENCODING)
+            _tiktoken_available = True
+        except ImportError:
+            logger.debug("tiktoken not available, falling back to heuristic token estimation")
+            _tiktoken_available = False
+            return None
     return _cached_encoding
 
 
-def _count_content_block_tokens(block: ContentBlock, encoding: Any) -> int:
-    """Count tokens for a single content block."""
+def _count_content_block_tokens(
+    block: ContentBlock, count_text: Callable[[str], int], count_json: Callable[[Any], int]
+) -> int:
+    """Count tokens for a single content block.
+
+    Args:
+        block: The content block to count tokens for.
+        count_text: Function that returns token count for a text string.
+        count_json: Function that returns token count for a JSON-serializable object.
+    """
     total = 0
 
     if "text" in block:
-        total += len(encoding.encode(block["text"]))
+        total += count_text(block["text"])
 
     if "toolUse" in block:
         tool_use = block["toolUse"]
-        total += len(encoding.encode(tool_use.get("name", "")))
-        try:
-            total += len(encoding.encode(json.dumps(tool_use.get("input", {}))))
-        except (TypeError, ValueError):
-            logger.debug(
-                "tool_name=<%s> | skipping non-serializable toolUse input for token estimation",
-                tool_use.get("name", "unknown"),
-            )
+        total += count_text(tool_use.get("name", ""))
+        total += count_json(tool_use.get("input", {}))
 
     if "toolResult" in block:
         tool_result = block["toolResult"]
         for item in tool_result.get("content", []):
             if "text" in item:
-                total += len(encoding.encode(item["text"]))
+                total += count_text(item["text"])
 
     if "reasoningContent" in block:
         reasoning = block["reasoningContent"]
         if "reasoningText" in reasoning:
             reasoning_text = reasoning["reasoningText"]
             if "text" in reasoning_text:
-                total += len(encoding.encode(reasoning_text["text"]))
+                total += count_text(reasoning_text["text"])
 
     if "guardContent" in block:
         guard = block["guardContent"]
         if "text" in guard and "text" in guard["text"]:
-            total += len(encoding.encode(guard["text"]["text"]))
+            total += count_text(guard["text"]["text"])
 
     if "citationsContent" in block:
         citations = block["citationsContent"]
         if "content" in citations:
             for citation_item in citations["content"]:
                 if "text" in citation_item:
-                    total += len(encoding.encode(citation_item["text"]))
+                    total += count_text(citation_item["text"])
 
     return total
 
@@ -97,8 +121,23 @@ def _estimate_tokens_with_tiktoken(
 
     This is a best-effort fallback for providers that don't expose native counting.
     Accuracy varies by model but is sufficient for threshold-based decisions.
+
+    Raises:
+        ImportError: If tiktoken is not installed.
     """
     encoding = _get_encoding()
+    if encoding is None:
+        raise ImportError("tiktoken is not available")
+
+    def count_text(text: str) -> int:
+        return len(encoding.encode(text))
+
+    def count_json(obj: Any) -> int:
+        try:
+            return len(encoding.encode(json.dumps(obj)))
+        except (TypeError, ValueError):
+            return 0
+
     total = 0
 
     # Prefer system_prompt_content (structured) over system_prompt (plain string) to avoid double-counting,
@@ -106,23 +145,47 @@ def _estimate_tokens_with_tiktoken(
     if system_prompt_content:
         for block in system_prompt_content:
             if "text" in block:
-                total += len(encoding.encode(block["text"]))
+                total += count_text(block["text"])
     elif system_prompt:
-        total += len(encoding.encode(system_prompt))
+        total += count_text(system_prompt)
 
     for message in messages:
         for block in message["content"]:
-            total += _count_content_block_tokens(block, encoding)
+            total += _count_content_block_tokens(block, count_text, count_json)
 
     if tool_specs:
         for spec in tool_specs:
-            try:
-                total += len(encoding.encode(json.dumps(spec)))
-            except (TypeError, ValueError):
-                logger.debug(
-                    "tool_name=<%s> | skipping non-serializable tool spec for token estimation",
-                    spec.get("name", "unknown"),
-                )
+            total += count_json(spec)
+
+    return total
+
+
+def _estimate_tokens_with_heuristic(
+    messages: Messages,
+    tool_specs: list[ToolSpec] | None = None,
+    system_prompt: str | None = None,
+    system_prompt_content: list[SystemContentBlock] | None = None,
+) -> int:
+    """Estimate tokens using character-based heuristics (text: chars/4, JSON: chars/2).
+
+    Dependency-free fallback when tiktoken is not installed.
+    """
+    total = 0
+
+    if system_prompt_content:
+        for block in system_prompt_content:
+            if "text" in block:
+                total += _heuristic_estimate_text(block["text"])
+    elif system_prompt:
+        total += _heuristic_estimate_text(system_prompt)
+
+    for message in messages:
+        for block in message["content"]:
+            total += _count_content_block_tokens(block, _heuristic_estimate_text, _heuristic_estimate_json)
+
+    if tool_specs:
+        for spec in tool_specs:
+            total += _heuristic_estimate_json(spec)
 
     return total
 
@@ -244,10 +307,10 @@ class Model(abc.ABC):
     ) -> int:
         """Estimate token count for the given input before sending to the model.
 
-        Used for proactive context management (e.g., triggering compression at a
-        threshold). This is a naive approximation using tiktoken's cl100k_base encoding.
-        Accuracy varies by model provider but is estimated to be within 5-15% for most providers.
-        Not intended for billing or precise quota calculations.
+        Used for proactive context management (e.g., triggering compression at a threshold).
+        Uses tiktoken's cl100k_base encoding when available, otherwise falls back to a
+        heuristic (characters / 4 for text, characters / 2 for JSON). Accuracy varies by
+        model provider. Not intended for billing or precise quota calculations.
 
         Subclasses may override this method to provide model-specific token counting
         using native APIs for improved accuracy.
@@ -261,7 +324,10 @@ class Model(abc.ABC):
         Returns:
             Estimated total input tokens.
         """
-        return _estimate_tokens_with_tiktoken(messages, tool_specs, system_prompt, system_prompt_content)
+        try:
+            return _estimate_tokens_with_tiktoken(messages, tool_specs, system_prompt, system_prompt_content)
+        except ImportError:
+            return _estimate_tokens_with_heuristic(messages, tool_specs, system_prompt, system_prompt_content)
 
 
 class _ModelPlugin(Plugin):

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -213,3 +213,256 @@ def test_model_plugin_preserves_messages_when_not_stateful(model_plugin):
     model_plugin._on_after_invocation(event)
 
     assert len(agent.messages) == 1
+
+
+def test_estimate_tokens_empty_messages(model):
+    assert model._estimate_tokens(messages=[]) == 0
+
+
+def test_estimate_tokens_system_prompt_only(model):
+    result = model._estimate_tokens(messages=[], system_prompt="You are a helpful assistant.")
+    assert result == 6
+
+
+def test_estimate_tokens_text_messages(model, messages):
+    result = model._estimate_tokens(messages=messages)
+    assert result == 1  # "hello"
+
+
+def test_estimate_tokens_with_tool_specs(model, messages, tool_specs):
+    without_tools = model._estimate_tokens(messages=messages)
+    with_tools = model._estimate_tokens(messages=messages, tool_specs=tool_specs)
+    assert without_tools == 1  # "hello"
+    assert with_tools == 49  # "hello" (1) + tool_spec (48)
+
+
+def test_estimate_tokens_with_system_prompt(model, messages, system_prompt):
+    without_prompt = model._estimate_tokens(messages=messages)
+    with_prompt = model._estimate_tokens(messages=messages, system_prompt=system_prompt)
+    assert without_prompt == 1  # "hello"
+    assert with_prompt == 3  # "hello" (1) + "s1" (2)
+
+
+def test_estimate_tokens_combined(model, messages, tool_specs, system_prompt):
+    result = model._estimate_tokens(messages=messages, tool_specs=tool_specs, system_prompt=system_prompt)
+    assert result == 51  # "hello" (1) + tool_spec (48) + "s1" (2)
+
+
+def test_estimate_tokens_tool_use_block(model):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolUse": {
+                        "toolUseId": "123",
+                        "name": "my_tool",
+                        "input": {"query": "test"},
+                    }
+                }
+            ],
+        }
+    ]
+    result = model._estimate_tokens(messages=messages)
+    # name "my_tool" (2) + json.dumps(input) (6) = 8
+    assert result == 8
+
+
+def test_estimate_tokens_tool_result_block(model):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "123",
+                        "content": [{"text": "tool output here"}],
+                        "status": "success",
+                    }
+                }
+            ],
+        }
+    ]
+    result = model._estimate_tokens(messages=messages)
+    assert result == 3  # "tool output here"
+
+
+def test_estimate_tokens_reasoning_block(model):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "reasoningContent": {
+                        "reasoningText": {
+                            "text": "Let me think about this step by step.",
+                        }
+                    }
+                }
+            ],
+        }
+    ]
+    result = model._estimate_tokens(messages=messages)
+    assert result == 9  # "Let me think about this step by step."
+
+
+def test_estimate_tokens_skips_binary_content(model):
+    messages = [
+        {
+            "role": "user",
+            "content": [{"image": {"format": "png", "source": {"bytes": b"fake image data"}}}],
+        }
+    ]
+    assert model._estimate_tokens(messages=messages) == 0
+
+
+def test_estimate_tokens_tool_result_with_bytes_only(model):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "123",
+                        "content": [{"image": {"format": "png", "source": {"bytes": b"image data"}}}],
+                        "status": "success",
+                    }
+                }
+            ],
+        }
+    ]
+    result = model._estimate_tokens(messages=messages)
+    assert result == 0
+
+
+def test_estimate_tokens_tool_result_with_text_and_bytes(model):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "123",
+                        "content": [
+                            {"text": "Here is the screenshot"},
+                            {"image": {"format": "png", "source": {"bytes": b"image data"}}},
+                        ],
+                        "status": "success",
+                    }
+                }
+            ],
+        }
+    ]
+    result = model._estimate_tokens(messages=messages)
+    assert result > 0
+
+
+def test_estimate_tokens_guard_content_block(model):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"guardContent": {"text": {"text": "This content was filtered by guardrails."}}}],
+        }
+    ]
+    result = model._estimate_tokens(messages=messages)
+    assert result == 8  # "This content was filtered by guardrails."
+
+
+def test_estimate_tokens_tool_use_with_bytes(model):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolUse": {
+                        "toolUseId": "123",
+                        "name": "my_tool",
+                        "input": {"data": b"binary data"},
+                    }
+                }
+            ],
+        }
+    ]
+    result = model._estimate_tokens(messages=messages)
+    # Should still count the tool name even though input has non-serializable bytes
+    assert result == 2  # "my_tool" name only
+
+
+def test_estimate_tokens_non_serializable_tool_spec(model, messages):
+    tool_specs = [
+        {
+            "name": "test",
+            "description": "a tool",
+            "inputSchema": {"json": {"default": b"bytes"}},
+        }
+    ]
+    result = model._estimate_tokens(messages=messages, tool_specs=tool_specs)
+    # Should still count the message tokens even though tool spec fails
+    assert result == 1  # "hello" only, tool spec skipped
+
+
+def test_estimate_tokens_citations_block(model):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "citationsContent": {
+                        "content": [{"text": "According to the document, the answer is 42."}],
+                        "citations": [],
+                    }
+                }
+            ],
+        }
+    ]
+    result = model._estimate_tokens(messages=messages)
+    assert result == 11  # "According to the document, the answer is 42."
+
+
+def test_estimate_tokens_system_prompt_content(model):
+    result = model._estimate_tokens(
+        messages=[],
+        system_prompt_content=[{"text": "You are a helpful assistant."}],
+    )
+    assert result == 6  # "You are a helpful assistant."
+
+
+def test_estimate_tokens_system_prompt_content_with_cache_point(model):
+    result = model._estimate_tokens(
+        messages=[],
+        system_prompt_content=[
+            {"text": "You are a helpful assistant."},
+            {"cachePoint": {"type": "default"}},
+        ],
+    )
+    assert result == 6  # "You are a helpful assistant.", cachePoint adds 0
+
+
+def test_estimate_tokens_system_prompt_content_takes_priority(model):
+    content_only = model._estimate_tokens(
+        messages=[],
+        system_prompt_content=[{"text": "Short."}],
+    )
+    # When both are provided, system_prompt_content wins — system_prompt is ignored
+    both = model._estimate_tokens(
+        messages=[],
+        system_prompt="This is a much longer system prompt that should have more tokens.",
+        system_prompt_content=[{"text": "Short."}],
+    )
+    assert content_only == 2  # "Short."
+    assert content_only == both
+
+
+def test_estimate_tokens_all_inputs(model):
+    messages = [
+        {"role": "user", "content": [{"text": "hello world"}]},
+        {"role": "assistant", "content": [{"text": "hi there"}]},
+    ]
+    result = model._estimate_tokens(
+        messages=messages,
+        tool_specs=[{"name": "test", "description": "a test tool", "inputSchema": {"json": {}}}],
+        system_prompt="Be helpful.",
+        system_prompt_content=[{"text": "Additional system context."}],
+    )
+    # system_prompt_content (4) + "hello world" (2) + "hi there" (2) + tool_spec (23) = 31
+    assert result == 31

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -216,46 +216,46 @@ def test_model_plugin_preserves_messages_when_not_stateful(model_plugin):
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_empty_messages(model):
-    assert await model._estimate_tokens(messages=[]) == 0
+async def test_count_tokens_empty_messages(model):
+    assert await model.count_tokens(messages=[]) == 0
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_system_prompt_only(model):
-    result = await model._estimate_tokens(messages=[], system_prompt="You are a helpful assistant.")
+async def test_count_tokens_system_prompt_only(model):
+    result = await model.count_tokens(messages=[], system_prompt="You are a helpful assistant.")
     assert result == 6
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_text_messages(model, messages):
-    result = await model._estimate_tokens(messages=messages)
+async def test_count_tokens_text_messages(model, messages):
+    result = await model.count_tokens(messages=messages)
     assert result == 1  # "hello"
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_with_tool_specs(model, messages, tool_specs):
-    without_tools = await model._estimate_tokens(messages=messages)
-    with_tools = await model._estimate_tokens(messages=messages, tool_specs=tool_specs)
+async def test_count_tokens_with_tool_specs(model, messages, tool_specs):
+    without_tools = await model.count_tokens(messages=messages)
+    with_tools = await model.count_tokens(messages=messages, tool_specs=tool_specs)
     assert without_tools == 1  # "hello"
     assert with_tools == 49  # "hello" (1) + tool_spec (48)
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_with_system_prompt(model, messages, system_prompt):
-    without_prompt = await model._estimate_tokens(messages=messages)
-    with_prompt = await model._estimate_tokens(messages=messages, system_prompt=system_prompt)
+async def test_count_tokens_with_system_prompt(model, messages, system_prompt):
+    without_prompt = await model.count_tokens(messages=messages)
+    with_prompt = await model.count_tokens(messages=messages, system_prompt=system_prompt)
     assert without_prompt == 1  # "hello"
     assert with_prompt == 3  # "hello" (1) + "s1" (2)
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_combined(model, messages, tool_specs, system_prompt):
-    result = await model._estimate_tokens(messages=messages, tool_specs=tool_specs, system_prompt=system_prompt)
+async def test_count_tokens_combined(model, messages, tool_specs, system_prompt):
+    result = await model.count_tokens(messages=messages, tool_specs=tool_specs, system_prompt=system_prompt)
     assert result == 51  # "hello" (1) + tool_spec (48) + "s1" (2)
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_tool_use_block(model):
+async def test_count_tokens_tool_use_block(model):
     messages = [
         {
             "role": "assistant",
@@ -270,13 +270,13 @@ async def test_estimate_tokens_tool_use_block(model):
             ],
         }
     ]
-    result = await model._estimate_tokens(messages=messages)
+    result = await model.count_tokens(messages=messages)
     # name "my_tool" (2) + json.dumps(input) (6) = 8
     assert result == 8
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_tool_result_block(model):
+async def test_count_tokens_tool_result_block(model):
     messages = [
         {
             "role": "user",
@@ -291,12 +291,12 @@ async def test_estimate_tokens_tool_result_block(model):
             ],
         }
     ]
-    result = await model._estimate_tokens(messages=messages)
+    result = await model.count_tokens(messages=messages)
     assert result == 3  # "tool output here"
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_reasoning_block(model):
+async def test_count_tokens_reasoning_block(model):
     messages = [
         {
             "role": "assistant",
@@ -311,23 +311,23 @@ async def test_estimate_tokens_reasoning_block(model):
             ],
         }
     ]
-    result = await model._estimate_tokens(messages=messages)
+    result = await model.count_tokens(messages=messages)
     assert result == 9  # "Let me think about this step by step."
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_skips_binary_content(model):
+async def test_count_tokens_skips_binary_content(model):
     messages = [
         {
             "role": "user",
             "content": [{"image": {"format": "png", "source": {"bytes": b"fake image data"}}}],
         }
     ]
-    assert await model._estimate_tokens(messages=messages) == 0
+    assert await model.count_tokens(messages=messages) == 0
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_tool_result_with_bytes_only(model):
+async def test_count_tokens_tool_result_with_bytes_only(model):
     messages = [
         {
             "role": "user",
@@ -342,12 +342,12 @@ async def test_estimate_tokens_tool_result_with_bytes_only(model):
             ],
         }
     ]
-    result = await model._estimate_tokens(messages=messages)
+    result = await model.count_tokens(messages=messages)
     assert result == 0
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_tool_result_with_text_and_bytes(model):
+async def test_count_tokens_tool_result_with_text_and_bytes(model):
     messages = [
         {
             "role": "user",
@@ -365,24 +365,24 @@ async def test_estimate_tokens_tool_result_with_text_and_bytes(model):
             ],
         }
     ]
-    result = await model._estimate_tokens(messages=messages)
+    result = await model.count_tokens(messages=messages)
     assert result > 0
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_guard_content_block(model):
+async def test_count_tokens_guard_content_block(model):
     messages = [
         {
             "role": "assistant",
             "content": [{"guardContent": {"text": {"text": "This content was filtered by guardrails."}}}],
         }
     ]
-    result = await model._estimate_tokens(messages=messages)
+    result = await model.count_tokens(messages=messages)
     assert result == 8  # "This content was filtered by guardrails."
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_tool_use_with_bytes(model):
+async def test_count_tokens_tool_use_with_bytes(model):
     messages = [
         {
             "role": "assistant",
@@ -397,13 +397,13 @@ async def test_estimate_tokens_tool_use_with_bytes(model):
             ],
         }
     ]
-    result = await model._estimate_tokens(messages=messages)
+    result = await model.count_tokens(messages=messages)
     # Should still count the tool name even though input has non-serializable bytes
     assert result == 2  # "my_tool" name only
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_non_serializable_tool_spec(model, messages):
+async def test_count_tokens_non_serializable_tool_spec(model, messages):
     tool_specs = [
         {
             "name": "test",
@@ -411,13 +411,13 @@ async def test_estimate_tokens_non_serializable_tool_spec(model, messages):
             "inputSchema": {"json": {"default": b"bytes"}},
         }
     ]
-    result = await model._estimate_tokens(messages=messages, tool_specs=tool_specs)
+    result = await model.count_tokens(messages=messages, tool_specs=tool_specs)
     # Should still count the message tokens even though tool spec fails
     assert result == 1  # "hello" only, tool spec skipped
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_citations_block(model):
+async def test_count_tokens_citations_block(model):
     messages = [
         {
             "role": "assistant",
@@ -431,13 +431,13 @@ async def test_estimate_tokens_citations_block(model):
             ],
         }
     ]
-    result = await model._estimate_tokens(messages=messages)
+    result = await model.count_tokens(messages=messages)
     assert result == 11  # "According to the document, the answer is 42."
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_system_prompt_content(model):
-    result = await model._estimate_tokens(
+async def test_count_tokens_system_prompt_content(model):
+    result = await model.count_tokens(
         messages=[],
         system_prompt_content=[{"text": "You are a helpful assistant."}],
     )
@@ -445,8 +445,8 @@ async def test_estimate_tokens_system_prompt_content(model):
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_system_prompt_content_with_cache_point(model):
-    result = await model._estimate_tokens(
+async def test_count_tokens_system_prompt_content_with_cache_point(model):
+    result = await model.count_tokens(
         messages=[],
         system_prompt_content=[
             {"text": "You are a helpful assistant."},
@@ -457,13 +457,13 @@ async def test_estimate_tokens_system_prompt_content_with_cache_point(model):
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_system_prompt_content_takes_priority(model):
-    content_only = await model._estimate_tokens(
+async def test_count_tokens_system_prompt_content_takes_priority(model):
+    content_only = await model.count_tokens(
         messages=[],
         system_prompt_content=[{"text": "Short."}],
     )
     # When both are provided, system_prompt_content wins — system_prompt is ignored
-    both = await model._estimate_tokens(
+    both = await model.count_tokens(
         messages=[],
         system_prompt="This is a much longer system prompt that should have more tokens.",
         system_prompt_content=[{"text": "Short."}],
@@ -473,12 +473,12 @@ async def test_estimate_tokens_system_prompt_content_takes_priority(model):
 
 
 @pytest.mark.asyncio
-async def test_estimate_tokens_all_inputs(model):
+async def test_count_tokens_all_inputs(model):
     messages = [
         {"role": "user", "content": [{"text": "hello world"}]},
         {"role": "assistant", "content": [{"text": "hi there"}]},
     ]
-    result = await model._estimate_tokens(
+    result = await model.count_tokens(
         messages=messages,
         tool_specs=[{"name": "test", "description": "a test tool", "inputSchema": {"json": {}}}],
         system_prompt="Be helpful.",
@@ -489,7 +489,7 @@ async def test_estimate_tokens_all_inputs(model):
 
 
 def test_get_encoding_falls_back_without_tiktoken(monkeypatch):
-    """Test that _get_encoding returns None and _estimate_tokens falls back to heuristic."""
+    """Test that _get_encoding returns None and count_tokens falls back to heuristic."""
     import strands.models.model as model_module
 
     model_module._get_encoding.cache_clear()
@@ -563,7 +563,7 @@ class TestHeuristicEstimation:
 
     @pytest.mark.asyncio
     async def test_model_falls_back_to_heuristic(self, monkeypatch, model):
-        """Model._estimate_tokens falls back to heuristic when tiktoken unavailable."""
+        """Model.count_tokens falls back to heuristic when tiktoken unavailable."""
         import strands.models.model as model_module
 
         model_module._get_encoding.cache_clear()
@@ -577,7 +577,7 @@ class TestHeuristicEstimation:
         monkeypatch.setattr("builtins.__import__", _block_tiktoken)
 
         try:
-            result = await model._estimate_tokens(
+            result = await model.count_tokens(
                 messages=[{"role": "user", "content": [{"text": "hello world!"}]}]
             )
             assert result == 3  # ceil(12 / 4)

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -468,11 +468,12 @@ def test_estimate_tokens_all_inputs(model):
     assert result == 31
 
 
-def test_get_encoding_raises_without_tiktoken(monkeypatch):
-    """Test that _get_encoding raises ImportError with install instructions when tiktoken is missing."""
+def test_get_encoding_falls_back_without_tiktoken(monkeypatch):
+    """Test that _get_encoding returns None and _estimate_tokens falls back to heuristic."""
     import strands.models.model as model_module
 
     monkeypatch.setattr(model_module, "_cached_encoding", None)
+    monkeypatch.setattr(model_module, "_tiktoken_available", None)
     original_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
 
     def _block_tiktoken(name, *args, **kwargs):
@@ -482,5 +483,16 @@ def test_get_encoding_raises_without_tiktoken(monkeypatch):
 
     monkeypatch.setattr("builtins.__import__", _block_tiktoken)
 
-    with pytest.raises(ImportError, match="pip install strands-agents\\[token-estimation\\]"):
-        model_module._get_encoding()
+    assert model_module._get_encoding() is None
+
+    # _estimate_tokens_with_tiktoken should raise when tiktoken is unavailable
+    with pytest.raises(ImportError):
+        model_module._estimate_tokens_with_tiktoken(
+            messages=[{"role": "user", "content": [{"text": "hello world!"}]}],
+        )
+
+    # _estimate_tokens_with_heuristic uses chars/4 for text
+    result = model_module._estimate_tokens_with_heuristic(
+        messages=[{"role": "user", "content": [{"text": "hello world!"}]}],
+    )
+    assert result == 3  # ceil(12 / 4)

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -492,8 +492,7 @@ def test_get_encoding_falls_back_without_tiktoken(monkeypatch):
     """Test that _get_encoding returns None and _estimate_tokens falls back to heuristic."""
     import strands.models.model as model_module
 
-    monkeypatch.setattr(model_module, "_cached_encoding", None)
-    monkeypatch.setattr(model_module, "_tiktoken_available", None)
+    model_module._get_encoding.cache_clear()
     original_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
 
     def _block_tiktoken(name, *args, **kwargs):
@@ -503,19 +502,22 @@ def test_get_encoding_falls_back_without_tiktoken(monkeypatch):
 
     monkeypatch.setattr("builtins.__import__", _block_tiktoken)
 
-    assert model_module._get_encoding() is None
+    try:
+        assert model_module._get_encoding() is None
 
-    # _estimate_tokens_with_tiktoken should raise when tiktoken is unavailable
-    with pytest.raises(ImportError):
-        model_module._estimate_tokens_with_tiktoken(
+        # _estimate_tokens_with_tiktoken should raise when tiktoken is unavailable
+        with pytest.raises(ImportError):
+            model_module._estimate_tokens_with_tiktoken(
+                messages=[{"role": "user", "content": [{"text": "hello world!"}]}],
+            )
+
+        # _estimate_tokens_with_heuristic uses chars/4 for text
+        result = model_module._estimate_tokens_with_heuristic(
             messages=[{"role": "user", "content": [{"text": "hello world!"}]}],
         )
-
-    # _estimate_tokens_with_heuristic uses chars/4 for text
-    result = model_module._estimate_tokens_with_heuristic(
-        messages=[{"role": "user", "content": [{"text": "hello world!"}]}],
-    )
-    assert result == 3  # ceil(12 / 4)
+        assert result == 3  # ceil(12 / 4)
+    finally:
+        model_module._get_encoding.cache_clear()
 
 
 class TestHeuristicEstimation:
@@ -564,8 +566,20 @@ class TestHeuristicEstimation:
         """Model._estimate_tokens falls back to heuristic when tiktoken unavailable."""
         import strands.models.model as model_module
 
-        monkeypatch.setattr(model_module, "_cached_encoding", None)
-        monkeypatch.setattr(model_module, "_tiktoken_available", False)
+        model_module._get_encoding.cache_clear()
+        original_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
 
-        result = await model._estimate_tokens(messages=[{"role": "user", "content": [{"text": "hello world!"}]}])
-        assert result == 3  # ceil(12 / 4)
+        def _block_tiktoken(name, *args, **kwargs):
+            if name == "tiktoken":
+                raise ImportError("No module named 'tiktoken'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", _block_tiktoken)
+
+        try:
+            result = await model._estimate_tokens(
+                messages=[{"role": "user", "content": [{"text": "hello world!"}]}]
+            )
+            assert result == 3  # ceil(12 / 4)
+        finally:
+            model_module._get_encoding.cache_clear()

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -215,40 +215,47 @@ def test_model_plugin_preserves_messages_when_not_stateful(model_plugin):
     assert len(agent.messages) == 1
 
 
-def test_estimate_tokens_empty_messages(model):
-    assert model._estimate_tokens(messages=[]) == 0
+@pytest.mark.asyncio
+async def test_estimate_tokens_empty_messages(model):
+    assert await model._estimate_tokens(messages=[]) == 0
 
 
-def test_estimate_tokens_system_prompt_only(model):
-    result = model._estimate_tokens(messages=[], system_prompt="You are a helpful assistant.")
+@pytest.mark.asyncio
+async def test_estimate_tokens_system_prompt_only(model):
+    result = await model._estimate_tokens(messages=[], system_prompt="You are a helpful assistant.")
     assert result == 6
 
 
-def test_estimate_tokens_text_messages(model, messages):
-    result = model._estimate_tokens(messages=messages)
+@pytest.mark.asyncio
+async def test_estimate_tokens_text_messages(model, messages):
+    result = await model._estimate_tokens(messages=messages)
     assert result == 1  # "hello"
 
 
-def test_estimate_tokens_with_tool_specs(model, messages, tool_specs):
-    without_tools = model._estimate_tokens(messages=messages)
-    with_tools = model._estimate_tokens(messages=messages, tool_specs=tool_specs)
+@pytest.mark.asyncio
+async def test_estimate_tokens_with_tool_specs(model, messages, tool_specs):
+    without_tools = await model._estimate_tokens(messages=messages)
+    with_tools = await model._estimate_tokens(messages=messages, tool_specs=tool_specs)
     assert without_tools == 1  # "hello"
     assert with_tools == 49  # "hello" (1) + tool_spec (48)
 
 
-def test_estimate_tokens_with_system_prompt(model, messages, system_prompt):
-    without_prompt = model._estimate_tokens(messages=messages)
-    with_prompt = model._estimate_tokens(messages=messages, system_prompt=system_prompt)
+@pytest.mark.asyncio
+async def test_estimate_tokens_with_system_prompt(model, messages, system_prompt):
+    without_prompt = await model._estimate_tokens(messages=messages)
+    with_prompt = await model._estimate_tokens(messages=messages, system_prompt=system_prompt)
     assert without_prompt == 1  # "hello"
     assert with_prompt == 3  # "hello" (1) + "s1" (2)
 
 
-def test_estimate_tokens_combined(model, messages, tool_specs, system_prompt):
-    result = model._estimate_tokens(messages=messages, tool_specs=tool_specs, system_prompt=system_prompt)
+@pytest.mark.asyncio
+async def test_estimate_tokens_combined(model, messages, tool_specs, system_prompt):
+    result = await model._estimate_tokens(messages=messages, tool_specs=tool_specs, system_prompt=system_prompt)
     assert result == 51  # "hello" (1) + tool_spec (48) + "s1" (2)
 
 
-def test_estimate_tokens_tool_use_block(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_tool_use_block(model):
     messages = [
         {
             "role": "assistant",
@@ -263,12 +270,13 @@ def test_estimate_tokens_tool_use_block(model):
             ],
         }
     ]
-    result = model._estimate_tokens(messages=messages)
+    result = await model._estimate_tokens(messages=messages)
     # name "my_tool" (2) + json.dumps(input) (6) = 8
     assert result == 8
 
 
-def test_estimate_tokens_tool_result_block(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_tool_result_block(model):
     messages = [
         {
             "role": "user",
@@ -283,11 +291,12 @@ def test_estimate_tokens_tool_result_block(model):
             ],
         }
     ]
-    result = model._estimate_tokens(messages=messages)
+    result = await model._estimate_tokens(messages=messages)
     assert result == 3  # "tool output here"
 
 
-def test_estimate_tokens_reasoning_block(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_reasoning_block(model):
     messages = [
         {
             "role": "assistant",
@@ -302,21 +311,23 @@ def test_estimate_tokens_reasoning_block(model):
             ],
         }
     ]
-    result = model._estimate_tokens(messages=messages)
+    result = await model._estimate_tokens(messages=messages)
     assert result == 9  # "Let me think about this step by step."
 
 
-def test_estimate_tokens_skips_binary_content(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_skips_binary_content(model):
     messages = [
         {
             "role": "user",
             "content": [{"image": {"format": "png", "source": {"bytes": b"fake image data"}}}],
         }
     ]
-    assert model._estimate_tokens(messages=messages) == 0
+    assert await model._estimate_tokens(messages=messages) == 0
 
 
-def test_estimate_tokens_tool_result_with_bytes_only(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_tool_result_with_bytes_only(model):
     messages = [
         {
             "role": "user",
@@ -331,11 +342,12 @@ def test_estimate_tokens_tool_result_with_bytes_only(model):
             ],
         }
     ]
-    result = model._estimate_tokens(messages=messages)
+    result = await model._estimate_tokens(messages=messages)
     assert result == 0
 
 
-def test_estimate_tokens_tool_result_with_text_and_bytes(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_tool_result_with_text_and_bytes(model):
     messages = [
         {
             "role": "user",
@@ -353,22 +365,24 @@ def test_estimate_tokens_tool_result_with_text_and_bytes(model):
             ],
         }
     ]
-    result = model._estimate_tokens(messages=messages)
+    result = await model._estimate_tokens(messages=messages)
     assert result > 0
 
 
-def test_estimate_tokens_guard_content_block(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_guard_content_block(model):
     messages = [
         {
             "role": "assistant",
             "content": [{"guardContent": {"text": {"text": "This content was filtered by guardrails."}}}],
         }
     ]
-    result = model._estimate_tokens(messages=messages)
+    result = await model._estimate_tokens(messages=messages)
     assert result == 8  # "This content was filtered by guardrails."
 
 
-def test_estimate_tokens_tool_use_with_bytes(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_tool_use_with_bytes(model):
     messages = [
         {
             "role": "assistant",
@@ -383,12 +397,13 @@ def test_estimate_tokens_tool_use_with_bytes(model):
             ],
         }
     ]
-    result = model._estimate_tokens(messages=messages)
+    result = await model._estimate_tokens(messages=messages)
     # Should still count the tool name even though input has non-serializable bytes
     assert result == 2  # "my_tool" name only
 
 
-def test_estimate_tokens_non_serializable_tool_spec(model, messages):
+@pytest.mark.asyncio
+async def test_estimate_tokens_non_serializable_tool_spec(model, messages):
     tool_specs = [
         {
             "name": "test",
@@ -396,12 +411,13 @@ def test_estimate_tokens_non_serializable_tool_spec(model, messages):
             "inputSchema": {"json": {"default": b"bytes"}},
         }
     ]
-    result = model._estimate_tokens(messages=messages, tool_specs=tool_specs)
+    result = await model._estimate_tokens(messages=messages, tool_specs=tool_specs)
     # Should still count the message tokens even though tool spec fails
     assert result == 1  # "hello" only, tool spec skipped
 
 
-def test_estimate_tokens_citations_block(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_citations_block(model):
     messages = [
         {
             "role": "assistant",
@@ -415,20 +431,22 @@ def test_estimate_tokens_citations_block(model):
             ],
         }
     ]
-    result = model._estimate_tokens(messages=messages)
+    result = await model._estimate_tokens(messages=messages)
     assert result == 11  # "According to the document, the answer is 42."
 
 
-def test_estimate_tokens_system_prompt_content(model):
-    result = model._estimate_tokens(
+@pytest.mark.asyncio
+async def test_estimate_tokens_system_prompt_content(model):
+    result = await model._estimate_tokens(
         messages=[],
         system_prompt_content=[{"text": "You are a helpful assistant."}],
     )
     assert result == 6  # "You are a helpful assistant."
 
 
-def test_estimate_tokens_system_prompt_content_with_cache_point(model):
-    result = model._estimate_tokens(
+@pytest.mark.asyncio
+async def test_estimate_tokens_system_prompt_content_with_cache_point(model):
+    result = await model._estimate_tokens(
         messages=[],
         system_prompt_content=[
             {"text": "You are a helpful assistant."},
@@ -438,13 +456,14 @@ def test_estimate_tokens_system_prompt_content_with_cache_point(model):
     assert result == 6  # "You are a helpful assistant.", cachePoint adds 0
 
 
-def test_estimate_tokens_system_prompt_content_takes_priority(model):
-    content_only = model._estimate_tokens(
+@pytest.mark.asyncio
+async def test_estimate_tokens_system_prompt_content_takes_priority(model):
+    content_only = await model._estimate_tokens(
         messages=[],
         system_prompt_content=[{"text": "Short."}],
     )
     # When both are provided, system_prompt_content wins — system_prompt is ignored
-    both = model._estimate_tokens(
+    both = await model._estimate_tokens(
         messages=[],
         system_prompt="This is a much longer system prompt that should have more tokens.",
         system_prompt_content=[{"text": "Short."}],
@@ -453,12 +472,13 @@ def test_estimate_tokens_system_prompt_content_takes_priority(model):
     assert content_only == both
 
 
-def test_estimate_tokens_all_inputs(model):
+@pytest.mark.asyncio
+async def test_estimate_tokens_all_inputs(model):
     messages = [
         {"role": "user", "content": [{"text": "hello world"}]},
         {"role": "assistant", "content": [{"text": "hi there"}]},
     ]
-    result = model._estimate_tokens(
+    result = await model._estimate_tokens(
         messages=messages,
         tool_specs=[{"name": "test", "description": "a test tool", "inputSchema": {"json": {}}}],
         system_prompt="Be helpful.",
@@ -539,12 +559,13 @@ class TestHeuristicEstimation:
         )
         assert result == 2  # only tool name counted: ceil(len("my_tool") / 4)
 
-    def test_model_falls_back_to_heuristic(self, monkeypatch, model):
+    @pytest.mark.asyncio
+    async def test_model_falls_back_to_heuristic(self, monkeypatch, model):
         """Model._estimate_tokens falls back to heuristic when tiktoken unavailable."""
         import strands.models.model as model_module
 
         monkeypatch.setattr(model_module, "_cached_encoding", None)
         monkeypatch.setattr(model_module, "_tiktoken_available", False)
 
-        result = model._estimate_tokens(messages=[{"role": "user", "content": [{"text": "hello world!"}]}])
+        result = await model._estimate_tokens(messages=[{"role": "user", "content": [{"text": "hello world!"}]}])
         assert result == 3  # ceil(12 / 4)

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -466,3 +466,21 @@ def test_estimate_tokens_all_inputs(model):
     )
     # system_prompt_content (4) + "hello world" (2) + "hi there" (2) + tool_spec (23) = 31
     assert result == 31
+
+
+def test_get_encoding_raises_without_tiktoken(monkeypatch):
+    """Test that _get_encoding raises ImportError with install instructions when tiktoken is missing."""
+    import strands.models.model as model_module
+
+    monkeypatch.setattr(model_module, "_cached_encoding", None)
+    original_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def _block_tiktoken(name, *args, **kwargs):
+        if name == "tiktoken":
+            raise ImportError("No module named 'tiktoken'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _block_tiktoken)
+
+    with pytest.raises(ImportError, match="pip install strands-agents\\[token-estimation\\]"):
+        model_module._get_encoding()

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -496,3 +496,55 @@ def test_get_encoding_falls_back_without_tiktoken(monkeypatch):
         messages=[{"role": "user", "content": [{"text": "hello world!"}]}],
     )
     assert result == 3  # ceil(12 / 4)
+
+
+class TestHeuristicEstimation:
+    """Tests for _estimate_tokens_with_heuristic."""
+
+    def test_all_content_types(self):
+        """One call covering text, toolUse, toolResult, reasoning, guard, citations, system prompt, tool specs."""
+        from strands.models.model import _estimate_tokens_with_heuristic
+
+        messages = [
+            {"role": "user", "content": [{"text": "hello world!"}]},
+            {"role": "assistant", "content": [
+                {"toolUse": {"toolUseId": "1", "name": "my_tool", "input": {"q": "test"}}},
+                {"reasoningContent": {"reasoningText": {"text": "Let me think."}}},
+                {"guardContent": {"text": {"text": "Filtered."}}},
+                {"citationsContent": {"content": [{"text": "Citation."}]}},
+            ]},
+            {"role": "user", "content": [
+                {"toolResult": {"toolUseId": "1", "content": [{"text": "tool output here"}]}},
+            ]},
+        ]
+        result = _estimate_tokens_with_heuristic(
+            messages=messages,
+            tool_specs=[{"name": "test", "description": "a tool"}],
+            system_prompt="ignored",
+            system_prompt_content=[{"text": "Be helpful."}],
+        )
+        assert result > 0
+
+    def test_non_serializable_inputs(self):
+        """Heuristic gracefully handles non-serializable tool input and tool specs."""
+        from strands.models.model import _estimate_tokens_with_heuristic
+
+        result = _estimate_tokens_with_heuristic(
+            messages=[
+                {"role": "assistant", "content": [
+                    {"toolUse": {"toolUseId": "1", "name": "my_tool", "input": {"data": b"bytes"}}},
+                ]},
+            ],
+            tool_specs=[{"name": "t", "inputSchema": {"json": {"default": b"bytes"}}}],
+        )
+        assert result == 2  # only tool name counted: ceil(len("my_tool") / 4)
+
+    def test_model_falls_back_to_heuristic(self, monkeypatch, model):
+        """Model._estimate_tokens falls back to heuristic when tiktoken unavailable."""
+        import strands.models.model as model_module
+
+        monkeypatch.setattr(model_module, "_cached_encoding", None)
+        monkeypatch.setattr(model_module, "_tiktoken_available", False)
+
+        result = model._estimate_tokens(messages=[{"role": "user", "content": [{"text": "hello world!"}]}])
+        assert result == 3  # ceil(12 / 4)


### PR DESCRIPTION
## Motivation

Model providers expose native token counting endpoints (Bedrock CountTokens, Anthropic countTokens, OpenAI token counting, Gemini countTokens), and SDK internals such as context compression need a way to estimate input token count before sending to the model. Making `estimate_tokens` a public method on the `Model` base class enables both internal SDK features and plugins to use token estimation directly, and allows individual providers to override with native implementations for improved accuracy.

Resolves #1294

## Public API Changes

`Model.estimate_tokens()` is a new async method on the base `Model` class:

```python
# Estimate tokens for proactive context management
token_count = await agent.model.estimate_tokens(
    messages=messages,
    tool_specs=tool_specs,
    system_prompt="You are a helpful assistant.",
)

if token_count > threshold:
    # trigger context compression
    ...
```

The base implementation uses tiktoken (`cl100k_base`) when available, falling back to a character-based heuristic (`chars/4` for text, `chars/2` for JSON) when tiktoken is not installed. Subclasses can override to use provider-native counting APIs.

## Use Cases

- **Proactive context compression**: Trigger summarization or sliding-window trimming when estimated tokens approach a model's context limit
- **Plugin token awareness**: Plugins (e.g., steering, conversation managers) can make token-informed decisions without provider-specific code
- **Provider-native overrides**: Model subclasses can override with 100% accurate native APIs (tracked in #2179)

## Type of Change

New feature

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published