### PR TITLE
fix: pin mistralai to GitHub in dev envs while PyPI is quarantined

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,8 @@ dependencies = [
   "ruff>=0.13.0,<0.15.0",
   # Include required package dependencies for mypy
   "strands-agents @ {root:uri}",
+  # Pin mistralai to GitHub while PyPI package is quarantined
+  "mistralai @ git+https://github.com/mistralai/client-python.git@v1.12.4",
 ]
 python = "3.10"
 
@@ -155,6 +157,8 @@ dependencies = [
     "pytest-xdist>=3.0.0,<4.0.0",
     "pytest-timeout>=2.0.0,<3.0.0",
     "moto>=5.1.0,<6.0.0",
+    # Pin mistralai to GitHub while PyPI package is quarantined
+    "mistralai @ git+https://github.com/mistralai/client-python.git@v1.12.4",
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
@@ -175,6 +179,8 @@ dependencies = [
     "commitizen>=4.4.0,<5.0.0",
     "hatch>=1.0.0,<2.0.0",
     "pre-commit>=3.2.0,<4.7.0",
+    # Pin mistralai to GitHub while PyPI package is quarantined
+    "mistralai @ git+https://github.com/mistralai/client-python.git@v1.12.4",
 ]
 
 


### PR DESCRIPTION
## Description

The `mistralai` package on PyPI is currently quarantined due to a supply chain compromise in v2.4.6 ([mistralai/client-python#523](https://github.com/mistralai/client-python/issues/523)). This blocks all CI/CD pipelines because hatch environments with `features = ["all"]` cannot resolve `mistralai` from PyPI.

This PR adds a direct GitHub reference (`mistralai @ git+https://github.com/mistralai/client-python.git@v1.12.4`) to the `dependencies` of the three hatch environments used in development and CI:

- `hatch-static-analysis` (linting)
- `hatch-test` (unit/integration tests)
- `default` (local dev shell)

When uv resolves dependencies, the direct URL takes priority and satisfies the `mistralai>=1.8.2,<2.0.0` constraint from the `mistral` extra without querying PyPI. The public `[project.optional-dependencies]` are unchanged, so end users running `pip install strands-agents[mistral]` are not affected by this change.

This is a temporary measure. Once PyPI lifts the quarantine, the GitHub pins should be removed.

## Related Issues

Fixes #2288

## Type of Change

Bug fix

## Testing

CI pipelines should now pass since `mistralai` is resolved from GitHub rather than the quarantined PyPI package.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.