### PR TITLE
chore(bedrock): update default model to Claude Sonnet 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ agent = Agent(tools=[calculator])
 agent("What is the square root of 1764")
 ```
 
-> **Note**: For the default Amazon Bedrock model provider, you'll need AWS credentials configured and model access enabled for Claude 4 Sonnet in the us-west-2 region. See the [Quickstart Guide](https://strandsagents.com/) for details on configuring other model providers.
+> **Note**: For the default Amazon Bedrock model provider, you'll need AWS credentials configured and model access enabled for Claude Sonnet 4.6 via the `global.anthropic.claude-sonnet-4-6` cross-region inference profile. See the [Quickstart Guide](https://strandsagents.com/) for details on configuring other model providers.
 
 ## Installation
 

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -35,9 +35,7 @@ from .model import BaseModelConfig, CacheConfig, Model
 
 logger = logging.getLogger(__name__)
 
-# See: `BedrockModel._get_default_model_with_warning` for why we need both
-DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
-_DEFAULT_BEDROCK_MODEL_ID = "{}.anthropic.claude-sonnet-4-20250514-v1:0"
+DEFAULT_BEDROCK_MODEL_ID = "global.anthropic.claude-sonnet-4-6"
 DEFAULT_BEDROCK_REGION = "us-west-2"
 
 BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
@@ -90,7 +88,7 @@ class BedrockModel(Model):
             guardrail_latest_message: Flag to send only the lastest user message to guardrails.
                 Defaults to False.
             max_tokens: Maximum number of tokens to generate in the response
-            model_id: The Bedrock model ID (e.g., "us.anthropic.claude-sonnet-4-20250514-v1:0")
+            model_id: The Bedrock model ID (e.g., "global.anthropic.claude-sonnet-4-6")
             include_tool_result_status: Flag to include status field in tool results.
                 True includes status, False removes status, "auto" determines based on model_id. Defaults to "auto".
             service_tier: Service tier for the request, controlling the trade-off between latency and cost.
@@ -151,11 +149,15 @@ class BedrockModel(Model):
 
         session = boto_session or boto3.Session()
         resolved_region = region_name or session.region_name or os.environ.get("AWS_REGION") or DEFAULT_BEDROCK_REGION
-        self.config = BedrockModel.BedrockConfig(
-            model_id=BedrockModel._get_default_model_with_warning(resolved_region, model_config),
-            include_tool_result_status="auto",
-        )
+        self.config = BedrockModel.BedrockConfig(model_id=DEFAULT_BEDROCK_MODEL_ID, include_tool_result_status="auto")
         self.update_config(**model_config)
+
+        if self.config.get("model_id") == DEFAULT_BEDROCK_MODEL_ID:
+            warnings.warn(
+                f"You're using default model '{DEFAULT_BEDROCK_MODEL_ID}', which is subject to change. "
+                "Specify a model explicitly to pin the model target.",
+                stacklevel=2,
+            )
 
         logger.debug("config=<%s> | initializing", self.config)
 
@@ -1081,52 +1083,3 @@ class BedrockModel(Model):
             raise ValueError("No valid tool use or tool use input was found in the Bedrock response.")
 
         yield {"output": output_model(**output_response)}
-
-    @staticmethod
-    def _get_default_model_with_warning(region_name: str, model_config: BedrockConfig | None = None) -> str:
-        """Get the default Bedrock modelId based on region.
-
-        If the region is not **known** to support inference then we show a helpful warning
-        that compliments the exception that Bedrock will throw.
-        If the customer provided a model_id in their config or they overrode the `DEFAULT_BEDROCK_MODEL_ID`
-        then we should not process further.
-
-        Args:
-            region_name (str): region for bedrock model
-            model_config (Optional[dict[str, Any]]): Model Config that caller passes in on init
-        """
-        if DEFAULT_BEDROCK_MODEL_ID != _DEFAULT_BEDROCK_MODEL_ID.format("us"):
-            return DEFAULT_BEDROCK_MODEL_ID
-
-        model_config = model_config or {}
-        if model_config.get("model_id"):
-            return model_config["model_id"]
-
-        prefix_inference_map = {"ap": "apac"}  # some inference endpoints can be a bit different than the region prefix
-
-        prefix = "-".join(region_name.split("-")[:-2]).lower()  # handles `us-east-1` or `us-gov-east-1`
-        if prefix not in {"us", "eu", "ap", "us-gov"}:
-            warnings.warn(
-                f"""
-            ================== WARNING ==================
-
-                This region {region_name} does not support
-                our default inference endpoint: {_DEFAULT_BEDROCK_MODEL_ID.format(prefix)}.
-                Update the agent to pass in a 'model_id' like so:
-                ```
-                Agent(..., model='valid_model_id', ...)
-                ````
-                Documentation: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
-
-            ==================================================
-            """,
-                stacklevel=2,
-            )
-
-        default_model_id = _DEFAULT_BEDROCK_MODEL_ID.format(prefix_inference_map.get(prefix, prefix))
-        warnings.warn(
-            f"You're using default model '{default_model_id}', which is subject to change. "
-            "Specify a model explicitly to pin the model target.",
-            stacklevel=2,
-        )
-        return default_model_id

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -34,9 +34,6 @@ from strands.types.session import Session, SessionAgent, SessionMessage, Session
 from tests.fixtures.mock_session_repository import MockedSessionRepository
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
-# For unit testing we will use the the us inference
-FORMATTED_DEFAULT_MODEL_ID = DEFAULT_BEDROCK_MODEL_ID.format("us")
-
 
 @pytest.fixture
 def mock_model(request):
@@ -244,7 +241,7 @@ def test_agent__init__with_default_model():
     agent = Agent()
 
     assert isinstance(agent.model, BedrockModel)
-    assert agent.model.config["model_id"] == FORMATTED_DEFAULT_MODEL_ID
+    assert agent.model.config["model_id"] == DEFAULT_BEDROCK_MODEL_ID
 
 
 def test_agent__init__with_explicit_model(mock_model):
@@ -854,7 +851,7 @@ def test_agent_tool_names(tools, agent):
 def test_agent_init_with_no_model_or_model_id():
     agent = Agent()
     assert agent.model is not None
-    assert agent.model.get_config().get("model_id") == FORMATTED_DEFAULT_MODEL_ID
+    assert agent.model.get_config().get("model_id") == DEFAULT_BEDROCK_MODEL_ID
 
 
 def test_agent_with_none_callback_handler_prints_nothing():

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -16,15 +16,12 @@ import strands
 from strands import _exception_notes
 from strands.models import BedrockModel, CacheConfig
 from strands.models.bedrock import (
-    _DEFAULT_BEDROCK_MODEL_ID,
     DEFAULT_BEDROCK_MODEL_ID,
     DEFAULT_BEDROCK_REGION,
     DEFAULT_READ_TIMEOUT,
 )
 from strands.types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from strands.types.tools import ToolSpec
-
-FORMATTED_DEFAULT_MODEL_ID = DEFAULT_BEDROCK_MODEL_ID.format("us")
 
 
 @pytest.fixture
@@ -132,7 +129,7 @@ def test__init__default_model_id(bedrock_client):
     model = BedrockModel()
 
     tru_model_id = model.get_config().get("model_id")
-    exp_model_id = FORMATTED_DEFAULT_MODEL_ID
+    exp_model_id = DEFAULT_BEDROCK_MODEL_ID
 
     assert tru_model_id == exp_model_id
 
@@ -2165,84 +2162,24 @@ def test_tool_choice_none_no_warning(model, messages, captured_warnings):
     assert len(captured_warnings) == 0
 
 
-def test_get_default_model_with_warning_supported_regions_shows_no_warning(captured_warnings):
-    """Test get_model_prefix_with_warning doesn't warn for supported region prefixes."""
-    BedrockModel._get_default_model_with_warning("us-west-2")
-    BedrockModel._get_default_model_with_warning("eu-west-2")
-    assert all("does not support" not in str(w.message) for w in captured_warnings)
+def test_init_with_default_model_warns_subject_to_change(session_cls, captured_warnings):
+    """Test BedrockModel initialization warns when relying on the default model id."""
+    BedrockModel()
+
+    default_warnings = [w for w in captured_warnings if "which is subject to change" in str(w.message)]
+    assert len(default_warnings) == 1
+    assert f"You're using default model '{DEFAULT_BEDROCK_MODEL_ID}'" in str(default_warnings[0].message)
 
 
-def test_get_default_model_for_supported_eu_region_returns_correct_model_id(captured_warnings):
-    model_id = BedrockModel._get_default_model_with_warning("eu-west-1")
-    assert model_id == "eu.anthropic.claude-sonnet-4-20250514-v1:0"
-    assert all("does not support" not in str(w.message) for w in captured_warnings)
+def test_init_with_custom_model_id_no_default_warning(session_cls, captured_warnings):
+    """Test BedrockModel initialization doesn't emit the default-model warning when model_id is provided."""
+    BedrockModel(model_id="custom-model")
+
+    default_warnings = [w for w in captured_warnings if "which is subject to change" in str(w.message)]
+    assert len(default_warnings) == 0
 
 
-def test_get_default_model_for_supported_us_region_returns_correct_model_id(captured_warnings):
-    model_id = BedrockModel._get_default_model_with_warning("us-east-1")
-    assert model_id == "us.anthropic.claude-sonnet-4-20250514-v1:0"
-    assert all("does not support" not in str(w.message) for w in captured_warnings)
-
-
-def test_get_default_model_for_supported_gov_region_returns_correct_model_id(captured_warnings):
-    model_id = BedrockModel._get_default_model_with_warning("us-gov-west-1")
-    assert model_id == "us-gov.anthropic.claude-sonnet-4-20250514-v1:0"
-    assert all("does not support" not in str(w.message) for w in captured_warnings)
-
-
-def test_get_model_prefix_for_ap_region_converts_to_apac_endpoint(captured_warnings):
-    """Test _get_default_model_with_warning warns for APAC regions since 'ap' is not in supported prefixes."""
-    model_id = BedrockModel._get_default_model_with_warning("ap-southeast-1")
-    assert model_id == "apac.anthropic.claude-sonnet-4-20250514-v1:0"
-
-
-def test_get_default_model_with_warning_unsupported_region_warns(captured_warnings):
-    """Test _get_default_model_with_warning warns for unsupported regions."""
-    BedrockModel._get_default_model_with_warning("ca-central-1")
-    region_warnings = [w for w in captured_warnings if "does not support" in str(w.message)]
-    assert len(region_warnings) == 1
-    assert "This region ca-central-1 does not support" in str(region_warnings[0].message)
-    assert "our default inference endpoint" in str(region_warnings[0].message)
-
-
-def test_get_default_model_with_warning_no_warning_with_custom_model_id(captured_warnings):
-    """Test _get_default_model_with_warning doesn't warn when custom model_id provided."""
-    model_config = {"model_id": "custom-model"}
-    model_id = BedrockModel._get_default_model_with_warning("ca-central-1", model_config)
-
-    assert model_id == "custom-model"
-    assert len(captured_warnings) == 0
-
-
-def test_init_with_unsupported_region_warns(session_cls, captured_warnings):
-    """Test BedrockModel initialization warns for unsupported regions."""
-    BedrockModel(region_name="ca-central-1")
-
-    region_warnings = [w for w in captured_warnings if "does not support" in str(w.message)]
-    assert len(region_warnings) == 1
-    assert "This region ca-central-1 does not support" in str(region_warnings[0].message)
-
-
-def test_init_with_unsupported_region_custom_model_no_warning(session_cls, captured_warnings):
-    """Test BedrockModel initialization doesn't warn when custom model_id provided."""
-    BedrockModel(region_name="ca-central-1", model_id="custom-model")
-    assert len(captured_warnings) == 0
-
-
-def test_override_default_model_id_uses_the_overriden_value(captured_warnings):
-    with unittest.mock.patch("strands.models.bedrock.DEFAULT_BEDROCK_MODEL_ID", "custom-overridden-model"):
-        model_id = BedrockModel._get_default_model_with_warning("us-east-1")
-        assert model_id == "custom-overridden-model"
-
-
-def test_no_override_uses_formatted_default_model_id(captured_warnings):
-    model_id = BedrockModel._get_default_model_with_warning("us-east-1")
-    assert model_id == "us.anthropic.claude-sonnet-4-20250514-v1:0"
-    assert model_id != _DEFAULT_BEDROCK_MODEL_ID
-    assert all("does not support" not in str(w.message) for w in captured_warnings)
-
-
-def test_custom_model_id_not_overridden_by_region_formatting(session_cls):
+def test_custom_model_id_not_overridden(session_cls):
     """Test that custom model_id is not overridden by region formatting."""
     custom_model_id = "custom.model.id"
 


