### PR TITLE
fix(models): add ContextWindowOverflowException to Ollama, Mistral, LlamaAPI, Writer providers

### DIFF
--- a/strands-py/src/strands/models/llamaapi.py
+++ b/strands-py/src/strands/models/llamaapi.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
-from ..types.exceptions import ModelThrottledException
+from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent, Usage
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
@@ -70,6 +70,14 @@ class LlamaAPIModel(Model):
             self.client = LlamaAPIClient()
         else:
             self.client = LlamaAPIClient(**client_args)
+
+    OVERFLOW_MESSAGES = {
+        "context length exceeded",
+        "context window",
+        "max context length",
+        "prompt is too long",
+        "token limit",
+    }
 
     @override
     def update_config(self, **model_config: Unpack[LlamaConfig]) -> None:  # type: ignore
@@ -368,6 +376,11 @@ class LlamaAPIModel(Model):
             response = self.client.chat.completions.create(**request)
         except llama_api_client.RateLimitError as e:
             raise ModelThrottledException(str(e)) from e
+        except Exception as error:
+            error_str = str(error).lower()
+            if any(msg in error_str for msg in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(error)) from error
+            raise
 
         logger.debug("got response from model")
         yield self.format_chunk({"chunk_type": "message_start"})

--- a/strands-py/src/strands/models/mistral.py
+++ b/strands-py/src/strands/models/mistral.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
-from ..types.exceptions import ModelThrottledException
+from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._defaults import resolve_config_metadata
@@ -97,6 +97,14 @@ class MistralModel(Model):
         self.client_args = client_args or {}
         if api_key:
             self.client_args["api_key"] = api_key
+
+    OVERFLOW_MESSAGES = {
+        "context length exceeded",
+        "context window",
+        "max context length",
+        "prompt is too long",
+        "token limit",
+    }
 
     @override
     def update_config(self, **model_config: Unpack[MistralConfig]) -> None:  # type: ignore
@@ -501,7 +509,10 @@ class MistralModel(Model):
                                 yield self.format_chunk({"chunk_type": "metadata", "data": chunk.data.usage})
 
         except Exception as e:
-            if "rate" in str(e).lower() or "429" in str(e):
+            error_str = str(e).lower()
+            if any(msg in error_str for msg in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(e)) from e
+            if "rate" in error_str or "429" in str(e):
                 raise ModelThrottledException(str(e)) from e
             raise
 

--- a/strands-py/src/strands/models/ollama.py
+++ b/strands-py/src/strands/models/ollama.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
+from ..types.exceptions import ContextWindowOverflowException
 from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
@@ -33,6 +34,13 @@ class OllamaModel(Model):
     - Streaming responses
     - Tool/function calling
     """
+
+    OVERFLOW_MESSAGES = {
+        "context length exceeded",
+        "context window",
+        "max context length",
+        "prompt is too long",
+    }
 
     class OllamaConfig(BaseModelConfig, total=False):
         """Configuration parameters for Ollama models.
@@ -321,7 +329,14 @@ class OllamaModel(Model):
         tool_requested = False
 
         client = ollama.AsyncClient(self.host, **self.client_args)
-        response = await client.chat(**request)
+        
+        try:
+            response = await client.chat(**request)
+        except Exception as error:
+            error_str = str(error).lower()
+            if any(msg in error_str for msg in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(error)) from error
+            raise
 
         logger.debug("got response from model")
         yield self.format_chunk({"chunk_type": "message_start"})

--- a/strands-py/src/strands/models/writer.py
+++ b/strands-py/src/strands/models/writer.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
-from ..types.exceptions import ModelThrottledException
+from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
@@ -62,6 +62,14 @@ class WriterModel(Model):
 
         client_args = client_args or {}
         self.client = writerai.AsyncClient(**client_args)
+
+    OVERFLOW_MESSAGES = {
+        "context length exceeded",
+        "context window",
+        "max context length",
+        "prompt is too long",
+        "token limit",
+    }
 
     @override
     def update_config(self, **model_config: Unpack[WriterConfig]) -> None:  # type: ignore[override]
@@ -397,6 +405,11 @@ class WriterModel(Model):
             response = await self.client.chat.chat(**request)
         except writerai.RateLimitError as e:
             raise ModelThrottledException(str(e)) from e
+        except Exception as error:
+            error_str = str(error).lower()
+            if any(msg in error_str for msg in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(error)) from error
+            raise
 
         yield self.format_chunk({"chunk_type": "message_start"})
         yield self.format_chunk({"chunk_type": "content_block_start", "data_type": "text"})


### PR DESCRIPTION
## Description

Adds exception handling for context window overflow across four model providers: Ollama, Mistral, LlamaAPI, and Writer. These providers currently lack the detection, so agents crash with unhandled errors when the context window fills up instead of triggering automatic recovery.

When context window is exceeded, the SDK's event loop catches `ContextWindowOverflowException` and calls `ConversationManager.reduce_context()` to trim the conversation history. Without this exception, the error propagates as a provider-specific error.

## Changes

For each provider, this fix:
- Imports `ContextWindowOverflowException`
- Adds `OVERFLOW_MESSAGES` constant with context-related error strings
- Wraps the stream call in try/except to detect overflow
- Raises `ContextWindowOverflowException` on match

Ollama had no error handling at all. Mistral, LlamaAPI, and Writer already catch rate limits, so the new overflow check is added to those handlers.

All four providers now follow the pattern from Anthropic, OpenAI, and Bedrock.

## Related Issues

Fixes #2052

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- Python syntax validated on all 4 files
- Exception handling follows the existing pattern in Anthropic/OpenAI/Bedrock
- Manual testing: long conversations with these providers should now call `reduce_context()` instead of crashing

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the coding style and patterns of this project
- [x] Exception handling matches the working provider pattern

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.