### PR TITLE
feat(offloader): return explicit paths in preview and auto-enable retrieval

### DIFF
--- a/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/src/strands/vended_plugins/context_offloader/plugin.py
@@ -42,7 +42,7 @@ from ...plugins import Plugin, hook
 from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
-from .storage import Storage
+from .storage import InMemoryStorage, Storage
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
@@ -109,7 +109,7 @@ class ContextOffloader(Plugin):
         max_result_tokens: int = _DEFAULT_MAX_RESULT_TOKENS,
         preview_tokens: int = _DEFAULT_PREVIEW_TOKENS,
         *,
-        include_retrieval_tool: bool = False,
+        include_retrieval_tool: bool | None = None,
     ) -> None:
         """Initialize the ContextOffloader plugin.
 
@@ -121,7 +121,9 @@ class ContextOffloader(Plugin):
                 Uses tiktoken for exact slicing when available, falls back to
                 chars/4 heuristic. Defaults to ``_DEFAULT_PREVIEW_TOKENS`` (1,000).
             include_retrieval_tool: Whether to register the ``retrieve_offloaded_content``
-                tool so the agent can fetch offloaded content. Defaults to False.
+                tool so the agent can fetch offloaded content. Defaults to True for
+                ``InMemoryStorage`` (where the retrieval tool is the only access
+                method) and False for other backends.
 
         Raises:
             ValueError: If max_result_tokens is not positive, preview_tokens is negative,
@@ -133,6 +135,9 @@ class ContextOffloader(Plugin):
             raise ValueError("preview_tokens must be non-negative")
         if preview_tokens >= max_result_tokens:
             raise ValueError("preview_tokens must be less than max_result_tokens")
+
+        if include_retrieval_tool is None:
+            include_retrieval_tool = isinstance(storage, InMemoryStorage)
 
         self._storage = storage
         self._max_result_tokens = max_result_tokens

--- a/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/src/strands/vended_plugins/context_offloader/plugin.py
@@ -42,7 +42,7 @@ from ...plugins import Plugin, hook
 from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
-from .storage import InMemoryStorage, Storage
+from .storage import Storage
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
@@ -88,7 +88,7 @@ class ContextOffloader(Plugin):
         max_result_tokens: Offload results whose estimated token count exceeds this threshold.
         preview_tokens: Number of tokens to keep as a text preview in context.
         include_retrieval_tool: Whether to register the ``retrieve_offloaded_content`` tool.
-            Defaults to False.
+            Defaults to True.
 
     Example:
         ```python
@@ -109,7 +109,7 @@ class ContextOffloader(Plugin):
         max_result_tokens: int = _DEFAULT_MAX_RESULT_TOKENS,
         preview_tokens: int = _DEFAULT_PREVIEW_TOKENS,
         *,
-        include_retrieval_tool: bool | None = None,
+        include_retrieval_tool: bool = True,
     ) -> None:
         """Initialize the ContextOffloader plugin.
 
@@ -121,9 +121,7 @@ class ContextOffloader(Plugin):
                 Uses tiktoken for exact slicing when available, falls back to
                 chars/4 heuristic. Defaults to ``_DEFAULT_PREVIEW_TOKENS`` (1,000).
             include_retrieval_tool: Whether to register the ``retrieve_offloaded_content``
-                tool so the agent can fetch offloaded content. Defaults to True for
-                ``InMemoryStorage`` (where the retrieval tool is the only access
-                method) and False for other backends.
+                tool so the agent can fetch offloaded content. Defaults to True.
 
         Raises:
             ValueError: If max_result_tokens is not positive, preview_tokens is negative,
@@ -135,9 +133,6 @@ class ContextOffloader(Plugin):
             raise ValueError("preview_tokens must be non-negative")
         if preview_tokens >= max_result_tokens:
             raise ValueError("preview_tokens must be less than max_result_tokens")
