### PR TITLE
fix(streaming): handle tool use metadata in contentBlockDelta for non-standard models

### DIFF
--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -218,10 +218,19 @@ def handle_content_block_delta(
     typed_event: ModelStreamEvent = ModelStreamEvent({})
 
     if "toolUse" in delta_content:
+        tool_use_delta = delta_content["toolUse"]
         if "input" not in state["current_tool_use"]:
             state["current_tool_use"]["input"] = ""
 
-        state["current_tool_use"]["input"] += delta_content["toolUse"]["input"]
+        state["current_tool_use"]["input"] += tool_use_delta.get("input", "")
+
+        # Some models provide toolUseId and name in contentBlockDelta instead of contentBlockStart.
+        # Capture them here if not already set from a prior contentBlockStart event.
+        if "toolUseId" not in state["current_tool_use"] and "toolUseId" in tool_use_delta:
+            state["current_tool_use"]["toolUseId"] = tool_use_delta["toolUseId"]
+        if "name" not in state["current_tool_use"] and "name" in tool_use_delta:
+            state["current_tool_use"]["name"] = tool_use_delta["name"]
+
         typed_event = ToolUseStreamEvent(delta_content, state["current_tool_use"])
 
     elif "text" in delta_content:
@@ -289,8 +298,16 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
         except ValueError:
             current_tool_use["input"] = {}
 
-        tool_use_id = current_tool_use["toolUseId"]
-        tool_use_name = current_tool_use["name"]
+        tool_use_id = current_tool_use.get("toolUseId", "")
+        tool_use_name = current_tool_use.get("name", "")
+
+        if not tool_use_id or not tool_use_name:
+            logger.warning(
+                "Incomplete tool use block (missing toolUseId or name); skipping content block. "
+                "The model may be using a non-standard streaming format."
+            )
+            state["current_tool_use"] = {}
+            return state
 
         tool_use = ToolUse(
             toolUseId=tool_use_id,

--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -224,12 +224,10 @@ def handle_content_block_delta(
 
         state["current_tool_use"]["input"] += tool_use_delta.get("input", "")
 
-        # Some models provide toolUseId and name in contentBlockDelta instead of contentBlockStart.
-        # Capture them here if not already set from a prior contentBlockStart event.
-        if "toolUseId" not in state["current_tool_use"] and "toolUseId" in tool_use_delta:
-            state["current_tool_use"]["toolUseId"] = tool_use_delta["toolUseId"]
-        if "name" not in state["current_tool_use"] and "name" in tool_use_delta:
-            state["current_tool_use"]["name"] = tool_use_delta["name"]
+        # Some models emit toolUseId/name in the delta instead of contentBlockStart; keep values already set.
+        for field in ("toolUseId", "name"):
+            if field not in state["current_tool_use"] and field in tool_use_delta:
+                state["current_tool_use"][field] = tool_use_delta[field]
 
         typed_event = ToolUseStreamEvent(delta_content, state["current_tool_use"])
 
@@ -302,9 +300,12 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
         tool_use_name = current_tool_use.get("name", "")
 
         if not tool_use_id or not tool_use_name:
+            # Skip, don't raise: an empty tool_uses list still appends a valid toolResult, so the loop continues.
             logger.warning(
-                "Incomplete tool use block (missing toolUseId or name); skipping content block. "
-                "The model may be using a non-standard streaming format."
+                "tool_use_id=<%s>, tool_name=<%s> | incomplete tool use block, skipping content block "
+                "(model may be using a non-standard streaming format)",
+                tool_use_id,
+                tool_use_name,
             )
             state["current_tool_use"] = {}
             return state

--- a/strands-py/src/strands/types/streaming.py
+++ b/strands-py/src/strands/types/streaming.py
@@ -5,7 +5,7 @@ These types are modeled after the Bedrock API.
 - Bedrock docs: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Types_Amazon_Bedrock_Runtime.html
 """
 
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from .citations import CitationLocation
 from .content import ContentBlockStart, Role
@@ -51,9 +51,15 @@ class ContentBlockDeltaToolUse(TypedDict):
 
     Attributes:
         input: The tool input fragment being streamed.
+        toolUseId: Optional tool use identifier. Some providers emit this in the delta
+            instead of contentBlockStart.
+        name: Optional tool name. Some providers emit this in the delta instead of
+            contentBlockStart.
     """
 
     input: str
+    toolUseId: NotRequired[str]
+    name: NotRequired[str]
 
 
 class CitationSourceContentDelta(TypedDict, total=False):

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -1495,3 +1495,110 @@ async def test_process_stream_keeps_tool_use_stop_reason_unchanged(agenerator, a
     last_event = cast(ModelStopReason, (await alist(stream))[-1])
 
     assert last_event["stop"][0] == "tool_use"
+
+
+def test_handle_content_block_delta_captures_tool_use_id_and_name_from_delta():
+    """Delta events that include toolUseId and name should populate current_tool_use."""
+    event = {"delta": {"toolUse": {"input": '{"x": 1}', "toolUseId": "abc123", "name": "output_slide"}}}
+    state = {"current_tool_use": {}}
+
+    updated_state, _ = strands.event_loop.streaming.handle_content_block_delta(event, state)
+
+    assert updated_state["current_tool_use"]["toolUseId"] == "abc123"
+    assert updated_state["current_tool_use"]["name"] == "output_slide"
+    assert updated_state["current_tool_use"]["input"] == '{"x": 1}'
+
+
+def test_handle_content_block_delta_does_not_override_existing_tool_use_id_and_name():
+    """toolUseId and name from contentBlockStart should not be overridden by a later delta."""
+    event = {"delta": {"toolUse": {"input": '{"x": 1}', "toolUseId": "from_delta", "name": "from_delta"}}}
+    state = {"current_tool_use": {"toolUseId": "from_start", "name": "from_start", "input": ""}}
+
+    updated_state, _ = strands.event_loop.streaming.handle_content_block_delta(event, state)
+
+    assert updated_state["current_tool_use"]["toolUseId"] == "from_start"
+    assert updated_state["current_tool_use"]["name"] == "from_start"
+
+
+def test_handle_content_block_delta_tool_use_without_input_key():
+    """A toolUse delta missing the input key should not raise KeyError."""
+    event = {"delta": {"toolUse": {}}}
+    state = {"current_tool_use": {"toolUseId": "t1", "name": "tool"}}
+
+    updated_state, _ = strands.event_loop.streaming.handle_content_block_delta(event, state)
+
+    assert updated_state["current_tool_use"]["input"] == ""
+
+
+def test_handle_content_block_stop_skips_incomplete_tool_use_missing_id(caplog):
+    """A tool use block missing toolUseId is skipped with a warning."""
+    import logging
+
+    state = {
+        "content": [],
+        "current_tool_use": {"name": "output_slide", "input": '{"x": 1}'},
+        "text": "",
+        "reasoningText": "",
+        "citationsContent": [],
+    }
+
+    with caplog.at_level(logging.WARNING, logger="strands.event_loop.streaming"):
+        updated_state = strands.event_loop.streaming.handle_content_block_stop(state)
+
+    assert updated_state["content"] == []
+    assert updated_state["current_tool_use"] == {}
+    assert "Incomplete tool use block" in caplog.text
+
+
+def test_handle_content_block_stop_skips_incomplete_tool_use_missing_name(caplog):
+    """A tool use block missing name is skipped with a warning."""
+    import logging
+
+    state = {
+        "content": [],
+        "current_tool_use": {"toolUseId": "abc123", "input": '{"x": 1}'},
+        "text": "",
+        "reasoningText": "",
+        "citationsContent": [],
+    }
+
+    with caplog.at_level(logging.WARNING, logger="strands.event_loop.streaming"):
+        updated_state = strands.event_loop.streaming.handle_content_block_stop(state)
+
+    assert updated_state["content"] == []
+    assert updated_state["current_tool_use"] == {}
+    assert "Incomplete tool use block" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_process_stream_tool_use_info_in_delta(agenerator, alist):
+    """Models that provide toolUseId and name in contentBlockDelta (not contentBlockStart) work correctly."""
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {
+            "contentBlockDelta": {
+                "delta": {"toolUse": {"input": '{"title": "Test"}', "toolUseId": "xyz789", "name": "output_slide"}}
+            }
+        },
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "tool_use"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 5, "outputTokens": 10, "totalTokens": 15},
+                "metrics": {"latencyMs": 50},
+            }
+        },
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+    events = await alist(stream)
+    last_event = cast(ModelStopReason, events[-1])
+
+    stop_reason, message, _, _ = last_event["stop"]
+    assert stop_reason == "tool_use"
+    assert len(message["content"]) == 1
+    tool_use = message["content"][0]["toolUse"]
+    assert tool_use["toolUseId"] == "xyz789"
+    assert tool_use["name"] == "output_slide"
+    assert tool_use["input"] == {"title": "Test"}

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -1504,9 +1504,11 @@ def test_handle_content_block_delta_captures_tool_use_id_and_name_from_delta():
 
     updated_state, _ = strands.event_loop.streaming.handle_content_block_delta(event, state)
 
-    assert updated_state["current_tool_use"]["toolUseId"] == "abc123"
-    assert updated_state["current_tool_use"]["name"] == "output_slide"
-    assert updated_state["current_tool_use"]["input"] == '{"x": 1}'
+    assert updated_state["current_tool_use"] == {
+        "toolUseId": "abc123",
+        "name": "output_slide",
+        "input": '{"x": 1}',
+    }
 
 
 def test_handle_content_block_delta_does_not_override_existing_tool_use_id_and_name():
@@ -1516,8 +1518,11 @@ def test_handle_content_block_delta_does_not_override_existing_tool_use_id_and_n
 
     updated_state, _ = strands.event_loop.streaming.handle_content_block_delta(event, state)
 
-    assert updated_state["current_tool_use"]["toolUseId"] == "from_start"
-    assert updated_state["current_tool_use"]["name"] == "from_start"
+    assert updated_state["current_tool_use"] == {
+        "toolUseId": "from_start",
+        "name": "from_start",
+        "input": '{"x": 1}',
+    }
 
 
 def test_handle_content_block_delta_tool_use_without_input_key():
@@ -1547,7 +1552,7 @@ def test_handle_content_block_stop_skips_incomplete_tool_use_missing_id(caplog):
 
     assert updated_state["content"] == []
     assert updated_state["current_tool_use"] == {}
-    assert "Incomplete tool use block" in caplog.text
+    assert "incomplete tool use block" in caplog.text
 
 
 def test_handle_content_block_stop_skips_incomplete_tool_use_missing_name(caplog):
@@ -1567,7 +1572,7 @@ def test_handle_content_block_stop_skips_incomplete_tool_use_missing_name(caplog
 
     assert updated_state["content"] == []
     assert updated_state["current_tool_use"] == {}
-    assert "Incomplete tool use block" in caplog.text
+    assert "incomplete tool use block" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1599,6 +1604,4 @@ async def test_process_stream_tool_use_info_in_delta(agenerator, alist):
     assert stop_reason == "tool_use"
     assert len(message["content"]) == 1
     tool_use = message["content"][0]["toolUse"]
-    assert tool_use["toolUseId"] == "xyz789"
-    assert tool_use["name"] == "output_slide"
-    assert tool_use["input"] == {"title": "Test"}
+    assert tool_use == {"toolUseId": "xyz789", "name": "output_slide", "input": {"title": "Test"}}


### PR DESCRIPTION
## Problem

When Kimi K2.5 (`moonshotai.kimi-k2.5`) is used via the Amazon Bedrock Converse streaming API, tool calls on the second cycle crash with a `KeyError`. The streaming parser in `handle_content_block_delta` only reads `input` from `contentBlockDelta.delta.toolUse`, ignoring `toolUseId` and `name`. When a model provides those fields in the delta rather than in `contentBlockStart` (a non-standard but valid variation), `current_tool_use` reaches `handle_content_block_stop` without `toolUseId` or `name`, causing a crash.

A secondary gap: if `delta.toolUse` has no `input` key, the direct dict access raises `KeyError` instead of treating it as an empty string.

## Solution

In `handle_content_block_delta`, capture `toolUseId` and `name` from the delta when they are present and not already set from a prior `contentBlockStart`. Use `.get("input", "")` to handle deltas with no `input` key.

In `handle_content_block_stop`, replace the direct `current_tool_use["toolUseId"]` and `current_tool_use["name"]` accesses with `.get()` calls, and log a warning and skip the block if either field is still missing after processing all events.

## Testing

- Added `test_handle_content_block_delta_captures_tool_use_id_and_name_from_delta`: delta with all three fields populates `current_tool_use` correctly.
- Added `test_handle_content_block_delta_does_not_override_existing_tool_use_id_and_name`: fields set by `contentBlockStart` are not overwritten by a later delta.
- Added `test_handle_content_block_delta_tool_use_without_input_key`: delta missing `input` does not raise.
- Added `test_handle_content_block_stop_skips_incomplete_tool_use_missing_id` / `_missing_name`: warning logged and block skipped when fields are absent.
- Added `test_process_stream_tool_use_info_in_delta`: end-to-end check simulating a model that sends all tool use metadata in the delta.
- All 132 existing event loop tests pass. Lint clean.

Fixes #1646

## Documentation PR

N/A

## Type of Change

Bug fix

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
