### PR TITLE
fix(bedrock): skip S3 location sources for models that do not support them

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -70,6 +70,11 @@ def _suppress_task_exception(task: "asyncio.Task[None]") -> None:
         task.exception()
 
 
+# Models supporting S3 location sources (documents, images, videos) via Bedrock Converse API; other families reject them with ValidationException.
+_MODELS_SUPPORT_S3_LOCATION = [
+    "amazon.nova",
+]
+
 T = TypeVar("T", bound=BaseModel)
 
 DEFAULT_READ_TIMEOUT = 120
@@ -547,9 +552,33 @@ class BedrockModel(Model):
         else:  # "auto"
             return any(model in self.config["model_id"] for model in _MODELS_INCLUDE_STATUS)
 
+    @property
+    def _supports_s3_location(self) -> bool:
+        """Whether this model supports S3 location sources in the Bedrock Converse API.
+
+        Only Amazon Nova models support S3 location sources for documents, images, and videos.
+        Other families (Anthropic Claude, Meta Llama, Mistral, Cohere, etc.) only accept inline
+        bytes and reject S3 location sources with a ValidationException.
+
+        Returns:
+            True if the model supports S3 location sources, False otherwise.
+        """
+        model_id = self.config.get("model_id", "").lower()
+        return any(prefix in model_id for prefix in _MODELS_SUPPORT_S3_LOCATION)
+
     def _handle_location(self, location: SourceLocation) -> dict[str, Any] | None:
-        """Convert location content block to Bedrock format if its an S3Location."""
+        """Convert location content block to Bedrock format if its an S3Location.
+
+        Returns None if the location type is unsupported or if the current model does not
+        support S3 location sources.
+        """
         if location["type"] == "s3":
+            if not self._supports_s3_location:
+                logger.warning(
+                    "model_id=<%s> | S3 location sources are not supported by this model; skipping content block",
+                    self.config.get("model_id"),
+                )
+                return None
             s3_location = cast(S3Location, location)
             formatted_document_s3: dict[str, Any] = {"uri": s3_location["uri"]}
             if "bucketOwner" in s3_location:

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -2126,8 +2126,10 @@ def test_format_request_filters_image_content_blocks(model, model_id):
     assert "metadata" not in image_block
 
 
-def test_format_request_image_s3_location_only(model, model_id):
-    """Test that image with only s3Location is properly formatted."""
+def test_format_request_image_s3_location_only(bedrock_client):
+    """Test that image with only s3Location is properly formatted for Nova models."""
+    nova_model_id = "amazon.nova-pro-v1:0"
+    nova_model = BedrockModel(model_id=nova_model_id)
     messages = [
         {
             "role": "user",
@@ -2144,7 +2146,7 @@ def test_format_request_image_s3_location_only(model, model_id):
         }
     ]
 
-    formatted_request = model.format_request(messages)
+    formatted_request = nova_model.format_request(messages)
     image_source = formatted_request["messages"][0]["content"][0]["image"]["source"]
 
     assert image_source == {"s3Location": {"uri": "s3://my-bucket/image.png"}}
@@ -2172,8 +2174,10 @@ def test_format_request_image_bytes_only(model, model_id):
     assert image_source == {"bytes": b"image_data"}
 
 
-def test_format_request_document_s3_location(model, model_id):
-    """Test that document with s3Location is properly formatted."""
+def test_format_request_document_s3_location(bedrock_client):
+    """Test that document with s3Location is properly formatted for Nova models."""
+    nova_model_id = "amazon.nova-pro-v1:0"
+    nova_model = BedrockModel(model_id=nova_model_id)
     messages = [
         {
             "role": "user",
@@ -2204,7 +2208,7 @@ def test_format_request_document_s3_location(model, model_id):
         }
     ]
 