-
-        if include_retrieval_tool is None:
-            include_retrieval_tool = isinstance(storage, InMemoryStorage)
 
         self._storage = storage
         self._max_result_tokens = max_result_tokens
@@ -278,7 +273,10 @@ class ContextOffloader(Plugin):
             "Use your available tools to selectively access the data you need."
         )
         if self._include_retrieval_tool:
-            guidance += "\nYou can also use retrieve_offloaded_content with a reference to get the full content."
+            guidance += (
+                "\nOnly use retrieve_offloaded_content as a fallback"
+                " if the data cannot be accessed using your existing tools."
+            )
 
         preview_text = (
             f"[Offloaded: {len(content)} blocks, ~{token_count:,} tokens]\n"

--- a/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/src/strands/vended_plugins/context_offloader/plugin.py
@@ -155,7 +155,8 @@ class ContextOffloader(Plugin):
         """Retrieve offloaded content by reference.
 
         Use this tool when you see a placeholder with a reference (ref: ...)
-        and need the full content.
+        and need the full content. Only use this as a fallback if the data
+        cannot be accessed using your existing tools.
 
         Args:
             reference: The reference string from the offload placeholder.
@@ -273,10 +274,7 @@ class ContextOffloader(Plugin):
             "Use your available tools to selectively access the data you need."
         )
         if self._include_retrieval_tool:
-            guidance += (
-                "\nOnly use retrieve_offloaded_content as a fallback"
-                " if the data cannot be accessed using your existing tools."
-            )
+            guidance += "\nYou can also use retrieve_offloaded_content with a reference to get the full content."
 
         preview_text = (
             f"[Offloaded: {len(content)} blocks, ~{token_count:,} tokens]\n"

--- a/src/strands/vended_plugins/context_offloader/storage.py
+++ b/src/strands/vended_plugins/context_offloader/storage.py
@@ -131,7 +131,11 @@ class FileStorage:
         return f".{content_type.split('/')[-1]}"
 
     def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
-        """Store content as a file and return the filename as reference.
+        """Store content as a file and return the path as reference.
+
+        The returned path preserves the form of ``artifact_dir`` passed to
+        the constructor: a relative ``artifact_dir`` yields a relative
+        reference, an absolute one yields an absolute reference.
 
         Args:
             key: A unique key for this content block.
@@ -139,7 +143,7 @@ class FileStorage:
             content_type: MIME type of the content.
 
         Returns:
-            The filename (not full path) used as the reference.
+            The file path (e.g., ``./artifacts/1234_1_key.txt``).
         """
         self._artifact_dir.mkdir(parents=True, exist_ok=True)
 
@@ -156,13 +160,16 @@ class FileStorage:
         file_path = self._artifact_dir / filename
         file_path.write_bytes(content)
 
-        return filename
+        return str(file_path)
 
     def retrieve(self, reference: str) -> tuple[bytes, str]:
         """Retrieve content from a stored file.
 
+        Accepts both full paths (as returned by ``store()``) and bare
+        filenames for backward compatibility.
+
         Args:
-            reference: The filename reference returned by store().
+            reference: The file path or filename returned by store().
 
         Returns:
             A tuple of (content bytes, content type).
@@ -170,12 +177,16 @@ class FileStorage:
         Raises:
             KeyError: If the file does not exist.
         """
-        file_path = (self._artifact_dir / reference).resolve()
+        ref_path = Path(reference)
+        file_path = ref_path.resolve() if len(ref_path.parts) > 1 else (self._artifact_dir / reference).resolve()
+        if not file_path.is_relative_to(self._artifact_dir.resolve()):
+            file_path = (self._artifact_dir / reference).resolve()
         if not file_path.is_relative_to(self._artifact_dir.resolve()):
             raise KeyError(f"Reference not found: {reference}")
         if not file_path.is_file():
             raise KeyError(f"Reference not found: {reference}")
-        content_type = self._content_types.get(reference, "application/octet-stream")
+        filename = file_path.name
+        content_type = self._content_types.get(filename, "application/octet-stream")
         return file_path.read_bytes(), content_type
 
     def _load_metadata(self) -> dict[str, str]:
@@ -320,7 +331,7 @@ class S3Storage:
         self._lock = threading.Lock()
 
     def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
-        """Store content as an S3 object and return the object key as reference.
+        """Store content as an S3 object and return an ``s3://`` URI as reference.
 
         Args:
             key: A unique key for this content block.
@@ -328,7 +339,7 @@ class S3Storage:
             content_type: MIME type of the content.
 
         Returns:
-            The S3 object key used as the reference.
+            An S3 URI (e.g., ``s3://bucket/prefix/1234_1_key``).
 
         Raises:
             botocore.exceptions.ClientError: If the S3 operation fails (e.g., bucket
@@ -348,13 +359,16 @@ class S3Storage:
             ContentType=content_type,
         )
 
-        return s3_key
+        return f"s3://{self._bucket}/{s3_key}"
 
     def retrieve(self, reference: str) -> tuple[bytes, str]:
         """Retrieve content from an S3 object.
 
+        Accepts both ``s3://`` URIs (as returned by ``store()``) and raw
+        S3 keys for backward compatibility.
+
         Args:
-            reference: The S3 object key returned by store().
+            reference: The S3 URI or object key returned by store().
 
         Returns:
             A tuple of (content bytes, content type).
@@ -362,8 +376,14 @@ class S3Storage:
         Raises:
             KeyError: If the object does not exist.
         """
+        s3_key = reference
+        if reference.startswith("s3://"):
+            expected_prefix = f"s3://{self._bucket}/"
+            if not reference.startswith(expected_prefix):
+                raise KeyError(f"Reference not found: {reference}")
+            s3_key = reference[len(expected_prefix):]
         try:
-            response = self._client.get_object(Bucket=self._bucket, Key=reference)
+            response = self._client.get_object(Bucket=self._bucket, Key=s3_key)
             content: bytes = response["Body"].read()
             content_type: str = response.get("ContentType", "application/octet-stream")
             return content, content_type

--- a/src/strands/vended_plugins/context_offloader/storage.py
+++ b/src/strands/vended_plugins/context_offloader/storage.py
@@ -177,11 +177,12 @@ class FileStorage:
         Raises:
             KeyError: If the file does not exist.
         """
+        resolved_dir = self._artifact_dir.resolve()
         ref_path = Path(reference)
         file_path = ref_path.resolve() if len(ref_path.parts) > 1 else (self._artifact_dir / reference).resolve()
-        if not file_path.is_relative_to(self._artifact_dir.resolve()):
+        if not file_path.is_relative_to(resolved_dir):
             file_path = (self._artifact_dir / reference).resolve()
-        if not file_path.is_relative_to(self._artifact_dir.resolve()):
+        if not file_path.is_relative_to(resolved_dir):
             raise KeyError(f"Reference not found: {reference}")
         if not file_path.is_file():
             raise KeyError(f"Reference not found: {reference}")
@@ -381,7 +382,7 @@ class S3Storage:
             expected_prefix = f"s3://{self._bucket}/"
             if not reference.startswith(expected_prefix):
                 raise KeyError(f"Reference not found: {reference}")
-            s3_key = reference[len(expected_prefix):]
+            s3_key = reference[len(expected_prefix) :]
         try:
             response = self._client.get_object(Bucket=self._bucket, Key=s3_key)
             content: bytes = response["Body"].read()

--- a/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -27,6 +27,7 @@ def plugin(storage):
         storage=storage,
         max_result_tokens=25,
         preview_tokens=10,
+        include_retrieval_tool=False,
     )
 
 
@@ -467,8 +468,14 @@ class TestRetrievalTool:
         tool_names = [t.tool_name for t in plugin.tools]
         assert "retrieve_offloaded_content" in tool_names
 
-    def test_retrieval_tool_not_registered_by_default(self):
+    def test_retrieval_tool_registered_by_default_for_inmemory(self):
         plugin = ContextOffloader(storage=InMemoryStorage())
+        plugin.init_agent(MagicMock())
+        tool_names = [t.tool_name for t in plugin.tools]
+        assert "retrieve_offloaded_content" in tool_names
+
+    def test_retrieval_tool_not_registered_by_default_for_file_storage(self, tmp_path):
+        plugin = ContextOffloader(storage=FileStorage(artifact_dir=str(tmp_path)))
         plugin.init_agent(MagicMock())
         tool_names = [t.tool_name for t in plugin.tools]
         assert "retrieve_offloaded_content" not in tool_names
@@ -532,7 +539,9 @@ class TestInlineGuidance:
 
     @pytest.mark.asyncio
     async def test_guidance_does_not_mention_retrieval_tool_when_disabled(self, storage, mock_agent):
-        plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+        plugin = ContextOffloader(
+            storage=storage, max_result_tokens=25, preview_tokens=10, include_retrieval_tool=False
+        )
         event = _make_event(mock_agent, "x" * 200)
         await plugin._handle_tool_result(event)
         result_text = event.result["content"][0]["text"]

--- a/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -468,14 +468,14 @@ class TestRetrievalTool:
         tool_names = [t.tool_name for t in plugin.tools]
         assert "retrieve_offloaded_content" in tool_names
 
-    def test_retrieval_tool_registered_by_default_for_inmemory(self):
+    def test_retrieval_tool_registered_by_default(self):
         plugin = ContextOffloader(storage=InMemoryStorage())
         plugin.init_agent(MagicMock())
         tool_names = [t.tool_name for t in plugin.tools]
         assert "retrieve_offloaded_content" in tool_names
 
-    def test_retrieval_tool_not_registered_by_default_for_file_storage(self, tmp_path):
-        plugin = ContextOffloader(storage=FileStorage(artifact_dir=str(tmp_path)))
+    def test_retrieval_tool_not_registered_when_disabled(self):
+        plugin = ContextOffloader(storage=InMemoryStorage(), include_retrieval_tool=False)
         plugin.init_agent(MagicMock())
         tool_names = [t.tool_name for t in plugin.tools]
         assert "retrieve_offloaded_content" not in tool_names

--- a/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -11,6 +11,7 @@ from strands.hooks.events import AfterToolCallEvent
 from strands.types.tools import ToolContext, ToolUse
 from strands.vended_plugins.context_offloader import (
     ContextOffloader,
+    FileStorage,
     InMemoryStorage,
 )
 
@@ -537,3 +538,45 @@ class TestInlineGuidance:
         result_text = event.result["content"][0]["text"]
         assert "retrieve_offloaded_content" not in result_text
         assert "available tools" in result_text
+
+
+class TestActionableReferences:
+    """Tests that storage-specific references appear in the offloaded preview."""
+
+    @pytest.mark.asyncio
+    async def test_file_storage_path_in_preview(self, tmp_path, mock_agent):
+        storage = FileStorage(artifact_dir=str(tmp_path / "artifacts"))
+        plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+        event = _make_event(mock_agent, "a" * 200)
+
+        await plugin._handle_tool_result(event)
+
+        result_text = event.result["content"][0]["text"]
+        assert str(tmp_path / "artifacts") in result_text
+
+    @pytest.mark.asyncio
+    async def test_file_storage_image_placeholder_has_path(self, tmp_path, mock_agent):
+        storage = FileStorage(artifact_dir=str(tmp_path / "artifacts"))
+        plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+        img_bytes = b"\x89PNG" + b"\x00" * 100
+        content = [
+            {"text": "x" * 200},
+            {"image": {"format": "png", "source": {"bytes": img_bytes}}},
+        ]
+        event = _make_event(mock_agent, content)
+
+        await plugin._handle_tool_result(event)
+
+        placeholder = event.result["content"][1]["text"]
+        assert str(tmp_path / "artifacts") in placeholder
+
+    @pytest.mark.asyncio
+    async def test_inmemory_storage_opaque_reference_in_preview(self, mock_agent):
+        storage = InMemoryStorage()
+        plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+        event = _make_event(mock_agent, "a" * 200)
+
+        await plugin._handle_tool_result(event)
+
+        result_text = event.result["content"][0]["text"]
+        assert "mem_" in result_text

--- a/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -1,6 +1,7 @@
 """Tests for offload storage backends."""
 
 import threading
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -147,7 +148,30 @@ class TestFileStorage:
         storage = FileStorage(artifact_dir=str(tmp_path))
         ref = storage.store("../../etc/passwd", b"content")
         assert ".." not in ref
-        assert "/" not in ref
+        assert "/" not in Path(ref).name
+
+    def test_reference_includes_artifact_dir(self, tmp_path):
+        artifact_dir = str(tmp_path / "artifacts")
+        storage = FileStorage(artifact_dir=artifact_dir)
+        ref = storage.store("key_1", b"content")
+        assert Path(ref).parent == Path(artifact_dir)
+
+    def test_relative_artifact_dir_gives_relative_reference(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        storage = FileStorage(artifact_dir="./artifacts")
+        ref = storage.store("key_1", b"content")
+        assert Path(ref).parent == Path("artifacts")
+        content, content_type = storage.retrieve(ref)
+        assert content == b"content"
+        assert content_type == "text/plain"
+
+    def test_retrieve_accepts_bare_filename(self, tmp_path):
+        storage = FileStorage(artifact_dir=str(tmp_path))
+        ref = storage.store("key_1", b"hello world")
+        filename = Path(ref).name
+        content, content_type = storage.retrieve(filename)
+        assert content == b"hello world"
+        assert content_type == "text/plain"
 
     def test_metadata_survives_across_instances(self, tmp_path):
         artifact_dir = str(tmp_path / "artifacts")
@@ -233,9 +257,9 @@ class TestS3Storage:
         assert storage.retrieve(ref1)[0] == b"content a"
         assert storage.retrieve(ref2)[0] == b"content b"
 
-    def test_reference_includes_prefix(self, storage):
+    def test_reference_is_s3_uri(self, storage):
         ref = storage.store("tool_abc", b"content")
-        assert ref.startswith("artifacts/")
+        assert ref.startswith("s3://test-bucket/artifacts/")
 
     def test_empty_prefix(self, mock_s3_client):
         with patch("boto3.Session") as mock_session_cls:
@@ -245,8 +269,19 @@ class TestS3Storage:
             storage = S3Storage(bucket="test-bucket", prefix="")
 
         ref = storage.store("tool_abc", b"content")
-        assert not ref.startswith("/")
+        assert ref.startswith("s3://test-bucket/")
         assert storage.retrieve(ref)[0] == b"content"
+
+    def test_retrieve_accepts_raw_key(self, storage, mock_s3_client):
+        ref = storage.store("key_1", b"hello world")
+        raw_key = ref.removeprefix("s3://test-bucket/")
+        content, content_type = storage.retrieve(raw_key)
+        assert content == b"hello world"
+        assert content_type == "text/plain"
+
+    def test_retrieve_rejects_wrong_bucket_uri(self, storage):
+        with pytest.raises(KeyError, match="Reference not found"):
+            storage.retrieve("s3://wrong-bucket/artifacts/some_key")
 
     def test_put_object_called_with_correct_params(self, storage, mock_s3_client):
         storage.store("key_1", b"test content", "application/json")


### PR DESCRIPTION
## Description

`FileStorage.store()` and `S3Storage.store()` return internal keys (e.g., `1234567890_1_tooluse_abc.txt` or `artifacts/1234567890_1_tooluse_abc`) that appear in the agent's offloaded preview. While the agent could infer usable paths from these, doing so required the LLM to reason about the storage backend and construct the correct path — this PR makes the references explicit.

### Storage changes

- **FileStorage** — `store()` now returns the full file path (e.g., `./artifacts/1234_1_key.txt`), preserving whatever relative/absolute form the user configured for `artifact_dir`. `retrieve()` accepts both full paths and bare filenames for backward compatibility. Metadata lookup uses the filename portion of the resolved path.

<details>
<summary>Example preview (absolute dir)</summary>

```
[Offloaded: 1 blocks, ~563 tokens]
Tool result was offloaded to external storage due to size.
Use the preview below to answer if possible.
Use your available tools to selectively access the data you need.
Only use retrieve_offloaded_content as a fallback if the data cannot be accessed using your existing tools.

The quick brown fox jumps over the lazy dog.

[Stored references:]
  /home/user/project/artifacts/1714300000000_1_tooluse_abc123_0.txt (text, 2,250 chars)
```
</details>

<details>
<summary>Example preview (relative dir)</summary>

```
[Offloaded: 1 blocks, ~563 tokens]
Tool result was offloaded to external storage due to size.
Use the preview below to answer if possible.
Use your available tools to selectively access the data you need.
Only use retrieve_offloaded_content as a fallback if the data cannot be accessed using your existing tools.

The quick brown fox jumps over the lazy dog.

[Stored references:]
  artifacts/1714300000000_1_tooluse_abc123_0.txt (text, 2,250 chars)
```
</details>

- **S3Storage** — `store()` now returns an `s3://` URI (e.g., `s3://my-bucket/prefix/1234_1_key`). `retrieve()` strips the `s3://bucket/` prefix when present, also accepts raw keys. Rejects URIs for the wrong bucket early with `KeyError`.

<details>
<summary>Example preview</summary>

```
[Offloaded: 1 blocks, ~563 tokens]
Tool result was offloaded to external storage due to size.
Use the preview below to answer if possible.
Use your available tools to selectively access the data you need.
Only use retrieve_offloaded_content as a fallback if the data cannot be accessed using your existing tools.

The quick brown fox jumps over the lazy dog.

[Stored references:]
  s3://my-bucket/tool-results/1714300000000_1_tooluse_abc123_0 (text, 2,250 chars)
```
</details>

- **InMemoryStorage** — reference format unchanged. No external access path exists.

<details>
<summary>Example preview</summary>

```
[Offloaded: 1 blocks, ~125 tokens]
Tool result was offloaded to external storage due to size.
Use the preview below to answer if possible.
Use your available tools to selectively access the data you need.
Only use retrieve_offloaded_content as a fallback if the data cannot be accessed using your existing tools.

xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

[Stored references:]
  mem_1_tooluse_abc123_0 (text, 500 chars)
```
</details>

### Retrieval tool default

`include_retrieval_tool` now defaults to `True` (previously `False`). The inline guidance steers agents to use existing tools first (e.g., file read, bash, AWS CLI) and only fall back to `retrieve_offloaded_content` when direct access is not possible. This ensures `InMemoryStorage` users can always access offloaded content without needing to explicitly opt in.

## Related Issues

#1296

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?

- 76 tests passing across `test_storage.py` and `test_plugin.py`
- New storage tests: reference format, relative/absolute artifact dir, bare filename retrieval, raw S3 key retrieval, wrong bucket rejection, path traversal on filename portion
- New plugin integration tests (`TestActionableReferences`): FileStorage path in preview text, FileStorage path in image placeholder, InMemoryStorage opaque reference in preview
- New default-behavior tests: retrieval tool registered by default, not registered when explicitly disabled
- End-to-end test script against real S3 (`tool-externalization-demo` bucket)

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.