### PR TITLE
feat: enable openai provider use aws profile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ litellm = ["litellm>=1.75.9,<=1.83.13", "openai>=1.68.0,<3.0.0"]
 llamaapi = ["llama-api-client>=0.1.0,<1.0.0"]
 mistral = ["mistralai>=1.8.2,<2.0.0"]
 ollama = ["ollama>=0.4.8,<1.0.0"]
-openai = ["openai>=1.68.0,<3.0.0"]
+openai = ["openai>=1.68.0,<3.0.0", "aws-bedrock-token-generator>=1.1.0,<2.0.0"]
 writer = ["writer-sdk>=2.2.0,<3.0.0"]
 sagemaker = [
     "boto3-stubs[sagemaker-runtime]>=1.26.0,<2.0.0",

--- a/src/strands/models/_openai_bedrock.py
+++ b/src/strands/models/_openai_bedrock.py
@@ -4,6 +4,11 @@ Converts an ``aws_config`` dict into the ``base_url`` and ``api_key`` that the
 OpenAI Python SDK consumes. Tokens are minted on demand via
 ``aws_bedrock_token_generator.provide_token`` so long-running agents keep working
 past the bearer token's maximum lifetime.
+
+``aws_bedrock_token_generator`` is imported lazily inside
+:func:`resolve_bedrock_client_args` so that users of OpenAI-compatible extras
+(``sagemaker``, ``litellm``, bare ``openai`` without Mantle) don't pay an
+``ImportError`` just for importing the model class.
 """
 
 from __future__ import annotations
@@ -11,7 +16,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, TypedDict
 
-from aws_bedrock_token_generator import provide_token
+from typing_extensions import Required
 
 _MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
 
@@ -27,7 +32,7 @@ class AwsConfig(TypedDict, total=False):
             to ``provide_token``.
     """
 
-    region: str
+    region: Required[str]
     credentials_provider: Any
     expiry: timedelta
 
@@ -40,11 +45,21 @@ def resolve_bedrock_client_args(aws_config: AwsConfig, client_args: dict[str, An
     overridden by the values derived from ``aws_config``.
 
     Raises:
-        ValueError: If ``aws_config['region']`` is missing.
+        ValueError: If ``aws_config['region']`` is missing or empty.
+        ImportError: If ``aws-bedrock-token-generator`` is not installed.
+        RuntimeError: If token minting fails (e.g. missing AWS credentials).
     """
     region = aws_config.get("region")
     if not region:
         raise ValueError("aws_config must include a non-empty 'region'.")
+
+    try:
+        from aws_bedrock_token_generator import provide_token
+    except ImportError as e:
+        raise ImportError(
+            "aws_config requires the 'aws-bedrock-token-generator' package. "
+            "Install it with: pip install strands-agents[openai]"
+        ) from e
 
     # Only forward optional kwargs when explicitly set, so provide_token's own
     # defaults apply. Passing expiry=None in particular crashes the library.
@@ -53,7 +68,14 @@ def resolve_bedrock_client_args(aws_config: AwsConfig, client_args: dict[str, An
         token_kwargs["aws_credentials_provider"] = aws_config["credentials_provider"]
     if "expiry" in aws_config:
         token_kwargs["expiry"] = aws_config["expiry"]
-    token = provide_token(**token_kwargs)
+
+    try:
+        token = provide_token(**token_kwargs)
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to mint Bedrock Mantle bearer token for region '{region}'. "
+            "Verify your AWS credentials and network connectivity."
+        ) from e
 
     resolved: dict[str, Any] = dict(client_args or {})
     resolved["base_url"] = _MANTLE_BASE_URL_TEMPLATE.format(region=region)

--- a/src/strands/models/_openai_bedrock.py
+++ b/src/strands/models/_openai_bedrock.py
@@ -1,0 +1,61 @@
+"""Internal helpers for routing OpenAI-compatible clients to Bedrock Mantle.
+
+Converts an ``aws_config`` dict into the ``base_url`` and ``api_key`` that the
+OpenAI Python SDK consumes. Tokens are minted on demand via
+``aws_bedrock_token_generator.provide_token`` so long-running agents keep working
+past the bearer token's maximum lifetime.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, TypedDict
+
+from aws_bedrock_token_generator import provide_token
+
+_MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
+
+
+class AwsConfig(TypedDict, total=False):
+    """AWS-side config for reaching Bedrock Mantle via an OpenAI-compatible client.
+
+    Attributes:
+        region: AWS region hosting the Bedrock Mantle endpoint (required).
+        credentials_provider: Optional botocore ``CredentialProvider`` forwarded to
+            ``provide_token``. Defaults to the AWS credential chain.
+        expiry: Optional ``timedelta`` for the bearer token's lifetime, forwarded
+            to ``provide_token``.
+    """
+
+    region: str
+    credentials_provider: Any
+    expiry: timedelta
+
+
+def resolve_bedrock_client_args(aws_config: AwsConfig, client_args: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Resolve an ``AwsConfig`` (plus optional ``client_args``) into OpenAI client kwargs.
+
+    Mints a fresh bearer token on every call. When ``client_args`` is provided, its
+    entries are preserved except for ``base_url`` and ``api_key``, which are always
+    overridden by the values derived from ``aws_config``.
+
+    Raises:
+        ValueError: If ``aws_config['region']`` is missing.
+    """
+    region = aws_config.get("region")
+    if not region:
+        raise ValueError("aws_config must include a non-empty 'region'.")
+
+    # Only forward optional kwargs when explicitly set, so provide_token's own
+    # defaults apply. Passing expiry=None in particular crashes the library.
+    token_kwargs: dict[str, Any] = {"region": region}
+    if "credentials_provider" in aws_config:
+        token_kwargs["aws_credentials_provider"] = aws_config["credentials_provider"]
+    if "expiry" in aws_config:
+        token_kwargs["expiry"] = aws_config["expiry"]
+    token = provide_token(**token_kwargs)
+
+    resolved: dict[str, Any] = dict(client_args or {})
+    resolved["base_url"] = _MANTLE_BASE_URL_TEMPLATE.format(region=region)
+    resolved["api_key"] = token
+    return resolved

--- a/src/strands/models/_openai_bedrock.py
+++ b/src/strands/models/_openai_bedrock.py
@@ -2,13 +2,12 @@
 
 Converts an ``aws_config`` dict into the ``base_url`` and ``api_key`` that the
 OpenAI Python SDK consumes. Tokens are minted on demand via
-``aws_bedrock_token_generator.provide_token`` so long-running agents keep working
-past the bearer token's maximum lifetime.
+``aws_bedrock_token_generator.provide_token`` so long-running agents survive the
+bearer token's maximum lifetime.
 
-``aws_bedrock_token_generator`` is imported lazily inside
-:func:`resolve_bedrock_client_args` so that users of OpenAI-compatible extras
-(``sagemaker``, ``litellm``, bare ``openai`` without Mantle) don't pay an
-``ImportError`` just for importing the model class.
+``aws_bedrock_token_generator`` is imported lazily so that extras which reuse
+the OpenAI package without pulling the Mantle dependency do not hit an
+``ImportError`` at module load.
 """
 
 from __future__ import annotations
@@ -25,7 +24,7 @@ class AwsConfig(TypedDict, total=False):
     """AWS-side config for reaching Bedrock Mantle via an OpenAI-compatible client.
 
     Attributes:
-        region: AWS region hosting the Bedrock Mantle endpoint (required).
+        region: AWS region hosting the Bedrock Mantle endpoint.
         credentials_provider: Optional botocore ``CredentialProvider`` forwarded to
             ``provide_token``. Defaults to the AWS credential chain.
         expiry: Optional ``timedelta`` for the bearer token's lifetime, forwarded
@@ -61,8 +60,7 @@ def resolve_bedrock_client_args(aws_config: AwsConfig, client_args: dict[str, An
             "Install it with: pip install strands-agents[openai]"
         ) from e
 
-    # Only forward optional kwargs when explicitly set, so provide_token's own
-    # defaults apply. Passing expiry=None in particular crashes the library.
+    # Only forward kwargs the user set; provide_token rejects expiry=None.
     token_kwargs: dict[str, Any] = {"region": region}
     if "credentials_provider" in aws_config:
         token_kwargs["aws_credentials_provider"] = aws_config["credentials_provider"]

--- a/src/strands/models/_openai_bedrock.py
+++ b/src/strands/models/_openai_bedrock.py
@@ -83,23 +83,15 @@ def resolve_bedrock_client_args(
 ) -> dict[str, Any]:
     """Resolve a ``BedrockMantleConfig`` (plus optional ``client_args``) into OpenAI client kwargs.
 
-    Mints a fresh bearer token on every call. When ``client_args`` is provided, it must
-    not contain ``base_url`` or ``api_key`` — those are always derived from the config.
+    Mints a fresh bearer token on every call. Callers are expected to validate that
+    ``client_args`` does not contain ``base_url`` or ``api_key`` before calling this
+    function (typically at ``__init__`` time for fail-fast behavior).
 
     Raises:
-        ValueError: If no region can be resolved, or if ``client_args`` contains
-            ``base_url`` or ``api_key``.
+        ValueError: If no region can be resolved.
         ImportError: If ``aws-bedrock-token-generator`` is not installed.
         RuntimeError: If token minting fails (e.g. missing AWS credentials).
     """
-    if client_args:
-        conflicting = [k for k in ("api_key", "base_url") if k in client_args]
-        if conflicting:
-            raise ValueError(
-                f"client_args must not contain {conflicting} when bedrock_mantle_config is set; "
-                "these are derived from the Mantle config automatically."
-            )
-
     region = _resolve_region(config)
 
     # ``aws-bedrock-token-generator`` is included in the ``openai`` extras group but not in

--- a/src/strands/models/_openai_bedrock.py
+++ b/src/strands/models/_openai_bedrock.py
@@ -1,13 +1,15 @@
 """Internal helpers for routing OpenAI-compatible clients to Bedrock Mantle.
 
-Converts an ``aws_config`` dict into the ``base_url`` and ``api_key`` that the
+Converts a ``bedrock_mantle_config`` dict into the ``base_url`` and ``api_key`` that the
 OpenAI Python SDK consumes. Tokens are minted on demand via
 ``aws_bedrock_token_generator.provide_token`` so long-running agents survive the
 bearer token's maximum lifetime.
 
-``aws_bedrock_token_generator`` is imported lazily so that extras which reuse
-the OpenAI package without pulling the Mantle dependency do not hit an
-``ImportError`` at module load.
+``aws_bedrock_token_generator`` is part of the ``openai`` extras group
+(``pip install strands-agents[openai]``) but is *not* included in the ``litellm``
+or ``sagemaker`` extras, which also pull in the ``openai`` package. The import is
+therefore lazy — it happens inside :func:`resolve_bedrock_client_args` so that
+those other extras never trigger an ``ImportError`` at module load.
 """
 
 from __future__ import annotations
@@ -15,57 +17,108 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, TypedDict
 
-from typing_extensions import Required
+import boto3
+from botocore.credentials import CredentialProvider
 
 _MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
+_MANTLE_DOCS_URL = "https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html"
 
 
-class AwsConfig(TypedDict, total=False):
-    """AWS-side config for reaching Bedrock Mantle via an OpenAI-compatible client.
+class BedrockMantleConfig(TypedDict, total=False):
+    """Config for routing an OpenAI-compatible client through Bedrock Mantle.
 
     Attributes:
-        region: AWS region hosting the Bedrock Mantle endpoint.
-        credentials_provider: Optional botocore ``CredentialProvider`` forwarded to
-            ``provide_token``. Defaults to the AWS credential chain.
-        expiry: Optional ``timedelta`` for the bearer token's lifetime, forwarded
-            to ``provide_token``.
+        region: AWS region hosting the Bedrock Mantle endpoint. If omitted, resolved
+            from ``boto_session`` (if provided) or the standard boto3 chain
+            (``AWS_REGION`` / ``AWS_DEFAULT_REGION`` / active profile / EC2 metadata).
+            A :class:`ValueError` is raised if none resolve.
+        boto_session: Optional :class:`boto3.Session` used to resolve the region when
+            ``region`` is not provided. Useful for picking up a non-default profile
+            without exporting env vars.
+        credentials_provider: Optional botocore :class:`~botocore.credentials.CredentialProvider`
+            forwarded to ``provide_token``. Omit to let the token generator use the
+            standard AWS credential chain.
+        expiry: Optional ``timedelta`` for the bearer token's lifetime, forwarded to
+            ``provide_token``. Defaults to the generator's built-in lifetime when
+            omitted.
     """
 
-    region: Required[str]
-    credentials_provider: Any
+    region: str
+    boto_session: boto3.Session
+    credentials_provider: CredentialProvider
     expiry: timedelta
 
 
-def resolve_bedrock_client_args(aws_config: AwsConfig, client_args: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Resolve an ``AwsConfig`` (plus optional ``client_args``) into OpenAI client kwargs.
-
-    Mints a fresh bearer token on every call. When ``client_args`` is provided, its
-    entries are preserved except for ``base_url`` and ``api_key``, which are always
-    overridden by the values derived from ``aws_config``.
+def _resolve_region(config: BedrockMantleConfig) -> str:
+    """Resolve the AWS region, preferring explicit config then falling back to boto3.
 
     Raises:
-        ValueError: If ``aws_config['region']`` is missing or empty.
+        ValueError: If no region can be resolved from the config, an attached session,
+            or the standard boto3 credential chain.
+    """
+    region = config.get("region")
+    if region:
+        return region
+
+    session = config.get("boto_session")
+    if session is not None and session.region_name:
+        return str(session.region_name)
+
+    # ``boto3.Session()`` with no args reads ``AWS_REGION`` / ``AWS_DEFAULT_REGION``,
+    # the active profile, and falls back to EC2 instance metadata — the same chain
+    # :class:`BedrockModel` uses.
+    default_region = boto3.Session().region_name
+    if default_region:
+        return str(default_region)
+
+    raise ValueError(
+        "Could not resolve an AWS region for Bedrock Mantle. Pass 'region' in "
+        "bedrock_mantle_config, attach a boto_session with a configured region, or set "
+        f"AWS_REGION in the environment. See {_MANTLE_DOCS_URL} for supported regions."
+    )
+
+
+def resolve_bedrock_client_args(
+    config: BedrockMantleConfig, client_args: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Resolve a ``BedrockMantleConfig`` (plus optional ``client_args``) into OpenAI client kwargs.
+
+    Mints a fresh bearer token on every call. When ``client_args`` is provided, it must
+    not contain ``base_url`` or ``api_key`` — those are always derived from the config.
+
+    Raises:
+        ValueError: If no region can be resolved, or if ``client_args`` contains
+            ``base_url`` or ``api_key``.
         ImportError: If ``aws-bedrock-token-generator`` is not installed.
         RuntimeError: If token minting fails (e.g. missing AWS credentials).
     """
-    region = aws_config.get("region")
-    if not region:
-        raise ValueError("aws_config must include a non-empty 'region'.")
+    if client_args:
+        conflicting = [k for k in ("api_key", "base_url") if k in client_args]
+        if conflicting:
+            raise ValueError(
+                f"client_args must not contain {conflicting} when bedrock_mantle_config is set; "
+                "these are derived from the Mantle config automatically."
+            )
 
+    region = _resolve_region(config)
+
+    # ``aws-bedrock-token-generator`` is included in the ``openai`` extras group but not in
+    # ``litellm`` or ``sagemaker`` (which also depend on the ``openai`` package). The lazy
+    # import keeps those extras from hitting an ImportError at module load.
     try:
         from aws_bedrock_token_generator import provide_token
     except ImportError as e:
         raise ImportError(
-            "aws_config requires the 'aws-bedrock-token-generator' package. "
+            "bedrock_mantle_config requires the 'aws-bedrock-token-generator' package. "
             "Install it with: pip install strands-agents[openai]"
         ) from e
 
     # Only forward kwargs the user set; provide_token rejects expiry=None.
     token_kwargs: dict[str, Any] = {"region": region}
-    if "credentials_provider" in aws_config:
-        token_kwargs["aws_credentials_provider"] = aws_config["credentials_provider"]
-    if "expiry" in aws_config:
-        token_kwargs["expiry"] = aws_config["expiry"]
+    if "credentials_provider" in config:
+        token_kwargs["aws_credentials_provider"] = config["credentials_provider"]
+    if "expiry" in config:
+        token_kwargs["expiry"] = config["expiry"]
 
     try:
         token = provide_token(**token_kwargs)

--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -89,27 +89,20 @@ class OpenAIModel(Model):
                 Note: The client should not be shared across different asyncio event loops.
             client_args: Arguments for the OpenAI client (legacy approach).
                 For a complete list of supported arguments, see https://pypi.org/project/openai/.
-                May be combined with ``aws_config``; transport-level options like ``http_client``,
-                ``timeout``, or ``default_headers`` are preserved, while ``base_url`` and
-                ``api_key`` are always overridden by ``aws_config`` when both are set.
+                May be combined with ``aws_config``; when both are set, ``aws_config`` overrides
+                ``base_url`` and ``api_key`` only.
             aws_config: Route requests through Amazon Bedrock's Mantle (OpenAI-compatible)
-                endpoint. Provide ``{"region": "us-east-1"}`` at minimum. Accepts optional
-                ``credentials_provider`` (a botocore ``CredentialProvider``) and ``expiry``
-                (a ``datetime.timedelta`` up to 12h). When set, a fresh bearer token is minted
-                on every request via ``aws-bedrock-token-generator`` and the OpenAI client is
-                pointed at ``https://bedrock-mantle.<region>.api.aws/v1``. Cannot be combined
-                with a pre-built ``client``.
+                endpoint. See :class:`AwsConfig` for accepted keys. When set, a fresh bearer
+                token is minted on every request. Cannot be combined with a pre-built ``client``.
             **model_config: Configuration options for the OpenAI model.
 
         Raises:
-            ValueError: If ``client`` is combined with ``client_args`` or ``aws_config``,
-                or if ``aws_config`` is missing a region.
+            ValueError: If ``client`` is combined with ``client_args`` or ``aws_config``.
         """
         validate_config_keys(model_config, self.OpenAIConfig)
         self.config = dict(model_config)
 
-        # Validate that client configuration methods are mutually exclusive where they conflict.
-        # client_args + aws_config is allowed — aws_config will override base_url / api_key only.
+        # client_args + aws_config is allowed; aws_config overrides base_url / api_key only.
         client_args_provided = client_args is not None and len(client_args) > 0
         if client is not None and client_args_provided:
             raise ValueError("Only one of 'client' or 'client_args' should be provided, not both.")
@@ -125,9 +118,7 @@ class OpenAIModel(Model):
     def _resolve_client_args(self) -> dict[str, Any]:
         """Return the kwargs to pass to ``openai.AsyncOpenAI`` for the current request.
 
-        When ``aws_config`` is set, a fresh Bedrock Mantle bearer token is minted on every
-        call and ``base_url`` / ``api_key`` are overridden. Any other entries from
-        ``client_args`` (e.g. ``http_client``, ``timeout``) are preserved.
+        Delegates to :func:`resolve_bedrock_client_args` when ``aws_config`` is set.
         """
         if self._aws_config is not None:
             return resolve_bedrock_client_args(self._aws_config, self.client_args)
@@ -619,7 +610,6 @@ class OpenAIModel(Model):
             # Use the injected client (caller manages lifecycle)
             yield self._custom_client
         else:
-            # Create a new client from resolved args (static client_args or freshly-minted Bedrock creds).
             # We initialize an OpenAI context on every request so as to avoid connection sharing in the underlying
             # httpx client. The asyncio event loop does not allow connections to be shared. For more details, please
             # refer to https://github.com/encode/httpx/discussions/2959.

--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -110,6 +110,13 @@ class OpenAIModel(Model):
             raise ValueError("Only one of 'client' or 'client_args' should be provided, not both.")
         if bedrock_mantle_config is not None and client is not None:
             raise ValueError("'bedrock_mantle_config' cannot be combined with a pre-built 'client'.")
+        if bedrock_mantle_config is not None and client_args:
+            conflicting = [k for k in ("api_key", "base_url") if k in client_args]
+            if conflicting:
+                raise ValueError(
+                    f"client_args must not contain {conflicting} when bedrock_mantle_config is set; "
+                    "these are derived from the Mantle config automatically."
+                )
 
         self._custom_client = client
         self.client_args = client_args or {}

--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -113,11 +113,8 @@ class OpenAIModel(Model):
         client_args_provided = client_args is not None and len(client_args) > 0
         if client is not None and client_args_provided:
             raise ValueError("Only one of 'client' or 'client_args' should be provided, not both.")
-        if aws_config is not None:
-            if client is not None:
-                raise ValueError("'aws_config' cannot be combined with a pre-built 'client'.")
-            if not aws_config.get("region"):
-                raise ValueError("aws_config must include a non-empty 'region'.")
+        if aws_config is not None and client is not None:
+            raise ValueError("'aws_config' cannot be combined with a pre-built 'client'.")
 
         self._custom_client = client
         self.client_args = client_args or {}

--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -21,7 +21,7 @@ from ..types.event_loop import Usage
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
-from ._openai_bedrock import AwsConfig, resolve_bedrock_client_args
+from ._openai_bedrock import BedrockMantleConfig, resolve_bedrock_client_args
 from ._validation import _has_location_source, validate_config_keys
 from .model import BaseModelConfig, Model
 
@@ -72,7 +72,7 @@ class OpenAIModel(Model):
         self,
         client: Client | None = None,
         client_args: dict[str, Any] | None = None,
-        aws_config: AwsConfig | None = None,
+        bedrock_mantle_config: BedrockMantleConfig | None = None,
         **model_config: Unpack[OpenAIConfig],
     ) -> None:
         """Initialize provider instance.
@@ -89,39 +89,41 @@ class OpenAIModel(Model):
                 Note: The client should not be shared across different asyncio event loops.
             client_args: Arguments for the OpenAI client (legacy approach).
                 For a complete list of supported arguments, see https://pypi.org/project/openai/.
-                May be combined with ``aws_config``; when both are set, ``aws_config`` overrides
-                ``base_url`` and ``api_key`` only.
-            aws_config: Route requests through Amazon Bedrock's Mantle (OpenAI-compatible)
-                endpoint. See :class:`AwsConfig` for accepted keys. When set, a fresh bearer
-                token is minted on every request. Cannot be combined with a pre-built ``client``.
+                May be combined with ``bedrock_mantle_config``; when both are set,
+                ``bedrock_mantle_config`` derives ``base_url`` and ``api_key`` (which must not
+                appear in ``client_args``).
+            bedrock_mantle_config: Route requests through Amazon Bedrock's Mantle
+                (OpenAI-compatible) endpoint. See :class:`BedrockMantleConfig` for accepted
+                keys. When set, a fresh bearer token is minted on every request. Cannot be
+                combined with a pre-built ``client``.
             **model_config: Configuration options for the OpenAI model.
 
         Raises:
-            ValueError: If ``client`` is combined with ``client_args`` or ``aws_config``.
+            ValueError: If ``client`` is combined with ``client_args`` or ``bedrock_mantle_config``.
         """
         validate_config_keys(model_config, self.OpenAIConfig)
         self.config = dict(model_config)
 
-        # client_args + aws_config is allowed; aws_config overrides base_url / api_key only.
+        # client_args + bedrock_mantle_config is allowed; the config derives base_url / api_key.
         client_args_provided = client_args is not None and len(client_args) > 0
         if client is not None and client_args_provided:
             raise ValueError("Only one of 'client' or 'client_args' should be provided, not both.")
-        if aws_config is not None and client is not None:
-            raise ValueError("'aws_config' cannot be combined with a pre-built 'client'.")
+        if bedrock_mantle_config is not None and client is not None:
+            raise ValueError("'bedrock_mantle_config' cannot be combined with a pre-built 'client'.")
 
         self._custom_client = client
         self.client_args = client_args or {}
-        self._aws_config = aws_config
+        self._bedrock_mantle_config = bedrock_mantle_config
 
         logger.debug("config=<%s> | initializing", self.config)
 
     def _resolve_client_args(self) -> dict[str, Any]:
         """Return the kwargs to pass to ``openai.AsyncOpenAI`` for the current request.
 
-        Delegates to :func:`resolve_bedrock_client_args` when ``aws_config`` is set.
+        Delegates to :func:`resolve_bedrock_client_args` when ``bedrock_mantle_config`` is set.
         """
-        if self._aws_config is not None:
-            return resolve_bedrock_client_args(self._aws_config, self.client_args)
+        if self._bedrock_mantle_config is not None:
+            return resolve_bedrock_client_args(self._bedrock_mantle_config, self.client_args)
         return self.client_args
 
     @override

--- a/src/strands/models/openai.py
+++ b/src/strands/models/openai.py
@@ -21,6 +21,7 @@ from ..types.event_loop import Usage
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
+from ._openai_bedrock import AwsConfig, resolve_bedrock_client_args
 from ._validation import _has_location_source, validate_config_keys
 from .model import BaseModelConfig, Model
 
@@ -71,6 +72,7 @@ class OpenAIModel(Model):
         self,
         client: Client | None = None,
         client_args: dict[str, Any] | None = None,
+        aws_config: AwsConfig | None = None,
         **model_config: Unpack[OpenAIConfig],
     ) -> None:
         """Initialize provider instance.
@@ -87,22 +89,52 @@ class OpenAIModel(Model):
                 Note: The client should not be shared across different asyncio event loops.
             client_args: Arguments for the OpenAI client (legacy approach).
                 For a complete list of supported arguments, see https://pypi.org/project/openai/.
+                May be combined with ``aws_config``; transport-level options like ``http_client``,
+                ``timeout``, or ``default_headers`` are preserved, while ``base_url`` and
+                ``api_key`` are always overridden by ``aws_config`` when both are set.
+            aws_config: Route requests through Amazon Bedrock's Mantle (OpenAI-compatible)
+                endpoint. Provide ``{"region": "us-east-1"}`` at minimum. Accepts optional
+                ``credentials_provider`` (a botocore ``CredentialProvider``) and ``expiry``
+                (a ``datetime.timedelta`` up to 12h). When set, a fresh bearer token is minted
+                on every request via ``aws-bedrock-token-generator`` and the OpenAI client is
+                pointed at ``https://bedrock-mantle.<region>.api.aws/v1``. Cannot be combined
+                with a pre-built ``client``.
             **model_config: Configuration options for the OpenAI model.
 
         Raises:
-            ValueError: If both `client` and `client_args` are provided.
+            ValueError: If ``client`` is combined with ``client_args`` or ``aws_config``,
+                or if ``aws_config`` is missing a region.
         """
         validate_config_keys(model_config, self.OpenAIConfig)
         self.config = dict(model_config)
 
-        # Validate that only one client configuration method is provided
-        if client is not None and client_args is not None and len(client_args) > 0:
+        # Validate that client configuration methods are mutually exclusive where they conflict.
+        # client_args + aws_config is allowed — aws_config will override base_url / api_key only.
+        client_args_provided = client_args is not None and len(client_args) > 0
+        if client is not None and client_args_provided:
             raise ValueError("Only one of 'client' or 'client_args' should be provided, not both.")
+        if aws_config is not None:
+            if client is not None:
+                raise ValueError("'aws_config' cannot be combined with a pre-built 'client'.")
+            if not aws_config.get("region"):
+                raise ValueError("aws_config must include a non-empty 'region'.")
 
         self._custom_client = client
         self.client_args = client_args or {}
+        self._aws_config = aws_config
 
         logger.debug("config=<%s> | initializing", self.config)
+
+    def _resolve_client_args(self) -> dict[str, Any]:
+        """Return the kwargs to pass to ``openai.AsyncOpenAI`` for the current request.
+
+        When ``aws_config`` is set, a fresh Bedrock Mantle bearer token is minted on every
+        call and ``base_url`` / ``api_key`` are overridden. Any other entries from
+        ``client_args`` (e.g. ``http_client``, ``timeout``) are preserved.
+        """
+        if self._aws_config is not None:
+            return resolve_bedrock_client_args(self._aws_config, self.client_args)
+        return self.client_args
 
     @override
     def update_config(self, **model_config: Unpack[OpenAIConfig]) -> None:  # type: ignore[override]
@@ -590,11 +622,11 @@ class OpenAIModel(Model):
             # Use the injected client (caller manages lifecycle)
             yield self._custom_client
         else:
-            # Create a new client from client_args
+            # Create a new client from resolved args (static client_args or freshly-minted Bedrock creds).
             # We initialize an OpenAI context on every request so as to avoid connection sharing in the underlying
             # httpx client. The asyncio event loop does not allow connections to be shared. For more details, please
             # refer to https://github.com/encode/httpx/discussions/2959.
-            async with openai.AsyncOpenAI(**self.client_args) as client:
+            async with openai.AsyncOpenAI(**self._resolve_client_args()) as client:
                 yield client
 
     @override

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -58,7 +58,7 @@ from ..types.content import ContentBlock, Messages, Role, SystemContentBlock  # 
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException  # noqa: E402
 from ..types.streaming import StreamEvent  # noqa: E402
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse  # noqa: E402
-from ._openai_bedrock import AwsConfig, resolve_bedrock_client_args  # noqa: E402
+from ._openai_bedrock import BedrockMantleConfig, resolve_bedrock_client_args  # noqa: E402
 from ._validation import validate_config_keys  # noqa: E402
 from .model import BaseModelConfig, Model  # noqa: E402
 
@@ -144,7 +144,7 @@ class OpenAIResponsesModel(Model):
     def __init__(
         self,
         client_args: dict[str, Any] | None = None,
-        aws_config: AwsConfig | None = None,
+        bedrock_mantle_config: BedrockMantleConfig | None = None,
         **model_config: Unpack[OpenAIResponsesConfig],
     ) -> None:
         """Initialize provider instance.
@@ -152,28 +152,28 @@ class OpenAIResponsesModel(Model):
         Args:
             client_args: Arguments for the OpenAI client.
                 For a complete list of supported arguments, see https://pypi.org/project/openai/.
-                May be combined with ``aws_config``; when both are set, ``aws_config`` overrides
-                ``base_url`` and ``api_key`` only.
-            aws_config: Route requests through Amazon Bedrock's Mantle (OpenAI-compatible)
-                endpoint. See :class:`AwsConfig` for accepted keys. When set, a fresh bearer
-                token is minted on every request.
+                May be combined with ``bedrock_mantle_config``; when both are set, the config
+                derives ``base_url`` and ``api_key`` (which must not appear in ``client_args``).
+            bedrock_mantle_config: Route requests through Amazon Bedrock's Mantle
+                (OpenAI-compatible) endpoint. See :class:`BedrockMantleConfig` for accepted
+                keys. When set, a fresh bearer token is minted on every request.
             **model_config: Configuration options for the OpenAI Responses API model.
         """
         validate_config_keys(model_config, self.OpenAIResponsesConfig)
         self.config = dict(model_config)
 
         self.client_args = client_args or {}
-        self._aws_config = aws_config
+        self._bedrock_mantle_config = bedrock_mantle_config
 
         logger.debug("config=<%s> | initializing", self.config)
 
     def _resolve_client_args(self) -> dict[str, Any]:
         """Return the kwargs to pass to ``openai.AsyncOpenAI`` for the current request.
 
-        Delegates to :func:`resolve_bedrock_client_args` when ``aws_config`` is set.
+        Delegates to :func:`resolve_bedrock_client_args` when ``bedrock_mantle_config`` is set.
         """
-        if self._aws_config is not None:
-            return resolve_bedrock_client_args(self._aws_config, self.client_args)
+        if self._bedrock_mantle_config is not None:
+            return resolve_bedrock_client_args(self._bedrock_mantle_config, self.client_args)
         return self.client_args
 
     @property

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -165,6 +165,14 @@ class OpenAIResponsesModel(Model):
         self.client_args = client_args or {}
         self._bedrock_mantle_config = bedrock_mantle_config
 
+        if bedrock_mantle_config is not None and client_args:
+            conflicting = [k for k in ("api_key", "base_url") if k in client_args]
+            if conflicting:
+                raise ValueError(
+                    f"client_args must not contain {conflicting} when bedrock_mantle_config is set; "
+                    "these are derived from the Mantle config automatically."
+                )
+
         logger.debug("config=<%s> | initializing", self.config)
 
     def _resolve_client_args(self) -> dict[str, Any]:

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -152,19 +152,12 @@ class OpenAIResponsesModel(Model):
         Args:
             client_args: Arguments for the OpenAI client.
                 For a complete list of supported arguments, see https://pypi.org/project/openai/.
-                May be combined with ``aws_config``; transport-level options like ``http_client``,
-                ``timeout``, or ``default_headers`` are preserved, while ``base_url`` and
-                ``api_key`` are always overridden by ``aws_config`` when both are set.
+                May be combined with ``aws_config``; when both are set, ``aws_config`` overrides
+                ``base_url`` and ``api_key`` only.
             aws_config: Route requests through Amazon Bedrock's Mantle (OpenAI-compatible)
-                endpoint. Provide ``{"region": "us-east-1"}`` at minimum. Accepts optional
-                ``credentials_provider`` (a botocore ``CredentialProvider``) and ``expiry``
-                (a ``datetime.timedelta`` up to 12h). When set, a fresh bearer token is minted
-                on every request via ``aws-bedrock-token-generator`` and the OpenAI client is
-                pointed at ``https://bedrock-mantle.<region>.api.aws/v1``.
+                endpoint. See :class:`AwsConfig` for accepted keys. When set, a fresh bearer
+                token is minted on every request.
             **model_config: Configuration options for the OpenAI Responses API model.
-
-        Raises:
-            ValueError: If ``aws_config`` is missing a region.
         """
         validate_config_keys(model_config, self.OpenAIResponsesConfig)
         self.config = dict(model_config)
@@ -177,9 +170,7 @@ class OpenAIResponsesModel(Model):
     def _resolve_client_args(self) -> dict[str, Any]:
         """Return the kwargs to pass to ``openai.AsyncOpenAI`` for the current request.
 
-        When ``aws_config`` is set, a fresh Bedrock Mantle bearer token is minted on every
-        call and ``base_url`` / ``api_key`` are overridden. Any other entries from
-        ``client_args`` (e.g. ``http_client``, ``timeout``) are preserved.
+        Delegates to :func:`resolve_bedrock_client_args` when ``aws_config`` is set.
         """
         if self._aws_config is not None:
             return resolve_bedrock_client_args(self._aws_config, self.client_args)

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -58,6 +58,7 @@ from ..types.content import ContentBlock, Messages, Role, SystemContentBlock  # 
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException  # noqa: E402
 from ..types.streaming import StreamEvent  # noqa: E402
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse  # noqa: E402
+from ._openai_bedrock import AwsConfig, resolve_bedrock_client_args  # noqa: E402
 from ._validation import validate_config_keys  # noqa: E402
 from .model import BaseModelConfig, Model  # noqa: E402
 
@@ -141,20 +142,51 @@ class OpenAIResponsesModel(Model):
         stateful: bool
 
     def __init__(
-        self, client_args: dict[str, Any] | None = None, **model_config: Unpack[OpenAIResponsesConfig]
+        self,
+        client_args: dict[str, Any] | None = None,
+        aws_config: AwsConfig | None = None,
+        **model_config: Unpack[OpenAIResponsesConfig],
     ) -> None:
         """Initialize provider instance.
 
         Args:
             client_args: Arguments for the OpenAI client.
                 For a complete list of supported arguments, see https://pypi.org/project/openai/.
+                May be combined with ``aws_config``; transport-level options like ``http_client``,
+                ``timeout``, or ``default_headers`` are preserved, while ``base_url`` and
+                ``api_key`` are always overridden by ``aws_config`` when both are set.
+            aws_config: Route requests through Amazon Bedrock's Mantle (OpenAI-compatible)
+                endpoint. Provide ``{"region": "us-east-1"}`` at minimum. Accepts optional
+                ``credentials_provider`` (a botocore ``CredentialProvider``) and ``expiry``
+                (a ``datetime.timedelta`` up to 12h). When set, a fresh bearer token is minted
+                on every request via ``aws-bedrock-token-generator`` and the OpenAI client is
+                pointed at ``https://bedrock-mantle.<region>.api.aws/v1``.
             **model_config: Configuration options for the OpenAI Responses API model.
+
+        Raises:
+            ValueError: If ``aws_config`` is missing a region.
         """
         validate_config_keys(model_config, self.OpenAIResponsesConfig)
         self.config = dict(model_config)
+
+        if aws_config is not None and not aws_config.get("region"):
+            raise ValueError("aws_config must include a non-empty 'region'.")
+
         self.client_args = client_args or {}
+        self._aws_config = aws_config
 
         logger.debug("config=<%s> | initializing", self.config)
+
+    def _resolve_client_args(self) -> dict[str, Any]:
+        """Return the kwargs to pass to ``openai.AsyncOpenAI`` for the current request.
+
+        When ``aws_config`` is set, a fresh Bedrock Mantle bearer token is minted on every
+        call and ``base_url`` / ``api_key`` are overridden. Any other entries from
+        ``client_args`` (e.g. ``http_client``, ``timeout``) are preserved.
+        """
+        if self._aws_config is not None:
+            return resolve_bedrock_client_args(self._aws_config, self.client_args)
+        return self.client_args
 
     @property
     @override
@@ -215,7 +247,7 @@ class OpenAIResponsesModel(Model):
             count_tokens_fields = {"model", "input", "instructions", "tools"}
             request = {k: request[k] for k in request.keys() & count_tokens_fields}
 
-            async with openai.AsyncOpenAI(**self.client_args) as client:
+            async with openai.AsyncOpenAI(**self._resolve_client_args()) as client:
                 response = await client.responses.input_tokens.count(**request)
                 total_tokens: int = response.input_tokens
 
@@ -267,7 +299,7 @@ class OpenAIResponsesModel(Model):
 
         logger.debug("invoking OpenAI Responses API model")
 
-        async with openai.AsyncOpenAI(**self.client_args) as client:
+        async with openai.AsyncOpenAI(**self._resolve_client_args()) as client:
             try:
                 response = await client.responses.create(**request)
 
@@ -447,7 +479,7 @@ class OpenAIResponsesModel(Model):
             ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: If the request is throttled by OpenAI (rate limits).
         """
-        async with openai.AsyncOpenAI(**self.client_args) as client:
+        async with openai.AsyncOpenAI(**self._resolve_client_args()) as client:
             try:
                 response = await client.responses.parse(
                     model=self.get_config()["model_id"],

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -169,9 +169,6 @@ class OpenAIResponsesModel(Model):
         validate_config_keys(model_config, self.OpenAIResponsesConfig)
         self.config = dict(model_config)
 
-        if aws_config is not None and not aws_config.get("region"):
-            raise ValueError("aws_config must include a non-empty 'region'.")
-
         self.client_args = client_args or {}
         self._aws_config = aws_config
 

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -1798,16 +1798,15 @@ class TestOpenAIModelBedrockMantleConfig:
         assert resolved["http_client"] is sentinel_http_client
         assert resolved["default_headers"] == {"X-Trace-Id": "abc"}
 
-    def test_bedrock_mantle_config_rejects_base_url_in_client_args(self, openai_client, mock_provide_token):
+    def test_bedrock_mantle_config_rejects_base_url_in_client_args(self, openai_client):
         """client_args must not contain base_url or api_key when bedrock_mantle_config is set."""
         _ = openai_client
-        model = OpenAIModel(
-            model_id="openai.gpt-oss-120b",
-            client_args={"base_url": "https://custom.example.com"},
-            bedrock_mantle_config={"region": "us-east-1"},
-        )
         with pytest.raises(ValueError, match="client_args must not contain"):
-            model._resolve_client_args()
+            OpenAIModel(
+                model_id="openai.gpt-oss-120b",
+                client_args={"base_url": "https://custom.example.com"},
+                bedrock_mantle_config={"region": "us-east-1"},
+            )
 
     def test_bedrock_mantle_config_requires_region(self, openai_client):
         """bedrock_mantle_config raises when no region can be resolved from config, session, or env."""

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -1710,3 +1710,102 @@ def test_format_request_messages_multiple_tool_calls_with_images():
         },
     ]
     assert tru_result == exp_result
+
+
+# =============================================================================
+# Bedrock Mantle (aws_config) integration with OpenAIModel
+# =============================================================================
+
+
+class TestOpenAIModelAwsConfig:
+    """Tests for the Bedrock Mantle pathway via the aws_config kwarg."""
+
+    @pytest.fixture
+    def mock_provide_token(self):
+        with unittest.mock.patch("strands.models._openai_bedrock.provide_token") as mock:
+            mock.return_value = "bedrock-api-key-deadbeef&Version=1"
+            yield mock
+
+    def test_aws_config_sets_base_url_and_api_key(self, openai_client, mock_provide_token):
+        """aws_config produces the Mantle base_url and a minted bearer token as api_key."""
+        _ = openai_client
+        model = OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+
+        # api_key is resolved per-request (lazy), so check via the resolved client_args at call time
+        resolved = model._resolve_client_args()
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
+        assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
+        # Only region is forwarded when the user did not set optional kwargs,
+        # so provide_token's own defaults (e.g. 12h expiry) apply.
+        mock_provide_token.assert_called_once_with(region="us-east-1")
+
+    def test_aws_config_forwards_credentials_provider_and_expiry(self, openai_client, mock_provide_token):
+        """Optional credentials_provider and expiry are forwarded to provide_token."""
+        _ = openai_client
+        from datetime import timedelta
+
+        provider = unittest.mock.Mock()
+        model = OpenAIModel(
+            model_id="openai.gpt-oss-120b",
+            aws_config={
+                "region": "us-west-2",
+                "credentials_provider": provider,
+                "expiry": timedelta(minutes=15),
+            },
+        )
+        model._resolve_client_args()
+        mock_provide_token.assert_called_once_with(
+            region="us-west-2",
+            aws_credentials_provider=provider,
+            expiry=timedelta(minutes=15),
+        )
+
+    def test_aws_config_mints_token_per_request(self, openai_client, mock_provide_token):
+        """Each call to _resolve_client_args mints a fresh token (long-lived processes)."""
+        _ = openai_client
+        model = OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        model._resolve_client_args()
+        model._resolve_client_args()
+        model._resolve_client_args()
+        assert mock_provide_token.call_count == 3
+
+    def test_aws_config_conflicts_with_custom_client(self, openai_client):
+        """Cannot pass both aws_config and a pre-built client."""
+        _ = openai_client
+        custom_client = unittest.mock.Mock()
+        with pytest.raises(ValueError, match="aws_config"):
+            OpenAIModel(
+                model_id="openai.gpt-oss-120b",
+                client=custom_client,
+                aws_config={"region": "us-east-1"},
+            )
+
+    def test_aws_config_merges_with_client_args(self, openai_client, mock_provide_token):
+        """aws_config is allowed alongside client_args; base_url and api_key are overridden,
+        other transport-level options (timeout, http_client, default_headers) are preserved.
+        """
+        _ = openai_client
+        sentinel_http_client = unittest.mock.Mock()
+        model = OpenAIModel(
+            model_id="openai.gpt-oss-120b",
+            client_args={
+                "api_key": "will-be-overridden",
+                "base_url": "https://also-overridden.example.com",
+                "timeout": 42,
+                "http_client": sentinel_http_client,
+                "default_headers": {"X-Trace-Id": "abc"},
+            },
+            aws_config={"region": "us-east-1"},
+        )
+        resolved = model._resolve_client_args()
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
+        assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
+        assert resolved["timeout"] == 42
+        assert resolved["http_client"] is sentinel_http_client
+        assert resolved["default_headers"] == {"X-Trace-Id": "abc"}
+
+    def test_aws_config_requires_region(self, openai_client):
+        """aws_config must include a region."""
+        _ = openai_client
+        with pytest.raises(ValueError, match="region"):
+            OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={})

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import unittest.mock
 
 import openai
@@ -1713,21 +1714,21 @@ def test_format_request_messages_multiple_tool_calls_with_images():
 
 
 # =============================================================================
-# Bedrock Mantle (aws_config) integration with OpenAIModel
+# Bedrock Mantle (bedrock_mantle_config) integration with OpenAIModel
 # =============================================================================
 
 
-class TestOpenAIModelAwsConfig:
+class TestOpenAIModelBedrockMantleConfig:
     @pytest.fixture
     def mock_provide_token(self):
         with unittest.mock.patch("aws_bedrock_token_generator.provide_token") as mock:
             mock.return_value = "bedrock-api-key-deadbeef&Version=1"
             yield mock
 
-    def test_aws_config_sets_base_url_and_api_key(self, openai_client, mock_provide_token):
-        """aws_config produces the Mantle base_url and a minted bearer token as api_key."""
+    def test_bedrock_mantle_config_sets_base_url_and_api_key(self, openai_client, mock_provide_token):
+        """bedrock_mantle_config produces the Mantle base_url and a minted bearer token as api_key."""
         _ = openai_client
-        model = OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        model = OpenAIModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={"region": "us-east-1"})
 
         # Token is minted lazily per request, so inspect the resolved kwargs.
         resolved = model._resolve_client_args()
@@ -1736,7 +1737,7 @@ class TestOpenAIModelAwsConfig:
         # Optional kwargs aren't forwarded so provide_token's own defaults apply.
         mock_provide_token.assert_called_once_with(region="us-east-1")
 
-    def test_aws_config_forwards_credentials_provider_and_expiry(self, openai_client, mock_provide_token):
+    def test_bedrock_mantle_config_forwards_credentials_provider_and_expiry(self, openai_client, mock_provide_token):
         """Optional credentials_provider and expiry are forwarded to provide_token."""
         _ = openai_client
         from datetime import timedelta
@@ -1744,7 +1745,7 @@ class TestOpenAIModelAwsConfig:
         provider = unittest.mock.Mock()
         model = OpenAIModel(
             model_id="openai.gpt-oss-120b",
-            aws_config={
+            bedrock_mantle_config={
                 "region": "us-west-2",
                 "credentials_provider": provider,
                 "expiry": timedelta(minutes=15),
@@ -1757,42 +1758,38 @@ class TestOpenAIModelAwsConfig:
             expiry=timedelta(minutes=15),
         )
 
-    def test_aws_config_mints_token_per_request(self, openai_client, mock_provide_token):
+    def test_bedrock_mantle_config_mints_token_per_request(self, openai_client, mock_provide_token):
         """Each call to _resolve_client_args mints a fresh token (long-lived processes)."""
         _ = openai_client
-        model = OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        model = OpenAIModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={"region": "us-east-1"})
         model._resolve_client_args()
         model._resolve_client_args()
         model._resolve_client_args()
         assert mock_provide_token.call_count == 3
 
-    def test_aws_config_conflicts_with_custom_client(self, openai_client):
-        """Cannot pass both aws_config and a pre-built client."""
+    def test_bedrock_mantle_config_conflicts_with_custom_client(self, openai_client):
+        """Cannot pass both bedrock_mantle_config and a pre-built client."""
         _ = openai_client
         custom_client = unittest.mock.Mock()
-        with pytest.raises(ValueError, match="aws_config"):
+        with pytest.raises(ValueError, match="bedrock_mantle_config"):
             OpenAIModel(
                 model_id="openai.gpt-oss-120b",
                 client=custom_client,
-                aws_config={"region": "us-east-1"},
+                bedrock_mantle_config={"region": "us-east-1"},
             )
 
-    def test_aws_config_merges_with_client_args(self, openai_client, mock_provide_token):
-        """aws_config is allowed alongside client_args; base_url and api_key are overridden,
-        other transport-level options (timeout, http_client, default_headers) are preserved.
-        """
+    def test_bedrock_mantle_config_merges_with_client_args(self, openai_client, mock_provide_token):
+        """bedrock_mantle_config composes with client_args; transport options are preserved."""
         _ = openai_client
         sentinel_http_client = unittest.mock.Mock()
         model = OpenAIModel(
             model_id="openai.gpt-oss-120b",
             client_args={
-                "api_key": "will-be-overridden",
-                "base_url": "https://also-overridden.example.com",
                 "timeout": 42,
                 "http_client": sentinel_http_client,
                 "default_headers": {"X-Trace-Id": "abc"},
             },
-            aws_config={"region": "us-east-1"},
+            bedrock_mantle_config={"region": "us-east-1"},
         )
         resolved = model._resolve_client_args()
         assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
@@ -1801,17 +1798,73 @@ class TestOpenAIModelAwsConfig:
         assert resolved["http_client"] is sentinel_http_client
         assert resolved["default_headers"] == {"X-Trace-Id": "abc"}
 
-    def test_aws_config_requires_region(self, openai_client):
-        """aws_config must include a region; validated when the helper mints a token."""
+    def test_bedrock_mantle_config_rejects_base_url_in_client_args(self, openai_client, mock_provide_token):
+        """client_args must not contain base_url or api_key when bedrock_mantle_config is set."""
         _ = openai_client
-        model = OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={})
-        with pytest.raises(ValueError, match="region"):
+        model = OpenAIModel(
+            model_id="openai.gpt-oss-120b",
+            client_args={"base_url": "https://custom.example.com"},
+            bedrock_mantle_config={"region": "us-east-1"},
+        )
+        with pytest.raises(ValueError, match="client_args must not contain"):
             model._resolve_client_args()
 
-    def test_aws_config_wraps_token_failures_with_context(self, openai_client, mock_provide_token):
+    def test_bedrock_mantle_config_requires_region(self, openai_client):
+        """bedrock_mantle_config raises when no region can be resolved from config, session, or env."""
+        _ = openai_client
+        with (
+            unittest.mock.patch("boto3.Session") as mock_session_cls,
+            unittest.mock.patch.dict(os.environ, {}, clear=True),
+        ):
+            mock_session_cls.return_value.region_name = None
+            model = OpenAIModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={})
+            with pytest.raises(ValueError, match="Could not resolve an AWS region"):
+                model._resolve_client_args()
+
+    def test_bedrock_mantle_config_region_resolved_from_boto3_default(self, openai_client, mock_provide_token):
+        """When region is omitted, the default boto3 session chain resolves it."""
+        _ = openai_client
+        with unittest.mock.patch("boto3.Session") as mock_session_cls:
+            mock_session_cls.return_value.region_name = "eu-west-1"
+            model = OpenAIModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={})
+            resolved = model._resolve_client_args()
+
+        assert resolved["base_url"] == "https://bedrock-mantle.eu-west-1.api.aws/v1"
+        mock_provide_token.assert_called_once_with(region="eu-west-1")
+
+    def test_bedrock_mantle_config_region_resolved_from_boto_session(self, openai_client, mock_provide_token):
+        """An explicit ``boto_session`` supplies the region when ``region`` is omitted."""
+        _ = openai_client
+        session = unittest.mock.Mock()
+        session.region_name = "ap-southeast-2"
+        model = OpenAIModel(
+            model_id="openai.gpt-oss-120b",
+            bedrock_mantle_config={"boto_session": session},
+        )
+
+        resolved = model._resolve_client_args()
+
+        assert resolved["base_url"] == "https://bedrock-mantle.ap-southeast-2.api.aws/v1"
+        mock_provide_token.assert_called_once_with(region="ap-southeast-2")
+
+    def test_bedrock_mantle_config_explicit_region_wins_over_boto_session(self, openai_client, mock_provide_token):
+        """``region`` takes precedence over a session's region."""
+        _ = openai_client
+        session = unittest.mock.Mock()
+        session.region_name = "ap-southeast-2"
+        model = OpenAIModel(
+            model_id="openai.gpt-oss-120b",
+            bedrock_mantle_config={"region": "us-east-1", "boto_session": session},
+        )
+
+        model._resolve_client_args()
+
+        mock_provide_token.assert_called_once_with(region="us-east-1")
+
+    def test_bedrock_mantle_config_wraps_token_failures_with_context(self, openai_client, mock_provide_token):
         """provide_token failures are wrapped in a RuntimeError with actionable context."""
         _ = openai_client
         mock_provide_token.side_effect = RuntimeError("no credentials in chain")
