### PR TITLE
fix(bedrock): fix on-demand throughput doc URL to preserve anchor fragment

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -600,7 +600,7 @@ class Agent(AgentBase):
         warnings.warn(
             "Agent.structured_output method is deprecated."
             " You should pass in `structured_output_model` directly into the agent invocation."
-            " see: https://strandsagents.com/latest/documentation/docs/user-guide/concepts/agents/structured-output/",
+            " see: https://strandsagents.com/docs/user-guide/concepts/agents/structured-output/",
             category=DeprecationWarning,
             stacklevel=2,
         )
@@ -631,7 +631,7 @@ class Agent(AgentBase):
         warnings.warn(
             "Agent.structured_output_async method is deprecated."
             " You should pass in `structured_output_model` directly into the agent invocation."
-            " see: https://strandsagents.com/latest/documentation/docs/user-guide/concepts/agents/structured-output/",
+            " see: https://strandsagents.com/docs/user-guide/concepts/agents/structured-output/",
             category=DeprecationWarning,
             stacklevel=2,
         )
@@ -774,7 +774,7 @@ class Agent(AgentBase):
             agent.add_hook(multi_handler, [BeforeModelCallEvent, AfterModelCallEvent])
             ```
         Docs:
-            https://strandsagents.com/latest/documentation/docs/user-guide/concepts/agents/hooks/
+            https://strandsagents.com/docs/user-guide/concepts/agents/hooks/
         """
         self.hooks.add_callback(event_type, callback)
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -273,7 +273,7 @@ async def event_loop_cycle(
                     message=(
                         "Agent has reached an unrecoverable state due to max_tokens limit. "
                         "For more information see: "
-                        "https://strandsagents.com/latest/user-guide/concepts/agents/agent-loop/#maxtokensreachedexception"
+                        "https://strandsagents.com/docs/user-guide/concepts/agents/agent-loop/#maxtokensreachedexception"
                     )
                 )
 

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -1031,7 +1031,7 @@ class BedrockModel(Model):
                 add_exception_note(
                     e,
                     "└ For more information see "
-                    "https://strandsagents.com/latest/user-guide/concepts/model-providers/amazon-bedrock/#on-demand-throughput-isnt-supported",
+                    "https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#on-demand-throughput-isnt-supported",
                 )
 
             raise e

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -1021,7 +1021,7 @@ class BedrockModel(Model):
                 add_exception_note(
                     e,
                     "└ For more information see "
-                    "https://strandsagents.com/latest/user-guide/concepts/model-providers/amazon-bedrock/#model-access-issue",
+                    "https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#required-iam-permissions",
                 )
 
             if (

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -89,7 +89,7 @@ MIME_TO_FORMAT: dict[str, ImageFormat] = {
 CLIENT_SESSION_NOT_RUNNING_ERROR_MESSAGE = (
     "the client session is not running. Ensure the agent is used within "
     "the MCP client context manager. For more information see: "
-    "https://strandsagents.com/latest/user-guide/concepts/tools/mcp-tools/#mcpclientinitializationerror"
+    "https://strandsagents.com/docs/user-guide/concepts/tools/mcp-tools/#mcpclientinitializationerror-python"
 )
 
 # Non-fatal error patterns that should not cause connection collapse

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -629,7 +629,7 @@ async def test_event_loop_cycle_max_tokens_exception(
     expected_message = (
         "Agent has reached an unrecoverable state due to max_tokens limit. "
         "For more information see: "
-        "https://strandsagents.com/latest/user-guide/concepts/agents/agent-loop/#maxtokensreachedexception"
+        "https://strandsagents.com/docs/user-guide/concepts/agents/agent-loop/#maxtokensreachedexception"
     )
     with pytest.raises(MaxTokensReachedException, match=expected_message):
         stream = strands.event_loop.event_loop.event_loop_cycle(

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -1758,7 +1758,7 @@ async def test_add_note_on_validation_exception_throughput(bedrock_client, model
         "└ Bedrock region: us-west-2",
         "└ Model id: m1",
         "└ For more information see "
-        "https://strandsagents.com/latest/user-guide/concepts/model-providers/amazon-bedrock/#on-demand-throughput-isnt-supported",
+        "https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#on-demand-throughput-isnt-supported",
     ]
 
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -1730,7 +1730,7 @@ async def test_add_note_on_access_denied_exception(bedrock_client, model, alist,
         "└ Bedrock region: us-west-2",
         "└ Model id: m1",
         "└ For more information see "
-        "https://strandsagents.com/latest/user-guide/concepts/model-providers/amazon-bedrock/#model-access-issue",
+        "https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#required-iam-permissions",
     ]
 
 


### PR DESCRIPTION
## Summary

- Replace `/latest/` with `/docs/` in the on-demand throughput error URL
- The `/latest/` path redirects to `/docs/` but drops the URL anchor fragment in the process, making the link land on the top of the page instead of the relevant section

## Test plan

- [ ] Verify the error URL `https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#on-demand-throughput-isnt-supported` correctly navigates to the anchor