### PR TITLE
feat(mcp): add MCP server config loading from file/dict (#1625)

### DIFF
--- a/src/strands/experimental/agent_config.py
+++ b/src/strands/experimental/agent_config.py
@@ -18,6 +18,8 @@ from typing import Any
 import jsonschema
 from jsonschema import ValidationError
 
+from ..tools.mcp.mcp_config import MCP_SERVER_CONFIG_SCHEMA
+
 # JSON Schema for agent configuration
 AGENT_CONFIG_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -43,6 +45,7 @@ AGENT_CONFIG_SCHEMA = {
             "items": {"type": "string"},
             "default": [],
         },
+        "mcp_servers": MCP_SERVER_CONFIG_SCHEMA,
     },
     "additionalProperties": False,
 }
@@ -54,12 +57,27 @@ _VALIDATOR = jsonschema.Draft7Validator(AGENT_CONFIG_SCHEMA)
 def config_to_agent(config: str | dict[str, Any], **kwargs: dict[str, Any]) -> Any:
     """Create an Agent from a configuration file or dictionary.
 
-    This function supports tools that can be loaded declaratively (file paths, module names,
-    or @tool annotated functions). For tools requiring code-based instantiation with constructor
-    arguments, add them programmatically after creating the agent:
+    This function supports tools that can be loaded declaratively (file paths,
+    module names, or @tool annotated functions). For tools requiring code-based
+    instantiation with constructor arguments, add them programmatically after
+    creating the agent:
 
         agent = config_to_agent("config.json")
         agent.process_tools([ToolWithConfigArg(HttpsConnection("localhost"))])
+
+    MCP servers can be configured declaratively in the config under the
+    ``mcp_servers`` key. The format is compatible with the Claude Desktop /
+    Cursor / VS Code mcpServers convention::
+
+        {
+            "model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "mcp_servers": {
+                "aws_docs": {
+                    "command": "uvx",
+                    "args": ["awslabs.aws-documentation-mcp-server@latest"]
+                }
+            }
+        }
 
     Args:
         config: Either a file path (with optional file:// prefix) or a configuration dictionary
@@ -75,20 +93,32 @@ def config_to_agent(config: str | dict[str, Any], **kwargs: dict[str, Any]) -> A
 
     Examples:
         Create agent from file:
+
         >>> agent = config_to_agent("/path/to/config.json")
 
         Create agent from file with file:// prefix:
+
         >>> agent = config_to_agent("file:///path/to/config.json")
 
         Create agent from dictionary:
+
         >>> config = {"model": "anthropic.claude-3-5-sonnet-20241022-v2:0", "tools": ["calculator"]}
+        >>> agent = config_to_agent(config)
+
+        Create agent with MCP servers:
+
+        >>> config = {
+        ...     "model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        ...     "mcp_servers": {
+        ...         "my_server": {"command": "uvx", "args": ["my-mcp-server"]}
+        ...     }
+        ... }
         >>> agent = config_to_agent(config)
     """
     # Parse configuration
     if isinstance(config, str):
         # Handle file path
         file_path = config
-
         # Remove file:// prefix if present
         if file_path.startswith("file://"):
             file_path = file_path[7:]
@@ -128,6 +158,17 @@ def config_to_agent(config: str | dict[str, Any], **kwargs: dict[str, Any]) -> A
     for config_key, agent_param in config_mapping.items():
         if config_key in config_dict and config_dict[config_key] is not None:
             agent_kwargs[agent_param] = config_dict[config_key]
+
+    # Process mcp_servers configuration
+    if "mcp_servers" in config_dict and config_dict["mcp_servers"]:
+        from ..tools.mcp.mcp_config import load_mcp_clients_from_config
+
+        mcp_clients = load_mcp_clients_from_config(config_dict["mcp_servers"])
+
+        # Append MCP clients to the tools list
+        tools = list(agent_kwargs.get("tools", []))
+        tools.extend(mcp_clients.values())
+        agent_kwargs["tools"] = tools
 
     # Override with any additional kwargs provided
     agent_kwargs.update(kwargs)

--- a/src/strands/tools/mcp/__init__.py
+++ b/src/strands/tools/mcp/__init__.py
@@ -1,14 +1,15 @@
 """Model Context Protocol (MCP) integration.
 
-This package provides integration with the Model Context Protocol (MCP), allowing agents to use tools provided by MCP
-servers.
+This package provides integration with the Model Context Protocol (MCP),
+allowing agents to use tools provided by MCP servers.
 
 - Docs: https://www.anthropic.com/news/model-context-protocol
 """
 
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_client import MCPClient, ToolFilters
+from .mcp_config import load_mcp_clients_from_config
 from .mcp_tasks import TasksConfig
 from .mcp_types import MCPTransport
 
-__all__ = ["MCPAgentTool", "MCPClient", "MCPTransport", "TasksConfig", "ToolFilters"]
+__all__ = ["MCPAgentTool", "MCPClient", "MCPTransport", "TasksConfig", "ToolFilters", "load_mcp_clients_from_config"]

