### PR TITLE
fix(litellm): forward ttl field from CachePoint in _format_system_messages

### DIFF
--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -224,7 +224,10 @@ class LiteLLMModel(OpenAIModel):
                 # Apply cache control to the immediately preceding content block
                 # for LiteLLM/Anthropic compatibility
                 if system_content:
-                    system_content[-1]["cache_control"] = {"type": "ephemeral"}
+                    cache_control: dict[str, Any] = {"type": "ephemeral"}
+                    if ttl := block["cachePoint"].get("ttl"):
+                        cache_control["ttl"] = ttl
+                    system_content[-1]["cache_control"] = cache_control
 
         # Create single system message with content array rather than mulitple system messages
         return [{"role": "system", "content": system_content}] if system_content else []

--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -220,7 +220,7 @@ class LiteLLMModel(OpenAIModel):
         for block in system_prompt_content or []:
             if "text" in block:
                 system_content.append({"type": "text", "text": block["text"]})
-            elif "cachePoint" in block and block["cachePoint"].get("type") == "default":
+            elif "cachePoint" in block and block["cachePoint"]["type"] == "default":
                 # Apply cache control to the immediately preceding content block
                 # for LiteLLM/Anthropic compatibility
                 if system_content:

--- a/src/strands/types/content.py
+++ b/src/strands/types/content.py
@@ -62,7 +62,7 @@ class ReasoningContentBlock(TypedDict, total=False):
     redactedContent: bytes
 
 
-class CachePoint(TypedDict, total=False):
+class CachePoint(TypedDict):
     """A cache point configuration for optimizing conversation history.
 
     Attributes:
@@ -72,7 +72,7 @@ class CachePoint(TypedDict, total=False):
     """
 
     type: Required[str]
-    ttl: str
+    ttl: NotRequired[str]
 
 
 class ContentBlock(TypedDict, total=False):

--- a/src/strands/types/content.py
+++ b/src/strands/types/content.py
@@ -8,7 +8,7 @@ SDK. These types are modeled after the Bedrock API.
 
 from typing import Any, Literal
 
-from typing_extensions import NotRequired, Required, TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from .citations import CitationsContentBlock
 from .event_loop import Metrics, Usage
@@ -71,7 +71,7 @@ class CachePoint(TypedDict):
             that accept Anthropic-compatible cache_control fields.
     """
 
-    type: Required[str]
+    type: str
     ttl: NotRequired[str]
 
 

--- a/src/strands/types/content.py
+++ b/src/strands/types/content.py
@@ -8,7 +8,7 @@ SDK. These types are modeled after the Bedrock API.
 
 from typing import Any, Literal
 
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import NotRequired, Required, TypedDict
 
 from .citations import CitationsContentBlock
 from .event_loop import Metrics, Usage
@@ -62,14 +62,17 @@ class ReasoningContentBlock(TypedDict, total=False):
     redactedContent: bytes
 
 
-class CachePoint(TypedDict):
+class CachePoint(TypedDict, total=False):
     """A cache point configuration for optimizing conversation history.
 
     Attributes:
         type: The type of cache point, typically "default".
+        ttl: Optional cache TTL duration (e.g. "5m", "1h"). Supported by providers
+            that accept Anthropic-compatible cache_control fields.
     """
 
-    type: str
+    type: Required[str]
+    ttl: str
 
 
 class ContentBlock(TypedDict, total=False):

--- a/tests/strands/models/test_litellm.py
+++ b/tests/strands/models/test_litellm.py
@@ -978,6 +978,16 @@ def test_format_system_messages_cache_point_without_ttl():
     assert "ttl" not in result[0]["content"][0]["cache_control"]
 
 
+def test_format_system_messages_cache_point_with_no_preceding_content():
+    """CachePoint with no preceding text block should be silently ignored."""
+    result = LiteLLMModel._format_system_messages(
+        system_prompt_content=[
+            {"cachePoint": {"type": "default", "ttl": "1h"}},
+        ]
+    )
+    assert result == []
+
+
 def test_thought_signature_round_trip():
     """Test that thought signature is preserved through a full response -> internal -> request cycle."""
     model = LiteLLMModel(model_id="test")

--- a/tests/strands/models/test_litellm.py
+++ b/tests/strands/models/test_litellm.py
@@ -955,6 +955,29 @@ def test_format_request_message_tool_call_no_reasoning_signature():
     assert "__thought__" not in result["id"]
 
 
+def test_format_system_messages_preserves_cache_point_ttl():
+    """CachePoint with ttl="1h" should produce cache_control with ttl field."""
+    result = LiteLLMModel._format_system_messages(
+        system_prompt_content=[
+            {"text": "You are a helpful assistant."},
+            {"cachePoint": {"type": "default", "ttl": "1h"}},
+        ]
+    )
+    assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_format_system_messages_cache_point_without_ttl():
+    """CachePoint without ttl should produce cache_control with no ttl key (backward compat)."""
+    result = LiteLLMModel._format_system_messages(
+        system_prompt_content=[
+            {"text": "You are a helpful assistant."},
+            {"cachePoint": {"type": "default"}},
+        ]
+    )
+    assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert "ttl" not in result[0]["content"][0]["cache_control"]
+
+
 def test_thought_signature_round_trip():
     """Test that thought signature is preserved through a full response -> internal -> request cycle."""
     model = LiteLLMModel(model_id="test")


### PR DESCRIPTION
## Description

`LiteLLMModel._format_system_messages()` was silently dropping the `ttl` field from `CachePoint` blocks, always emitting `{"type": "ephemeral"}` regardless of the specified TTL. This meant `CachePoint(type="default", ttl="1h")` had no effect when using `LiteLLMModel` with Anthropic-compatible endpoints (e.g. a Databricks external model proxying to AWS Bedrock), causing the provider to fall back to its default cache duration.

Two changes:

1. **`src/strands/models/litellm.py`** — `_format_system_messages()` now builds the `cache_control` dict and conditionally includes `ttl` when present, falling back to existing behavior when absent. Fully backward compatible.

2. **`src/strands/types/content.py`** — `CachePoint` TypedDict updated to include `ttl: str` as an optional field, keeping the type system in sync with the runtime behavior now that `ttl` is read and forwarded.

Before:
```python
system_content[-1]["cache_control"] = {"type": "ephemeral"}
```

After:
```python
cache_control: dict[str, Any] = {"type": "ephemeral"}
if ttl := block["cachePoint"].get("ttl"):
    cache_control["ttl"] = ttl
system_content[-1]["cache_control"] = cache_control
```

## Related Issues

Addresses part of #1721

## Documentation PR

No documentation changes needed — this is a bug fix for an already-documented feature.

## Type of Change

Bug fix

## Testing

Added two unit tests to `tests/strands/models/test_litellm.py`:
- `test_format_system_messages_preserves_cache_point_ttl` — verifies `ttl="1h"` is forwarded to `cache_control`
- `test_format_system_messages_cache_point_without_ttl` — verifies no regression when `ttl` is absent

- [x] I ran `hatch run prepare` — 2613 passed, formatter clean, linter clean, mypy clean, no warnings introduced

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly *(no docs needed for this bug fix)*
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed *(no new docs needed)*
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published *(no dependencies)*

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
