### PR TITLE
chore(log): added warning for default model awareness and is subject to change

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -1123,4 +1123,10 @@ class BedrockModel(Model):
                 stacklevel=2,
             )
 
-        return _DEFAULT_BEDROCK_MODEL_ID.format(prefix_inference_map.get(prefix, prefix))
+        default_model_id = _DEFAULT_BEDROCK_MODEL_ID.format(prefix_inference_map.get(prefix, prefix))
+        warnings.warn(
+            f"You're using default model '{default_model_id}', which is subject to change. "
+            "Specify a model explicitly to pin the model target.",
+            stacklevel=2,
+        )
+        return default_model_id

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2160,25 +2160,25 @@ def test_get_default_model_with_warning_supported_regions_shows_no_warning(captu
     """Test get_model_prefix_with_warning doesn't warn for supported region prefixes."""
     BedrockModel._get_default_model_with_warning("us-west-2")
     BedrockModel._get_default_model_with_warning("eu-west-2")
-    assert len(captured_warnings) == 0
+    assert all("does not support" not in str(w.message) for w in captured_warnings)
 
 
 def test_get_default_model_for_supported_eu_region_returns_correct_model_id(captured_warnings):
     model_id = BedrockModel._get_default_model_with_warning("eu-west-1")
     assert model_id == "eu.anthropic.claude-sonnet-4-20250514-v1:0"
-    assert len(captured_warnings) == 0
+    assert all("does not support" not in str(w.message) for w in captured_warnings)
 
 
 def test_get_default_model_for_supported_us_region_returns_correct_model_id(captured_warnings):
     model_id = BedrockModel._get_default_model_with_warning("us-east-1")
     assert model_id == "us.anthropic.claude-sonnet-4-20250514-v1:0"
-    assert len(captured_warnings) == 0
+    assert all("does not support" not in str(w.message) for w in captured_warnings)
 
 
 def test_get_default_model_for_supported_gov_region_returns_correct_model_id(captured_warnings):
     model_id = BedrockModel._get_default_model_with_warning("us-gov-west-1")
     assert model_id == "us-gov.anthropic.claude-sonnet-4-20250514-v1:0"
-    assert len(captured_warnings) == 0
+    assert all("does not support" not in str(w.message) for w in captured_warnings)
 
 
 def test_get_model_prefix_for_ap_region_converts_to_apac_endpoint(captured_warnings):
@@ -2190,9 +2190,10 @@ def test_get_model_prefix_for_ap_region_converts_to_apac_endpoint(captured_warni
 def test_get_default_model_with_warning_unsupported_region_warns(captured_warnings):
     """Test _get_default_model_with_warning warns for unsupported regions."""
     BedrockModel._get_default_model_with_warning("ca-central-1")
-    assert len(captured_warnings) == 1
-    assert "This region ca-central-1 does not support" in str(captured_warnings[0].message)
-    assert "our default inference endpoint" in str(captured_warnings[0].message)
+    region_warnings = [w for w in captured_warnings if "does not support" in str(w.message)]
+    assert len(region_warnings) == 1
+    assert "This region ca-central-1 does not support" in str(region_warnings[0].message)
+    assert "our default inference endpoint" in str(region_warnings[0].message)
 
 
 def test_get_default_model_with_warning_no_warning_with_custom_model_id(captured_warnings):
@@ -2208,8 +2209,9 @@ def test_init_with_unsupported_region_warns(session_cls, captured_warnings):
     """Test BedrockModel initialization warns for unsupported regions."""
     BedrockModel(region_name="ca-central-1")
 
-    assert len(captured_warnings) == 1
-    assert "This region ca-central-1 does not support" in str(captured_warnings[0].message)
+    region_warnings = [w for w in captured_warnings if "does not support" in str(w.message)]
+    assert len(region_warnings) == 1
+    assert "This region ca-central-1 does not support" in str(region_warnings[0].message)
 
 
 def test_init_with_unsupported_region_custom_model_no_warning(session_cls, captured_warnings):
@@ -2228,7 +2230,7 @@ def test_no_override_uses_formatted_default_model_id(captured_warnings):
     model_id = BedrockModel._get_default_model_with_warning("us-east-1")
     assert model_id == "us.anthropic.claude-sonnet-4-20250514-v1:0"
     assert model_id != _DEFAULT_BEDROCK_MODEL_ID
-    assert len(captured_warnings) == 0
+    assert all("does not support" not in str(w.message) for w in captured_warnings)
 
 
 def test_custom_model_id_not_overridden_by_region_formatting(session_cls):


### PR DESCRIPTION
## Description
Inform user about what default model is used and the model is subject to change.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/2130

## Documentation PR
N/A

## Type of Change

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
