### PR TITLE
fix(bedrock): resolve cache strategy for ARN-based application inference profiles

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -220,9 +220,10 @@ class BedrockModel(Model):
     def _resolve_application_inference_profile_strategy(self) -> str | None:
         """Resolve the cache strategy for an ARN-based application inference profile.
 
-        Calls GetInferenceProfile on the Bedrock management API to discover the underlying
+        Calls GetInferenceProfile on the Bedrock management API (requires the
+        ``bedrock:GetInferenceProfile`` IAM permission) to discover the underlying
         foundation model, then checks whether that model supports prompt caching.
-        Returns None (and logs a debug message) on any error.
+        Returns None and logs a debug message on any error, including missing permissions.
         """
         try:
             # GetInferenceProfile is a Bedrock management API, not available on bedrock-runtime.

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -208,6 +208,32 @@ class BedrockModel(Model):
         model_id = self.config.get("model_id", "").lower()
         if "claude" in model_id or "anthropic" in model_id:
             return "anthropic"
+        # ARN-based application inference profiles use opaque IDs that don't contain the model name.
+        # Resolve the underlying foundation model via GetInferenceProfile, then re-check.
+        if "application-inference-profile" in model_id:
+            if not hasattr(self, "_resolved_application_profile_strategy"):
+                self._resolved_application_profile_strategy = self._resolve_application_inference_profile_strategy()
+            return self._resolved_application_profile_strategy
+        return None
+
+    def _resolve_application_inference_profile_strategy(self) -> str | None:
+        """Resolve the cache strategy for an ARN-based application inference profile.
+
+        Calls GetInferenceProfile to discover the underlying foundation model, then checks whether
+        that model supports prompt caching.  Returns None (and logs a debug message) on any error.
+        """
+        try:
+            response = self.client.get_inference_profile(inferenceProfileIdentifier=self.config["model_id"])
+            for model_ref in response.get("models", []):
+                model_arn = model_ref.get("modelArn", "").lower()
+                if "claude" in model_arn or "anthropic" in model_arn:
+                    return "anthropic"
+        except Exception:
+            logger.debug(
+                "model_id=<%s> | could not resolve application inference profile for cache strategy detection; "
+                "use CacheConfig(strategy='anthropic') to force-enable caching",
+                self.config.get("model_id"),
+            )
         return None
 
     @override
@@ -218,6 +244,8 @@ class BedrockModel(Model):
             **model_config: Configuration overrides.
         """
         validate_config_keys(model_config, self.BedrockConfig)
+        if "model_id" in model_config:
+            self.__dict__.pop("_resolved_application_profile_strategy", None)
         self.config.update(model_config)
 
     @override

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -196,6 +196,7 @@ class BedrockModel(Model):
             endpoint_url=endpoint_url,
             region_name=resolved_region,
         )
+        self._boto_session = session
 
         logger.debug("region=<%s> | bedrock client created", self.client.meta.region_name)
 
@@ -219,11 +220,17 @@ class BedrockModel(Model):
     def _resolve_application_inference_profile_strategy(self) -> str | None:
         """Resolve the cache strategy for an ARN-based application inference profile.
 
