### PR TITLE
fix: use per-invocation usage on agent OTEL span instead of accumulated

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -689,16 +689,19 @@ class Tracer:
             if hasattr(response, "metrics") and hasattr(response.metrics, "accumulated_usage"):
                 if self.is_langfuse:
                     attributes.update({"langfuse.observation.type": "span"})
-                accumulated_usage = response.metrics.accumulated_usage
+                # Use the latest invocation's usage so each agent span reports only its
+                # own tokens, not the session-lifetime accumulated total (issue #2010).
+                invocation = response.metrics.latest_agent_invocation
+                usage = invocation.usage if invocation is not None else response.metrics.accumulated_usage
                 attributes.update(
                     {
-                        "gen_ai.usage.prompt_tokens": accumulated_usage["inputTokens"],
-                        "gen_ai.usage.completion_tokens": accumulated_usage["outputTokens"],
-                        "gen_ai.usage.input_tokens": accumulated_usage["inputTokens"],
-                        "gen_ai.usage.output_tokens": accumulated_usage["outputTokens"],
-                        "gen_ai.usage.total_tokens": accumulated_usage["totalTokens"],
-                        "gen_ai.usage.cache_read_input_tokens": accumulated_usage.get("cacheReadInputTokens", 0),
-                        "gen_ai.usage.cache_write_input_tokens": accumulated_usage.get("cacheWriteInputTokens", 0),
+                        "gen_ai.usage.prompt_tokens": usage["inputTokens"],
+                        "gen_ai.usage.completion_tokens": usage["outputTokens"],
+                        "gen_ai.usage.input_tokens": usage["inputTokens"],
+                        "gen_ai.usage.output_tokens": usage["outputTokens"],
+                        "gen_ai.usage.total_tokens": usage["totalTokens"],
+                        "gen_ai.usage.cache_read_input_tokens": usage.get("cacheReadInputTokens", 0),
+                        "gen_ai.usage.cache_write_input_tokens": usage.get("cacheWriteInputTokens", 0),
                     }
                 )
 

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -923,6 +923,7 @@ def test_end_agent_span(mock_span):
     # Mock AgentResult with metrics
     mock_metrics = mock.MagicMock()
     mock_metrics.accumulated_usage = {"inputTokens": 50, "outputTokens": 100, "totalTokens": 150}
+    mock_metrics.latest_agent_invocation.usage = {"inputTokens": 50, "outputTokens": 100, "totalTokens": 150}
 
     mock_response = mock.MagicMock()
     mock_response.metrics = mock_metrics
@@ -958,6 +959,7 @@ def test_end_agent_span_with_langfuse_observation_type(mock_span, monkeypatch):
     # Mock AgentResult with metrics
     mock_metrics = mock.MagicMock()
     mock_metrics.accumulated_usage = {"inputTokens": 50, "outputTokens": 100, "totalTokens": 150}
+    mock_metrics.latest_agent_invocation.usage = {"inputTokens": 50, "outputTokens": 100, "totalTokens": 150}
 
     mock_response = mock.MagicMock()
     mock_response.metrics = mock_metrics
@@ -994,6 +996,7 @@ def test_end_agent_span_latest_conventions(mock_span, monkeypatch):
     # Mock AgentResult with metrics
     mock_metrics = mock.MagicMock()
     mock_metrics.accumulated_usage = {"inputTokens": 50, "outputTokens": 100, "totalTokens": 150}
+    mock_metrics.latest_agent_invocation.usage = {"inputTokens": 50, "outputTokens": 100, "totalTokens": 150}
 
     mock_response = mock.MagicMock()
     mock_response.metrics = mock_metrics
@@ -1077,6 +1080,13 @@ def test_end_agent_span_with_cache_metrics(mock_span):
         "cacheReadInputTokens": 25,
         "cacheWriteInputTokens": 10,
     }
+    mock_metrics.latest_agent_invocation.usage = {
+        "inputTokens": 50,
+        "outputTokens": 100,
+        "totalTokens": 150,
+        "cacheReadInputTokens": 25,
+        "cacheWriteInputTokens": 10,
+    }
 
     mock_response = mock.MagicMock()
     mock_response.metrics = mock_metrics
@@ -1098,6 +1108,37 @@ def test_end_agent_span_with_cache_metrics(mock_span):
     )
     mock_span.set_status.assert_called_once_with(StatusCode.OK)
     mock_span.end.assert_called_once()
+
+
+def test_end_agent_span_uses_invocation_not_accumulated_usage(mock_span):
+    """Test that the agent span reports per-invocation usage, not session-lifetime accumulated usage."""
+    tracer = Tracer()
+
+    mock_metrics = mock.MagicMock()
+    # Accumulated usage is larger (simulating a multi-request session)
+    mock_metrics.accumulated_usage = {"inputTokens": 300, "outputTokens": 600, "totalTokens": 900}
+    # Latest invocation used only 100/200/300 tokens
+    mock_metrics.latest_agent_invocation.usage = {"inputTokens": 100, "outputTokens": 200, "totalTokens": 300}
+
+    mock_response = mock.MagicMock()
+    mock_response.metrics = mock_metrics
+    mock_response.stop_reason = "end_turn"
+    mock_response.__str__ = mock.MagicMock(return_value="Agent response")
+
+    tracer.end_agent_span(mock_span, mock_response)
+
+    # Span should report the per-invocation values, not the inflated accumulated values
+    mock_span.set_attributes.assert_called_once_with(
+        {
+            "gen_ai.usage.prompt_tokens": 100,
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.completion_tokens": 200,
+            "gen_ai.usage.output_tokens": 200,
+            "gen_ai.usage.total_tokens": 300,
+            "gen_ai.usage.cache_read_input_tokens": 0,
+            "gen_ai.usage.cache_write_input_tokens": 0,
+        }
+    )
 
 
 def test_get_tracer_singleton():


### PR DESCRIPTION
## Description

`end_agent_span` in `tracer.py` reported `response.metrics.accumulated_usage` on
each span, which grows with every request in a session. In a session with 10
requests each using 100k tokens, request 1 would correctly show 100k, request 2
would show 200k, request 3 would show 300k, and so on. Observability backends like
Langfuse then sum these values, producing wildly inflated token counts and cost
estimates.

The fix replaces `accumulated_usage` with `response.metrics.latest_agent_invocation.usage`,
which contains only the tokens consumed during the current agent invocation. The
`accumulated_usage` field is retained as a fallback for the edge case where no
invocation has been recorded.

## Related Issues

Resolves #2010

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- Updated all four existing `test_end_agent_span*` tests to wire
  `latest_agent_invocation.usage` on the mock (matching the value they were
  already asserting, so expectations are unchanged).
- Added `test_end_agent_span_uses_invocation_not_accumulated_usage`: sets
  invocation usage to 100/200/300 tokens while accumulated usage is 300/600/900,
  and asserts the span receives only the invocation values.
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.