### PR TITLE
fix(anthropic): map webp images explicitly

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
-IMAGE_MEDIA_TYPES = {
+_IMAGE_MEDIA_TYPES = {
     "gif": "image/gif",
     "jpeg": "image/jpeg",
     "jpg": "image/jpeg",
@@ -143,7 +143,7 @@ class AnthropicModel(Model):
             return {
                 "source": {
                     "data": base64.b64encode(content["image"]["source"]["bytes"]).decode("utf-8"),
-                    "media_type": IMAGE_MEDIA_TYPES.get(
+                    "media_type": _IMAGE_MEDIA_TYPES.get(
                         image_format,
                         mimetypes.types_map.get(f".{image_format}", "application/octet-stream"),
                     ),

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -28,6 +28,14 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
+IMAGE_MEDIA_TYPES = {
+    "gif": "image/gif",
+    "jpeg": "image/jpeg",
+    "jpg": "image/jpeg",
+    "png": "image/png",
+    "webp": "image/webp",
+}
+
 
 class AnthropicModel(Model):
     """Anthropic model provider implementation."""
@@ -131,10 +139,14 @@ class AnthropicModel(Model):
             }
 
         if "image" in content:
+            image_format = content["image"]["format"]
             return {
                 "source": {
                     "data": base64.b64encode(content["image"]["source"]["bytes"]).decode("utf-8"),
-                    "media_type": mimetypes.types_map.get(f".{content['image']['format']}", "application/octet-stream"),
+                    "media_type": IMAGE_MEDIA_TYPES.get(
+                        image_format,
+                        mimetypes.types_map.get(f".{image_format}", "application/octet-stream"),
+                    ),
                     "type": "base64",
                 },
                 "type": "image",

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1,4 +1,5 @@
 import logging
+import mimetypes
 import unittest.mock
 import warnings
 
@@ -252,6 +253,21 @@ def test_format_request_with_image(model, model_id, max_tokens):
     }
 
     assert tru_request == exp_request
+
+
+def test_format_request_with_webp_image_does_not_depend_on_mimetypes(model, model_id, max_tokens, monkeypatch):
+    monkeypatch.delitem(mimetypes.types_map, ".webp", raising=False)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [{"image": {"format": "webp", "source": {"bytes": b"webpimage"}}}],
+        },
+    ]
+
+    tru_request = model.format_request(messages)
+
+    assert tru_request["messages"][0]["content"][0]["source"]["media_type"] == "image/webp"
 
 
 def test_format_request_with_reasoning(model, model_id, max_tokens):


### PR DESCRIPTION
Fixes the Anthropic WebP part of #2204.

The Anthropic formatter was relying on `mimetypes.types_map` for image media types. That map is platform/Python-install dependent, so `.webp` can fall back to `application/octet-stream` even though Strands already accepts `webp` as an image format.

This keeps a small explicit map for the Anthropic image formats Strands supports and falls back to `mimetypes` only for unknown formats.

Validation:
- `python -m pip install -e ".[anthropic]"`
- `python -m pytest tests/strands/models/test_anthropic.py -q`
- `python -m ruff check src/strands/models/anthropic.py tests/strands/models/test_anthropic.py`
- `python -m ruff format --check src/strands/models/anthropic.py tests/strands/models/test_anthropic.py`
- `git diff --check`
