### PR TITLE
fix: do not synthesize exception for cancelled tools

### DIFF
--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -212,6 +212,8 @@ class Tracer:
                 status_description = error_message or str(error) or type(error).__name__
                 span.set_status(StatusCode.ERROR, status_description)
                 span.record_exception(error)
+            elif error_message:
+                span.set_status(StatusCode.ERROR, error_message)
             else:
                 span.set_status(StatusCode.OK)
         except Exception as e:
@@ -454,15 +456,13 @@ class Tracer:
             error: Optional exception if the tool call failed.
         """
         attributes: dict[str, AttributeValue] = {}
+        status: str | None = None
+        content: list[Any] = []
+
         if tool_result is not None:
             status = tool_result.get("status")
-            status_str = str(status) if status is not None else ""
-
-            attributes.update(
-                {
-                    "gen_ai.tool.status": status_str,
-                }
-            )
+            content = tool_result.get("content", [])
+            attributes["gen_ai.tool.status"] = str(status) if status is not None else ""
 
             if self.use_latest_genai_conventions:
                 self._add_event(
@@ -477,7 +477,7 @@ class Tracer:
                                         {
                                             "type": "tool_call_response",
                                             "id": tool_result.get("toolUseId", ""),
-                                            "response": tool_result.get("content"),
+                                            "response": content,
                                         }
                                     ],
                                 }
@@ -491,12 +491,16 @@ class Tracer:
                     span,
                     "gen_ai.choice",
                     event_attributes={
-                        "message": serialize(tool_result.get("content")),
+                        "message": serialize(content),
                         "id": tool_result.get("toolUseId", ""),
                     },
                 )
 
-        self._end_span(span, attributes, error)
+        if error is None and status == "error":
+            error_message = next((b["text"] for b in content if "text" in b), "tool returned error status")
+            self._end_span(span, attributes, error_message=error_message)
+        else:
+            self._end_span(span, attributes, error)
 
     def start_event_loop_cycle_span(
         self,

--- a/src/strands/telemetry/tracer.py
+++ b/src/strands/telemetry/tracer.py
@@ -212,6 +212,8 @@ class Tracer:
                 status_description = error_message or str(error) or type(error).__name__
                 span.set_status(StatusCode.ERROR, status_description)
                 span.record_exception(error)
+            elif error_message:
+                span.set_status(StatusCode.ERROR, error_message)
             else:
                 span.set_status(StatusCode.OK)
         except Exception as e:
@@ -460,15 +462,13 @@ class Tracer:
             error: Optional exception if the tool call failed.
         """
         attributes: dict[str, AttributeValue] = {}
+        status: str | None = None
+        content: list[Any] = []
+
         if tool_result is not None:
             status = tool_result.get("status")
-            status_str = str(status) if status is not None else ""
-
-            attributes.update(
-                {
-                    "gen_ai.tool.status": status_str,
-                }
-            )
+            content = tool_result.get("content", [])
+            attributes["gen_ai.tool.status"] = str(status) if status is not None else ""
 
             if self.use_latest_genai_conventions:
                 self._add_event(
@@ -483,7 +483,7 @@ class Tracer:
                                         {
                                             "type": "tool_call_response",
                                             "id": tool_result.get("toolUseId", ""),
-                                            "response": tool_result.get("content"),
+                                            "response": content,
                                         }
                                     ],
                                 }
@@ -497,12 +497,16 @@ class Tracer:
                     span,
                     "gen_ai.choice",
                     event_attributes={
-                        "message": serialize(tool_result.get("content")),
+                        "message": serialize(content),
                         "id": tool_result.get("toolUseId", ""),
                     },
                 )
 
-        self._end_span(span, attributes, error)
+        if error is None and status == "error":
+            error_message = next((b["text"] for b in content if "text" in b), "tool returned error status")
+            self._end_span(span, attributes, error_message=error_message)
+        else:
+            self._end_span(span, attributes, error)
 
     def start_event_loop_cycle_span(
         self,
@@ -527,9 +531,7 @@ class Tracer:
         event_loop_cycle_id = str(invocation_state.get("event_loop_cycle_id"))
         parent_span = parent_span if parent_span else invocation_state.get("event_loop_parent_span")
 
-        attributes: dict[str, AttributeValue] = self._get_common_attributes(
-            operation_name="execute_event_loop_cycle"
-        )
+        attributes: dict[str, AttributeValue] = self._get_common_attributes(operation_name="execute_event_loop_cycle")
         attributes["event_loop.cycle_id"] = event_loop_cycle_id
 
         if custom_trace_attributes:

--- a/src/strands/tools/executors/_executor.py
+++ b/src/strands/tools/executors/_executor.py
@@ -176,10 +176,9 @@ class ToolExecutor(abc.ABC):
                     tool_use,
                     invocation_state,
                     cancel_result,
-                    exception=Exception(cancel_message),
                     cancel_message=cancel_message,
                 )
-                yield ToolResultEvent(after_event.result, exception=after_event.exception)
+                yield ToolResultEvent(after_event.result)
                 tool_results.append(after_event.result)
                 return
 

--- a/tests/strands/telemetry/test_tracer.py
+++ b/tests/strands/telemetry/test_tracer.py
@@ -722,6 +722,19 @@ def test_end_tool_call_span_with_error(mock_span):
     mock_span.end.assert_called_once()
 
 
