### PR TITLE
feat(bedrock): add strict_tools config with auto-inject of additional…

### DIFF
--- a/src/strands/models/_strict_schema.py
+++ b/src/strands/models/_strict_schema.py
@@ -1,0 +1,144 @@
+"""Strict JSON schema transformation for tool definitions.
+
+When model providers require `strict: true` on tool definitions, they also require
+`"additionalProperties": false` on every `object` type in the input schema. This module
+provides a utility to recursively apply that constraint.
+
+Modeled after OpenAI's `_ensure_strict_json_schema`:
+https://github.com/openai/openai-python/blob/main/src/openai/lib/_pydantic.py
+"""
+
+import copy
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_strict_json_schema(
+    schema: dict[str, Any],
+    *,
+    require_all_properties: bool = False,
+) -> dict[str, Any]:
+    """Ensure a JSON schema conforms to strict tool use requirements.
+
+    Creates a deep copy of the schema and recursively:
+    1. Adds ``"additionalProperties": false`` to all ``object`` types that do not already define it
+    2. Optionally adds all properties to the ``required`` array (needed for OpenAI)
+    3. Handles ``$defs``, ``definitions``, ``anyOf``, ``allOf``, ``items``, and ``$ref``
+
+    Args:
+        schema: The JSON schema to process. A deep copy is made internally so the original is not mutated.
+        require_all_properties: If True, set ``required`` to include all property keys. OpenAI strict mode
+            requires this; Bedrock and Anthropic do not.
+
+    Returns:
+        A new schema dict with strict-mode constraints applied.
+    """
+    schema_copy = copy.deepcopy(schema)
+    _apply_strict(schema_copy, root=schema_copy, require_all_properties=require_all_properties)
+    return schema_copy
+
+
+def _apply_strict(
+    schema: dict[str, Any],
+    *,
+    root: dict[str, Any],
+    require_all_properties: bool,
+) -> None:
+    """Recursively apply strict-mode constraints to a JSON schema in place.
+
+    Args:
+        schema: The schema node to process (modified in place).
+        root: The root schema, used for resolving ``$ref`` pointers.
+        require_all_properties: If True, add all properties to ``required``.
+    """
+    # Process $defs / definitions blocks
+    for defs_key in ("$defs", "definitions"):
+        defs = schema.get(defs_key)
+        if isinstance(defs, dict):
+            for def_schema in defs.values():
+                if isinstance(def_schema, dict):
+                    _apply_strict(def_schema, root=root, require_all_properties=require_all_properties)
+
+    # Add additionalProperties: false to object types that lack it
+    if schema.get("type") == "object" and "additionalProperties" not in schema:
+        schema["additionalProperties"] = False
+
+    # Process properties and optionally enforce required
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        if require_all_properties:
+            schema["required"] = list(properties.keys())
+
+        for prop_schema in properties.values():
+            if isinstance(prop_schema, dict):
+                _apply_strict(prop_schema, root=root, require_all_properties=require_all_properties)
+
+    # Process array items
+    items = schema.get("items")
+    if isinstance(items, dict):
+        _apply_strict(items, root=root, require_all_properties=require_all_properties)
+
+    # Process anyOf variants
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list):
+        for variant in any_of:
+            if isinstance(variant, dict):
+                _apply_strict(variant, root=root, require_all_properties=require_all_properties)
+
+    # Process allOf variants
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list):
+        for entry in all_of:
+            if isinstance(entry, dict):
+                _apply_strict(entry, root=root, require_all_properties=require_all_properties)
+
+    # Process oneOf variants
+    one_of = schema.get("oneOf")
+    if isinstance(one_of, list):
+        for variant in one_of:
+            if isinstance(variant, dict):
+                _apply_strict(variant, root=root, require_all_properties=require_all_properties)
+
+    # Resolve $ref combined with other keys by inlining the referenced schema
+    ref = schema.get("$ref")
+    if isinstance(ref, str) and len(schema) > 1:
+        resolved = _resolve_ref(root, ref)
+        if isinstance(resolved, dict):
+            # Inline the resolved schema, giving priority to existing keys
+            merged = {**copy.deepcopy(resolved), **schema}
+            merged.pop("$ref", None)
+            schema.clear()
+            schema.update(merged)
+            # Re-apply strict to the inlined schema
+            _apply_strict(schema, root=root, require_all_properties=require_all_properties)
+
+
+def _resolve_ref(root: dict[str, Any], ref: str) -> dict[str, Any] | None:
+    """Resolve a JSON Schema ``$ref`` pointer against the root schema.
+
+    Args:
+        root: The root schema containing definitions.
+        ref: A JSON pointer string (e.g., ``#/$defs/MyModel``).
+
+    Returns:
+        The resolved schema dict, or None if resolution fails.
+    """
+    if not ref.startswith("#/"):
+        logger.warning("ref=<%s> | unexpected $ref format, skipping resolution", ref)
+        return None
+
+    path = ref[2:].split("/")
+    current: Any = root
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            logger.warning("ref=<%s> | failed to resolve $ref path", ref)
+            return None
+        current = current[key]
+
+    if not isinstance(current, dict):
+        logger.warning("ref=<%s> | resolved to non-dict value", ref)
+        return None
+
+    return current

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -30,6 +30,7 @@ from ..types.exceptions import (
 )
 from ..types.streaming import CitationsDelta, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
