### PR TITLE
fix: preserve tool_results request order in ConcurrentToolExecutor

### DIFF
--- a/src/strands/tools/executors/concurrent.py
+++ b/src/strands/tools/executors/concurrent.py
@@ -48,6 +48,12 @@ class ConcurrentToolExecutor(ToolExecutor):
         task_events = [asyncio.Event() for _ in tool_uses]
         stop_event = object()
 
+        # Build a mapping from toolUseId to its original request index so we can
+        # restore request order after concurrent execution completes.
+        tool_use_id_to_index: dict[str, int] = {
+            str(tool_use.get("toolUseId")): idx for idx, tool_use in enumerate(tool_uses)
+        }
+
         tasks = []
         try:
             for task_id, tool_use in enumerate(tool_uses):
@@ -85,6 +91,14 @@ class ConcurrentToolExecutor(ToolExecutor):
             for task in tasks:
                 task.cancel()
             await asyncio.gather(*tasks, return_exceptions=True)
+
+            # Re-order tool_results to match the original request order.
+            # The base ``_stream`` method appends results as each task finishes,
+            # so when tools complete out-of-order the list reflects completion
+            # order rather than request order.
+            tool_results.sort(
+                key=lambda r: tool_use_id_to_index.get(str(r.get("toolUseId")), 0)
+            )
 
     async def _task(
         self,

--- a/tests/strands/tools/executors/test_concurrent.py
+++ b/tests/strands/tools/executors/test_concurrent.py
@@ -42,6 +42,27 @@ async def test_concurrent_executor_execute(
 
 
 @pytest.mark.asyncio
+async def test_concurrent_executor_preserves_request_order(
+    executor, agent, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context, alist
+):
+    """tool_results must follow the original tool_uses order, not completion order."""
+    # temperature_tool is synchronous and completes instantly.
+    # We put it second to verify it doesn't overtake the first tool in tool_results.
+    tool_uses = [
+        {"name": "temperature_tool", "toolUseId": "id-first", "input": {}},
+        {"name": "weather_tool", "toolUseId": "id-second", "input": {}},
+    ]
+    stream = executor._execute(
+        agent, tool_uses, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context
+    )
+    await alist(stream)
+
+    # The slow_tool result should appear first because it was requested first,
+    # even though weather_tool completes sooner.
+    assert [r["toolUseId"] for r in tool_results] == ["id-first", "id-second"]
+
+
+@pytest.mark.asyncio
 async def test_concurrent_executor_interrupt(
     executor, agent, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context, alist
 ):


### PR DESCRIPTION
## Problem

`ConcurrentToolExecutor` collects tool results in **task completion order** rather than the original **request order**. When a fast tool finishes before a slow tool, the `tool_results` list does not match the `tool_uses` ordering.

Reported in #2112.

## Solution

After all concurrent tasks complete, sort `tool_results` by the original `tool_uses` index using a `toolUseId → index` mapping built before execution. The sort happens in the `finally` block of `_execute()` so it applies regardless of how tasks complete.

## Testing

Added `test_concurrent_executor_preserves_request_order` that verifies `tool_results` order matches the original `tool_uses` order when tools complete at different speeds.

Closes #2112