### PR TITLE
feat(bedrock): enable OpenAI model via mantle model endpoint

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -10,10 +10,14 @@ Supports two transports:
   Unlocks features such as server-side stateful conversations, Responses API reasoning, and
   built-in tools.
 
-Generic inference parameters (``temperature``, ``top_p``, ``max_tokens``, ``stop_sequences``,
-``streaming``) apply to both transports and live at the top level of ``BedrockConfig``.
-Converse-only fields (``guardrail_*``, ``cache_*``, ``service_tier``, etc.) may not be combined
-with ``openai_endpoint``; doing so raises at init time.
+Generic inference parameters (``temperature``, ``top_p``, ``max_tokens``) apply to both
+transports and live at the top level of ``BedrockConfig``. The ``openai_endpoint`` path
+always streams (the OpenAI SDK's Responses and Chat Completions surfaces do not offer a
+non-streaming mode), and ``stop_sequences`` is forwarded to Chat Completions as ``stop``
+but is not accepted by the Responses API. Converse-only fields (``guardrail_*``,
+``cache_*``, ``service_tier``, ``additional_args``, etc.) may not be combined with
+``openai_endpoint``; the same applies to ``streaming=False`` and to ``stop_sequences``
+when ``api="responses"``. All of these raise at init time rather than silently no-op.
 
 Docs:
 
