### PR TITLE
feat(bedrock-model): Support content and text DocumentSource

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -534,16 +534,22 @@ class BedrockModel(Model):
             if "format" in document:
                 result["format"] = document["format"]
 
-            # Handle source - supports bytes or location
+            # Handle source - supports bytes, content, location, or text
             if "source" in document:
-                source = document["source"]
-                formatted_document_source: dict[str, Any] | None
-                if "location" in source:
-                    formatted_document_source = self._handle_location(source["location"])
+                document_source = document["source"]
+                formatted_document_source: dict[str, Any] | None = None
+                if "location" in document_source:
+                    formatted_document_source = self._handle_location(document_source["location"])
                     if formatted_document_source is None:
                         return None
-                elif "bytes" in source:
-                    formatted_document_source = {"bytes": source["bytes"]}
+                elif "bytes" in document_source:
+                    formatted_document_source = {"bytes": document_source["bytes"]}
+                elif "text" in document_source:
+                    formatted_document_source = {"text": document_source["text"]}
+                elif "content" in document_source:
+                    formatted_document_source = {
+                        "content": [{"text": item["text"]} for item in document_source["content"] if "text" in item]
+                    }
                 result["source"] = formatted_document_source
 
             # Handle optional fields
@@ -564,14 +570,14 @@ class BedrockModel(Model):
         # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ImageBlock.html
         if "image" in content:
             image = content["image"]
-            source = image["source"]
+            image_source = image["source"]
             formatted_image_source: dict[str, Any] | None
-            if "location" in source:
-                formatted_image_source = self._handle_location(source["location"])
+            if "location" in image_source:
+                formatted_image_source = self._handle_location(image_source["location"])
                 if formatted_image_source is None:
                     return None
-            elif "bytes" in source:
-                formatted_image_source = {"bytes": source["bytes"]}
+            elif "bytes" in image_source:
+                formatted_image_source = {"bytes": image_source["bytes"]}
             result = {"format": image["format"], "source": formatted_image_source}
             return {"image": result}
 
@@ -636,14 +642,14 @@ class BedrockModel(Model):
         # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_VideoBlock.html
         if "video" in content:
             video = content["video"]
-            source = video["source"]
+            video_source = video["source"]
             formatted_video_source: dict[str, Any] | None
-            if "location" in source:
-                formatted_video_source = self._handle_location(source["location"])
+            if "location" in video_source:
+                formatted_video_source = self._handle_location(video_source["location"])
                 if formatted_video_source is None:
                     return None
-            elif "bytes" in source:
-                formatted_video_source = {"bytes": source["bytes"]}
+            elif "bytes" in video_source:
+                formatted_video_source = {"bytes": video_source["bytes"]}
             result = {"format": video["format"], "source": formatted_video_source}
             return {"video": result}
 

--- a/src/strands/types/media.py
+++ b/src/strands/types/media.py
@@ -47,18 +47,32 @@ class S3Location(Location, total=False):
 SourceLocation: TypeAlias = Location | S3Location
 
 
+class DocumentBlockContent(TypedDict, total=False):
+    """An inline content block within a document source.
+
+    Attributes:
+        text: The text content of the block.
+    """
+
+    text: str
+
+
 class DocumentSource(TypedDict, total=False):
     """Contains the content of a document.
 
-    Only one of `bytes` or `s3Location` should be specified.
+    Only one of `bytes`, `content`, `location`, or `text` should be specified.
 
     Attributes:
         bytes: The binary content of the document.
+        content: List of content blocks.
         location: Location of the document.
+        text: Text contents of the document.
     """
 
     bytes: bytes
+    content: list[DocumentBlockContent]
     location: SourceLocation
+    text: str
 
 
 class DocumentContent(TypedDict, total=False):

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -1970,6 +1970,58 @@ def test_format_request_filters_document_content_blocks(model, model_id):
     assert "metadata" not in document_block
 
 
