### PR TITLE
fix(openai): support vLLM >=0.19.1 delta.reasoning field for streaming reasoning content

### DIFF
--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -931,25 +931,33 @@ async def test_stream(openai_client, model_id, model, agenerator, alist):
     mock_tool_call_2_part_1 = unittest.mock.Mock(index=1)
     mock_delta_1 = unittest.mock.Mock(
         reasoning_content="",
+        reasoning=None,
         content=None,
         tool_calls=None,
     )
     mock_delta_2 = unittest.mock.Mock(
         reasoning_content="\nI'm thinking",
+        reasoning=None,
         content=None,
         tool_calls=None,
     )
     mock_delta_3 = unittest.mock.Mock(
-        content="I'll calculate", tool_calls=[mock_tool_call_1_part_1, mock_tool_call_2_part_1], reasoning_content=None
+        content="I'll calculate",
+        tool_calls=[mock_tool_call_1_part_1, mock_tool_call_2_part_1],
+        reasoning_content=None,
+        reasoning=None,
     )
 
     mock_tool_call_1_part_2 = unittest.mock.Mock(index=0)
     mock_tool_call_2_part_2 = unittest.mock.Mock(index=1)
     mock_delta_4 = unittest.mock.Mock(
-        content="that for you", tool_calls=[mock_tool_call_1_part_2, mock_tool_call_2_part_2], reasoning_content=None
+        content="that for you",
+        tool_calls=[mock_tool_call_1_part_2, mock_tool_call_2_part_2],
+        reasoning_content=None,
+        reasoning=None,
     )
 
-    mock_delta_5 = unittest.mock.Mock(content="", tool_calls=None, reasoning_content=None)
+    mock_delta_5 = unittest.mock.Mock(content="", tool_calls=None, reasoning_content=None, reasoning=None)
 
     mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_1)])
     mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_2)])
@@ -1055,8 +1063,48 @@ async def test_stream_accepts_vllm_reasoning_delta(openai_client, model, message
 
 
 @pytest.mark.asyncio
+async def test_stream_vllm_reasoning_field(openai_client, model_id, model, agenerator, alist):
+    """vLLM >=0.19.1 emits delta.reasoning instead of delta.reasoning_content."""
+    mock_delta_1 = unittest.mock.Mock(content=None, tool_calls=None, reasoning_content=None, reasoning="thinking...")
+    mock_delta_2 = unittest.mock.Mock(content="done", tool_calls=None, reasoning_content=None, reasoning=None)
+    mock_usage = unittest.mock.Mock(
+        prompt_tokens=5, completion_tokens=5, total_tokens=10, prompt_tokens_details=None
+    )
+
+    mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_1)])
+    mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_2)])
+    mock_event_3 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="stop", delta=mock_delta_2)])
+    mock_event_4 = unittest.mock.Mock(usage=mock_usage)
+
+    openai_client.chat.completions.create = unittest.mock.AsyncMock(
+        return_value=agenerator([mock_event_1, mock_event_2, mock_event_3, mock_event_4])
+    )
+
+    messages = [{"role": "user", "content": [{"text": "hi"}]}]
+    tru_events = await alist(model.stream(messages))
+    exp_events = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "thinking..."}}}},
+        {"contentBlockStop": {}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": "done"}}},
+        {"contentBlockDelta": {"delta": {"text": "done"}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 5, "outputTokens": 5, "totalTokens": 10},
+                "metrics": {"latencyMs": 0},
+            }
+        },
+    ]
+
+    assert tru_events == exp_events
+
+@pytest.mark.asyncio
 async def test_stream_empty(openai_client, model_id, model, agenerator, alist):
-    mock_delta = unittest.mock.Mock(content=None, tool_calls=None, reasoning_content=None)
+    mock_delta = unittest.mock.Mock(content=None, tool_calls=None, reasoning_content=None, reasoning=None)
 
     mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta)])
     mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="stop", delta=mock_delta)])
@@ -1090,7 +1138,7 @@ async def test_stream_empty(openai_client, model_id, model, agenerator, alist):
 
 @pytest.mark.asyncio
 async def test_stream_with_empty_choices(openai_client, model, agenerator, alist):
-    mock_delta = unittest.mock.Mock(content="content", tool_calls=None, reasoning_content=None)
+    mock_delta = unittest.mock.Mock(content="content", tool_calls=None, reasoning_content=None, reasoning=None)
     mock_usage = unittest.mock.Mock(prompt_tokens=10, completion_tokens=20, total_tokens=30)
 
     # Event with no choices attribute
