### PR TITLE
fix: clear leaked running loop in MCP client background thread

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -835,6 +835,9 @@ class MCPClient(ToolProvider):
         This allows for a long-running event loop.
         """
         self._log_debug_with_thread("setting up background task event loop")
+        # Clear any running-loop state leaked by OpenTelemetry's ThreadingInstrumentor, which wraps Thread.run()
+        # and can propagate the parent thread's event loop reference, causing run_until_complete() to fail.
+        asyncio._set_running_loop(None)
         self._background_thread_event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._background_thread_event_loop)
         self._background_thread_event_loop.run_until_complete(self._async_background_thread())

--- a/tests/strands/tools/mcp/test_mcp_client_contextvar.py
+++ b/tests/strands/tools/mcp/test_mcp_client_contextvar.py
@@ -88,3 +88,39 @@ def test_mcp_client_propagates_contextvars_to_background_thread(mock_transport, 
     )
     # Verify it was indeed a different thread
     assert background_thread_value["thread_id"] != main_thread_id, "Background task should run in a different thread"
+
+
+def test_mcp_client_clears_running_loop_in_background_thread(mock_transport, mock_session):
+    """Test that _background_task clears any leaked running event loop state.
+
+    When OpenTelemetry's ThreadingInstrumentor is active, Thread.run() is wrapped to propagate
+    trace context, which can leak the parent thread's running event loop reference into child
+    threads. This causes "RuntimeError: Cannot run the event loop while another loop is running"
+    when the background thread calls run_until_complete().
+
+    This test simulates that scenario by setting a running loop before _background_task runs
+    and verifying it gets cleared.
+    """
+    import asyncio
+
+    cleared_running_loop = {}
+
+    original_background_task = MCPClient._background_task
+
+    def simulating_otel_leak_background_task(self):
+        # Simulate OTEL ThreadingInstrumentor leaking the parent's running loop
+        fake_loop = asyncio.new_event_loop()
+        asyncio._set_running_loop(fake_loop)  # type: ignore[attr-defined]
+
+        # Call the real _background_task — it should clear the leaked loop and succeed
+        try:
+            return original_background_task(self)
+        finally:
+            cleared_running_loop["success"] = True
+            fake_loop.close()
+
+    with patch.object(MCPClient, "_background_task", simulating_otel_leak_background_task):
+        with MCPClient(mock_transport["transport_callable"]) as client:
+            assert client._background_thread is not None
+
+    assert cleared_running_loop.get("success"), "_background_task should have run successfully despite leaked loop"


### PR DESCRIPTION
## Description

When `opentelemetry-instrumentation-threading` is active — the documented pattern for AgentCore observability — the `ThreadingInstrumentor` wraps `Thread.run()` to propagate trace context. Combined with `contextvars.copy_context()` in `MCPClient.start()`, this leaks the parent thread's running event loop reference into the background thread. When `_background_task` then calls `run_until_complete()`, asyncio sees a "running" loop already set and raises `RuntimeError: Cannot run the event loop while another loop is running`.

This adds `asyncio._set_running_loop(None)` at the top of `_background_task()` to clear leaked loop state before creating the new event loop. This is the same pattern the bedrock-agentcore team shipped in [aws/bedrock-agentcore-sdk-python#405](https://github.com/aws/bedrock-agentcore-sdk-python/pull/405).

Confirmed on SDK versions 1.28.0 and 1.35.0.

## Related Issues

N/A

## Documentation PR

N/A — no documentation changes needed.

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

Added a unit test that simulates the OTEL leak by setting a running loop before `_background_task` executes, verifying the method clears it and completes successfully.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
