### PR TITLE
fix: repair orphaned toolUse in the last session message during restore

### DIFF
--- a/src/strands/session/repository_session_manager.py
+++ b/src/strands/session/repository_session_manager.py
@@ -273,37 +273,48 @@ class RepositorySessionManager(SessionManager):
 
         # Then check for orphaned toolUse messages
         for index, message in enumerate(messages):
-            # Check all but the latest message in the messages array
-            # The latest message being orphaned is handled in the agent class
-            if index + 1 < len(messages):
-                if any("toolUse" in content for content in message["content"]):
-                    tool_use_ids = [
-                        content["toolUse"]["toolUseId"] for content in message["content"] if "toolUse" in content
-                    ]
+            if not any("toolUse" in content for content in message["content"]):
+                continue
 
-                    # Check if there are more messages after the current toolUse message
-                    tool_result_ids = [
-                        content["toolResult"]["toolUseId"]
-                        for content in messages[index + 1]["content"]
-                        if "toolResult" in content
-                    ]
+            tool_use_ids = [
+                content["toolUse"]["toolUseId"] for content in message["content"] if "toolUse" in content
+            ]
 
-                    missing_tool_use_ids = list(set(tool_use_ids) - set(tool_result_ids))
-                    # If there are missing tool use ids, that means the messages history is broken
-                    if missing_tool_use_ids:
-                        logger.warning(
-                            "Session message history has an orphaned toolUse with no toolResult. "
-                            "Adding toolResult content blocks to create valid conversation."
-                        )
-                        # Create the missing toolResult content blocks
-                        missing_content_blocks = generate_missing_tool_result_content(missing_tool_use_ids)
+            if index + 1 >= len(messages):
+                # The last message has an orphaned toolUse. The in-process fallback
+                # (_has_tool_use_in_latest_message) only works within the same process.
+                # On cross-process restore the tool execution context is lost, so report
+                # an error to the model and let it decide how to proceed.
+                logger.warning(
+                    "Session message history ends with an orphaned toolUse with no toolResult. "
+                    "Adding toolResult content blocks to create valid conversation."
+                )
+                missing_content_blocks = generate_missing_tool_result_content(tool_use_ids)
+                messages.append({"role": "user", "content": missing_content_blocks})
+            else:
+                # Check if the next message already has tool results
+                tool_result_ids = [
+                    content["toolResult"]["toolUseId"]
+                    for content in messages[index + 1]["content"]
+                    if "toolResult" in content
+                ]
 
-                        if tool_result_ids:
-                            # If there were any toolResult ids, that means only some of the content blocks are missing
-                            messages[index + 1]["content"].extend(missing_content_blocks)
-                        else:
-                            # The message following the toolUse was not a toolResult, so lets insert it
-                            messages.insert(index + 1, {"role": "user", "content": missing_content_blocks})
+                missing_tool_use_ids = list(set(tool_use_ids) - set(tool_result_ids))
+                # If there are missing tool use ids, that means the messages history is broken
+                if missing_tool_use_ids:
+                    logger.warning(
+                        "Session message history has an orphaned toolUse with no toolResult. "
+                        "Adding toolResult content blocks to create valid conversation."
+                    )
+                    # Create the missing toolResult content blocks
+                    missing_content_blocks = generate_missing_tool_result_content(missing_tool_use_ids)
+
+                    if tool_result_ids:
+                        # If there were any toolResult ids, that means only some of the content blocks are missing
+                        messages[index + 1]["content"].extend(missing_content_blocks)
+                    else:
+                        # The message following the toolUse was not a toolResult, so lets insert it
+                        messages.insert(index + 1, {"role": "user", "content": missing_content_blocks})
         return messages
 
     def sync_multi_agent(self, source: "MultiAgentBase", **kwargs: Any) -> None:

--- a/tests/strands/session/test_repository_session_manager.py
+++ b/tests/strands/session/test_repository_session_manager.py
@@ -416,8 +416,8 @@ def test_fix_broken_tool_use_handles_multiple_orphaned_tools(existing_session_ma
     assert tool_use_ids == {"orphaned-123", "orphaned-456"}
 
 
-def test_fix_broken_tool_use_ignores_last_message(session_manager):
-    """Test that orphaned toolUse in the last message is not fixed."""
+def test_fix_broken_tool_use_repairs_orphaned_last_message(session_manager):
+    """Test that orphaned toolUse in the last message is repaired with a synthetic toolResult."""
     messages = [
         {"role": "user", "content": [{"text": "Hello"}]},
         {
@@ -430,8 +430,13 @@ def test_fix_broken_tool_use_ignores_last_message(session_manager):
 
     fixed_messages = session_manager._fix_broken_tool_use(messages)
 
-    # Should remain unchanged since toolUse is in last message
-    assert fixed_messages == messages
+    # A synthetic toolResult should be appended for the orphaned toolUse
+    assert len(fixed_messages) == 3
+    assert fixed_messages[2]["role"] == "user"
+    tool_result_ids = [
+        c["toolResult"]["toolUseId"] for c in fixed_messages[2]["content"] if "toolResult" in c
+    ]
+    assert "last-message-123" in tool_result_ids
 
 
 def test_fix_broken_tool_use_does_not_change_valid_message(session_manager):


### PR DESCRIPTION
## Description

`_fix_broken_tool_use` explicitly skipped the last message in the session history,
relying on the agent-class fallback (`_has_tool_use_in_latest_message`) to handle
it. That fallback only works when the same agent instance re-enters the event loop
within the same process. When a different process restores a session that ended with
an orphaned `toolUse` — for example, after a runtime timeout while waiting for a
long-running tool — and a new user message is then appended, the orphaned `toolUse`
reaches the model without a corresponding `toolResult`, producing a
`ValidationException`.

The fix removes the guard and handles the last-message case the same way as interior
messages: append a synthetic `toolResult` with `status: "error"`. The original tool
execution context is already lost at restore time, so reporting an error to the model
and letting it decide how to proceed is the correct behavior.

## Related Issues

Resolves #2025

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- Updated `test_fix_broken_tool_use_ignores_last_message` (which asserted the old,
  incorrect behavior) to `test_fix_broken_tool_use_repairs_orphaned_last_message`,
  verifying that a synthetic `toolResult` is appended.
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.