@@ -91,6 +95,7 @@ _BEDROCK_MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
 # the Mantle path either way, so requiring users to clear it would be a pure footgun.
 _CONVERSE_ONLY_CONFIG_KEYS: frozenset[str] = frozenset(
     {
+        "additional_args",
         "additional_request_fields",
         "additional_response_field_paths",
         "cache_prompt",
@@ -137,7 +142,11 @@ class OpenAIEndpointConfig(TypedDict, total=False):
         client_args: Extra arguments merged into the OpenAI client constructor. Use this
             to plug in a custom ``http_client`` (for example, to sign requests with AWS
             SigV4) or to override timeouts. ``api_key`` and ``base_url`` set here override
-            the values derived from ``api_key`` and ``region``.
+            the values derived from ``api_key`` and ``region``. When providing a custom
+            ``http_client``, the caller owns its lifecycle: the OpenAI SDK's per-request
+            context manager will call ``aclose()`` on whatever client it is given, so a
+            long-lived injected client should either override ``aclose()`` to a no-op or
+            be constructed fresh per request.
     """
 
     api: Literal["responses", "chat_completions"]
@@ -185,8 +194,10 @@ class BedrockModel(Model):
                 True includes status, False removes status, "auto" determines based on model_id. Defaults to "auto".
             openai_endpoint: When set, route requests through Bedrock's OpenAI-compatible endpoint
                 (``bedrock-mantle``) using the OpenAI Python SDK instead of the Converse API.
-                See :class:`OpenAIEndpointConfig`. Converse-only fields (``guardrail_*``,
-                ``cache_*``, ``service_tier``, etc.) may not be combined with this option.
+                See :class:`OpenAIEndpointConfig`. Raises at init time when combined with
+                Converse-only fields (``guardrail_*``, ``cache_*``, ``service_tier``,
+                ``additional_args``, etc.), with ``streaming=False``, or with
+                ``stop_sequences`` when ``api="responses"``.
             service_tier: Service tier for the request, controlling the trade-off between latency and cost.
                 Valid values: "default" (standard), "priority" (faster, premium), "flex" (cheaper, slower).
                 Please check https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html for
@@ -295,11 +306,22 @@ class BedrockModel(Model):
         logger.debug("region=<%s> | bedrock client created", self.client.meta.region_name)
 
     def _validate_openai_endpoint_config(self) -> None:
-        """Validate that ``openai_endpoint`` is not combined with Converse-only fields.
+        """Validate ``openai_endpoint`` against the rest of :class:`BedrockConfig`.
+
+        Runs the full set of Mantle-path checks:
+
+        1. ``api`` must be one of ``"responses"`` or ``"chat_completions"``.
+        2. No Converse-only fields may be set alongside ``openai_endpoint``.
+        3. ``streaming=False`` is rejected; both OpenAI delegate APIs always stream.
+        4. ``stop_sequences`` is rejected when ``api="responses"``; the Responses API
+           does not accept stop sequences. It is forwarded as ``stop`` for Chat Completions.
+        5. ``stateful=True`` is Responses-only.
+
+        Each failure raises rather than silently no-opping so misconfigurations surface
+        at init time.
 
         Raises:
-            ValueError: If a Converse-only config field is set alongside ``openai_endpoint``
-                or if ``api`` is missing from ``openai_endpoint``.
+            ValueError: When any of the above checks fail.
         """
         endpoint = cast(OpenAIEndpointConfig, self.config["openai_endpoint"])
         api = endpoint.get("api")
@@ -311,6 +333,24 @@ class BedrockModel(Model):
             raise ValueError(
                 "openai_endpoint cannot be combined with Converse-only config fields: "
                 f"{conflicting}. Remove these fields or drop openai_endpoint to use the Converse API."
+            )
+
+        # Both OpenAI delegates always stream; ``streaming=False`` would be silently
+        # overridden on the Mantle path, which is the class of bug this validator exists
+        # to prevent.
+        if self.config.get("streaming") is False:
+            raise ValueError(
+                "openai_endpoint does not support streaming=False. The OpenAI SDK's Responses "
+                "and Chat Completions surfaces always stream; remove streaming=False or drop "
+                "openai_endpoint to use the Converse API."
+            )
+
+        # The Responses API does not accept stop sequences. Chat Completions forwards them
+        # as ``stop``, so this only applies on the Responses path.
+        if api == "responses" and self.config.get("stop_sequences") is not None:
+            raise ValueError(
+                'openai_endpoint with api="responses" does not accept stop_sequences. '
+                'Remove stop_sequences or use api="chat_completions".'
             )
 
         # ``stateful`` is only meaningful for the Responses API.
@@ -348,11 +388,9 @@ class BedrockModel(Model):
             params.setdefault("top_p", top_p)
         stop_sequences = self.config.get("stop_sequences")
         if stop_sequences is not None:
-            # Chat Completions uses `stop`; Responses does not accept stop sequences.
-            if api == "chat_completions":
-                params.setdefault("stop", stop_sequences)
-            else:
-                logger.debug("stop_sequences ignored when routing through Responses API")
+            # Reaching this branch implies api == "chat_completions"; the validator
+            # rejects stop_sequences on the Responses path so no fallback is needed.
+            params.setdefault("stop", stop_sequences)
 
         # The OpenAI SDK's ``api_key`` parameter is just the bearer token it sends in the
         # Authorization header; when pointed at bedrock-mantle this is a Bedrock-issued key.
@@ -431,7 +469,7 @@ class BedrockModel(Model):
         """Get the current Bedrock Model configuration.
 
         Returns:
-            The Bedrock model configuration.405
+            The Bedrock model configuration.
         """
         return self.config
 
@@ -1067,10 +1105,20 @@ class BedrockModel(Model):
             ModelThrottledException: If the model service is throttling requests.
         """
         if self._openai_delegate is not None:
+            # The OpenAI delegates accept ``system_prompt`` (a plain string) but not
+            # ``system_prompt_content``. Collapse structured text blocks into a single
+            # string so the delegate receives the same content; non-text blocks (cache
+            # points, etc.) are Converse-only and are dropped here rather than silently
+            # forwarded as unsupported payload.
+            delegate_system_prompt = system_prompt
+            if delegate_system_prompt is None and system_prompt_content:
+                delegate_system_prompt = (
+                    "\n\n".join(block["text"] for block in system_prompt_content if "text" in block) or None
+                )
             async for delegate_event in self._openai_delegate.stream(
                 messages,
                 tool_specs,
-                system_prompt,
+                delegate_system_prompt,
                 tool_choice=tool_choice,
                 **kwargs,
             ):

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -1,6 +1,24 @@
 """AWS Bedrock model provider.
 
-- Docs: https://aws.amazon.com/bedrock/
+Supports two transports:
+
+- Converse API (default) via the ``bedrock-runtime`` endpoint. Used when ``openai_endpoint``
+  is not set on the config. Provides guardrails, prompt caching, and the full Converse feature
+  set.
+- OpenAI-compatible endpoint (``bedrock-mantle``) when ``openai_endpoint`` is provided on the
+  config. Routes through the OpenAI Python SDK to the Responses or Chat Completions API.
+  Unlocks features such as server-side stateful conversations, Responses API reasoning, and
+  built-in tools.
+
+Generic inference parameters (``temperature``, ``top_p``, ``max_tokens``, ``stop_sequences``,
+``streaming``) apply to both transports and live at the top level of ``BedrockConfig``.
+Converse-only fields (``guardrail_*``, ``cache_*``, ``service_tier``, etc.) may not be combined
+with ``openai_endpoint``; doing so raises at init time.
+
+Docs:
+
+- Bedrock overview: https://aws.amazon.com/bedrock/
+- OpenAI-compatible endpoints: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html
 """
 
 import asyncio
@@ -9,7 +27,7 @@ import logging
 import os
 import warnings
 from collections.abc import AsyncGenerator, Callable, Iterable, ValuesView
-from typing import Any, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar, cast
 
 import boto3
 from botocore.config import Config as BotocoreConfig
@@ -34,6 +52,10 @@ from ..types.tools import ToolChoice, ToolSpec
 from ._validation import validate_config_keys
 from .model import BaseModelConfig, CacheConfig, Model
 
+if TYPE_CHECKING:
+    from .openai import OpenAIModel
+    from .openai_responses import OpenAIResponsesModel
+
 logger = logging.getLogger(__name__)
 
 # See: `BedrockModel._get_default_model_with_warning` for why we need both
@@ -56,6 +78,73 @@ _MODELS_INCLUDE_STATUS = [
 T = TypeVar("T", bound=BaseModel)
 
 DEFAULT_READ_TIMEOUT = 120
+
+# Bedrock OpenAI-compatible endpoint (Mantle). See:
+# https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html
+_BEDROCK_MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
+
+# Config fields that only apply to the Converse transport. Setting any of these together with
+# ``openai_endpoint`` would silently no-op, so we reject the combination at init time.
+#
+# ``include_tool_result_status`` is intentionally excluded: it is always auto-defaulted by
+# ``__init__`` and only affects Converse-side tool-result serialization. It has no effect on
+# the Mantle path either way, so requiring users to clear it would be a pure footgun.
+_CONVERSE_ONLY_CONFIG_KEYS: frozenset[str] = frozenset(
+    {
+        "additional_request_fields",
+        "additional_response_field_paths",
+        "cache_prompt",
+        "cache_config",
+        "cache_tools",
+        "guardrail_id",
+        "guardrail_trace",
+        "guardrail_version",
+        "guardrail_stream_processing_mode",
+        "guardrail_redact_input",
+        "guardrail_redact_input_message",
+        "guardrail_redact_output",
+        "guardrail_redact_output_message",
+        "guardrail_latest_message",
+        "service_tier",
+    }
+)
+
+
+class OpenAIEndpointConfig(TypedDict, total=False):
+    """Configuration for routing a :class:`BedrockModel` through the OpenAI-compatible endpoint.
+
+    When this config is present on :class:`BedrockModel.BedrockConfig`, requests are sent
+    through the Bedrock Mantle endpoint (``bedrock-mantle.<region>.api.aws``) using the OpenAI
+    Python SDK instead of the Converse API. This unlocks features that are specific to the
+    OpenAI-compatible surface, such as the Responses API's server-side stateful conversations
+    and reasoning controls.
+
+    Generic inference parameters (``temperature``, ``top_p``, ``max_tokens``,
+    ``stop_sequences``, ``streaming``) continue to live on :class:`BedrockModel.BedrockConfig`
+    and are forwarded to the underlying OpenAI model.
+
+    Attributes:
+        api: Which OpenAI API surface to use. ``"responses"`` maps to the Responses API and
+            ``"chat_completions"`` maps to the Chat Completions API. Required.
+        api_key: Bedrock API key to send as the bearer token. The OpenAI SDK is only the
+            transport here; this is a Bedrock-issued key, not an OpenAI account key. The
+            AWS docs recommend setting the ``OPENAI_API_KEY`` environment variable to your
+            Bedrock API key, which is the OpenAI SDK's default env var. When ``api_key`` is
+            omitted, the underlying SDK picks up ``OPENAI_API_KEY`` automatically.
+        stateful: Enable server-side conversation state management. Responses API only.
+        params: Extra parameters forwarded to the OpenAI SDK ``params`` dict. Use this for
+            Responses-only options such as ``reasoning``.
+        client_args: Extra arguments merged into the OpenAI client constructor. Use this
+            to plug in a custom ``http_client`` (for example, to sign requests with AWS
+            SigV4) or to override timeouts. ``api_key`` and ``base_url`` set here override
+            the values derived from ``api_key`` and ``region``.
+    """
+
+    api: Literal["responses", "chat_completions"]
+    api_key: str | None
+    stateful: bool | None
+    params: dict[str, Any] | None
+    client_args: dict[str, Any] | None
 
 
 class BedrockModel(Model):
@@ -94,6 +183,10 @@ class BedrockModel(Model):
             model_id: The Bedrock model ID (e.g., "global.anthropic.claude-sonnet-4-6")
             include_tool_result_status: Flag to include status field in tool results.
                 True includes status, False removes status, "auto" determines based on model_id. Defaults to "auto".
+            openai_endpoint: When set, route requests through Bedrock's OpenAI-compatible endpoint
+                (``bedrock-mantle``) using the OpenAI Python SDK instead of the Converse API.
+                See :class:`OpenAIEndpointConfig`. Converse-only fields (``guardrail_*``,
+                ``cache_*``, ``service_tier``, etc.) may not be combined with this option.
             service_tier: Service tier for the request, controlling the trade-off between latency and cost.
                 Valid values: "default" (standard), "priority" (faster, premium), "flex" (cheaper, slower).
                 Please check https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html for
@@ -127,6 +220,7 @@ class BedrockModel(Model):
         streaming: bool | None
         temperature: float | None
         top_p: float | None
+        openai_endpoint: OpenAIEndpointConfig | None
 
     def __init__(
         self,
@@ -152,6 +246,7 @@ class BedrockModel(Model):
 
         session = boto_session or boto3.Session()
         resolved_region = region_name or session.region_name or os.environ.get("AWS_REGION") or DEFAULT_BEDROCK_REGION
+        self._resolved_region = resolved_region
         self.config = BedrockModel.BedrockConfig(
             model_id=BedrockModel._get_default_model_with_warning(resolved_region, model_config),
             include_tool_result_status="auto",
@@ -159,6 +254,22 @@ class BedrockModel(Model):
         self.update_config(**model_config)
 
         logger.debug("config=<%s> | initializing", self.config)
+
+        # When ``openai_endpoint`` is configured, requests are routed through the Bedrock Mantle
+        # OpenAI-compatible endpoint via the OpenAI Python SDK. Skip the boto client since it is
+        # not used on that path.
+        self._openai_delegate: OpenAIModel | OpenAIResponsesModel | None = None
+        endpoint_config = self.config.get("openai_endpoint")
+        if endpoint_config is not None:
+            self._validate_openai_endpoint_config()
+            self._openai_delegate = self._build_openai_delegate()
+            self.client = None
+            logger.debug(
+                "region=<%s>, api=<%s> | bedrock openai-compatible delegate created",
+                resolved_region,
+                endpoint_config["api"],
+            )
+            return
 
         # Add strands-agents to the request user agent
         if boto_client_config:
@@ -183,6 +294,98 @@ class BedrockModel(Model):
 
         logger.debug("region=<%s> | bedrock client created", self.client.meta.region_name)
 
+    def _validate_openai_endpoint_config(self) -> None:
+        """Validate that ``openai_endpoint`` is not combined with Converse-only fields.
+
+        Raises:
+            ValueError: If a Converse-only config field is set alongside ``openai_endpoint``
+                or if ``api`` is missing from ``openai_endpoint``.
+        """
+        endpoint = cast(OpenAIEndpointConfig, self.config["openai_endpoint"])
+        api = endpoint.get("api")
+        if api not in ("responses", "chat_completions"):
+            raise ValueError(f'openai_endpoint requires "api" to be "responses" or "chat_completions", got {api!r}')
+
+        conflicting = sorted(k for k in _CONVERSE_ONLY_CONFIG_KEYS if self.config.get(k) is not None)
+        if conflicting:
+            raise ValueError(
+                "openai_endpoint cannot be combined with Converse-only config fields: "
+                f"{conflicting}. Remove these fields or drop openai_endpoint to use the Converse API."
+            )
+
+        # ``stateful`` is only meaningful for the Responses API.
+        if endpoint.get("stateful") and api != "responses":
+            raise ValueError(f'openai_endpoint.stateful is only supported when api="responses". Got api={api!r}.')
+
+    def _build_openai_delegate(self) -> "OpenAIModel | OpenAIResponsesModel":
+        """Construct the OpenAI-compatible delegate for the Mantle endpoint.
+
+        Forwards generic inference params from :class:`BedrockConfig` into the OpenAI SDK
+        ``params`` dict, translating names where the OpenAI and Bedrock conventions differ.
+
+        Returns:
+            An :class:`OpenAIResponsesModel` or :class:`OpenAIModel` configured to talk to
+            ``bedrock-mantle.<region>.api.aws``.
+        """
+        endpoint = cast(OpenAIEndpointConfig, self.config["openai_endpoint"])
+        api = endpoint["api"]
+
+        # The Mantle base URL is fully determined by region; AWS owns the endpoint list:
+        # https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html
+        base_url = _BEDROCK_MANTLE_BASE_URL_TEMPLATE.format(region=self._resolved_region)
+
+        params: dict[str, Any] = dict(endpoint.get("params") or {})
+        # Forward generic inference params from BedrockConfig. Translate naming where the
+        # Responses API differs from Chat Completions (max_tokens -> max_output_tokens).
+        max_tokens = self.config.get("max_tokens")
+        if max_tokens is not None:
+            params.setdefault("max_output_tokens" if api == "responses" else "max_tokens", max_tokens)
+        temperature = self.config.get("temperature")
+        if temperature is not None:
+            params.setdefault("temperature", temperature)
+        top_p = self.config.get("top_p")
+        if top_p is not None:
+            params.setdefault("top_p", top_p)
+        stop_sequences = self.config.get("stop_sequences")
+        if stop_sequences is not None:
+            # Chat Completions uses `stop`; Responses does not accept stop sequences.
+            if api == "chat_completions":
+                params.setdefault("stop", stop_sequences)
+            else:
+                logger.debug("stop_sequences ignored when routing through Responses API")
+
+        # The OpenAI SDK's ``api_key`` parameter is just the bearer token it sends in the
+        # Authorization header; when pointed at bedrock-mantle this is a Bedrock-issued key.
+        # The AWS docs recommend setting OPENAI_API_KEY to the Bedrock API key so existing
+        # OpenAI SDK code works unchanged. If the user does not pass ``api_key`` here, the
+        # OpenAI SDK will read OPENAI_API_KEY from the environment on its own.
+        client_args: dict[str, Any] = {"base_url": base_url}
+        if api_key := endpoint.get("api_key"):
+            client_args["api_key"] = api_key
+        # User-supplied client_args win over derived defaults. This is the escape hatch for
+        # plumbing a signed httpx client (SigV4), custom timeouts, etc.
+        if extra_client_args := endpoint.get("client_args"):
+            client_args.update(extra_client_args)
+
+        if api == "responses":
+            from .openai_responses import OpenAIResponsesModel
+
+            stateful = bool(endpoint.get("stateful"))
+            return OpenAIResponsesModel(
+                client_args=client_args,
+                model_id=self.config["model_id"],
+                params=params,
+                stateful=stateful,
+            )
+
+        from .openai import OpenAIModel
+
+        return OpenAIModel(
+            client_args=client_args,
+            model_id=self.config["model_id"],
+            params=params,
+        )
+
     @property
     def _cache_strategy(self) -> str | None:
         """The cache strategy for this model based on its model ID.
@@ -194,6 +397,18 @@ class BedrockModel(Model):
             return "anthropic"
         return None
 
+    @property
+    @override
+    def stateful(self) -> bool:
+        """Whether the model manages conversation state server-side.
+
+        Delegates to the underlying OpenAI-compatible model when ``openai_endpoint`` is configured,
+        otherwise returns False (the Converse API is always stateless).
+        """
+        if self._openai_delegate is not None:
+            return self._openai_delegate.stateful
+        return False
+
     @override
     def update_config(self, **model_config: Unpack[BedrockConfig]) -> None:  # type: ignore
         """Update the Bedrock Model configuration with the provided arguments.
@@ -204,12 +419,19 @@ class BedrockModel(Model):
         validate_config_keys(model_config, self.BedrockConfig)
         self.config.update(model_config)
 
+        # If the delegate is already built and the caller changed anything the delegate depends on,
+        # rebuild it so subsequent calls pick up the new config. Skipped during __init__ where
+        # ``_openai_delegate`` is not yet set.
+        if getattr(self, "_openai_delegate", None) is not None:
+            self._validate_openai_endpoint_config()
+            self._openai_delegate = self._build_openai_delegate()
+
     @override
     def get_config(self) -> BedrockConfig:
         """Get the current Bedrock Model configuration.
 
         Returns:
-            The Bedrock model configuration.
+            The Bedrock model configuration.405
         """
         return self.config
 
@@ -772,7 +994,15 @@ class BedrockModel(Model):
         Returns:
             Total input token count.
         """
+        # The openai_endpoint path has no Bedrock Converse client and no equivalent native
+        # count endpoint, so fall back to the base ``Model.count_tokens`` estimation
+        # (tiktoken when available, heuristic otherwise).
+        if self._openai_delegate is not None:
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
+
         try:
+            # The openai_endpoint early-return above guarantees ``self.client`` exists here.
+            assert self.client is not None, "Bedrock Converse client is unavailable"
             if system_prompt and system_prompt_content is None:
                 system_prompt_content = [{"text": system_prompt}]
 
@@ -836,6 +1066,16 @@ class BedrockModel(Model):
             ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: If the model service is throttling requests.
         """
+        if self._openai_delegate is not None:
+            async for delegate_event in self._openai_delegate.stream(
+                messages,
+                tool_specs,
+                system_prompt,
+                tool_choice=tool_choice,
+                **kwargs,
+            ):
+                yield delegate_event
+            return
 
         def callback(event: StreamEvent | None = None) -> None:
             loop.call_soon_threadsafe(queue.put_nowait, event)
@@ -885,6 +1125,8 @@ class BedrockModel(Model):
             ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: If the model service is throttling requests.
         """
+        # Converse-only path; the Mantle delegate handles streaming directly in ``stream``.
+        assert self.client is not None, "Bedrock Converse client is unavailable"
         try:
             logger.debug("formatting request")
             request = self._format_request(messages, tool_specs, system_prompt_content, tool_choice)
@@ -1110,6 +1352,13 @@ class BedrockModel(Model):
         Yields:
             Model events with the last being the structured output.
         """
+        if self._openai_delegate is not None:
+            async for delegate_event in self._openai_delegate.structured_output(
+                output_model, prompt, system_prompt, **kwargs
+            ):
+                yield delegate_event
+            return
+
         tool_spec = convert_pydantic_to_tool_spec(output_model)
 
         response = self.stream(

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -124,9 +124,12 @@ class OpenAIEndpointConfig(TypedDict, total=False):
     OpenAI-compatible surface, such as the Responses API's server-side stateful conversations
     and reasoning controls.
 
-    Generic inference parameters (``temperature``, ``top_p``, ``max_tokens``,
-    ``stop_sequences``, ``streaming``) continue to live on :class:`BedrockModel.BedrockConfig`
-    and are forwarded to the underlying OpenAI model.
+    Generic inference parameters (``temperature``, ``top_p``, ``max_tokens``) live on
+    :class:`BedrockModel.BedrockConfig` and are forwarded to the underlying OpenAI model.
+    ``stop_sequences`` is forwarded to Chat Completions as ``stop`` but is rejected at
+    init time when ``api="responses"`` (the Responses API does not accept stop sequences).
+    ``streaming=False`` is not supported on this path and is also rejected at init time,
+    since the OpenAI SDK's Responses and Chat Completions surfaces always stream.
 
     Attributes:
         api: Which OpenAI API surface to use. ``"responses"`` maps to the Responses API and

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -3414,3 +3414,29 @@ def test_openai_endpoint_invalid_config_raises(session_cls, config_kwargs, error
 
     with pytest.raises(ValueError, match=error_match):
         BedrockModel(model_id="openai.gpt-oss-120b", region_name="us-east-1", **config_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_openai_endpoint_count_tokens_falls_back_to_base(session_cls, openai_responses_model_cls, messages):
+    """count_tokens bypasses the Converse client on the openai_endpoint path.
+
+    Bedrock's native CountTokens API lives on ``bedrock-runtime`` and has no Mantle
+    equivalent, so ``BedrockModel.count_tokens`` must route to the base ``Model.count_tokens``
+    estimator (tiktoken or heuristic). A regression that routed through ``self.client`` would
+    raise ``AttributeError`` since ``self.client is None`` on the Mantle path.
+    """
+    _ = session_cls
+
+    model = BedrockModel(
+        model_id="openai.gpt-oss-120b",
+        region_name="us-east-1",
+        openai_endpoint={"api": "responses"},
+    )
+
+    # Delegate is a mock and does not implement count_tokens. Call should still succeed
+    # because the override dispatches to super() rather than the delegate or the boto client.
+    result = await model.count_tokens(messages=messages)
+
+    assert isinstance(result, int)
+    assert result > 0
+    openai_responses_model_cls.return_value.count_tokens.assert_not_called()

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -3293,8 +3293,9 @@ def test_openai_endpoint_chat_completions_builds_delegate(session_cls, mock_clie
 def test_openai_endpoint_responses_builds_delegate(session_cls, mock_client_method, openai_responses_model_cls):
     """api=responses builds OpenAIResponsesModel with stateful, user params, and Responses naming.
 
-    Responses translates ``max_tokens`` to ``max_output_tokens`` and drops ``stop_sequences``.
-    User ``params`` take precedence over BedrockConfig-derived values for the same key.
+    Responses translates ``max_tokens`` to ``max_output_tokens``. ``stop_sequences`` is not
+    allowed on this path (rejected by validation) so it is not set here. User ``params``
+    take precedence over BedrockConfig-derived values for the same key.
     """
     _ = session_cls
 
@@ -3303,7 +3304,6 @@ def test_openai_endpoint_responses_builds_delegate(session_cls, mock_client_meth
         region_name="us-west-2",
         max_tokens=256,
         temperature=0.1,
-        stop_sequences=["END"],
         openai_endpoint={
             "api": "responses",
             "stateful": True,
@@ -3374,6 +3374,32 @@ def test_openai_endpoint_update_config_rebuilds_delegate(session_cls, openai_res
             },
             "Converse-only config fields",
             id="cache_config_conflict",
+        ),
+        pytest.param(
+            {
+                "additional_args": {"k": "v"},
+                "openai_endpoint": {"api": "responses"},
+            },
+            "Converse-only config fields",
+            id="additional_args_conflict",
+        ),
+        pytest.param(
+            {"streaming": False, "openai_endpoint": {"api": "responses"}},
+            "does not support streaming=False",
+            id="streaming_false_with_responses",
+        ),
+        pytest.param(
+            {"streaming": False, "openai_endpoint": {"api": "chat_completions"}},
+            "does not support streaming=False",
+            id="streaming_false_with_chat_completions",
+        ),
+        pytest.param(
+            {
+                "stop_sequences": ["STOP"],
+                "openai_endpoint": {"api": "responses"},
+            },
+            'api="responses" does not accept stop_sequences',
+            id="stop_sequences_with_responses",
         ),
         pytest.param(
             {"openai_endpoint": {"api": "chat_completions", "stateful": True}},

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -3227,3 +3227,164 @@ class TestCountTokens:
             await model_with_client.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)
+
+
+# ======================================================================================
+# openai_endpoint
+#
+# Unit tests for BedrockModel's ``openai_endpoint`` config. Tests patch the lazily-
+# imported delegate classes (``OpenAIModel`` / ``OpenAIResponsesModel``) so assertions
+# focus on routing, parameter forwarding, and validation without touching the OpenAI
+# SDK or the network.
+# ======================================================================================
+
+
+@pytest.fixture
+def openai_model_cls():
+    """Patch the lazy import of OpenAIModel inside bedrock._build_openai_delegate."""
+    with unittest.mock.patch("strands.models.openai.OpenAIModel", autospec=True) as mock_cls:
+        mock_cls.return_value.stateful = False
+        yield mock_cls
+
+
+@pytest.fixture
+def openai_responses_model_cls():
+    """Patch the lazy import of OpenAIResponsesModel inside bedrock._build_openai_delegate."""
+    with unittest.mock.patch("strands.models.openai_responses.OpenAIResponsesModel", autospec=True) as mock_cls:
+        mock_cls.return_value.stateful = False
+        yield mock_cls
+
+
+def test_openai_endpoint_chat_completions_builds_delegate(session_cls, mock_client_method, openai_model_cls):
+    """api=chat_completions builds OpenAIModel with derived base_url and translated params.
+
+    Also verifies that the boto Converse client is not constructed on the Mantle path, and
+    that ``include_tool_result_status`` (auto-defaulted by ``__init__``) does not trip the
+    Converse-only conflict check (regression guard for a shipped bug).
+    """
+    _ = session_cls
+
+    BedrockModel(
+        model_id="openai.gpt-oss-120b",
+        region_name="us-east-1",
+        max_tokens=256,
+        temperature=0.3,
+        top_p=0.9,
+        stop_sequences=["END"],
+        openai_endpoint={"api": "chat_completions", "api_key": "bedrock-key"},
+    )
+
+    openai_model_cls.assert_called_once_with(
+        client_args={
+            "api_key": "bedrock-key",
+            "base_url": "https://bedrock-mantle.us-east-1.api.aws/v1",
+        },
+        model_id="openai.gpt-oss-120b",
+        params={
+            "max_tokens": 256,
+            "temperature": 0.3,
+            "top_p": 0.9,
+            "stop": ["END"],
+        },
+    )
+    mock_client_method.assert_not_called()
+
+
+def test_openai_endpoint_responses_builds_delegate(session_cls, mock_client_method, openai_responses_model_cls):
+    """api=responses builds OpenAIResponsesModel with stateful, user params, and Responses naming.
+
+    Responses translates ``max_tokens`` to ``max_output_tokens`` and drops ``stop_sequences``.
+    User ``params`` take precedence over BedrockConfig-derived values for the same key.
+    """
+    _ = session_cls
+
+    BedrockModel(
+        model_id="openai.gpt-oss-120b",
+        region_name="us-west-2",
+        max_tokens=256,
+        temperature=0.1,
+        stop_sequences=["END"],
+        openai_endpoint={
+            "api": "responses",
+            "stateful": True,
+            "params": {"temperature": 0.9, "reasoning": {"effort": "low"}},
+        },
+    )
+
+    openai_responses_model_cls.assert_called_once_with(
+        client_args={"base_url": "https://bedrock-mantle.us-west-2.api.aws/v1"},
+        model_id="openai.gpt-oss-120b",
+        params={
+            "temperature": 0.9,
+            "reasoning": {"effort": "low"},
+            "max_output_tokens": 256,
+        },
+        stateful=True,
+    )
+    mock_client_method.assert_not_called()
+
+
+def test_openai_endpoint_update_config_rebuilds_delegate(session_cls, openai_responses_model_cls):
+    """update_config rebuilds the delegate with the merged config so changes take effect."""
+    _ = session_cls
+
+    model = BedrockModel(
+        model_id="openai.gpt-oss-120b",
+        region_name="us-east-1",
+        openai_endpoint={"api": "responses"},
+    )
+    openai_responses_model_cls.reset_mock()
+
+    model.update_config(max_tokens=512, temperature=0.7)
+
+    openai_responses_model_cls.assert_called_once_with(
+        client_args={"base_url": "https://bedrock-mantle.us-east-1.api.aws/v1"},
+        model_id="openai.gpt-oss-120b",
+        params={"max_output_tokens": 512, "temperature": 0.7},
+        stateful=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("config_kwargs", "error_match"),
+    [
+        pytest.param(
+            {"openai_endpoint": {}},
+            '"api" to be "responses" or "chat_completions"',
+            id="missing_api",
+        ),
+        pytest.param(
+            {"openai_endpoint": {"api": "whatever"}},
+            '"api" to be "responses" or "chat_completions"',
+            id="invalid_api",
+        ),
+        pytest.param(
+            {
+                "guardrail_id": "g1",
+                "guardrail_version": "v1",
+                "openai_endpoint": {"api": "responses"},
+            },
+            "Converse-only config fields",
+            id="guardrail_conflict",
+        ),
+        pytest.param(
+            {
+                "cache_config": CacheConfig(strategy="auto"),
+                "openai_endpoint": {"api": "responses"},
+            },
+            "Converse-only config fields",
+            id="cache_config_conflict",
+        ),
+        pytest.param(
+            {"openai_endpoint": {"api": "chat_completions", "stateful": True}},
+            'stateful is only supported when api="responses"',
+            id="stateful_with_chat_completions",
+        ),
+    ],
+)
+def test_openai_endpoint_invalid_config_raises(session_cls, config_kwargs, error_match):
+    """openai_endpoint rejects invalid or conflicting configurations at init time."""
+    _ = session_cls
+
+    with pytest.raises(ValueError, match=error_match):
+        BedrockModel(model_id="openai.gpt-oss-120b", region_name="us-east-1", **config_kwargs)

--- a/tests_integ/models/test_model_bedrock.py
+++ b/tests_integ/models/test_model_bedrock.py
@@ -1,8 +1,12 @@
 import time
 import uuid
 
+import httpx
 import pydantic
 import pytest
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.session import Session as BotocoreSession
 
 import strands
 from strands import Agent
@@ -552,3 +556,165 @@ class TestCountTokens:
         without = await model.count_tokens(messages=messages)
         with_tools = await model.count_tokens(messages=messages, tool_specs=tool_specs, system_prompt="Be helpful.")
         assert with_tools > without
+
+
+# --------------------------------------------------------------------------------------
+# openai_endpoint (Bedrock Mantle OpenAI-compatible endpoint)
+#
+# These tests exercise BedrockModel's ``openai_endpoint`` config, which routes requests
+# through ``bedrock-mantle.<region>.api.aws`` using the OpenAI Python SDK.
+#
+# Auth: tests sign requests with AWS SigV4 via a custom httpx client, using the caller's
+# AWS credentials (same resolution chain as the Converse tests above). This keeps the
+# integration test suite self-contained — no extra environment variables, no bearer
+# tokens to provision. End users of ``openai_endpoint`` typically set ``OPENAI_API_KEY``
+# to their Bedrock API key as shown in the AWS docs:
+# https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html
+#
+# Coverage is deliberately minimal: one test per behavior that is unique to this code
+# path. Generic OpenAI semantics (streaming events, structured output, etc.) are covered
+# by the OpenAI provider's own integration tests.
+# --------------------------------------------------------------------------------------
+
+_OPENAI_ENDPOINT_REGION = "us-east-1"
+_OPENAI_ENDPOINT_MODEL_ID = "openai.gpt-oss-120b"
+
+
+class _MantleSigV4Auth(httpx.Auth):
+    """httpx Auth handler that signs bedrock-mantle requests with AWS SigV4."""
+
+    def __init__(self, region: str):
+        session = BotocoreSession()
+        self.credentials = session.get_credentials().get_frozen_credentials()
+        self.signer = SigV4Auth(self.credentials, "bedrock", region)
+
+    def auth_flow(self, request: httpx.Request):
+        aws_request = AWSRequest(
+            method=request.method,
+            url=str(request.url),
+            headers=dict(request.headers),
+            data=request.content,
+        )
+        self.signer.add_auth(aws_request)
+        for key, value in aws_request.headers.items():
+            request.headers[key] = value
+        yield request
+
+
+class _MantleNonClosingAsyncClient(httpx.AsyncClient):
+    """AsyncClient that survives the OpenAI SDK's per-request context manager.
+
+    ``OpenAIModel`` / ``OpenAIResponsesModel`` wrap each request in ``async with
+    openai.AsyncOpenAI(...)``. On ``__aexit__`` the OpenAI base client calls
+    ``self._client.aclose()`` on whatever httpx client it owns — including an
+    injected one. Subsequent turns in the same test would then fail because the
+    signed client has been closed. Overriding ``aclose`` to a no-op keeps the
+    client alive across turns.
+    """
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _signed_mantle_client_args() -> dict[str, object]:
+    """Build ``client_args`` that sign Mantle requests with the caller's AWS credentials.
+
+    The OpenAI SDK still requires a non-empty ``api_key`` value even when a custom
+    ``http_client`` replaces the Authorization header; any placeholder string works.
+    """
+    return {
+        "api_key": "unused",
+        "http_client": _MantleNonClosingAsyncClient(auth=_MantleSigV4Auth(_OPENAI_ENDPOINT_REGION)),
+    }
+
+
+def test_openai_endpoint_chat_completions_invoke():
+    """BedrockModel routes through the Chat Completions API and returns a valid response."""
+    model = BedrockModel(
+        model_id=_OPENAI_ENDPOINT_MODEL_ID,
+        region_name=_OPENAI_ENDPOINT_REGION,
+        openai_endpoint={
+            "api": "chat_completions",
+            "client_args": _signed_mantle_client_args(),
+        },
+    )
+    agent = Agent(model=model, system_prompt="Reply in one short sentence.", load_tools_from_directory=False)
+    result = agent("What is 2+2?")
+
+    assert "4" in str(result)
+
+
+def test_openai_endpoint_responses_invoke_with_reasoning():
+    """Responses dispatch works and ``params.reasoning`` reaches the underlying SDK.
+
+    The gpt-oss models emit ``reasoningContent`` blocks when reasoning is enabled, so
+    their presence in assistant messages confirms both the dispatch and the params
+    forwarding.
+    """
+    model = BedrockModel(
+        model_id=_OPENAI_ENDPOINT_MODEL_ID,
+        region_name=_OPENAI_ENDPOINT_REGION,
+        openai_endpoint={
+            "api": "responses",
+            "client_args": _signed_mantle_client_args(),
+            "params": {"reasoning": {"effort": "low"}},
+        },
+    )
+    agent = Agent(model=model, system_prompt="Reply in one short sentence.", callback_handler=None)
+
+    result = agent("What is 2+2?")
+    assert "4" in str(result)
+
+    has_reasoning = any(
+        "reasoningContent" in block for msg in agent.messages if msg["role"] == "assistant" for block in msg["content"]
+    )
+    assert has_reasoning, "expected reasoningContent blocks on the Responses API"
+
+    # Second turn must not raise despite reasoningContent in message history.
+    agent("What about 3+3?")
+
+
+def test_openai_endpoint_responses_stateful():
+    """``stateful=True`` clears local messages and the server recalls prior context."""
+    model = BedrockModel(
+        model_id=_OPENAI_ENDPOINT_MODEL_ID,
+        region_name=_OPENAI_ENDPOINT_REGION,
+        openai_endpoint={
+            "api": "responses",
+            "stateful": True,
+            "client_args": _signed_mantle_client_args(),
+        },
+    )
+    agent = Agent(model=model, system_prompt="Reply in one short sentence.")
+
+    agent("My name is Alice.")
+    assert len(agent.messages) == 0, "stateful mode should clear local messages between turns"
+
+    result = agent("What is my name?")
+    assert "alice" in str(result).lower()
+
+
+def test_openai_endpoint_tool_use():
+    """Tool invocation works end-to-end when routed through the Responses API."""
+
+    @strands.tool
+    def tool_time() -> str:
+        """Return the current time."""
+        return "12:00"
+
+    @strands.tool
+    def tool_weather() -> str:
+        """Return the current weather."""
+        return "sunny"
+
+    model = BedrockModel(
+        model_id=_OPENAI_ENDPOINT_MODEL_ID,
+        region_name=_OPENAI_ENDPOINT_REGION,
+        openai_endpoint={"api": "responses", "client_args": _signed_mantle_client_args()},
+    )
+    agent = Agent(model=model, tools=[tool_time, tool_weather], load_tools_from_directory=False)
+
+    result = agent("What is the time and weather in New York?")
+    text = " ".join(block["text"] for block in result.message["content"] if "text" in block).lower()
+
+    assert all(s in text for s in ["12:00", "sunny"])


### PR DESCRIPTION
## Motivation

Amazon Bedrock now exposes an OpenAI-compatible endpoint (Mantle) at
`bedrock-mantle.<region>.api.aws`, which provides the Responses API, Chat Completions
API, and built-in features like server-side stateful conversations and reasoning
controls. These capabilities are not available through the Converse API that
`BedrockModel` uses today.

Today, users who want to reach those capabilities have to bypass `BedrockModel` and
configure `OpenAIModel` / `OpenAIResponsesModel` by hand with the correct base URL and
auth. That's workable but leaks Bedrock routing details into application code and
splits the Bedrock experience across two provider classes depending on which API
surface the user wants.

This change lets users stay on `BedrockModel` and opt into the OpenAI-compatible
transport via config.

## Public API Changes

`BedrockConfig` gains an optional `openai_endpoint` field. When set, requests route
through the Mantle endpoint via the OpenAI Python SDK instead of Converse; when unset,
behavior is unchanged.

```python
# Converse (existing, unchanged)
BedrockModel(model_id="openai.gpt-oss-20b-1:0", region_name="us-west-2")

# Chat Completions via Mantle
BedrockModel(
    model_id="openai.gpt-oss-120b",
    region_name="us-east-1",
    max_tokens=1024,
    temperature=0.7,
    openai_endpoint={"api": "chat_completions"},
)

# Responses API with reasoning and stateful sessions
BedrockModel(
    model_id="openai.gpt-oss-120b",
    region_name="us-east-1",
    openai_endpoint={
        "api": "responses",
        "stateful": True,
        "params": {"reasoning": {"effort": "medium"}},
    },
)
```

The nested `OpenAIEndpointConfig` holds the fields that are meaningful only on the
OpenAI-compatible surface:

- `api` (required): `"responses"` or `"chat_completions"`.
- `api_key`: Bedrock-issued API key used as the bearer token. Omit to let the OpenAI
  SDK read `OPENAI_API_KEY` per AWS's documented flow.
- `stateful`: server-side conversation state (Responses only).
- `params`: pass-through to the OpenAI SDK for Responses-only options like `reasoning`.
- `client_args`: escape hatch for a custom `http_client` (e.g. SigV4 for tests) or
  other SDK constructor options.

Generic inference parameters (`temperature`, `top_p`, `max_tokens`) stay on
`BedrockConfig` and are forwarded to the delegate with naming translated where the
APIs differ (for example `max_tokens` → `max_output_tokens` on the Responses path).
`stop_sequences` is forwarded as `stop` for Chat Completions but is rejected with
`api="responses"` since the Responses API does not accept stop sequences.

Config that only applies to the Converse transport cannot be combined with
`openai_endpoint`. This includes `guardrail_*`, `cache_*`, `service_tier`,
`additional_args`, `streaming=False` (both OpenAI delegate APIs always stream), and
`stop_sequences` when `api="responses"`. All such combinations raise at init time
with a specific, actionable message so misconfigurations fail loudly instead of
silently no-opping.

## Use Cases

- **Reach Responses-only features on Bedrock-hosted OpenAI models** (stateful sessions,
  reasoning effort, built-in tools) without swapping provider classes.
- **Migrate existing OpenAI SDK code to Bedrock with minimal changes.** Setting
  `OPENAI_API_KEY` to a Bedrock API key and passing `openai_endpoint={"api": "chat_completions"}`
  is typically all that's needed.
- **Mix transports in the same app.** Use Converse for Claude with guardrails, and
  `openai_endpoint` for gpt-oss with reasoning, both through `BedrockModel`.

## Backward Compatibility

Not a breaking change. The Converse path is untouched; all existing `BedrockModel`
configurations continue to work exactly as before. The only new surface is the
opt-in `openai_endpoint` field.


- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
