### PR TITLE
fix(tests): update retired claude-3-haiku model in integration tests

### DIFF
--- a/tests_integ/test_summarizing_conversation_manager_integration.py
+++ b/tests_integ/test_summarizing_conversation_manager_integration.py
@@ -34,7 +34,7 @@ def model():
         client_args={
             "api_key": os.getenv("ANTHROPIC_API_KEY"),
         },
-        model_id="claude-3-haiku-20240307",  # Using Haiku for faster/cheaper tests
+        model_id="claude-haiku-4-5-20251001",  # Using Haiku for faster/cheaper tests
         max_tokens=1024,
     )
 
@@ -46,7 +46,7 @@ def summarization_model():
         client_args={
             "api_key": os.getenv("ANTHROPIC_API_KEY"),
         },
-        model_id="claude-3-haiku-20240307",
+        model_id="claude-haiku-4-5-20251001",
         max_tokens=512,
     )
 


### PR DESCRIPTION

## Description
Replace claude-3-haiku-20240307 with claude-haiku-4-5-20251001 in summarizing conversation manager integration test fixtures. The old model was retired by Anthropic on April 20, 2026, causing 404 errors.

https://platform.claude.com/docs/en/about-claude/model-deprecations#model-status


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
