### PR TITLE
fix(bedrock): normalize empty toolResult content arrays in _format_bedrock_messages

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -438,6 +438,16 @@ class BedrockModel(Model):
                     dropped_deepseek_reasoning_content = True
                     continue
 
+                # Normalize empty toolResult content arrays.
+                # Some model providers (e.g., Nemotron) reject toolResult blocks with
+                # content: [] via the Converse API, while others (e.g., Claude) accept
+                # them. Replace empty content with a minimal text block to ensure
+                # cross-model compatibility. This follows the same pattern as the
+                # TypeScript SDK's _formatMessages in bedrock.ts.
+                if "toolResult" in content_block:
+                    if not content_block["toolResult"].get("content"):
+                        content_block["toolResult"]["content"] = [{"text": ""}]
+
                 # Format content blocks for Bedrock API compatibility
                 formatted_content = self._format_request_message_content(content_block)
                 if formatted_content is None:

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -438,16 +438,6 @@ class BedrockModel(Model):
                     dropped_deepseek_reasoning_content = True
                     continue
 
-                # Normalize empty toolResult content arrays.
-                # Some model providers (e.g., Nemotron) reject toolResult blocks with
-                # content: [] via the Converse API, while others (e.g., Claude) accept
-                # them. Replace empty content with a minimal text block to ensure
-                # cross-model compatibility. This follows the same pattern as the
-                # TypeScript SDK's _formatMessages in bedrock.ts.
-                if "toolResult" in content_block:
-                    if not content_block["toolResult"].get("content"):
-                        content_block["toolResult"]["content"] = [{"text": ""}]
-
                 # Format content blocks for Bedrock API compatibility
                 formatted_content = self._format_request_message_content(content_block)
                 if formatted_content is None:
@@ -611,8 +601,15 @@ class BedrockModel(Model):
         # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html
         if "toolResult" in content:
             tool_result = content["toolResult"]
+            # Normalize empty toolResult content arrays.
+            # Some model providers (e.g., Nemotron) reject toolResult blocks with
+            # content: [] via the Converse API, while others (e.g., Claude) accept
+            # them. Replace empty content with a minimal text block to ensure
+            # cross-model compatibility. This follows the same pattern as the
+            # TypeScript SDK's _formatMessages in bedrock.ts.
+            tool_result_content_list = tool_result.get("content") or [{"text": ""}]
             formatted_content: list[dict[str, Any]] = []
