### PR TITLE
feat: override count_tokens with native token counting for supported providers

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -16,7 +16,7 @@ from typing_extensions import Required, Unpack, override
 
 from ..event_loop.streaming import process_stream
 from ..tools.structured_output.structured_output_utils import convert_pydantic_to_tool_spec
-from ..types.content import ContentBlock, Messages
+from ..types.content import ContentBlock, Messages, SystemContentBlock
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolChoiceToolDict, ToolSpec
@@ -370,6 +370,54 @@ class AnthropicModel(Model):
 
             case _:
                 raise RuntimeError(f"event_type=<{event['type']} | unknown type")
+
+    @override
+    async def count_tokens(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+    ) -> int:
+        """Count tokens using Anthropic's native count_tokens API.
+
+        Uses the same message format as the Messages API to get accurate token counts
+        directly from the Anthropic service.
+
+        Args:
+            messages: List of message objects to count tokens for.
+            tool_specs: List of tool specifications to include in the count.
+            system_prompt: Plain string system prompt. Ignored if system_prompt_content is provided.
+            system_prompt_content: Structured system prompt content blocks.
+
+        Returns:
+            Total input token count.
+        """
+        try:
+            # system_prompt_content is not used; this provider only accepts system_prompt as a plain string,
+            # matching the behavior of stream(). The caller always provides system_prompt alongside
+            # system_prompt_content, so the plain string is always available.
+            request = self.format_request(messages, tool_specs, system_prompt)
+            # Keep only fields accepted by count_tokens; strip inference params (max_tokens, temperature, etc.)
+            count_tokens_fields = {"model", "messages", "tools", "tool_choice", "system"}
+            request = {k: request[k] for k in request.keys() & count_tokens_fields}
+
+            response = await self.client.messages.count_tokens(**request)
+            total_tokens: int = response.input_tokens
+
+            logger.debug(
+                "model_id=<%s>, total_tokens=<%d> | native token count",
+                self.config["model_id"],
+                total_tokens,
+            )
+            return total_tokens
+        except Exception as e:
+            logger.warning(
+                "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
+                self.config["model_id"],
+                e,
+            )
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
 
     @override
     async def stream(

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -750,6 +750,58 @@ class BedrockModel(Model):
         return events
 
     @override
+    async def count_tokens(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+    ) -> int:
+        """Count tokens using Bedrock's native CountTokens API.
+
+        Uses the same message format as the Converse API to get accurate token counts
+        directly from the Bedrock service.
+
+        Args:
+            messages: List of message objects to count tokens for.
+            tool_specs: List of tool specifications to include in the count.
+            system_prompt: Plain string system prompt. Ignored if system_prompt_content is provided.
+            system_prompt_content: Structured system prompt content blocks.
+
+        Returns:
+            Total input token count.
+        """
+        try:
+            if system_prompt and system_prompt_content is None:
+                system_prompt_content = [{"text": system_prompt}]
+
+            request = self._format_request(messages, tool_specs, system_prompt_content)
+            converse_input: dict[str, Any] = {}
+            if "messages" in request:
+                converse_input["messages"] = request["messages"]
+            if "system" in request:
+                converse_input["system"] = request["system"]
+            if "toolConfig" in request:
+                converse_input["toolConfig"] = request["toolConfig"]
+
+            response = await asyncio.to_thread(
+                self.client.count_tokens,
+                modelId=self.config["model_id"],
+                input={"converse": converse_input},
+            )
+            total_tokens: int = response["inputTokens"]
+
+            logger.debug("model_id=<%s>, total_tokens=<%d> | native token count", self.config["model_id"], total_tokens)
+            return total_tokens
+        except Exception as e:
+            logger.warning(
+                "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
+                self.config["model_id"],
+                e,
+            )
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
+
+    @override
     async def stream(
         self,
         messages: Messages,

--- a/src/strands/models/gemini.py
+++ b/src/strands/models/gemini.py
@@ -15,7 +15,7 @@ import pydantic
 from google import genai
 from typing_extensions import Required, Unpack, override
 
-from ..types.content import ContentBlock, ContentBlockStartToolUse, Messages
+from ..types.content import ContentBlock, ContentBlockStartToolUse, Messages, SystemContentBlock
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
@@ -433,6 +433,65 @@ class GeminiModel(Model):
 
             case _:  # pragma: no cover
                 raise RuntimeError(f"chunk_type=<{event['chunk_type']} | unknown type")
+
+    @override
+    async def count_tokens(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+    ) -> int:
+        """Count tokens using Gemini's native count_tokens API.
+
+        Uses the Gemini count_tokens API for message contents. The Gemini API does not support
+        counting system_instruction or tools, so those are estimated via the base class heuristic.
+
+        Args:
+            messages: List of message objects to count tokens for.
+            tool_specs: List of tool specifications to include in the count.
+            system_prompt: Plain string system prompt.
+            system_prompt_content: Structured system prompt content blocks.
+
+        Returns:
+            Total input token count.
+        """
+        try:
+            contents = list(self._format_request_content(messages))
+
+            client = self._get_client().aio
+            response = await client.models.count_tokens(
+                model=self.config["model_id"],
+                contents=contents,
+            )
+            if response.total_tokens is None:
+                raise ValueError("Gemini count_tokens returned None for total_tokens")
+            total_tokens: int = response.total_tokens
+
+            # The google-genai SDK explicitly raises ValueError for system_instruction, tools, and
+            # generation_config in CountTokensConfig on the non-Vertex (mldev) backend.
+            # Use heuristic for these.
+            extra = await super().count_tokens(
+                messages=[],
+                tool_specs=tool_specs,
+                system_prompt=system_prompt,
+                system_prompt_content=system_prompt_content,
+            )
+            total_tokens += extra
+
+            logger.debug(
+                "model_id=<%s>, total_tokens=<%d> | native token count",
+                self.config["model_id"],
+                total_tokens,
+            )
+            return total_tokens
+        except Exception as e:
+            logger.warning(
+                "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
+                self.config["model_id"],
+                e,
+            )
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
 
     async def stream(
         self,

--- a/src/strands/models/llamacpp.py
+++ b/src/strands/models/llamacpp.py
@@ -25,7 +25,7 @@ import httpx
 from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
-from ..types.content import ContentBlock, Messages
+from ..types.content import ContentBlock, Messages, SystemContentBlock
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
@@ -507,6 +507,60 @@ class LlamaCppModel(Model):
 
             case _:
                 raise RuntimeError(f"chunk_type=<{event['chunk_type']}> | unknown type")
+
+    @override
+    async def count_tokens(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+    ) -> int:
+        """Count tokens using llama.cpp's native /tokenize endpoint.
+
+        Sends the formatted prompt to the llama.cpp server's tokenization endpoint
+        to get an accurate token count. Requires a llama.cpp server version that supports
+        chat-template-aware tokenization via the ``messages`` field in /tokenize requests.
+        Older server versions that only accept ``{"content": "string"}`` are not supported
+        and will fall back to estimation.
+
+        Args:
+            messages: List of message objects to count tokens for.
+            tool_specs: List of tool specifications to include in the count.
+            system_prompt: Plain string system prompt. Ignored if system_prompt_content is provided.
+            system_prompt_content: Structured system prompt content blocks.
+
+        Returns:
+            Total input token count.
+        """
+        try:
+            # system_prompt_content is not used; this provider only accepts system_prompt as a plain string,
+            # matching the behavior of stream(). The caller always provides system_prompt alongside
+            # system_prompt_content, so the plain string is always available.
+            request = self._format_request(messages, tool_specs, system_prompt)
+            payload = {
+                "messages": request["messages"],
+                **({"tools": request["tools"]} if request.get("tools") else {}),
+            }
+
+            response = await self.client.post("/tokenize", json=payload)
+            response.raise_for_status()
+            data = response.json()
+            total_tokens: int = len(data.get("tokens", []))
+
+            logger.debug(
+                "model_id=<%s>, total_tokens=<%d> | native token count",
+                self.config.get("model_id", "default"),
+                total_tokens,
+            )
+            return total_tokens
+        except Exception as e:
+            logger.warning(
+                "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
+                self.config.get("model_id", "default"),
+                e,
+            )
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
 
     @override
     async def stream(

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -54,7 +54,7 @@ except Exception as e:
 import openai  # noqa: E402 - must import after version check
 
 from ..types.citations import WebLocationDict  # noqa: E402
-from ..types.content import ContentBlock, Messages, Role  # noqa: E402
+from ..types.content import ContentBlock, Messages, Role, SystemContentBlock  # noqa: E402
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException  # noqa: E402
 from ..types.streaming import StreamEvent  # noqa: E402
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse  # noqa: E402
@@ -183,6 +183,55 @@ class OpenAIResponsesModel(Model):
             The OpenAI Responses API model configuration.
         """
         return cast(OpenAIResponsesModel.OpenAIResponsesConfig, self.config)
+
+    @override
+    async def count_tokens(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+    ) -> int:
+        """Count tokens using the OpenAI Responses API input_tokens.count endpoint.
+
+        Uses the same message format as the Responses API to get accurate token counts
+        directly from the OpenAI service.
+
+        Args:
+            messages: List of message objects to count tokens for.
+            tool_specs: List of tool specifications to include in the count.
+            system_prompt: Plain string system prompt. Ignored if system_prompt_content is provided.
+            system_prompt_content: Structured system prompt content blocks.
+
+        Returns:
+            Total input token count.
+        """
+        try:
+            # system_prompt_content is not used; this provider only accepts system_prompt as a plain string,
+            # matching the behavior of stream(). The caller always provides system_prompt alongside
+            # system_prompt_content, so the plain string is always available.
+            request = self._format_request(messages, tool_specs, system_prompt)
+            # Keep only fields accepted by input_tokens.count
+            count_tokens_fields = {"model", "input", "instructions", "tools"}
+            request = {k: request[k] for k in request.keys() & count_tokens_fields}
+
+            async with openai.AsyncOpenAI(**self.client_args) as client:
+                response = await client.responses.input_tokens.count(**request)
+                total_tokens: int = response.input_tokens
+
+            logger.debug(
+                "model_id=<%s>, total_tokens=<%d> | native token count",
+                self.config["model_id"],
+                total_tokens,
+            )
+            return total_tokens
+        except Exception as e:
+            logger.warning(
+                "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
+                self.config["model_id"],
+                e,
+            )
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
 
     @override
     async def stream(

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -1040,3 +1040,101 @@ async def test_stream_message_stop_no_pydantic_warnings(anthropic_client, model,
 
     # Verify the message_stop event was still processed correctly
     assert {"messageStop": {"stopReason": mock_message_stop.message.stop_reason}} in events
+
+
+class TestCountTokens:
+    """Tests for AnthropicModel.count_tokens native token counting."""
+
+    @pytest.fixture
+    def model_with_client(self, anthropic_client, model_id, max_tokens):
+        _ = anthropic_client
+        return AnthropicModel(model_id=model_id, max_tokens=max_tokens)
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": [{"text": "hello"}]}]
+
+    @pytest.fixture
+    def tool_specs(self):
+        return [
+            {
+                "name": "test_tool",
+                "description": "A test tool",
+                "inputSchema": {"json": {"type": "object", "properties": {}}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_success(self, model_with_client, anthropic_client, messages):
+        mock_response = unittest.mock.MagicMock()
+        mock_response.input_tokens = 42
+        anthropic_client.messages.count_tokens = unittest.mock.AsyncMock(return_value=mock_response)
+
+        result = await model_with_client.count_tokens(messages=messages)
+
+        assert result == 42
+        anthropic_client.messages.count_tokens.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_system_prompt(self, model_with_client, anthropic_client, messages):
+        mock_response = unittest.mock.MagicMock()
+        mock_response.input_tokens = 55
+        anthropic_client.messages.count_tokens = unittest.mock.AsyncMock(return_value=mock_response)
+
+        result = await model_with_client.count_tokens(messages=messages, system_prompt="Be helpful.")
+
+        assert result == 55
+        call_kwargs = anthropic_client.messages.count_tokens.call_args[1]
+        assert call_kwargs["system"] == "Be helpful."
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_tool_specs(self, model_with_client, anthropic_client, messages, tool_specs):
+        mock_response = unittest.mock.MagicMock()
+        mock_response.input_tokens = 100
+        anthropic_client.messages.count_tokens = unittest.mock.AsyncMock(return_value=mock_response)
+
+        result = await model_with_client.count_tokens(messages=messages, tool_specs=tool_specs)
+
+        assert result == 100
+        call_kwargs = anthropic_client.messages.count_tokens.call_args[1]
+        assert "tools" in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_stripped_from_request(self, model_with_client, anthropic_client, messages):
+        mock_response = unittest.mock.MagicMock()
+        mock_response.input_tokens = 10
+        anthropic_client.messages.count_tokens = unittest.mock.AsyncMock(return_value=mock_response)
+
+        await model_with_client.count_tokens(messages=messages)
+
+        call_kwargs = anthropic_client.messages.count_tokens.call_args[1]
+        assert "max_tokens" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_api_error(self, model_with_client, anthropic_client, messages):
+        anthropic_client.messages.count_tokens = unittest.mock.AsyncMock(
+            side_effect=anthropic.APIError(message="Unsupported", request=unittest.mock.MagicMock(), body=None)
+        )
+
+        result = await model_with_client.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_generic_exception(self, model_with_client, anthropic_client, messages):
+        anthropic_client.messages.count_tokens = unittest.mock.AsyncMock(side_effect=RuntimeError("Connection failed"))
+
+        result = await model_with_client.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_logs_warning(self, model_with_client, anthropic_client, messages, caplog):
+        anthropic_client.messages.count_tokens = unittest.mock.AsyncMock(side_effect=RuntimeError("API down"))
+
+        with caplog.at_level(logging.WARNING):
+            await model_with_client.count_tokens(messages=messages)
+
+        assert any("native token counting failed" in record.message for record in caplog.records)

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -3103,3 +3103,115 @@ async def test_non_streaming_citations_with_only_location(bedrock_client, model,
     assert citation["location"] == {"web": {"url": "https://example.com", "domain": "example.com"}}
     assert "title" not in citation
     assert "sourceContent" not in citation
+
+
+class TestCountTokens:
+    """Tests for BedrockModel.count_tokens native token counting."""
+
+    @pytest.fixture
+    def model_with_client(self, bedrock_client, model_id):
+        _ = bedrock_client
+        return BedrockModel(model_id=model_id)
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": [{"text": "hello"}]}]
+
+    @pytest.fixture
+    def tool_specs(self):
+        return [
+            {
+                "name": "test_tool",
+                "description": "A test tool",
+                "inputSchema": {"json": {"type": "object", "properties": {}}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_success(self, model_with_client, bedrock_client, messages):
+        bedrock_client.count_tokens.return_value = {"inputTokens": 42}
+
+        result = await model_with_client.count_tokens(messages=messages)
+
+        assert result == 42
+        bedrock_client.count_tokens.assert_called_once()
+        call_kwargs = bedrock_client.count_tokens.call_args[1]
+        assert "input" in call_kwargs
+        assert "converse" in call_kwargs["input"]
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_system_prompt(self, model_with_client, bedrock_client, messages):
+        bedrock_client.count_tokens.return_value = {"inputTokens": 55}
+
+        result = await model_with_client.count_tokens(messages=messages, system_prompt="Be helpful.")
+
+        assert result == 55
+        call_kwargs = bedrock_client.count_tokens.call_args[1]
+        assert call_kwargs["input"]["converse"]["system"] == [{"text": "Be helpful."}]
+        assert "toolConfig" not in call_kwargs["input"]["converse"]
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_tool_specs(self, model_with_client, bedrock_client, messages, tool_specs):
+        bedrock_client.count_tokens.return_value = {"inputTokens": 100}
+
+        result = await model_with_client.count_tokens(messages=messages, tool_specs=tool_specs)
+
+        assert result == 100
+        call_kwargs = bedrock_client.count_tokens.call_args[1]
+        assert "toolConfig" in call_kwargs["input"]["converse"]
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_system_prompt_content(self, model_with_client, bedrock_client, messages):
+        bedrock_client.count_tokens.return_value = {"inputTokens": 60}
+
+        result = await model_with_client.count_tokens(
+            messages=messages,
+            system_prompt_content=[{"text": "Be helpful."}, {"text": "Be concise."}],
+        )
+
+        assert result == 60
+        call_kwargs = bedrock_client.count_tokens.call_args[1]
+        assert call_kwargs["input"]["converse"]["system"] == [{"text": "Be helpful."}, {"text": "Be concise."}]
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_strips_inference_config(self, model_with_client, bedrock_client, messages):
+        bedrock_client.count_tokens.return_value = {"inputTokens": 10}
+        model_with_client.update_config(max_tokens=100)
+
+        await model_with_client.count_tokens(messages=messages)
+
+        call_kwargs = bedrock_client.count_tokens.call_args[1]
+        converse = call_kwargs["input"]["converse"]
+        assert "inferenceConfig" not in converse
+        assert "additionalModelRequestFields" not in converse
+        assert "guardrailConfig" not in converse
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_api_error(self, model_with_client, bedrock_client, messages):
+        bedrock_client.count_tokens.side_effect = ClientError(
+            {"Error": {"Code": "ValidationException", "Message": "Unsupported"}},
+            "CountTokens",
+        )
+
+        result = await model_with_client.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_generic_exception(self, model_with_client, bedrock_client, messages):
+        bedrock_client.count_tokens.side_effect = RuntimeError("Connection failed")
+
+        result = await model_with_client.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_logs_warning(self, model_with_client, bedrock_client, messages, caplog):
+        bedrock_client.count_tokens.side_effect = RuntimeError("API down")
+
+        with caplog.at_level(logging.WARNING):
+            await model_with_client.count_tokens(messages=messages)
+
+        assert any("native token counting failed" in record.message for record in caplog.records)

--- a/tests/strands/models/test_gemini.py
+++ b/tests/strands/models/test_gemini.py
@@ -1105,3 +1105,102 @@ def test_format_request_filters_location_source_document(model, caplog):
     assert len(formatted_content) == 1
     assert "text" in formatted_content[0]
     assert "Location sources are not supported by Gemini" in caplog.text
+
+
+class TestCountTokens:
+    """Tests for GeminiModel.count_tokens native token counting."""
+
+    @pytest.fixture
+    def gemini_client(self):
+        with unittest.mock.patch.object(strands.models.gemini.genai, "Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value
+            mock_client.aio = unittest.mock.AsyncMock()
+            yield mock_client
+
+    @pytest.fixture
+    def model(self, gemini_client):
+        _ = gemini_client
+        return GeminiModel(model_id="m1")
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": [{"text": "hello"}]}]
+
+    @pytest.fixture
+    def tool_specs(self):
+        return [
+            {
+                "name": "test_tool",
+                "description": "A test tool",
+                "inputSchema": {"json": {"type": "object", "properties": {}}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_success(self, model, gemini_client, messages):
+        mock_response = unittest.mock.AsyncMock()
+        mock_response.total_tokens = 42
+        gemini_client.aio.models.count_tokens.return_value = mock_response
+
+        result = await model.count_tokens(messages=messages)
+
+        assert result == 42
+        gemini_client.aio.models.count_tokens.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_system_prompt(self, model, gemini_client, messages):
+        mock_response = unittest.mock.AsyncMock()
+        mock_response.total_tokens = 55
+        gemini_client.aio.models.count_tokens.return_value = mock_response
+
+        result = await model.count_tokens(messages=messages, system_prompt="Be helpful.")
+
+        assert result > 55  # native (55) + heuristic estimate for system_prompt
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_tool_specs(self, model, gemini_client, messages, tool_specs):
+        mock_response = unittest.mock.AsyncMock()
+        mock_response.total_tokens = 100
+        gemini_client.aio.models.count_tokens.return_value = mock_response
+
+        result = await model.count_tokens(messages=messages, tool_specs=tool_specs)
+
+        assert result > 100  # native (100) + heuristic estimate for tool_specs
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_none_total_tokens(self, model, gemini_client, messages):
+        mock_response = unittest.mock.AsyncMock()
+        mock_response.total_tokens = None
+        gemini_client.aio.models.count_tokens.return_value = mock_response
+
+        result = await model.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_api_error(self, model, gemini_client, messages):
+        gemini_client.aio.models.count_tokens.side_effect = genai.errors.ClientError("Unsupported", response_json={})
+
+        result = await model.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_generic_exception(self, model, gemini_client, messages):
+        gemini_client.aio.models.count_tokens.side_effect = RuntimeError("Connection failed")
+
+        result = await model.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_logs_warning(self, model, gemini_client, messages, caplog):
+        gemini_client.aio.models.count_tokens.side_effect = RuntimeError("API down")
+
+        with caplog.at_level(logging.WARNING):
+            await model.count_tokens(messages=messages)
+
+        assert any("native token counting failed" in record.message for record in caplog.records)

--- a/tests/strands/models/test_llamacpp.py
+++ b/tests/strands/models/test_llamacpp.py
@@ -706,3 +706,100 @@ def test_format_request_filters_location_source_document(caplog) -> None:
     assert len(user_content) == 1
     assert user_content[0]["type"] == "text"
     assert "Location sources are not supported by llama.cpp" in caplog.text
+
+
+class TestCountTokens:
+    """Tests for LlamaCppModel.count_tokens native token counting."""
+
+    @pytest.fixture
+    def model(self):
+        return LlamaCppModel(base_url="http://localhost:8080")
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": [{"text": "hello"}]}]
+
+    @pytest.fixture
+    def tool_specs(self):
+        return [
+            {
+                "name": "test_tool",
+                "description": "A test tool",
+                "inputSchema": {"json": {"type": "object", "properties": {}}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_success(self, model, messages):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"tokens": [1, 2, 3, 4, 5]}
+        mock_response.raise_for_status = MagicMock()
+        model.client.post = AsyncMock(return_value=mock_response)
+
+        result = await model.count_tokens(messages=messages)
+
+        assert result == 5
+        model.client.post.assert_called_once()
+        call_args = model.client.post.call_args
+        assert call_args[0][0] == "/tokenize"
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_system_prompt(self, model, messages):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"tokens": list(range(10))}
+        mock_response.raise_for_status = MagicMock()
+        model.client.post = AsyncMock(return_value=mock_response)
+
+        result = await model.count_tokens(messages=messages, system_prompt="Be helpful.")
+
+        assert result == 10
+        call_kwargs = model.client.post.call_args[1]
+        payload = call_kwargs["json"]
+        assert payload["messages"][0]["role"] == "system"
+        assert payload["messages"][0]["content"] == "Be helpful."
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_tool_specs(self, model, messages, tool_specs):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"tokens": list(range(20))}
+        mock_response.raise_for_status = MagicMock()
+        model.client.post = AsyncMock(return_value=mock_response)
+
+        result = await model.count_tokens(messages=messages, tool_specs=tool_specs)
+
+        assert result == 20
+        call_kwargs = model.client.post.call_args[1]
+        payload = call_kwargs["json"]
+        assert "tools" in payload
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_http_error(self, model, messages):
+        model.client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError("Server error", request=MagicMock(), response=MagicMock(status_code=500))
+        )
+
+        result = await model.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_connection_error(self, model, messages):
+        model.client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+
+        result = await model.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_logs_warning(self, model, messages, caplog):
+        model.client.post = AsyncMock(side_effect=RuntimeError("Server down"))
+
+        with caplog.at_level(logging.WARNING):
+            await model.count_tokens(messages=messages)
+
+        assert any("native token counting failed" in record.message for record in caplog.records)

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -1190,3 +1190,111 @@ def test_format_request_messages_excludes_reasoning_content(caplog):
         {"role": "user", "content": [{"type": "input_text", "text": "Thanks"}]},
     ]
     assert "reasoningContent is not yet supported" in caplog.text
+
+
+class TestCountTokens:
+    """Tests for OpenAIResponsesModel.count_tokens native token counting."""
+
+    @pytest.fixture
+    def openai_client(self):
+        with unittest.mock.patch.object(strands.models.openai_responses.openai, "AsyncOpenAI") as mock_client_cls:
+            mock_client = unittest.mock.AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+            yield mock_client
+
+    @pytest.fixture
+    def model(self, openai_client):
+        _ = openai_client
+        return OpenAIResponsesModel(model_id="gpt-4o")
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": [{"text": "hello"}]}]
+
+    @pytest.fixture
+    def tool_specs(self):
+        return [
+            {
+                "name": "test_tool",
+                "description": "A test tool",
+                "inputSchema": {"json": {"type": "object", "properties": {}}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_success(self, model, openai_client, messages):
+        mock_response = unittest.mock.AsyncMock()
+        mock_response.input_tokens = 42
+        openai_client.responses.input_tokens.count.return_value = mock_response
+
+        result = await model.count_tokens(messages=messages)
+
+        assert result == 42
+        openai_client.responses.input_tokens.count.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_system_prompt(self, model, openai_client, messages):
+        mock_response = unittest.mock.AsyncMock()
+        mock_response.input_tokens = 55
+        openai_client.responses.input_tokens.count.return_value = mock_response
+
+        result = await model.count_tokens(messages=messages, system_prompt="Be helpful.")
+
+        assert result == 55
+        call_kwargs = openai_client.responses.input_tokens.count.call_args[1]
+        assert call_kwargs["instructions"] == "Be helpful."
+
+    @pytest.mark.asyncio
+    async def test_native_count_tokens_with_tool_specs(self, model, openai_client, messages, tool_specs):
+        mock_response = unittest.mock.AsyncMock()
+        mock_response.input_tokens = 100
+        openai_client.responses.input_tokens.count.return_value = mock_response
+
+        result = await model.count_tokens(messages=messages, tool_specs=tool_specs)
+
+        assert result == 100
+        call_kwargs = openai_client.responses.input_tokens.count.call_args[1]
+        assert "tools" in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_stream_and_store_stripped(self, model, openai_client, messages):
+        mock_response = unittest.mock.AsyncMock()
+        mock_response.input_tokens = 10
+        openai_client.responses.input_tokens.count.return_value = mock_response
+
+        await model.count_tokens(messages=messages)
+
+        call_kwargs = openai_client.responses.input_tokens.count.call_args[1]
+        assert "stream" not in call_kwargs
+        assert "store" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_api_error(self, model, openai_client, messages):
+        openai_client.responses.input_tokens.count.side_effect = openai.APIError(
+            message="Unsupported", request=unittest.mock.MagicMock(), body=None
+        )
+
+        result = await model.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_generic_exception(self, model, openai_client, messages):
+        openai_client.responses.input_tokens.count.side_effect = RuntimeError("Connection failed")
+
+        result = await model.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_logs_warning(self, model, openai_client, messages, caplog):
+        import logging
+
+        openai_client.responses.input_tokens.count.side_effect = RuntimeError("API down")
+
+        with caplog.at_level(logging.WARNING):
+            await model.count_tokens(messages=messages)
+
+        assert any("native token counting failed" in record.message for record in caplog.records)

--- a/tests_integ/models/test_model_anthropic.py
+++ b/tests_integ/models/test_model_anthropic.py
@@ -182,3 +182,42 @@ def test_input_and_max_tokens_exceed_context_limit():
 
     with pytest.raises(ContextWindowOverflowException):
         agent(messages)
+
+
+class TestCountTokens:
+    @pytest.fixture
+    def model(self):
+        return AnthropicModel(
+            model_id="claude-sonnet-4-20250514",
+            max_tokens=1024,
+            client_args={"api_key": os.environ["ANTHROPIC_API_KEY"]},
+        )
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": [{"text": "What is the capital of France? Explain in detail."}]}]
+
+    @pytest.fixture
+    def tool_specs(self):
+        return [
+            {
+                "name": "get_weather",
+                "description": "Get the current weather for a location",
+                "inputSchema": {"json": {"type": "object", "properties": {"location": {"type": "string"}}}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_messages_only(self, model, messages, caplog):
+        with caplog.at_level("DEBUG"):
+            result = await model.count_tokens(messages=messages)
+        assert isinstance(result, int)
+        assert result > 0
+        assert "native token count" in caplog.text
+        assert "falling back" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_with_tools_greater_than_without(self, model, messages, tool_specs):
+        without = await model.count_tokens(messages=messages)
+        with_tools = await model.count_tokens(messages=messages, tool_specs=tool_specs, system_prompt="Be helpful.")
+        assert with_tools > without

--- a/tests_integ/models/test_model_bedrock.py
+++ b/tests_integ/models/test_model_bedrock.py
@@ -517,3 +517,38 @@ def test_prompt_caching_backward_compatibility_no_ttl(non_streaming_model):
     assert result.metrics.accumulated_usage.get("cacheWriteInputTokens", 0) > 0, (
         "Expected cacheWriteInputTokens > 0 even without TTL specified"
     )
+
+
+class TestCountTokens:
+    @pytest.fixture
+    def model(self):
+        return BedrockModel(model_id="anthropic.claude-sonnet-4-20250514-v1:0")
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": [{"text": "What is the capital of France? Explain in detail."}]}]
+
+    @pytest.fixture
+    def tool_specs(self):
+        return [
+            {
+                "name": "get_weather",
+                "description": "Get the current weather for a location",
+                "inputSchema": {"json": {"type": "object", "properties": {"location": {"type": "string"}}}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_messages_only(self, model, messages, caplog):
+        with caplog.at_level("DEBUG"):
+            result = await model.count_tokens(messages=messages)
+        assert isinstance(result, int)
+        assert result > 0
+        assert "native token count" in caplog.text
+        assert "falling back" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_with_tools_greater_than_without(self, model, messages, tool_specs):
+        without = await model.count_tokens(messages=messages)
+        with_tools = await model.count_tokens(messages=messages, tool_specs=tool_specs, system_prompt="Be helpful.")
+        assert with_tools > without

--- a/tests_integ/models/test_model_gemini.py
+++ b/tests_integ/models/test_model_gemini.py
@@ -219,3 +219,41 @@ def test_agent_with_reasoning_content(model, assistant_agent):
     result = assistant_agent("Think about what 2+2 is")
     assert "reasoningContent" in result.message["content"][0]
     assert result.message["content"][0]["reasoningContent"]["reasoningText"]["text"]
+
+
+class TestCountTokens:
+    @pytest.fixture
+    def model(self):
+        return GeminiModel(
+            model_id="gemini-2.0-flash",
+            client_args={"api_key": os.environ["GOOGLE_API_KEY"]},
+        )
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": [{"text": "What is the capital of France? Explain in detail."}]}]
+
+    @pytest.fixture
+    def tool_specs(self):
+        return [
+            {
+                "name": "get_weather",
+                "description": "Get the current weather for a location",
+                "inputSchema": {"json": {"type": "object", "properties": {"location": {"type": "string"}}}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_messages_only(self, model, messages, caplog):
+        with caplog.at_level("DEBUG"):
+            result = await model.count_tokens(messages=messages)
+        assert isinstance(result, int)
+        assert result > 0
+        assert "native token count" in caplog.text
+        assert "falling back" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_with_tools_greater_than_without(self, model, messages, tool_specs):
+        without = await model.count_tokens(messages=messages)
+        with_tools = await model.count_tokens(messages=messages, tool_specs=tool_specs, system_prompt="Be helpful.")
+        assert with_tools > without

--- a/tests_integ/models/test_model_openai.py
+++ b/tests_integ/models/test_model_openai.py
@@ -400,3 +400,41 @@ def test_responses_builtin_tool_shell():
     result = agent("Use the shell to compute the md5sum of the string 'strands-test'. Return only the hash.")
     text = result.message["content"][0]["text"]
     assert "d82f373f079b00a1db7ef1eec7f15c68" in text
+
+
+class TestOpenAIResponsesCountTokens:
+    @pytest.fixture
+    def model(self):
+        return OpenAIResponsesModel(
+            model_id="gpt-4o",
+            client_args={"api_key": os.environ["OPENAI_API_KEY"]},
+        )
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": [{"text": "What is the capital of France? Explain in detail."}]}]
+
+    @pytest.fixture
+    def tool_specs(self):
+        return [
+            {
+                "name": "get_weather",
+                "description": "Get the current weather for a location",
+                "inputSchema": {"json": {"type": "object", "properties": {"location": {"type": "string"}}}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_messages_only(self, model, messages, caplog):
+        with caplog.at_level("DEBUG"):
+            result = await model.count_tokens(messages=messages)
+        assert isinstance(result, int)
+        assert result > 0
+        assert "native token count" in caplog.text
+        assert "falling back" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_with_tools_greater_than_without(self, model, messages, tool_specs):
+        without = await model.count_tokens(messages=messages)
+        with_tools = await model.count_tokens(messages=messages, tool_specs=tool_specs, system_prompt="Be helpful.")
+        assert with_tools > without


### PR DESCRIPTION
## Motivation

Proactive context management relies on accurate token counting to make threshold-based compression decisions. The tiktoken/heuristic fallback from PR #2031 introduces a 5-15% estimation error that can cause premature or delayed compression triggers. Native token counting APIs provided by model services eliminate this error by returning exact token counts using the model's own tokenizer.

This change overrides `count_tokens()` in each provider subclass that exposes a native token counting API, falling back to the base class estimation if the native call fails.

Resolves: #2179

## Public API Changes

No new public API surface. The existing `count_tokens()` method (added in #2031) is overridden in 5 provider subclasses to use native APIs instead of tiktoken/heuristic estimation. The method signature is unchanged. Providers without native APIs (OpenAI Chat Completions, Ollama, LlamaAPI, Writer, SageMaker, LiteLLM, Mistral) continue using the tiktoken/heuristic fallback.

```python
# Usage is identical — native counting is transparent to callers
token_count = await agent.model.count_tokens(
    messages=messages,
    tool_specs=tool_specs,
    system_prompt="You are a helpful assistant.",
)
```

## Use Cases

Each provider reuses its existing message formatting logic, calls the native counting API, and falls back to `super().count_tokens()` with a warning log on any failure:

- **Bedrock** — `client.count_tokens()` via boto3 (same format as Converse API)
- **Anthropic** — `client.messages.count_tokens()` (same format as Messages API)
- **OpenAI Responses** — `client.responses.input_tokens.count()` (same format as Responses API)
- **Gemini** — `client.models.count_tokens()` for messages, with heuristic fallback for system prompt and tools (google-genai SDK raises ValueError for these on non-Vertex backend)
- **llama.cpp** — `POST /tokenize` HTTP endpoint on the local server

Fields irrelevant to token counting (e.g., `inferenceConfig`, `stream`, `store`, `max_tokens`) are stripped from the request before calling the counting API. All native calls are async and run on the provider's existing client.

Note: Mistral is excluded because the `mistralai` SDK does not expose a `tokenize_async` method.
