### PR TITLE
feat: add context_window_limit to model configs

### DIFF
--- a/src/strands/models/__init__.py
+++ b/src/strands/models/__init__.py
@@ -7,11 +7,12 @@ from typing import Any
 
 from . import bedrock, model
 from .bedrock import BedrockModel
-from .model import CacheConfig, Model
+from .model import BaseModelConfig, CacheConfig, Model
 
 __all__ = [
     "bedrock",
     "model",
+    "BaseModelConfig",
     "BedrockModel",
     "CacheConfig",
     "Model",

--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -8,7 +8,7 @@ import json
 import logging
 import mimetypes
 from collections.abc import AsyncGenerator
-from typing import Any, TypedDict, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import anthropic
 from pydantic import BaseModel
@@ -21,7 +21,7 @@ from ..types.exceptions import ContextWindowOverflowException, ModelThrottledExc
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolChoiceToolDict, ToolSpec
 from ._validation import _has_location_source, validate_config_keys
-from .model import Model
+from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class AnthropicModel(Model):
         "input and output tokens exceed your context limit",
     }
 
-    class AnthropicConfig(TypedDict, total=False):
+    class AnthropicConfig(BaseModelConfig, total=False):
         """Configuration options for Anthropic models.
 
         Attributes:

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -15,7 +15,7 @@ import boto3
 from botocore.config import Config as BotocoreConfig
 from botocore.exceptions import ClientError
 from pydantic import BaseModel
-from typing_extensions import TypedDict, Unpack, override
+from typing_extensions import Unpack, override
 
 from strands.types.media import S3Location, SourceLocation
 
@@ -31,7 +31,7 @@ from ..types.exceptions import (
 from ..types.streaming import CitationsDelta, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 from ._validation import validate_config_keys
-from .model import CacheConfig, Model
+from .model import BaseModelConfig, CacheConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ class BedrockModel(Model):
     - Context window overflow detection
     """
 
-    class BedrockConfig(TypedDict, total=False):
+    class BedrockConfig(BaseModelConfig, total=False):
         """Configuration options for Bedrock models.
 
         Attributes:

--- a/src/strands/models/gemini.py
+++ b/src/strands/models/gemini.py
@@ -9,7 +9,7 @@ import logging
 import mimetypes
 import secrets
 from collections.abc import AsyncGenerator
-from typing import Any, TypedDict, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import pydantic
 from google import genai
@@ -20,7 +20,7 @@ from ..types.exceptions import ContextWindowOverflowException, ModelThrottledExc
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 from ._validation import _has_location_source, validate_config_keys
-from .model import Model
+from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class GeminiModel(Model):
     - Docs: https://ai.google.dev/api
     """
 
-    class GeminiConfig(TypedDict, total=False):
+    class GeminiConfig(BaseModelConfig, total=False):
         """Configuration options for Gemini models.
 
         Attributes:

--- a/src/strands/models/litellm.py
+++ b/src/strands/models/litellm.py
@@ -6,7 +6,7 @@
 import json
 import logging
 from collections.abc import AsyncGenerator
-from typing import Any, TypedDict, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import litellm
 from litellm.exceptions import ContextWindowExceededError
@@ -21,6 +21,7 @@ from ..types.exceptions import ContextWindowOverflowException
 from ..types.streaming import MetadataEvent, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec, ToolUse
 from ._validation import validate_config_keys
+from .model import BaseModelConfig
 from .openai import OpenAIModel
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ T = TypeVar("T", bound=BaseModel)
 class LiteLLMModel(OpenAIModel):
     """LiteLLM model provider implementation."""
 
-    class LiteLLMConfig(TypedDict, total=False):
+    class LiteLLMConfig(BaseModelConfig, total=False):
         """Configuration options for LiteLLM models.
 
         Attributes:

--- a/src/strands/models/llamaapi.py
+++ b/src/strands/models/llamaapi.py
@@ -14,14 +14,14 @@ from typing import Any, TypeVar, cast
 import llama_api_client
 from llama_api_client import LlamaAPIClient
 from pydantic import BaseModel
-from typing_extensions import TypedDict, Unpack, override
+from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
 from ..types.exceptions import ModelThrottledException
 from ..types.streaming import StreamEvent, Usage
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import Model
+from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ T = TypeVar("T", bound=BaseModel)
 class LlamaAPIModel(Model):
     """Llama API model provider implementation."""
 
-    class LlamaConfig(TypedDict, total=False):
+    class LlamaConfig(BaseModelConfig, total=False):
         """Configuration options for Llama API models.
 
         Attributes:

--- a/src/strands/models/llamacpp.py
+++ b/src/strands/models/llamacpp.py
@@ -17,7 +17,6 @@ import time
 from collections.abc import AsyncGenerator
 from typing import (
     Any,
-    TypedDict,
     TypeVar,
     cast,
 )
@@ -31,7 +30,7 @@ from ..types.exceptions import ContextWindowOverflowException, ModelThrottledExc
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import Model
+from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +85,7 @@ class LlamaCppModel(Model):
         >>> response = agent(image_content)
     """
 
