### PR TITLE
fix: include reasoning block with empty text and non-empty signature

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -303,7 +303,7 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
             content.append({"text": text})
         state["text"] = ""
 
-    elif reasoning_text:
+    elif reasoning_text or "signature" in state:
         content_block: ContentBlock = {
             "reasoningContent": {
                 "reasoningText": {

--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -311,7 +311,7 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
             content.append({"text": text})
         state["text"] = ""
 
-    elif reasoning_text:
+    elif reasoning_text or "signature" in state:
         content_block: ContentBlock = {
             "reasoningContent": {
                 "reasoningText": {

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -499,6 +499,27 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, event_type, s
                 "redactedContent": b"",
             },
         ),
+        # Reasoning with empty text but non-empty signature
+        (
+            {
+                "content": [],
+                "current_tool_use": {},
+                "text": "",
+                "reasoningText": "",
+                "signature": "123",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+            {
+                "content": [{"reasoningContent": {"reasoningText": {"text": "", "signature": "123"}}}],
+                "current_tool_use": {},
+                "text": "",
+                "reasoningText": "",
+                "signature": "123",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+        ),
         # redactedContent
         (
             {


### PR DESCRIPTION
## Motivation

Some models like Opus 4.7 emit reasoning content blocks that carry only a `signature` with no accompanying `reasoningText`. The prior condition in `handle_content_block_stop` checked only `reasoning_text`, which evaluated to falsy for an empty string, causing the entire reasoning content block (including the signature) to be silently dropped from the assembled message content.

## Public API Changes

No public API changes. This is an internal streaming assembly fix.

## Change

The condition in `handle_content_block_stop` is broadened from:

```python
elif reasoning_text:
```

to:

```python
elif reasoning_text or "signature" in state:
```

This ensures that reasoning blocks carrying only a signature are preserved in the output content, matching the behavior models like Opus 4.7 expect.

## Testing

Added two tests covering the signature-only reasoning scenario:
- A parametrized case in `test_handle_content_block_stop` for empty `reasoningText` with a `signature` present
- An end-to-end `test_process_stream_with_signature_only` that simulates the Opus 4.7 streaming pattern (signature-only reasoning block followed by a text response)