+def test_end_tool_call_span_error_result_no_exception(mock_span):
+    """Test that an error result without an exception still sets StatusCode.ERROR."""
+    tracer = Tracer()
+    tool_result = {"status": "error", "content": [{"text": "tool cancelled by user"}]}
+
+    tracer.end_tool_call_span(mock_span, tool_result)
+
+    mock_span.set_attributes.assert_called_once_with({"gen_ai.tool.status": "error"})
+    mock_span.set_status.assert_called_once_with(StatusCode.ERROR, "tool cancelled by user")
+    mock_span.record_exception.assert_not_called()
+    mock_span.end.assert_called_once()
+
+
 def test_start_event_loop_cycle_span(mock_tracer):
     """Test starting an event loop cycle span."""
     with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):

--- a/tests/strands/tools/executors/test_executor.py
+++ b/tests/strands/tools/executors/test_executor.py
@@ -954,8 +954,8 @@ async def test_executor_stream_unknown_tool_has_exception(executor, agent, tool_
 
 
 @pytest.mark.asyncio
-async def test_executor_stream_cancel_has_exception(executor, agent, tool_results, invocation_state, alist):
-    """Test that _stream yields a ToolResultEvent with exception for cancelled tools."""
+async def test_executor_stream_cancel_no_exception(executor, agent, tool_results, invocation_state, alist):
+    """Test that _stream yields a ToolResultEvent with no exception for cancelled tools."""
 
     def cancel_callback(event):
         event.cancel_tool = True
@@ -969,5 +969,25 @@ async def test_executor_stream_cancel_has_exception(executor, agent, tool_result
     result_event = events[-1]
     assert isinstance(result_event, ToolResultEvent)
     assert result_event.tool_result["status"] == "error"
-    assert result_event.exception is not None
-    assert "cancelled" in str(result_event.exception)
+    assert result_event.exception is None
+
+
+@pytest.mark.asyncio
+async def test_executor_stream_cancel_after_hook_sees_no_exception(
+    executor, agent, tool_results, invocation_state, hook_events, alist
+):
+    """Test that AfterToolCallEvent.exception is None when a tool is cancelled."""
+
+    def cancel_callback(event):
+        event.cancel_tool = "user denied permission"
+        return event
+
+    agent.hooks.add_callback(BeforeToolCallEvent, cancel_callback)
+    tool_use: ToolUse = {"name": "weather_tool", "toolUseId": "1", "input": {}}
+    stream = executor._stream(agent, tool_use, tool_results, invocation_state)
+    await alist(stream)
+
+    after_event = hook_events[-1]
+    assert isinstance(after_event, AfterToolCallEvent)
+    assert after_event.exception is None
+    assert after_event.cancel_message == "user denied permission"

--- a/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -251,9 +251,7 @@ class TestTaskMetaForwarding:
 
         with MCPClient(mock_transport["transport_callable"], tasks_config=TasksConfig()) as client:
             client.list_tools_sync()
-            client.call_tool_sync(
-                tool_use_id="test-id", name="meta_tool", arguments={"param": "value"}, meta=meta
-            )
+            client.call_tool_sync(tool_use_id="test-id", name="meta_tool", arguments={"param": "value"}, meta=meta)
 
             experimental.call_tool_as_task.assert_called_once()
             call_kwargs = experimental.call_tool_as_task.call_args
@@ -281,9 +279,7 @@ class TestTaskMetaForwarding:
 
         with MCPClient(mock_transport["transport_callable"], tasks_config=TasksConfig()) as client:
             client.list_tools_sync()
-            client.call_tool_sync(
-                tool_use_id="test-id", name="no_meta_tool", arguments={"param": "value"}
-            )
+            client.call_tool_sync(tool_use_id="test-id", name="no_meta_tool", arguments={"param": "value"})
 
             experimental.call_tool_as_task.assert_called_once()
             call_kwargs = experimental.call_tool_as_task.call_args


### PR DESCRIPTION
## Description

After #2046 , setting `cancel_tool` on a `BeforeToolCallEvent` now populates `AfterToolCallEvent.exception` with a synthesized exception which cannot be overwritten, causing tool cancellations to appear as failures to downstream hooks.

Cancellation is a deliberate action, not a failure. `AfterToolCallEvent.cancel_message` already exists to identify cancelled tools; hooks can use it to distinguish cancellations from genuine exceptions without needing a fake exception object. Additionally, tool result status remains as `error` for cancellations.

Span observability is preserved: `StatusCode.ERROR` is now set by inspecting `tool_result["status"]` directly rather than relying on a synthesized exception.


### Public API Changes

`AfterToolCallEvent.exception` is once again `None` for cancelled tools. `cancel_message` remains the correct field to detect cancellations.

## Related Issues

#2046 

## Documentation PR

No documentation changes needed.

## Type of Change

Bug fix

## Testing

- [x ] I ran `hatch run prepare`

## Checklist
- [x ] I have read the CONTRIBUTING document
- [ x] I have added any necessary tests that prove my fix is effective or my feature works
- [ x] I have updated the documentation accordingly
- [ x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ x] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published



----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