--- a/src/strands/tools/mcp/mcp_config.py
+++ b/src/strands/tools/mcp/mcp_config.py
@@ -1,0 +1,396 @@
+"""MCP server configuration loading and MCPClient factory.
+
+This module handles parsing MCP server configurations from dictionaries or JSON files
+and creating MCPClient instances with the appropriate transport. The configuration format
+is compatible with the Claude Desktop / Cursor / VS Code mcpServers convention.
+
+Supported transport types:
+- stdio: Subprocess-based transport (default when ``command`` is present)
+- sse: Server-Sent Events transport
+- streamable-http: Streamable HTTP transport
+
+Example configuration::
+
+    {
+        "aws_docs": {
+            "command": "uvx",
+            "args": ["awslabs.aws-documentation-mcp-server@latest"],
+            "env": {"AWS_PROFILE": "default"},
+            "prefix": "aws",
+            "startup_timeout": 30,
+            "tool_filters": {
+                "allowed": ["search_.*"],
+                "rejected": ["dangerous_tool"]
+            }
+        },
+        "remote_service": {
+            "transport": "sse",
+            "url": "http://localhost:8000/sse",
+            "headers": {"Authorization": "Bearer token"},
+            "prefix": "remote"
+        }
+    }
+"""
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+from jsonschema import ValidationError
+
+from .mcp_client import MCPClient, ToolFilters
+
+logger = logging.getLogger(__name__)
+
+MCP_SERVER_CONFIG_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MCP Server Configuration",
+    "description": "Configuration for one or more MCP servers",
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "command": {
+                "description": "Command to run the MCP server (stdio transport)",
+                "type": "string",
+            },
+            "args": {
+                "description": "Arguments for the command",
+                "type": "array",
+                "items": {"type": "string"},
+                "default": [],
+            },
+            "env": {
+                "description": "Environment variables for the subprocess",
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "default": {},
+            },
+            "cwd": {
+                "description": "Working directory for stdio subprocess",
+                "type": ["string", "null"],
+                "default": None,
+            },
+            "transport": {
+                "description": "Transport type: stdio, sse, or streamable-http (auto-detected if omitted)",
+                "type": "string",
+                "enum": ["stdio", "sse", "streamable-http"],
+            },
+            "url": {
+                "description": "URL of the remote MCP server (sse or streamable-http transport)",
+                "type": "string",
+            },
+            "headers": {
+                "description": "HTTP headers for sse/http transports",
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "default": {},
+            },
+            "prefix": {
+                "description": "Prefix for tool names to avoid collisions",
+                "type": ["string", "null"],
+                "default": None,
+            },
+            "startup_timeout": {
+                "description": "Timeout for server initialization in seconds",
+                "type": "integer",
+                "minimum": 1,
+                "default": 30,
+            },
+            "tool_filters": {
+                "description": "Tool filter config with allowed and rejected patterns",
+                "type": "object",
+                "properties": {
+                    "allowed": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "rejected": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "additionalProperties": False,
+            },
+        },
+        "additionalProperties": False,
+    },
+}
+
+_VALIDATOR = jsonschema.Draft7Validator(MCP_SERVER_CONFIG_SCHEMA)
+
+
+def _detect_transport(server_config: dict[str, Any]) -> str:
+    """Detect the transport type from server configuration.
+
+    Detection logic:
+    - If ``transport`` is explicitly set, use it
+    - If ``command`` is present, default to ``stdio``
+    - If ``url`` is present, default to ``streamable-http``
+    - Otherwise raise ValueError
+
+    Args:
+        server_config: Configuration dictionary for a single MCP server.
+
+    Returns:
+        The transport type string.
+
+    Raises:
+        ValueError: If transport cannot be determined from the configuration.
+    """
+    if "transport" in server_config:
+        return server_config["transport"]
+
+    if "command" in server_config:
+        return "stdio"
+
+    if "url" in server_config:
+        return "streamable-http"
+
+    raise ValueError(
+        "cannot determine transport type: provide 'transport', 'command' (for stdio), or 'url' (for sse/http)"
+    )
+
+
+def _parse_tool_filters(filters_config: dict[str, Any] | None) -> ToolFilters | None:
+    """Parse tool filter configuration into ToolFilters.
+
+    String patterns are compiled as regex patterns. Exact-match strings (no regex
+    metacharacters) are compiled into anchored patterns for safety.
+
+    Args:
+        filters_config: Raw filter configuration with ``allowed`` and/or ``rejected`` lists.
+
+    Returns:
+        A ToolFilters dict or None if no filters are configured.
+    """
+    if not filters_config:
+        return None
+
+    tool_filters: ToolFilters = {}
+
+    for key in ("allowed", "rejected"):
+        if key in filters_config:
+            compiled: list[str | re.Pattern[str]] = []
+            for pattern in filters_config[key]:
+                try:
+                    compiled.append(re.compile(pattern))
+                except re.error:
+                    # If it fails to compile as regex, use as exact string match
+                    logger.warning("pattern=<%s> | invalid regex, using as literal string match", pattern)
+                    compiled.append(pattern)
+            tool_filters[key] = compiled  # type: ignore[literal-required]
+
+    return tool_filters if tool_filters else None
+
+
+def _create_stdio_transport(server_config: dict[str, Any]) -> Any:
+    """Create a stdio transport callable from configuration.
+
+    Args:
+        server_config: Server configuration containing ``command`` and optional ``args``, ``env``, ``cwd``.
+
+    Returns:
+        A callable that returns an MCPTransport context manager.
+
+    Raises:
+        ValueError: If ``command`` is not specified.
+    """
+    if "command" not in server_config:
+        raise ValueError("'command' is required for stdio transport")
+
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
+    params = StdioServerParameters(
+        command=server_config["command"],
+        args=server_config.get("args", []),
+        env=server_config.get("env") or None,
+        cwd=server_config.get("cwd"),
+    )
+
+    def transport_callable() -> Any:
+        return stdio_client(params)
+
+    return transport_callable
+
+
+def _create_sse_transport(server_config: dict[str, Any]) -> Any:
+    """Create an SSE transport callable from configuration.
+
+    Args:
+        server_config: Server configuration containing ``url`` and optional ``headers``.
+
+    Returns:
+        A callable that returns an MCPTransport context manager.
+
+    Raises:
+        ValueError: If ``url`` is not specified.
+    """
+    if "url" not in server_config:
+        raise ValueError("'url' is required for sse transport")
+
+    from mcp.client.sse import sse_client
+
+    url = server_config["url"]
+    headers = server_config.get("headers", {})
+
+    def transport_callable() -> Any:
+        return sse_client(url=url, headers=headers)
+
+    return transport_callable
+
+
+def _create_streamable_http_transport(server_config: dict[str, Any]) -> Any:
+    """Create a streamable-http transport callable from configuration.
+
+    Args:
+        server_config: Server configuration containing ``url`` and optional ``headers``.
+
+    Returns:
+        A callable that returns an MCPTransport context manager.
+
+    Raises:
+        ValueError: If ``url`` is not specified.
+    """
+    if "url" not in server_config:
+        raise ValueError("'url' is required for streamable-http transport")
+
+    from mcp.client.streamable_http import streamablehttp_client
+
+    url = server_config["url"]
+    headers = server_config.get("headers", {})
+
+    def transport_callable() -> Any:
+        return streamablehttp_client(url=url, headers=headers)
+
+    return transport_callable
+
+
+_TRANSPORT_FACTORIES = {
+    "stdio": _create_stdio_transport,
+    "sse": _create_sse_transport,
+    "streamable-http": _create_streamable_http_transport,
+}
+
+
+def _create_mcp_client(server_name: str, server_config: dict[str, Any]) -> MCPClient:
+    """Create an MCPClient from a single server configuration entry.
+
+    Args:
+        server_name: Name of the server (used in error messages).
+        server_config: Configuration dictionary for the server.
+
+    Returns:
+        A configured MCPClient instance (not yet started).
+
+    Raises:
+        ValueError: If the configuration is invalid.
+    """
+    transport_type = _detect_transport(server_config)
+    logger.debug("server=<%s>, transport=<%s> | creating MCP client", server_name, transport_type)
+
+    factory = _TRANSPORT_FACTORIES.get(transport_type)
+    if factory is None:
+        raise ValueError(f"unsupported transport type: {transport_type}")
+
+    transport_callable = factory(server_config)
+
+    # Build MCPClient constructor kwargs
+    client_kwargs: dict[str, Any] = {
+        "transport_callable": transport_callable,
+    }
+
+    if "startup_timeout" in server_config:
+        client_kwargs["startup_timeout"] = server_config["startup_timeout"]
+
+    if "prefix" in server_config and server_config["prefix"] is not None:
+        client_kwargs["prefix"] = server_config["prefix"]
+
+    tool_filters = _parse_tool_filters(server_config.get("tool_filters"))
+    if tool_filters is not None:
+        client_kwargs["tool_filters"] = tool_filters
+
+    return MCPClient(**client_kwargs)
+
+
+def load_mcp_clients_from_config(
+    config: str | dict[str, Any],
+) -> dict[str, MCPClient]:
+    """Load MCP clients from a configuration file or dictionary.
+
+    Creates MCPClient instances for each server defined in the configuration.
+    The clients are returned unstarted — they will be started automatically
+    when used with an Agent (via the ToolProvider lifecycle) or can be started
+    manually with ``client.start()``.
+
+    Args:
+        config: Either a file path to a JSON configuration file, or a dictionary
+            mapping server names to their configuration. The file can contain
+            either a top-level ``mcp_servers`` key or be a flat mapping of
+            server names to configs.
+
+    Returns:
+        A dictionary mapping server names to MCPClient instances.
+
+    Raises:
+        FileNotFoundError: If the configuration file does not exist.
+        json.JSONDecodeError: If the file contains invalid JSON.
+        ValueError: If the configuration is invalid.
+
+    Examples:
+        Load from file::
+
+            clients = load_mcp_clients_from_config("mcp_config.json")
+
+        Load from dictionary::
+
+            clients = load_mcp_clients_from_config({
+                "aws_docs": {
+                    "command": "uvx",
+                    "args": ["awslabs.aws-documentation-mcp-server@latest"]
+                }
+            })
+
+        Use with agent::
+
+            from strands import Agent
+            clients = load_mcp_clients_from_config("mcp_config.json")
+            agent = Agent(tools=list(clients.values()))
+    """
+    if isinstance(config, str):
+        config_path = Path(config)
+        if not config_path.exists():
+            raise FileNotFoundError(f"MCP configuration file not found: {config}")
+        with open(config_path) as f:
+            config_dict = json.load(f)
+    elif isinstance(config, dict):
+        config_dict = config.copy()
+    else:
+        raise ValueError("config must be a file path string or dictionary")
+
+    # Support both top-level mcp_servers key and flat dict
+    if "mcp_servers" in config_dict and isinstance(config_dict["mcp_servers"], dict):
+        servers_config = config_dict["mcp_servers"]
+    else:
+        servers_config = config_dict
+
+    # Validate against schema
+    try:
+        _VALIDATOR.validate(servers_config)
+    except ValidationError as e:
+        error_path = " -> ".join(str(p) for p in e.absolute_path) if e.absolute_path else "root"
+        raise ValueError(f"MCP configuration validation error at {error_path}: {e.message}") from e
+
+    clients: dict[str, MCPClient] = {}
+    for server_name, server_config in servers_config.items():
+        try:
+            clients[server_name] = _create_mcp_client(server_name, server_config)
+            logger.debug("server=<%s> | MCP client created successfully", server_name)
+        except Exception as e:
+            raise ValueError(f"failed to create MCP client for server '{server_name}': {e}") from e
+
+    logger.debug("total_clients=<%d> | all MCP clients created", len(clients))
+    return clients

