### PR TITLE
feat: add useNativeTokenCount flag to skip token counting API calls

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -57,11 +57,15 @@ class AnthropicModel(Model):
                 https://docs.anthropic.com/en/docs/about-claude/models/all-models.
             params: Additional model parameters (e.g., temperature).
                 For a complete list of supported parameters, see https://docs.anthropic.com/en/api/messages.
+            native_token_counting: Whether to use the native Anthropic count_tokens API.
+                When True (default), count_tokens() calls the Anthropic API for accurate counts.
+                When False, skips the API call and uses the local estimator.
         """
 
         max_tokens: Required[int]
         model_id: Required[str]
         params: dict[str, Any] | None
+        native_token_counting: bool
 
     def __init__(self, *, client_args: dict[str, Any] | None = None, **model_config: Unpack[AnthropicConfig]):
         """Initialize provider instance.
@@ -394,6 +398,9 @@ class AnthropicModel(Model):
         Returns:
             Total input token count.
         """
+        if self.config.get("native_token_counting") is False:
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
+
         try:
             # system_prompt_content is not used; this provider only accepts system_prompt as a plain string,
             # matching the behavior of stream(). The caller always provides system_prompt alongside

--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -57,7 +57,7 @@ class AnthropicModel(Model):
                 https://docs.anthropic.com/en/docs/about-claude/models/all-models.
             params: Additional model parameters (e.g., temperature).
                 For a complete list of supported parameters, see https://docs.anthropic.com/en/api/messages.
-            native_token_counting: Whether to use the native Anthropic count_tokens API.
+            use_native_token_count: Whether to use the native Anthropic count_tokens API.
                 When True (default), count_tokens() calls the Anthropic API for accurate counts.
                 When False, skips the API call and uses the local estimator.
         """
@@ -65,7 +65,7 @@ class AnthropicModel(Model):
         max_tokens: Required[int]
         model_id: Required[str]
         params: dict[str, Any] | None
-        native_token_counting: bool
+        use_native_token_count: bool
 
     def __init__(self, *, client_args: dict[str, Any] | None = None, **model_config: Unpack[AnthropicConfig]):
         """Initialize provider instance.
@@ -398,7 +398,7 @@ class AnthropicModel(Model):
         Returns:
             Total input token count.
         """
-        if self.config.get("native_token_counting") is False:
+        if self.config.get("use_native_token_count") is False:
             return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
 
         try:

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -117,6 +117,9 @@ class BedrockModel(Model):
                 See https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
             temperature: Controls randomness in generation (higher = more random)
             top_p: Controls diversity via nucleus sampling (alternative to temperature)
+            native_token_counting: Whether to use the native Bedrock CountTokens API.
+                When True (default), count_tokens() calls the Bedrock API for accurate counts.
+                When False, skips the API call and uses the local estimator.
         """
 
         additional_args: dict[str, Any] | None
@@ -143,6 +146,7 @@ class BedrockModel(Model):
         strict_tools: bool | None
         temperature: float | None
         top_p: float | None
+        native_token_counting: bool
 
     def __init__(
         self,
@@ -794,6 +798,9 @@ class BedrockModel(Model):
         Returns:
             Total input token count.
         """
+        if self.config.get("native_token_counting") is False:
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
+
         model_id: str = self.config["model_id"]
 
         if model_id in _UNSUPPORTED_COUNT_TOKENS_MODELS:

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -117,7 +117,7 @@ class BedrockModel(Model):
                 See https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
             temperature: Controls randomness in generation (higher = more random)
             top_p: Controls diversity via nucleus sampling (alternative to temperature)
-            native_token_counting: Whether to use the native Bedrock CountTokens API.
+            use_native_token_count: Whether to use the native Bedrock CountTokens API.
                 When True (default), count_tokens() calls the Bedrock API for accurate counts.
                 When False, skips the API call and uses the local estimator.
         """
@@ -146,7 +146,7 @@ class BedrockModel(Model):
         strict_tools: bool | None
         temperature: float | None
         top_p: float | None
-        native_token_counting: bool
+        use_native_token_count: bool
 
     def __init__(
         self,
@@ -798,7 +798,7 @@ class BedrockModel(Model):
         Returns:
             Total input token count.
         """
-        if self.config.get("native_token_counting") is False:
+        if self.config.get("use_native_token_count") is False:
             return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
 
         model_id: str = self.config["model_id"]

--- a/src/strands/models/gemini.py
+++ b/src/strands/models/gemini.py
@@ -49,7 +49,7 @@ class GeminiModel(Model):
                 Use the standard tools interface for function calling tools.
                 For a complete list of supported tools, see
                 https://ai.google.dev/api/caching#Tool
