### PR TITLE
fix: forward config params to structured_output() in OpenAIResponsesModel

### DIFF
--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -400,10 +400,13 @@ class OpenAIResponsesModel(Model):
         """
         async with openai.AsyncOpenAI(**self.client_args) as client:
             try:
+                request = self._format_request(prompt, system_prompt=system_prompt)
+                parse_kwargs = {k: v for k, v in request.items() if k not in {"model", "input", "stream"}}
                 response = await client.responses.parse(
                     model=self.get_config()["model_id"],
-                    input=self._format_request(prompt, system_prompt=system_prompt)["input"],
+                    input=request["input"],
                     text_format=output_model,
+                    **parse_kwargs,
                 )
             except openai.BadRequestError as e:
                 if hasattr(e, "code") and e.code == "context_length_exceeded":

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -724,6 +724,44 @@ async def test_structured_output(openai_client, model, test_output_model_cls, al
 
 
 @pytest.mark.asyncio
+async def test_structured_output_forwards_config_params(openai_client, test_output_model_cls, alist):
+    """Test that structured_output passes config params (e.g. max_output_tokens, reasoning) to parse()."""
+    model_with_params = OpenAIResponsesModel(
+        model_id="gpt-4o",
+        params={"max_output_tokens": 500, "reasoning": {"effort": "high"}},
+    )
+
+    messages = [{"role": "user", "content": [{"text": "Generate a person"}]}]
+    mock_parsed_instance = test_output_model_cls(name="Jane", age=25)
+    mock_response = unittest.mock.Mock(output_parsed=mock_parsed_instance)
+    openai_client.responses.parse = unittest.mock.AsyncMock(return_value=mock_response)
+
+    stream = model_with_params.structured_output(test_output_model_cls, messages)
+    await alist(stream)
+
+    call_kwargs = openai_client.responses.parse.call_args[1]
+    assert call_kwargs.get("max_output_tokens") == 500
+    assert call_kwargs.get("reasoning") == {"effort": "high"}
+    assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_structured_output_forwards_system_prompt(openai_client, model, test_output_model_cls, alist):
+    """Test that structured_output forwards system_prompt as instructions to parse()."""
+    messages = [{"role": "user", "content": [{"text": "Generate a person"}]}]
+    mock_parsed_instance = test_output_model_cls(name="Jane", age=25)
+    mock_response = unittest.mock.Mock(output_parsed=mock_parsed_instance)
+    openai_client.responses.parse = unittest.mock.AsyncMock(return_value=mock_response)
+
+    stream = model.structured_output(test_output_model_cls, messages, system_prompt="You are helpful.")
+    await alist(stream)
+
+    call_kwargs = openai_client.responses.parse.call_args[1]
+    assert call_kwargs.get("instructions") == "You are helpful."
+    assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
 async def test_stream_context_overflow_exception(openai_client, model, messages):
     """Test that OpenAI context overflow errors are properly converted to ContextWindowOverflowException."""
     mock_error = openai.BadRequestError(


### PR DESCRIPTION
## Description

structured_output() called _format_request() but only extracted ["input"],
silently dropping all config params (max_output_tokens, reasoning,
instructions, etc.). The stream() method does not have this issue because
it passes the full request dict to responses.create().

The fix calls _format_request() once, then builds parse_kwargs from the
full result excluding "model" and "input" (handled explicitly) and "stream"
(hardcoded by _format_request(), incompatible with responses.parse()).

## Related Issues

Resolves #1908

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.