### PR TITLE
fix: handle Field(default_factory=...) in @tool decorator without warning

### DIFF
--- a/strands-py/src/strands/tools/decorator.py
+++ b/strands-py/src/strands/tools/decorator.py
@@ -62,7 +62,7 @@ from typing import (
 import docstring_parser
 from pydantic import BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
-from pydantic_core import PydanticSerializationError
+from pydantic_core import PydanticSerializationError, PydanticUndefined
 from typing_extensions import override
 
 from ..interrupt import InterruptException
@@ -163,8 +163,28 @@ class FunctionToolMetadata:
         final_description = description
         if final_description is None:
             final_description = self.param_descriptions.get(param_name) or f"Parameter {param_name}"
-        # Create FieldInfo object from scratch
-        final_field = Field(default=param_default, description=final_description)
+        # Create FieldInfo object from scratch.
+        # When the caller uses ``Field(default_factory=list)`` (or similar) as a
+        # parameter default, ``param_default`` is already a ``FieldInfo`` instance.
+        # Passing it directly to ``Field(default=...)`` would wrap it in *another*
+        # FieldInfo, producing a non-serialisable default and triggering a
+        # ``PydanticJsonSchemaWarning``.  Detect this case and forward the
+        # original default / default_factory instead.
+        field_kwargs: dict[str, Any] = {"description": final_description}
+        if isinstance(param_default, FieldInfo):
+            # Prefer the description already extracted from Annotated / docstring,
+            # but fall back to the one embedded in the FieldInfo when no other
+            # source provides one.
+            if final_description == f"Parameter {param_name}" and param_default.description:
+                field_kwargs["description"] = param_default.description
+            if param_default.default_factory is not None:
+                field_kwargs["default_factory"] = param_default.default_factory
+            elif param_default.default is not PydanticUndefined:
+                field_kwargs["default"] = param_default.default
+        else:
+            field_kwargs["default"] = param_default
+
+        final_field = Field(**field_kwargs)
 
         return actual_type, final_field
 

--- a/strands-py/src/strands/tools/decorator.py
+++ b/strands-py/src/strands/tools/decorator.py
@@ -181,6 +181,9 @@ class FunctionToolMetadata:
                 field_kwargs["default_factory"] = param_default.default_factory
             elif param_default.default is not PydanticUndefined:
                 field_kwargs["default"] = param_default.default
+            # Re-attach constraints (ge, le, pattern, ...) so they stay in the schema and validated.
+            if param_default.metadata:
+                actual_type = Annotated[tuple([actual_type, *param_default.metadata])]
         else:
             field_kwargs["default"] = param_default
 

--- a/strands-py/tests/strands/tools/test_decorator.py
+++ b/strands-py/tests/strands/tools/test_decorator.py
@@ -2,13 +2,14 @@
 Tests for the function-based tool decorator pattern.
 """
 
+import warnings
 from asyncio import Queue
 from collections.abc import AsyncGenerator
 from typing import Annotated, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 import strands
 from strands import Agent
@@ -2145,10 +2146,6 @@ def test_tool_field_default_factory_no_warning():
 
     Regression test for https://github.com/strands-agents/sdk-python/issues/1914.
     """
-    import warnings
-
-    from pydantic import Field
-
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
 
@@ -2170,7 +2167,6 @@ def test_tool_field_default_factory_no_warning():
 
 def test_tool_field_default_value():
     """Field(default=...) as a parameter default is handled correctly."""
-    from pydantic import Field
 
     @strands.tool
     def default_val_tool(name: str = Field(default="world", description="A name")):
@@ -2180,3 +2176,21 @@ def test_tool_field_default_value():
     schema = default_val_tool.tool_spec["inputSchema"]["json"]
     assert "name" not in schema.get("required", [])
     assert schema["properties"]["name"]["description"] == "A name"
+
+
+def test_tool_field_default_constraints_preserved():
+    """Field(...) constraints are kept in the schema and enforced on validation."""
+
+    @strands.tool
+    def scored_tool(score: int = Field(default=50, ge=0, le=100)):
+        """Tool with constrained Field default."""
+        return score
+
+    schema = scored_tool.tool_spec["inputSchema"]["json"]
+    assert schema["properties"]["score"]["minimum"] == 0
+    assert schema["properties"]["score"]["maximum"] == 100
+
+    metadata = scored_tool._metadata
+    metadata.input_model(score=50)
+    with pytest.raises(ValidationError):
+        metadata.input_model(score=999)

--- a/strands-py/tests/strands/tools/test_decorator.py
+++ b/strands-py/tests/strands/tools/test_decorator.py
@@ -2138,3 +2138,45 @@ def test_tool_nullable_optional_field_simplifies_anyof():
     # Since tag is not required, anyOf should be simplified away
     assert "anyOf" not in schema["properties"]["tag"]
     assert schema["properties"]["tag"]["type"] == "string"
+
+
+def test_tool_field_default_factory_no_warning():
+    """Field(default_factory=...) must not trigger PydanticJsonSchemaWarning.
+
+    Regression test for https://github.com/strands-agents/sdk-python/issues/1914.
+    """
+    import warnings
+
+    from pydantic import Field
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+
+        @strands.tool
+        def factory_tool(items: list = Field(default_factory=list), tags: list = Field(default_factory=list)):  # noqa: B008
+            """Tool with default_factory params."""
+            return items + tags
+
+    pydantic_warnings = [w for w in caught if "PydanticJsonSchema" in w.category.__name__]
+    assert pydantic_warnings == [], f"Unexpected warnings: {pydantic_warnings}"
+
+    schema = factory_tool.tool_spec["inputSchema"]["json"]
+    # items and tags should be optional (not in required)
+    assert "items" not in schema.get("required", [])
+    assert "tags" not in schema.get("required", [])
+    assert schema["properties"]["items"]["type"] == "array"
+    assert schema["properties"]["tags"]["type"] == "array"
+
+
+def test_tool_field_default_value():
+    """Field(default=...) as a parameter default is handled correctly."""
+    from pydantic import Field
+
+    @strands.tool
+    def default_val_tool(name: str = Field(default="world", description="A name")):
+        """Tool with Field default value."""
+        return name
+
+    schema = default_val_tool.tool_spec["inputSchema"]["json"]
+    assert "name" not in schema.get("required", [])
+    assert schema["properties"]["name"]["description"] == "A name"


### PR DESCRIPTION
## Problem

When a `@tool`-decorated function uses `Field(default_factory=list)` as a parameter default:

```python
@tool
def my_tool(items: list = Field(default_factory=list)):
    ...
```

The decorator passes the `FieldInfo` object as `default=<FieldInfo>` into another `Field()` call, producing a non-serialisable default that triggers `PydanticJsonSchemaWarning`.

Reported in #1914.

## Solution

In `_extract_annotated_metadata()`, detect when `param_default` is already a `FieldInfo` instance and extract its `default`/`default_factory`/`description` attributes to build a clean `Field()` instead of wrapping it again.

## Testing

Added two tests:
- `test_tool_field_default_factory_no_warning` — verifies no `PydanticJsonSchemaWarning` is emitted and the schema is correct
- `test_tool_field_default_value` — verifies `Field(default=...)` as a parameter default works correctly

Closes #1914