-    class LlamaCppConfig(TypedDict, total=False):
+    class LlamaCppConfig(BaseModelConfig, total=False):
         """Configuration options for llama.cpp models.
 
         Attributes:

--- a/src/strands/models/mistral.py
+++ b/src/strands/models/mistral.py
@@ -11,14 +11,14 @@ from typing import Any, TypeVar
 
 import mistralai
 from pydantic import BaseModel
-from typing_extensions import TypedDict, Unpack, override
+from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
 from ..types.exceptions import ModelThrottledException
 from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import Model
+from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ class MistralModel(Model):
     - System prompts
     """
 
-    class MistralConfig(TypedDict, total=False):
+    class MistralConfig(BaseModelConfig, total=False):
         """Configuration parameters for Mistral models.
 
         Attributes:

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -4,7 +4,7 @@ import abc
 import logging
 from collections.abc import AsyncGenerator, AsyncIterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar
 
 from pydantic import BaseModel
 
@@ -20,6 +20,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
+
+
+class BaseModelConfig(TypedDict, total=False):
+    """Base configuration shared by all model providers.
+
+    Attributes:
+        context_window_limit: Maximum context window size in tokens for the model.
+            This value represents the total token capacity shared between input and output.
+    """
+
+    context_window_limit: int | None
 
 
 @dataclass
@@ -50,6 +61,16 @@ class Model(abc.ABC):
             False by default. Model providers that support server-side state should override this.
         """
         return False
+
+    @property
+    def context_window_limit(self) -> int | None:
+        """Maximum context window size in tokens, or None if not configured."""
+        config = self.get_config()
+        return (
+            config.get("context_window_limit")
+            if isinstance(config, dict)
+            else getattr(config, "context_window_limit", None)
+        )
 
     @abc.abstractmethod
     # pragma: no cover

--- a/src/strands/models/ollama.py
+++ b/src/strands/models/ollama.py
@@ -10,13 +10,13 @@ from typing import Any, TypeVar, cast
 
 import ollama
 from pydantic import BaseModel
-from typing_extensions import TypedDict, Unpack, override
+from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
 from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import Model
+from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class OllamaModel(Model):
     - Tool/function calling
     """
 
-    class OllamaConfig(TypedDict, total=False):
+    class OllamaConfig(BaseModelConfig, total=False):
         """Configuration parameters for Ollama models.
 
         Attributes:

--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -9,7 +9,7 @@ import logging
 import mimetypes
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, Protocol, TypedDict, TypeVar, cast
+from typing import Any, Protocol, TypeVar, cast
 
 import openai
 from openai.types.chat.parsed_chat_completion import ParsedChatCompletion
@@ -22,7 +22,7 @@ from ..types.exceptions import ContextWindowOverflowException, ModelThrottledExc
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._validation import _has_location_source, validate_config_keys
-from .model import Model
+from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class OpenAIModel(Model):
 
     client: Client
 
-    class OpenAIConfig(TypedDict, total=False):
+    class OpenAIConfig(BaseModelConfig, total=False):
         """Configuration options for OpenAI models.
 
         Attributes:

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -59,7 +59,7 @@ from ..types.exceptions import ContextWindowOverflowException, ModelThrottledExc
 from ..types.streaming import StreamEvent  # noqa: E402
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse  # noqa: E402
 from ._validation import validate_config_keys  # noqa: E402
-from .model import Model  # noqa: E402
+from .model import BaseModelConfig, Model  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ class OpenAIResponsesModel(Model):
     client: Client
     client_args: dict[str, Any]
 
-    class OpenAIResponsesConfig(TypedDict, total=False):
+    class OpenAIResponsesConfig(BaseModelConfig, total=False):
         """Configuration options for OpenAI Responses API models.
 
         Attributes:

--- a/src/strands/models/sagemaker.py
+++ b/src/strands/models/sagemaker.py
@@ -17,6 +17,7 @@ from ..types.content import ContentBlock, Messages
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec
 from ._validation import validate_config_keys, warn_on_tool_choice_not_supported
+from .model import BaseModelConfig
 from .openai import OpenAIModel
 
 T = TypeVar("T", bound=BaseModel)
@@ -116,7 +117,7 @@ class SageMakerAIModel(OpenAIModel):
         tool_results_as_user_messages: bool | None
         additional_args: dict[str, Any] | None
 