-            for tool_result_content in tool_result["content"]:
+            for tool_result_content in tool_result_content_list:
                 if "json" in tool_result_content:
                     # Handle json field since not in ContentBlock but valid in ToolResultContent
                     formatted_content.append({"json": tool_result_content["json"]})

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1636,9 +1636,7 @@ def test_format_bedrock_messages_normalizes_empty_tool_result_content(model, mod
     formatted_request = model._format_request(messages)
 
     tool_result = formatted_request["messages"][2]["content"][0]["toolResult"]
-    assert tool_result["content"] == [{"text": ""}], (
-        "Empty toolResult content should be normalized to [{'text': ''}]"
-    )
+    assert tool_result["content"] == [{"text": ""}], "Empty toolResult content should be normalized to [{'text': ''}]"
 
 
 def test_format_bedrock_messages_preserves_nonempty_tool_result_content(model, model_id):

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1607,8 +1607,8 @@ def test_format_request_cleans_tool_result_content_blocks(model, model_id):
     assert "status" not in tool_result
 
 
-def test_format_bedrock_messages_normalizes_empty_tool_result_content(model, model_id):
-    """Test that _format_bedrock_messages replaces empty toolResult content with a minimal text block.
+def test_format_request_message_content_normalizes_empty_tool_result_content(model, model_id):
+    """Test that _format_request_message_content replaces empty toolResult content with a minimal text block.
 
     Some model providers (e.g., Nemotron) reject toolResult blocks with content: [] via the
     Converse API, while others (e.g., Claude) accept them. The SDK should normalize empty
@@ -1639,8 +1639,32 @@ def test_format_bedrock_messages_normalizes_empty_tool_result_content(model, mod
     assert tool_result["content"] == [{"text": ""}], "Empty toolResult content should be normalized to [{'text': ''}]"
 
 
-def test_format_bedrock_messages_preserves_nonempty_tool_result_content(model, model_id):
-    """Test that _format_bedrock_messages does not modify non-empty toolResult content."""
+def test_format_request_message_content_does_not_mutate_empty_tool_result(model, model_id):
+    """Test that normalizing empty toolResult content does not mutate the original messages."""
+    messages = [
+        {"role": "user", "content": [{"text": "List tables"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {"toolUse": {"toolUseId": "tool_001", "name": "run_query", "input": {"sql": "SELECT 1"}}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"toolResult": {"toolUseId": "tool_001", "content": []}},
+            ],
+        },
+    ]
+
+    original_content = messages[2]["content"][0]["toolResult"]["content"]
+    model._format_request(messages)
+
+    assert original_content == [], "Original empty content list should not be mutated"
+
+
+def test_format_request_message_content_preserves_nonempty_tool_result_content(model, model_id):
+    """Test that _format_request_message_content does not modify non-empty toolResult content."""
     messages = [
         {"role": "user", "content": [{"text": "List tables"}]},
         {

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1607,6 +1607,65 @@ def test_format_request_cleans_tool_result_content_blocks(model, model_id):
     assert "status" not in tool_result
 
 
+def test_format_bedrock_messages_normalizes_empty_tool_result_content(model, model_id):
+    """Test that _format_bedrock_messages replaces empty toolResult content with a minimal text block.
+
+    Some model providers (e.g., Nemotron) reject toolResult blocks with content: [] via the
+    Converse API, while others (e.g., Claude) accept them. The SDK should normalize empty
+    content arrays to ensure cross-model compatibility.
+
+    See: https://github.com/strands-agents/sdk-python/issues/2122
+    """
+    messages = [
+        {"role": "user", "content": [{"text": "List tables"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {"text": "Querying...\n"},
+                {"toolUse": {"toolUseId": "tool_001", "name": "run_query", "input": {"sql": "SELECT 1"}}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"toolResult": {"toolUseId": "tool_001", "content": []}},
+            ],
+        },
+    ]
+
+    formatted_request = model._format_request(messages)
+
+    tool_result = formatted_request["messages"][2]["content"][0]["toolResult"]
+    assert tool_result["content"] == [{"text": ""}], (
+        "Empty toolResult content should be normalized to [{'text': ''}]"
+    )
+
+
+def test_format_bedrock_messages_preserves_nonempty_tool_result_content(model, model_id):
+    """Test that _format_bedrock_messages does not modify non-empty toolResult content."""
+    messages = [
+        {"role": "user", "content": [{"text": "List tables"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {"text": "Querying...\n"},
+                {"toolUse": {"toolUseId": "tool_001", "name": "run_query", "input": {"sql": "SELECT 1"}}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"toolResult": {"toolUseId": "tool_001", "content": [{"text": "some result"}]}},
+            ],
+        },
+    ]
+
+    formatted_request = model._format_request(messages)
+
+    tool_result = formatted_request["messages"][2]["content"][0]["toolResult"]
+    assert tool_result["content"] == [{"text": "some result"}]
+
+
 def test_format_request_removes_status_field_when_configured(model, model_id):
     model.update_config(include_tool_result_status=False)
 


### PR DESCRIPTION
## Description

Some model providers (e.g., Nemotron) reject `toolResult` blocks with `content: []` via the Bedrock Converse API, while others (e.g., Claude) accept them. When a tool returns an empty result (common with MCP tools like `awslabs/postgres-mcp-server`), the SDK passes the empty content array through to the Converse API unchanged, causing a `ValidationException` on strict models.

This PR normalizes empty `toolResult.content` arrays to `[{"text": ""}]` in `_format_bedrock_messages`, following the same pattern as:
- The TypeScript SDK's `_formatMessages` in `bedrock.ts`, which already filters empty content
- Existing Python SDK normalizations in the same function (`SDK_UNKNOWN_MEMBER` filtering, DeepSeek `reasoningContent` dropping)

## Related Issues

Fixes #2122

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- Added `test_format_bedrock_messages_normalizes_empty_tool_result_content` — verifies empty `toolResult.content` is replaced with `[{"text": ""}]`
- Added `test_format_bedrock_messages_preserves_nonempty_tool_result_content` — verifies non-empty content is not modified
- All 129 existing `test_bedrock.py` tests pass with no regressions
- Verified fix against live Bedrock endpoints: Nemotron succeeds with the fix, Claude continues to work unchanged

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