+def test_format_request_document_text_source(model, model_id):
+    """Test that document with text source is properly formatted."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "document": {
+                        "name": "notes.txt",
+                        "format": "txt",
+                        "source": {"text": "plain text content"},
+                    }
+                },
+            ],
+        }
+    ]
+
+    formatted_request = model._format_request(messages)
+
+    document_source = formatted_request["messages"][0]["content"][0]["document"]["source"]
+    assert document_source == {"text": "plain text content"}
+
+
+def test_format_request_document_content_source(model, model_id):
+    """Test that document with content source is properly formatted, filtering items without text."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "document": {
+                        "name": "doc.txt",
+                        "format": "txt",
+                        "source": {
+                            "content": [
+                                {"text": "block one"},
+                                {"text": "block two"},
+                                {},  # This should be filtered out
+                            ]
+                        },
+                    }
+                },
+            ],
+        }
+    ]
+
+    formatted_request = model._format_request(messages)
+
+    document_source = formatted_request["messages"][0]["content"][0]["document"]["source"]
+    assert document_source == {"content": [{"text": "block one"}, {"text": "block two"}]}
+
+
 def test_format_request_filters_nested_reasoning_content(model, model_id):
     """Test deep filtering of nested reasoningText fields."""
     messages = [

--- a/tests/strands/types/test_media.py
+++ b/tests/strands/types/test_media.py
@@ -1,6 +1,7 @@
 """Tests for media type definitions."""
 
 from strands.types.media import (
+    DocumentBlockContent,
     DocumentSource,
     ImageSource,
     S3Location,
@@ -51,6 +52,42 @@ class TestDocumentSource:
         assert "bytes" not in doc_source
         assert doc_source["s3Location"]["uri"] == "s3://my-bucket/docs/report.pdf"
         assert doc_source["s3Location"]["bucketOwner"] == "123456789012"
+
+    def test_document_source_with_text(self):
+        """Test DocumentSource with text content."""
+        doc_source: DocumentSource = {"text": "plain text content"}
+
+        assert doc_source["text"] == "plain text content"
+        assert "bytes" not in doc_source
+        assert "location" not in doc_source
+        assert "content" not in doc_source
+
+    def test_document_source_with_content(self):
+        """Test DocumentSource with content blocks."""
+        doc_source: DocumentSource = {"content": [{"text": "block one"}, {"text": "block two"}]}
+
+        assert len(doc_source["content"]) == 2
+        assert doc_source["content"][0]["text"] == "block one"
+        assert doc_source["content"][1]["text"] == "block two"
+        assert "bytes" not in doc_source
+        assert "location" not in doc_source
+        assert "text" not in doc_source
+
+
+class TestDocumentBlockContent:
+    """Tests for DocumentBlockContent TypedDict."""
+
+    def test_document_block_content_with_text(self):
+        """Test DocumentBlockContent with text field."""
+        block: DocumentBlockContent = {"text": "hello"}
+
+        assert block["text"] == "hello"
+
+    def test_document_block_content_empty(self):
+        """Test DocumentBlockContent with no fields (total=False)."""
+        block: DocumentBlockContent = {}
+
+        assert "text" not in block
 
 
 class TestImageSource:


### PR DESCRIPTION
## Description
Bedrock ConverseStream requests allow message [Content](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Message.html#bedrock-Type-runtime_Message-content) to include the [DocumentBlock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html) which has the fields `text` and `content` in [DocumentSource](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentSource.html) which is missing in the `BedrockModel` message formatting. This change enables the passing of these fields so features (e.g. citations) can utilize these document types.

_note_: mypy was raising linter errors due to `source` variable in `_format_request_message_content(...)` being used for different object types, so those variable names were updated to satisfy mypy and add clarity for the type of source in the block. 

changes:
 - Add handling for the content and text DocumentSource fields
 - Add media object for DocumentBlockContent

### Other Notes

Testing done using model Claude Sonnet 4.6

When `content` or `text` sources are passed in, `citations` must also be enabled in the `document` field. This is not documented anywhere from what I have seen and unsure if this is coming from client side botocore validation or from AWS itself.

e.g.
```
{
    "document": {
        "format": "txt",
        "name": "document",
        "source": {
            "content": [{ "text": "Paris is the capital of France." }, { "text": "The capital of Germany is Berlin." }]
        },
        "citations": { "enabled": True}
    },
}
```

when `citations` is disabled or not passed in at all, botocore raises a Validation exception

```
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the ConverseStream operation: DocumentSource object at messages.0.content.1.document.source must set one of the following keys: bytes, s3Location.
```

However, when `citations` is enabled, it works correctly.

```
messages: list[Message] = [
    {
        "role": "user",
        "content": [
            {
                "text": "What is the capital of France?"
            },
            {
                "document": {
                    "format": "txt",
                    "name": "document",
                    "source": {
                        "content": [{ "text": "Paris is the capital of France." }, { "text": "The capital of Germany is Berlin." }]
                    },
                    "citations": { "enabled": True}
                },
            }
        ]
    }
]
```

```
{
  "citation": {
    "title": "document",
    "sourceContent": [
      {
        "text": "Paris is the capital of France."
      }
    ],
    "location": {
      "documentChunk": {
        "documentIndex": 0,
        "start": 0,
        "end": 1
      }
    }
  },
  "delta": {
    "citation": {
      "title": "document",
      "sourceContent": [
        {
          "text": "Paris is the capital of France."
        }
      ],
      "location": {
        "documentChunk": {
          "documentIndex": 0,
          "start": 0,
          "end": 1
        }
      }
    }
  },
  "agent": "<strands.agent.agent.Agent object>",
  "event_loop_cycle_id": "024ff76b-cd42-4f78-bf69-d9929c3cf101",
  "request_state": {},
  "event_loop_cycle_trace": "<strands.telemetry.metrics.Trace object>",
  "event_loop_cycle_span": "NonRecordingSpan(trace_id=0x0, span_id=0x0)"
}
```

## Related Issues

#1066 

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
