### PR TITLE
fix(bidi): add configurable event_queue_size to prevent choppy audio

### DIFF
--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -74,6 +74,7 @@ class BidiAgent:
         state: AgentState | dict | None = None,
         session_manager: "SessionManager | None" = None,
         tool_executor: ToolExecutor | None = None,
+        event_queue_size: int = 1,
         **kwargs: Any,
     ):
         """Initialize bidirectional agent.
@@ -93,6 +94,11 @@ class BidiAgent:
             session_manager: Manager for handling agent sessions including conversation history and state.
                 If provided, enables session-based persistence and state management.
             tool_executor: Definition of tool execution strategy (e.g., sequential, concurrent, etc.).
+            event_queue_size: Maximum size of the internal event queue between the model receive loop
+                and the output handler. Higher values provide more buffer for bursty audio delivery
+                (e.g., Gemini Live) at the cost of slightly higher memory usage. Lower values apply
+                more backpressure. Default of 32 provides ~640ms of audio buffer at typical chunk rates.
+                Set to 1 for legacy behavior (may cause choppy audio with fast-delivering models).
             **kwargs: Additional configuration for future extensibility.
 
         Raises:
@@ -108,6 +114,7 @@ class BidiAgent:
 
         self.system_prompt = system_prompt
         self.messages = messages or []
+        self._event_queue_size = event_queue_size
 
         # Agent identification
         self.agent_id = _identifier.validate(agent_id or _DEFAULT_AGENT_ID, _identifier.Identifier.AGENT)

--- a/src/strands/experimental/bidi/agent/loop.py
+++ b/src/strands/experimental/bidi/agent/loop.py
@@ -49,6 +49,8 @@ class _BidiAgentLoop:
         _invocation_state: Optional context to pass to tools during execution.
             This allows passing custom data (user_id, session_id, database connections, etc.)
             that tools can access via their invocation_state parameter.
+        _event_queue_size: Maximum size of the internal event queue. Controls backpressure
+            between the model receive loop and the output handler.
         _send_gate: Gate the sending of events to the model.
             Blocks when agent is reseting the model connection after timeout.
     """
@@ -65,6 +67,7 @@ class _BidiAgentLoop:
         self._started = False
         self._task_pool = _TaskPool()
         self._event_queue: asyncio.Queue
+        self._event_queue_size = agent._event_queue_size
         self._invocation_state: dict[str, Any]
 
         self._send_gate = asyncio.Event()
@@ -94,7 +97,7 @@ class _BidiAgentLoop:
             messages=self._agent.messages,
         )
 
-        self._event_queue = asyncio.Queue(maxsize=1)
+        self._event_queue = asyncio.Queue(maxsize=self._event_queue_size)
 
         self._task_pool = _TaskPool()
         self._task_pool.create(self._run_model())


### PR DESCRIPTION
Motivation
When using BidiAgent with BidiGeminiLiveModel, audio playback is choppy and bursty. The internal event queue between the model receive loop and the output handler is hardcoded to maxsize=1. This causes the model receive loop to block whenever the output handler performs any async I/O (e.g., websocket.send_json()), resulting in audio chunks piling up on the model SDK side and arriving in bursts.

This is particularly noticeable with Gemini Live, which sends many small audio chunks rapidly (~50 chunks/sec), unlike Nova Sonic which sends fewer, larger chunks with built-in TTS buffering.

Public API Changes
BidiAgent.__init__() accepts a new event_queue_size parameter:

# Default behavior preserved (maxsize=1)
agent = BidiAgent(model=model, tools=[...])

# Opt in to larger buffer for smooth audio with fast-delivering models
agent = BidiAgent(
    model=BidiGeminiLiveModel(...),
    tools=[...],
    event_queue_size=32,  # ~640ms buffer at typical Gemini chunk rates
)
The parameter controls the asyncio.Queue maxsize between the model receive loop and the output handler. Higher values absorb I/O latency spikes without stalling the model loop.

Use Cases
Gemini Live audio streaming: Prevents choppy playback when the output handler has non-trivial async I/O latency (WebSocket, WebRTC)
Custom output handlers: Any output handler doing network I/O benefits from decoupling via a larger buffer
Tuning backpressure: Users can balance memory usage vs. smoothness for their specific model and handler combination