### PR TITLE
fix: change token counting fallback log from warning to debug

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -412,7 +412,7 @@ class AnthropicModel(Model):
             )
             return total_tokens
         except Exception as e:
-            logger.warning(
+            logger.debug(
                 "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
                 self.config["model_id"],
                 e,

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -798,7 +798,7 @@ class BedrockModel(Model):
             logger.debug("model_id=<%s>, total_tokens=<%d> | native token count", self.config["model_id"], total_tokens)
             return total_tokens
         except Exception as e:
-            logger.warning(
+            logger.debug(
                 "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
                 self.config["model_id"],
                 e,

--- a/src/strands/models/gemini.py
+++ b/src/strands/models/gemini.py
@@ -486,7 +486,7 @@ class GeminiModel(Model):
             )
             return total_tokens
         except Exception as e:
-            logger.warning(
+            logger.debug(
                 "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
                 self.config["model_id"],
                 e,

--- a/src/strands/models/llamacpp.py
+++ b/src/strands/models/llamacpp.py
@@ -555,7 +555,7 @@ class LlamaCppModel(Model):
             )
             return total_tokens
         except Exception as e:
-            logger.warning(
+            logger.debug(
                 "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
                 self.config.get("model_id", "default"),
                 e,

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -226,7 +226,7 @@ class OpenAIResponsesModel(Model):
             )
             return total_tokens
         except Exception as e:
-            logger.warning(
+            logger.debug(
                 "model_id=<%s>, error=<%s> | native token counting failed, falling back to estimation",
                 self.config["model_id"],
                 e,

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -1131,10 +1131,10 @@ class TestCountTokens:
         assert result >= 0
 
     @pytest.mark.asyncio
-    async def test_fallback_logs_warning(self, model_with_client, anthropic_client, messages, caplog):
+    async def test_fallback_logs_debug(self, model_with_client, anthropic_client, messages, caplog):
         anthropic_client.messages.count_tokens = unittest.mock.AsyncMock(side_effect=RuntimeError("API down"))
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG, logger="strands.models.anthropic"):
             await model_with_client.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -3220,10 +3220,10 @@ class TestCountTokens:
         assert result >= 0
 
     @pytest.mark.asyncio
-    async def test_fallback_logs_warning(self, model_with_client, bedrock_client, messages, caplog):
+    async def test_fallback_logs_debug(self, model_with_client, bedrock_client, messages, caplog):
         bedrock_client.count_tokens.side_effect = RuntimeError("API down")
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG, logger="strands.models.bedrock"):
             await model_with_client.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)

--- a/tests/strands/models/test_gemini.py
+++ b/tests/strands/models/test_gemini.py
@@ -1197,10 +1197,10 @@ class TestCountTokens:
         assert result >= 0
 
     @pytest.mark.asyncio
-    async def test_fallback_logs_warning(self, model, gemini_client, messages, caplog):
+    async def test_fallback_logs_debug(self, model, gemini_client, messages, caplog):
         gemini_client.aio.models.count_tokens.side_effect = RuntimeError("API down")
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG, logger="strands.models.gemini"):
             await model.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)

--- a/tests/strands/models/test_llamacpp.py
+++ b/tests/strands/models/test_llamacpp.py
@@ -796,10 +796,10 @@ class TestCountTokens:
         assert result >= 0
 
     @pytest.mark.asyncio
-    async def test_fallback_logs_warning(self, model, messages, caplog):
+    async def test_fallback_logs_debug(self, model, messages, caplog):
         model.client.post = AsyncMock(side_effect=RuntimeError("Server down"))
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG, logger="strands.models.llamacpp"):
             await model.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -1289,12 +1289,12 @@ class TestCountTokens:
         assert result >= 0
 
     @pytest.mark.asyncio
-    async def test_fallback_logs_warning(self, model, openai_client, messages, caplog):
+    async def test_fallback_logs_debug(self, model, openai_client, messages, caplog):
         import logging
 
         openai_client.responses.input_tokens.count.side_effect = RuntimeError("API down")
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG, logger="strands.models.openai_responses"):
             await model.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)


### PR DESCRIPTION
## Description

Change the native token counting fallback log from `warning` to `debug` in all model providers. When a provider's native `count_tokens` API fails (e.g., missing credentials, API unavailable), the SDK falls back to heuristic estimation. This is expected behavior, not an actionable warning. Demoting it to debug reduces log noise.

## Related Issues

#2189 

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
