### PR TITLE
Fix reasoning parsing when streaming from AWS SageMaker AI

### DIFF
--- a/src/strands/models/sagemaker.py
+++ b/src/strands/models/sagemaker.py
@@ -372,7 +372,14 @@ class SageMakerAIModel(OpenAIModel):
                         # NOTE: Both `reasoning` and `reasoning_content` need to be handled as vLLM v0.16.0 deprecated
                         # the `reasoning_content` in favour of `reasoning`
                         # See https://github.com/vllm-project/vllm/pull/33402
-                        if any(k in choice["delta"] for k in {"reasoning_content", "reasoning"}):
+                        if any(
+                            k in choice["delta"]
+                            and choice["delta"].get(k) is not None
+                            # NOTE: Here we call `strip()` for safety, as some models will skip the reasoning
+                            # autonomously by just emitting line breaks e.g., `\n\n`
+                            and choice["delta"][k].strip() != ""
+                            for k in {"reasoning_content", "reasoning"}
+                        ):
                             if not reasoning_content_started:
                                 yield self.format_chunk(
                                     {"chunk_type": "content_start", "data_type": "reasoning_content"}

--- a/src/strands/models/sagemaker.py
+++ b/src/strands/models/sagemaker.py
@@ -369,7 +369,10 @@ class SageMakerAIModel(OpenAIModel):
                             )
 
                         # Handle reasoning content
-                        if choice["delta"].get("reasoning_content"):
+                        # NOTE: Both `reasoning` and `reasoning_content` need to be handled as vLLM v0.16.0 deprecated
+                        # the `reasoning_content` in favour of `reasoning`
+                        # See https://github.com/vllm-project/vllm/pull/33402
+                        if any(k in choice["delta"] for k in {"reasoning_content", "reasoning"}):
                             if not reasoning_content_started:
                                 yield self.format_chunk(
                                     {"chunk_type": "content_start", "data_type": "reasoning_content"}
@@ -379,7 +382,7 @@ class SageMakerAIModel(OpenAIModel):
                                 {
                                     "chunk_type": "content_delta",
                                     "data_type": "reasoning_content",
-                                    "data": choice["delta"]["reasoning_content"],
+                                    "data": choice["delta"].get("reasoning_content", choice["delta"].get("reasoning")),
                                 }
                             )
 

--- a/src/strands/models/sagemaker.py
+++ b/src/strands/models/sagemaker.py
@@ -389,7 +389,10 @@ class SageMakerAIModel(OpenAIModel):
                                 {
                                     "chunk_type": "content_delta",
                                     "data_type": "reasoning_content",
-                                    "data": choice["delta"].get("reasoning_content", choice["delta"].get("reasoning")),
+                                    # SAFETY: Here we guarantee that at least one of `reasoning` or `reasoning_content`
+                                    # is not None and a  non-empty string
+                                    "data": choice["delta"].get("reasoning_content")
+                                    or choice["delta"].get("reasoning"),
                                 }
                             )
 


### PR DESCRIPTION
## Description

As of https://github.com/vllm-project/vllm/pull/33402 released in vLLM v0.16.0, see https://github.com/vllm-project/vllm/releases/tag/v0.16.0; the `reasoning_content` field within the `delta` when streaming has been deprecated in favour of `reasoning`.

Also given that the latest AWS SageMaker AI DLC for vLLM runs with vLLM v0.20.1, see https://aws.github.io/deep-learning-containers/vllm/ and https://github.com/aws/deep-learning-containers/blob/9d519f6bca375b87422e5429803e7f2c3ca390df/docker/vllm/Dockerfile#L3, this means that the reasoning content when streaming will be ignored, whereas with this PR the content will be correctly parsed.

> [!NOTE]
> By submitting this PR, I disclose that all the code in this PR was written entirely by me, @alvarobartt, without the use of any coding assistants or third-party agentic tools.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/2182 and https://github.com/strands-agents/sdk-python/pull/2191, though both of those wrongly claim that the issue is with vLLM v0.19.1 whereas https://github.com/vllm-project/vllm/releases/tag/v0.16.0 says v0.16.0 onwards.

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.