--- a/tests/strands/experimental/test_agent_config.py
+++ b/tests/strands/experimental/test_agent_config.py
@@ -202,7 +202,7 @@ def test_config_to_agent_mcp_servers_appended_to_tools(mock_load_mcp):
             "test_server": {"command": "echo"},
         },
     }
-    agent = config_to_agent(config)
+    config_to_agent(config)
 
     # The MCP client should be in the agent's tools
     mock_load_mcp.assert_called_once()
@@ -225,7 +225,7 @@ def test_config_to_agent_multiple_mcp_servers(mock_load_mcp):
             "server_b": {"transport": "sse", "url": "http://localhost:8000/sse"},
         },
     }
-    agent = config_to_agent(config)
+    config_to_agent(config)
 
     mock_load_mcp.assert_called_once_with(config["mcp_servers"])
 

--- a/tests/strands/experimental/test_agent_config.py
+++ b/tests/strands/experimental/test_agent_config.py
@@ -3,6 +3,7 @@
 import json
 import os
 import tempfile
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -45,14 +46,12 @@ def test_config_to_agent_file_prefix_required():
 
     config_data = {"model": "test-model"}
     temp_path = ""
-
     # We need to create files like this for windows compatibility
     try:
         with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as f:
             json.dump(config_data, f)
             f.flush()
             temp_path = f.name