### PR DESCRIPTION
## Motivation

Claude Sonnet 4 (`claude-sonnet-4-20250514`) was deprecated on April 14, 2026 and will be retired on June 15, 2026 per [Anthropic's model deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations). Since `DEFAULT_BEDROCK_MODEL_ID` is the model used when no explicit `model_id` is passed, this is a critical update — agents using the default will stop working after the retirement date.

This change also switches from region-specific inference profiles (`us.`/`eu.`/`apac.`) to the `global.` cross-region inference profile, aligning with the [TypeScript SDK](https://github.com/strands-agents/sdk-typescript/blob/main/src/models/bedrock.ts#L59) which already uses `global.anthropic.claude-sonnet-4-6`. This simplification aligns with two of our Development Tenets:

- **Simple at any scale** — The region-to-prefix mapping logic (`_get_default_model_with_warning`) was necessary when `apac.` profiles existed, but Claude Sonnet 4.6 no longer offers an `apac.` profile (APAC regions have been split into `jp.` and `au.`, with other APAC regions only supporting `global.`). The `global.` profile works across all Bedrock regions, making the mapping logic unnecessary.
- **Embrace common standards** — The TypeScript SDK already adopted `global.` as the default. Using the same approach ensures consistency across SDKs and reduces cognitive overhead for developers working with both.

Resolves: #2130

## Public API Changes

`DEFAULT_BEDROCK_MODEL_ID` changes from `us.anthropic.claude-sonnet-4-20250514-v1:0` to `global.anthropic.claude-sonnet-4-6`:

```python
# Before
from strands import Agent
agent = Agent()  # uses us.anthropic.claude-sonnet-4-20250514-v1:0

# After
from strands import Agent
agent = Agent()  # uses global.anthropic.claude-sonnet-4-6
```

The internal `_DEFAULT_BEDROCK_MODEL_ID` template and `_get_default_model_with_warning()` static method have been removed as they are no longer needed with the `global.` profile.

## Breaking Changes

**Users must enable Claude Sonnet 4.6 model access** in their AWS Bedrock console. The `global.anthropic.claude-sonnet-4-6` cross-region inference profile must be accessible from the user's configured region.

### Migration

Users relying on the previous default need no code changes — only Bedrock model access enablement. Users who want to continue using Sonnet 4 (until retirement) can explicitly pass the model ID:

```python
from strands import Agent
from strands.models import BedrockModel

agent = Agent(model=BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0"))
```

## Related Issues

#2130

## Type of Change

Breaking change

## Testing

- [x] All unit tests pass (`hatch test` — 235 passed)
- [x] Formatter and linter pass (`hatch fmt --formatter`, `hatch fmt --linter`)
- [x] Verified real Bedrock API calls succeed with `global.anthropic.claude-sonnet-4-6` from `us-east-1` and `ap-northeast-1`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.