### PR TITLE
fix(bedrock): normalize 3gp video format

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -43,6 +43,12 @@ DEFAULT_BEDROCK_MODEL_ID = "global.anthropic.claude-sonnet-4-6"
 _DEFAULT_BEDROCK_MODEL_ID = "{}.anthropic.claude-sonnet-4-6"
 DEFAULT_BEDROCK_REGION = "us-west-2"
 
+_BEDROCK_VIDEO_FORMAT_ALIASES = {
+    "3gp": "three_gp",
+    "3g2": "three_gp",
+    "3gpp": "three_gp",
+}
+
 BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
     "Input is too long for requested model",
     "input length and `max_tokens` exceed context limit",
@@ -702,7 +708,8 @@ class BedrockModel(Model):
                     return None
             elif "bytes" in source:
                 formatted_video_source = {"bytes": source["bytes"]}
-            result = {"format": video["format"], "source": formatted_video_source}
+            video_format = _BEDROCK_VIDEO_FORMAT_ALIASES.get(video["format"], video["format"])
+            result = {"format": video_format, "source": formatted_video_source}
             return {"video": result}
 
         # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CitationsContentBlock.html

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -2254,6 +2254,28 @@ def test_format_request_video_s3_location(model, model_id):
     assert video_source == {"s3Location": {"uri": "s3://my-bucket/video.mp4"}}
 
 
+@pytest.mark.parametrize("video_format", ["3gp", "3g2", "3gpp"])
+def test_format_request_maps_3gp_video_formats(model, model_id, video_format):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "video": {
+                        "format": video_format,
+                        "source": {"bytes": b"video_data"},
+                    }
+                },
+            ],
+        }
+    ]
+
+    formatted_request = model._format_request(messages)
+
+    video_block = formatted_request["messages"][0]["content"][0]["video"]
+    assert video_block == {"format": "three_gp", "source": {"bytes": b"video_data"}}
+
+
 def test_format_request_filters_document_content_blocks(model, model_id):
     """Test that format_request filters extra fields from document content blocks."""
     messages = [


### PR DESCRIPTION
## Summary

Fixes the Bedrock 3GP part of #2204.

Bedrock expects the video format enum to be `three_gp`, while common MIME/extension paths produce `3gp`, `3gpp`, or `3g2`. The SDK currently forwards the value as-is, so a valid 3GP video content block can be rejected by the Bedrock Converse API.

This normalizes those aliases when formatting Bedrock video content blocks. Other media-format gaps from #2204 are left out of this PR.

## To verify

Ran locally:

```bash
python -m pytest tests/strands/models/test_bedrock.py::test_format_request_maps_3gp_video_formats -q
python -m pytest tests/strands/models/test_bedrock.py -q
python -m ruff check src/strands/models/bedrock.py tests/strands/models/test_bedrock.py
python -m py_compile src/strands/models/bedrock.py tests/strands/models/test_bedrock.py
git diff --check
```