-
         agent = config_to_agent(temp_path)
         assert agent.model.config["model_id"] == "test-model"
     finally:
@@ -65,13 +64,11 @@ def test_config_to_agent_file_prefix_valid():
     """Test that file:// prefix is properly handled."""
     config_data = {"model": "test-model", "prompt": "Test prompt"}
     temp_path = ""
-
     try:
         with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as f:
             json.dump(config_data, f)
             f.flush()
             temp_path = f.name
-
         agent = config_to_agent(f"file://{temp_path}")
         assert agent.model.config["model_id"] == "test-model"
         assert agent.system_prompt == "Test prompt"
@@ -93,7 +90,6 @@ def test_config_to_agent_invalid_json():
         with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as f:
             f.write("invalid json content")
             temp_path = f.name
-
         with pytest.raises(json.JSONDecodeError):
             config_to_agent(temp_path)
     finally:
@@ -170,3 +166,111 @@ def test_config_to_agent_with_tool():
     config = {"model": "test-model", "tools": ["tests.fixtures.say_tool:say"]}
     agent = config_to_agent(config)
     assert "say" in agent.tool_names
+
+
+# === MCP Server Configuration Tests ===
+
+
+@patch("strands.tools.mcp.mcp_config.load_mcp_clients_from_config")
+def test_config_to_agent_with_mcp_servers(mock_load_mcp):
+    """Test config_to_agent creates MCP clients from mcp_servers config."""
+    mock_client = MagicMock()
+    mock_load_mcp.return_value = {"test_server": mock_client}
+
+    config = {
+        "model": "test-model",
+        "mcp_servers": {
+            "test_server": {"command": "echo", "args": ["hello"]},
+        },
+    }
+    agent = config_to_agent(config)
+
+    mock_load_mcp.assert_called_once_with(config["mcp_servers"])
+    assert agent.model.config["model_id"] == "test-model"
+
+
+@patch("strands.tools.mcp.mcp_config.load_mcp_clients_from_config")
+def test_config_to_agent_mcp_servers_appended_to_tools(mock_load_mcp):
+    """Test that MCP clients are appended to existing tools list."""
+    mock_client = MagicMock()
+    mock_load_mcp.return_value = {"test_server": mock_client}
+
+    config = {
+        "model": "test-model",
+        "tools": [],
+        "mcp_servers": {
+            "test_server": {"command": "echo"},
+        },
+    }
+    agent = config_to_agent(config)
+
+    # The MCP client should be in the agent's tools
+    mock_load_mcp.assert_called_once()
+
+
+@patch("strands.tools.mcp.mcp_config.load_mcp_clients_from_config")
+def test_config_to_agent_multiple_mcp_servers(mock_load_mcp):
+    """Test config_to_agent handles multiple MCP servers."""
+    mock_client_a = MagicMock()
+    mock_client_b = MagicMock()
+    mock_load_mcp.return_value = {
+        "server_a": mock_client_a,
+        "server_b": mock_client_b,
+    }
+
+    config = {
+        "model": "test-model",
+        "mcp_servers": {
+            "server_a": {"command": "echo"},
+            "server_b": {"transport": "sse", "url": "http://localhost:8000/sse"},
+        },
+    }
+    agent = config_to_agent(config)
+
+    mock_load_mcp.assert_called_once_with(config["mcp_servers"])
+
+
+def test_config_to_agent_empty_mcp_servers():
+    """Test config_to_agent handles empty mcp_servers gracefully."""
+    config = {"model": "test-model", "mcp_servers": {}}
+    agent = config_to_agent(config)
+    assert agent.model.config["model_id"] == "test-model"
+
+
+def test_config_to_agent_mcp_servers_validation_error():
+    """Test that invalid mcp_servers config raises validation errors."""
+    config = {
+        "model": "test-model",
+        "mcp_servers": {
+            "bad_server": {"invalid_field": "value"},
+        },
+    }
+    with pytest.raises(ValueError, match="Configuration validation error"):
+        config_to_agent(config)
+
+
+@patch("strands.tools.mcp.mcp_config.load_mcp_clients_from_config")
+def test_config_to_agent_mcp_servers_from_file(mock_load_mcp):
+    """Test loading mcp_servers from a config file."""
+    mock_client = MagicMock()
+    mock_load_mcp.return_value = {"test_server": mock_client}
+
+    config_data = {
+        "model": "test-model",
+        "mcp_servers": {
+            "test_server": {"command": "echo"},
+        },
+    }
+    temp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as f:
+            json.dump(config_data, f)
+            f.flush()
+            temp_path = f.name
+
+        agent = config_to_agent(temp_path)
+        mock_load_mcp.assert_called_once()
+        assert agent.model.config["model_id"] == "test-model"
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)

