### PR TITLE
fix: correct MCPClient.__exit__ and stop() type annotations

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -178,7 +178,12 @@ class MCPClient(ToolProvider):
         """
         return self.start()
 
-    def __exit__(self, exc_type: BaseException, exc_val: BaseException, exc_tb: TracebackType) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Context manager exit point that cleans up resources."""
         self.stop(exc_type, exc_val, exc_tb)
 
@@ -318,7 +323,7 @@ class MCPClient(ToolProvider):
 
     # MCP-specific methods
 
-    def stop(self, exc_type: BaseException | None, exc_val: BaseException | None, exc_tb: TracebackType | None) -> None:
+    def stop(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None) -> None:
         """Signals the background thread to stop and waits for it to complete, ensuring proper cleanup of all resources.
 
         This method is defensive and can handle partial initialization states that may occur

--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -323,7 +323,12 @@ class MCPClient(ToolProvider):
 
     # MCP-specific methods
 
-    def stop(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None) -> None:
+    def stop(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Signals the background thread to stop and waits for it to complete, ensuring proper cleanup of all resources.
 
         This method is defensive and can handle partial initialization states that may occur


### PR DESCRIPTION
## Description

Fix `__exit__` and `stop()` parameter types to match the context-manager protocol: `exc_type` should be `type[BaseException] | None` (not `BaseException`), and all params on `__exit__` need `| None`.

## Related Issues

Fixes #2247

## Type of Change

Bug fix

## Testing

- [x] `uvx ty check` passes (previously errored with `invalid-context-manager`)
- [x] `pytest tests/strands/tools/mcp/test_mcp_client.py` — 62 passed
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.