### PR TITLE
fix(ollama): update return type of latencyMs metric for ollama model provider

### DIFF
--- a/src/strands/models/ollama.py
+++ b/src/strands/models/ollama.py
@@ -280,7 +280,7 @@ class OllamaModel(Model):
                             "totalTokens": event["data"].eval_count + event["data"].prompt_eval_count,
                         },
                         "metrics": {
-                            "latencyMs": event["data"].total_duration / 1e6,
+                            "latencyMs": int(event["data"].total_duration / 1e6),
                         },
                     },
                 }

--- a/tests/strands/models/test_ollama.py
+++ b/tests/strands/models/test_ollama.py
@@ -407,7 +407,7 @@ def test_format_chunk_metadata(model):
                 "totalTokens": 150,
             },
             "metrics": {
-                "latencyMs": 1.0,
+                "latencyMs": 1,
             },
         },
     }
@@ -447,7 +447,7 @@ async def test_stream(ollama_client, model, agenerator, alist, captured_warnings
         {
             "metadata": {
                 "usage": {"inputTokens": 5, "outputTokens": 10, "totalTokens": 15},
-                "metrics": {"latencyMs": 1.0},
+                "metrics": {"latencyMs": 1},
             }
         },
     ]
@@ -525,7 +525,7 @@ async def test_stream_with_tool_calls(ollama_client, model, agenerator, alist):
     assert tru_events[8] == {
         "metadata": {
             "usage": {"inputTokens": 8, "outputTokens": 15, "totalTokens": 23},
-            "metrics": {"latencyMs": 2.0},
+            "metrics": {"latencyMs": 2},
         }
     }
     expected_request = {


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
update return type of latencyMs metric for ollama model provider to return int value instead of float as per the requirement: https://github.com/strands-agents/sdk-python/blob/6e208a8c546a6a9e27351cf289e730a13b07fc55/src/strands/types/event_loop.py#L35

## Related Issues

<!-- Link to related issues using #issue-number format -->
#2235 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->
N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
