### PR TITLE
fix: use non-interactive flag for Nova Sonic history and system promp…

### DIFF
--- a/src/strands/experimental/bidi/models/nova_sonic.py
+++ b/src/strands/experimental/bidi/models/nova_sonic.py
@@ -96,6 +96,9 @@ NOVA_AUDIO_OUTPUT_CONFIG = {
 NOVA_TEXT_CONFIG = {"mediaType": "text/plain"}
 NOVA_TOOL_CONFIG = {"mediaType": "application/json"}
 
+_MAX_HISTORY_MESSAGE_BYTES = 50 * 1024  # 50KB per message
+_MAX_HISTORY_TOTAL_BYTES = 200 * 1024  # 200KB total history
+
 
 class BidiNovaSonicModel(BidiModel):
     """Nova Sonic implementation for bidirectional streaming.
@@ -726,7 +729,7 @@ class BidiNovaSonicModel(BidiModel):
         """Generate system prompt events."""
         content_name = str(uuid.uuid4())
         return [
-            self._get_text_content_start_event(content_name, "SYSTEM"),
+            self._get_text_content_start_event(content_name, "SYSTEM", interactive=False),
             self._get_text_input_event(content_name, system_prompt or ""),
             self._get_content_end_event(content_name),
         ]
@@ -737,42 +740,98 @@ class BidiNovaSonicModel(BidiModel):
         Converts agent message history to Nova Sonic format following the
         contentStart/textInput/contentEnd pattern for each message.
 
+        History messages are sent as non-interactive (interactive=False) so Nova Sonic
+        treats them as prior context rather than new inputs requiring a response.
+
+        Individual messages are truncated to 50KB and total history is capped
+        at 200KB. When the limit is reached, the oldest messages are dropped
+        to prioritize recent conversation context.
+
         Args:
             messages: List of conversation messages with role and content.
 
         Returns:
             List of JSON event strings for Nova Sonic.
         """
-        events = []
+        max_message_bytes = _MAX_HISTORY_MESSAGE_BYTES
+        max_total_bytes = _MAX_HISTORY_TOTAL_BYTES
 
-        for message in messages:
-            role = message["role"].upper()  # Convert to ASSISTANT or USER
+        # First pass: extract and truncate text from each message, walking backwards
+        # to prioritize recent messages when the total size limit is hit
+        prepared: list[tuple[str, str]] = []  # (role, text)
+        total_bytes = 0
+
+        for message in reversed(messages):
+            role = message["role"].upper()
             content_blocks = message.get("content", [])
 
-            # Extract text content from content blocks
             text_parts = []
             for block in content_blocks:
                 if "text" in block:
                     text_parts.append(block["text"])
 
-            # Combine all text parts
-            if text_parts:
-                combined_text = "\n".join(text_parts)
-                content_name = str(uuid.uuid4())
+            if not text_parts:
+                continue
 
-                # Add contentStart, textInput, and contentEnd events
-                events.extend(
-                    [
-                        self._get_text_content_start_event(content_name, role),
-                        self._get_text_input_event(content_name, combined_text),
-                        self._get_content_end_event(content_name),
-                    ]
+            combined_text = "\n".join(text_parts)
+
+            # Truncate individual message
+            encoded = combined_text.encode("utf-8")
+            if len(encoded) > max_message_bytes:
+                encoded = encoded[:max_message_bytes]
+                combined_text = encoded.decode("utf-8", errors="ignore")
+                encoded = combined_text.encode("utf-8")
+
+            msg_bytes = len(encoded)
+
+            if total_bytes + msg_bytes > max_total_bytes:
+                logger.debug(
+                    "total_bytes=<%d>, msg_bytes=<%d>, max_total_bytes=<%d> | dropping older messages to fit limit",
+                    total_bytes,
+                    msg_bytes,
+                    max_total_bytes,
                 )
+                break
+
+            total_bytes += msg_bytes
+            prepared.append((role, combined_text))
+
+        # Reverse back to chronological order
+        prepared.reverse()
+
+        # Ensure the first message is from the user role — drop leading assistant messages
+        while prepared and prepared[0][0] != "USER":
+            dropped_role, dropped_text = prepared.pop(0)
+            logger.debug(
+                "role=<%s>, text_preview=<%s> | dropping leading non-user message from history",
+                dropped_role,
+                dropped_text[:100],
+            )
+
+        logger.debug("prepared_count=<%d>, total_bytes=<%d> | final history after trimming", len(prepared), total_bytes)
+
+        # Second pass: build events
+        events: list[str] = []
+        for role, text in prepared:
+            content_name = str(uuid.uuid4())
+            events.extend(
+                [
+                    self._get_text_content_start_event(content_name, role, interactive=False),
+                    self._get_text_input_event(content_name, text),
+                    self._get_content_end_event(content_name),
+                ]
+            )
 
         return events
 
-    def _get_text_content_start_event(self, content_name: str, role: str = "USER") -> str:
-        """Generate text content start event."""
+    def _get_text_content_start_event(self, content_name: str, role: str = "USER", interactive: bool = True) -> str:
+        """Generate text content start event.
+
+        Args:
+            content_name: Unique identifier for this content block.
+            role: Message role (USER, ASSISTANT, SYSTEM).
+            interactive: Whether this is a live input (True) or history context (False).
+        """
         return json.dumps(
             {
                 "event": {
@@ -781,7 +840,7 @@ class BidiNovaSonicModel(BidiModel):
                         "contentName": content_name,
                         "type": "TEXT",
                         "role": role,
-                        "interactive": True,
+                        "interactive": interactive,
                         "textInputConfiguration": NOVA_TEXT_CONFIG,
                     }
                 }


### PR DESCRIPTION
…t events


## Description

When a `BidiAgent` session is renewed (stopped and recreated with conversation history), Nova Sonic repeats or re-summarizes prior assistant responses. This happens because conversation history messages are sent with `interactive: True`, causing Nova Sonic to treat them as new live inputs requiring a response rather than prior context.

Additionally, there are no size guards on replayed history, so unbounded message accumulation can cause failures or degraded performance on session renewal.

### Public API Changes

`_get_text_content_start_event` now accepts an optional `interactive` parameter (defaults to `True`, fully backward compatible):

```python
# Before
def _get_text_content_start_event(self, content_name: str, role: str = "USER") -> str:

# After
def _get_text_content_start_event(self, content_name: str, role: str = "USER", interactive: bool = True) -> str:
```

No changes to any public-facing API. All changes are internal to `BidiNovaSonicModel`.

### Changes

- History messages are now sent with `interactive: False` so Nova Sonic treats them as prior context, not new inputs
- System prompt events are also sent with `interactive: False` to match Nova Sonic best practices
- Individual history messages are truncated to 50KB, total history capped at 200KB
- When the size limit is reached, oldest messages are dropped first to prioritize recent context
- History replay always starts with a user-role message (leading assistant messages are dropped)

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug fix

## Testing

- Tested with a local BidiAgent harness that refreshes sessions every 30 seconds
- Verified via debug logging that history messages are sent with `interactive: false`
- Confirmed Nova Sonic no longer repeats prior responses after session renewal
- Validated that oldest messages are correctly dropped when history exceeds size limits

- [x] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

