### PR TITLE
feat(session): add endpoint_url parameter to S3SessionManager

### DIFF
--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -51,6 +51,7 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
         boto_session: boto3.Session | None = None,
         boto_client_config: BotocoreConfig | None = None,
         region_name: str | None = None,
+        endpoint_url: str | None = None,
         **kwargs: Any,
     ):
         """Initialize S3SessionManager with S3 storage.
@@ -63,6 +64,8 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             boto_session: Optional boto3 session
             boto_client_config: Optional boto3 client configuration
             region_name: AWS region for S3 storage
+            endpoint_url: Custom endpoint URL for S3-compatible storage (e.g., MinIO, LocalStack).
+                When set, requests are sent to this URL instead of the default AWS S3 endpoint.
             **kwargs: Additional keyword arguments for future extensibility.
         """
         self.bucket = bucket
@@ -82,7 +85,7 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
         else:
             client_config = BotocoreConfig(user_agent_extra="strands-agents")
 
-        self.client = session.client(service_name="s3", config=client_config)
+        self.client = session.client(service_name="s3", config=client_config, endpoint_url=endpoint_url)
         super().__init__(session_id=session_id, session_repository=self)
 
     def _get_session_path(self, session_id: str) -> str:

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -89,6 +89,22 @@ def test_init_s3_session_manager_with_existing_user_agent(mocked_aws, s3_bucket)
     assert "strands-agents" in session_manager.client.meta.config.user_agent_extra
 
 
+def test_init_s3_session_manager_with_endpoint_url():
+    from unittest.mock import patch
+
+    from strands.session.repository_session_manager import RepositorySessionManager
+
+    endpoint = "http://localhost:9000"
+    with patch("boto3.Session.client") as mock_client:
+        mock_client.return_value = Mock()
+        # Skip session initialization so no S3 calls are made
+        with patch.object(RepositorySessionManager, "__init__", return_value=None):
+            S3SessionManager(session_id="test", bucket="my-bucket", endpoint_url=endpoint)
+
+    _, kwargs = mock_client.call_args
+    assert kwargs.get("endpoint_url") == endpoint
+
+
 def test_empty_prefix_session_roundtrip(mocked_aws, s3_bucket, sample_session, sample_agent):
     """Test that session data can be written and read back with default empty prefix."""
     manager = S3SessionManager(session_id="test", bucket=s3_bucket, prefix="", region_name="us-west-2")


### PR DESCRIPTION
## Description

\`S3SessionManager\` creates its boto3 S3 client without accepting an \`endpoint_url\` parameter. This makes it impossible to use the session manager with S3-compatible storage backends such as MinIO or LocalStack, which are common in local development and VPC endpoint configurations.

\`BedrockModel\` already accepts \`endpoint_url\` as a first-class constructor parameter and forwards it to its boto3 client. This change applies the same pattern to \`S3SessionManager\`.

**Changes:**

- Add \`endpoint_url: str | None = None\` to \`S3SessionManager.__init__()\`
- Forward it to \`session.client(service_name="s3", ...)\`

```python
# Local development with MinIO
session_manager = S3SessionManager(
    session_id="dev-session",
    bucket="dev-bucket",
    endpoint_url="http://localhost:9000",
)

# VPC endpoint / PrivateLink
session_manager = S3SessionManager(
    session_id="prod-session",
    bucket="prod-bucket",
    endpoint_url="https://bucket.vpce-abc123.s3.us-east-1.vpce.amazonaws.com",
)
```

When \`endpoint_url\` is not provided (the default), behavior is unchanged.

## Related Issues

Fixes #1794

## Documentation PR

N/A

## Type of Change

New feature

## Testing

- Added \`test_init_s3_session_manager_with_endpoint_url\` verifying that \`endpoint_url\` is forwarded to the boto3 client creation call
- All 47 existing S3SessionManager tests pass

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.