### PR TITLE
ci: use centralized reusable markdown link check workflow from devtools

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -7,45 +7,4 @@ on:
 
 jobs:
   check-links:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
-        id: link-check
-        with:
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
-          config-file: '.markdown-link-check.json'
-        continue-on-error: true
-
-      - name: Create issue if links are broken
-        if: steps.link-check.outcome == 'failure'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const title = '🔗 Broken markdown links detected';
-            const label = 'broken-links';
-
-            // Check for existing open issue to avoid duplicates
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: label,
-            });
-
-            if (existing.data.length > 0) {
-              console.log(`Issue already exists: #${existing.data[0].number}`);
-              return;
-            }
-
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body: `The weekly markdown link check found broken links.\n\nSee the [workflow run](${runUrl}) for details.`,
-              labels: [label],
-            });
+    uses: strands-agents/devtools/.github/workflows/check-markdown-links.yml@main

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,6 +1,0 @@
-{
-  "retryOn429": true,
-  "retryCount": 3,
-  "fallbackRetryDelay": "30s",
-  "aliveStatusCodes": [200, 206]
-}


### PR DESCRIPTION
## Description

Migrates the existing markdown link check workflow to use the centralized reusable workflow from `strands-agents/devtools`.

### Changes

- Replace inline workflow with thin caller referencing `strands-agents/devtools/.github/workflows/check-markdown-links.yml@main`
- Remove local `.markdown-link-check.json` (now centralized in devtools as default config)

### How it works

The reusable workflow in devtools:
1. Checks if the repo has a local `.markdown-link-check.json` (for per-repo overrides)
2. Falls back to the default config from devtools if none exists
3. Runs the link checker and creates an issue if broken links are found

## Related

- Centralized config: strands-agents/devtools#49
- Original request: https://github.com/strands-agents/sdk-typescript/pull/799#issuecomment-4209365609
- Also updating: strands-agents/sdk-typescript#799, strands-agents/tools#446, strands-agents/evals#188

## Type of Change

CI

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.