-            native_token_counting: Whether to use the native Gemini count_tokens API.
+            use_native_token_count: Whether to use the native Gemini count_tokens API.
                 When True (default), count_tokens() calls the Gemini API for accurate counts.
                 When False, skips the API call and uses the local estimator.
         """
@@ -57,7 +57,7 @@ class GeminiModel(Model):
         model_id: Required[str]
         params: dict[str, Any]
         gemini_tools: list[genai.types.Tool]
-        native_token_counting: bool
+        use_native_token_count: bool
 
     def __init__(
         self,
@@ -461,7 +461,7 @@ class GeminiModel(Model):
         Returns:
             Total input token count.
         """
-        if self.config.get("native_token_counting") is False:
+        if self.config.get("use_native_token_count") is False:
             return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
 
         try:

--- a/src/strands/models/gemini.py
+++ b/src/strands/models/gemini.py
@@ -49,11 +49,15 @@ class GeminiModel(Model):
                 Use the standard tools interface for function calling tools.
                 For a complete list of supported tools, see
                 https://ai.google.dev/api/caching#Tool
+            native_token_counting: Whether to use the native Gemini count_tokens API.
+                When True (default), count_tokens() calls the Gemini API for accurate counts.
+                When False, skips the API call and uses the local estimator.
         """
 
         model_id: Required[str]
         params: dict[str, Any]
         gemini_tools: list[genai.types.Tool]
+        native_token_counting: bool
 
     def __init__(
         self,
@@ -457,6 +461,9 @@ class GeminiModel(Model):
         Returns:
             Total input token count.
         """
+        if self.config.get("native_token_counting") is False:
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
+
         try:
             contents = list(self._format_request_content(messages))
 

--- a/src/strands/models/llamacpp.py
+++ b/src/strands/models/llamacpp.py
@@ -125,10 +125,14 @@ class LlamaCppModel(Model):
                 - cache_prompt: Cache the prompt for faster generation
                 - slot_id: Slot ID for parallel inference
                 - samplers: Custom sampler order
+            native_token_counting: Whether to use the native llama.cpp /tokenize endpoint.
+                When True (default), count_tokens() calls the server's tokenize endpoint for accurate counts.
+                When False, skips the API call and uses the local estimator.
         """
 
         model_id: str
         params: dict[str, Any] | None
+        native_token_counting: bool
 
     def __init__(
         self,
@@ -533,6 +537,9 @@ class LlamaCppModel(Model):
         Returns:
             Total input token count.
         """
+        if self.config.get("native_token_counting") is False:
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
+
         try:
             # system_prompt_content is not used; this provider only accepts system_prompt as a plain string,
             # matching the behavior of stream(). The caller always provides system_prompt alongside

--- a/src/strands/models/llamacpp.py
+++ b/src/strands/models/llamacpp.py
@@ -125,14 +125,14 @@ class LlamaCppModel(Model):
                 - cache_prompt: Cache the prompt for faster generation
                 - slot_id: Slot ID for parallel inference
                 - samplers: Custom sampler order
-            native_token_counting: Whether to use the native llama.cpp /tokenize endpoint.
+            use_native_token_count: Whether to use the native llama.cpp /tokenize endpoint.
                 When True (default), count_tokens() calls the server's tokenize endpoint for accurate counts.
                 When False, skips the API call and uses the local estimator.
         """
 
         model_id: str
         params: dict[str, Any] | None
-        native_token_counting: bool
+        use_native_token_count: bool
 
     def __init__(
         self,
@@ -537,7 +537,7 @@ class LlamaCppModel(Model):
         Returns:
             Total input token count.
         """
-        if self.config.get("native_token_counting") is False:
+        if self.config.get("use_native_token_count") is False:
             return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
 
         try:

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
+
 def _heuristic_estimate_text(text: str) -> int:
     """Estimate token count from text using characters / 4 heuristic."""
     return math.ceil(len(text) / 4)
