### PR TITLE
fix: integration test updates

### DIFF
--- a/tests_integ/models/test_model_bedrock.py
+++ b/tests_integ/models/test_model_bedrock.py
@@ -276,29 +276,6 @@ def test_structured_output_multi_modal_input(streaming_agent, yellow_img, yellow
     assert tru_color == exp_color
 
 
-def test_redacted_content_handling():
-    """Test redactedContent handling with thinking mode."""
-    bedrock_model = BedrockModel(
-        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
-        additional_request_fields={
-            "thinking": {
-                "type": "enabled",
-                "budget_tokens": 2000,
-            }
-        },
-    )
-
-    agent = Agent(name="test_redact", model=bedrock_model)
-    # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#example-working-with-redacted-thinking-blocks
-    result = agent(
-        "ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB"
-    )
-
-    assert "reasoningContent" in result.message["content"][0]
-    assert "redactedContent" in result.message["content"][0]["reasoningContent"]
-    assert isinstance(result.message["content"][0]["reasoningContent"]["redactedContent"], bytes)
-
-
 def test_reasoning_content_in_messages_with_thinking_disabled():
     """Test that messages with reasoningContent are accepted when thinking is explicitly disabled."""
     # First, get a real reasoning response with thinking enabled
@@ -489,14 +466,22 @@ def test_prompt_caching_with_ttl_in_messages():
     )
 
 
-def test_prompt_caching_backward_compatibility_no_ttl(non_streaming_model):
+def test_prompt_caching_backward_compatibility_no_ttl():
     """Test that prompt caching works without TTL (backward compatibility).
 
     Verifies that cache points work correctly when TTL is not specified,
     maintaining backward compatibility with existing code.
+
+    Uses Claude Haiku 4.5 which supports prompt caching on Bedrock.
+    Minimum 4096 tokens required for caching with Haiku 4.5.
     """
+    model = BedrockModel(
+        model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        streaming=False,
+    )
+
     unique_id = str(uuid.uuid4())
-    large_context = f"Background information for test {unique_id}: " + ("This is important context. " * 200)
+    large_context = f"Background information for test {unique_id}: " + ("This is important context. " * 1000)
 
     system_prompt_with_cache = [
         {"text": large_context},
@@ -505,7 +490,7 @@ def test_prompt_caching_backward_compatibility_no_ttl(non_streaming_model):
     ]
 
     agent = Agent(
-        model=non_streaming_model,
+        model=model,
         system_prompt=system_prompt_with_cache,
         load_tools_from_directory=False,
     )


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

#### Update integration tests
 - First test:  
 We merged this [PR](https://github.com/strands-agents/sdk-python/pull/2226) with the model update but it seems the newest model we updated to, `claude sonnet 4` doesn't support redactedContent.
 [Ref](https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-thinking-encryption.html): The following information applies specifically to Claude 3.7 Sonnet. Claude 4 models handle thinking differently and do not produce redacted thinking blocks
 - Second test:
  Increased the context to meet the minimum # tokens required to add a cache checkpoint. 
  Ref: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