-        Calls GetInferenceProfile to discover the underlying foundation model, then checks whether
-        that model supports prompt caching.  Returns None (and logs a debug message) on any error.
+        Calls GetInferenceProfile on the Bedrock management API to discover the underlying
+        foundation model, then checks whether that model supports prompt caching.
+        Returns None (and logs a debug message) on any error.
         """
         try:
-            response = self.client.get_inference_profile(inferenceProfileIdentifier=self.config["model_id"])
+            # GetInferenceProfile is a Bedrock management API, not available on bedrock-runtime.
+            bedrock_client = self._boto_session.client(
+                service_name="bedrock",
+                region_name=self.client.meta.region_name,
+            )
+            response = bedrock_client.get_inference_profile(inferenceProfileIdentifier=self.config["model_id"])
             for model_ref in response.get("models", []):
                 model_arn = model_ref.get("modelArn", "").lower()
                 if "claude" in model_arn or "anthropic" in model_arn:

--- a/src/strands/models/model.py
+++ b/src/strands/models/model.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
+
 def _heuristic_estimate_text(text: str) -> int:
     """Estimate token count from text using characters / 4 heuristic."""
     return math.ceil(len(text) / 4)
@@ -82,7 +83,6 @@ def _count_content_block_tokens(
                     total += count_text(citation_item["text"])
 
     return total
-
 
 
 def _estimate_tokens_with_heuristic(

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2942,9 +2942,9 @@ def test_cache_strategy_application_inference_profile_claude(mock_client_method,
     assert model._cache_strategy == "anthropic"
     bedrock_client.get_inference_profile.assert_called_once_with(inferenceProfileIdentifier=profile_arn)
 
-    # Verify the management client ("bedrock") was created, not the runtime client ("bedrock-runtime")
-    service_names = [str(c) for c in mock_client_method.call_args_list]
-    assert any("'bedrock'" in s and "'bedrock-runtime'" not in s.split("'bedrock'")[0] for s in service_names)
+    # Verify the management client ("bedrock") was used, not the runtime client ("bedrock-runtime")
+    bedrock_mgmt_calls = [c for c in mock_client_method.call_args_list if c.kwargs.get("service_name") == "bedrock"]
+    assert len(bedrock_mgmt_calls) == 1
 
 
 def test_cache_strategy_application_inference_profile_non_claude(bedrock_client):

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2929,6 +2929,98 @@ def test_cache_strategy_none_for_non_claude(bedrock_client):
     assert model._cache_strategy is None
 
 
+def test_cache_strategy_application_inference_profile_claude(bedrock_client):
+    """ARN-based application inference profiles resolve to 'anthropic' when backed by a Claude model."""
+    bedrock_client.get_inference_profile.return_value = {
+        "models": [
+            {"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"}
+        ]
+    }
+    profile_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+    model = BedrockModel(model_id=profile_arn)
+
+    assert model._cache_strategy == "anthropic"
+    bedrock_client.get_inference_profile.assert_called_once_with(inferenceProfileIdentifier=profile_arn)
+
+
+def test_cache_strategy_application_inference_profile_non_claude(bedrock_client):
+    """ARN-based application inference profiles backed by non-Claude models return None."""
+    bedrock_client.get_inference_profile.return_value = {
+        "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"}]
+    }
+    profile_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+    model = BedrockModel(model_id=profile_arn)
+
+    assert model._cache_strategy is None
+
+
+def test_cache_strategy_application_inference_profile_api_error(bedrock_client):
+    """GetInferenceProfile failure is handled gracefully — returns None without raising."""
+    bedrock_client.get_inference_profile.side_effect = Exception("AccessDeniedException")
+    profile_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+    model = BedrockModel(model_id=profile_arn)
+
+    assert model._cache_strategy is None
+
+
+def test_cache_strategy_application_inference_profile_cached(bedrock_client):
+    """GetInferenceProfile is called only once per model instance, not on every _cache_strategy access."""
+    bedrock_client.get_inference_profile.return_value = {
+        "models": [
+            {"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"}
+        ]
+    }
+    profile_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+    model = BedrockModel(model_id=profile_arn)
+
+    _ = model._cache_strategy
+    _ = model._cache_strategy
+    _ = model._cache_strategy
+
+    bedrock_client.get_inference_profile.assert_called_once()
+
+
+def test_cache_strategy_application_inference_profile_invalidated_on_model_id_change(bedrock_client):
+    """Cached resolution is cleared when update_config changes the model_id."""
+    bedrock_client.get_inference_profile.return_value = {
+        "models": [
+            {"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"}
+        ]
+    }
+    profile_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+    model = BedrockModel(model_id=profile_arn)
+
+    assert model._cache_strategy == "anthropic"
+    assert bedrock_client.get_inference_profile.call_count == 1
+
+    # Switch to a different application inference profile
+    new_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/xyz999"
+    bedrock_client.get_inference_profile.return_value = {
+        "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"}]
+    }
+    model.update_config(model_id=new_arn)
+
+    assert model._cache_strategy is None
+    assert bedrock_client.get_inference_profile.call_count == 2
+
+
+def test_cache_strategy_application_inference_profile_auto_injects_cache_point(bedrock_client):
+    """End-to-end: auto strategy enables caching for messages when profile resolves to Claude."""
+    bedrock_client.get_inference_profile.return_value = {
+        "models": [
+            {"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"}
+        ]
+    }
+    profile_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+    model = BedrockModel(model_id=profile_arn, cache_config=CacheConfig(strategy="auto"))
+    messages = [{"role": "user", "content": [{"text": "hello"}]}]
+
+    result = model._format_request(messages)
+
+    last_content = result["messages"][-1]["content"]
+    assert any("cachePoint" in block for block in last_content)
+
+
 def test_inject_cache_point_adds_to_last_user(bedrock_client):
     """Test that _inject_cache_point adds cache point to last user message."""
     model = BedrockModel(

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2929,7 +2929,7 @@ def test_cache_strategy_none_for_non_claude(bedrock_client):
     assert model._cache_strategy is None
 
 
-def test_cache_strategy_application_inference_profile_claude(bedrock_client):
+def test_cache_strategy_application_inference_profile_claude(mock_client_method, bedrock_client):
     """ARN-based application inference profiles resolve to 'anthropic' when backed by a Claude model."""
     bedrock_client.get_inference_profile.return_value = {
         "models": [
@@ -2941,6 +2941,10 @@ def test_cache_strategy_application_inference_profile_claude(bedrock_client):
 
     assert model._cache_strategy == "anthropic"
     bedrock_client.get_inference_profile.assert_called_once_with(inferenceProfileIdentifier=profile_arn)
+
+    # Verify the management client ("bedrock") was created, not the runtime client ("bedrock-runtime")
+    service_names = [str(c) for c in mock_client_method.call_args_list]
+    assert any("'bedrock'" in s and "'bedrock-runtime'" not in s.split("'bedrock'")[0] for s in service_names)
 
 
 def test_cache_strategy_application_inference_profile_non_claude(bedrock_client):

--- a/tests/strands/models/test_model.py
+++ b/tests/strands/models/test_model.py
@@ -509,7 +509,6 @@ async def test_count_tokens_all_inputs(model):
     assert result == 50
 
 
-
 class TestHeuristicEstimation:
     """Tests for _estimate_tokens_with_heuristic."""
 


### PR DESCRIPTION
## Description

`CacheConfig(strategy="auto")` silently disabled caching for ARN-based application inference profiles like `arn:aws:bedrock:us-east-1:123456:application-inference-profile/abc123`. Application inference profiles use opaque resource IDs that don't contain `"claude"` or `"anthropic"`, so `_cache_strategy`'s string-match returns `None` and logs a spurious warning, even when the profile is backed by Claude Sonnet.

The fix detects the `application-inference-profile` ARN pattern and calls `GetInferenceProfile` on the Bedrock management API to find the underlying foundation model. That model ARN does contain `"anthropic"` for Claude-backed profiles, so the existing string-match works correctly from there.

Two implementation notes:

- `GetInferenceProfile` is on the `bedrock` management client, not `bedrock-runtime`. The fix stores the boto session in `__init__` so the management client can be created on demand using the same credentials and region. It requires the `bedrock:GetInferenceProfile` IAM permission; on error it falls back to `None` and logs a debug message pointing to `CacheConfig(strategy="anthropic")` as an explicit workaround.
- The resolved strategy is cached on the instance (one API call per model) and cleared by `update_config` when `model_id` changes.

`_should_include_tool_result_status` has the same string-match issue for application inference profiles. Lower impact, but I can address that in a follow-up if useful.

## Related Issues

Closes strands-agents/sdk-python#2601

## Documentation PR

No docs change needed — the public API is unchanged.

## Type of Change

Bug fix

## Testing

Six new tests in `test_bedrock.py`:

- Claude-backed profile resolves to `"anthropic"`; verifies the `bedrock` management client is used (not `bedrock-runtime`)
- Non-Claude-backed profile returns `None`
- `GetInferenceProfile` failure handled gracefully with no exception raised
- `GetInferenceProfile` called only once per instance across multiple `_cache_strategy` accesses
- Cached result cleared when `update_config` changes `model_id`
- End-to-end: `cachePoint` injected into messages when profile resolves to Claude with `strategy="auto"`

163 bedrock tests pass. Full suite: 2873 passed, 4 skipped. `hatch run prepare` clean.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published