### PR TITLE
feat(checkpoint): wire checkpointing into agent event loop

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -29,6 +29,7 @@ from .. import _identifier
 from .._async import run_async
 from ..event_loop._retry import ModelRetryStrategy
 from ..event_loop.event_loop import INITIAL_DELAY, MAX_ATTEMPTS, MAX_DELAY, event_loop_cycle
+from ..experimental.checkpoint import Checkpoint, CheckpointPosition
 from ..tools._tool_helpers import generate_missing_tool_result_content
 from ..types._snapshot import (
     SNAPSHOT_SCHEMA_VERSION,
@@ -146,6 +147,7 @@ class Agent(AgentBase):
         tool_executor: ToolExecutor | None = None,
         retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
         concurrent_invocation_mode: ConcurrentInvocationMode = ConcurrentInvocationMode.THROW,
+        checkpointing: bool = False,
     ):
         """Initialize the Agent with the specified configuration.
 
@@ -214,6 +216,13 @@ class Agent(AgentBase):
                 Set to "unsafe_reentrant" to skip lock acquisition entirely, allowing concurrent invocations.
                 Warning: "unsafe_reentrant" makes no guarantees about resulting behavior and is provided
                 only for advanced use cases where the caller understands the risks.
+            checkpointing: When True, the event loop pauses at cycle boundaries
+                (after_model, after_tools) and returns ``stop_reason="checkpoint"``
+                with a populated ``checkpoint`` field. Resume by passing the
+                checkpoint back as ``{"checkpointResume": {"checkpoint": ...}}``.
+                The SDK does not capture conversation state in the checkpoint;
+                pair with a SessionManager for cross-process state continuity.
+                Defaults to False. See :mod:`strands.experimental.checkpoint`.
 
         Raises:
             ValueError: If agent id contains path separators.
@@ -304,6 +313,12 @@ class Agent(AgentBase):
 
         self._interrupt_state = _InterruptState()
 
+        # Checkpointing: pause at cycle boundaries when enabled.
+        self._checkpointing: bool = checkpointing
+        self._checkpoint: Checkpoint | None = None
+        self._checkpoint_cycle_index: int = 0
+        self._checkpoint_resume_position: CheckpointPosition | None = None
+
         # Runtime state for model providers (e.g., server-side response ids)
         self._model_state: dict[str, Any] = {}
 
@@ -374,7 +389,7 @@ class Agent(AgentBase):
         This method is thread-safe and can be called from any context
         (e.g., another thread, web request handler, background task).
 
-        The agent will stop gracefully at the next checkpoint:
+        The agent will stop gracefully at the next cancellation-safe point:
         - During model response streaming
         - Before tool execution
 
@@ -832,6 +847,12 @@ class Agent(AgentBase):
 
             self.event_loop_metrics.reset_usage_metrics()
 
+            # Reset invocation-scoped checkpoint state. On resume, the event loop's
+            # priming step re-derives the cycle index from the resumed checkpoint,
+            # so this reset only affects the fresh-prompt path.
+            self._checkpoint_cycle_index = 0
+            self._checkpoint_resume_position = None
+
             merged_state = {}
             if kwargs:
                 warnings.warn("`**kwargs` parameter is deprecating, use `invocation_state` instead.", stacklevel=2)
@@ -1006,8 +1027,34 @@ class Agent(AgentBase):
             if structured_output_context:
                 structured_output_context.cleanup(self.tool_registry)
 
+    def _try_consume_checkpoint_resume(self, prompt: Any) -> bool:
+        """Consume a ``checkpointResume`` prompt block, returning True if found.
+
+        The block is a dict of the form ``{"checkpointResume": {"checkpoint": ...}}``.
+        A missing ``checkpoint`` key raises ``KeyError``; ``checkpointing=False``
+        raises ``ValueError``; a schema mismatch raises ``CheckpointException``.
+        """
+        if not (isinstance(prompt, dict) and "checkpointResume" in prompt):
+            return False
+
+        if not self._checkpointing:
+            raise ValueError(
+                "Received checkpointResume block but agent was created with checkpointing=False. "
+                "Pass checkpointing=True when constructing the Agent."
+            )
+
+        payload = prompt["checkpointResume"]
+        if not isinstance(payload, dict) or "checkpoint" not in payload:
+            raise KeyError("checkpoint | missing required key in checkpointResume block")
+
+        self._checkpoint = Checkpoint.from_dict(payload["checkpoint"])
+        return True
+
     async def _convert_prompt_to_messages(self, prompt: AgentInput) -> Messages:
         if self._interrupt_state.activated:
+            return []
+
+        if self._try_consume_checkpoint_resume(prompt):
             return []
 
         messages: Messages | None = None

--- a/strands-py/src/strands/agent/agent_result.py
+++ b/strands-py/src/strands/agent/agent_result.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 from pydantic import BaseModel
 
+from ..experimental.checkpoint import Checkpoint
 from ..interrupt import Interrupt
 from ..telemetry.metrics import EventLoopMetrics
 from ..types.content import Message
@@ -26,6 +27,9 @@ class AgentResult:
         state: Additional state information from the event loop.
         interrupts: List of interrupts if raised by user.
         structured_output: Parsed structured output when structured_output_model was specified.
+        checkpoint: Checkpoint captured when the agent paused for durable execution.
+            Populated only when stop_reason == "checkpoint". See
+            strands.experimental.checkpoint for usage.
     """
 
     stop_reason: StopReason
@@ -34,6 +38,7 @@ class AgentResult:
     state: Any
     interrupts: Sequence[Interrupt] | None = None
     structured_output: BaseModel | None = None
+    checkpoint: Checkpoint | None = None
 
     @property
     def context_size(self) -> int | None:
@@ -94,15 +99,23 @@ class AgentResult:
         Returns:
             AgentResult instance
         Raises:
