### PR TITLE
fix(bedrock): fall back to toolChoice.auto when model does not support toolChoice.any

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -52,6 +52,13 @@ _MODELS_INCLUDE_STATUS = [
     "anthropic.claude",
 ]
 
+# Models that support toolConfig.toolChoice.any in the Bedrock Converse API.
+# Other model families (Meta Llama, Amazon Titan/Nova, Mistral, Cohere, etc.) reject
+# toolChoice.any with a ValidationException.
+_MODELS_SUPPORT_TOOL_CHOICE_ANY = [
+    "anthropic.claude",
+]
+
 T = TypeVar("T", bound=BaseModel)
 
 DEFAULT_READ_TIMEOUT = 120
@@ -193,6 +200,39 @@ class BedrockModel(Model):
             return "anthropic"
         return None
 
+    @property
+    def _supports_tool_choice_any(self) -> bool:
+        """Whether this model supports toolConfig.toolChoice.any in the Bedrock Converse API.
+
+        Only Anthropic Claude models support toolChoice.any. Other families (Meta Llama, Amazon
+        Titan/Nova, Mistral, Cohere, etc.) reject it with a ValidationException.
+
+        Returns:
+            True if the model supports toolChoice.any, False otherwise.
+        """
+        model_id = self.config.get("model_id", "").lower()
+        return any(prefix in model_id for prefix in _MODELS_SUPPORT_TOOL_CHOICE_ANY)
+
+    def _resolve_tool_choice(self, tool_choice: ToolChoice | None) -> dict[str, Any]:
+        """Resolve the effective toolChoice for a Bedrock Converse request.
+
+        Falls back from toolChoice.any to toolChoice.auto for models that do not
+        support toolChoice.any (e.g. Meta Llama, Amazon Titan/Nova, Mistral).
+
+        Args:
+            tool_choice: Requested tool choice, or None for the default.
+
+        Returns:
+            A toolChoice dict safe to include in the Bedrock Converse request.
+        """
+        if tool_choice and "any" in tool_choice and not self._supports_tool_choice_any:
+            logger.warning(
+                "model_id=<%s> | toolChoice.any is not supported by this model; falling back to toolChoice.auto",
+                self.config.get("model_id"),
+            )
+            return {"auto": {}}
+        return tool_choice if tool_choice else {"auto": {}}
+
     @override
     def update_config(self, **model_config: Unpack[BedrockConfig]) -> None:  # type: ignore
         """Update the Bedrock Model configuration with the provided arguments.
@@ -271,7 +311,11 @@ class BedrockModel(Model):
                                 else []
                             ),
                         ],
-                        **({"toolChoice": tool_choice if tool_choice else {"auto": {}}}),
+                        **(
+                            {
+                                "toolChoice": self._resolve_tool_choice(tool_choice),
+                            }
+                        ),
                     }
                 }
                 if tool_specs

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -502,9 +502,34 @@ def test_format_request_tool_choice_auto(model, messages, model_id, tool_spec):
     assert tru_request == exp_request
 
 
-def test_format_request_tool_choice_any(model, messages, model_id, tool_spec):
+def test_format_request_tool_choice_any(bedrock_client, messages, tool_spec):
+    """toolChoice.any passes through unchanged for Anthropic Claude models."""
+    claude_model_id = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+    claude_model = BedrockModel(model_id=claude_model_id)
     tool_choice = {"any": {}}
-    tru_request = model._format_request(messages, [tool_spec], tool_choice=tool_choice)
+    tru_request = claude_model._format_request(messages, [tool_spec], tool_choice=tool_choice)
+    exp_request = {
+        "inferenceConfig": {},
+        "modelId": claude_model_id,
+        "messages": messages,
+        "system": [],
+        "toolConfig": {
+            "tools": [{"toolSpec": tool_spec}],
+            "toolChoice": tool_choice,
+        },
+    }
+
+    assert tru_request == exp_request
+
+
+def test_format_request_tool_choice_any_falls_back_for_unsupported_models(
+    bedrock_client, messages, model_id, tool_spec
+):
+    """toolChoice.any falls back to toolChoice.auto for models that do not support it."""
+    # model_id fixture is "m1" (not a Claude model)
+    non_claude_model = BedrockModel(model_id=model_id)
+    tool_choice = {"any": {}}
+    tru_request = non_claude_model._format_request(messages, [tool_spec], tool_choice=tool_choice)
     exp_request = {
         "inferenceConfig": {},
         "modelId": model_id,
@@ -512,7 +537,7 @@ def test_format_request_tool_choice_any(model, messages, model_id, tool_spec):
         "system": [],
         "toolConfig": {
             "tools": [{"toolSpec": tool_spec}],
-            "toolChoice": tool_choice,
+            "toolChoice": {"auto": {}},
         },
     }
 


### PR DESCRIPTION
## Description

When the structured output context enters forced mode it sets `tool_choice = {"any": {}}` to
require the model to call the structured output tool. `BedrockModel._format_request` forwarded
this directly as `toolConfig.toolChoice.any` to the Bedrock Converse API.

The Bedrock Converse API only supports `toolChoice.any` for Anthropic Claude models. All other
model families — Meta Llama, Amazon Titan/Nova, Mistral, Cohere — reject it with a
`ValidationException: This model doesn't support the toolConfig.toolChoice.any field`.

The fix adds a `_resolve_tool_choice` helper to `BedrockModel` that detects whether the active
model supports `toolChoice.any` and falls back to `toolChoice.auto` when it does not. The model
list follows the existing `_MODELS_INCLUDE_STATUS` pattern already used in the file.

## Related Issues

Fixes #1241

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `hatch run prepare`
- Added `test_format_request_tool_choice_any` using a Claude model ID to verify `toolChoice.any` passes through unchanged
- Added `test_format_request_tool_choice_any_falls_back_for_unsupported_models` using a non-Claude model ID to verify fallback to `toolChoice.auto`
- All 2489 existing tests pass

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.