-    formatted_request = model.format_request(messages)
+    formatted_request = nova_model.format_request(messages)
     document = formatted_request["messages"][0]["content"][0]["document"]
     document_with_bucket_owner = formatted_request["messages"][0]["content"][1]["document"]
 
@@ -2265,8 +2269,10 @@ def test_format_request_unsupported_location(model, caplog):
     assert "Non s3 location sources are not supported by Bedrock | skipping content block" in caplog.text
 
 
-def test_format_request_video_s3_location(model, model_id):
-    """Test that video with s3Location is properly formatted."""
+def test_format_request_video_s3_location(bedrock_client):
+    """Test that video with s3Location is properly formatted for Nova models."""
+    nova_model_id = "amazon.nova-pro-v1:0"
+    nova_model = BedrockModel(model_id=nova_model_id)
     messages = [
         {
             "role": "user",
@@ -2283,10 +2289,53 @@ def test_format_request_video_s3_location(model, model_id):
         }
     ]
 
-    formatted_request = model.format_request(messages)
+    formatted_request = nova_model.format_request(messages)
     video_source = formatted_request["messages"][0]["content"][0]["video"]["source"]
 
     assert video_source == {"s3Location": {"uri": "s3://my-bucket/video.mp4"}}
+
+
+def test_format_request_s3_location_skipped_for_unsupported_models(bedrock_client, model_id, caplog):
+    """S3 location sources are skipped with a warning for models that do not support them."""
+    caplog.set_level(logging.WARNING, logger="strands.models.bedrock")
+
+    # model_id fixture is "m1" (not an Amazon Nova model)
+    non_nova_model = BedrockModel(model_id=model_id)
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "analyze this"},
+                {
+                    "document": {
+                        "name": "report.pdf",
+                        "format": "pdf",
+                        "source": {"location": {"type": "s3", "uri": "s3://my-bucket/report.pdf"}},
+                    }
+                },
+                {
+                    "image": {
+                        "format": "png",
+                        "source": {"location": {"type": "s3", "uri": "s3://my-bucket/image.png"}},
+                    }
+                },
+                {
+                    "video": {
+                        "format": "mp4",
+                        "source": {"location": {"type": "s3", "uri": "s3://my-bucket/video.mp4"}},
+                    }
+                },
+            ],
+        }
+    ]
+
+    formatted_request = non_nova_model.format_request(messages)
+    content = formatted_request["messages"][0]["content"]
+
+    # Only the text block should remain; all three S3 location blocks are dropped
+    assert len(content) == 1
+    assert content[0] == {"text": "analyze this"}
+    assert "S3 location sources are not supported by this model" in caplog.text
 
 
 def test_format_request_filters_document_content_blocks(model, model_id):


### PR DESCRIPTION
## Problem

When using S3 location sources for documents, images, or videos with non-Nova Bedrock models (Anthropic Claude, Meta Llama, Mistral, Cohere), the Converse API returns a `ValidationException` with the message `source.type: Field required`. The SDK forwards the S3 location unconditionally, with no model capability check, so users receive a confusing error instead of a clear warning.

S3 location sources are only supported by Amazon Nova models. All other model families require inline bytes.

## Solution

Added `_MODELS_SUPPORT_S3_LOCATION = ["amazon.nova"]` alongside the existing `_MODELS_INCLUDE_STATUS` capability constant. Added a `_supports_s3_location` property and updated `_handle_location` to check model support before formatting the S3 location. When the model does not support S3 locations, a warning is logged and the content block is dropped, matching the behavior of the existing non-S3 location fallback.

## Testing

- Updated `test_format_request_image_s3_location_only`, `test_format_request_document_s3_location`, and `test_format_request_video_s3_location` to use `amazon.nova-pro-v1:0`.
- Added `test_format_request_s3_location_skipped_for_unsupported_models` to verify all three S3 location content types are dropped with a warning for non-Nova models.
- 2489 tests pass, lint clean.

Fixes #1744

## Documentation PR

N/A

## Type of Change

Bug fix

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.