-            TypeError: If the data format is invalid@
+            TypeError: If the data format is invalid
         """
         if data.get("type") != "agent_result":
             raise TypeError(f"AgentResult.from_dict: unexpected type {data.get('type')!r}")
 
         message = cast(Message, data.get("message"))
         stop_reason = cast(StopReason, data.get("stop_reason"))
+        checkpoint_data = data.get("checkpoint")
+        checkpoint = Checkpoint.from_dict(checkpoint_data) if checkpoint_data else None
 
-        return cls(message=message, stop_reason=stop_reason, metrics=EventLoopMetrics(), state={})
+        return cls(
+            message=message,
+            stop_reason=stop_reason,
+            metrics=EventLoopMetrics(),
+            state={},
+            checkpoint=checkpoint,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Convert this AgentResult to JSON-serializable dictionary.
@@ -114,4 +127,5 @@ class AgentResult:
             "type": "agent_result",
             "message": self.message,
             "stop_reason": self.stop_reason,
+            "checkpoint": self.checkpoint.to_dict() if self.checkpoint else None,
         }

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from opentelemetry import trace as trace_api
 
+from ..experimental.checkpoint import Checkpoint, CheckpointPosition
 from ..hooks import AfterModelCallEvent, BeforeModelCallEvent, MessageAddedEvent
 from ..telemetry.metrics import Trace
 from ..telemetry.tracer import Tracer, get_tracer
@@ -117,6 +118,27 @@ async def _estimate_input_tokens(agent: "Agent") -> int:
     )
 
 
+def _build_checkpoint_stop_event(
+    agent: "Agent",
+    position: CheckpointPosition,
+    cycle_index: int,
+    message: Message,
+    request_state: Any,
+) -> EventLoopStopEvent:
+    """Build a checkpoint stop event. Used at ``after_model`` and ``after_tools``."""
+    checkpoint = Checkpoint(
+        position=position,
+        cycle_index=cycle_index,
+    )
+    return EventLoopStopEvent(
+        "checkpoint",
+        message,
+        agent.event_loop_metrics,
+        request_state,
+        checkpoint=checkpoint,
+    )
+
+
 async def event_loop_cycle(
     agent: "Agent",
     invocation_state: dict[str, Any],
@@ -145,12 +167,16 @@ async def event_loop_cycle(
         structured_output_context: Optional context for structured output management.
 
     Yields:
-        Model and tool stream events. The last event is a tuple containing:
+        Model and tool stream events. The final ``EventLoopStopEvent`` payload
+        (``event["stop"]``) is a 7-tuple:
 
-            - StopReason: Reason the model stopped generating (e.g., "tool_use")
+            - StopReason: Reason the model stopped generating (e.g., "tool_use", "checkpoint")
             - Message: The generated message from the model
             - EventLoopMetrics: Updated metrics for the event loop
             - Any: Updated request state
+            - Sequence[Interrupt] | None: Interrupts raised during the cycle, if any
+            - BaseModel | None: Structured output result, if any
+            - Checkpoint | None: Checkpoint captured when stop_reason == "checkpoint"
 
     Raises:
         EventLoopException: If an error occurs during execution
@@ -164,6 +190,18 @@ async def event_loop_cycle(
     # Initialize state and get cycle trace
     if "request_state" not in invocation_state:
         invocation_state["request_state"] = {}
+
+    # Consume the resume marker (one-shot).
+    resume_context = agent._checkpoint
+    if resume_context is not None:
+        agent._checkpoint = None
+        # after_tools means that cycle finished; resume increments cycle_index.
+        next_cycle = (
+            resume_context.cycle_index + 1 if resume_context.position == "after_tools" else resume_context.cycle_index
+        )
+        agent._checkpoint_cycle_index = next_cycle
+        agent._checkpoint_resume_position = resume_context.position
+
     attributes = {"event_loop_cycle_id": str(invocation_state.get("event_loop_cycle_id"))}
     cycle_start_time, cycle_trace = agent.event_loop_metrics.start_cycle(attributes=attributes)
     invocation_state["event_loop_cycle_trace"] = cycle_trace
@@ -223,6 +261,24 @@ async def event_loop_cycle(
                 )
 
             if stop_reason == "tool_use":
+                # Emit after_model checkpoint, unless we just resumed from one.
+                if agent._checkpointing and not agent._cancel_signal.is_set():
+                    resume_position = agent._checkpoint_resume_position
+                    agent._checkpoint_resume_position = None
+                    if resume_position != "after_model":
+                        cycle_index = agent._checkpoint_cycle_index
+                        agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
+                        if cycle_span:
+                            tracer.end_event_loop_cycle_span(span=cycle_span, message=message)
+                        yield _build_checkpoint_stop_event(
+                            agent=agent,
+                            position="after_model",
+                            cycle_index=cycle_index,
+                            message=message,
+                            request_state=invocation_state["request_state"],
+                        )
+                        return
+
                 # Handle tool execution
                 tool_events = _handle_tool_execution(
                     stop_reason,
@@ -637,6 +693,31 @@ async def _handle_tool_execution(
             agent.event_loop_metrics,
             invocation_state["request_state"],
             structured_output=structured_output_result,
+        )
+        return
+
+    # Emit after_tools checkpoint. Only fires on tool_use cycles: a model that
+    # returns end_turn first never reaches this branch.
+    if agent._checkpointing and not agent._cancel_signal.is_set():
+        cycle_index = agent._checkpoint_cycle_index
+        agent._checkpoint_cycle_index = cycle_index + 1
+        yield _build_checkpoint_stop_event(
+            agent=agent,
+            position="after_tools",
+            cycle_index=cycle_index,
+            message=message,
+            request_state=invocation_state["request_state"],
+        )
+        return
+
+    # If checkpointing is on and cancel suppressed the checkpoint above, emit
+    # "cancelled" now to avoid an extra model call.
+    if agent._checkpointing and agent._cancel_signal.is_set():
+        yield EventLoopStopEvent(
+            "cancelled",
+            message,
+            agent.event_loop_metrics,
+            invocation_state["request_state"],
         )
         return
 

--- a/strands-py/src/strands/experimental/checkpoint/checkpoint.py
+++ b/strands-py/src/strands/experimental/checkpoint/checkpoint.py
@@ -1,39 +1,39 @@
 """Checkpoint system for durable agent execution.
 
-Checkpoints enable crash-resilient agent workflows by capturing agent state at
-cycle boundaries in the agent loop. A durability provider (e.g. Temporal) can
-persist checkpoints and resume from them after failures.
+A ``Checkpoint`` is a pause-point marker emitted at agent cycle boundaries.
+It captures the position (which boundary fired) and the cycle index. It does
+**not** capture conversation state — pair with a ``SessionManager`` for
+cross-process state continuity.
 
-Two checkpoint positions per ReAct cycle:
-- after_model: model call completed, tools not yet executed.
-- after_tools: all tools executed, next model call pending.
+Positions per ReAct cycle:
+- ``after_model``: model returned tool_use; tools have not run yet.
+- ``after_tools``: tools finished; the next model call has not happened yet.
 
-Per-tool granularity is handled by the ToolExecutor abstraction (e.g.
-TemporalToolExecutor routes each tool to a separate Temporal activity).
-The SDK checkpoint operates at cycle boundaries.
+Per-tool granularity within a cycle is the ``ToolExecutor``'s responsibility.
 
-User-facing pattern (same as interrupts):
-- Pause via stop_reason="checkpoint" on AgentResult
-- State via AgentResult.checkpoint field
-- Resume via checkpointResume content block in next agent() call
+Usage (mirrors interrupts):
+- Pause: ``AgentResult`` with ``stop_reason="checkpoint"`` and ``checkpoint`` populated.
+- Resume: pass back ``{"checkpointResume": {"checkpoint": ckpt.to_dict()}}``.
 
