### PR TITLE
fix: add gen_ai common attributes to execute_event_loop_cycle spans

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -526,9 +526,10 @@ class Tracer:
         event_loop_cycle_id = str(invocation_state.get("event_loop_cycle_id"))
         parent_span = parent_span if parent_span else invocation_state.get("event_loop_parent_span")
 
-        attributes: dict[str, AttributeValue] = {
-            "event_loop.cycle_id": event_loop_cycle_id,
-        }
+        attributes: dict[str, AttributeValue] = self._get_common_attributes(
+            operation_name="execute_event_loop_cycle"
+        )
+        attributes["event_loop.cycle_id"] = event_loop_cycle_id
 
         if custom_trace_attributes:
             attributes.update(custom_trace_attributes)

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -729,6 +729,8 @@ def test_start_event_loop_cycle_span(mock_tracer):
 
         mock_span.set_attributes.assert_called_once_with(
             {
+                "gen_ai.operation.name": "execute_event_loop_cycle",
+                "gen_ai.system": "strands-agents",
                 "event_loop.cycle_id": "cycle-123",
                 "request_id": "req-456",
                 "trace_level": "debug",
@@ -758,7 +760,13 @@ def test_start_event_loop_cycle_span_latest_conventions(mock_tracer, monkeypatch
         mock_tracer.start_span.assert_called_once()
         assert mock_tracer.start_span.call_args[1]["name"] == "execute_event_loop_cycle"
 
-        mock_span.set_attributes.assert_called_once_with({"event_loop.cycle_id": "cycle-123"})
+        mock_span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.operation.name": "execute_event_loop_cycle",
+                "gen_ai.provider.name": "strands-agents",
+                "event_loop.cycle_id": "cycle-123",
+            }
+        )
         mock_span.add_event.assert_any_call(
             "gen_ai.client.inference.operation.details",
             attributes={
@@ -766,6 +774,27 @@ def test_start_event_loop_cycle_span_latest_conventions(mock_tracer, monkeypatch
             },
         )
         assert span is not None
+
+
+def test_start_event_loop_cycle_span_includes_common_attributes(mock_tracer):
+    """Test that start_event_loop_cycle_span includes gen_ai common attributes."""
+    with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+        tracer = Tracer()
+        tracer.tracer = mock_tracer
+
+        mock_span = mock.MagicMock()
+        mock_tracer.start_span.return_value = mock_span
+
+        event_loop_kwargs = {"event_loop_cycle_id": "cycle-123"}
+        messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+
+        tracer.start_event_loop_cycle_span(event_loop_kwargs, messages=messages)
+
+        set_attrs_call = mock_span.set_attributes.call_args[0][0]
+        assert "gen_ai.operation.name" in set_attrs_call
+        assert set_attrs_call["gen_ai.operation.name"] == "execute_event_loop_cycle"
+        assert "gen_ai.system" in set_attrs_call
+        assert set_attrs_call["gen_ai.system"] == "strands-agents"
 
 
 def test_end_event_loop_cycle_span(mock_span):


### PR DESCRIPTION
## Description

start_event_loop_cycle_span() initializes its attributes dict manually,
omitting the gen_ai.system / gen_ai.provider.name and gen_ai.operation.name
attributes produced by _get_common_attributes(). The four other span-start
methods (start_model_invoke_span, start_tool_call_span, start_agent_span,
start_multiagent_span) all call _get_common_attributes() first. This made
execute_event_loop_cycle spans inconsistent: they carry gen_ai.input.messages
(promoted by _add_event_messages()) but lack the identification attributes that
downstream OTEL tooling (collectors, exporters, redaction processors) relies on
for filtering.

The fix calls _get_common_attributes(operation_name="execute_event_loop_cycle")
at the start of start_event_loop_cycle_span(), consistent with the other span
methods.

## Related Issues

Resolves #1876

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.