### PR TITLE
fix: swarm bug "Failed to detach context" with opentelemetry

### DIFF
--- a/src/strands/multiagent/swarm.py
+++ b/src/strands/multiagent/swarm.py
@@ -450,9 +450,12 @@ class Swarm(MultiAgentBase):
             except asyncio.TimeoutError as err:
                 raise Exception(timeout_message) from err
         else:
-            start_time = asyncio.get_event_loop().time()
+            # Python 3.10 fallback: timeout is only checked between yielded events.
+            # A generator that hangs mid-await won't be interrupted until the next event.
+            # Remove once Python 3.10 support is dropped (Oct 2026).
+            start_time = asyncio.get_running_loop().time()
             async for event in async_generator:
-                elapsed = asyncio.get_event_loop().time() - start_time
+                elapsed = asyncio.get_running_loop().time() - start_time
                 if elapsed > timeout:
                     raise Exception(timeout_message)
                 yield event

--- a/src/strands/multiagent/swarm.py
+++ b/src/strands/multiagent/swarm.py
@@ -17,6 +17,7 @@ import asyncio
 import copy
 import json
 import logging
+import sys
 import time
 from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass, field
@@ -439,28 +440,22 @@ class Swarm(MultiAgentBase):
             Exception: If total execution time exceeds timeout
         """
         if timeout is None:
-            # No timeout - just pass through
             async for event in async_generator:
                 yield event
+        elif sys.version_info >= (3, 11):
+            try:
+                async with asyncio.timeout(timeout):
+                    async for event in async_generator:
+                        yield event
+            except asyncio.TimeoutError as err:
+                raise Exception(timeout_message) from err
         else:
-            # Track start time for total timeout
             start_time = asyncio.get_event_loop().time()
-
-            while True:
-                # Calculate remaining time from total timeout budget
+            async for event in async_generator:
                 elapsed = asyncio.get_event_loop().time() - start_time
-                remaining = timeout - elapsed
-
-                if remaining <= 0:
+                if elapsed > timeout:
                     raise Exception(timeout_message)
-
-                try:
-                    event = await asyncio.wait_for(async_generator.__anext__(), timeout=remaining)
-                    yield event
-                except StopAsyncIteration:
-                    break
-                except asyncio.TimeoutError as err:
-                    raise Exception(timeout_message) from err
+                yield event
 
     def _setup_swarm(self, nodes: list[Agent]) -> None:
         """Initialize swarm configuration."""


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

When using the Swarm multiagent pattern with OpenTelemetry tracing enabled, users encounter repeated "Failed to detach context" errors with ValueError: <Token> was created in a different Context. This happens because _stream_with_timeout uses asyncio.wait_for() to wrap each __anext__() call on the async generator. Each wait_for invocation creates a new asyncio.Task with a copied contextvars.Context, so OTEL span tokens attached in one iteration's context cannot be detached in a subsequent iteration's different context.   

Note:
On Python 3.10 only, a node that hangs indefinitely mid-await (e.g., unresponsive model API that never returns) will not be          interrupted until the next event arrives. This is an unavoidable limitation of Python 3.10's async APIs and affects an edge case on a version approaching EOL (Oct 2026). Python 3.11+ retains full mid-await cancellation semantics via asyncio.timeout().

## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/1316

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