-        model = OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        model = OpenAIModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={"region": "us-east-1"})
         with pytest.raises(RuntimeError, match="Bedrock Mantle bearer token.*us-east-1"):
             model._resolve_client_args()

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -1722,7 +1722,7 @@ class TestOpenAIModelAwsConfig:
 
     @pytest.fixture
     def mock_provide_token(self):
-        with unittest.mock.patch("strands.models._openai_bedrock.provide_token") as mock:
+        with unittest.mock.patch("aws_bedrock_token_generator.provide_token") as mock:
             mock.return_value = "bedrock-api-key-deadbeef&Version=1"
             yield mock
 
@@ -1805,7 +1805,16 @@ class TestOpenAIModelAwsConfig:
         assert resolved["default_headers"] == {"X-Trace-Id": "abc"}
 
     def test_aws_config_requires_region(self, openai_client):
-        """aws_config must include a region."""
+        """aws_config must include a region; validated when the helper mints a token."""
         _ = openai_client
+        model = OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={})
         with pytest.raises(ValueError, match="region"):
-            OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={})
+            model._resolve_client_args()
+
+    def test_aws_config_wraps_token_failures_with_context(self, openai_client, mock_provide_token):
+        """provide_token failures are wrapped in a RuntimeError with actionable context."""
+        _ = openai_client
+        mock_provide_token.side_effect = RuntimeError("no credentials in chain")
+        model = OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        with pytest.raises(RuntimeError, match="Bedrock Mantle bearer token.*us-east-1"):
+            model._resolve_client_args()