--- a/tests/strands/tools/mcp/test_mcp_config.py
+++ b/tests/strands/tools/mcp/test_mcp_config.py
@@ -1,0 +1,334 @@
+"""Tests for MCP configuration loading and MCPClient factory."""
+
+import json
+import os
+import re
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands.tools.mcp.mcp_config import (
+    _create_mcp_client,
+    _detect_transport,
+    _parse_tool_filters,
+    load_mcp_clients_from_config,
+)
+
+
+class TestDetectTransport:
+    """Tests for transport type auto-detection."""
+
+    def test_explicit_stdio(self):
+        assert _detect_transport({"transport": "stdio", "command": "echo"}) == "stdio"
+
+    def test_explicit_sse(self):
+        assert _detect_transport({"transport": "sse", "url": "http://localhost:8000/sse"}) == "sse"
+
+    def test_explicit_streamable_http(self):
+        assert _detect_transport({"transport": "streamable-http", "url": "http://localhost:8000/mcp"}) == "streamable-http"
+
+    def test_infer_stdio_from_command(self):
+        assert _detect_transport({"command": "uvx"}) == "stdio"
+
+    def test_infer_streamable_http_from_url(self):
+        assert _detect_transport({"url": "http://localhost:8000/mcp"}) == "streamable-http"
+
+    def test_explicit_transport_overrides_command(self):
+        """Explicit transport takes priority over command presence."""
+        assert _detect_transport({"transport": "sse", "command": "echo", "url": "http://x"}) == "sse"
+
+    def test_command_takes_priority_over_url(self):
+        """When both command and url are present without explicit transport, stdio wins."""
+        assert _detect_transport({"command": "echo", "url": "http://x"}) == "stdio"
+
+    def test_no_transport_info_raises(self):
+        with pytest.raises(ValueError, match="cannot determine transport type"):
+            _detect_transport({})
+
+    def test_no_transport_info_with_irrelevant_keys_raises(self):
+        with pytest.raises(ValueError, match="cannot determine transport type"):
+            _detect_transport({"prefix": "test"})
+
+
+class TestParseToolFilters:
+    """Tests for tool filter parsing."""
+
+    def test_none_input(self):
+        assert _parse_tool_filters(None) is None
+
+    def test_empty_dict(self):
+        assert _parse_tool_filters({}) is None
+
+    def test_allowed_patterns(self):
+        filters = _parse_tool_filters({"allowed": ["search_.*", "list_.*"]})
+        assert filters is not None
+        assert "allowed" in filters
+        assert len(filters["allowed"]) == 2
+        # Should be compiled regex patterns
+        assert isinstance(filters["allowed"][0], re.Pattern)
+        assert isinstance(filters["allowed"][1], re.Pattern)
+
+    def test_rejected_patterns(self):
+        filters = _parse_tool_filters({"rejected": ["dangerous_tool"]})
+        assert filters is not None
+        assert "rejected" in filters
+        assert len(filters["rejected"]) == 1
+
+    def test_both_allowed_and_rejected(self):
+        filters = _parse_tool_filters({
+            "allowed": ["search_.*"],
+            "rejected": ["search_dangerous"],
+        })
+        assert filters is not None
+        assert "allowed" in filters
+        assert "rejected" in filters
+
+    def test_invalid_regex_falls_back_to_string(self):
+        """Invalid regex patterns should be kept as literal strings with a warning."""
+        filters = _parse_tool_filters({"allowed": ["[invalid"]})
+        assert filters is not None
+        assert len(filters["allowed"]) == 1
+        # Should be a string, not a compiled pattern
+        assert isinstance(filters["allowed"][0], str)
+        assert filters["allowed"][0] == "[invalid"
+
+    def test_regex_pattern_compilation(self):
+        filters = _parse_tool_filters({"allowed": ["^search_.*$"]})
+        assert filters is not None
+        pattern = filters["allowed"][0]
+        assert isinstance(pattern, re.Pattern)
+        assert pattern.match("search_docs")
+        assert not pattern.match("list_docs")
+
+
+class TestCreateMcpClient:
+    """Tests for MCPClient creation from config."""
+
+    @patch("mcp.client.stdio.stdio_client")
+    def test_stdio_client(self, mock_stdio):
+        mock_stdio.return_value = MagicMock()
+        config = {"command": "echo", "args": ["hello"]}
+        client = _create_mcp_client("test_server", config)
+        assert client is not None
+
+    @patch("mcp.client.sse.sse_client")
+    def test_sse_client(self, mock_sse):
+        mock_sse.return_value = MagicMock()
+        config = {"transport": "sse", "url": "http://localhost:8000/sse"}
+        client = _create_mcp_client("test_server", config)
+        assert client is not None
+
+    @patch("mcp.client.streamable_http.streamablehttp_client")
+    def test_streamable_http_client(self, mock_http):
+        mock_http.return_value = MagicMock()
+        config = {"transport": "streamable-http", "url": "http://localhost:8000/mcp"}
+        client = _create_mcp_client("test_server", config)
+        assert client is not None
+
+    @patch("mcp.client.stdio.stdio_client")
+    def test_client_with_prefix(self, mock_stdio):
+        mock_stdio.return_value = MagicMock()
+        config = {"command": "echo", "prefix": "test"}
+        client = _create_mcp_client("test_server", config)
+        assert client._prefix == "test"
+
+    @patch("mcp.client.stdio.stdio_client")
+    def test_client_with_startup_timeout(self, mock_stdio):
+        mock_stdio.return_value = MagicMock()
+        config = {"command": "echo", "startup_timeout": 60}
+        client = _create_mcp_client("test_server", config)
+        assert client._startup_timeout == 60
+
+    @patch("mcp.client.stdio.stdio_client")
+    def test_client_with_tool_filters(self, mock_stdio):
+        mock_stdio.return_value = MagicMock()
+        config = {
+            "command": "echo",
+            "tool_filters": {"allowed": ["search_.*"], "rejected": ["dangerous"]},
+        }
+        client = _create_mcp_client("test_server", config)
+        assert client._tool_filters is not None
+
+    def test_unsupported_transport_raises(self):
+        with pytest.raises(ValueError, match="cannot determine transport type"):
+            _create_mcp_client("test_server", {})
+
+
+class TestLoadMcpClientsFromConfig:
+    """Tests for loading MCPClient instances from configuration."""
+
+    @patch("strands.tools.mcp.mcp_config._create_mcp_client")
+    def test_load_from_dict(self, mock_create):
+        mock_client = MagicMock()
+        mock_create.return_value = mock_client
+
+        config = {
+            "server_a": {"command": "echo", "args": ["hello"]},
+            "server_b": {"transport": "sse", "url": "http://localhost:8000/sse"},
+        }
+        clients = load_mcp_clients_from_config(config)
+
+        assert len(clients) == 2
+        assert "server_a" in clients
+        assert "server_b" in clients
+        assert mock_create.call_count == 2
+
+    @patch("strands.tools.mcp.mcp_config._create_mcp_client")
+    def test_load_from_file(self, mock_create):
+        mock_client = MagicMock()
+        mock_create.return_value = mock_client
+
+        config_data = {
+            "test_server": {"command": "echo"},
+        }
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as f:
+                json.dump(config_data, f)
+                f.flush()
+                temp_path = f.name
+
+            clients = load_mcp_clients_from_config(temp_path)
+            assert len(clients) == 1
+            assert "test_server" in clients
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    @patch("strands.tools.mcp.mcp_config._create_mcp_client")
+    def test_load_from_file_with_mcp_servers_key(self, mock_create):
+        """Support files where servers are nested under mcp_servers key."""
+        mock_client = MagicMock()
+        mock_create.return_value = mock_client
+
+        config_data = {
+            "mcp_servers": {
+                "test_server": {"command": "echo"},
+            }
+        }
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as f:
+                json.dump(config_data, f)
+                f.flush()
+                temp_path = f.name
+
+            clients = load_mcp_clients_from_config(temp_path)
+            assert len(clients) == 1
+            assert "test_server" in clients
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def test_load_file_not_found(self):
+        with pytest.raises(FileNotFoundError, match="MCP configuration file not found"):
+            load_mcp_clients_from_config("/nonexistent/mcp_config.json")
+
+    def test_load_invalid_json_file(self):
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as f:
+                f.write("not valid json")
+                temp_path = f.name
+
+            with pytest.raises(json.JSONDecodeError):
+                load_mcp_clients_from_config(temp_path)
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def test_load_invalid_config_type(self):
+        with pytest.raises(ValueError, match="config must be a file path string or dictionary"):
+            load_mcp_clients_from_config(123)
+
+    def test_load_empty_config(self):
+        clients = load_mcp_clients_from_config({})
+        assert len(clients) == 0
+
+    def test_validation_error_invalid_server_config(self):
+        config = {
+            "bad_server": {"invalid_field": "value"},
+        }
+        with pytest.raises(ValueError, match="MCP configuration validation error"):
+            load_mcp_clients_from_config(config)
+
+    def test_validation_error_wrong_type(self):
+        config = {
+            "bad_server": {"command": 123},
+        }
+        with pytest.raises(ValueError, match="MCP configuration validation error"):
+            load_mcp_clients_from_config(config)
+
+    @patch("strands.tools.mcp.mcp_config._create_mcp_client")
+    def test_create_failure_wraps_error(self, mock_create):
+        mock_create.side_effect = RuntimeError("transport init failed")
+
+        config = {"test_server": {"command": "echo"}}
+        with pytest.raises(ValueError, match="failed to create MCP client for server 'test_server'"):
+            load_mcp_clients_from_config(config)
+
+
+class TestStdioTransport:
+    """Tests for stdio transport creation."""
+
+    @patch("mcp.client.stdio.stdio_client")
+    def test_create_stdio_with_all_options(self, mock_stdio):
+        from strands.tools.mcp.mcp_config import _create_stdio_transport
+
+        config = {
+            "command": "uvx",
+            "args": ["my-server"],
+            "env": {"KEY": "value"},
+            "cwd": "/tmp",
+        }
+        transport_fn = _create_stdio_transport(config)
+        assert callable(transport_fn)
+
+    def test_create_stdio_missing_command(self):
+        from strands.tools.mcp.mcp_config import _create_stdio_transport
+
+        with pytest.raises(ValueError, match="'command' is required"):
+            _create_stdio_transport({})
+
+
+class TestSseTransport:
+    """Tests for SSE transport creation."""
+
+    @patch("mcp.client.sse.sse_client")
+    def test_create_sse_with_headers(self, mock_sse):
+        from strands.tools.mcp.mcp_config import _create_sse_transport
+
+        config = {
+            "url": "http://localhost:8000/sse",
+            "headers": {"Authorization": "[REDACTED_TOKEN]"},
+        }
+        transport_fn = _create_sse_transport(config)
+        assert callable(transport_fn)
+
+    def test_create_sse_missing_url(self):
+        from strands.tools.mcp.mcp_config import _create_sse_transport
+
+        with pytest.raises(ValueError, match="'url' is required"):
+            _create_sse_transport({})
+
+
+class TestStreamableHttpTransport:
+    """Tests for streamable-http transport creation."""
+
+    @patch("mcp.client.streamable_http.streamablehttp_client")
+    def test_create_http_with_headers(self, mock_http):
+        from strands.tools.mcp.mcp_config import _create_streamable_http_transport
+
+        config = {
+            "url": "http://localhost:8000/mcp",
+            "headers": {"Authorization": "[REDACTED_TOKEN]"},
+        }
+        transport_fn = _create_streamable_http_transport(config)
+        assert callable(transport_fn)
+
+    def test_create_http_missing_url(self):
+        from strands.tools.mcp.mcp_config import _create_streamable_http_transport
+
+        with pytest.raises(ValueError, match="'url' is required"):
+            _create_streamable_http_transport({})

