### PR TITLE
fix(conversation-manager): handle window_size=0 and reject negative values

### DIFF
--- a/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
+++ b/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
@@ -42,7 +42,7 @@ class SlidingWindowConversationManager(ConversationManager):
 
         Args:
             window_size: Maximum number of messages to keep in the agent's history.
-                Defaults to 40 messages.
+                Use 0 to clear all messages on every reduction. Defaults to 40 messages.
             should_truncate_results: Truncate tool results when a message is too large for the model's context window
             per_turn: Controls when to apply message management during agent execution.
                 - False (default): Only apply management at the end (default behavior)
@@ -56,8 +56,10 @@ class SlidingWindowConversationManager(ConversationManager):
                 for performance tuning.
 
         Raises:
-            ValueError: If per_turn is 0 or a negative integer.
+            ValueError: If window_size is negative, or if per_turn is 0 or a negative integer.
         """
+        if not isinstance(window_size, bool) and window_size < 0:
+            raise ValueError(f"window_size must be a non-negative integer, got {window_size}")
         if isinstance(per_turn, int) and not isinstance(per_turn, bool) and per_turn <= 0:
             raise ValueError(f"per_turn must be a positive integer, True, or False, got {per_turn}")
 
@@ -172,6 +174,12 @@ class SlidingWindowConversationManager(ConversationManager):
                 logs a warning and returns without modification.
         """
         messages = agent.messages
+
+        # window_size=0 means "remove all messages" (matches TypeScript SDK behaviour)
+        if self.window_size == 0:
+            self.removed_message_count += len(messages)
+            messages[:] = []
+            return
 
         # Try to truncate the tool result first
         oldest_message_idx_with_tool_results = self._find_oldest_message_with_tool_results(messages)

--- a/tests/strands/agent/test_conversation_manager.py
+++ b/tests/strands/agent/test_conversation_manager.py
@@ -703,3 +703,55 @@ def test_boundary_text_in_tool_result_not_truncated():
 
     assert not changed
     assert messages[0]["content"][0]["toolResult"]["content"][0]["text"] == boundary_text
+
+
+# ==============================================================================
+# window_size=0 and negative window_size validation tests
+# ==============================================================================
+
+
+def test_window_size_negative_raises_value_error():
+    with pytest.raises(ValueError, match="window_size"):
+        SlidingWindowConversationManager(window_size=-1)
+
+
+def test_window_size_zero_clears_all_messages_on_apply_management():
+    """window_size=0 should remove all messages, matching TypeScript SDK behaviour (issue #2205)."""
+    manager = SlidingWindowConversationManager(window_size=0, should_truncate_results=False)
+    messages = [
+        {"role": "user", "content": [{"text": "Hello"}]},
+        {"role": "assistant", "content": [{"text": "Hi there"}]},
+    ]
+    test_agent = Agent(messages=messages)
+    manager.apply_management(test_agent)
+
+    assert messages == []
+    assert manager.removed_message_count == 2
+
+
+def test_window_size_zero_clears_all_messages_on_reduce_context():
+    """reduce_context with window_size=0 should clear all messages even without overflow."""
+    manager = SlidingWindowConversationManager(window_size=0, should_truncate_results=False)
+    messages = [
+        {"role": "user", "content": [{"text": "First"}]},
+        {"role": "assistant", "content": [{"text": "Second"}]},
+        {"role": "user", "content": [{"text": "Third"}]},
+    ]
+    test_agent = Agent(messages=messages)
+    manager.reduce_context(test_agent)
+
+    assert messages == []
+    assert manager.removed_message_count == 3
+
+
+def test_window_size_zero_clears_on_overflow():
+    """reduce_context with window_size=0 should clear messages even when called with an overflow exception."""
+    manager = SlidingWindowConversationManager(window_size=0, should_truncate_results=False)
+    messages = [
+        {"role": "user", "content": [{"text": "Hello"}]},
+        {"role": "assistant", "content": [{"text": "Hi"}]},
+    ]
+    test_agent = Agent(messages=messages)
+    manager.reduce_context(test_agent, e=Exception("overflow"))
+
+    assert messages == []


### PR DESCRIPTION
## Problem

`SlidingWindowConversationManager` with `window_size=0` silently fails to clear messages — the opposite of the intended behaviour documented in the TypeScript SDK.

Root cause in `reduce_context`:
```python
trim_index = 2 if len(messages) <= self.window_size else len(messages) - self.window_size
```
With `window_size=0` this sets `trim_index = len(messages)`.
The `while trim_index < len(messages)` guard is immediately `False`, so the `else` branch fires:
- During routine management (`e is None`): logs a warning and returns — messages **unchanged**.
- During overflow recovery (`e is not None`): raises `ContextWindowOverflowException` — also wrong.

Negative `window_size` values weren't validated at construction time either.

Closes #2205.

## Fix

1. **`__init__`** — raise `ValueError` for `window_size < 0` (parallel to the existing `per_turn` guard).
2. **`reduce_context`** — add a fast-path for `window_size == 0`: empty `messages` in-place, increment `removed_message_count`, and return. This matches the TypeScript SDK's explicit `window_size=0` → "clear all messages" semantics ([sdk-typescript#789](https://github.com/strands-agents/sdk-typescript/issues/789)).

## Tests

Four new tests added to `tests/strands/agent/test_conversation_manager.py`:

| Test | What it checks |
|------|---------------|
| `test_window_size_negative_raises_value_error` | `window_size=-1` raises `ValueError` at construction |
| `test_window_size_zero_clears_all_messages_on_apply_management` | `apply_management` with `window_size=0` empties messages and updates `removed_message_count` |
| `test_window_size_zero_clears_all_messages_on_reduce_context` | `reduce_context` with `window_size=0` empties messages without overflow |
| `test_window_size_zero_clears_on_overflow` | `reduce_context` with `window_size=0` still clears messages even when `e` is provided |

All 44 existing + new tests pass.