-V0 Known Limitations:
-- Metrics reset on each resume call. The caller is responsible for aggregating
-  metrics across a durable run. EventLoopMetrics reflects only the current call.
-- OpenAIResponsesModel(stateful=True) is not supported. The server-side
-  response_id (_model_state) is not captured in the snapshot.
-- When position is "after_tools", AgentResult.message is the assistant message
-  that requested the tools; tool results are in the snapshot messages.
-- BeforeInvocationEvent and AfterInvocationEvent fire on every resume call,
-  same as interrupts. Hooks counting invocations will see each resume as a
-  separate invocation.
-- Per-tool granularity within a cycle requires a custom ToolExecutor
-  (e.g. TemporalToolExecutor).
+Precedence:
+- Interrupt > checkpoint: an interrupt during a checkpointing cycle returns
+  ``stop_reason="interrupt"`` and skips ``after_tools``.
+- Cancel > checkpoint: a cancel signal at either boundary returns
+  ``stop_reason="cancelled"``.
+
+Notes:
+- Checkpoints are only emitted on tool_use cycles. A turn with no tool calls
+  emits no checkpoint; use a ``SessionManager`` for durability of every turn.
+- ``EventLoopMetrics`` resets per invocation; aggregate yourself if needed.
+- ``BeforeInvocationEvent`` / ``AfterInvocationEvent`` fire on every resume,
+  same as interrupts.
 """
 
 import logging
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
+
+from ...types.exceptions import CheckpointException
 
 logger = logging.getLogger(__name__)
 
@@ -42,23 +42,19 @@ CHECKPOINT_SCHEMA_VERSION = "1.0"
 CheckpointPosition = Literal["after_model", "after_tools"]
 
 
-@dataclass
+@dataclass(frozen=True)
 class Checkpoint:
-    """Pause point in the agent loop. Treat as opaque — pass back to resume.
+    """Pause-point marker. Treat as opaque — pass back to resume.
 
     Attributes:
-        position: What just completed (after_model or after_tools).
-        cycle_index: Which ReAct loop cycle (0-based).
-        snapshot: Serialized agent state as a dict, produced by ``Snapshot.to_dict()``.
-            Stored as ``dict[str, Any]`` (not a ``Snapshot`` object) because checkpoints
-            must be JSON-serializable for cross-process persistence. The consumer
-            reconstructs via ``Snapshot.from_dict()`` on resume.
-        app_data: Application-level internal state data. The SDK does not read
-            or modify this. Applications can store arbitrary data needed across
-            checkpoint boundaries (e.g. session context, workflow metadata).
-            Separate from ``Snapshot.app_data`` which captures agent-state-level
-            data managed by the SDK.
-        schema_version: Rejects mismatches on resume across schema versions.
+        position: Which boundary fired (``after_model`` or ``after_tools``).
+        cycle_index: ReAct loop cycle (0-based).
+        snapshot: Reserved for forward extensibility (e.g. a future hook that lets
+            callers attach agent state to the checkpoint). The SDK does not
+            populate or read it today; it round-trips through serialization.
+        app_data: Reserved for forward extensibility — caller metadata that
+            round-trips through serialization. The SDK does not populate or read it.
+        schema_version: Rejects incompatible checkpoints on resume.
     """
 
     position: CheckpointPosition
@@ -79,11 +75,11 @@ class Checkpoint:
             data: Serialized checkpoint data.
 
         Raises:
-            ValueError: If schema_version doesn't match the current version.
+            CheckpointException: If schema_version doesn't match the current version.
         """
         version = data.get("schema_version", "")
         if version != CHECKPOINT_SCHEMA_VERSION:
-            raise ValueError(
+            raise CheckpointException(
                 f"Checkpoints with schema version {version!r} are not compatible "
                 f"with current version {CHECKPOINT_SCHEMA_VERSION}."
             )

--- a/strands-py/src/strands/types/_events.py
+++ b/strands-py/src/strands/types/_events.py
@@ -22,6 +22,7 @@ from .tools import ToolResult, ToolUse
 if TYPE_CHECKING:
     from ..agent import AgentResult
     from ..agent._agent_as_tool import _AgentAsTool
+    from ..experimental.checkpoint import Checkpoint
     from ..multiagent.base import MultiAgentResult, NodeResult
 
 
@@ -227,6 +228,7 @@ class EventLoopStopEvent(TypedEvent):
         request_state: Any,
         interrupts: Sequence[Interrupt] | None = None,
         structured_output: BaseModel | None = None,
+        checkpoint: "Checkpoint | None" = None,
     ) -> None:
         """Initialize with the final execution results.
 
@@ -237,8 +239,11 @@ class EventLoopStopEvent(TypedEvent):
             request_state: Final state of the agent execution
             interrupts: Interrupts raised by user during agent execution.
             structured_output: Optional structured output result
+            checkpoint: Optional checkpoint when stop_reason == "checkpoint".
         """
-        super().__init__({"stop": (stop_reason, message, metrics, request_state, interrupts, structured_output)})
+        super().__init__(
+            {"stop": (stop_reason, message, metrics, request_state, interrupts, structured_output, checkpoint)}
+        )
 
     @property
     @override

--- a/strands-py/src/strands/types/exceptions.py
+++ b/strands-py/src/strands/types/exceptions.py
@@ -121,3 +121,9 @@ class ConcurrencyException(Exception):
     """
 
     pass
+
+
+class CheckpointException(Exception):
+    """Exception raised when checkpoint operations fail (e.g., incompatible schema version)."""
+
+    pass

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -29,7 +29,12 @@ from strands.telemetry.tracer import serialize
 from strands.types._events import EventLoopStopEvent, ModelStreamEvent
 from strands.types.agent import ConcurrentInvocationMode
 from strands.types.content import Messages
-from strands.types.exceptions import ConcurrencyException, ContextWindowOverflowException, EventLoopException
+from strands.types.exceptions import (
+    CheckpointException,
+    ConcurrencyException,
+    ContextWindowOverflowException,
+    EventLoopException,
+)
 from strands.types.session import Session, SessionAgent, SessionMessage, SessionType
 from tests.fixtures.mock_session_repository import MockedSessionRepository
 from tests.fixtures.mocked_model_provider import MockedModelProvider
@@ -2800,3 +2805,60 @@ def test_as_tool_defaults_description_when_agent_has_none():
     tool = agent.as_tool()
 
     assert tool.tool_spec["description"] == "Use the researcher agent as a tool by providing a natural language input"
