### PR TITLE
fix: guard state reset in GraphNode.reset_executor_state() for MultiAgentBase executors

### DIFF
--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -193,7 +193,7 @@ class GraphNode:
         if hasattr(self.executor, "messages"):
             self.executor.messages = copy.deepcopy(self._initial_messages)
 
-        if hasattr(self.executor, "state"):
+        if hasattr(self.executor, "state") and hasattr(self.executor.state, "get"):
             self.executor.state = AgentState(self._initial_state.get())
 
         if hasattr(self.executor, "_model_state"):

--- a/tests/strands/multiagent/test_graph.py
+++ b/tests/strands/multiagent/test_graph.py
@@ -794,6 +794,32 @@ async def test_node_reset_executor_state():
     assert multi_agent_node.result is None
 
 
+def test_node_reset_executor_state_does_not_corrupt_nested_graph_state():
+    """Test that reset_executor_state does not overwrite a nested Graph's GraphState with AgentState."""
+    inner_agent = create_mock_agent("inner_agent")
+    builder = GraphBuilder()
+    builder.add_node(inner_agent, "inner_a")
+    inner_graph = builder.build()
+
+    # The nested Graph's .state is GraphState, which does not have a .get() method
+    assert isinstance(inner_graph.state, GraphState)
+    assert not hasattr(inner_graph.state, "get")
+
+    # Wrap the nested graph in a GraphNode
+    outer_node = GraphNode("outer", inner_graph)
+    outer_node.execution_status = Status.COMPLETED
+
+    # Before fix: reset_executor_state would call AgentState(self._initial_state.get())
+    # and assign it to inner_graph.state, overwriting GraphState with AgentState.
+    outer_node.reset_executor_state()
+
+    # Verify the nested graph's state was NOT replaced with AgentState
+    assert isinstance(inner_graph.state, GraphState), (
+        "reset_executor_state must not replace a nested Graph's GraphState with AgentState"
+    )
+    assert outer_node.execution_status == Status.PENDING
+
+
 def test_graph_dataclasses_and_enums():
     """Test dataclass initialization, properties, and enum behavior."""
     # Test Status enum


### PR DESCRIPTION
## Description

reset_executor_state() checked hasattr(self.executor, "state") without
checking whether the state is an AgentState. Graph (a MultiAgentBase) has
a .state attribute of type GraphState, which does not have a .get() method.
The method would overwrite GraphState with a blank AgentState(), corrupting
the nested executor on every reset -- triggered by reset_on_revisit cycles
or deserialize_state after a completed run.

__post_init__ already has the correct guard:
  hasattr(self.executor.state, "get")
which resolves to True only for AgentState. The fix mirrors that same
guard in reset_executor_state(), making the two methods consistent.

## Related Issues

Resolves #1775

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.