### PR TITLE
feat: add agent invoke with checkpoint and related classes

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -39,6 +39,7 @@ from ..types._snapshot import (
 )
 
 if TYPE_CHECKING:
+    from ..experimental.checkpoint.types import Checkpoint as _Checkpoint
     from ..tools import ToolProvider
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from ..hooks import (
@@ -1182,6 +1183,50 @@ class Agent(AgentBase):
             self._interrupt_state = _InterruptState.from_dict(data["interrupt_state"])
         if "system_prompt" in data:
             self.system_prompt = copy.deepcopy(data["system_prompt"])
+
+    async def invoke_with_checkpoint(
+        self,
+        prompt: str | None = None,
+        *,
+        checkpoint: "_Checkpoint | None" = None,
+    ) -> "_Checkpoint | AgentResult":
+        """Run one step of the agent loop.
+
+        ⚠️ Experimental — API may change in future releases.
+
+        Each call does exactly one unit of I/O: a model call or a single tool
+        execution. Returns a
+        :class:`~strands.experimental.checkpoint.Checkpoint` if there's more
+        work to do, or an :class:`AgentResult` if done.
+
+        This per-tool granularity ensures that on crash recovery, only the
+        incomplete tool re-executes. Completed tools are cached by the
+        durability provider.
+
+        The following invoke() features are NOT supported in checkpoint mode.
+        See :mod:`strands.experimental.checkpoint.types` for the full list of
+        known limitations.
+
+        Usage::
+
+            from strands.experimental.checkpoint import Checkpoint
+
+            result = await agent.invoke_with_checkpoint("Hello")
+            while isinstance(result, Checkpoint):
+                result = await agent.invoke_with_checkpoint(checkpoint=result)
+            # result is AgentResult
+
+        Args:
+            prompt: User prompt for the first call.
+            checkpoint: Checkpoint from a previous call to continue from.
+                Must be a :class:`~strands.experimental.checkpoint.Checkpoint` instance.
+
+        Returns:
+            :class:`~strands.experimental.checkpoint.Checkpoint` | :class:`AgentResult`
+        """
+        from ..experimental.checkpoint import invoke_with_checkpoint as _invoke
+
+        return await _invoke(self, prompt, checkpoint=checkpoint)
 
     def _redact_user_content(self, content: list[ContentBlock], redact_message: str) -> list[ContentBlock]:
         """Redact user content preserving toolResult blocks.

--- a/src/strands/experimental/__init__.py
+++ b/src/strands/experimental/__init__.py
@@ -3,7 +3,7 @@
 This module implements experimental features that are subject to change in future revisions without notice.
 """
 
-from . import steering, tools
+from . import checkpoint, steering, tools
 from .agent_config import config_to_agent
 
-__all__ = ["config_to_agent", "tools", "steering"]
+__all__ = ["checkpoint", "config_to_agent", "tools", "steering"]

--- a/src/strands/experimental/checkpoint/__init__.py
+++ b/src/strands/experimental/checkpoint/__init__.py
@@ -1,0 +1,13 @@
+"""Experimental checkpoint types for durable agent execution.
+
+This module is experimental and subject to change in future revisions without notice.
+
+Checkpoints enable crash-resilient agent execution by breaking the agent loop into
+discrete steps (one model call or one tool execution per step). Each step returns either
+a Checkpoint (keep going) or an AgentResult (done).
+"""
+
+from .invoke import invoke_with_checkpoint
+from .types import Checkpoint, CheckpointPosition
+
+__all__ = ["Checkpoint", "CheckpointPosition", "invoke_with_checkpoint"]

--- a/src/strands/experimental/checkpoint/invoke.py
+++ b/src/strands/experimental/checkpoint/invoke.py
@@ -19,6 +19,7 @@ See types.py module docstring for the full list of known limitations.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import TYPE_CHECKING
 
@@ -30,6 +31,8 @@ from ...types.content import Message
 from ...types.streaming import Metrics, StopReason, Usage
 from ...types.tools import ToolResult, ToolUse
 from .types import Checkpoint
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
@@ -73,8 +76,16 @@ async def invoke_with_checkpoint(
         Checkpoint if the loop should continue, AgentResult if done.
 
     Raises:
+        ValueError: If both prompt and checkpoint are provided, or if the
+            checkpoint has an invalid position/stop_reason combination.
         Exception: Model or infrastructure errors propagate directly.
     """
+    if prompt is not None and checkpoint is not None:
+        raise ValueError(
+            "Cannot provide both 'prompt' and 'checkpoint'. "
+            "Use 'prompt' for a fresh invocation or 'checkpoint' to resume."
+        )
+
     # Fresh invocation
     if checkpoint is None:
         agent.event_loop_metrics.reset_usage_metrics()
@@ -93,7 +104,13 @@ async def invoke_with_checkpoint(
     if checkpoint.position == "after_tools":
         return await _run_model_and_checkpoint(agent, checkpoint.cycle_index + 1)
 
-    raise ValueError(f"Unknown checkpoint position: {checkpoint.position}")
+    if checkpoint.position in ("after_model", "after_tool"):
+        raise ValueError(
+            f"Checkpoint at position={checkpoint.position!r} requires stop_reason='tool_use', "
+            f"got {checkpoint.stop_reason!r}"
+        )
+
+    raise ValueError(f"Unknown checkpoint position: {checkpoint.position!r}")
 
 
 async def _run_model_and_checkpoint(agent: Agent, cycle_index: int) -> Checkpoint | AgentResult:
@@ -214,6 +231,7 @@ async def _consume_model_stream(agent: Agent) -> tuple[StopReason, Message, Usag
         tool_specs,
         system_prompt_content=agent._system_prompt_content,
         model_state=agent._model_state,
+        invocation_state={"agent": agent},
     ):
         if "stop" in event:
             result = event["stop"]
@@ -232,6 +250,8 @@ async def _execute_single_tool(agent: Agent, tool_use: ToolUse) -> ToolResult:
     subclasses (which may yield raw dicts with toolUseId).
     """
     tool_name = tool_use.get("name", "")
+    # NOTE: ToolRegistry does not expose a public get_tool(name) method.
+    # This reaches into internals (registry + dynamic_tools dicts).
     tool_func = agent.tool_registry.registry.get(tool_name) or agent.tool_registry.dynamic_tools.get(tool_name)
 
     if tool_func is None:
@@ -265,6 +285,7 @@ async def _execute_single_tool(agent: Agent, tool_use: ToolUse) -> ToolResult:
         return result
 
     except Exception as e:
+        logger.warning("tool_name=<%s> | tool execution failed: %s", tool_name, e, exc_info=True)
         return ToolResult(
             toolUseId=tool_use["toolUseId"],
             status="error",

--- a/src/strands/experimental/checkpoint/invoke.py
+++ b/src/strands/experimental/checkpoint/invoke.py
@@ -88,6 +88,7 @@ async def invoke_with_checkpoint(
 
     # Fresh invocation
     if checkpoint is None:
+        logger.debug("starting fresh invocation")
         agent.event_loop_metrics.reset_usage_metrics()
         if prompt is not None:
             messages = await agent._convert_prompt_to_messages(prompt)
@@ -95,6 +96,12 @@ async def invoke_with_checkpoint(
         return await _run_model_and_checkpoint(agent, cycle_index=0)
 
     # Resuming — restore agent state, then dispatch on position
+    logger.debug(
+        "resuming from checkpoint position=%s cycle=%d tool_index=%d",
+        checkpoint.position,
+        checkpoint.cycle_index,
+        checkpoint.tool_index,
+    )
     if checkpoint.snapshot:
         agent.load_snapshot(Snapshot.from_dict(checkpoint.snapshot))
 
@@ -125,7 +132,9 @@ async def _run_model_and_checkpoint(agent: Agent, cycle_index: int) -> Checkpoin
         agent.event_loop_metrics.reset_usage_metrics()
 
     agent.event_loop_metrics.start_cycle(attributes={"event_loop_cycle_id": str(uuid.uuid4())})
+    logger.debug("cycle_index=%d | calling model", cycle_index)
     stop_reason, message, usage, metrics = await _consume_model_stream(agent)
+    logger.debug("cycle_index=%d | model returned stop_reason=%s", cycle_index, stop_reason)
 
     agent.event_loop_metrics.update_usage(usage)
     agent.event_loop_metrics.update_metrics(metrics)
@@ -180,12 +189,19 @@ async def _resume_tool_execution(agent: Agent, checkpoint: Checkpoint) -> Checkp
     tool_index = checkpoint.tool_index
     if tool_index >= len(tool_use_blocks):
         raise ValueError(
-            f"Checkpoint tool_index={tool_index} is out of range "
-            f"for {len(tool_use_blocks)} tool use blocks"
+            f"Checkpoint tool_index={tool_index} is out of range for {len(tool_use_blocks)} tool use blocks"
         )
     completed = list(checkpoint.completed_tool_results)
 
     tool_use = tool_use_blocks[tool_index]
+    tool_name = tool_use.get("name", "")
+    logger.debug(
+        "cycle=%d tool_index=%d/%d | executing tool=%s",
+        checkpoint.cycle_index,
+        tool_index,
+        len(tool_use_blocks),
+        tool_name,
+    )
     result = await _execute_single_tool(agent, tool_use)
     completed.append(result)
 

--- a/src/strands/experimental/checkpoint/invoke.py
+++ b/src/strands/experimental/checkpoint/invoke.py
@@ -178,6 +178,11 @@ async def _resume_tool_execution(agent: Agent, checkpoint: Checkpoint) -> Checkp
         )
 
     tool_index = checkpoint.tool_index
+    if tool_index >= len(tool_use_blocks):
+        raise ValueError(
+            f"Checkpoint tool_index={tool_index} is out of range "
+            f"for {len(tool_use_blocks)} tool use blocks"
+        )
     completed = list(checkpoint.completed_tool_results)
 
     tool_use = tool_use_blocks[tool_index]

--- a/src/strands/experimental/checkpoint/invoke.py
+++ b/src/strands/experimental/checkpoint/invoke.py
@@ -88,7 +88,7 @@ async def invoke_with_checkpoint(
 
     # Fresh invocation
     if checkpoint is None:
-        logger.debug("starting fresh invocation")
+        logger.debug("has_prompt=<%s> | starting fresh checkpoint invocation", prompt is not None)
         agent.event_loop_metrics.reset_usage_metrics()
         if prompt is not None:
             messages = await agent._convert_prompt_to_messages(prompt)
@@ -97,7 +97,7 @@ async def invoke_with_checkpoint(
 
     # Resuming — restore agent state, then dispatch on position
     logger.debug(
-        "resuming from checkpoint position=%s cycle=%d tool_index=%d",
+        "position=<%s>, cycle_index=<%s>, tool_index=<%s> | resuming from checkpoint",
         checkpoint.position,
         checkpoint.cycle_index,
         checkpoint.tool_index,
@@ -132,9 +132,9 @@ async def _run_model_and_checkpoint(agent: Agent, cycle_index: int) -> Checkpoin
         agent.event_loop_metrics.reset_usage_metrics()
 
     agent.event_loop_metrics.start_cycle(attributes={"event_loop_cycle_id": str(uuid.uuid4())})
-    logger.debug("cycle_index=%d | calling model", cycle_index)
+    logger.debug("cycle_index=<%s> | calling model", cycle_index)
     stop_reason, message, usage, metrics = await _consume_model_stream(agent)
-    logger.debug("cycle_index=%d | model returned stop_reason=%s", cycle_index, stop_reason)
+    logger.debug("cycle_index=<%s>, stop_reason=<%s> | model call completed", cycle_index, stop_reason)
 
     agent.event_loop_metrics.update_usage(usage)
     agent.event_loop_metrics.update_metrics(metrics)
@@ -196,7 +196,7 @@ async def _resume_tool_execution(agent: Agent, checkpoint: Checkpoint) -> Checkp
     tool_use = tool_use_blocks[tool_index]
     tool_name = tool_use.get("name", "")
     logger.debug(
-        "cycle=%d tool_index=%d/%d | executing tool=%s",
+        "cycle_index=<%s>, tool_index=<%s>, total_tools=<%s>, tool_name=<%s> | executing tool",
         checkpoint.cycle_index,
         tool_index,
         len(tool_use_blocks),

--- a/src/strands/experimental/checkpoint/invoke.py
+++ b/src/strands/experimental/checkpoint/invoke.py
@@ -1,0 +1,272 @@
+"""Checkpoint-based agent execution for durable workflows.
+
+⚠️ Experimental — APIs may change in future releases.
+
+Design:
+- Three checkpoint positions: after_model, after_tool, after_tools
+- Per-tool granularity: each tool executes in its own step
+- Model-driven: tool errors become tool results the model sees and decides on
+- Provider-agnostic: any durability provider can wrap invoke_with_checkpoint
+- Returns Checkpoint (keep going) or AgentResult (done) — no wrapper type
+
+V1 simplifications (documented for future extension):
+- _consume_model_stream: bypasses hooks and ModelRetryStrategy.
+- _execute_single_tool: bypasses tool executor, hooks, tracing, and interrupts.
+- No max_cycles guard — the caller/orchestrator is responsible for stopping.
+
+See types.py module docstring for the full list of known limitations.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from ...agent.agent_result import AgentResult
+from ...event_loop.streaming import stream_messages
+from ...types._events import ToolResultEvent
+from ...types._snapshot import Snapshot
+from ...types.content import Message
+from ...types.streaming import Metrics, StopReason, Usage
+from ...types.tools import ToolResult, ToolUse
+from .types import Checkpoint
+
+if TYPE_CHECKING:
+    from ...agent.agent import Agent
+
+
+async def invoke_with_checkpoint(
+    agent: Agent,
+    prompt: str | None = None,
+    *,
+    checkpoint: Checkpoint | None = None,
+) -> Checkpoint | AgentResult:
+    """Run one step of the agent loop.
+
+    Returns a Checkpoint if there's more work to do, or an AgentResult if done.
+
+    Each call does exactly one unit of I/O:
+    - A model call, OR
+    - A single tool execution
+
+    This per-tool granularity ensures that on crash recovery, only the
+    incomplete tool re-executes. Completed tools are cached by the
+    durability provider (e.g. Temporal Activity results in Event History).
+
+    Model and tool errors propagate as exceptions; the caller maps them
+    to their orchestrator's retry policy.
+
+    Usage::
+
+        result = await invoke_with_checkpoint(agent, "Hello")
+        while isinstance(result, Checkpoint):
+            result = await invoke_with_checkpoint(agent, checkpoint=result)
+        # result is AgentResult
+        print(result)
+
+    Args:
+        agent: The agent to execute.
+        prompt: User prompt for the first call.
+        checkpoint: Checkpoint from a previous call to continue from.
+
+    Returns:
+        Checkpoint if the loop should continue, AgentResult if done.
+
+    Raises:
+        Exception: Model or infrastructure errors propagate directly.
+    """
+    # Fresh invocation
+    if checkpoint is None:
+        agent.event_loop_metrics.reset_usage_metrics()
+        if prompt is not None:
+            messages = await agent._convert_prompt_to_messages(prompt)
+            await agent._append_messages(*messages)
+        return await _run_model_and_checkpoint(agent, cycle_index=0)
+
+    # Resuming — restore agent state, then dispatch on position
+    if checkpoint.snapshot:
+        agent.load_snapshot(Snapshot.from_dict(checkpoint.snapshot))
+
+    if checkpoint.position in ("after_model", "after_tool") and checkpoint.stop_reason == "tool_use":
+        return await _resume_tool_execution(agent, checkpoint)
+
+    if checkpoint.position == "after_tools":
+        return await _run_model_and_checkpoint(agent, checkpoint.cycle_index + 1)
+
+    raise ValueError(f"Unknown checkpoint position: {checkpoint.position}")
+
+
+async def _run_model_and_checkpoint(agent: Agent, cycle_index: int) -> Checkpoint | AgentResult:
+    """Run a model call and return a Checkpoint or AgentResult.
+
+    V1: Calls model directly via stream_messages. Does not fire
+    BeforeModelCallEvent/AfterModelCallEvent or use ModelRetryStrategy.
+    """
+    # On crash recovery, a fresh agent may have empty agent_invocations.
+    # start_cycle requires at least one invocation entry.
+    if not agent.event_loop_metrics.agent_invocations:
+        agent.event_loop_metrics.reset_usage_metrics()
+
+    agent.event_loop_metrics.start_cycle(attributes={"event_loop_cycle_id": str(uuid.uuid4())})
+    stop_reason, message, usage, metrics = await _consume_model_stream(agent)
+
+    agent.event_loop_metrics.update_usage(usage)
+    agent.event_loop_metrics.update_metrics(metrics)
+
+    await agent._append_messages(message)
+
+    if stop_reason == "tool_use":
+        return Checkpoint(
+            position="after_model",
+            stop_reason=stop_reason,
+            cycle_index=cycle_index,
+            tool_index=0,
+            completed_tool_results=[],
+            snapshot=agent.take_snapshot(preset="session").to_dict(),
+        )
+
+    return AgentResult(
+        stop_reason=stop_reason,
+        message=message,
+        metrics=agent.event_loop_metrics,
+        state={},
+    )
+
+
+async def _resume_tool_execution(agent: Agent, checkpoint: Checkpoint) -> Checkpoint:
+    """Execute ONE tool and return a checkpoint.
+
+    If more tools remain, returns after_tool checkpoint.
+    If this was the last tool, appends the combined tool result message
+    and returns after_tools checkpoint.
+
+    The model message is already in agent.messages (restored from snapshot).
+    Tool use blocks are extracted from the last assistant message.
+
+    V1: Executes tool via tool_func.stream() directly. Does not use the
+    agent's tool_executor, fire before/after tool hooks, create tracing
+    spans, or handle interrupts.
+    Tool errors are captured as tool results with status="error" — the model
+    will see them on the next cycle and decide what to do.
+    """
+    model_message = agent.messages[-1]
+    tool_use_blocks: list[ToolUse] = [
+        content["toolUse"] for content in model_message.get("content", []) if "toolUse" in content
+    ]
+
+    if not tool_use_blocks:
+        raise RuntimeError(
+            f"Checkpoint at position={checkpoint.position} has stop_reason='tool_use' "
+            f"but no toolUse blocks in the model message"
+        )
+
+    tool_index = checkpoint.tool_index
+    completed = list(checkpoint.completed_tool_results)
+
+    tool_use = tool_use_blocks[tool_index]
+    result = await _execute_single_tool(agent, tool_use)
+    completed.append(result)
+
+    next_index = tool_index + 1
+
+    if next_index < len(tool_use_blocks):
+        # More tools remaining — checkpoint between them
+        return Checkpoint(
+            position="after_tool",
+            stop_reason=checkpoint.stop_reason,
+            cycle_index=checkpoint.cycle_index,
+            tool_index=next_index,
+            completed_tool_results=completed,
+            snapshot=agent.take_snapshot(preset="session").to_dict(),
+        )
+
+    # Last tool — build combined tool result message, append, return after_tools
+    # The API contract requires one user message with all toolResult blocks together.
+    tool_result_message: Message = {
+        "role": "user",
+        "content": [{"toolResult": r} for r in completed],
+    }
+    await agent._append_messages(tool_result_message)
+
+    return Checkpoint(
+        position="after_tools",
+        stop_reason=checkpoint.stop_reason,
+        cycle_index=checkpoint.cycle_index,
+        snapshot=agent.take_snapshot(preset="session").to_dict(),
+    )
+
+
+# ── Internal helpers (V1 simplified implementations) ──
+
+
+async def _consume_model_stream(agent: Agent) -> tuple[StopReason, Message, Usage, Metrics]:
+    """Call model, drain stream, return (stop_reason, message, usage, metrics).
+
+    V1: Direct call to stream_messages. No hooks, no retry strategy.
+    """
+    tool_specs = agent.tool_registry.get_all_tool_specs()
+    result: tuple[StopReason, Message, Usage, Metrics] | None = None
+
+    async for event in stream_messages(
+        agent.model,
+        agent.system_prompt,
+        agent.messages,
+        tool_specs,
+        system_prompt_content=agent._system_prompt_content,
+        model_state=agent._model_state,
+    ):
+        if "stop" in event:
+            result = event["stop"]
+            break
+
+    if result is None:
+        raise RuntimeError("Model stream ended without a stop event")
+
+    return result
+
+
+async def _execute_single_tool(agent: Agent, tool_use: ToolUse) -> ToolResult:
+    """Execute one tool. Errors are captured as error results, not raised.
+
+    Handles both SDK tools (which yield ToolResultEvent) and custom AgentTool
+    subclasses (which may yield raw dicts with toolUseId).
+    """
+    tool_name = tool_use.get("name", "")
+    tool_func = agent.tool_registry.registry.get(tool_name) or agent.tool_registry.dynamic_tools.get(tool_name)
+
+    if tool_func is None:
+        return ToolResult(
+            toolUseId=tool_use["toolUseId"],
+            status="error",
+            content=[{"text": f"Tool not found: {tool_name}"}],
+        )
+
+    try:
+        result: ToolResult | None = None
+        async for event in tool_func.stream(tool_use, {"agent": agent}):
+            if isinstance(event, ToolResultEvent):
+                result = event.tool_result
+                break
+            # Fallback for custom AgentTool subclasses that yield raw dicts
+            if isinstance(event, dict) and "toolUseId" in event:
+                result = ToolResult(
+                    toolUseId=event["toolUseId"],
+                    status=event.get("status", "success"),
+                    content=event.get("content", []),
+                )
+                break
+
+        if result is None:
+            return ToolResult(
+                toolUseId=tool_use["toolUseId"],
+                status="error",
+                content=[{"text": f"Tool {tool_name} did not return a result"}],
+            )
+        return result
+
+    except Exception as e:
+        return ToolResult(
+            toolUseId=tool_use["toolUseId"],
+            status="error",
+            content=[{"text": f"Tool error: {e}"}],
+        )

--- a/src/strands/experimental/checkpoint/types.py
+++ b/src/strands/experimental/checkpoint/types.py
@@ -21,6 +21,7 @@ Known limitations (V1):
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -62,7 +63,7 @@ class Checkpoint:
 
     position: CheckpointPosition
     stop_reason: StopReason
-    schema_version: str = CHECKPOINT_SCHEMA_VERSION
+    schema_version: str = field(init=False, default=CHECKPOINT_SCHEMA_VERSION)
     cycle_index: int = 0
     tool_index: int = 0
     completed_tool_results: list[ToolResult] = field(default_factory=list)
@@ -71,16 +72,7 @@ class Checkpoint:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize for persistence (e.g. Temporal Event History)."""
-        return {
-            "schema_version": self.schema_version,
-            "position": self.position,
-            "stop_reason": self.stop_reason,
-            "cycle_index": self.cycle_index,
-            "tool_index": self.tool_index,
-            "completed_tool_results": self.completed_tool_results,
-            "snapshot": self.snapshot,
-            "app_data": self.app_data,
-        }
+        return dataclasses.asdict(self)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> Checkpoint:
@@ -96,4 +88,4 @@ class Checkpoint:
                 f"Current version: {CHECKPOINT_SCHEMA_VERSION}. "
                 f"Checkpoints from a different SDK version cannot be resumed."
             )
-        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__ and k != "schema_version"})

--- a/src/strands/experimental/checkpoint/types.py
+++ b/src/strands/experimental/checkpoint/types.py
@@ -13,7 +13,8 @@ Known limitations (V1):
 5. Streaming: Token-by-token events are not re-emitted on replay.
    Use callback_handler=None for durable agents.
 6. MCP: Remote servers (HTTP/SSE) work. Stdio servers do not survive worker crashes.
-7. invocation_state is not supported in checkpoint mode.
+7. invocation_state: User-provided invocation_state (request_state, custom data) is not
+   carried through in checkpoint mode. Only {"agent": agent} is passed internally.
 8. Stateful models: OpenAIResponsesModel(stateful=True) is not supported.
    The server-side response_id is not preserved across checkpoints.
    Use stateful=False or OpenAIModel (Chat Completions) for durable execution.

--- a/src/strands/experimental/checkpoint/types.py
+++ b/src/strands/experimental/checkpoint/types.py
@@ -1,0 +1,99 @@
+"""Checkpoint types for durable agent execution.
+
+⚠️ Experimental — APIs may change in future releases.
+
+Known limitations (V1):
+
+1. Hooks: BeforeInvocationEvent/AfterInvocationEvent, BeforeModelCallEvent/AfterModelCallEvent,
+   and BeforeToolCallEvent/AfterToolCallEvent are not fired. No tracing spans.
+2. Model retry: ModelRetryStrategy is bypassed; the orchestrator handles retries.
+3. Structured output: structured_output_model / structured_output_prompt not supported.
+4. Conversation management: apply_management / reduce_context do not run between
+   checkpoint steps. The caller manages conversation after the final result.
+5. Streaming: Token-by-token events are not re-emitted on replay.
+   Use callback_handler=None for durable agents.
+6. MCP: Remote servers (HTTP/SSE) work. Stdio servers do not survive worker crashes.
+7. invocation_state is not supported in checkpoint mode.
+8. Stateful models: OpenAIResponsesModel(stateful=True) is not supported.
+   The server-side response_id is not preserved across checkpoints.
+   Use stateful=False or OpenAIModel (Chat Completions) for durable execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from ...types.streaming import StopReason
+from ...types.tools import ToolResult
+
+CHECKPOINT_SCHEMA_VERSION = "1.0"
+
+CheckpointPosition = Literal["after_model", "after_tool", "after_tools"]
+
+
+@dataclass
+class Checkpoint:
+    """Pause point in the agent loop. Treat as opaque — pass back to resume.
+
+    Three positions:
+    - after_model: model call completed, no tools executed yet.
+    - after_tool: one tool executed, more tools remaining.
+    - after_tools: all tools executed, next model call not yet started.
+
+    Attributes:
+        schema_version: Version of the checkpoint schema. Used to detect
+            incompatible checkpoints across SDK upgrades. The SDK will reject
+            checkpoints with a different schema_version.
+        position: Where in the loop this checkpoint was taken.
+        stop_reason: Why the model stopped (e.g. "tool_use", "end_turn").
+        cycle_index: Which model→tools cycle this checkpoint is in (0-based).
+        tool_index: Index of the next tool to execute (0-based). Only meaningful
+            at after_model and after_tool positions.
+        completed_tool_results: Tool results accumulated so far in this cycle.
+            Carried across after_tool checkpoints. Appended to messages when
+            the last tool finishes.
+        snapshot: Agent state snapshot for restoration. Contains messages,
+            state, conversation_manager_state, and interrupt_state.
+        app_data: Provider-owned arbitrary data. The SDK does not read or modify this.
+            Durability providers can use this to store provider-specific metadata
+            (e.g. Temporal workflow IDs, Lambda step tokens, retry counts).
+    """
+
+    position: CheckpointPosition
+    stop_reason: StopReason
+    schema_version: str = CHECKPOINT_SCHEMA_VERSION
+    cycle_index: int = 0
+    tool_index: int = 0
+    completed_tool_results: list[ToolResult] = field(default_factory=list)
+    snapshot: dict[str, Any] = field(default_factory=dict)
+    app_data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for persistence (e.g. Temporal Event History)."""
+        return {
+            "schema_version": self.schema_version,
+            "position": self.position,
+            "stop_reason": self.stop_reason,
+            "cycle_index": self.cycle_index,
+            "tool_index": self.tool_index,
+            "completed_tool_results": self.completed_tool_results,
+            "snapshot": self.snapshot,
+            "app_data": self.app_data,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Checkpoint:
+        """Reconstruct from a dict produced by to_dict().
+
+        Raises:
+            ValueError: If schema_version doesn't match the current version.
+        """
+        version = d.get("schema_version", "")
+        if version != CHECKPOINT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Incompatible checkpoint schema version: {version!r}. "
+                f"Current version: {CHECKPOINT_SCHEMA_VERSION}. "
+                f"Checkpoints from a different SDK version cannot be resumed."
+            )
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})

--- a/tests/strands/experimental/checkpoint/test_checkpoint.py
+++ b/tests/strands/experimental/checkpoint/test_checkpoint.py
@@ -416,7 +416,7 @@ class TestAgentMethod:
 
 class TestEdgeCases:
     @pytest.mark.asyncio
-    async def test_tool_index_out_of_range_raises(self):
+    async def test_tool_index_out_of_range_raises(self, echo_tool):
         """Corrupted checkpoint with tool_index >= number of tool blocks."""
         agent = Agent(
             model=MockedModelProvider([_tool_use("echo"), _end_turn("x")]),

--- a/tests/strands/experimental/checkpoint/test_checkpoint.py
+++ b/tests/strands/experimental/checkpoint/test_checkpoint.py
@@ -1,11 +1,4 @@
-"""Tests for experimental checkpoint-based agent execution.
-
-Design:
-- Three checkpoint positions: after_model, after_tool, after_tools
-- Per-tool granularity: each tool executes in its own step
-- Model-driven: tool errors are tool results the model sees
-- Returns Checkpoint (keep going) or AgentResult (done)
-"""
+"""Tests for experimental checkpoint-based agent execution."""
 
 import json
 
@@ -43,40 +36,12 @@ def echo_tool():
     return echo
 
 
-# ── Serialization ──
-
-
 class TestCheckpointSerialization:
     def test_round_trip(self):
-        cp = Checkpoint(position="after_model", stop_reason="tool_use", cycle_index=1)
-        restored = Checkpoint.from_dict(cp.to_dict())
+        cp = Checkpoint(position="after_model", stop_reason="tool_use", cycle_index=1, app_data={"wf_id": "123"})
+        restored = Checkpoint.from_dict(json.loads(json.dumps(cp.to_dict())))
         assert restored.cycle_index == 1
         assert restored.schema_version == CHECKPOINT_SCHEMA_VERSION
-
-    def test_json_round_trip(self):
-        cp = Checkpoint(
-            position="after_tool",
-            stop_reason="tool_use",
-            tool_index=2,
-            completed_tool_results=[{"toolUseId": "t1", "status": "success", "content": []}],
-        )
-        restored = Checkpoint.from_dict(json.loads(json.dumps(cp.to_dict())))
-        assert restored.position == "after_tool"
-        assert restored.tool_index == 2
-        assert len(restored.completed_tool_results) == 1
-
-    def test_ignores_unknown_fields(self):
-        d = {
-            "schema_version": CHECKPOINT_SCHEMA_VERSION,
-            "position": "after_model",
-            "stop_reason": "tool_use",
-            "extra": 1,
-        }
-        assert Checkpoint.from_dict(d).position == "after_model"
-
-    def test_app_data_round_trip(self):
-        cp = Checkpoint(position="after_model", stop_reason="tool_use", app_data={"wf_id": "123"})
-        restored = Checkpoint.from_dict(json.loads(json.dumps(cp.to_dict())))
         assert restored.app_data["wf_id"] == "123"
 
     def test_schema_version_mismatch_raises(self):
@@ -84,44 +49,17 @@ class TestCheckpointSerialization:
         with pytest.raises(ValueError, match="Incompatible checkpoint schema version"):
             Checkpoint.from_dict(d)
 
-    def test_schema_version_missing_raises(self):
-        d = {"position": "after_model", "stop_reason": "tool_use"}
-        with pytest.raises(ValueError, match="Incompatible checkpoint schema version"):
-            Checkpoint.from_dict(d)
 
-
-# ── No tools ──
-
-
-class TestNoTools:
+class TestBasicFlow:
     @pytest.mark.asyncio
-    async def test_completes_immediately(self):
+    async def test_no_tools_completes_immediately(self):
         agent = Agent(model=MockedModelProvider([_end_turn("Hello")]), callback_handler=None)
         r = await invoke_with_checkpoint(agent, "Hi")
         assert isinstance(r, AgentResult)
-
-    @pytest.mark.asyncio
-    async def test_messages_appended(self):
-        agent = Agent(model=MockedModelProvider([_end_turn("Hello")]), callback_handler=None)
-        await invoke_with_checkpoint(agent, "Hi")
         assert len(agent.messages) == 2
 
     @pytest.mark.asyncio
-    async def test_no_prompt_uses_existing_messages(self):
-        agent = Agent(
-            model=MockedModelProvider([_end_turn("Response")]),
-            messages=[{"role": "user", "content": [{"text": "existing"}]}],
-            callback_handler=None,
-        )
-        assert isinstance(await invoke_with_checkpoint(agent), AgentResult)
-
-
-# ── Single tool: model → tool → model → done (3 steps) ──
-
-
-class TestSingleTool:
-    @pytest.mark.asyncio
-    async def test_three_steps(self, echo_tool):
+    async def test_single_tool_three_steps(self, echo_tool):
         agent = Agent(
             model=MockedModelProvider([_tool_use("echo"), _end_turn("Done")]),
             tools=[echo_tool],
@@ -131,82 +69,41 @@ class TestSingleTool:
         r = await invoke_with_checkpoint(agent, "Go")
         assert isinstance(r, Checkpoint) and r.position == "after_model"
 
-        # Single tool → goes directly to after_tools (no after_tool for last tool)
         r = await invoke_with_checkpoint(agent, checkpoint=r)
         assert isinstance(r, Checkpoint) and r.position == "after_tools"
 
         r = await invoke_with_checkpoint(agent, checkpoint=r)
         assert isinstance(r, AgentResult)
-        assert len(agent.messages) == 4
 
-
-# ── Per-tool granularity: 5 tools = 5 separate steps ──
-
-
-class TestPerToolGranularity:
     @pytest.mark.asyncio
-    async def test_five_tools_five_steps(self, echo_tool):
+    async def test_per_tool_granularity(self, echo_tool):
+        """3 tools = 3 separate tool steps."""
         agent = Agent(
-            model=MockedModelProvider(
-                [
-                    _tool_use("echo", "echo", "echo", "echo", "echo"),
-                    _end_turn("All done"),
-                ]
-            ),
+            model=MockedModelProvider([_tool_use("echo", "echo", "echo"), _end_turn("Done")]),
             tools=[echo_tool],
             callback_handler=None,
         )
 
-        # Model call
         r = await invoke_with_checkpoint(agent, "Go")
-        assert isinstance(r, Checkpoint) and r.position == "after_model"
-        assert r.tool_index == 0
+        assert r.position == "after_model" and r.tool_index == 0
 
-        # Tool 1 → after_tool (more tools remaining)
         r = await invoke_with_checkpoint(agent, checkpoint=r)
-        assert isinstance(r, Checkpoint) and r.position == "after_tool"
-        assert r.tool_index == 1
-        assert len(r.completed_tool_results) == 1
+        assert r.position == "after_tool" and r.tool_index == 1
 
-        # Tool 2
         r = await invoke_with_checkpoint(agent, checkpoint=r)
         assert r.position == "after_tool" and r.tool_index == 2
 
-        # Tool 3
         r = await invoke_with_checkpoint(agent, checkpoint=r)
-        assert r.position == "after_tool" and r.tool_index == 3
+        assert r.position == "after_tools"
+        assert len(agent.messages[-1]["content"]) == 3
 
-        # Tool 4
-        r = await invoke_with_checkpoint(agent, checkpoint=r)
-        assert r.position == "after_tool" and r.tool_index == 4
-        assert len(r.completed_tool_results) == 4
-
-        # Tool 5 (last) → after_tools
-        r = await invoke_with_checkpoint(agent, checkpoint=r)
-        assert isinstance(r, Checkpoint) and r.position == "after_tools"
-
-        # 5 tool results in the message
-        assert len(agent.messages[-1]["content"]) == 5
-
-        # Final model call
         r = await invoke_with_checkpoint(agent, checkpoint=r)
         assert isinstance(r, AgentResult)
 
-
-# ── Multi-cycle ──
-
-
-class TestMultiCycle:
     @pytest.mark.asyncio
     async def test_two_cycles(self, echo_tool):
         agent = Agent(
-            model=MockedModelProvider(
-                [
-                    _tool_use("echo"),
-                    _tool_use("echo"),
-                    _end_turn("Final"),
-                ]
-            ),
+            model=MockedModelProvider([_tool_use("echo"), _tool_use("echo"), _end_turn("Final")]),
             tools=[echo_tool],
             callback_handler=None,
         )
@@ -222,31 +119,20 @@ class TestMultiCycle:
 
         assert isinstance(r, AgentResult)
 
-
-# ── Crash recovery ──
-
-
-class TestCrashRecovery:
     @pytest.mark.asyncio
-    async def test_recover_after_model(self, echo_tool):
-        agent1 = Agent(
+    async def test_agent_method(self, echo_tool):
+        agent = Agent(
             model=MockedModelProvider([_tool_use("echo"), _end_turn("Done")]),
             tools=[echo_tool],
             callback_handler=None,
         )
-        r = await invoke_with_checkpoint(agent1, "Go")
-        saved = json.dumps(r.to_dict())
-
-        agent2 = Agent(
-            model=MockedModelProvider([_end_turn("Recovered")]),
-            tools=[echo_tool],
-            callback_handler=None,
-        )
-        r = await invoke_with_checkpoint(agent2, checkpoint=Checkpoint.from_dict(json.loads(saved)))
-        assert isinstance(r, Checkpoint) and r.position == "after_tools"
-        r = await invoke_with_checkpoint(agent2, checkpoint=r)
+        r = await agent.invoke_with_checkpoint("Go")
+        while isinstance(r, Checkpoint):
+            r = await agent.invoke_with_checkpoint(checkpoint=r)
         assert isinstance(r, AgentResult)
 
+
+class TestCrashRecovery:
     @pytest.mark.asyncio
     async def test_crash_between_tools_only_reruns_remaining(self):
         """3 tools. Crash after tool 2. Only tool 3 re-runs."""
@@ -261,12 +147,7 @@ class TestCrashRecovery:
             return f"done: {label}"
 
         agent1 = Agent(
-            model=MockedModelProvider(
-                [
-                    _tool_use("tracked", "tracked", "tracked"),
-                    _end_turn("Done"),
-                ]
-            ),
+            model=MockedModelProvider([_tool_use("tracked", "tracked", "tracked"), _end_turn("Done")]),
             tools=[tracked],
             callback_handler=None,
         )
@@ -274,8 +155,7 @@ class TestCrashRecovery:
         r = await invoke_with_checkpoint(agent1, "Go")
         r = await invoke_with_checkpoint(agent1, checkpoint=r)  # tool 1
         r = await invoke_with_checkpoint(agent1, checkpoint=r)  # tool 2
-        assert r.position == "after_tool" and r.tool_index == 2
-        assert len(r.completed_tool_results) == 2
+        assert r.tool_index == 2 and len(r.completed_tool_results) == 2
 
         # "Crash" — serialize, new agent
         saved = json.dumps(r.to_dict())
@@ -286,21 +166,16 @@ class TestCrashRecovery:
             tools=[tracked],
             callback_handler=None,
         )
-        cp = Checkpoint.from_dict(json.loads(saved))
 
-        # Only tool 3 runs
-        r = await invoke_with_checkpoint(agent2, checkpoint=cp)
-        assert isinstance(r, Checkpoint) and r.position == "after_tools"
+        r = await invoke_with_checkpoint(agent2, checkpoint=Checkpoint.from_dict(json.loads(saved)))
+        assert r.position == "after_tools"
         assert len(log) == 1  # only tool 3 executed
 
         r = await invoke_with_checkpoint(agent2, checkpoint=r)
         assert isinstance(r, AgentResult)
 
 
-# ── Model-driven tool errors ──
-
-
-class TestModelDrivenToolErrors:
+class TestToolErrors:
     @pytest.mark.asyncio
     async def test_tool_error_sent_to_model(self):
         from strands import tool
@@ -317,101 +192,24 @@ class TestModelDrivenToolErrors:
         )
 
         r = await invoke_with_checkpoint(agent, "Go")
-        r = await invoke_with_checkpoint(agent, checkpoint=r)  # tool fails → after_tools
-        assert isinstance(r, Checkpoint) and r.position == "after_tools"
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert r.position == "after_tools"
         assert agent.messages[-1]["content"][0]["toolResult"]["status"] == "error"
 
         r = await invoke_with_checkpoint(agent, checkpoint=r)
         assert isinstance(r, AgentResult)
 
     @pytest.mark.asyncio
-    async def test_five_tools_third_fails_model_retries(self):
-        from strands import tool
-
-        log = []
-        deploy_n = {"n": 0}
-
-        @tool
-        def fetch() -> str:
-            """Fetch."""
-            log.append("fetch")
-            return "ok"
-
-        @tool
-        def validate() -> str:
-            """Validate."""
-            log.append("validate")
-            return "ok"
-
-        @tool
-        def deploy() -> str:
-            """Deploy."""
-            log.append("deploy")
-            deploy_n["n"] += 1
-            if deploy_n["n"] == 1:
-                raise RuntimeError("timeout")
-            return "deployed"
-
-        @tool
-        def notify() -> str:
-            """Notify."""
-            log.append("notify")
-            return "ok"
-
-        @tool
-        def cleanup() -> str:
-            """Cleanup."""
-            log.append("cleanup")
-            return "ok"
-
+    async def test_unknown_tool_error_sent_to_model(self):
         agent = Agent(
-            model=MockedModelProvider(
-                [
-                    _tool_use("fetch", "validate", "deploy", "notify", "cleanup"),
-                    _tool_use("deploy"),
-                    _end_turn("Pipeline complete."),
-                ]
-            ),
-            tools=[fetch, validate, deploy, notify, cleanup],
+            model=MockedModelProvider([_tool_use("nonexistent"), _end_turn("Not found.")]),
             callback_handler=None,
         )
-
-        # Cycle 1: model → 5 tools (per-tool) → model sees deploy error
-        r = await invoke_with_checkpoint(agent, "Run pipeline")
-        for _ in range(5):
-            r = await invoke_with_checkpoint(agent, checkpoint=r)
-        assert isinstance(r, Checkpoint) and r.position == "after_tools"
-        assert log == ["fetch", "validate", "deploy", "notify", "cleanup"]
-
-        r = await invoke_with_checkpoint(agent, checkpoint=r)  # model sees results
-        assert isinstance(r, Checkpoint) and r.position == "after_model"
-
-        # Cycle 2: model retries just deploy
-        r = await invoke_with_checkpoint(agent, checkpoint=r)  # deploy succeeds
-        assert isinstance(r, Checkpoint) and r.position == "after_tools"
-        r = await invoke_with_checkpoint(agent, checkpoint=r)  # model done
+        r = await invoke_with_checkpoint(agent, "Go")
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert agent.messages[-1]["content"][0]["toolResult"]["status"] == "error"
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
         assert isinstance(r, AgentResult)
-        assert deploy_n["n"] == 2
-
-
-# ── Agent method ──
-
-
-class TestAgentMethod:
-    @pytest.mark.asyncio
-    async def test_method_style(self, echo_tool):
-        agent = Agent(
-            model=MockedModelProvider([_tool_use("echo"), _end_turn("Done")]),
-            tools=[echo_tool],
-            callback_handler=None,
-        )
-        r = await agent.invoke_with_checkpoint("Go")
-        while isinstance(r, Checkpoint):
-            r = await agent.invoke_with_checkpoint(checkpoint=r)
-        assert isinstance(r, AgentResult)
-
-
-# ── Edge cases ──
 
 
 class TestEdgeCases:
@@ -423,13 +221,18 @@ class TestEdgeCases:
             tools=[echo_tool],
             callback_handler=None,
         )
-        # Get a valid after_model checkpoint
         r = await invoke_with_checkpoint(agent, "Go")
         assert isinstance(r, Checkpoint)
-        # Tamper with tool_index
         r.tool_index = 99
         with pytest.raises(ValueError, match="tool_index=99 is out of range"):
             await invoke_with_checkpoint(agent, checkpoint=r)
+
+    @pytest.mark.asyncio
+    async def test_prompt_and_checkpoint_raises(self):
+        cp = Checkpoint(position="after_tools", stop_reason="tool_use")
+        agent = Agent(model=MockedModelProvider([_end_turn("x")]), callback_handler=None)
+        with pytest.raises(ValueError, match="Cannot provide both"):
+            await invoke_with_checkpoint(agent, "Hello", checkpoint=cp)
 
     @pytest.mark.asyncio
     async def test_invalid_position_raises(self):
@@ -439,16 +242,7 @@ class TestEdgeCases:
             await invoke_with_checkpoint(agent, checkpoint=cp)
 
     @pytest.mark.asyncio
-    async def test_prompt_and_checkpoint_raises(self):
-        """Cannot provide both prompt and checkpoint."""
-        cp = Checkpoint(position="after_tools", stop_reason="tool_use")
-        agent = Agent(model=MockedModelProvider([_end_turn("x")]), callback_handler=None)
-        with pytest.raises(ValueError, match="Cannot provide both"):
-            await invoke_with_checkpoint(agent, "Hello", checkpoint=cp)
-
-    @pytest.mark.asyncio
     async def test_valid_position_wrong_stop_reason_raises(self):
-        """after_model with stop_reason != 'tool_use' raises specific error."""
         cp = Checkpoint(
             position="after_model",
             stop_reason="end_turn",
@@ -463,81 +257,3 @@ class TestEdgeCases:
         agent = Agent(model=MockedModelProvider([_end_turn("x")]), callback_handler=None)
         with pytest.raises(ValueError, match="requires stop_reason='tool_use'"):
             await invoke_with_checkpoint(agent, checkpoint=cp)
-
-    @pytest.mark.asyncio
-    async def test_unknown_tool_error_sent_to_model(self):
-        agent = Agent(
-            model=MockedModelProvider([_tool_use("nonexistent"), _end_turn("Not found.")]),
-            callback_handler=None,
-        )
-        r = await invoke_with_checkpoint(agent, "Go")
-        r = await invoke_with_checkpoint(agent, checkpoint=r)
-        assert agent.messages[-1]["content"][0]["toolResult"]["status"] == "error"
-        r = await invoke_with_checkpoint(agent, checkpoint=r)
-        assert isinstance(r, AgentResult)
-
-    @pytest.mark.asyncio
-    async def test_tool_returning_no_result(self):
-        """A tool whose stream yields nothing gets an error result."""
-        from unittest.mock import AsyncMock, PropertyMock
-
-        from strands.types.tools import AgentTool
-
-        mock_tool = AsyncMock(spec=AgentTool)
-        type(mock_tool).tool_name = PropertyMock(return_value="empty")
-        type(mock_tool).tool_spec = PropertyMock(
-            return_value={
-                "name": "empty",
-                "description": "Does nothing",
-                "inputSchema": {"json": {"type": "object", "properties": {}}},
-            }
-        )
-        type(mock_tool).tool_type = PropertyMock(return_value="tool")
-
-        async def empty_stream(tool_use, invocation_state):
-            return
-            yield  # noqa: unreachable — makes this an async generator
-
-        mock_tool.stream = empty_stream
-
-        agent = Agent(
-            model=MockedModelProvider([_tool_use("empty"), _end_turn("Ok")]),
-            tools=[mock_tool],
-            callback_handler=None,
-        )
-        r = await invoke_with_checkpoint(agent, "Go")
-        r = await invoke_with_checkpoint(agent, checkpoint=r)
-        assert agent.messages[-1]["content"][0]["toolResult"]["status"] == "error"
-        assert "did not return a result" in agent.messages[-1]["content"][0]["toolResult"]["content"][0]["text"]
-
-    @pytest.mark.asyncio
-    async def test_tool_receives_agent_in_invocation_state(self):
-        """Tools executed in checkpoint mode receive invocation_state['agent']."""
-        from strands import tool
-
-        captured = {}
-
-        @tool
-        def spy() -> str:
-            """Spy tool."""
-            return "ok"
-
-        # Patch the tool's stream to capture invocation_state
-        original_stream = spy.stream
-
-        async def capturing_stream(tool_use, invocation_state):
-            captured["invocation_state"] = invocation_state
-            async for event in original_stream(tool_use, invocation_state):
-                yield event
-
-        spy.stream = capturing_stream
-
-        agent = Agent(
-            model=MockedModelProvider([_tool_use("spy"), _end_turn("Done")]),
-            tools=[spy],
-            callback_handler=None,
-        )
-        r = await invoke_with_checkpoint(agent, "Go")
-        r = await invoke_with_checkpoint(agent, checkpoint=r)
-        assert "agent" in captured["invocation_state"]
-        assert captured["invocation_state"]["agent"] is agent

--- a/tests/strands/experimental/checkpoint/test_checkpoint.py
+++ b/tests/strands/experimental/checkpoint/test_checkpoint.py
@@ -423,21 +423,29 @@ class TestEdgeCases:
             await invoke_with_checkpoint(agent, checkpoint=cp)
 
     @pytest.mark.asyncio
+    async def test_prompt_and_checkpoint_raises(self):
+        """Cannot provide both prompt and checkpoint."""
+        cp = Checkpoint(position="after_tools", stop_reason="tool_use")
+        agent = Agent(model=MockedModelProvider([_end_turn("x")]), callback_handler=None)
+        with pytest.raises(ValueError, match="Cannot provide both"):
+            await invoke_with_checkpoint(agent, "Hello", checkpoint=cp)
+
+    @pytest.mark.asyncio
     async def test_valid_position_wrong_stop_reason_raises(self):
-        """after_model with stop_reason != 'tool_use' falls through to ValueError."""
+        """after_model with stop_reason != 'tool_use' raises specific error."""
         cp = Checkpoint(
             position="after_model",
             stop_reason="end_turn",
             snapshot={
                 "scope": "agent",
-                "schema_version": "1.0",
+                "schema_version": CHECKPOINT_SCHEMA_VERSION,
                 "created_at": "2025-01-01T00:00:00Z",
                 "data": {"messages": [{"role": "user", "content": [{"text": "hi"}]}]},
                 "app_data": {},
             },
         )
         agent = Agent(model=MockedModelProvider([_end_turn("x")]), callback_handler=None)
-        with pytest.raises(ValueError, match="Unknown checkpoint position"):
+        with pytest.raises(ValueError, match="requires stop_reason='tool_use'"):
             await invoke_with_checkpoint(agent, checkpoint=cp)
 
     @pytest.mark.asyncio

--- a/tests/strands/experimental/checkpoint/test_checkpoint.py
+++ b/tests/strands/experimental/checkpoint/test_checkpoint.py
@@ -1,0 +1,519 @@
+"""Tests for experimental checkpoint-based agent execution.
+
+Design:
+- Three checkpoint positions: after_model, after_tool, after_tools
+- Per-tool granularity: each tool executes in its own step
+- Model-driven: tool errors are tool results the model sees
+- Returns Checkpoint (keep going) or AgentResult (done)
+"""
+
+import json
+
+import pytest
+
+from strands import Agent
+from strands.agent.agent_result import AgentResult
+from strands.experimental.checkpoint import Checkpoint, invoke_with_checkpoint
+from strands.experimental.checkpoint.types import CHECKPOINT_SCHEMA_VERSION
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+def _end_turn(text: str) -> dict:
+    return {"role": "assistant", "content": [{"text": text}]}
+
+
+def _tool_use(*tool_names: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": [
+            {"toolUse": {"toolUseId": f"tu_{name}_{i}", "name": name, "input": {}}} for i, name in enumerate(tool_names)
+        ],
+    }
+
+
+@pytest.fixture
+def echo_tool():
+    from strands import tool
+
+    @tool
+    def echo(message: str = "ok") -> str:
+        """Echo a message back."""
+        return f"echo: {message}"
+
+    return echo
+
+
+# ── Serialization ──
+
+
+class TestCheckpointSerialization:
+    def test_round_trip(self):
+        cp = Checkpoint(position="after_model", stop_reason="tool_use", cycle_index=1)
+        restored = Checkpoint.from_dict(cp.to_dict())
+        assert restored.cycle_index == 1
+        assert restored.schema_version == CHECKPOINT_SCHEMA_VERSION
+
+    def test_json_round_trip(self):
+        cp = Checkpoint(
+            position="after_tool",
+            stop_reason="tool_use",
+            tool_index=2,
+            completed_tool_results=[{"toolUseId": "t1", "status": "success", "content": []}],
+        )
+        restored = Checkpoint.from_dict(json.loads(json.dumps(cp.to_dict())))
+        assert restored.position == "after_tool"
+        assert restored.tool_index == 2
+        assert len(restored.completed_tool_results) == 1
+
+    def test_ignores_unknown_fields(self):
+        d = {
+            "schema_version": CHECKPOINT_SCHEMA_VERSION,
+            "position": "after_model",
+            "stop_reason": "tool_use",
+            "extra": 1,
+        }
+        assert Checkpoint.from_dict(d).position == "after_model"
+
+    def test_app_data_round_trip(self):
+        cp = Checkpoint(position="after_model", stop_reason="tool_use", app_data={"wf_id": "123"})
+        restored = Checkpoint.from_dict(json.loads(json.dumps(cp.to_dict())))
+        assert restored.app_data["wf_id"] == "123"
+
+    def test_schema_version_mismatch_raises(self):
+        d = {"schema_version": "99.0", "position": "after_model", "stop_reason": "tool_use"}
+        with pytest.raises(ValueError, match="Incompatible checkpoint schema version"):
+            Checkpoint.from_dict(d)
+
+    def test_schema_version_missing_raises(self):
+        d = {"position": "after_model", "stop_reason": "tool_use"}
+        with pytest.raises(ValueError, match="Incompatible checkpoint schema version"):
+            Checkpoint.from_dict(d)
+
+
+# ── No tools ──
+
+
+class TestNoTools:
+    @pytest.mark.asyncio
+    async def test_completes_immediately(self):
+        agent = Agent(model=MockedModelProvider([_end_turn("Hello")]), callback_handler=None)
+        r = await invoke_with_checkpoint(agent, "Hi")
+        assert isinstance(r, AgentResult)
+
+    @pytest.mark.asyncio
+    async def test_messages_appended(self):
+        agent = Agent(model=MockedModelProvider([_end_turn("Hello")]), callback_handler=None)
+        await invoke_with_checkpoint(agent, "Hi")
+        assert len(agent.messages) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_prompt_uses_existing_messages(self):
+        agent = Agent(
+            model=MockedModelProvider([_end_turn("Response")]),
+            messages=[{"role": "user", "content": [{"text": "existing"}]}],
+            callback_handler=None,
+        )
+        assert isinstance(await invoke_with_checkpoint(agent), AgentResult)
+
+
+# ── Single tool: model → tool → model → done (3 steps) ──
+
+
+class TestSingleTool:
+    @pytest.mark.asyncio
+    async def test_three_steps(self, echo_tool):
+        agent = Agent(
+            model=MockedModelProvider([_tool_use("echo"), _end_turn("Done")]),
+            tools=[echo_tool],
+            callback_handler=None,
+        )
+
+        r = await invoke_with_checkpoint(agent, "Go")
+        assert isinstance(r, Checkpoint) and r.position == "after_model"
+
+        # Single tool → goes directly to after_tools (no after_tool for last tool)
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert isinstance(r, Checkpoint) and r.position == "after_tools"
+
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert isinstance(r, AgentResult)
+        assert len(agent.messages) == 4
+
+
+# ── Per-tool granularity: 5 tools = 5 separate steps ──
+
+
+class TestPerToolGranularity:
+    @pytest.mark.asyncio
+    async def test_five_tools_five_steps(self, echo_tool):
+        agent = Agent(
+            model=MockedModelProvider(
+                [
+                    _tool_use("echo", "echo", "echo", "echo", "echo"),
+                    _end_turn("All done"),
+                ]
+            ),
+            tools=[echo_tool],
+            callback_handler=None,
+        )
+
+        # Model call
+        r = await invoke_with_checkpoint(agent, "Go")
+        assert isinstance(r, Checkpoint) and r.position == "after_model"
+        assert r.tool_index == 0
+
+        # Tool 1 → after_tool (more tools remaining)
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert isinstance(r, Checkpoint) and r.position == "after_tool"
+        assert r.tool_index == 1
+        assert len(r.completed_tool_results) == 1
+
+        # Tool 2
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert r.position == "after_tool" and r.tool_index == 2
+
+        # Tool 3
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert r.position == "after_tool" and r.tool_index == 3
+
+        # Tool 4
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert r.position == "after_tool" and r.tool_index == 4
+        assert len(r.completed_tool_results) == 4
+
+        # Tool 5 (last) → after_tools
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert isinstance(r, Checkpoint) and r.position == "after_tools"
+
+        # 5 tool results in the message
+        assert len(agent.messages[-1]["content"]) == 5
+
+        # Final model call
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert isinstance(r, AgentResult)
+
+
+# ── Multi-cycle ──
+
+
+class TestMultiCycle:
+    @pytest.mark.asyncio
+    async def test_two_cycles(self, echo_tool):
+        agent = Agent(
+            model=MockedModelProvider(
+                [
+                    _tool_use("echo"),
+                    _tool_use("echo"),
+                    _end_turn("Final"),
+                ]
+            ),
+            tools=[echo_tool],
+            callback_handler=None,
+        )
+
+        r = await invoke_with_checkpoint(agent, "Go")
+        assert r.cycle_index == 0
+        r = await invoke_with_checkpoint(agent, checkpoint=r)  # tool
+        r = await invoke_with_checkpoint(agent, checkpoint=r)  # model
+
+        assert r.cycle_index == 1
+        r = await invoke_with_checkpoint(agent, checkpoint=r)  # tool
+        r = await invoke_with_checkpoint(agent, checkpoint=r)  # model → done
+
+        assert isinstance(r, AgentResult)
+
+
+# ── Crash recovery ──
+
+
+class TestCrashRecovery:
+    @pytest.mark.asyncio
+    async def test_recover_after_model(self, echo_tool):
+        agent1 = Agent(
+            model=MockedModelProvider([_tool_use("echo"), _end_turn("Done")]),
+            tools=[echo_tool],
+            callback_handler=None,
+        )
+        r = await invoke_with_checkpoint(agent1, "Go")
+        saved = json.dumps(r.to_dict())
+
+        agent2 = Agent(
+            model=MockedModelProvider([_end_turn("Recovered")]),
+            tools=[echo_tool],
+            callback_handler=None,
+        )
+        r = await invoke_with_checkpoint(agent2, checkpoint=Checkpoint.from_dict(json.loads(saved)))
+        assert isinstance(r, Checkpoint) and r.position == "after_tools"
+        r = await invoke_with_checkpoint(agent2, checkpoint=r)
+        assert isinstance(r, AgentResult)
+
+    @pytest.mark.asyncio
+    async def test_crash_between_tools_only_reruns_remaining(self):
+        """3 tools. Crash after tool 2. Only tool 3 re-runs."""
+        from strands import tool
+
+        log = []
+
+        @tool
+        def tracked(label: str = "x") -> str:
+            """Tracked tool."""
+            log.append(label)
+            return f"done: {label}"
+
+        agent1 = Agent(
+            model=MockedModelProvider(
+                [
+                    _tool_use("tracked", "tracked", "tracked"),
+                    _end_turn("Done"),
+                ]
+            ),
+            tools=[tracked],
+            callback_handler=None,
+        )
+
+        r = await invoke_with_checkpoint(agent1, "Go")
+        r = await invoke_with_checkpoint(agent1, checkpoint=r)  # tool 1
+        r = await invoke_with_checkpoint(agent1, checkpoint=r)  # tool 2
+        assert r.position == "after_tool" and r.tool_index == 2
+        assert len(r.completed_tool_results) == 2
+
+        # "Crash" — serialize, new agent
+        saved = json.dumps(r.to_dict())
+        log.clear()
+
+        agent2 = Agent(
+            model=MockedModelProvider([_end_turn("Recovered")]),
+            tools=[tracked],
+            callback_handler=None,
+        )
+        cp = Checkpoint.from_dict(json.loads(saved))
+
+        # Only tool 3 runs
+        r = await invoke_with_checkpoint(agent2, checkpoint=cp)
+        assert isinstance(r, Checkpoint) and r.position == "after_tools"
+        assert len(log) == 1  # only tool 3 executed
+
+        r = await invoke_with_checkpoint(agent2, checkpoint=r)
+        assert isinstance(r, AgentResult)
+
+
+# ── Model-driven tool errors ──
+
+
+class TestModelDrivenToolErrors:
+    @pytest.mark.asyncio
+    async def test_tool_error_sent_to_model(self):
+        from strands import tool
+
+        @tool
+        def failing() -> str:
+            """Always fails."""
+            raise RuntimeError("Connection timeout")
+
+        agent = Agent(
+            model=MockedModelProvider([_tool_use("failing"), _end_turn("Tool failed.")]),
+            tools=[failing],
+            callback_handler=None,
+        )
+
+        r = await invoke_with_checkpoint(agent, "Go")
+        r = await invoke_with_checkpoint(agent, checkpoint=r)  # tool fails → after_tools
+        assert isinstance(r, Checkpoint) and r.position == "after_tools"
+        assert agent.messages[-1]["content"][0]["toolResult"]["status"] == "error"
+
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert isinstance(r, AgentResult)
+
+    @pytest.mark.asyncio
+    async def test_five_tools_third_fails_model_retries(self):
+        from strands import tool
+
+        log = []
+        deploy_n = {"n": 0}
+
+        @tool
+        def fetch() -> str:
+            """Fetch."""
+            log.append("fetch")
+            return "ok"
+
+        @tool
+        def validate() -> str:
+            """Validate."""
+            log.append("validate")
+            return "ok"
+
+        @tool
+        def deploy() -> str:
+            """Deploy."""
+            log.append("deploy")
+            deploy_n["n"] += 1
+            if deploy_n["n"] == 1:
+                raise RuntimeError("timeout")
+            return "deployed"
+
+        @tool
+        def notify() -> str:
+            """Notify."""
+            log.append("notify")
+            return "ok"
+
+        @tool
+        def cleanup() -> str:
+            """Cleanup."""
+            log.append("cleanup")
+            return "ok"
+
+        agent = Agent(
+            model=MockedModelProvider(
+                [
+                    _tool_use("fetch", "validate", "deploy", "notify", "cleanup"),
+                    _tool_use("deploy"),
+                    _end_turn("Pipeline complete."),
+                ]
+            ),
+            tools=[fetch, validate, deploy, notify, cleanup],
+            callback_handler=None,
+        )
+
+        # Cycle 1: model → 5 tools (per-tool) → model sees deploy error
+        r = await invoke_with_checkpoint(agent, "Run pipeline")
+        for _ in range(5):
+            r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert isinstance(r, Checkpoint) and r.position == "after_tools"
+        assert log == ["fetch", "validate", "deploy", "notify", "cleanup"]
+
+        r = await invoke_with_checkpoint(agent, checkpoint=r)  # model sees results
+        assert isinstance(r, Checkpoint) and r.position == "after_model"
+
+        # Cycle 2: model retries just deploy
+        r = await invoke_with_checkpoint(agent, checkpoint=r)  # deploy succeeds
+        assert isinstance(r, Checkpoint) and r.position == "after_tools"
+        r = await invoke_with_checkpoint(agent, checkpoint=r)  # model done
+        assert isinstance(r, AgentResult)
+        assert deploy_n["n"] == 2
+
+
+# ── Agent method ──
+
+
+class TestAgentMethod:
+    @pytest.mark.asyncio
+    async def test_method_style(self, echo_tool):
+        agent = Agent(
+            model=MockedModelProvider([_tool_use("echo"), _end_turn("Done")]),
+            tools=[echo_tool],
+            callback_handler=None,
+        )
+        r = await agent.invoke_with_checkpoint("Go")
+        while isinstance(r, Checkpoint):
+            r = await agent.invoke_with_checkpoint(checkpoint=r)
+        assert isinstance(r, AgentResult)
+
+
+# ── Edge cases ──
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_invalid_position_raises(self):
+        cp = Checkpoint(position="invalid", stop_reason="end_turn")
+        agent = Agent(model=MockedModelProvider([_end_turn("x")]), callback_handler=None)
+        with pytest.raises(ValueError, match="Unknown checkpoint position"):
+            await invoke_with_checkpoint(agent, checkpoint=cp)
+
+    @pytest.mark.asyncio
+    async def test_valid_position_wrong_stop_reason_raises(self):
+        """after_model with stop_reason != 'tool_use' falls through to ValueError."""
+        cp = Checkpoint(
+            position="after_model",
+            stop_reason="end_turn",
+            snapshot={
+                "scope": "agent",
+                "schema_version": "1.0",
+                "created_at": "2025-01-01T00:00:00Z",
+                "data": {"messages": [{"role": "user", "content": [{"text": "hi"}]}]},
+                "app_data": {},
+            },
+        )
+        agent = Agent(model=MockedModelProvider([_end_turn("x")]), callback_handler=None)
+        with pytest.raises(ValueError, match="Unknown checkpoint position"):
+            await invoke_with_checkpoint(agent, checkpoint=cp)
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_error_sent_to_model(self):
+        agent = Agent(
+            model=MockedModelProvider([_tool_use("nonexistent"), _end_turn("Not found.")]),
+            callback_handler=None,
+        )
+        r = await invoke_with_checkpoint(agent, "Go")
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert agent.messages[-1]["content"][0]["toolResult"]["status"] == "error"
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert isinstance(r, AgentResult)
+
+    @pytest.mark.asyncio
+    async def test_tool_returning_no_result(self):
+        """A tool whose stream yields nothing gets an error result."""
+        from unittest.mock import AsyncMock, PropertyMock
+
+        from strands.types.tools import AgentTool
+
+        mock_tool = AsyncMock(spec=AgentTool)
+        type(mock_tool).tool_name = PropertyMock(return_value="empty")
+        type(mock_tool).tool_spec = PropertyMock(
+            return_value={
+                "name": "empty",
+                "description": "Does nothing",
+                "inputSchema": {"json": {"type": "object", "properties": {}}},
+            }
+        )
+        type(mock_tool).tool_type = PropertyMock(return_value="tool")
+
+        async def empty_stream(tool_use, invocation_state):
+            return
+            yield  # noqa: unreachable — makes this an async generator
+
+        mock_tool.stream = empty_stream
+
+        agent = Agent(
+            model=MockedModelProvider([_tool_use("empty"), _end_turn("Ok")]),
+            tools=[mock_tool],
+            callback_handler=None,
+        )
+        r = await invoke_with_checkpoint(agent, "Go")
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert agent.messages[-1]["content"][0]["toolResult"]["status"] == "error"
+        assert "did not return a result" in agent.messages[-1]["content"][0]["toolResult"]["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_tool_receives_agent_in_invocation_state(self):
+        """Tools executed in checkpoint mode receive invocation_state['agent']."""
+        from strands import tool
+
+        captured = {}
+
+        @tool
+        def spy() -> str:
+            """Spy tool."""
+            return "ok"
+
+        # Patch the tool's stream to capture invocation_state
+        original_stream = spy.stream
+
+        async def capturing_stream(tool_use, invocation_state):
+            captured["invocation_state"] = invocation_state
+            async for event in original_stream(tool_use, invocation_state):
+                yield event
+
+        spy.stream = capturing_stream
+
+        agent = Agent(
+            model=MockedModelProvider([_tool_use("spy"), _end_turn("Done")]),
+            tools=[spy],
+            callback_handler=None,
+        )
+        r = await invoke_with_checkpoint(agent, "Go")
+        r = await invoke_with_checkpoint(agent, checkpoint=r)
+        assert "agent" in captured["invocation_state"]
+        assert captured["invocation_state"]["agent"] is agent

--- a/tests/strands/experimental/checkpoint/test_checkpoint.py
+++ b/tests/strands/experimental/checkpoint/test_checkpoint.py
@@ -416,6 +416,22 @@ class TestAgentMethod:
 
 class TestEdgeCases:
     @pytest.mark.asyncio
+    async def test_tool_index_out_of_range_raises(self):
+        """Corrupted checkpoint with tool_index >= number of tool blocks."""
+        agent = Agent(
+            model=MockedModelProvider([_tool_use("echo"), _end_turn("x")]),
+            tools=[echo_tool],
+            callback_handler=None,
+        )
+        # Get a valid after_model checkpoint
+        r = await invoke_with_checkpoint(agent, "Go")
+        assert isinstance(r, Checkpoint)
+        # Tamper with tool_index
+        r.tool_index = 99
+        with pytest.raises(ValueError, match="tool_index=99 is out of range"):
+            await invoke_with_checkpoint(agent, checkpoint=r)
+
+    @pytest.mark.asyncio
     async def test_invalid_position_raises(self):
         cp = Checkpoint(position="invalid", stop_reason="end_turn")
         agent = Agent(model=MockedModelProvider([_end_turn("x")]), callback_handler=None)


### PR DESCRIPTION
## Description

Adds `invoke_with_checkpoint()` — a checkpoint-based execution mode for durable agent workflows.

The normal agent event loop runs model→tools→model→done as one continuous function. If it crashes at step 47, you restart from step 1. `invoke_with_checkpoint` breaks this into individually resumable steps: each call does exactly one unit of I/O (one model call OR one tool execution), then returns a `Checkpoint`. The caller (e.g., a Temporal workflow) persists that checkpoint. On crash, execution resumes from the last checkpoint — not from scratch.

**Key design decisions:**
- Per-tool granularity: if the model requests 5 tools and you crash after tool 3, only tools 4-5 re-execute on recovery
- Model-driven error handling: tool errors become tool results the model sees and decides on (no special error paths)
- Provider-agnostic: works with any model provider that implements the standard `stream()` contract
- V1 simplifications: bypasses hooks, tracing, retry strategy, structured output, and conversation management — the orchestrator handles these concerns

**New files:**
- `src/strands/experimental/checkpoint/__init__.py` — exports
- `src/strands/experimental/checkpoint/types.py` — `Checkpoint` dataclass with serialization
- `src/strands/experimental/checkpoint/invoke.py` — the step-by-step execution logic

**Modified files:**
- `src/strands/agent/agent.py` — adds `Agent.invoke_with_checkpoint()` convenience method
- `src/strands/experimental/__init__.py` — registers the checkpoint submodule

**Usage:**
```python
from strands.experimental.checkpoint import Checkpoint

result = await agent.invoke_with_checkpoint("Hello")
while isinstance(result, Checkpoint):
    result = await agent.invoke_with_checkpoint(checkpoint=result)
# result is AgentResult
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

https://github.com/strands-agents/sdk-typescript/issues/822

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New feature

## Testing

22 unit tests covering:
- Checkpoint serialization/deserialization round-trips
- Fresh invocation (no tools, with tools)
- Per-tool granularity (5 tools = 5 separate steps)
- Multi-cycle execution (model → tool → model → tool → done)
- Crash recovery (serialize checkpoint, new agent, resume)
- Model-driven tool errors (errors become tool results)
- Complex scenario (5 tools, 3rd fails, model retries just that tool)
- Agent method wrapper
- Edge cases (invalid position, unknown tool, tool returning no result, invocation_state contract)

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
