### PR TITLE
perf: replace deepcopy with shallow copy in graph/swarm state management

### DIFF
--- a/src/strands/multiagent/graph.py
+++ b/src/strands/multiagent/graph.py
@@ -15,7 +15,6 @@ Key Features:
 """
 
 import asyncio
-import copy
 import logging
 import time
 from collections.abc import AsyncIterator, Callable, Mapping
@@ -54,6 +53,30 @@ from ..types.multiagent import MultiAgentInput
 from ..types.session import decode_bytes_values, encode_bytes_values
 from ..types.traces import AttributeValue
 from .base import MultiAgentBase, MultiAgentResult, NodeResult, Status
+
+
+def _copy_messages(messages: list) -> list:
+    """Shallow-copy message list and each message dict.
+
+    This is sufficient because the executor only appends new messages
+    and replaces content blocks — it does not mutate existing message
+    dicts in-place. ~67x faster than copy.deepcopy for typical
+    conversation sizes (20 messages with tool specs).
+    """
+    return [msg.copy() for msg in messages]
+
+
+def _copy_model_state(state: dict) -> dict:
+    """Shallow-copy model state dict.
+
+    Model state contains scalar values and a tools list that is
+    replaced, not mutated in-place. ~70x faster than copy.deepcopy.
+    """
+    new = state.copy()
+    if "tools" in new:
+        new["tools"] = state["tools"].copy()
+    return new
+
 
 logger = logging.getLogger(__name__)
 
@@ -176,13 +199,13 @@ class GraphNode:
         """Capture initial executor state after initialization."""
         # Deep copy the initial messages and state to preserve them
         if hasattr(self.executor, "messages"):
-            self._initial_messages = copy.deepcopy(self.executor.messages)
+            self._initial_messages = _copy_messages(self.executor.messages)
 
         if hasattr(self.executor, "state") and hasattr(self.executor.state, "get"):
             self._initial_state = AgentState(self.executor.state.get())
 
         if hasattr(self.executor, "_model_state"):
-            self._initial_model_state = copy.deepcopy(self.executor._model_state)
+            self._initial_model_state = _copy_model_state(self.executor._model_state)
 
     def reset_executor_state(self) -> None:
         """Reset GraphNode executor state to initial state when graph was created.
@@ -191,13 +214,13 @@ class GraphNode:
         fresh on each execution, providing stateless behavior.
         """
         if hasattr(self.executor, "messages"):
-            self.executor.messages = copy.deepcopy(self._initial_messages)
+            self.executor.messages = _copy_messages(self._initial_messages)
 
         if hasattr(self.executor, "state"):
             self.executor.state = AgentState(self._initial_state.get())
 
         if hasattr(self.executor, "_model_state"):
-            self.executor._model_state = copy.deepcopy(self._initial_model_state)
+            self.executor._model_state = _copy_model_state(self._initial_model_state)
 
         # Reset execution status
         self.execution_status = Status.PENDING

--- a/src/strands/multiagent/swarm.py
+++ b/src/strands/multiagent/swarm.py
@@ -14,7 +14,6 @@ Key Features:
 """
 
 import asyncio
-import copy
 import json
 import logging
 import time
@@ -54,6 +53,7 @@ from ..types.multiagent import MultiAgentInput
 from ..types.session import decode_bytes_values, encode_bytes_values
 from ..types.traces import AttributeValue
 from .base import MultiAgentBase, MultiAgentResult, NodeResult, Status
+from .graph import _copy_messages, _copy_model_state
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +74,9 @@ class SwarmNode:
     def __post_init__(self) -> None:
         """Capture initial executor state after initialization."""
         # Deep copy the initial messages and state to preserve them
-        self._initial_messages = copy.deepcopy(self.executor.messages)
+        self._initial_messages = _copy_messages(self.executor.messages)
         self._initial_state = AgentState(self.executor.state.get())
-        self._initial_model_state = copy.deepcopy(self.executor._model_state)
+        self._initial_model_state = _copy_model_state(self.executor._model_state)
 
     def __hash__(self) -> int:
         """Return hash for SwarmNode based on node_id."""
@@ -109,9 +109,9 @@ class SwarmNode:
             self.executor._model_state = context.get("model_state", {})
             return
 
-        self.executor.messages = copy.deepcopy(self._initial_messages)
+        self.executor.messages = _copy_messages(self._initial_messages)
         self.executor.state = AgentState(self._initial_state.get())
-        self.executor._model_state = copy.deepcopy(self._initial_model_state)
+        self.executor._model_state = _copy_model_state(self._initial_model_state)
 
 
 @dataclass

--- a/tests/strands/multiagent/test_graph.py
+++ b/tests/strands/multiagent/test_graph.py
@@ -2478,3 +2478,53 @@ def test_find_newly_ready_nodes_only_evaluates_outbound_edges():
     ready = graph._find_newly_ready_nodes([node_d])
     ready_ids = {n.node_id for n in ready}
     assert ready_ids == {"E"}, f"Expected only E, got {ready_ids}"
+
+
+@pytest.mark.asyncio
+async def test_copy_messages_isolation():
+    """Test that _copy_messages produces an isolated copy.
+
+    The shallow copy must ensure that appending to the copy does not
+    affect the original, and that replacing values in copied message
+    dicts does not affect the original.
+    """
+    from strands.multiagent.graph import _copy_messages
+
+    original_messages = [
+        {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "Hi"}]},
+    ]
+
+    copied = _copy_messages(original_messages)
+
+    # Appending to copy should not affect original
+    copied.append({"role": "user", "content": [{"type": "text", "text": "New"}]})
+    assert len(original_messages) == 2
+    assert len(copied) == 3
+
+    # Replacing a value in a copied message dict should not affect original
+    copied[0]["role"] = "system"
+    assert original_messages[0]["role"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_copy_model_state_isolation():
+    """Test that _copy_model_state produces an isolated copy."""
+    from strands.multiagent.graph import _copy_model_state
+
+    original_state = {
+        "temperature": 0.7,
+        "max_tokens": 4096,
+        "tools": [{"name": "tool_1"}, {"name": "tool_2"}],
+    }
+
+    copied = _copy_model_state(original_state)
+
+    # Modifying scalar in copy should not affect original
+    copied["temperature"] = 0.9
+    assert original_state["temperature"] == 0.7
+
+    # Appending to tools in copy should not affect original
+    copied["tools"].append({"name": "tool_3"})
+    assert len(original_state["tools"]) == 2
+    assert len(copied["tools"]) == 3


### PR DESCRIPTION
Closes #2275

## Summary

Replace `copy.deepcopy()` with targeted shallow copies in `GraphNode` and `SwarmNode` state save/restore.

## Motivation

`deepcopy` on a typical conversation (20 messages, 10 tools) costs 0.218ms per call. In a 5-node graph that's 1.1ms of pure copy overhead. See #2275 for full benchmark.

## Changes

- Added `_copy_messages()` helper: `[msg.copy() for msg in messages]` (~67x faster)
- Added `_copy_model_state()` helper: shallow dict copy + tools list copy (~70x faster)
- Replaced 8 `copy.deepcopy()` calls across `graph.py` and `swarm.py`
- Added 2 tests verifying copy isolation (append safety + mutation safety)

## Safety

Safe because the executor only:
1. Appends new messages (`agent.py:1123`) — never mutates existing message dicts
2. Replaces model state values — never mutates nested tool specs

## Testing

- `hatch fmt --formatter` ✓
- `hatch fmt --linter` ✓ (ruff + mypy pass)
- New tests: `test_copy_messages_isolation`, `test_copy_model_state_isolation`