--- a/tests/strands/models/test_openai.py
+++ b/tests/strands/models/test_openai.py
@@ -1718,8 +1718,6 @@ def test_format_request_messages_multiple_tool_calls_with_images():
 
 
 class TestOpenAIModelAwsConfig:
-    """Tests for the Bedrock Mantle pathway via the aws_config kwarg."""
-
     @pytest.fixture
     def mock_provide_token(self):
         with unittest.mock.patch("aws_bedrock_token_generator.provide_token") as mock:
@@ -1731,12 +1729,11 @@ class TestOpenAIModelAwsConfig:
         _ = openai_client
         model = OpenAIModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
 
-        # api_key is resolved per-request (lazy), so check via the resolved client_args at call time
+        # Token is minted lazily per request, so inspect the resolved kwargs.
         resolved = model._resolve_client_args()
         assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
         assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
-        # Only region is forwarded when the user did not set optional kwargs,
-        # so provide_token's own defaults (e.g. 12h expiry) apply.
+        # Optional kwargs aren't forwarded so provide_token's own defaults apply.
         mock_provide_token.assert_called_once_with(region="us-east-1")
 
     def test_aws_config_forwards_credentials_provider_and_expiry(self, openai_client, mock_provide_token):

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -1,3 +1,4 @@
+import os
 import unittest.mock
 
 import openai
