### PR TITLE
fix(mcp): expose CallToolResult.isError in MCPToolResult

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -732,6 +732,8 @@ class MCPClient(ToolProvider):
             content=mapped_contents,
         )
 
+        if call_tool_result.isError:
+            result["isError"] = True
         if call_tool_result.structuredContent:
             result["structuredContent"] = call_tool_result.structuredContent
         if call_tool_result.meta:

--- a/src/strands/tools/mcp/mcp_types.py
+++ b/src/strands/tools/mcp/mcp_types.py
@@ -61,7 +61,12 @@ class MCPToolResult(ToolResult):
         metadata: Optional arbitrary metadata returned by the MCP tool. This field allows
             MCP servers to attach custom metadata to tool results (e.g., token usage,
             performance metrics, or business-specific tracking information).
+        isError: Whether the MCP tool itself reported an application-level error.
+            True means the tool executed but returned a failure result (application error).
+            Absent means the call succeeded or that an exception was raised before the
+            tool could return a result (protocol or transport error).
     """
 
     structuredContent: NotRequired[dict[str, Any]]
     metadata: NotRequired[dict[str, Any]]
+    isError: NotRequired[bool]

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -167,6 +167,21 @@ def test_call_tool_sync_with_structured_content(mock_transport, mock_session):
         assert result["structuredContent"]["status"] == "completed"
 
 
+@pytest.mark.parametrize("is_error,expect_is_error_field", [(True, True), (False, False)])
+def test_call_tool_sync_preserves_is_error(mock_transport, mock_session, is_error, expect_is_error_field):
+    """Test that call_tool_sync exposes CallToolResult.isError in MCPToolResult."""
+    mock_content = MCPTextContent(type="text", text="Tool output")
+    mock_session.call_tool.return_value = MCPCallToolResult(isError=is_error, content=[mock_content])
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={})
+
+        if expect_is_error_field:
+            assert result.get("isError") is True
+        else:
+            assert "isError" not in result
+
+
 def test_call_tool_sync_exception(mock_transport, mock_session):
     """Test that call_tool_sync correctly handles exceptions."""
     mock_session.call_tool.side_effect = Exception("Test exception")


### PR DESCRIPTION
## Description

MCP tools can return \`isError=True\` to signal an application-level failure (the tool ran but reported an error). This flag was used internally in \`_handle_tool_result()\` to set \`MCPToolResult.status="error"\` but was not preserved in the result, making it impossible for callers to distinguish between:

- An **application error** (\`isError=True\` from the MCP server, meaning the tool executed and returned a failure)
- A **protocol error** (a Python exception raised before the tool could return a result)

Both produce \`status="error"\` today, but they are fundamentally different failure modes.

**Changes:**

- Add \`isError: NotRequired[bool]\` to \`MCPToolResult\` in \`mcp_types.py\`
- Populate it from \`call_tool_result.isError\` in \`_handle_tool_result()\`, only set when \`True\`, matching the existing pattern used by \`structuredContent\` and \`metadata\`

## Related Issues

Fixes #1670

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- Added \`test_call_tool_sync_preserves_is_error\`, parametrized over \`isError=True\` and \`isError=False\`, verifying the field is present only when \`True\`
- All 136 existing MCP tests pass

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.