### PR TITLE
feat: add ProviderTokenCountError for native token counting failures

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -27,6 +27,7 @@ from ..types.content import ContentBlock, Messages, SystemContentBlock
 from ..types.exceptions import (
     ContextWindowOverflowException,
     ModelThrottledException,
+    ProviderTokenCountError,
 )
 from ..types.streaming import CitationsDelta, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
@@ -789,7 +790,10 @@ class BedrockModel(Model):
                 modelId=self.config["model_id"],
                 input={"converse": converse_input},
             )
-            total_tokens: int = response["inputTokens"]
+            input_tokens = response.get("inputTokens")
+            if input_tokens is None:
+                raise ProviderTokenCountError("Bedrock count_tokens returned None for inputTokens")
+            total_tokens: int = input_tokens
 
             logger.debug("model_id=<%s>, total_tokens=<%d> | native token count", self.config["model_id"], total_tokens)
             return total_tokens

--- a/src/strands/models/gemini.py
+++ b/src/strands/models/gemini.py
@@ -16,7 +16,7 @@ from google import genai
 from typing_extensions import Required, Unpack, override
 
 from ..types.content import ContentBlock, ContentBlockStartToolUse, Messages, SystemContentBlock
-from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
+from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException, ProviderTokenCountError
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 from ._validation import _has_location_source, validate_config_keys
@@ -465,7 +465,7 @@ class GeminiModel(Model):
                 contents=contents,
             )
             if response.total_tokens is None:
-                raise ValueError("Gemini count_tokens returned None for total_tokens")
+                raise ProviderTokenCountError("Gemini count_tokens returned None for total_tokens")
             total_tokens: int = response.total_tokens
 
             # The google-genai SDK explicitly raises ValueError for system_instruction, tools, and

--- a/src/strands/types/exceptions.py
+++ b/src/strands/types/exceptions.py
@@ -83,6 +83,16 @@ class SnapshotException(Exception):
     pass
 
 
+class ProviderTokenCountError(Exception):
+    """Thrown when a model provider's native token counting API fails.
+
+    This error is used as internal control flow within provider ``count_tokens()`` overrides.
+    When caught, the provider falls back to the base class heuristic estimation.
+    """
+
+    pass
+
+
 class ToolProviderException(Exception):
     """Exception raised when a tool provider fails to load or cleanup tools."""
 

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -3211,6 +3211,15 @@ class TestCountTokens:
         assert result >= 0
 
     @pytest.mark.asyncio
+    async def test_fallback_on_none_input_tokens(self, model_with_client, bedrock_client, messages):
+        bedrock_client.count_tokens.return_value = {}
+
+        result = await model_with_client.count_tokens(messages=messages)
+
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @pytest.mark.asyncio
     async def test_fallback_logs_warning(self, model_with_client, bedrock_client, messages, caplog):
         bedrock_client.count_tokens.side_effect = RuntimeError("API down")
 


### PR DESCRIPTION
## Description

Add `ProviderTokenCountError` to the Python SDK, matching the typed error introduced in the TypeScript SDK ([sdk-typescript#886](https://github.com/strands-agents/sdk-typescript/pull/886)). This error is thrown when a model provider's native token counting API returns an unexpected null result, and is used as internal control flow within provider `count_tokens()` overrides. 

### TypeScript port of
- TypeScript PR: [feat: override countTokens with native token counting for supported providers sdk-typescript#886](https://github.com/strands-agents/sdk-typescript/pull/886)

## Related Issues

#2179

## Documentation PR

Will update as part of proactive compression doc updated 

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- Existing `TestCountTokens` tests for Bedrock and Gemini (including `test_fallback_on_none_total_tokens`, `test_fallback_on_api_error`, `test_fallback_on_generic_exception`) continue to pass — 188
tests, 0 failures

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.