### PR TITLE
fix: add warning log when tool input JSON parsing fails

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -279,6 +279,11 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
         try:
             current_tool_use["input"] = json.loads(current_tool_use["input"])
         except ValueError:
+            logger.warning(
+                "tool_name=<%s> raw_input=<%s> | failed to parse tool input as JSON; falling back to empty dict",
+                current_tool_use.get("name"),
+                current_tool_use["input"][:200],
+            )
             current_tool_use["input"] = {}
 
         tool_use_id = current_tool_use["toolUseId"]

--- a/tests/strands/event_loop/test_streaming.py
+++ b/tests/strands/event_loop/test_streaming.py
@@ -527,6 +527,25 @@ def test_handle_content_block_stop(state, exp_updated_state):
     assert tru_updated_state == exp_updated_state
 
 
+def test_handle_content_block_stop_invalid_json_logs_warning(caplog):
+    state = {
+        "content": [],
+        "current_tool_use": {"toolUseId": "123", "name": "my_tool", "input": "not valid json"},
+        "text": "",
+        "reasoningText": "",
+        "citationsContent": [],
+        "redactedContent": b"",
+    }
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="strands.event_loop.streaming"):
+        tru_updated_state = strands.event_loop.streaming.handle_content_block_stop(state)
+
+    assert tru_updated_state["content"] == [{"toolUse": {"toolUseId": "123", "name": "my_tool", "input": {}}}]
+    assert any("failed to parse tool input as JSON" in record.message for record in caplog.records)
+
+
 def test_handle_message_stop():
     event: MessageStopEvent = {"stopReason": "end_turn"}
 


### PR DESCRIPTION
## Description

When a model returns tool input that cannot be parsed as JSON, the SDK silently falls back to an empty dict. This makes it impossible to distinguish between a tool that legitimately received `{}` from the model and one that received unparseable content.

This change adds a `WARNING` log before the fallback that includes the tool name and the first 200 characters of the raw input, making the silent failure observable in logs.

## Related Issues

Fixes #2051

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Added `test_handle_content_block_stop_invalid_json_logs_warning` to `tests/strands/event_loop/test_streaming.py`. The test verifies that when `handle_content_block_stop` encounters invalid JSON tool input, it falls back to `{}` and emits a warning log containing "failed to parse tool input as JSON".

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.