@@ -1521,7 +1569,7 @@ async def test_stream_with_injected_client(model_id, agenerator, alist):
     mock_injected_client = unittest.mock.AsyncMock()
     mock_injected_client.close = unittest.mock.AsyncMock()
 
-    mock_delta = unittest.mock.Mock(content="Hello", tool_calls=None, reasoning_content=None)
+    mock_delta = unittest.mock.Mock(content="Hello", tool_calls=None, reasoning_content=None, reasoning=None)
     mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta)])
     mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="stop", delta=mock_delta)])
     mock_event_3 = unittest.mock.Mock()

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1067,9 +1067,7 @@ async def test_stream_vllm_reasoning_field(openai_client, model_id, model, agene
     """vLLM >=0.19.1 emits delta.reasoning instead of delta.reasoning_content."""
     mock_delta_1 = unittest.mock.Mock(content=None, tool_calls=None, reasoning_content=None, reasoning="thinking...")
     mock_delta_2 = unittest.mock.Mock(content="done", tool_calls=None, reasoning_content=None, reasoning=None)
-    mock_usage = unittest.mock.Mock(
-        prompt_tokens=5, completion_tokens=5, total_tokens=10, prompt_tokens_details=None
-    )
+    mock_usage = unittest.mock.Mock(prompt_tokens=5, completion_tokens=5, total_tokens=10, prompt_tokens_details=None)
 
     mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_1)])
     mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_2)])
@@ -1101,6 +1099,36 @@ async def test_stream_vllm_reasoning_field(openai_client, model_id, model, agene
     ]
 
     assert tru_events == exp_events
+
+@pytest.mark.asyncio
+async def test_stream_reasoning_content_takes_priority_over_reasoning(
+    openai_client, model_id, model, agenerator, alist
+):
+    """reasoning_content takes priority when both fields are present (backward compat)."""
+    mock_delta_1 = unittest.mock.Mock(
+        content=None, tool_calls=None, reasoning_content="from_reasoning_content", reasoning="from_reasoning"
+    )
+    mock_delta_2 = unittest.mock.Mock(content="done", tool_calls=None, reasoning_content=None, reasoning=None)
+    mock_usage = unittest.mock.Mock(prompt_tokens=5, completion_tokens=5, total_tokens=10, prompt_tokens_details=None)
+
+    mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_1)])
+    mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_2)])
+    mock_event_3 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="stop", delta=mock_delta_2)])
+    mock_event_4 = unittest.mock.Mock(usage=mock_usage)
+
+    openai_client.chat.completions.create = unittest.mock.AsyncMock(
+        return_value=agenerator([mock_event_1, mock_event_2, mock_event_3, mock_event_4])
+    )
+
+    messages = [{"role": "user", "content": [{"text": "hi"}]}]
+    tru_events = await alist(model.stream(messages))
+
+    reasoning_deltas = [
+        e for e in tru_events if "contentBlockDelta" in e and "reasoningContent" in e["contentBlockDelta"]["delta"]
+    ]
+    assert len(reasoning_deltas) == 1
+    assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"]["text"] == "from_reasoning_content"
+
 
 @pytest.mark.asyncio
 async def test_stream_empty(openai_client, model_id, model, agenerator, alist):


### PR DESCRIPTION
Fixes #2182

## Description

vLLM 0.19.1 renamed the streaming reasoning field from `delta.reasoning_content` to
`delta.reasoning`. The SDK only checked `reasoning_content`, so reasoning output was
silently dropped for users on newer vLLM backends.

`OpenAIModel._stream()` now checks both field names: `reasoning_content` first (backward
compat with DeepSeek and older vLLM), then `reasoning`. Whichever is set gets forwarded.

The existing OpenAI mock deltas also needed `reasoning=None` set explicitly.
`unittest.mock.Mock` auto-creates any accessed attribute as a truthy value, so without
it the fallback would have fired on all the old tests. Three new tests cover the
`delta.reasoning` path, the priority behavior when both fields are present, and the
existing `delta.reasoning_content` path via the updated mocks.

## Documentation PR

No documentation changes needed.

## Type of Change

Bug fix

## Testing

`hatch run prepare` passed: 2647 passed, 4 skipped.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.