### PR TITLE
fix: propagate tool exceptions to spans so StatusCode.ERROR is set correctly

### DIFF
--- a/src/strands/tools/executors/_executor.py
+++ b/src/strands/tools/executors/_executor.py
@@ -171,9 +171,15 @@ class ToolExecutor(abc.ABC):
                 }
 
                 after_event, _ = await ToolExecutor._invoke_after_tool_call_hook(
-                    agent, None, tool_use, invocation_state, cancel_result, cancel_message=cancel_message
+                    agent,
+                    None,
+                    tool_use,
+                    invocation_state,
+                    cancel_result,
+                    exception=Exception(cancel_message),
+                    cancel_message=cancel_message,
                 )
-                yield ToolResultEvent(after_event.result)
+                yield ToolResultEvent(after_event.result, exception=after_event.exception)
                 tool_results.append(after_event.result)
                 return
 
@@ -202,15 +208,16 @@ class ToolExecutor(abc.ABC):
                         "content": [{"text": f"Unknown tool: {tool_name}"}],
                     }
 
+                    unknown_tool_error = Exception(f"Unknown tool: {tool_name}")
                     after_event, _ = await ToolExecutor._invoke_after_tool_call_hook(
-                        agent, selected_tool, tool_use, invocation_state, result
+                        agent, selected_tool, tool_use, invocation_state, result, exception=unknown_tool_error
                     )
                     # Check if retry requested for unknown tool error
                     # Use getattr because BidiAfterToolCallEvent doesn't have retry attribute
                     if getattr(after_event, "retry", False):
                         logger.debug("tool_name=<%s> | retry requested, retrying tool call", tool_name)
                         continue
-                    yield ToolResultEvent(after_event.result)
+                    yield ToolResultEvent(after_event.result, exception=after_event.exception)
                     tool_results.append(after_event.result)
                     return
                 if structured_output_context.is_enabled:
@@ -258,7 +265,7 @@ class ToolExecutor(abc.ABC):
                     logger.debug("tool_name=<%s> | retry requested, retrying tool call", tool_name)
                     continue
 
-                yield ToolResultEvent(after_event.result)
+                yield ToolResultEvent(after_event.result, exception=after_event.exception)
                 tool_results.append(after_event.result)
                 return
 
@@ -277,7 +284,7 @@ class ToolExecutor(abc.ABC):
                 if getattr(after_event, "retry", False):
                     logger.debug("tool_name=<%s> | retry requested after exception, retrying tool call", tool_name)
                     continue
-                yield ToolResultEvent(after_event.result)
+                yield ToolResultEvent(after_event.result, exception=after_event.exception)
                 tool_results.append(after_event.result)
                 return
 
@@ -338,7 +345,7 @@ class ToolExecutor(abc.ABC):
                 agent.event_loop_metrics.add_tool_usage(tool_use, tool_duration, tool_trace, tool_success, message)
             cycle_trace.add_child(tool_trace)
 
-            tracer.end_tool_call_span(tool_call_span, result)
+            tracer.end_tool_call_span(tool_call_span, result, error=result_event.exception)
 
     @abc.abstractmethod
     # pragma: no cover

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -707,6 +707,20 @@ def test_end_tool_call_span_latest_conventions(mock_span, monkeypatch):
     mock_span.end.assert_called_once()
 
 
+def test_end_tool_call_span_with_error(mock_span):
+    """Test ending a tool call span with an explicit error sets StatusCode.ERROR."""
+    tracer = Tracer()
+    error = ValueError("tool exploded")
+    tool_result = {"status": "error", "content": [{"text": "Error: tool exploded"}]}
+
+    tracer.end_tool_call_span(mock_span, tool_result, error=error)
+
+    mock_span.set_attributes.assert_called_once_with({"gen_ai.tool.status": "error"})
+    mock_span.set_status.assert_called_once_with(StatusCode.ERROR, "tool exploded")
+    mock_span.record_exception.assert_called_once_with(error)
+    mock_span.end.assert_called_once()
+
+
 def test_start_event_loop_cycle_span(mock_tracer):
     """Test starting an event loop cycle span."""
     with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):

--- a/tests/strands/tools/executors/test_executor.py
+++ b/tests/strands/tools/executors/test_executor.py
@@ -189,6 +189,7 @@ async def test_executor_stream_yields_unknown_tool(executor, agent, tool_results
         tool_use=tool_use,
         invocation_state=invocation_state,
         result=exp_results[0],
+        exception=unittest.mock.ANY,
     )
     assert tru_hook_after_event == exp_hook_after_event
 