+from ._strict_schema import ensure_strict_json_schema
 from ._validation import validate_config_keys
 from .model import BaseModelConfig, CacheConfig, Model
 
@@ -99,6 +100,10 @@ class BedrockModel(Model):
                 supported service tiers, models, and regions
             stop_sequences: List of sequences that will stop generation when encountered
             streaming: Flag to enable/disable streaming. Defaults to True.
+            strict_tools: Flag to enable structured output enforcement on tool definitions.
+                When True, adds strict: true to each tool spec and automatically injects
+                "additionalProperties": false into all object types in tool input schemas.
+                See https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
             temperature: Controls randomness in generation (higher = more random)
             top_p: Controls diversity via nucleus sampling (alternative to temperature)
         """
@@ -124,6 +129,7 @@ class BedrockModel(Model):
         service_tier: str | None
         stop_sequences: list[str] | None
         streaming: bool | None
+        strict_tools: bool | None
         temperature: float | None
         top_p: float | None
 
@@ -239,6 +245,7 @@ class BedrockModel(Model):
 
         # Use system_prompt_content directly (copy for mutability)
         system_blocks: list[SystemContentBlock] = system_prompt_content.copy() if system_prompt_content else []
+
         # Add cache point if configured (backwards compatibility)
         if cache_prompt := self.config.get("cache_prompt"):
             warnings.warn(
@@ -260,7 +267,12 @@ class BedrockModel(Model):
                                     "toolSpec": {
                                         "name": tool_spec["name"],
                                         "description": tool_spec["description"],
-                                        "inputSchema": tool_spec["inputSchema"],
+                                        "inputSchema": (
+                                            {"json": ensure_strict_json_schema(tool_spec["inputSchema"]["json"])}
+                                            if self.config.get("strict_tools")
+                                            else tool_spec["inputSchema"]
+                                        ),
+                                        **({"strict": True} if self.config.get("strict_tools") else {}),
                                     }
                                 }
                                 for tool_spec in tool_specs

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -493,6 +493,188 @@ def test_format_request_tool_specs(model, messages, model_id, tool_spec):
     assert tru_request == exp_request
 
 
+def test_format_request_strict_tools_injects_strict_and_closes_schema(bedrock_client, model_id, messages):
+    tool_specs = [
+        {
+            "name": "my_tool",
+            "description": "A tool",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {"param": {"type": "string"}},
+                    "required": ["param"],
+                }
+            },
+        }
+    ]
+    model = BedrockModel(model_id=model_id, strict_tools=True)
+    request = model._format_request(messages, tool_specs=tool_specs)
+    tool_spec_result = request["toolConfig"]["tools"][0]["toolSpec"]
+
+    assert tool_spec_result == {
+        "name": "my_tool",
+        "description": "A tool",
+        "inputSchema": {
+            "json": {
+                "type": "object",
+                "properties": {"param": {"type": "string"}},
+                "required": ["param"],
+                "additionalProperties": False,
+            }
+        },
+        "strict": True,
+    }
+
+
+def test_format_request_strict_tools_does_not_mutate_original(bedrock_client, model_id, messages):
+    tool_specs = [
+        {
+            "name": "my_tool",
+            "description": "A tool",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {"param": {"type": "string"}},
+                    "required": ["param"],
+                }
+            },
+        }
+    ]
+    model = BedrockModel(model_id=model_id, strict_tools=True)
+    model._format_request(messages, tool_specs=tool_specs)
+
+    assert "additionalProperties" not in tool_specs[0]["inputSchema"]["json"]
+
+
+def test_format_request_strict_tools_preserves_additional_properties_true(bedrock_client, model_id, messages):
+    tool_specs = [
+        {
+            "name": "my_tool",
+            "description": "A tool",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {"param": {"type": "string"}},
+                    "required": ["param"],
+                    "additionalProperties": True,
+                }
+            },
+        }
+    ]
+    model = BedrockModel(model_id=model_id, strict_tools=True)
+    request = model._format_request(messages, tool_specs=tool_specs)
+    schema = request["toolConfig"]["tools"][0]["toolSpec"]["inputSchema"]["json"]
+
+    assert schema["additionalProperties"] is True
+
+
+def test_format_request_strict_tools_nested_objects(bedrock_client, model_id, messages):
+    tool_specs = [
+        {
+            "name": "my_tool",
+            "description": "A tool",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "properties": {"value": {"type": "integer"}},
+                        }
+                    },
+                    "required": ["config"],
+                }
+            },
+        }
+    ]
+    model = BedrockModel(model_id=model_id, strict_tools=True)
+    request = model._format_request(messages, tool_specs=tool_specs)
+    schema = request["toolConfig"]["tools"][0]["toolSpec"]["inputSchema"]["json"]
+
+    assert schema == {
+        "type": "object",
+        "properties": {
+            "config": {
+                "type": "object",
+                "properties": {"value": {"type": "integer"}},
+                "additionalProperties": False,
+            }
+        },
+        "required": ["config"],
+        "additionalProperties": False,
+    }
+
+
+def test_format_request_strict_tools_default_no_strict(bedrock_client, model_id, messages):
+    tool_specs = [
+        {
+            "name": "my_tool",
+            "description": "A tool",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {"param": {"type": "string"}},
+                    "required": ["param"],
+                }
+            },
+        }
+    ]
+    model = BedrockModel(model_id=model_id)
+    request = model._format_request(messages, tool_specs=tool_specs)
+    tool_spec_result = request["toolConfig"]["tools"][0]["toolSpec"]
+
+    assert "strict" not in tool_spec_result
+    assert tool_spec_result["inputSchema"]["json"] == {
+        "type": "object",
+        "properties": {"param": {"type": "string"}},
+        "required": ["param"],
+    }
+
+
+def test_format_request_strict_tools_false_no_strict(bedrock_client, model_id, messages):
+    tool_specs = [
+        {
+            "name": "my_tool",
+            "description": "A tool",
+            "inputSchema": {"json": {"type": "object", "properties": {"x": {"type": "string"}}}},
+        }
+    ]
+    model = BedrockModel(model_id=model_id, strict_tools=False)
+    request = model._format_request(messages, tool_specs=tool_specs)
+    tool_spec_result = request["toolConfig"]["tools"][0]["toolSpec"]
+
+    assert "strict" not in tool_spec_result
+
+
+def test_format_request_strict_tools_none_no_strict(bedrock_client, model_id, messages):
+    tool_specs = [
+        {
+            "name": "my_tool",
+            "description": "A tool",
+            "inputSchema": {"json": {"type": "object", "properties": {"x": {"type": "string"}}}},
+        }
+    ]
+    model = BedrockModel(model_id=model_id, strict_tools=None)
+    request = model._format_request(messages, tool_specs=tool_specs)
+    tool_spec_result = request["toolConfig"]["tools"][0]["toolSpec"]
+
+    assert "strict" not in tool_spec_result
+
+
+def test_format_request_strict_tools_applies_to_all_tools(bedrock_client, model_id, messages):
+    tool_specs = [
+        {"name": "tool_a", "description": "Tool A", "inputSchema": {"json": {"type": "object", "properties": {}}}},
+        {"name": "tool_b", "description": "Tool B", "inputSchema": {"json": {"type": "object", "properties": {}}}},
+    ]
+    model = BedrockModel(model_id=model_id, strict_tools=True)
+    request = model._format_request(messages, tool_specs=tool_specs)
+
+    for tool in request["toolConfig"]["tools"]:
+        if "toolSpec" in tool:
+            assert tool["toolSpec"]["strict"] is True
+            assert tool["toolSpec"]["inputSchema"]["json"]["additionalProperties"] is False
+
+
 def test_format_request_tool_choice_auto(model, messages, model_id, tool_spec):
     tool_choice = {"auto": {}}
     tru_request = model._format_request(messages, [tool_spec], tool_choice=tool_choice)

--- a/tests/strands/models/test_strict_schema.py
+++ b/tests/strands/models/test_strict_schema.py
@@ -1,0 +1,302 @@
+from strands.models._strict_schema import ensure_strict_json_schema
+
+
+def test_basic_object():
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result == {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "additionalProperties": False,
+    }
+    assert "additionalProperties" not in schema
+
+
+def test_nested_objects():
+    schema = {
+        "type": "object",
+        "properties": {
+            "outer": {
+                "type": "object",
+                "properties": {"inner": {"type": "integer"}},
+            }
+        },
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result == {
+        "type": "object",
+        "properties": {
+            "outer": {
+                "type": "object",
+                "properties": {"inner": {"type": "integer"}},
+                "additionalProperties": False,
+            }
+        },
+        "additionalProperties": False,
+    }
+
+
+def test_defs():
+    schema = {
+        "type": "object",
+        "properties": {"item": {"$ref": "#/$defs/MyItem"}},
+        "$defs": {
+            "MyItem": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            }
+        },
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result["additionalProperties"] is False
+    assert result["$defs"]["MyItem"] == {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "additionalProperties": False,
+    }
+
+
+def test_definitions():
+    schema = {
+        "type": "object",
+        "properties": {"item": {"$ref": "#/definitions/MyItem"}},
+        "definitions": {
+            "MyItem": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            }
+        },
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result["additionalProperties"] is False
+    assert result["definitions"]["MyItem"] == {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "additionalProperties": False,
+    }
+
+
+def test_ref_inline():
+    schema = {
+        "type": "object",
+        "properties": {
+            "item": {
+                "$ref": "#/$defs/MyItem",
+                "description": "An item",
+            }
+        },
+        "$defs": {
+            "MyItem": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            }
+        },
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result["properties"]["item"] == {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "description": "An item",
+        "additionalProperties": False,
+    }
+
+
+def test_ref_inline_uses_deep_copy():
+    """Two properties referencing the same $def get independent copies."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"$ref": "#/$defs/Shared", "description": "first"},
+            "b": {"$ref": "#/$defs/Shared", "description": "second"},
+        },
+        "$defs": {
+            "Shared": {
+                "type": "object",
+                "properties": {"val": {"type": "string"}},
+            }
+        },
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result["properties"]["a"]["description"] == "first"
+    assert result["properties"]["b"]["description"] == "second"
+    assert result["properties"]["a"] is not result["properties"]["b"]
+
+
+def test_arrays_anyof_allof():
+    schema = {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {"type": "object", "properties": {"a": {"type": "string"}}},
+            },
+            "union": {
+                "anyOf": [
+                    {"type": "object", "properties": {"b": {"type": "string"}}},
+                    {"type": "null"},
+                ]
+            },
+            "intersection": {
+                "allOf": [
+                    {"type": "object", "properties": {"c": {"type": "string"}}},
+                ]
+            },
+        },
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result == {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"a": {"type": "string"}},
+                    "additionalProperties": False,
+                },
+            },
+            "union": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {"b": {"type": "string"}},
+                        "additionalProperties": False,
+                    },
+                    {"type": "null"},
+                ]
+            },
+            "intersection": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {"c": {"type": "string"}},
+                        "additionalProperties": False,
+                    },
+                ]
+            },
+        },
+        "additionalProperties": False,
+    }
+
+
+def test_oneof():
+    schema = {
+        "type": "object",
+        "properties": {
+            "value": {
+                "oneOf": [
+                    {"type": "object", "properties": {"a": {"type": "string"}}},
+                    {"type": "object", "properties": {"b": {"type": "integer"}}},
+                ]
+            }
+        },
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result == {
+        "type": "object",
+        "properties": {
+            "value": {
+                "oneOf": [
+                    {"type": "object", "properties": {"a": {"type": "string"}}, "additionalProperties": False},
+                    {"type": "object", "properties": {"b": {"type": "integer"}}, "additionalProperties": False},
+                ]
+            }
+        },
+        "additionalProperties": False,
+    }
+
+
+def test_require_all_properties():
+    schema = {
+        "type": "object",
+        "properties": {
+            "required_field": {"type": "string"},
+            "optional_field": {"type": "string"},
+        },
+        "required": ["required_field"],
+    }
+
+    without = ensure_strict_json_schema(schema)
+    assert without["required"] == ["required_field"]
+
+    with_all = ensure_strict_json_schema(schema, require_all_properties=True)
+    assert set(with_all["required"]) == {"required_field", "optional_field"}
+
+
+def test_preserves_additional_properties_true():
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "additionalProperties": True,
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result == {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "additionalProperties": True,
+    }
+
+
+def test_preserves_additional_properties_false():
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "additionalProperties": False,
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result == {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "additionalProperties": False,
+    }
+
+
+def test_non_object_type_unchanged():
+    schema = {"type": "string"}
+    result = ensure_strict_json_schema(schema)
+
+    assert result == {"type": "string"}
+
+
+def test_ref_with_invalid_format_is_ignored():
+    """A $ref that doesn't start with #/ is silently skipped."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "item": {"$ref": "external.json#/Foo", "description": "ext"},
+        },
+    }
+    result = ensure_strict_json_schema(schema)
+
+    # $ref is not resolved, but additionalProperties is still added to root
+    assert result["additionalProperties"] is False
+    assert result["properties"]["item"]["$ref"] == "external.json#/Foo"
+
+
+def test_ref_with_missing_path_is_ignored():
+    """A $ref pointing to a non-existent path is silently skipped."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "item": {"$ref": "#/$defs/Missing", "description": "gone"},
+        },
+        "$defs": {},
+    }
+    result = ensure_strict_json_schema(schema)
+
+    assert result["additionalProperties"] is False
+    # $ref stays because resolution failed
+    assert "$ref" in result["properties"]["item"]