@@ -82,7 +83,6 @@ def _count_content_block_tokens(
                     total += count_text(citation_item["text"])
 
     return total
-
 
 
 def _estimate_tokens_with_heuristic(

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -136,7 +136,7 @@ class OpenAIResponsesModel(Model):
             stateful: Whether to enable server-side conversation state management.
                 When True, the server stores conversation history and the client does not need to
                 send the full message history with each request. Defaults to False.
-            native_token_counting: Whether to use the native OpenAI input_tokens.count API.
+            use_native_token_count: Whether to use the native OpenAI input_tokens.count API.
                 When True (default), count_tokens() calls the OpenAI API for accurate counts.
                 When False, skips the API call and uses the local estimator.
         """
@@ -144,7 +144,7 @@ class OpenAIResponsesModel(Model):
         model_id: str
         params: dict[str, Any] | None
         stateful: bool
-        native_token_counting: bool
+        use_native_token_count: bool
 
     def __init__(
         self,
@@ -242,7 +242,7 @@ class OpenAIResponsesModel(Model):
         Returns:
             Total input token count.
         """
-        if self.config.get("native_token_counting") is False:
+        if self.config.get("use_native_token_count") is False:
             return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
 
         try:

--- a/src/strands/models/openai_responses.py
+++ b/src/strands/models/openai_responses.py
@@ -136,11 +136,15 @@ class OpenAIResponsesModel(Model):
             stateful: Whether to enable server-side conversation state management.
                 When True, the server stores conversation history and the client does not need to
                 send the full message history with each request. Defaults to False.
+            native_token_counting: Whether to use the native OpenAI input_tokens.count API.
+                When True (default), count_tokens() calls the OpenAI API for accurate counts.
+                When False, skips the API call and uses the local estimator.
         """
 
         model_id: str
         params: dict[str, Any] | None
         stateful: bool
+        native_token_counting: bool
 
     def __init__(
         self,
@@ -238,6 +242,9 @@ class OpenAIResponsesModel(Model):
         Returns:
             Total input token count.
         """
+        if self.config.get("native_token_counting") is False:
+            return await super().count_tokens(messages, tool_specs, system_prompt, system_prompt_content)
+
         try:
             # system_prompt_content is not used; this provider only accepts system_prompt as a plain string,
             # matching the behavior of stream(). The caller always provides system_prompt alongside

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -1164,11 +1164,11 @@ class TestCountTokens:
         assert any("native token counting failed" in record.message for record in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_skip_native_api_when_native_token_counting_false(
+    async def test_skip_native_api_when_use_native_token_count_false(
         self, anthropic_client, model_id, max_tokens, messages
     ):
         _ = anthropic_client
-        model = AnthropicModel(model_id=model_id, max_tokens=max_tokens, native_token_counting=False)
+        model = AnthropicModel(model_id=model_id, max_tokens=max_tokens, use_native_token_count=False)
 
         result = await model.count_tokens(messages=messages)
 

--- a/tests/strands/models/test_anthropic.py
+++ b/tests/strands/models/test_anthropic.py
@@ -1162,3 +1162,16 @@ class TestCountTokens:
             await model_with_client.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_skip_native_api_when_native_token_counting_false(
+        self, anthropic_client, model_id, max_tokens, messages
+    ):
+        _ = anthropic_client
+        model = AnthropicModel(model_id=model_id, max_tokens=max_tokens, native_token_counting=False)
+
+        result = await model.count_tokens(messages=messages)
+
+        anthropic_client.messages.count_tokens.assert_not_called()
+        assert isinstance(result, int)
+        assert result >= 0

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -3486,9 +3486,9 @@ class TestCountTokens:
         assert bedrock_client.count_tokens.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_skip_native_api_when_native_token_counting_false(self, bedrock_client, model_id, messages):
+    async def test_skip_native_api_when_use_native_token_count_false(self, bedrock_client, model_id, messages):
         _ = bedrock_client
-        model = BedrockModel(model_id=model_id, native_token_counting=False)
+        model = BedrockModel(model_id=model_id, use_native_token_count=False)
 
         result = await model.count_tokens(messages=messages)
 

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -3484,3 +3484,14 @@ class TestCountTokens:
         # Second call should still attempt the API
         await model.count_tokens(messages=messages)
         assert bedrock_client.count_tokens.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_skip_native_api_when_native_token_counting_false(self, bedrock_client, model_id, messages):
+        _ = bedrock_client
+        model = BedrockModel(model_id=model_id, native_token_counting=False)
+
+        result = await model.count_tokens(messages=messages)
+
+        bedrock_client.count_tokens.assert_not_called()
+        assert isinstance(result, int)
+        assert result >= 0

--- a/tests/strands/models/test_gemini.py
+++ b/tests/strands/models/test_gemini.py
@@ -1230,9 +1230,9 @@ class TestCountTokens:
         assert any("native token counting failed" in record.message for record in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_skip_native_api_when_native_token_counting_false(self, gemini_client, messages):
+    async def test_skip_native_api_when_use_native_token_count_false(self, gemini_client, messages):
         _ = gemini_client
-        model = GeminiModel(model_id="m1", native_token_counting=False)
+        model = GeminiModel(model_id="m1", use_native_token_count=False)
 
         result = await model.count_tokens(messages=messages)
 

--- a/tests/strands/models/test_gemini.py
+++ b/tests/strands/models/test_gemini.py
@@ -1228,3 +1228,14 @@ class TestCountTokens:
             await model.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_skip_native_api_when_native_token_counting_false(self, gemini_client, messages):
+        _ = gemini_client
+        model = GeminiModel(model_id="m1", native_token_counting=False)
+
+        result = await model.count_tokens(messages=messages)
+
+        gemini_client.aio.models.count_tokens.assert_not_called()
+        assert isinstance(result, int)
+        assert result >= 0

--- a/tests/strands/models/test_llamacpp.py
+++ b/tests/strands/models/test_llamacpp.py
@@ -803,3 +803,14 @@ class TestCountTokens:
             await model.count_tokens(messages=messages)
 
         assert any("native token counting failed" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_skip_native_api_when_native_token_counting_false(self, messages):
+        model = LlamaCppModel(base_url="http://localhost:8080", native_token_counting=False)
+        model.client.post = AsyncMock()
+
+        result = await model.count_tokens(messages=messages)
+
+        model.client.post.assert_not_called()
+        assert isinstance(result, int)
+        assert result >= 0

--- a/tests/strands/models/test_llamacpp.py
+++ b/tests/strands/models/test_llamacpp.py
@@ -805,8 +805,8 @@ class TestCountTokens:
         assert any("native token counting failed" in record.message for record in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_skip_native_api_when_native_token_counting_false(self, messages):
-        model = LlamaCppModel(base_url="http://localhost:8080", native_token_counting=False)
+    async def test_skip_native_api_when_use_native_token_count_false(self, messages):
+        model = LlamaCppModel(base_url="http://localhost:8080", use_native_token_count=False)
         model.client.post = AsyncMock()
 
         result = await model.count_tokens(messages=messages)

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -509,7 +509,6 @@ async def test_count_tokens_all_inputs(model):
     assert result == 50
 
 
-
 class TestHeuristicEstimation:
     """Tests for _estimate_tokens_with_heuristic."""
 

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -1319,9 +1319,9 @@ class TestCountTokens:
         assert any("native token counting failed" in record.message for record in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_skip_native_api_when_native_token_counting_false(self, openai_client, messages):
+    async def test_skip_native_api_when_use_native_token_count_false(self, openai_client, messages):
         _ = openai_client
-        model = OpenAIResponsesModel(model_id="gpt-4o", native_token_counting=False)
+        model = OpenAIResponsesModel(model_id="gpt-4o", use_native_token_count=False)
 
         result = await model.count_tokens(messages=messages)
 

--- a/tests/strands/models/test_openai_responses.py
+++ b/tests/strands/models/test_openai_responses.py
@@ -1318,6 +1318,17 @@ class TestCountTokens:
 
         assert any("native token counting failed" in record.message for record in caplog.records)
 
+    @pytest.mark.asyncio
+    async def test_skip_native_api_when_native_token_counting_false(self, openai_client, messages):
+        _ = openai_client
+        model = OpenAIResponsesModel(model_id="gpt-4o", native_token_counting=False)
+
+        result = await model.count_tokens(messages=messages)
+
+        openai_client.responses.input_tokens.count.assert_not_called()
+        assert isinstance(result, int)
+        assert result >= 0
+
 
 # =============================================================================
 # Bedrock Mantle (bedrock_mantle_config) integration with OpenAIResponsesModel


### PR DESCRIPTION
## Description

 Model providers with native token counting APIs (Bedrock, Anthropic, Gemini, OpenAI Responses, llama.cpp) make an additional API call on every `count_tokens()` invocation. In scenarios where latency or cost of these calls is undesirable — such as high-frequency proactive compression checks — users need a way to opt out and fall back to the local estimator.
  
Each provider that overrides `count_tokens()` with a native API call gains a new optional `use_native_token_count` field in its config:
  
  ```python
  # Before: native API always called (with estimator fallback on error)
  model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514")
  
  # After: skip native API, always use local estimator
  model = BedrockModel(
      model_id="us.anthropic.claude-sonnet-4-20250514",
      use_native_token_count=False,
  )
 ```

Defaults to True (current behavior). Available on BedrockConfig, AnthropicConfig, GeminiConfig, OpenAIResponsesConfig, and LlamaCppConfig — the five providers that override count_tokens() with native API calls. The base Model class is unaffected since it only has the local estimator implementation.



## Related Issues

Python port of https://github.com/strands-agents/sdk-typescript/pull/1009

## Documentation PR

NA

## Type of Change

New feature


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