+
+
+# ============================================================================
+# Checkpointing Tests
+# ============================================================================
+
+
+def test_agent_checkpointing_defaults_to_false() -> None:
+    agent = Agent()
+    assert agent._checkpointing is False
+    assert agent._checkpoint is None
+
+
+def test_agent_checkpointing_flag_stored() -> None:
+    agent = Agent(checkpointing=True)
+    assert agent._checkpointing is True
+    assert agent._checkpoint is None
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_cycle_index_resets_between_invocations() -> None:
+    """A stale cycle index from a prior invocation does not leak into the next."""
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "done"}]}])
+    agent = Agent(model=model, checkpointing=True)
+
+    # Simulate state left over from a prior checkpointing run.
+    agent._checkpoint_cycle_index = 5
+    agent._checkpoint_resume_position = "after_tools"
+
+    await agent.invoke_async("hello")
+
+    assert agent._checkpoint_cycle_index == 0
+    assert agent._checkpoint_resume_position is None
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_resume_without_checkpointing_flag_raises_value_error() -> None:
+    agent = Agent(checkpointing=False)
+    prompt = {"checkpointResume": {"checkpoint": {}}}
+    with pytest.raises(ValueError, match="checkpointing=True"):
+        await agent.invoke_async(prompt)
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_resume_missing_checkpoint_key_raises_key_error() -> None:
+    agent = Agent(checkpointing=True)
+    prompt = {"checkpointResume": {}}
+    with pytest.raises(KeyError, match="checkpoint"):
+        await agent.invoke_async(prompt)
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_resume_schema_mismatch_raises_checkpoint_exception() -> None:
+    agent = Agent(checkpointing=True)
+    prompt = {"checkpointResume": {"checkpoint": {"schema_version": "0.1", "position": "after_model"}}}
+    with pytest.raises(CheckpointException, match="schema version"):
+        await agent.invoke_async(prompt)

--- a/strands-py/tests/strands/agent/test_agent_result.py
+++ b/strands-py/tests/strands/agent/test_agent_result.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import BaseModel
 
 from strands.agent.agent_result import AgentResult
+from strands.experimental.checkpoint import Checkpoint
 from strands.interrupt import Interrupt
 from strands.telemetry.metrics import EventLoopMetrics
 from strands.types.content import Message
@@ -110,6 +111,7 @@ def test_to_dict(mock_metrics, simple_message: Message):
         "type": "agent_result",
         "message": simple_message,
         "stop_reason": "end_turn",
+        "checkpoint": None,
     }
 
 
