### PR TITLE
feat(multiagent): add __str__ support to MultiAgentResult

### DIFF
--- a/src/strands/multiagent/base.py
+++ b/src/strands/multiagent/base.py
@@ -136,6 +136,27 @@ class MultiAgentResult:
     execution_time: int = 0
     interrupts: list[Interrupt] = field(default_factory=list)
 
+    def __str__(self) -> str:
+        """Return a string representation of the multi-agent result.
+
+        Priority order:
+        1. Interrupts (if present) -> stringified list of interrupt dicts
+        2. Text output from all node results -> concatenated strings
+
+        Returns:
+            String representation based on the priority order above.
+        """
+        if self.interrupts:
+            return str([interrupt.to_dict() for interrupt in self.interrupts])
+
+        parts = []
+        for node_result in self.results.values():
+            for agent_result in node_result.get_agent_results():
+                text = str(agent_result).strip()
+                if text:
+                    parts.append(text)
+        return chr(10).join(parts)
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MultiAgentResult":
         """Rehydrate a MultiAgentResult from persisted JSON."""


### PR DESCRIPTION
## Description

MultiAgentResult had no `__str__` method. AgentResult already supports `str(result)` directly at `agent_result.py:47`, but the multi-agent equivalent required manually unwrapping nested results to get string output.

This adds `__str__` to MultiAgentResult following the same priority order as AgentResult:

1. Interrupts (if present) -> stringified list of interrupt dicts
2. Text output from all node results -> concatenated strings via `get_agent_results()`

Now `str(multi_agent_result)` works the same as `str(agent_result)`.

## Related Issues

Fixes #1561

## Documentation PR

N/A

## Type of Change

New feature

## Testing

- [x] Python syntax validated
- [x] Follows the same pattern as AgentResult.__str__
- [x] Handles interrupts first, then collects from all node results

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the coding style and patterns of this project

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.