--- a/tests_integ/models/test_model_bedrock.py
+++ b/tests_integ/models/test_model_bedrock.py
@@ -552,3 +552,27 @@ class TestCountTokens:
         without = await model.count_tokens(messages=messages)
         with_tools = await model.count_tokens(messages=messages, tool_specs=tool_specs, system_prompt="Be helpful.")
         assert with_tools > without
+
+
+def test_strict_tools_with_complex_schema():
+    """Test strict_tools=True with tools that have complex schemas including arrays and optional params."""
+
+    tools_called = set()
+
+    @strands.tool
+    def search(query: str, tags: list[str], max_results: int = 5) -> str:
+        """Search for items matching query and tags."""
+        tools_called.add("search")
+        return f"Found results for '{query}' with tags {tags} (limit {max_results})"
+
+    @strands.tool
+    def calculator(expression: str) -> float:
+        """Calculate the result of a mathematical expression."""
+        tools_called.add("calculator")
+        return eval(expression)
+
+    model = BedrockModel(strict_tools=True)
+    agent = Agent(model=model, tools=[search, calculator], load_tools_from_directory=False)
+    agent('Search for "python" with tags ["programming", "language"] using the search tool.')
+
+    assert "search" in tools_called


### PR DESCRIPTION
## Description

### Motivation

