### PR TITLE
fix: inject GPT-OSS stop tokens when not specified to prevent tool call failures (#1949)

### DIFF
--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -36,6 +36,10 @@ _CONTEXT_OVERFLOW_MESSAGES = [
     "too many total text bytes",
 ]
 
+# Stop tokens for GPT-OSS models to enforce generation boundaries
+# https://github.com/openai/harmony/blob/main/src/registry.rs
+_GPT_OSS_STOP_TOKENS = ["<|call|>", "<|return|>", "<|end|>"]
+
 
 class Client(Protocol):
     """Protocol defining the OpenAI-compatible interface for the underlying provider client."""
@@ -467,6 +471,11 @@ class OpenAIModel(Model):
             TypeError: If a message contains a content block type that cannot be converted to an OpenAI-compatible
                 format.
         """
+        params = cast(dict[str, Any], self.config.get("params", {}))
+        # Inject default GPT-OSS stop tokens unless the user has explicitly provided their own
+        if "gpt-oss" in cast(str, self.config.get("model_id", "")).lower() and "stop" not in params:
+            params = {**params, "stop": _GPT_OSS_STOP_TOKENS}
+
         return {
             "messages": self.format_request_messages(
                 messages, system_prompt, system_prompt_content=system_prompt_content
@@ -486,7 +495,7 @@ class OpenAIModel(Model):
                 for tool_spec in tool_specs or []
             ],
             **(self._format_request_tool_choice(tool_choice)),
-            **cast(dict[str, Any], self.config.get("params", {})),
+            **params,
         }
 
     def format_chunk(self, event: dict[str, Any], **kwargs: Any) -> StreamEvent:

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -627,6 +627,25 @@ def test_format_request(model, messages, tool_specs, system_prompt):
     assert tru_request == exp_request
 
 
+@pytest.mark.parametrize("model_id", ["openai.gpt-oss-120b"])
+def test_format_request_gpt_oss_injects_stop_tokens(model_id, model, messages, tool_specs, system_prompt):
+    tru_request = model.format_request(messages, tool_specs, system_prompt)
+    assert tru_request["stop"] == ["<|call|>", "<|return|>", "<|end|>"]
+
+
+@pytest.mark.parametrize("model_id", ["openai.gpt-oss-120b"])
+def test_format_request_gpt_oss_preserves_explicit_stop_tokens(model_id, model, messages, tool_specs, system_prompt):
+    model.update_config(params={"max_tokens": 1, "stop": ["<|end|>"]})
+
+    tru_request = model.format_request(messages, tool_specs, system_prompt)
+    assert tru_request["stop"] == ["<|end|>"]
+
+
+def test_format_request_non_gpt_oss_no_stop_tokens(model, messages, tool_specs, system_prompt):
+    tru_request = model.format_request(messages, tool_specs, system_prompt)
+    assert "stop" not in tru_request
+
+
 def test_format_request_with_tool_choice_auto(model, messages, tool_specs, system_prompt):
     tool_choice = {"auto": {}}
     tru_request = model.format_request(messages, tool_specs, system_prompt, tool_choice)


### PR DESCRIPTION
## Description

### Problem

A [customer had reported](https://github.com/strands-agents/sdk-python/issues/1949) that tool calling was broken when using GPT-OSS models on Bedrock via Strands' OpenAIModel provider.

GPT-OSS recognizes a few specific "stop sequences" – specifically  ["<|call|>", "<|return|>", "<|end|>"] – as generation boundaries during inference, telling the model when special action is required. Example:

```
<|call|>
get_weather
{"location": "Seattle", "unit": "fahrenheit"}
<|call|>
```

Without these stop sequences configured, the model continues to produce tokens past the tool call boundary, which breaks the actual call and can even lead to hallucinated tool output:

```
<|call|>
get_weather
{"location": "Seattle", "unit": "fahrenheit"}
<|call|>
Sure! I'm calling the weather tool for you. Let me also check
<|call|>
get_news
{"topic": "Seattle weather"}
<|call|>
Here are the results...
```

Amazon's hosted Bedrock endpoint for GPT-OSS is already configured with middleware to pass the proper stop sequences to model calls. However, this customer was hitting GPT-OSS self-hosted in their *personal* Bedrock behind a localhost endpoint – without the stop sequences being injected, all tool calls were failing.

### Solution

This PR updates the OpenAIModel provider's `format_request` method to automatically inject ["<|call|>", "<|return|>", "<|end|>"] as stop sequences for GPT-OSS models when the user *has not* explicitly set their own recognized sequences. So – if the user calls GPT-OSS via a custom endpoint (like this case), we now ensure that the proper stop tokens are passed along.

## Related Issues

#1949 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare` (added a few unit tests to verify stop token injection) 

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly `N/A`
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed `N/A`
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