@@ -1301,33 +1302,33 @@ class TestCountTokens:
 
 
 # =============================================================================
-# Bedrock Mantle (aws_config) integration with OpenAIResponsesModel
+# Bedrock Mantle (bedrock_mantle_config) integration with OpenAIResponsesModel
 # =============================================================================
 
 
-class TestOpenAIResponsesModelAwsConfig:
+class TestOpenAIResponsesModelBedrockMantleConfig:
     @pytest.fixture
     def mock_provide_token(self):
         with unittest.mock.patch("aws_bedrock_token_generator.provide_token") as mock:
             mock.return_value = "bedrock-api-key-deadbeef&Version=1"
             yield mock
 
-    def test_aws_config_sets_base_url_and_api_key(self, openai_client, mock_provide_token):
+    def test_bedrock_mantle_config_sets_base_url_and_api_key(self, openai_client, mock_provide_token):
         _ = openai_client
-        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={"region": "us-east-1"})
         resolved = model._resolve_client_args()
         assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
         assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
         mock_provide_token.assert_called_once_with(region="us-east-1")
 
-    def test_aws_config_forwards_credentials_provider_and_expiry(self, openai_client, mock_provide_token):
+    def test_bedrock_mantle_config_forwards_credentials_provider_and_expiry(self, openai_client, mock_provide_token):
         _ = openai_client
         from datetime import timedelta
 
         provider = unittest.mock.Mock()
         model = OpenAIResponsesModel(
             model_id="openai.gpt-oss-120b",
-            aws_config={
+            bedrock_mantle_config={
                 "region": "us-west-2",
                 "credentials_provider": provider,
                 "expiry": timedelta(minutes=15),
@@ -1340,28 +1341,24 @@ class TestOpenAIResponsesModelAwsConfig:
             expiry=timedelta(minutes=15),
         )
 
-    def test_aws_config_mints_token_per_request(self, openai_client, mock_provide_token):
+    def test_bedrock_mantle_config_mints_token_per_request(self, openai_client, mock_provide_token):
         _ = openai_client
-        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={"region": "us-east-1"})
         model._resolve_client_args()
         model._resolve_client_args()
         assert mock_provide_token.call_count == 2
 
-    def test_aws_config_merges_with_client_args(self, openai_client, mock_provide_token):
-        """aws_config is allowed alongside client_args; base_url and api_key are overridden,
-        other transport-level options are preserved.
-        """
+    def test_bedrock_mantle_config_merges_with_client_args(self, openai_client, mock_provide_token):
+        """bedrock_mantle_config composes with client_args; transport options are preserved."""
         _ = openai_client
         sentinel_http_client = unittest.mock.Mock()
         model = OpenAIResponsesModel(
             model_id="openai.gpt-oss-120b",
             client_args={
-                "api_key": "will-be-overridden",
-                "base_url": "https://also-overridden.example.com",
                 "timeout": 42,
                 "http_client": sentinel_http_client,
             },
-            aws_config={"region": "us-east-1"},
+            bedrock_mantle_config={"region": "us-east-1"},
         )
         resolved = model._resolve_client_args()
         assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
@@ -1369,16 +1366,59 @@ class TestOpenAIResponsesModelAwsConfig:
         assert resolved["timeout"] == 42
         assert resolved["http_client"] is sentinel_http_client
 
-    def test_aws_config_requires_region(self, openai_client):
+    def test_bedrock_mantle_config_rejects_base_url_in_client_args(self, openai_client, mock_provide_token):
+        """client_args must not contain base_url or api_key when bedrock_mantle_config is set."""
         _ = openai_client
-        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={})
-        with pytest.raises(ValueError, match="region"):
+        model = OpenAIResponsesModel(
+            model_id="openai.gpt-oss-120b",
+            client_args={"api_key": "should-not-be-here"},
+            bedrock_mantle_config={"region": "us-east-1"},
+        )
+        with pytest.raises(ValueError, match="client_args must not contain"):
             model._resolve_client_args()
 