@@ -398,3 +400,85 @@ def test_projected_context_size_none_when_no_data(mock_metrics, simple_message: 
     mock_metrics.projected_context_size = None
     result = AgentResult(stop_reason="end_turn", message=simple_message, metrics=mock_metrics, state={})
     assert result.projected_context_size is None
+
+
+# =========================================================================
+# Checkpoint field and round-trip serialization (Part B)
+#
+# Covers the V0 durable-execution contract: when stop_reason == "checkpoint",
+# AgentResult carries a Checkpoint that round-trips through to_dict/from_dict.
+# =========================================================================
+
+
+def test_agent_result_checkpoint_field_default_none() -> None:
+    result = AgentResult(
+        stop_reason="end_turn",
+        message={"role": "assistant", "content": [{"text": "hi"}]},
+        metrics=EventLoopMetrics(),
+        state={},
+    )
+    assert result.checkpoint is None
+
+
+def test_agent_result_accepts_checkpoint() -> None:
+    checkpoint = Checkpoint(position="after_model", cycle_index=0)
+    result = AgentResult(
+        stop_reason="checkpoint",
+        message={"role": "assistant", "content": [{"toolUse": {"toolUseId": "1", "name": "t", "input": {}}}]},
+        metrics=EventLoopMetrics(),
+        state={},
+        checkpoint=checkpoint,
+    )
+    assert result.checkpoint is checkpoint
+    assert result.checkpoint.position == "after_model"
+
+
+def test_agent_result_to_dict_includes_checkpoint() -> None:
+    checkpoint = Checkpoint(position="after_model", cycle_index=0)
+    result = AgentResult(
+        stop_reason="checkpoint",
+        message={"role": "assistant", "content": [{"toolUse": {"toolUseId": "1", "name": "t", "input": {}}}]},
+        metrics=EventLoopMetrics(),
+        state={},
+        checkpoint=checkpoint,
+    )
+    d = result.to_dict()
+    assert d["checkpoint"] is not None
+    assert d["checkpoint"]["position"] == "after_model"
+    assert d["checkpoint"]["cycle_index"] == 0
+
+
+def test_agent_result_to_dict_checkpoint_none_when_absent() -> None:
+    result = AgentResult(
+        stop_reason="end_turn",
+        message={"role": "assistant", "content": [{"text": "hi"}]},
+        metrics=EventLoopMetrics(),
+        state={},
+    )
+    d = result.to_dict()
+    assert d["checkpoint"] is None
+
+
+def test_agent_result_from_dict_round_trips_checkpoint() -> None:
+    original = AgentResult(
+        stop_reason="checkpoint",
+        message={"role": "assistant", "content": [{"toolUse": {"toolUseId": "1", "name": "t", "input": {}}}]},
+        metrics=EventLoopMetrics(),
+        state={},
+        checkpoint=Checkpoint(position="after_tools", cycle_index=3),
+    )
+    restored = AgentResult.from_dict(original.to_dict())
+    assert restored.checkpoint is not None
+    assert restored.checkpoint.position == "after_tools"
+    assert restored.checkpoint.cycle_index == 3
+
+
+def test_agent_result_from_dict_handles_missing_checkpoint() -> None:
+    restored = AgentResult.from_dict(
+        {
+            "type": "agent_result",
+            "message": {"role": "assistant", "content": [{"text": "done"}]},
+            "stop_reason": "end_turn",
+        }
+    )
+    assert restored.checkpoint is None

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -13,6 +13,7 @@ import strands
 import strands.telemetry
 from strands import Agent
 from strands.event_loop._retry import ModelRetryStrategy
+from strands.experimental.checkpoint import Checkpoint
 from strands.hooks import (
     AfterModelCallEvent,
     BeforeModelCallEvent,
@@ -157,6 +158,10 @@ def agent(model, system_prompt, messages, tool_registry, thread_pool, hook_regis
     mock._interrupt_state = _InterruptState()
     mock._cancel_signal = threading.Event()
     mock._model_state = {}
+    mock._checkpointing = False
+    mock._checkpoint = None
+    mock._checkpoint_cycle_index = 0
+    mock._checkpoint_resume_position = None
     mock.trace_attributes = {}
     mock.retry_strategy = ModelRetryStrategy()
 
@@ -190,7 +195,7 @@ async def test_event_loop_cycle_text_response(
         invocation_state={},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     exp_stop_reason = "end_turn"
     exp_message = {"role": "assistant", "content": [{"text": "test text"}], "metadata": ANY}
@@ -222,7 +227,7 @@ async def test_event_loop_cycle_text_response_throttling(
         invocation_state={},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     exp_stop_reason = "end_turn"
     exp_message = {"role": "assistant", "content": [{"text": "test text"}], "metadata": ANY}
@@ -260,7 +265,7 @@ async def test_event_loop_cycle_exponential_backoff(
         invocation_state={},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     # Verify the final response
     assert tru_stop_reason == "end_turn"
@@ -351,7 +356,7 @@ async def test_event_loop_cycle_tool_result(
         invocation_state={},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     exp_stop_reason = "end_turn"
     exp_message = {"role": "assistant", "content": [{"text": "test text"}], "metadata": ANY}
@@ -469,7 +474,7 @@ async def test_event_loop_cycle_stop(
         invocation_state={"request_state": {"stop_event_loop": True}},
     )
     events = await alist(stream)
-    tru_stop_reason, tru_message, _, tru_request_state, _, _ = events[-1]["stop"]
+    tru_stop_reason, tru_message, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     exp_stop_reason = "tool_use"
     exp_message = {
@@ -833,7 +838,7 @@ async def test_request_state_initialization(alist):
         invocation_state={},
     )
     events = await alist(stream)
-    _, _, _, tru_request_state, _, _ = events[-1]["stop"]
+    _, _, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     # Verify request_state was initialized to empty dict
     assert tru_request_state == {}
@@ -845,7 +850,7 @@ async def test_request_state_initialization(alist):
         invocation_state={"request_state": initial_request_state},
     )
     events = await alist(stream)
-    _, _, _, tru_request_state, _, _ = events[-1]["stop"]
+    _, _, _, tru_request_state, _, _, _ = events[-1]["stop"]
 
     # Verify existing request_state was preserved
     assert tru_request_state == initial_request_state
@@ -969,7 +974,7 @@ async def test_event_loop_cycle_interrupt(agent, model, tool_stream, agenerator,
     stream = strands.event_loop.event_loop.event_loop_cycle(agent, invocation_state={})
     events = await alist(stream)
 
-    tru_stop_reason, _, _, _, tru_interrupts, _ = events[-1]["stop"]
+    tru_stop_reason, _, _, _, tru_interrupts, _, _ = events[-1]["stop"]
     exp_stop_reason = "interrupt"
     exp_interrupts = [
         Interrupt(
@@ -1064,7 +1069,7 @@ async def test_event_loop_cycle_interrupt_resume(agent, model, tool, tool_times_
     stream = strands.event_loop.event_loop.event_loop_cycle(agent, invocation_state={})
     events = await alist(stream)
 
-    tru_stop_reason, _, _, _, _, _ = events[-1]["stop"]
+    tru_stop_reason, _, _, _, _, _, _ = events[-1]["stop"]
     exp_stop_reason = "end_turn"
     assert tru_stop_reason == exp_stop_reason
 
@@ -1196,7 +1201,7 @@ async def test_event_loop_metrics_recorded_before_recursion(
         assert mock_end_cycle.call_count == 2
 
         # Verify the event loop completed successfully
-        tru_stop_reason, _, _, _, _, _ = events[-1]["stop"]
+        tru_stop_reason, _, _, _, _, _, _ = events[-1]["stop"]
         assert tru_stop_reason == "end_turn"
 
 
@@ -1279,3 +1284,197 @@ class TestEstimateInputTokens:
 
         with pytest.raises(Exception, match="API unavailable"):
             await strands.event_loop.event_loop._estimate_input_tokens(agent)
+
+
+# --- Checkpoint event loop integration (Tasks 9-10) ---
+
+
+@pytest.mark.asyncio
+async def test_event_loop_cycle_checkpoint_after_model(
+    agent,
+    model,
+    tool_stream,
+    agenerator,
+    alist,
+):
+    """With checkpointing=True, tool_use stop_reason yields after_model checkpoint instead of running tools."""
+    agent._checkpointing = True
+    agent._checkpoint = None
+
+    model.stream.return_value = agenerator(tool_stream)
+
+    stream = strands.event_loop.event_loop.event_loop_cycle(
+        agent=agent,
+        invocation_state={},
+    )
+    events = await alist(stream)
+    stop = events[-1]["stop"]
+    tru_stop_reason, _, _, _, _, _, tru_checkpoint = stop
+
+    assert tru_stop_reason == "checkpoint"
+    assert tru_checkpoint is not None
+    assert tru_checkpoint.position == "after_model"
+    assert tru_checkpoint.cycle_index == 0
+
+
+@pytest.mark.asyncio
+async def test_event_loop_cycle_checkpoint_after_tools(
+    agent,
+    model,
+    tool,
+    tool_stream,
+    agenerator,
+    alist,
+):
+    """With checkpointing=True and resume from after_model, tools execute then yield after_tools checkpoint."""
+    agent._checkpointing = True
+    agent._checkpoint = Checkpoint(position="after_model", cycle_index=0)
+
+    model.stream.return_value = agenerator(tool_stream)
+
+    stream = strands.event_loop.event_loop.event_loop_cycle(
+        agent=agent,
+        invocation_state={},
+    )
+    events = await alist(stream)
+    tru_stop_reason, _, _, _, _, _, tru_checkpoint = events[-1]["stop"]
+
+    assert tru_stop_reason == "checkpoint"
+    assert tru_checkpoint is not None
+    assert tru_checkpoint.position == "after_tools"
+    assert tru_checkpoint.cycle_index == 0
+
+
+@pytest.mark.asyncio
+async def test_event_loop_cycle_checkpoint_resume_after_tools_increments_cycle(
+    agent,
+    model,
+    tool_stream,
+    agenerator,
+    alist,
+):
+    """Resuming from after_tools sets cycle_index to previous + 1 for the next after_model checkpoint."""
+    agent._checkpointing = True
+    agent._checkpoint = Checkpoint(position="after_tools", cycle_index=2)
+
+    model.stream.return_value = agenerator(tool_stream)
+
+    stream = strands.event_loop.event_loop.event_loop_cycle(
+        agent=agent,
+        invocation_state={},
+    )
+    events = await alist(stream)
+    tru_stop_reason, _, _, _, _, _, tru_checkpoint = events[-1]["stop"]
+
+    assert tru_stop_reason == "checkpoint"
+    assert tru_checkpoint.position == "after_model"
+    assert tru_checkpoint.cycle_index == 3
+
+
+@pytest.mark.asyncio
+async def test_event_loop_cycle_cancel_beats_after_model_checkpoint(
+    agent,
+    model,
+    tool_stream,
+    agenerator,
+    alist,
+):
+    """When a cancel signal is set after model call, cancel wins over after_model checkpoint.
+
+    A user who calls agent.cancel() expects stop_reason="cancelled", not a stray
+    "checkpoint" with a snapshot they never asked for. Documented in Agent.cancel().
+    """
+    agent._checkpointing = True
+    agent._checkpoint = None
+
+    # Cancel the agent before invoking. Model streams tool_use — the emission site
+    # that would normally fire an after_model checkpoint must yield "cancelled" instead.
+    agent._cancel_signal.set()
+    model.stream.return_value = agenerator(tool_stream)
+
+    stream = strands.event_loop.event_loop.event_loop_cycle(
+        agent=agent,
+        invocation_state={},
+    )
+    events = await alist(stream)
+    tru_stop_reason, _, _, _, _, _, tru_checkpoint = events[-1]["stop"]
+
+    assert tru_stop_reason == "cancelled"
+    assert tru_checkpoint is None
+
+
+@pytest.mark.asyncio
+async def test_event_loop_cycle_cancel_mid_cycle_beats_after_model_checkpoint(
+    agent,
+    model,
+    tool_stream,
+    agenerator,
+    alist,
+):
+    """Cancel signal set between model completion and after_model emission yields 'cancelled', not 'checkpoint'."""
+    agent._checkpointing = True
+    agent._checkpoint = None
+
+    # Stub the model stream so that after it yields its stop event, we simulate
+    # a cancel signal arriving between model completion and the after_model check.
+    original_stream = agenerator(tool_stream)
+
+    async def stream_with_mid_cycle_cancel():
+        async for item in original_stream:
+            yield item
+        agent._cancel_signal.set()
+
+    model.stream.return_value = stream_with_mid_cycle_cancel()
+
+    stream = strands.event_loop.event_loop.event_loop_cycle(
+        agent=agent,
+        invocation_state={},
+    )
+    events = await alist(stream)
+    tru_stop_reason, _, _, _, _, _, tru_checkpoint = events[-1]["stop"]
+
+    assert tru_stop_reason == "cancelled"
+    assert tru_checkpoint is None
+
+
+@pytest.mark.asyncio
+async def test_event_loop_cycle_cancel_mid_cycle_beats_after_tools_checkpoint(
+    agent,
+    model,
+    tool,
+    tool_stream,
+    agenerator,
+    alist,
+):
+    """Cancel set after tools complete but before after_tools emission yields 'cancelled'."""
+    from strands.experimental.checkpoint import Checkpoint
+
+    agent._checkpointing = True
+    agent._checkpoint = Checkpoint(position="after_model", cycle_index=0)
+
+    # Wrap the tool executor so that after tools complete, cancel is signaled.
+    # The real gap: cancel arriving between tool completion and checkpoint emission.
+    original_execute = agent.tool_executor._execute
+
+    def execute_then_cancel(*args, **kwargs):
+        stream = original_execute(*args, **kwargs)
+
+        async def wrapped():
+            async for event in stream:
+                yield event
+            agent._cancel_signal.set()
+
+        return wrapped()
+
+    model.stream.return_value = agenerator(tool_stream)
+
+    with unittest.mock.patch.object(agent.tool_executor, "_execute", side_effect=execute_then_cancel):
+        stream = strands.event_loop.event_loop.event_loop_cycle(
+            agent=agent,
+            invocation_state={},
+        )
+        events = await alist(stream)
+    tru_stop_reason, _, _, _, _, _, tru_checkpoint = events[-1]["stop"]
+
+    assert tru_stop_reason == "cancelled"
+    assert tru_checkpoint is None

--- a/strands-py/tests/strands/event_loop/test_event_loop_structured_output.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop_structured_output.py
@@ -60,6 +60,11 @@ def mock_agent():
     agent._interrupt_state.activated = False
     agent._interrupt_state.context = {}
     agent._cancel_signal = threading.Event()
+    agent._model_state = {}
+    agent._checkpointing = False
+    agent._checkpoint = None
+    agent._checkpoint_cycle_index = 0
+    agent._checkpoint_resume_position = None
 
     return agent
 

--- a/strands-py/tests/strands/experimental/checkpoint/test_checkpoint.py
+++ b/strands-py/tests/strands/experimental/checkpoint/test_checkpoint.py
@@ -3,51 +3,55 @@
 import pytest
 
 from strands.experimental.checkpoint import CHECKPOINT_SCHEMA_VERSION, Checkpoint
+from strands.types.exceptions import CheckpointException
 
 
-class TestCheckpoint:
-    """Checkpoint dataclass serialization tests."""
+def test_checkpoint_to_dict_from_dict_round_trip():
+    checkpoint = Checkpoint(
+        position="after_model",
+        cycle_index=1,
+        snapshot={"messages": []},
+        app_data={"workflow_id": "wf-123"},
+    )
+    data = checkpoint.to_dict()
+    restored = Checkpoint.from_dict(data)
 
-    def test_round_trip(self):
-        checkpoint = Checkpoint(
-            position="after_model",
-            cycle_index=1,
-            snapshot={"messages": []},
-            app_data={"workflow_id": "wf-123"},
-        )
-        data = checkpoint.to_dict()
-        restored = Checkpoint.from_dict(data)
+    # Full-object equality catches any future-added field that isn't round-tripped
+    # correctly, without requiring this test to be updated for every new field.
+    assert restored == checkpoint
+    # schema_version is init=False, so it is always set to the current constant —
+    # asserted once explicitly since dataclass equality covers it via __eq__.
+    assert restored.schema_version == CHECKPOINT_SCHEMA_VERSION
 
-        assert restored.position == checkpoint.position
-        assert restored.cycle_index == checkpoint.cycle_index
-        assert restored.snapshot == checkpoint.snapshot
-        assert restored.app_data == checkpoint.app_data
-        assert restored.schema_version == CHECKPOINT_SCHEMA_VERSION
 
-    def test_schema_version_immutable(self):
-        checkpoint = Checkpoint(position="after_tools")
-        assert checkpoint.schema_version == CHECKPOINT_SCHEMA_VERSION
+def test_checkpoint_init_schema_version_immutable():
+    checkpoint = Checkpoint(position="after_tools")
+    assert checkpoint.schema_version == CHECKPOINT_SCHEMA_VERSION
 
-    def test_schema_version_mismatch_raises(self):
-        data = Checkpoint(position="after_model").to_dict()
-        data["schema_version"] = "0.0"
-        with pytest.raises(ValueError, match="not compatible with current version"):
-            Checkpoint.from_dict(data)
 
-    def test_defaults(self):
-        checkpoint = Checkpoint(position="after_model")
-        assert checkpoint.cycle_index == 0
-        assert checkpoint.snapshot == {}
-        assert checkpoint.app_data == {}
+def test_checkpoint_init_defaults():
+    checkpoint = Checkpoint(position="after_model")
+    assert checkpoint.cycle_index == 0
+    assert checkpoint.snapshot == {}
+    assert checkpoint.app_data == {}
 
-    def test_from_dict_warns_on_unknown_fields(self, caplog):
-        data = Checkpoint(position="after_tools").to_dict()
-        data["unknown_future_field"] = "something"
-        restored = Checkpoint.from_dict(data)
-        assert restored.position == "after_tools"
-        assert "unknown_future_field" in caplog.text
 
-    def test_from_dict_missing_schema_version_raises(self):
-        data = {"position": "after_model", "cycle_index": 0, "snapshot": {}, "app_data": {}}
-        with pytest.raises(ValueError, match="not compatible with current version"):
-            Checkpoint.from_dict(data)
+def test_checkpoint_from_dict_schema_version_mismatch_raises():
+    data = Checkpoint(position="after_model").to_dict()
+    data["schema_version"] = "0.0"
+    with pytest.raises(CheckpointException, match="not compatible with current version"):
+        Checkpoint.from_dict(data)
+
+
+def test_checkpoint_from_dict_missing_schema_version_raises():
+    data = {"position": "after_model", "cycle_index": 0, "snapshot": {}, "app_data": {}}
+    with pytest.raises(CheckpointException, match="not compatible with current version"):
+        Checkpoint.from_dict(data)
+
+
+def test_checkpoint_from_dict_unknown_fields_warns(caplog):
+    data = Checkpoint(position="after_tools").to_dict()
+    data["unknown_future_field"] = "something"
+    restored = Checkpoint.from_dict(data)
+    assert restored.position == "after_tools"
+    assert "unknown_future_field" in caplog.text

--- a/strands-py/tests/strands/types/test__events.py
+++ b/strands-py/tests/strands/types/test__events.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock
 
 from pydantic import BaseModel
 
+from strands.experimental.checkpoint import Checkpoint
 from strands.telemetry import EventLoopMetrics
 from strands.types._events import (
     AgentAsToolStreamEvent,
@@ -279,7 +280,7 @@ class TestEventLoopStopEvent:
         request_state = {"state": "final"}
 
         event = EventLoopStopEvent(stop_reason, message, metrics, request_state)
-        assert event["stop"] == (stop_reason, message, metrics, request_state, None, None)
+        assert event["stop"] == (stop_reason, message, metrics, request_state, None, None, None)
         assert event.is_callback_event is False
 
     def test_initialization_with_structured_output(self):
@@ -291,7 +292,7 @@ class TestEventLoopStopEvent:
         structured_output = SampleModel(name="test", value=42)
 
         event = EventLoopStopEvent(stop_reason, message, metrics, request_state, structured_output)
-        assert event["stop"] == (stop_reason, message, metrics, request_state, structured_output, None)
+        assert event["stop"] == (stop_reason, message, metrics, request_state, structured_output, None, None)
         assert event.is_callback_event is False
 
 
@@ -502,3 +503,35 @@ class TestAgentAsToolStreamEvent:
         assert isinstance(event, ToolStreamEvent)
         assert isinstance(event, TypedEvent)
         assert type(event) is AgentAsToolStreamEvent
+
+
+# =========================================================================
+# EventLoopStopEvent checkpoint kwarg (Part B)
+# =========================================================================
+
+
+def test_event_loop_stop_event_carries_checkpoint() -> None:
+    checkpoint = Checkpoint(position="after_model", cycle_index=0)
+    event = EventLoopStopEvent(
+        "checkpoint",
+        {"role": "assistant", "content": [{"text": "hi"}]},
+        EventLoopMetrics(),
+        {},
+        checkpoint=checkpoint,
+    )
+    stop = event["stop"]
+    assert len(stop) == 7
+    assert stop[0] == "checkpoint"
+    assert stop[6] is checkpoint
+
+
+def test_event_loop_stop_event_checkpoint_defaults_to_none() -> None:
+    event = EventLoopStopEvent(
+        "end_turn",
+        {"role": "assistant", "content": [{"text": "done"}]},
+        EventLoopMetrics(),
+        {},
+    )
+    stop = event["stop"]
+    assert len(stop) == 7
+    assert stop[6] is None

--- a/strands-py/tests_integ/test_agent_checkpoint.py
+++ b/strands-py/tests_integ/test_agent_checkpoint.py
@@ -1,0 +1,209 @@
+"""Integration tests for agent checkpointing with Amazon Bedrock.
+
+These tests exercise the V0 durable-execution contract: an agent with
+``checkpointing=True`` pauses at ReAct cycle boundaries and returns an
+``AgentResult`` with ``stop_reason="checkpoint"`` and a ``checkpoint`` field
+carrying the pause-point marker. State persistence is the caller's job;
+these tests pair checkpointing with ``FileSessionManager`` to demonstrate
+the recommended pattern: SessionManager for state continuity, Checkpoint
+for boundary signalling.
+
+Requires valid AWS credentials and may incur API costs.
+
+To run:
+    hatch test tests_integ/test_agent_checkpoint.py
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from strands import Agent, tool
+from strands.experimental.checkpoint import Checkpoint
+from strands.models import BedrockModel
+from strands.session import FileSessionManager
+
+pytestmark = [
+    pytest.mark.skipif(not os.getenv("AWS_REGION"), reason="AWS credentials not available"),
+    pytest.mark.asyncio,
+]
+
+MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+def _build_agent(tools: list, *, session_id: str, storage_dir: Path) -> Agent:
+    """Build a checkpointing agent backed by FileSessionManager.
+
+    SessionManager provides conversation continuity across fresh Agent
+    instances; checkpointing provides the pause-point marker. Together
+    they form the V0 durable-execution recommendation.
+    """
+    return Agent(
+        model=BedrockModel(model_id=MODEL_ID),
+        tools=tools,
+        system_prompt=(
+            "You are a helpful assistant. When a user asks a factual question, "
+            "you MUST call the provided tools to answer. Do not answer from memory."
+        ),
+        session_manager=FileSessionManager(session_id=session_id, storage_dir=str(storage_dir)),
+        checkpointing=True,
+    )
+
+
+async def _drive_to_completion(
+    tools: list,
+    first_prompt: str,
+    *,
+    session_id: str,
+    storage_dir: Path,
+    max_resumes: int = 10,
+) -> tuple[Agent, list[Checkpoint]]:
+    """Drive a checkpointing agent to end_turn across fresh Agent instances.
+
+    Each pause: serialize the checkpoint, discard the Agent, build a fresh one
+    with the same ``session_id`` (so SessionManager rehydrates messages), and
+    pass the checkpoint back as a ``checkpointResume`` block. Returns the final
+    Agent and the ordered list of checkpoints observed along the way.
+    """
+    agent = _build_agent(tools, session_id=session_id, storage_dir=storage_dir)
+    result = await agent.invoke_async(first_prompt)
+
+    checkpoints: list[Checkpoint] = []
+    resumes = 0
+    while result.stop_reason == "checkpoint":
+        assert result.checkpoint is not None, "checkpoint field must be populated on pause"
+        checkpoints.append(result.checkpoint)
+
+        # Round-trip through JSON to prove the checkpoint survives serialization.
+        persisted = json.loads(json.dumps(result.checkpoint.to_dict()))
+
+        # Discard the Agent. A fresh Agent with the same session_id will
+        # rehydrate messages from the session store, then resume at the
+        # captured checkpoint position.
+        del agent
+        agent = _build_agent(tools, session_id=session_id, storage_dir=storage_dir)
+
+        result = await agent.invoke_async({"checkpointResume": {"checkpoint": persisted}})
+
+        resumes += 1
+        if resumes > max_resumes:
+            raise AssertionError(f"exceeded max_resumes={max_resumes} without reaching end_turn")
+
+    assert result.stop_reason == "end_turn", f"unexpected terminal stop_reason: {result.stop_reason}"
+    return agent, checkpoints
+
+
+async def test_checkpoint_roundtrip_completes_through_fresh_agent(tmp_path):
+    """Pause at a cycle boundary, resume on a fresh Agent, reach end_turn.
+
+    Single-tool prompt forces at least one ``after_model`` + ``after_tools``
+    pair before the final ``end_turn`` cycle.
+    """
+
+    @tool
+    def get_color_of_sky() -> str:
+        """Return the color of the sky."""
+        return "blue"
+
+    final_agent, checkpoints = await _drive_to_completion(
+        tools=[get_color_of_sky],
+        first_prompt="What color is the sky? Use the get_color_of_sky tool.",
+        session_id="roundtrip",
+        storage_dir=tmp_path,
+    )
+
+    assert len(checkpoints) >= 1
+    assert all(cp.position in ("after_model", "after_tools") for cp in checkpoints)
+
+    # Cycle indices are non-decreasing.
+    cycle_indices = [cp.cycle_index for cp in checkpoints]
+    assert cycle_indices == sorted(cycle_indices), f"cycle indices not monotonic: {cycle_indices}"
+
+    # Final agent's message history (rehydrated by SessionManager) contains
+    # the tool result and a final assistant message that references it.
+    tool_result_texts = [
+        block["toolResult"]["content"][0]["text"]
+        for message in final_agent.messages
+        for block in message["content"]
+        if "toolResult" in block
+    ]
+    assert "blue" in tool_result_texts
+    final_message_text = json.dumps(final_agent.messages[-1]).lower()
+    assert "blue" in final_message_text
+
+
+async def test_checkpoint_survives_process_boundary_no_tool_rerun(tmp_path):
+    """Completed tool calls are not re-invoked across a checkpoint resume.
+
+    Each tool increments a local counter on every call. After driving the
+    agent through multiple resume cycles (with SessionManager rehydrating
+    state and Checkpoint signalling pause points), each tool must have been
+    called exactly once.
+    """
+    call_counts = {"time": 0, "day": 0, "weather": 0}
+
+    @tool
+    def get_time() -> str:
+        """Return the current time."""
+        call_counts["time"] += 1
+        return "12:01"
+
+    @tool
+    def get_day() -> str:
+        """Return the current day of the week."""
+        call_counts["day"] += 1
+        return "monday"
+
+    @tool
+    def get_weather() -> str:
+        """Return the current weather."""
+        call_counts["weather"] += 1
+        return "sunny"
+
+    final_agent, checkpoints = await _drive_to_completion(
+        tools=[get_time, get_day, get_weather],
+        first_prompt=("What is the time, the day, and the weather? Use the get_time, get_day, and get_weather tools."),
+        session_id="no-rerun",
+        storage_dir=tmp_path,
+    )
+
+    assert call_counts == {"time": 1, "day": 1, "weather": 1}, (
+        f"tools were re-executed on resume — counts: {call_counts}"
+    )
+
+    assert any(cp.position == "after_tools" for cp in checkpoints), (
+        f"no after_tools checkpoint observed: {[cp.position for cp in checkpoints]}"
+    )
+
+    final_message_text = json.dumps(final_agent.messages[-1]).lower()
+    assert all(s in final_message_text for s in ["12:01", "monday", "sunny"])
+
+
+async def test_checkpoint_resume_preserves_conversation_history(tmp_path):
+    """The user's original prompt survives the full checkpoint/resume cycle.
+
+    Combining SessionManager (for state) with Checkpoint (for pause signalling)
+    gives the resumed agent both the original prompt and the tool results
+    needed to produce a coherent final response.
+    """
+
+    @tool
+    def get_favorite_number() -> int:
+        """Return the user's favorite number."""
+        return 42
+
+    final_agent, _ = await _drive_to_completion(
+        tools=[get_favorite_number],
+        first_prompt="What is my favorite number? Use the get_favorite_number tool.",
+        session_id="history",
+        storage_dir=tmp_path,
+    )
+
+    user_messages = [m for m in final_agent.messages if m["role"] == "user"]
+    first_user_message_text = json.dumps(user_messages[0]).lower()
+    assert "favorite number" in first_user_message_text
+
+    assert final_agent.messages[-1]["role"] == "assistant"
+    assert "42" in json.dumps(final_agent.messages[-1])


### PR DESCRIPTION
## Description

Wires the `Checkpoint` data model (landed in #2181) into the agent runtime so an opt-in `checkpointing=True` agent pauses at ReAct cycle boundaries and emits a serializable pause-point marker. The marker travels through `AgentResult.checkpoint` and is passed back to a fresh agent through a `checkpointResume` block. The design mirrors the existing interrupt pattern: `stop_reason="checkpoint"` to signal the pause, content-block resume, no new method surface to learn.

A `Checkpoint` is a position marker (which boundary fired and which cycle index), not a state snapshot. State persistence is the caller's responsibility. The recommended pairing is a `SessionManager` for state continuity plus `checkpointing=True` for boundary signalling. 

**User-facing API (zero breaking changes — opt-in only):**

```python
from strands import Agent
from strands.session import FileSessionManager

agent = Agent(
    tools=[...],
    session_manager=FileSessionManager(session_id="run-1", storage_dir="..."),
    checkpointing=True,
)

result = await agent.invoke_async("do the thing")

while result.stop_reason == "checkpoint":
    save_somewhere(result.checkpoint.to_dict())
    # later, possibly in a fresh process / activity:
    fresh = Agent(
        tools=[...],
        session_manager=FileSessionManager(session_id="run-1", storage_dir="..."),
        checkpointing=True,
    )
    result = await fresh.invoke_async(
        {"checkpointResume": {"checkpoint": load_somewhere()}}
    )

print(result.message)  # stop_reason == "end_turn"
```

**V0 known limitations:**

- Metrics reset on each resume call.
- `OpenAIResponsesModel(stateful=True)` not supported.
- `BeforeInvocationEvent` / `AfterInvocationEvent` fire on every resume (same as interrupts).
- Per-tool granularity within a cycle requires a custom `ToolExecutor`. The SDK checkpoint operates at cycle boundaries.
- Streaming callbacks do not re-emit on replay.

## Related Issues

<!-- Tracking: link the Part A PR and the durable-execution epic when filed -->

## Documentation PR

<!-- User-guide page is a separate PR in the agent-docs repo; will be linked here once drafted. -->

## Type of Change

New feature

## Testing

Verified the changes do not break functionality or introduce warnings in consuming repositories.

- [x] I ran `hatch run prepare`

Evidence from fresh runs:

- `hatch test` — 3026 passed, 4 skipped, 0 failed.
- `hatch run hatch-static-analysis:lint-check` — `ruff check` and `mypy` both clean.
- `hatch run hatch-static-analysis:format-check` — all files formatted.\

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly *(user-guide page is a follow-up PR in `agent-docs`; module-level docstring in `checkpoint.py` covers V0 limitations, precedence rules, and the recommended SessionManager pairing)*
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed *(reference Temporal / Dapr / Step Functions examples are the next milestone in the durable-execution tracking plan)*
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published *(Part A — #2181 — is merged on `main`; this PR builds on it)*

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
