### PR TITLE
chore: update style guide for tool spec navigation

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -74,3 +74,16 @@ class EdgeCondition(Protocol):
 ```
 
 Using `Protocol` with `**kwargs` allows the interface to evolve by adding new keyword arguments without breaking existing implementations that don't use them.
+
+### Tool Name References
+
+When comparing against tool names in hooks or plugins, use the tool instance's `tool_name` property instead of hardcoding strings. Tool specs can be modified at runtime via the `AgentTool.tool_spec` setter, so hardcoded names may not match the actual registered name.
+
+```python
+# Good
+if event.tool_use.get("name") == self.my_tool.tool_name:
+    ...
+
+# Bad — fragile if tool name is changed at runtime
+if event.tool_use.get("name") == "my_tool":
+    ...


### PR DESCRIPTION


## Description

Adds a "Tool Name References" guideline to the style guide: when comparing against tool names in hooks or plugins, use `tool.tool_name` instead of hardcoded strings, since tool specs can be modified at runtime via `AgentTool.tool_spec` setter.

Follow up from https://github.com/strands-agents/sdk-python/pull/2162#discussion_r3138962109

## Related Issues

Identified during review of #2162 (ContextOffloader plugin)

## Documentation PR

N/A

## Type of Change

Documentation update

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
- [x] I ran `hatch run prepare`
- Documentation-only change, no code affected

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.