-    def test_aws_config_wraps_token_failures_with_context(self, openai_client, mock_provide_token):
+    def test_bedrock_mantle_config_requires_region(self, openai_client):
+        """bedrock_mantle_config raises when no region can be resolved from config, session, or env."""
+        _ = openai_client
+        with (
+            unittest.mock.patch("boto3.Session") as mock_session_cls,
+            unittest.mock.patch.dict(os.environ, {}, clear=True),
+        ):
+            mock_session_cls.return_value.region_name = None
+            model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={})
+            with pytest.raises(ValueError, match="Could not resolve an AWS region"):
+                model._resolve_client_args()
+
+    def test_bedrock_mantle_config_region_resolved_from_boto3_default(self, openai_client, mock_provide_token):
+        """When region is omitted, the default boto3 session chain resolves it."""
+        _ = openai_client
+        with unittest.mock.patch("boto3.Session") as mock_session_cls:
+            mock_session_cls.return_value.region_name = "eu-west-1"
+            model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={})
+            resolved = model._resolve_client_args()
+
+        assert resolved["base_url"] == "https://bedrock-mantle.eu-west-1.api.aws/v1"
+        mock_provide_token.assert_called_once_with(region="eu-west-1")
+
+    def test_bedrock_mantle_config_region_resolved_from_boto_session(self, openai_client, mock_provide_token):
+        """An explicit ``boto_session`` supplies the region when ``region`` is omitted."""
+        _ = openai_client
+        session = unittest.mock.Mock()
+        session.region_name = "ap-southeast-2"
+        model = OpenAIResponsesModel(
+            model_id="openai.gpt-oss-120b",
+            bedrock_mantle_config={"boto_session": session},
+        )
+
+        resolved = model._resolve_client_args()
+
+        assert resolved["base_url"] == "https://bedrock-mantle.ap-southeast-2.api.aws/v1"
+        mock_provide_token.assert_called_once_with(region="ap-southeast-2")
+
+    def test_bedrock_mantle_config_wraps_token_failures_with_context(self, openai_client, mock_provide_token):
         """provide_token failures are wrapped in a RuntimeError with actionable context."""
         _ = openai_client
         mock_provide_token.side_effect = RuntimeError("no credentials in chain")