--- a/tests/strands/tools/mcp/test_mcp_config.py
+++ b/tests/strands/tools/mcp/test_mcp_config.py
@@ -26,7 +26,8 @@ class TestDetectTransport:
         assert _detect_transport({"transport": "sse", "url": "http://localhost:8000/sse"}) == "sse"
 
     def test_explicit_streamable_http(self):
-        assert _detect_transport({"transport": "streamable-http", "url": "http://localhost:8000/mcp"}) == "streamable-http"
+        config = {"transport": "streamable-http", "url": "http://localhost:8000/mcp"}
+        assert _detect_transport(config) == "streamable-http"
 
     def test_infer_stdio_from_command(self):
         assert _detect_transport({"command": "uvx"}) == "stdio"

--- a/tests_integ/mcp/test_mcp_config.py
+++ b/tests_integ/mcp/test_mcp_config.py
@@ -1,0 +1,186 @@
+"""Integration tests for MCP configuration loading.
+
+These tests verify end-to-end MCP tool usage from configuration,
+using the echo_server.py for stdio transport testing.
+"""
+
+import json
+import sys
+import tempfile
+
+import pytest
+
+from strands import Agent
+from strands.experimental import config_to_agent
+from strands.tools.mcp import MCPClient, load_mcp_clients_from_config
+
+ECHO_SERVER_PATH = "tests_integ/mcp/echo_server.py"
+
+
+@pytest.fixture
+def echo_server_config():
+    """Configuration for the echo server via stdio transport."""
+    return {
+        "echo": {
+            "command": sys.executable,
+            "args": [ECHO_SERVER_PATH],
+            "startup_timeout": 30,
+        }
+    }
+
+
+@pytest.fixture
+def echo_server_config_with_prefix():
+    """Configuration for the echo server with a tool name prefix."""
+    return {
+        "echo": {
+            "command": sys.executable,
+            "args": [ECHO_SERVER_PATH],
+            "prefix": "test",
+            "startup_timeout": 30,
+        }
+    }
+
+
+@pytest.fixture
+def echo_server_config_with_filters():
+    """Configuration for the echo server with tool filters."""
+    return {
+        "echo": {
+            "command": sys.executable,
+            "args": [ECHO_SERVER_PATH],
+            "tool_filters": {
+                "allowed": ["echo"],
+                "rejected": ["get_weather"],
+            },
+            "startup_timeout": 30,
+        }
+    }
+
+
+class TestLoadMcpClientsFromConfig:
+    """Tests for loading MCP clients from configuration dictionaries."""
+
+    def test_load_stdio_client(self, echo_server_config):
+        """Verify a stdio MCP client can be loaded from config."""
+        clients = load_mcp_clients_from_config(echo_server_config)
+        assert "echo" in clients
+        assert isinstance(clients["echo"], MCPClient)
+
+    def test_load_from_file(self, echo_server_config):
+        """Verify MCP clients can be loaded from a JSON config file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(echo_server_config, f)
+            f.flush()
+            temp_path = f.name
+
+        clients = load_mcp_clients_from_config(temp_path)
+        assert "echo" in clients
+        assert isinstance(clients["echo"], MCPClient)
+
+    def test_load_from_file_with_mcp_servers_key(self, echo_server_config):
+        """Verify loading from file where config is nested under mcp_servers key."""
+        wrapped_config = {"mcp_servers": echo_server_config}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(wrapped_config, f)
+            f.flush()
+            temp_path = f.name
+
+        clients = load_mcp_clients_from_config(temp_path)
+        assert "echo" in clients
+
+    def test_client_can_list_tools(self, echo_server_config):
+        """Verify loaded client can connect and list tools."""
+        clients = load_mcp_clients_from_config(echo_server_config)
+        client = clients["echo"]
+
+        with client:
+            tools = client.list_tools_sync()
+            tool_names = [t.tool_name for t in tools]
+            assert "echo" in tool_names
+
+    def test_client_with_prefix(self, echo_server_config_with_prefix):
+        """Verify tool prefix is applied from config."""
+        clients = load_mcp_clients_from_config(echo_server_config_with_prefix)
+        client = clients["echo"]
+
+        with client:
+            tools = client.list_tools_sync()
+            tool_names = [t.tool_name for t in tools]
+            # All tool names should be prefixed
+            assert all(name.startswith("test_") for name in tool_names)
+
+    def test_client_with_tool_filters(self, echo_server_config_with_filters):
+        """Verify tool filters are applied from config."""
+        clients = load_mcp_clients_from_config(echo_server_config_with_filters)
+        client = clients["echo"]
+
+        with client:
+            tools = client.list_tools_sync()
+            tool_names = [t.tool_name for t in tools]
+            assert "echo" in tool_names
+            assert "get_weather" not in tool_names
+
+
+class TestConfigToAgentWithMcpServers:
+    """Tests for config_to_agent with mcp_servers field."""
+
+    def test_agent_with_mcp_servers(self, echo_server_config):
+        """Verify an agent can be created with MCP tools from config."""
+        config = {
+            "mcp_servers": echo_server_config,
+        }
+        agent = config_to_agent(config)
+        assert "echo" in agent.tool_names
+
+    def test_agent_with_mcp_servers_from_file(self, echo_server_config):
+        """Verify an agent can be created from a config file with mcp_servers."""
+        config = {
+            "mcp_servers": echo_server_config,
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config, f)
+            f.flush()
+            temp_path = f.name
+
+        agent = config_to_agent(temp_path)
+        assert "echo" in agent.tool_names
+
+    def test_agent_can_call_mcp_tool(self, echo_server_config):
+        """Verify an agent with MCP config tools can invoke them."""
+        config = {
+            "mcp_servers": echo_server_config,
+        }
+        agent = config_to_agent(config)
+        result = agent.tool.echo(to_echo="hello from config")
+        assert "hello from config" in str(result)
+
+    def test_agent_standalone_usage(self, echo_server_config):
+        """Verify standalone usage: load clients, then pass to Agent."""
+        clients = load_mcp_clients_from_config(echo_server_config)
+        agent = Agent(tools=list(clients.values()))
+        assert "echo" in agent.tool_names
+
+    def test_multiple_servers_config(self):
+        """Verify multiple stdio servers can be configured."""
+        config = {
+            "echo_a": {
+                "command": sys.executable,
+                "args": [ECHO_SERVER_PATH],
+                "prefix": "a",
+                "startup_timeout": 30,
+            },
+            "echo_b": {
+                "command": sys.executable,
+                "args": [ECHO_SERVER_PATH],
+                "prefix": "b",
+                "startup_timeout": 30,
+            },
+        }
+        clients = load_mcp_clients_from_config(config)
+        assert len(clients) == 2
+
+        agent = Agent(tools=list(clients.values()))
+        tool_names = agent.tool_names
+        assert any(name.startswith("a_") for name in tool_names)
+        assert any(name.startswith("b_") for name in tool_names)


### PR DESCRIPTION
## Description

Add support for loading MCP server configurations from a JSON config file or dictionary, allowing users to define multiple MCP servers declaratively instead of programmatically. This extends the existing experimental `agent_config.py` to support an `mcp_servers` field that creates and manages `MCPClient` instances automatically.

The configuration format is compatible with the Claude Desktop / Cursor / VS Code `mcpServers` convention.

### What's included

- **New module `src/strands/tools/mcp/mcp_config.py`** — Config parsing, transport auto-detection, and `MCPClient` factory
  - `load_mcp_clients_from_config()` — standalone function to load MCP clients from a file path or dict
  - Supports `stdio`, `sse`, and `streamable-http` transports with auto-detection
  - Per-server options: `prefix`, `startup_timeout`, `tool_filters`, `env`, `headers`, `cwd`
  - JSON Schema validation with clear error messages

- **Updated `src/strands/experimental/agent_config.py`** — Added `mcp_servers` field to `AGENT_CONFIG_SCHEMA` and processing in `config_to_agent()`

- **Updated `src/strands/tools/mcp/__init__.py`** — Exports `load_mcp_clients_from_config`

### Config format example

```json
{
  "model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
  "prompt": "You are a helpful assistant.",
  "tools": ["strands_tools.file_read"],
  "mcp_servers": {
    "aws_docs": {
      "command": "uvx",
      "args": ["awslabs.aws-documentation-mcp-server@latest"],
      "env": {"AWS_PROFILE": "default"},
      "prefix": "aws",
      "startup_timeout": 30,
      "tool_filters": {
        "allowed": ["search_.*"],
        "rejected": ["dangerous_tool"]
      }
    },
    "remote_service": {
      "transport": "sse",
      "url": "http://localhost:8000/sse",
      "headers": {"Authorization": "Bearer token"}
    }
  }
}
```

### Standalone usage

```python
from strands.tools.mcp import load_mcp_clients_from_config
from strands import Agent

clients = load_mcp_clients_from_config("mcp_config.json")
agent = Agent(tools=list(clients.values()))
```

## Related Issues

- Closes #1625
- Closes #482

## Type of Change

New feature

## Testing

### Unit tests (`tests/strands/tools/mcp/test_mcp_config.py`) — 39 tests
- Config parsing and validation for each transport type
- Transport type auto-detection logic (stdio from `command`, http from `url`, explicit `transport`)
- Tool filter parsing (regex compilation, literal fallback)
- Error handling for invalid configs, missing files, wrong types
- MCPClient creation with correct parameters (prefix, timeout, filters)

### Unit tests (`tests/strands/experimental/test_agent_config.py`) — extended
- `config_to_agent` with `mcp_servers` field (single/multiple servers)
- Empty `mcp_servers` handling
- Validation errors for invalid server configs
- File-based config loading with `mcp_servers`

### Integration tests (`tests_integ/mcp/test_mcp_config.py`)
- Load MCP servers from config using existing `echo_server.py`
- Verify tools are loaded and callable via agent
- Prefix and tool filter application from config
- Multiple server config loading
- Standalone `load_mcp_clients_from_config()` → `Agent(tools=...)` workflow

- [x] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