Bedrock's Converse API supports a `strict` field on `ToolSpecification` that enables constrained decoding on tool names and inputs, preventing the model from hallucinating tool names or generating inputs that don't match the defined schema. Currently there is no way to enable this through the SDK because `_format_request` only forwards `name`, `description`, and `inputSchema` from each tool spec.

A key challenge with strict mode is that Bedrock requires `"additionalProperties": false` on every `object` type in the tool's input schema, validated recursively including nested objects. The Strands `@tool` decorator does not include this field in generated schemas, and in fact actively strips it in `_clean_pydantic_schema`. This means simply injecting `strict: true` into the request is not enough: every `@tool`-decorated function would fail with a `ValidationException`.

This PR adds a `strict_tools` config option to `BedrockModel` that both injects `strict: true` and automatically adds `"additionalProperties": false` to all object types in tool input schemas, making strict mode work out of the box with `@tool`-decorated functions. The schema transformation operates on a deep copy so original tool specs are never mutated. This follows the same pattern as OpenAI's Python SDK ([`_ensure_strict_json_schema`](https://github.com/openai/openai-python/blob/main/src/openai/lib/_pydantic.py)).

Resolves #2210

### Public API Changes

`BedrockConfig` now accepts an optional `strict_tools` boolean parameter:

```python
# Before: no way to enable strict schema validation on tools
model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-6")

# After: blanket toggle for all tool specs
model = BedrockModel(
    model_id="us.anthropic.claude-sonnet-4-6",
    strict_tools=True,
)
```

When `strict_tools=True`, every `toolSpec` in the formatted request includes `"strict": true` and all `object` types in tool input schemas have `"additionalProperties": false` injected. When unset, `None`, or `False`, tool specs remain unchanged.

### Use Cases

- **Preventing tool name hallucination**: Eliminates garbled tool names in production (e.g. `store-case-syummary-tool` instead of `store-case-summary-tool`), avoiding wasted cycles and tokens on self-correction
- **Input schema enforcement**: Ensures model-generated tool inputs always conform to the defined schema, preventing extra or misspelled parameters

## Related Issues

#2210

## Type of Change

New feature

## Testing

Verified with live Bedrock calls against `us.anthropic.claude-sonnet-4-6`:

| Configuration | Result |
|---|---|
| `strict_tools=True` with `@tool` decorated function | Works (previously failed with `ValidationException`) |
| `strict_tools=True` with manually defined schema | Works |
| `strict_tools` unset / `False` / `None` | Works, no regression |

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.