-        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={"region": "us-east-1"})
         with pytest.raises(RuntimeError, match="Bedrock Mantle bearer token.*us-east-1"):
             model._resolve_client_args()

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -1366,16 +1366,15 @@ class TestOpenAIResponsesModelBedrockMantleConfig:
         assert resolved["timeout"] == 42
         assert resolved["http_client"] is sentinel_http_client
 
-    def test_bedrock_mantle_config_rejects_base_url_in_client_args(self, openai_client, mock_provide_token):
+    def test_bedrock_mantle_config_rejects_base_url_in_client_args(self, openai_client):
         """client_args must not contain base_url or api_key when bedrock_mantle_config is set."""
         _ = openai_client
-        model = OpenAIResponsesModel(
-            model_id="openai.gpt-oss-120b",
-            client_args={"api_key": "should-not-be-here"},
-            bedrock_mantle_config={"region": "us-east-1"},
-        )
         with pytest.raises(ValueError, match="client_args must not contain"):
-            model._resolve_client_args()
+            OpenAIResponsesModel(
+                model_id="openai.gpt-oss-120b",
+                client_args={"api_key": "should-not-be-here"},
+                bedrock_mantle_config={"region": "us-east-1"},
+            )
 
     def test_bedrock_mantle_config_requires_region(self, openai_client):
         """bedrock_mantle_config raises when no region can be resolved from config, session, or env."""

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -1306,8 +1306,6 @@ class TestCountTokens:
 
 
 class TestOpenAIResponsesModelAwsConfig:
-    """Tests for the Bedrock Mantle pathway via the aws_config kwarg."""
-
     @pytest.fixture
     def mock_provide_token(self):
         with unittest.mock.patch("aws_bedrock_token_generator.provide_token") as mock:

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -1310,7 +1310,7 @@ class TestOpenAIResponsesModelAwsConfig:
 
     @pytest.fixture
     def mock_provide_token(self):
-        with unittest.mock.patch("strands.models._openai_bedrock.provide_token") as mock:
+        with unittest.mock.patch("aws_bedrock_token_generator.provide_token") as mock:
             mock.return_value = "bedrock-api-key-deadbeef&Version=1"
             yield mock
 
@@ -1373,5 +1373,14 @@ class TestOpenAIResponsesModelAwsConfig:
 
     def test_aws_config_requires_region(self, openai_client):
         _ = openai_client
+        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={})
         with pytest.raises(ValueError, match="region"):
-            OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={})
+            model._resolve_client_args()
+
+    def test_aws_config_wraps_token_failures_with_context(self, openai_client, mock_provide_token):
+        """provide_token failures are wrapped in a RuntimeError with actionable context."""
+        _ = openai_client
+        mock_provide_token.side_effect = RuntimeError("no credentials in chain")
+        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        with pytest.raises(RuntimeError, match="Bedrock Mantle bearer token.*us-east-1"):
+            model._resolve_client_args()

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -1298,3 +1298,80 @@ class TestCountTokens:
             await model.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)
+
+
+# =============================================================================
+# Bedrock Mantle (aws_config) integration with OpenAIResponsesModel
+# =============================================================================
+
+
+class TestOpenAIResponsesModelAwsConfig:
+    """Tests for the Bedrock Mantle pathway via the aws_config kwarg."""
+
+    @pytest.fixture
+    def mock_provide_token(self):
+        with unittest.mock.patch("strands.models._openai_bedrock.provide_token") as mock:
+            mock.return_value = "bedrock-api-key-deadbeef&Version=1"
+            yield mock
+
+    def test_aws_config_sets_base_url_and_api_key(self, openai_client, mock_provide_token):
+        _ = openai_client
+        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        resolved = model._resolve_client_args()
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
+        assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
+        mock_provide_token.assert_called_once_with(region="us-east-1")
+
+    def test_aws_config_forwards_credentials_provider_and_expiry(self, openai_client, mock_provide_token):
+        _ = openai_client
+        from datetime import timedelta
+
+        provider = unittest.mock.Mock()
+        model = OpenAIResponsesModel(
+            model_id="openai.gpt-oss-120b",
+            aws_config={
+                "region": "us-west-2",
+                "credentials_provider": provider,
+                "expiry": timedelta(minutes=15),
+            },
+        )
+        model._resolve_client_args()
+        mock_provide_token.assert_called_once_with(
+            region="us-west-2",
+            aws_credentials_provider=provider,
+            expiry=timedelta(minutes=15),
+        )
+
+    def test_aws_config_mints_token_per_request(self, openai_client, mock_provide_token):
+        _ = openai_client
+        model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={"region": "us-east-1"})
+        model._resolve_client_args()
+        model._resolve_client_args()
+        assert mock_provide_token.call_count == 2
+
+    def test_aws_config_merges_with_client_args(self, openai_client, mock_provide_token):
+        """aws_config is allowed alongside client_args; base_url and api_key are overridden,
+        other transport-level options are preserved.
+        """
+        _ = openai_client
+        sentinel_http_client = unittest.mock.Mock()
+        model = OpenAIResponsesModel(
+            model_id="openai.gpt-oss-120b",
+            client_args={
+                "api_key": "will-be-overridden",
+                "base_url": "https://also-overridden.example.com",
+                "timeout": 42,
+                "http_client": sentinel_http_client,
+            },
+            aws_config={"region": "us-east-1"},
+        )
+        resolved = model._resolve_client_args()
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
+        assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
+        assert resolved["timeout"] == 42
+        assert resolved["http_client"] is sentinel_http_client
+
+    def test_aws_config_requires_region(self, openai_client):
+        _ = openai_client
+        with pytest.raises(ValueError, match="region"):
+            OpenAIResponsesModel(model_id="openai.gpt-oss-120b", aws_config={})

