### PR TITLE
fix: add fallback trim point for tool-heavy conversations in SlidingWindowConversationManager

### DIFF
--- a/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
+++ b/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
@@ -192,9 +192,24 @@ class SlidingWindowConversationManager(ConversationManager):
         # 1. Starts with a user message (required by most model providers)
         # 2. Does not start with an orphaned toolResult
         # 3. Does not start with a toolUse unless its toolResult immediately follows
+        # Falls back to an assistant(toolUse) + user(toolResult) boundary if no plain user message exists.
+        # This is acceptable because providers treat a complete toolUse/toolResult pair as a valid
+        # conversation continuation, and without this fallback tool-heavy conversations cannot be trimmed.
+        fallback_trim_index = None
+
         while trim_index < len(messages):
-            # Must start with a user message
+            # Prefer starting with a user message
             if messages[trim_index]["role"] != "user":
+                # Track first valid assistant(toolUse) + user(toolResult) pair as fallback
+                if (
+                    fallback_trim_index is None
+                    and any("toolUse" in content for content in messages[trim_index]["content"])
+                    and trim_index + 1 < len(messages)
+                    and messages[trim_index + 1]["role"] == "user"
+                    and any("toolResult" in content for content in messages[trim_index + 1]["content"])
+                ):
+                    fallback_trim_index = trim_index
+
                 trim_index += 1
                 continue
 
@@ -216,15 +231,24 @@ class SlidingWindowConversationManager(ConversationManager):
             else:
                 break
         else:
-            # If we didn't find a valid trim_index
-            if e is not None:
+            # No plain user message found — use assistant+toolResult fallback if available
+            if fallback_trim_index is not None:
+                logger.debug(
+                    "trim_index=<%s> | no plain user message trim point found, "
+                    "falling back to assistant(toolUse) + user(toolResult) boundary",
+                    fallback_trim_index,
+                )
+                trim_index = fallback_trim_index
+            elif e is not None:
                 raise ContextWindowOverflowException("Unable to trim conversation context!") from e
-            logger.warning(
-                "window_size=<%s>, message_count=<%s> | unable to trim conversation context, no valid trim point found",
-                self.window_size,
-                len(messages),
-            )
-            return
+            else:
+                logger.warning(
+                    "window_size=<%s>, message_count=<%s> | unable to trim conversation context, "
+                    "no valid trim point found",
+                    self.window_size,
+                    len(messages),
+                )
+                return
 
         # trim_index represents the number of messages being removed from the agents messages array
         self.removed_message_count += trim_index

--- a/tests/strands/agent/test_conversation_manager.py
+++ b/tests/strands/agent/test_conversation_manager.py
@@ -230,6 +230,64 @@ def test_sliding_window_no_valid_trim_point_without_error_does_not_raise():
     assert messages == original_messages
 
 
+def test_sliding_window_tool_heavy_conversation_falls_back_to_tool_pair_boundary():
+    """Tool-heavy conversations trim to assistant(toolUse) + user(toolResult) boundary."""
+    manager = SlidingWindowConversationManager(window_size=4, should_truncate_results=False)
+    messages = [
+        {"role": "user", "content": [{"text": "Review this PR"}]},
+        {"role": "assistant", "content": [{"toolUse": {"toolUseId": "1", "name": "get_diff", "input": {}}}]},
+        {
+            "role": "user",
+            "content": [{"toolResult": {"toolUseId": "1", "content": [{"text": "diff"}], "status": "success"}}],
+        },
+        {"role": "assistant", "content": [{"toolUse": {"toolUseId": "2", "name": "get_file", "input": {}}}]},
+        {
+            "role": "user",
+            "content": [{"toolResult": {"toolUseId": "2", "content": [{"text": "file"}], "status": "success"}}],
+        },
+        {"role": "assistant", "content": [{"toolUse": {"toolUseId": "3", "name": "get_tree", "input": {}}}]},
+        {
+            "role": "user",
+            "content": [{"toolResult": {"toolUseId": "3", "content": [{"text": "tree"}], "status": "success"}}],
+        },
+        {"role": "assistant", "content": [{"text": "Here is my review"}]},
+    ]
+    test_agent = Agent(messages=messages)
+
+    manager.reduce_context(test_agent, e=Exception("context window overflow"))
+
+    # Should trim to first assistant(toolUse) + user(toolResult) pair after trim_index
+    # With 8 messages and window_size=4, trim_index starts at 4. First fallback at index 5 (toolUseId "3").
+    assert len(messages) == 3
+    assert messages[0]["role"] == "assistant"
+    assert messages[0]["content"][0]["toolUse"]["toolUseId"] == "3"
+    assert messages[1]["role"] == "user"
+    assert any("toolResult" in content for content in messages[1]["content"])
+
+
+def test_sliding_window_prefers_plain_user_message_over_tool_pair_fallback():
+    """Plain user messages are preferred over assistant+toolResult fallback when both exist."""
+    manager = SlidingWindowConversationManager(window_size=2, should_truncate_results=False)
+    messages = [
+        {"role": "user", "content": [{"text": "First"}]},
+        {"role": "assistant", "content": [{"toolUse": {"toolUseId": "1", "name": "tool1", "input": {}}}]},
+        {
+            "role": "user",
+            "content": [{"toolResult": {"toolUseId": "1", "content": [{"text": "result"}], "status": "success"}}],
+        },
+        {"role": "assistant", "content": [{"text": "Response"}]},
+        {"role": "user", "content": [{"text": "Plain user message"}]},
+        {"role": "assistant", "content": [{"text": "Final response"}]},
+    ]
+    test_agent = Agent(messages=messages)
+
+    manager.apply_management(test_agent)
+
+    # Should prefer the plain user message, not the assistant+toolResult fallback
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == [{"text": "Plain user message"}]
+
+
 def test_sliding_window_conversation_manager_with_tool_results_truncated():
     large_text = "A" * 300 + "B" * 300 + "C" * 300
     manager = SlidingWindowConversationManager(1)


### PR DESCRIPTION
## Description
PR #[2087](https://github.com/strands-agents/sdk-python/pull/2087) introduced user-first enforcement in reduce_context, which correctly prevents conversations from starting with an assistant message. However, in tool-heavy agent loops where every user message after the initial prompt contains toolResult, there are no valid plain user message trim points. This causes ContextWindowOverflowException on conversations that previously trimmed successfully.

This adds a fallback that trims to an assistant(toolUse) + user(toolResult) boundary when no plain user message exists within the trim range. This preserves valid message ordering for all providers while allowing tool-heavy conversations to be trimmed.

## Related Issues
https://github.com/strands-agents/sdk-python/issues/2173
## Type of Change
Bug fix
## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