@@ -216,6 +217,7 @@ async def test_executor_stream_with_trace(
     tracer.end_tool_call_span.assert_called_once_with(
         tracer.start_tool_call_span.return_value,
         {"content": [{"text": "sunny"}], "status": "success", "toolUseId": "1"},
+        error=None,
     )
 
     cycle_trace.add_child.assert_called_once()
@@ -901,3 +903,71 @@ async def test_executor_stream_retry_after_unknown_tool(executor, agent, tool_re
     assert len(tru_events) == 1
     assert tru_events[0].tool_result["status"] == "error"
     assert "Unknown tool" in tru_events[0].tool_result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_executor_stream_with_trace_error(
+    executor, tracer, agent, tool_results, cycle_trace, cycle_span, invocation_state, alist
+):
+    """Test that _stream_with_trace passes the exception to end_tool_call_span when a tool fails."""
+    tool_use: ToolUse = {"name": "exception_tool", "toolUseId": "1", "input": {}}
+    stream = executor._stream_with_trace(agent, tool_use, tool_results, cycle_trace, cycle_span, invocation_state)
+
+    await alist(stream)
+
+    tracer.end_tool_call_span.assert_called_once()
+    call_args = tracer.end_tool_call_span.call_args
+    assert call_args[0][1]["status"] == "error"
+    error_arg = call_args[1].get("error")
+    assert error_arg is not None
+    assert isinstance(error_arg, RuntimeError)
+    assert "Tool error" in str(error_arg)
+
+
+@pytest.mark.asyncio
+async def test_executor_stream_error_preserves_exception(executor, agent, tool_results, invocation_state, alist):
+    """Test that _stream yields a ToolResultEvent with the exception preserved."""
+    tool_use: ToolUse = {"name": "exception_tool", "toolUseId": "1", "input": {}}
+    stream = executor._stream(agent, tool_use, tool_results, invocation_state)
+
+    events = await alist(stream)
+    result_event = events[-1]
+    assert isinstance(result_event, ToolResultEvent)
+    assert result_event.tool_result["status"] == "error"
+    assert result_event.exception is not None
+    assert isinstance(result_event.exception, RuntimeError)
+    assert "Tool error" in str(result_event.exception)
+
+
+@pytest.mark.asyncio
+async def test_executor_stream_unknown_tool_has_exception(executor, agent, tool_results, invocation_state, alist):
+    """Test that _stream yields a ToolResultEvent with exception for unknown tools."""
+    tool_use: ToolUse = {"name": "nonexistent_tool", "toolUseId": "1", "input": {}}
+    stream = executor._stream(agent, tool_use, tool_results, invocation_state)
+
+    events = await alist(stream)
+    result_event = events[-1]
+    assert isinstance(result_event, ToolResultEvent)
+    assert result_event.tool_result["status"] == "error"
+    assert result_event.exception is not None
+    assert "Unknown tool" in str(result_event.exception)
+
+
+@pytest.mark.asyncio
+async def test_executor_stream_cancel_has_exception(executor, agent, tool_results, invocation_state, alist):
+    """Test that _stream yields a ToolResultEvent with exception for cancelled tools."""
+
+    def cancel_callback(event):
+        event.cancel_tool = True
+        return event
+
+    agent.hooks.add_callback(BeforeToolCallEvent, cancel_callback)
+    tool_use: ToolUse = {"name": "weather_tool", "toolUseId": "1", "input": {}}
+    stream = executor._stream(agent, tool_use, tool_results, invocation_state)
+
+    events = await alist(stream)
+    result_event = events[-1]
+    assert isinstance(result_event, ToolResultEvent)
+    assert result_event.tool_result["status"] == "error"
+    assert result_event.exception is not None
+    assert "cancelled" in str(result_event.exception)


### PR DESCRIPTION
When a tool fails, the exception was being dropped before reaching end_tool_call_span, causing all tool spans to get StatusCode.OK even on errors. This threads the original exception through ToolResultEvent yields and into the tracer, and creates exceptions for cancel/unknown tool paths that previously had none.

Fixes strands-agents#2016

## Description

When a tool raises an exception, Strands catches it and converts it to a `ToolResult` dict with `status='error'`. The original exception object was dropped at the `ToolResultEvent` yield points in `_executor.py`, so `end_tool_call_span` never received it and always set `StatusCode.OK`. This breaks observability backends like Langfuse that rely on span status codes for error detection.

This PR fixes the root cause by:
- Threading original exceptions through `ToolResultEvent` yields and into `end_tool_call_span` so tool spans correctly get `StatusCode.ERROR`
- Creating exceptions for cancel and unknown-tool error paths that previously produced `status: "error"` results without an exception object

PR #2027 proposed synthesizing an `Exception` from error text in `tracer.py`. This PR instead fixes the root cause — the exception was already available but simply not threaded through. This preserves the original exception type and traceback.

## Related Issues

Fixes #2016

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`
- Full test suite: 2488 passed, 0 failures
- New tests:
  - `test_end_tool_call_span_with_error` — explicit error sets `StatusCode.ERROR` and `record_exception`
  - `test_executor_stream_with_trace_error` — exception flows from tool to tracer
  - `test_executor_stream_error_preserves_exception` — `ToolResultEvent.exception` is set
  - `test_executor_stream_unknown_tool_has_exception` — unknown tool path
  - `test_executor_stream_cancel_has_exception` — cancel path

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