-    class SageMakerAIEndpointConfig(TypedDict, total=False):
+    class SageMakerAIEndpointConfig(BaseModelConfig, total=False):
         """Configuration options for SageMaker models.
 
         Attributes:

--- a/src/strands/models/writer.py
+++ b/src/strands/models/writer.py
@@ -8,7 +8,7 @@ import json
 import logging
 import mimetypes
 from collections.abc import AsyncGenerator
-from typing import Any, TypedDict, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import writerai
 from pydantic import BaseModel
@@ -19,7 +19,7 @@ from ..types.exceptions import ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import Model
+from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ T = TypeVar("T", bound=BaseModel)
 class WriterModel(Model):
     """Writer API model provider implementation."""
 
-    class WriterConfig(TypedDict, total=False):
+    class WriterConfig(BaseModelConfig, total=False):
         """Configuration options for Writer API.
 
         Attributes:

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -288,6 +288,15 @@ def test__init__model_config(bedrock_client):
     assert tru_max_tokens == exp_max_tokens
 
 
+def test__init__context_window_limit(bedrock_client):
+    _ = bedrock_client
+
+    model = BedrockModel(context_window_limit=200_000)
+
+    assert model.get_config().get("context_window_limit") == 200_000
+    assert model.context_window_limit == 200_000
+
+
 def test_update_config(model, model_id):
     model.update_config(model_id=model_id)
 

--- a/tests/strands/models/test_gemini.py
+++ b/tests/strands/models/test_gemini.py
@@ -70,6 +70,15 @@ def test__init__model_configs(gemini_client, model_id):
     assert tru_temperature == exp_temperature
 
 
+def test__init__context_window_limit(gemini_client):
+    _ = gemini_client
+
+    model = GeminiModel(model_id="gemini-2.5-flash", context_window_limit=1_048_576)
+
+    assert model.get_config().get("context_window_limit") == 1_048_576
+    assert model.context_window_limit == 1_048_576
+
+
 def test_update_config(model, model_id):
     model.update_config(model_id=model_id)
 

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -184,6 +184,27 @@ async def test_stream_with_tool_choice_parameter(messages, tool_specs, system_pr
     assert events[1]["contentBlockDelta"]["delta"]["text"] == "No tool choice"
 
 
+def test_context_window_limit_from_dict_config():
+    class DictConfigModel(SAModel):
+        def update_config(self, **model_config):
+            pass
+
+        def get_config(self):
+            return {"context_window_limit": 200_000}
+
+        async def structured_output(self, output_model, prompt=None, system_prompt=None, **kwargs):
+            yield {}
+
+        async def stream(self, messages, tool_specs=None, system_prompt=None):
+            yield {}
+
+    assert DictConfigModel().context_window_limit == 200_000
+
+
+def test_context_window_limit_none_when_not_configured(model):
+    assert model.context_window_limit is None
+
+
 def test_stateful_false(model):
     """Model.stateful defaults to False."""
     assert not model.stateful

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -89,6 +89,15 @@ def test_update_config(model, model_id):
     assert tru_model_id == exp_model_id
 
 
+def test__init__context_window_limit(openai_client):
+    _ = openai_client
+
+    model = OpenAIModel(model_id="gpt-4o", context_window_limit=128_000)
+
+    assert model.get_config().get("context_window_limit") == 128_000
+    assert model.context_window_limit == 128_000
+
+
 @pytest.mark.parametrize(
     "content, exp_result",
     [


### PR DESCRIPTION
## Description                                                                                                                                                                                          
                                                                                                                                                                                                        
Adds `context_window_limit` as an optional property on every model config TypedDict. This exposes the model's maximum token capacity (shared between input and output) so that conversation managers can implement proactive context compression — triggering reduction before the model rejects a request, rather than after.                                                                                   
                                                                                                                                                                                                        
Python port of https://github.com/strands-agents/sdk-typescript/pull/848                                                                                                                                
                                                                                                                                                                                                        
Per-provider lookup tables that auto-populate this value from model ID will be added in a follow-up.                                                                                                    
                                                                                                                                                                                                        
## Related Issues                                                                                                                                                                                       
                                                                                                                                                                                                        
- https://github.com/strands-agents/sdk-python/issues/1295                                                                                                                                              
- https://github.com/strands-agents/docs/pull/758                                                                                                                                                       
                                                                                                                                                                                                        
## Documentation PR                                                                                                                                                                                     
                                                                                                                                                                                                        
Docs will accompany the proactive context compression feature.                                                                                                                                          
                                                                                                                                                                                                        
## Type of Change                                                                                                                                                                                       
                                                                                                                                                                                                        
New feature                                                                                                                                                                                             
                                                                                                                                                                                                        
## Testing                                                                                                                                                                                              
                                                                                                                                                                                                        
How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli                              
                                                                                                                                                                                                        
- [x] I ran `hatch run prepare`                                                                                                                                                                         
                                                                                                                                                                                                        
## Checklist                                                                                                                                                                                            
- [x] I have read the CONTRIBUTING document                                                                                                                                                             
- [x] I have added any necessary tests that prove my fix is effective or my feature works                                                                                                               
- [x] I have updated the documentation accordingly                                                                                                                                                      
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed                                                                                        
- [x] My changes generate no new warnings                                                                                                                                                               
- [x] Any dependent changes have been merged and published                                                                                                                                              
                                                                                                                                                                                                        
----                                                                                                                                                                                                    
                                                                                                                                                                                                        
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.   