### PR TITLE
fix: include root cause in MCPClientInitializationError message

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -220,7 +220,7 @@ class MCPClient(ToolProvider):
             logger.exception("client failed to initialize")
             # Pass None for exc_type, exc_val, exc_tb since this isn't a context manager exit
             self.stop(None, None, None)
-            raise MCPClientInitializationError("the client initialization failed") from e
+            raise MCPClientInitializationError(f"the client initialization failed: {e}") from e
         return self
 
     # ToolProvider interface methods

--- a/tests/strands/tools/mcp/test_mcp_client.py
+++ b/tests/strands/tools/mcp/test_mcp_client.py
@@ -386,7 +386,10 @@ def test_enter_with_initialization_exception(mock_transport):
     client = MCPClient(mock_transport["transport_callable"])
 
     with patch.object(client, "stop") as mock_stop:
-        with pytest.raises(MCPClientInitializationError, match="the client initialization failed"):
+        with pytest.raises(
+            MCPClientInitializationError,
+            match="the client initialization failed: Transport initialization failed",
+        ):
             client.start()
 
         # Verify stop() was called for cleanup


### PR DESCRIPTION
## Description

When `MCPClient.start()` fails due to a transport or auth error (e.g., OAuth token exchange failure, connection refused), the `MCPClientInitializationError` thrown contains a generic message `"the client initialization failed"` that hides the root cause. The original exception is preserved in `__cause__` (via `from e`) but not in `str()`.

In managed environments like AgentCore Harness, the error message is surfaced through a streaming event and the full stack trace is not available to the user. This makes it impossible to diagnose the root cause.

This PR includes `str(e)` in the error message so the root cause is visible:

Before: `MCPClientInitializationError: the client initialization failed`
After: `MCPClientInitializationError: the client initialization failed: Failed to get OAuth token for Gateway (provider=my-provider): Token has expired`

The change is at `src/strands/tools/mcp/mcp_client.py` line 223.

## Related Issues

Fixes #2237

## Documentation PR

N/A — no documentation changes needed.

## Type of Change

Bug fix

## Testing

How have you tested the change?

- Ran full MCP test suite: 142 passed, 0 failed
- Updated `test_enter_with_initialization_exception` to verify the root cause message is included in the error
- Verified no warnings introduced in the MCP module

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.