### PR TITLE
feat(openai): plumb through cache tokens in metadata events

### DIFF
--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages, SystemContentBlock
+from ..types.event_loop import Usage
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
@@ -546,13 +547,19 @@ class OpenAIModel(Model):
                         return {"messageStop": {"stopReason": "end_turn"}}
 
             case "metadata":
+                usage_data: Usage = {
+                    "inputTokens": event["data"].prompt_tokens,
+                    "outputTokens": event["data"].completion_tokens,
+                    "totalTokens": event["data"].total_tokens,
+                }
+
+                if tokens_details := getattr(event["data"], "prompt_tokens_details", None):
+                    if cached := getattr(tokens_details, "cached_tokens", None):
+                        usage_data["cacheReadInputTokens"] = cached
+
                 return {
                     "metadata": {
-                        "usage": {
-                            "inputTokens": event["data"].prompt_tokens,
-                            "outputTokens": event["data"].completion_tokens,
-                            "totalTokens": event["data"].total_tokens,
-                        },
+                        "usage": usage_data,
                         "metrics": {
                             "latencyMs": 0,  # TODO
                         },

--- a/test_output.log
+++ b/test_output.log
@@ -1,1 +1,0 @@
-/bin/sh: 1: hatch: not found

--- a/test_output.log
+++ b/test_output.log
@@ -1,0 +1,1 @@
+/bin/sh: 1: hatch: not found

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -873,24 +873,6 @@ def test_format_chunk_metadata_with_cache_tokens(model):
     assert result["metadata"]["usage"]["cacheReadInputTokens"] == 25
 
 
-def test_format_chunk_metadata_without_cache_tokens(model):
-    """Test format_chunk for metadata without cache tokens."""
-    mock_usage = unittest.mock.Mock()
-    mock_usage.prompt_tokens = 100
-    mock_usage.completion_tokens = 50
-    mock_usage.total_tokens = 150
-    mock_usage.prompt_tokens_details = None
-
-    event = {"chunk_type": "metadata", "data": mock_usage}
-
-    result = model.format_chunk(event)
-
-    assert result["metadata"]["usage"]["inputTokens"] == 100
-    assert result["metadata"]["usage"]["outputTokens"] == 50
-    assert result["metadata"]["usage"]["totalTokens"] == 150
-    assert "cacheReadInputTokens" not in result["metadata"]["usage"]
-
-
 def test_format_chunk_metadata_with_zero_cached_tokens(model):
     """Test format_chunk for metadata when cached_tokens is 0."""
     mock_usage = unittest.mock.Mock()

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -818,7 +818,12 @@ def test_format_request_with_tool_choice_tool(model, messages, tool_specs, syste
         (
             {
                 "chunk_type": "metadata",
-                "data": unittest.mock.Mock(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+                "data": unittest.mock.Mock(
+                    prompt_tokens=100,
+                    completion_tokens=50,
+                    total_tokens=150,
+                    prompt_tokens_details=None,
+                ),
             },
             {
                 "metadata": {
@@ -845,6 +850,63 @@ def test_format_chunk_unknown_type(model):
 
     with pytest.raises(RuntimeError, match="chunk_type=<unknown> | unknown type"):
         model.format_chunk(event)
+
+
+def test_format_chunk_metadata_with_cache_tokens(model):
+    """Test format_chunk for metadata with cache tokens present."""
+    mock_usage = unittest.mock.Mock()
+    mock_usage.prompt_tokens = 100
+    mock_usage.completion_tokens = 50
+    mock_usage.total_tokens = 150
+
+    mock_tokens_details = unittest.mock.Mock()
+    mock_tokens_details.cached_tokens = 25
+    mock_usage.prompt_tokens_details = mock_tokens_details
+
+    event = {"chunk_type": "metadata", "data": mock_usage}
+
+    result = model.format_chunk(event)
+
+    assert result["metadata"]["usage"]["inputTokens"] == 100
+    assert result["metadata"]["usage"]["outputTokens"] == 50
+    assert result["metadata"]["usage"]["totalTokens"] == 150
+    assert result["metadata"]["usage"]["cacheReadInputTokens"] == 25
+
+
+def test_format_chunk_metadata_without_cache_tokens(model):
+    """Test format_chunk for metadata without cache tokens."""
+    mock_usage = unittest.mock.Mock()
+    mock_usage.prompt_tokens = 100
+    mock_usage.completion_tokens = 50
+    mock_usage.total_tokens = 150
+    mock_usage.prompt_tokens_details = None
+
+    event = {"chunk_type": "metadata", "data": mock_usage}
+
+    result = model.format_chunk(event)
+
+    assert result["metadata"]["usage"]["inputTokens"] == 100
+    assert result["metadata"]["usage"]["outputTokens"] == 50
+    assert result["metadata"]["usage"]["totalTokens"] == 150
+    assert "cacheReadInputTokens" not in result["metadata"]["usage"]
+
+
+def test_format_chunk_metadata_with_zero_cached_tokens(model):
+    """Test format_chunk for metadata when cached_tokens is 0."""
+    mock_usage = unittest.mock.Mock()
+    mock_usage.prompt_tokens = 100
+    mock_usage.completion_tokens = 50
+    mock_usage.total_tokens = 150
+
+    mock_tokens_details = unittest.mock.Mock()
+    mock_tokens_details.cached_tokens = 0
+    mock_usage.prompt_tokens_details = mock_tokens_details
+
+    event = {"chunk_type": "metadata", "data": mock_usage}
+
+    result = model.format_chunk(event)
+
+    assert "cacheReadInputTokens" not in result["metadata"]["usage"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Motivation

When OpenAI returns prompt caching information (`prompt_tokens_details.cached_tokens`), the OpenAI model provider currently discards it. Users have no way to see whether their requests hit the OpenAI prompt cache, which is valuable for cost optimization and debugging.

The LiteLLM provider already extracts this data, as does the experimental OpenAI Realtime bidi model — but the primary OpenAI provider was missing this support.

Resolves #2115

## Public API Changes

No public API changes. The `metadata` event emitted by `OpenAIModel.format_chunk` now includes `cacheReadInputTokens` in the usage data when OpenAI reports cached prompt tokens:

```python
# Before: metadata event usage
{"inputTokens": 1861, "outputTokens": 10, "totalTokens": 1871}

# After: metadata event usage (when cache hit occurs)
{"inputTokens": 1861, "outputTokens": 10, "totalTokens": 1871, "cacheReadInputTokens": 1792}
```

When `prompt_tokens_details` is `None` or `cached_tokens` is `None`/`0`, the field is omitted — preserving backward compatibility. The existing telemetry pipeline (tracer and metrics) already handles `cacheReadInputTokens`, so cache data flows through automatically.

Only `cacheReadInputTokens` is set because OpenAI's API does not expose a cache write token equivalent (unlike Anthropic).