### PR TITLE
feat: add checkpoint and wire it into event loop

### DIFF
--- a/src/strands/__init__.py
+++ b/src/strands/__init__.py
@@ -3,6 +3,7 @@
 from . import agent, models, telemetry, types
 from .agent.agent import Agent
 from .agent.base import AgentBase
+from .checkpoint import Checkpoint
 from .event_loop._retry import ModelRetryStrategy
 from .plugins import Plugin
 from .tools.decorator import tool
@@ -15,6 +16,7 @@ __all__ = [
     "AgentBase",
     "AgentSkills",
     "agent",
+    "Checkpoint",
     "models",
     "ModelRetryStrategy",
     "Plugin",

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -39,6 +39,7 @@ from ..types._snapshot import (
 )
 
 if TYPE_CHECKING:
+    from ..checkpoint import Checkpoint
     from ..tools import ToolProvider
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from ..hooks import (
@@ -310,8 +311,7 @@ class Agent(AgentBase):
 
         # Checkpointing: when True, event loop pauses at cycle boundaries
         self._checkpointing = checkpointing
-        self._checkpoint_resume_position: str | None = None
-        self._checkpoint_resumed_cycle_index: int | None = None
+        self._checkpoint_resume_context: Checkpoint | None = None
 
         # Runtime state for model providers (e.g., server-side response ids)
         self._model_state: dict[str, Any] = {}
@@ -1020,8 +1020,7 @@ class Agent(AgentBase):
                 invalid = [k for c in prompt if isinstance(c, dict) for k in c if k != "checkpointResume"]
                 if invalid:
                     raise TypeError(
-                        f"content_types={invalid} | "
-                        f"checkpointResume cannot be mixed with other content types"
+                        f"content_types={invalid} | checkpointResume cannot be mixed with other content types"
                     )
                 if len(prompt) != 1:
                     raise TypeError("Only one checkpointResume block permitted per prompt")
@@ -1037,12 +1036,7 @@ class Agent(AgentBase):
                 checkpoint_data = resume_block["checkpoint"]
                 checkpoint = Checkpoint.from_dict(checkpoint_data)
                 self.load_snapshot(Snapshot.from_dict(checkpoint.snapshot))
-                self._checkpoint_resume_position = checkpoint.position
-                # after_tools completed that cycle, so next cycle is +1
-                if checkpoint.position == "after_tools":
-                    self._checkpoint_resumed_cycle_index = checkpoint.cycle_index + 1
-                else:
-                    self._checkpoint_resumed_cycle_index = checkpoint.cycle_index
+                self._checkpoint_resume_context = checkpoint
                 return []
 
         messages: Messages | None = None

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -146,6 +146,7 @@ class Agent(AgentBase):
         tool_executor: ToolExecutor | None = None,
         retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
         concurrent_invocation_mode: ConcurrentInvocationMode = ConcurrentInvocationMode.THROW,
+        checkpointing: bool = False,
     ):
         """Initialize the Agent with the specified configuration.
 
@@ -214,6 +215,9 @@ class Agent(AgentBase):
                 Set to "unsafe_reentrant" to skip lock acquisition entirely, allowing concurrent invocations.
                 Warning: "unsafe_reentrant" makes no guarantees about resulting behavior and is provided
                 only for advanced use cases where the caller understands the risks.
+            checkpointing: When True, the event loop pauses at cycle boundaries (after model call,
+                after tool execution) and returns a checkpoint that can be persisted and resumed later.
+                Defaults to False.
 
         Raises:
             ValueError: If agent id contains path separators.
@@ -303,6 +307,11 @@ class Agent(AgentBase):
         self._plugin_registry = _PluginRegistry(self)
 
         self._interrupt_state = _InterruptState()
+
+        # Checkpointing: when True, event loop pauses at cycle boundaries
+        self._checkpointing = checkpointing
+        self._checkpoint_resume_position: str | None = None
+        self._checkpoint_resumed_cycle_index: int | None = None
 
         # Runtime state for model providers (e.g., server-side response ids)
         self._model_state: dict[str, Any] = {}
@@ -997,6 +1006,44 @@ class Agent(AgentBase):
     async def _convert_prompt_to_messages(self, prompt: AgentInput) -> Messages:
         if self._interrupt_state.activated:
             return []
+
+        # Detect checkpointResume blocks early — validate before processing
+        if isinstance(prompt, list) and prompt:
+            has_checkpoint_resume = any(isinstance(c, dict) and "checkpointResume" in c for c in prompt)
+            if has_checkpoint_resume:
+                if not self._checkpointing:
+                    raise ValueError(
+                        "Received checkpointResume block but agent was created with checkpointing=False. "
+                        "Pass checkpointing=True when constructing the Agent to enable durable execution."
+                    )
+                # Reject mixed content (mirror interrupt validation)
+                invalid = [k for c in prompt if isinstance(c, dict) for k in c if k != "checkpointResume"]
+                if invalid:
+                    raise TypeError(
+                        f"content_types={invalid} | "
+                        f"checkpointResume cannot be mixed with other content types"
+                    )
+                if len(prompt) != 1:
+                    raise TypeError("Only one checkpointResume block permitted per prompt")
+
+                from ..checkpoint import Checkpoint
+                from ..types._snapshot import Snapshot
+
+                resume_block = prompt[0].get("checkpointResume", {})
+                if "checkpoint" not in resume_block:
+                    raise ValueError(
+                        "checkpointResume block must contain a 'checkpoint' key with serialized checkpoint data."
+                    )
+                checkpoint_data = resume_block["checkpoint"]
+                checkpoint = Checkpoint.from_dict(checkpoint_data)
+                self.load_snapshot(Snapshot.from_dict(checkpoint.snapshot))
+                self._checkpoint_resume_position = checkpoint.position
+                # after_tools completed that cycle, so next cycle is +1
+                if checkpoint.position == "after_tools":
+                    self._checkpoint_resumed_cycle_index = checkpoint.cycle_index + 1
+                else:
+                    self._checkpoint_resumed_cycle_index = checkpoint.cycle_index
+                return []
 
         messages: Messages | None = None
         if prompt is not None:

--- a/src/strands/agent/agent_result.py
+++ b/src/strands/agent/agent_result.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 from pydantic import BaseModel
 
+from ..checkpoint import Checkpoint
 from ..interrupt import Interrupt
 from ..telemetry.metrics import EventLoopMetrics
 from ..types.content import Message
@@ -34,6 +35,7 @@ class AgentResult:
     state: Any
     interrupts: Sequence[Interrupt] | None = None
     structured_output: BaseModel | None = None
+    checkpoint: Checkpoint | None = None
 
     @property
     def context_size(self) -> int | None:

--- a/src/strands/checkpoint.py
+++ b/src/strands/checkpoint.py
@@ -1,0 +1,79 @@
+"""Checkpoint system for durable agent execution.
+
+Checkpoints enable crash-resilient agent workflows by capturing agent state at
+cycle boundaries in the event loop. A durability provider (e.g. Temporal) can
+persist checkpoints and resume from them after failures.
+
+Two checkpoint positions per ReAct cycle:
+- after_model: model call completed, tools not yet executed.
+- after_tools: all tools executed, next model call pending.
+
+Per-tool granularity is handled by the ToolExecutor abstraction (e.g.
+TemporalToolExecutor routes each tool to a separate Temporal activity).
+The SDK checkpoint operates at cycle boundaries.
+
+User-facing pattern (same as interrupts):
+- Pause via stop_reason="checkpoint" on AgentResult
+- State via AgentResult.checkpoint field
+- Resume via checkpointResume content block in next agent() call
+
+V0 Known Limitations:
+- Metrics reset on each resume call. The caller is responsible for aggregating
+  metrics across a durable run. EventLoopMetrics reflects only the current call.
+- OpenAIResponsesModel(stateful=True) is not supported. The server-side
+  response_id (_model_state) is not captured in the snapshot.
+- When position is "after_tools", AgentResult.message is the assistant message
+  that requested the tools; tool results are in the snapshot messages.
+- BeforeInvocationEvent and AfterInvocationEvent fire on every resume call,
+  same as interrupts. Hooks counting invocations will see each resume as a
+  separate invocation.
+- Per-tool granularity within a cycle requires a custom ToolExecutor
+  (e.g. TemporalToolExecutor).
+"""
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+CHECKPOINT_SCHEMA_VERSION = "1.0"
+
+CheckpointPosition = Literal["after_model", "after_tools"]
+
+
+@dataclass
+class Checkpoint:
+    """Pause point in the agent loop. Treat as opaque — pass back to resume.
+
+    Attributes:
+        position: What just completed (after_model or after_tools).
+        cycle_index: Which ReAct loop cycle (0-based).
+        snapshot: Agent state for reconstruction on a different worker.
+        app_data: Provider-owned data. SDK does not read this.
+            Temporal can store workflow_id, run_id, activity task tokens, etc.
+        schema_version: Rejects mismatches on resume across SDK versions.
+    """
+
+    position: CheckpointPosition
+    cycle_index: int = 0
+    snapshot: dict[str, Any] = field(default_factory=dict)
+    app_data: dict[str, Any] = field(default_factory=dict)
+    schema_version: str = field(init=False, default=CHECKPOINT_SCHEMA_VERSION)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for persistence."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "Checkpoint":
+        """Reconstruct from a dict produced by to_dict().
+
+        Raises:
+            ValueError: If schema_version doesn't match the current version.
+        """
+        version = d.get("schema_version", "")
+        if version != CHECKPOINT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Incompatible checkpoint schema version: {version!r}. "
+                f"Current version: {CHECKPOINT_SCHEMA_VERSION}. "
+                f"Checkpoints from a different SDK version cannot be resumed."
+            )
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__ and k != "schema_version"})

--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from opentelemetry import trace as trace_api
 
+from ..checkpoint import Checkpoint
 from ..hooks import AfterModelCallEvent, BeforeModelCallEvent, MessageAddedEvent
 from ..telemetry.metrics import Trace
 from ..telemetry.tracer import Tracer, get_tracer
@@ -122,6 +123,13 @@ async def event_loop_cycle(
     # Initialize state and get cycle trace
     if "request_state" not in invocation_state:
         invocation_state["request_state"] = {}
+
+    # Prime cycle_index from resumed checkpoint (Bug 3 fix: survives cross-process resume)
+    if "_checkpoint_cycle_index" not in invocation_state:
+        resumed_idx = getattr(agent, "_checkpoint_resumed_cycle_index", None)
+        if resumed_idx is not None:
+            invocation_state["_checkpoint_cycle_index"] = resumed_idx
+            agent._checkpoint_resumed_cycle_index = None
     attributes = {"event_loop_cycle_id": str(invocation_state.get("event_loop_cycle_id"))}
     cycle_start_time, cycle_trace = agent.event_loop_metrics.start_cycle(attributes=attributes)
     invocation_state["event_loop_cycle_trace"] = cycle_trace
@@ -181,6 +189,33 @@ async def event_loop_cycle(
                 )
 
             if stop_reason == "tool_use":
+                # Checkpoint after model call, before tool execution
+                if getattr(agent, "_checkpointing", False) is True:
+                    # Consume resume position (one-shot: cleared after reading)
+                    resume_pos = getattr(agent, "_checkpoint_resume_position", None)
+                    if resume_pos is not None:
+                        agent._checkpoint_resume_position = None
+                    if resume_pos == "after_model":
+                        pass  # Skip checkpoint — we just resumed here
+                    else:
+                        cycle_index = invocation_state.get("_checkpoint_cycle_index", 0)
+                        checkpoint = Checkpoint(
+                            position="after_model",
+                            cycle_index=cycle_index,
+                            snapshot=agent.take_snapshot(preset="session").to_dict(),
+                        )
+                        agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
+                        if cycle_span:
+                            tracer.end_event_loop_cycle_span(span=cycle_span, message=message)
+                        yield EventLoopStopEvent(
+                            "checkpoint",
+                            message,
+                            agent.event_loop_metrics,
+                            invocation_state["request_state"],
+                            checkpoint=checkpoint,
+                        )
+                        return
+
                 # Handle tool execution
                 tool_events = _handle_tool_execution(
                     stop_reason,
@@ -587,6 +622,24 @@ async def _handle_tool_execution(
             agent.event_loop_metrics,
             invocation_state["request_state"],
             structured_output=structured_output_result,
+        )
+        return
+
+    # Checkpoint after all tools complete, before next model call
+    if getattr(agent, "_checkpointing", False) is True:
+        cycle_index = invocation_state.get("_checkpoint_cycle_index", 0)
+        invocation_state["_checkpoint_cycle_index"] = cycle_index + 1
+        checkpoint = Checkpoint(
+            position="after_tools",
+            cycle_index=cycle_index,
+            snapshot=agent.take_snapshot(preset="session").to_dict(),
+        )
+        yield EventLoopStopEvent(
+            "checkpoint",
+            message,
+            agent.event_loop_metrics,
+            invocation_state["request_state"],
+            checkpoint=checkpoint,
         )
         return
 

--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -124,12 +124,14 @@ async def event_loop_cycle(
     if "request_state" not in invocation_state:
         invocation_state["request_state"] = {}
 
-    # Prime cycle_index from resumed checkpoint (Bug 3 fix: survives cross-process resume)
-    if "_checkpoint_cycle_index" not in invocation_state:
-        resumed_idx = getattr(agent, "_checkpoint_resumed_cycle_index", None)
-        if resumed_idx is not None:
-            invocation_state["_checkpoint_cycle_index"] = resumed_idx
-            agent._checkpoint_resumed_cycle_index = None
+    # Consume checkpoint resume context (one-shot: cleared after reading)
+    resume_ctx = getattr(agent, "_checkpoint_resume_context", None)
+    if resume_ctx is not None:
+        agent._checkpoint_resume_context = None
+        # after_tools completed that cycle, so next cycle starts at +1
+        next_cycle = resume_ctx.cycle_index + 1 if resume_ctx.position == "after_tools" else resume_ctx.cycle_index
+        invocation_state.setdefault("_checkpoint_cycle_index", next_cycle)
+        invocation_state["_checkpoint_resume_position"] = resume_ctx.position
     attributes = {"event_loop_cycle_id": str(invocation_state.get("event_loop_cycle_id"))}
     cycle_start_time, cycle_trace = agent.event_loop_metrics.start_cycle(attributes=attributes)
     invocation_state["event_loop_cycle_trace"] = cycle_trace
@@ -190,11 +192,8 @@ async def event_loop_cycle(
 
             if stop_reason == "tool_use":
                 # Checkpoint after model call, before tool execution
-                if getattr(agent, "_checkpointing", False) is True:
-                    # Consume resume position (one-shot: cleared after reading)
-                    resume_pos = getattr(agent, "_checkpoint_resume_position", None)
-                    if resume_pos is not None:
-                        agent._checkpoint_resume_position = None
+                if agent._checkpointing:
+                    resume_pos = invocation_state.pop("_checkpoint_resume_position", None)
                     if resume_pos == "after_model":
                         pass  # Skip checkpoint — we just resumed here
                     else:
@@ -626,7 +625,7 @@ async def _handle_tool_execution(
         return
 
     # Checkpoint after all tools complete, before next model call
-    if getattr(agent, "_checkpointing", False) is True:
+    if agent._checkpointing:
         cycle_index = invocation_state.get("_checkpoint_cycle_index", 0)
         invocation_state["_checkpoint_cycle_index"] = cycle_index + 1
         checkpoint = Checkpoint(

--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -125,12 +125,12 @@ async def event_loop_cycle(
         invocation_state["request_state"] = {}
 
     # Consume checkpoint resume context (one-shot: cleared after reading)
-    resume_ctx = getattr(agent, "_checkpoint_resume_context", None)
+    resume_ctx = agent._checkpoint_resume_context
     if resume_ctx is not None:
         agent._checkpoint_resume_context = None
         # after_tools completed that cycle, so next cycle starts at +1
         next_cycle = resume_ctx.cycle_index + 1 if resume_ctx.position == "after_tools" else resume_ctx.cycle_index
-        invocation_state.setdefault("_checkpoint_cycle_index", next_cycle)
+        invocation_state["_checkpoint_cycle_index"] = next_cycle
         invocation_state["_checkpoint_resume_position"] = resume_ctx.position
     attributes = {"event_loop_cycle_id": str(invocation_state.get("event_loop_cycle_id"))}
     cycle_start_time, cycle_trace = agent.event_loop_metrics.start_cycle(attributes=attributes)

--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -22,6 +22,7 @@ from .tools import ToolResult, ToolUse
 if TYPE_CHECKING:
     from ..agent import AgentResult
     from ..agent._agent_as_tool import _AgentAsTool
+    from ..checkpoint import Checkpoint
     from ..multiagent.base import MultiAgentResult, NodeResult
 
 
@@ -227,6 +228,7 @@ class EventLoopStopEvent(TypedEvent):
         request_state: Any,
         interrupts: Sequence[Interrupt] | None = None,
         structured_output: BaseModel | None = None,
+        checkpoint: "Checkpoint | None" = None,
     ) -> None:
         """Initialize with the final execution results.
 
@@ -237,8 +239,11 @@ class EventLoopStopEvent(TypedEvent):
             request_state: Final state of the agent execution
             interrupts: Interrupts raised by user during agent execution.
             structured_output: Optional structured output result
+            checkpoint: Checkpoint data if paused for durability
         """
-        super().__init__({"stop": (stop_reason, message, metrics, request_state, interrupts, structured_output)})
+        super().__init__(
+            {"stop": (stop_reason, message, metrics, request_state, interrupts, structured_output, checkpoint)}
+        )
 
     @property
     @override

--- a/src/strands/types/event_loop.py
+++ b/src/strands/types/event_loop.py
@@ -38,6 +38,7 @@ class Metrics(TypedDict, total=False):
 
 StopReason = Literal[
     "cancelled",
+    "checkpoint",
     "content_filtered",
     "end_turn",
     "guardrail_intervened",
@@ -49,6 +50,7 @@ StopReason = Literal[
 """Reason for the model ending its response generation.
 
 - "cancelled": Agent execution was cancelled via agent.cancel()
+- "checkpoint": Agent paused for durable checkpoint persistence
 - "content_filtered": Content was filtered due to policy violation
 - "end_turn": Normal completion of the response
 - "guardrail_intervened": Guardrail system intervened

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -157,6 +157,7 @@ def agent(model, system_prompt, messages, tool_registry, thread_pool, hook_regis
     mock._interrupt_state = _InterruptState()
     mock._cancel_signal = threading.Event()
     mock._model_state = {}
+    mock._checkpointing = False
     mock.trace_attributes = {}
     mock.retry_strategy = ModelRetryStrategy()
 

--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -190,7 +190,7 @@ async def test_event_loop_cycle_text_response(
         invocation_state={},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     exp_stop_reason = "end_turn"
     exp_message = {"role": "assistant", "content": [{"text": "test text"}], "metadata": ANY}
@@ -222,7 +222,7 @@ async def test_event_loop_cycle_text_response_throttling(
         invocation_state={},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     exp_stop_reason = "end_turn"
     exp_message = {"role": "assistant", "content": [{"text": "test text"}], "metadata": ANY}
@@ -260,7 +260,7 @@ async def test_event_loop_cycle_exponential_backoff(
         invocation_state={},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     # Verify the final response
     assert tru_stop_reason == "end_turn"
@@ -351,7 +351,7 @@ async def test_event_loop_cycle_tool_result(
         invocation_state={},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     exp_stop_reason = "end_turn"
     exp_message = {"role": "assistant", "content": [{"text": "test text"}], "metadata": ANY}
@@ -469,7 +469,7 @@ async def test_event_loop_cycle_stop(
         invocation_state={"request_state": {"stop_event_loop": True}},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     exp_stop_reason = "tool_use"
     exp_message = {
@@ -833,7 +833,7 @@ async def test_request_state_initialization(alist):
         invocation_state={},
     )
     events = await alist(stream)
-    _, _, _, tru_request_state, _, _ = events[-1]["stop"]
+    _, _, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     # Verify request_state was initialized to empty dict
     assert tru_request_state == {}
@@ -845,7 +845,7 @@ async def test_request_state_initialization(alist):
         invocation_state={"request_state": initial_request_state},
     )
     events = await alist(stream)
-    _, _, _, tru_request_state, _, _ = events[-1]["stop"]
+    _, _, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     # Verify existing request_state was preserved
     assert tru_request_state == initial_request_state
@@ -969,7 +969,7 @@ async def test_event_loop_cycle_interrupt(agent, model, tool_stream, agenerator,
     stream = strands.event_loop.event_loop.event_loop_cycle(agent, invocation_state={})
     events = await alist(stream)
 
-    tru_stop_reason, _, _, _, tru_interrupts, _ = events[-1]["stop"]
+    tru_stop_reason, _, _, _, tru_interrupts, _, _ = events[-1]["stop"]
     exp_stop_reason = "interrupt"
     exp_interrupts = [
         Interrupt(
@@ -1064,7 +1064,7 @@ async def test_event_loop_cycle_interrupt_resume(agent, model, tool, tool_times_
     stream = strands.event_loop.event_loop.event_loop_cycle(agent, invocation_state={})
     events = await alist(stream)
 
-    tru_stop_reason, _, _, _, _, _ = events[-1]["stop"]
+    tru_stop_reason, _, _, _, _, _, _ = events[-1]["stop"]
     exp_stop_reason = "end_turn"
     assert tru_stop_reason == exp_stop_reason
 
@@ -1196,5 +1196,5 @@ async def test_event_loop_metrics_recorded_before_recursion(
         assert mock_end_cycle.call_count == 2
 
         # Verify the event loop completed successfully
-        tru_stop_reason, _, _, _, _, _ = events[-1]["stop"]
+        tru_stop_reason, _, _, _, _, _, _ = events[-1]["stop"]
         assert tru_stop_reason == "end_turn"

--- a/tests/strands/event_loop/test_event_loop_structured_output.py
+++ b/tests/strands/event_loop/test_event_loop_structured_output.py
@@ -60,6 +60,7 @@ def mock_agent():
     agent._interrupt_state.activated = False
     agent._interrupt_state.context = {}
     agent._cancel_signal = threading.Event()
+    agent._checkpointing = False
 
     return agent
 

--- a/tests/strands/types/test__events.py
+++ b/tests/strands/types/test__events.py
@@ -279,7 +279,7 @@ class TestEventLoopStopEvent:
         request_state = {"state": "final"}
 
         event = EventLoopStopEvent(stop_reason, message, metrics, request_state)
-        assert event["stop"] == (stop_reason, message, metrics, request_state, None, None)
+        assert event["stop"] == (stop_reason, message, metrics, request_state, None, None, None)
         assert event.is_callback_event is False
 
     def test_initialization_with_structured_output(self):
@@ -290,8 +290,8 @@ class TestEventLoopStopEvent:
         request_state = {"state": "final"}
         structured_output = SampleModel(name="test", value=42)
 
-        event = EventLoopStopEvent(stop_reason, message, metrics, request_state, structured_output)
-        assert event["stop"] == (stop_reason, message, metrics, request_state, structured_output, None)
+        event = EventLoopStopEvent(stop_reason, message, metrics, request_state, structured_output=structured_output)
+        assert event["stop"] == (stop_reason, message, metrics, request_state, None, structured_output, None)
         assert event.is_callback_event is False
 
 


### PR DESCRIPTION
## Description

Promotes the checkpoint/durability system integrated directly into the agent event loop. 

### Checkpoint system (core change)

- New `strands.checkpoint.Checkpoint` dataclass with schema versioning, `to_dict()`/`from_dict()` serialization, and `app_data` for provider-owned metadata (e.g. Temporal workflow IDs).
- `Agent(checkpointing=True)` enables durable mode. The event loop emits `stop_reason="checkpoint"` at two positions per ReAct cycle: `after_model` (before tool execution) and `after_tools` (before next model call).
- Resume via `checkpointResume` content block — mirrors the existing interrupt resume pattern. Validates single-block, no-mixing, and checkpointing-enabled constraints.
- `AgentResult.checkpoint` field carries the checkpoint data when `stop_reason="checkpoint"`.
- `Checkpoint` exported from top-level `strands` package.


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
