### PR TITLE
fix(mcp): skip MCPClient cleanup during interpreter finalization

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -12,6 +12,7 @@ import base64
 import contextvars
 import json
 import logging
+import sys
 import threading
 import uuid
 from asyncio import AbstractEventLoop
@@ -342,6 +343,15 @@ class MCPClient(ToolProvider):
             exc_tb: Exception traceback if an exception was raised in the context
         """
         self._log_debug_with_thread("exiting MCPClient context")
+
+        # Skip cleanup during interpreter finalization. On Python 3.14+, joining a
+        # non-daemon thread at shutdown raises PythonFinalizationError; even though
+        # our background thread is a daemon and will be reclaimed automatically,
+        # the join call itself produces noisy tracebacks on stderr when the GC
+        # reaches Agent.__del__ during finalization. See issue #2143.
+        if sys.is_finalizing():
+            self._log_debug_with_thread("interpreter is finalizing, skipping MCPClient cleanup")
+            return
 
         # Only try to signal close future if we have a background thread
         if self._background_thread is not None:

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -594,6 +594,33 @@ def test_stop_closes_event_loop():
     assert client._background_thread_event_loop is None
 
 
+def test_stop_skips_cleanup_during_interpreter_finalization():
+    """Test that stop() is a no-op when the interpreter is finalizing.
+
+    On Python 3.14+, threading.Thread.join() raises PythonFinalizationError at
+    shutdown. The background thread is a daemon and is reclaimed automatically,
+    so stop() should skip join() and event loop cleanup to avoid noisy
+    tracebacks surfaced via Agent.__del__ during GC. See issue #2143.
+    """
+    client = MCPClient(MagicMock())
+
+    mock_thread = MagicMock()
+    mock_event_loop = MagicMock()
+    client._background_thread = mock_thread
+    client._background_thread_event_loop = mock_event_loop
+
+    with patch("strands.tools.mcp.mcp_client.sys.is_finalizing", return_value=True):
+        # Must not raise, and must not touch the thread or event loop.
+        client.stop(None, None, None)
+
+    mock_thread.join.assert_not_called()
+    mock_event_loop.close.assert_not_called()
+    # State is intentionally left alone during finalization — the interpreter
+    # is going away and cleanup is unnecessary.
+    assert client._background_thread is mock_thread
+    assert client._background_thread_event_loop is mock_event_loop
+
+
 def test_mcp_client_state_reset_after_timeout():
     """Test that all client state is properly reset after timeout."""
 


### PR DESCRIPTION
## Description

On Python 3.14+, `threading.Thread.join()` raises `PythonFinalizationError` when called at interpreter shutdown. The cleanup path in `Agent.__del__` → `tool_registry.cleanup()` → `MCPClient.remove_consumer()` → `stop()` triggers this during GC, producing a misleading `Exception ignored while calling deallocator` traceback on stderr even though the agent's response has already completed successfully.

The MCP background thread is already a daemon, so it is reclaimed by the interpreter automatically; the `join()` call is unnecessary (and harmful) during finalization. This change guards `MCPClient.stop()` with `sys.is_finalizing()` so the cleanup path short-circuits during shutdown, silencing the noise without changing normal runtime behavior.

The issue is particularly visible when:
- The host application uses `MCPClient` as a tool provider on an `Agent`
- The agent performs multiple MCP tool calls in one turn
- The interpreter exits immediately after

Python 3.13 and earlier are unaffected because the stricter thread-join finalization check was introduced in 3.14 (python/cpython#113964).

## Related Issues

Resolves: #2143

## Documentation PR

N/A — internal fix, no public API changes.

## Type of Change

Bug fix

## Testing

Added a unit test that patches `sys.is_finalizing` to `True` and verifies that `MCPClient.stop()` does not attempt to join the background thread or close the event loop.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.