--- a/tests_integ/models/test_model_mantle.py
+++ b/tests_integ/models/test_model_mantle.py
@@ -1,6 +1,6 @@
 """Integration tests for OpenAI-compatible APIs on Bedrock Mantle.
 
-Exercises the ``aws_config`` pathway on ``OpenAIModel`` (Chat Completions) and
+Exercises the ``bedrock_mantle_config`` pathway on ``OpenAIModel`` (Chat Completions) and
 ``OpenAIResponsesModel`` (Responses API) against the live
 ``bedrock-mantle.<region>.api.aws/v1`` endpoint. Credentials come from the
 ambient AWS credential chain; no explicit API key is passed by the user.
@@ -17,27 +17,27 @@ _MODEL_ID = "openai.gpt-oss-120b"
 
 
 @pytest.fixture
-def aws_config():
+def bedrock_mantle_config():
     return {"region": _REGION}
 
 
 @pytest.fixture
-def chat_completions_model(aws_config):
-    return OpenAIModel(model_id=_MODEL_ID, aws_config=aws_config)
+def chat_completions_model(bedrock_mantle_config):
+    return OpenAIModel(model_id=_MODEL_ID, bedrock_mantle_config=bedrock_mantle_config)
 
 
 @pytest.fixture
-def model(aws_config):
-    return OpenAIResponsesModel(model_id=_MODEL_ID, aws_config=aws_config)
+def model(bedrock_mantle_config):
+    return OpenAIResponsesModel(model_id=_MODEL_ID, bedrock_mantle_config=bedrock_mantle_config)
 
 
 @pytest.fixture
-def stateful_model(aws_config):
-    return OpenAIResponsesModel(model_id=_MODEL_ID, stateful=True, aws_config=aws_config)
+def stateful_model(bedrock_mantle_config):
+    return OpenAIResponsesModel(model_id=_MODEL_ID, stateful=True, bedrock_mantle_config=bedrock_mantle_config)
 
 
 def test_chat_completions_agent_invoke(chat_completions_model):
-    """OpenAIModel (Chat Completions) reaches Mantle via aws_config."""
+    """OpenAIModel (Chat Completions) reaches Mantle via bedrock_mantle_config."""
     agent = Agent(model=chat_completions_model, system_prompt="Reply in one short sentence.", callback_handler=None)
     result = agent("What is 2+2?")
     assert "4" in str(result)
@@ -59,11 +59,11 @@ def test_responses_server_side_conversation(stateful_model):
     assert "alice" in str(result).lower()
 
 
-def test_reasoning_content_multi_turn(aws_config):
+def test_reasoning_content_multi_turn(bedrock_mantle_config):
     """Test that reasoning content from gpt-oss models doesn't break multi-turn conversations."""
     model = OpenAIResponsesModel(
         model_id=_MODEL_ID,
-        aws_config=aws_config,
+        bedrock_mantle_config=bedrock_mantle_config,
         params={"reasoning": {"effort": "low"}},
     )
     agent = Agent(model=model, system_prompt="Reply in one short sentence.", callback_handler=None)

--- a/tests_integ/models/test_model_mantle.py
+++ b/tests_integ/models/test_model_mantle.py
@@ -1,61 +1,46 @@
-"""Integration tests for OpenAI Responses API on Bedrock Mantle with AWS credentials."""
+"""Integration tests for OpenAI-compatible APIs on Bedrock Mantle.
 
-import httpx
+Exercises the ``aws_config`` pathway on ``OpenAIModel`` (Chat Completions) and
+``OpenAIResponsesModel`` (Responses API) against the live
+``bedrock-mantle.<region>.api.aws/v1`` endpoint. Credentials come from the
+ambient AWS credential chain; no explicit API key is passed by the user.
+"""
+
 import pytest
-from botocore.auth import SigV4Auth
-from botocore.awsrequest import AWSRequest
-from botocore.session import Session as BotocoreSession
 
 from strands import Agent
+from strands.models.openai import OpenAIModel
 from strands.models.openai_responses import OpenAIResponsesModel
 
-
-class _SigV4Auth(httpx.Auth):
-    """httpx Auth handler that signs requests with AWS SigV4."""
-
-    def __init__(self, region: str):
-        session = BotocoreSession()
-        self.credentials = session.get_credentials().get_frozen_credentials()
-        self.signer = SigV4Auth(self.credentials, "bedrock", region)
-
-    def auth_flow(self, request: httpx.Request):
-        aws_request = AWSRequest(
-            method=request.method,
-            url=str(request.url),
-            headers=dict(request.headers),
-            data=request.content,
-        )
-        self.signer.add_auth(aws_request)
-        for key, value in aws_request.headers.items():
-            request.headers[key] = value
-        yield request
-
-
-class _NonClosingAsyncClient(httpx.AsyncClient):
-    """AsyncClient that survives the OpenAI SDK's context manager lifecycle."""
-
-    async def aclose(self) -> None:
-        pass
+_REGION = "us-east-1"
+_MODEL_ID = "openai.gpt-oss-120b"
 
 
 @pytest.fixture
-def client_args():
-    region = "us-east-1"
-    return {
-        "api_key": "unused",
-        "base_url": f"https://bedrock-mantle.{region}.api.aws/v1",
-        "http_client": _NonClosingAsyncClient(auth=_SigV4Auth(region)),
-    }
+def aws_config():
+    return {"region": _REGION}
 
 
 @pytest.fixture
-def model(client_args):
-    return OpenAIResponsesModel(model_id="openai.gpt-oss-120b", client_args=client_args)
+def chat_completions_model(aws_config):
+    return OpenAIModel(model_id=_MODEL_ID, aws_config=aws_config)
 
 
 @pytest.fixture
-def stateful_model(client_args):
-    return OpenAIResponsesModel(model_id="openai.gpt-oss-120b", stateful=True, client_args=client_args)
+def model(aws_config):
+    return OpenAIResponsesModel(model_id=_MODEL_ID, aws_config=aws_config)
+
+
+@pytest.fixture
+def stateful_model(aws_config):
+    return OpenAIResponsesModel(model_id=_MODEL_ID, stateful=True, aws_config=aws_config)
+
+
+def test_chat_completions_agent_invoke(chat_completions_model):
+    """OpenAIModel (Chat Completions) reaches Mantle via aws_config."""
+    agent = Agent(model=chat_completions_model, system_prompt="Reply in one short sentence.", callback_handler=None)
+    result = agent("What is 2+2?")
+    assert "4" in str(result)
 
 
 def test_agent_invoke(model):
@@ -74,11 +59,11 @@ def test_responses_server_side_conversation(stateful_model):
     assert "alice" in str(result).lower()
 
 
-def test_reasoning_content_multi_turn(client_args):
+def test_reasoning_content_multi_turn(aws_config):
     """Test that reasoning content from gpt-oss models doesn't break multi-turn conversations."""
     model = OpenAIResponsesModel(
-        model_id="openai.gpt-oss-120b",
-        client_args=client_args,
+        model_id=_MODEL_ID,
+        aws_config=aws_config,
         params={"reasoning": {"effort": "low"}},
     )
     agent = Agent(model=model, system_prompt="Reply in one short sentence.", callback_handler=None)


### PR DESCRIPTION
## Description

Amazon Bedrock's OpenAI-compatible endpoint (Mantle) at
`https://bedrock-mantle.<region>.api.aws/v1` serves the Chat Completions and
Responses APIs plus Responses-only features like stateful conversations and
reasoning controls — capabilities Converse doesn't expose.

Reaching Mantle today means hand-rolling the plumbing: mint a bearer token
with [`aws-bedrock-token-generator`](https://pypi.org/project/aws-bedrock-token-generator/)
(or sign with SigV4), compute the regional base URL, and pass both into
`OpenAIModel` / `OpenAIResponsesModel` via `client_args`. This PR adds a
first-class `bedrock_mantle_config` kwarg to both classes so the Bedrock routing stops
leaking into application code.

### Public API

```python
from strands.models.openai import OpenAIModel
from strands.models.openai_responses import OpenAIResponsesModel

OpenAIModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={"region": "us-east-1"})

OpenAIResponsesModel(
    model_id="openai.gpt-oss-120b",
    stateful=True,
    params={"reasoning": {"effort": "medium"}},
    bedrock_mantle_config={"region": "us-east-1"},
)
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

In-repo docs update covers the feature for Python. TypeScript tab in the
new section notes the pathway isn't yet supported on that SDK.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
