### PR TITLE
fix(bidi): respect role from BidiTextInputEvent instead of hardcoding user

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strands-agents"
-dynamic = ["version"]  # Version determined by git tags
+version = "1.32.0"
 description = "A model-driven approach to building AI agents in just a few lines of code"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strands-agents"
-dynamic = ["version"] # Version determined by git tags
+dynamic = ["version"]  # Version determined by git tags
 description = "A model-driven approach to building AI agents in just a few lines of code"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strands-agents"
-version = "1.32.0"
+dynamic = ["version"] # Version determined by git tags
 description = "A model-driven approach to building AI agents in just a few lines of code"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/strands/experimental/bidi/agent/loop.py
+++ b/src/strands/experimental/bidi/agent/loop.py
@@ -140,7 +140,7 @@ class _BidiAgentLoop:
             await self._send_gate.wait()
 
         if isinstance(event, BidiTextInputEvent):
-            message: Message = {"role": "user", "content": [{"text": event.text}]}
+            message: Message = {"role": event.role, "content": [{"text": event.text}]}
             await self._agent._append_messages(message)
 
         await self._agent.model.send(event)


### PR DESCRIPTION
## Motivation

The bidi agent loop hardcodes `"role": "user"` when appending messages from a `BidiTextInputEvent`, ignoring the event's `role` property entirely. This means callers who construct a `BidiTextInputEvent` with `role="assistant"` (e.g., for injecting assistant context into the conversation history) have that role silently overwritten. The `role` parameter on `BidiTextInputEvent` exists specifically to support this — it should be used.

## Related Issues

None (no existing upstream issue for this bug).

## Documentation PR

N/A — no documentation changes needed.

## Type of Change

Bug fix

## Public API Changes

No public API changes. `BidiTextInputEvent` already accepts a `role` parameter — this fix ensures the agent loop honors it.

```python
# Before: role parameter is accepted but ignored by the agent loop
event = BidiTextInputEvent(text="hello", role="assistant")
# internally creates: {"role": "user", "content": [{"text": "hello"}]}  # role silently overwritten

# After: role parameter is respected
event = BidiTextInputEvent(text="hello", role="assistant")
# internally creates: {"role": "assistant", "content": [{"text": "hello"}]}  # correct
```

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.