### PR TITLE
fix(tests): add use_native_token_count=True when expected

### DIFF
--- a/tests_integ/models/test_model_bedrock.py
+++ b/tests_integ/models/test_model_bedrock.py
@@ -516,7 +516,7 @@ def test_prompt_caching_backward_compatibility_no_ttl():
 class TestCountTokens:
     @pytest.fixture
     def model(self):
-        return BedrockModel(model_id="anthropic.claude-sonnet-4-20250514-v1:0")
+        return BedrockModel(model_id="anthropic.claude-sonnet-4-20250514-v1:0", use_native_token_count=True)
 
     @pytest.fixture
     def messages(self):

--- a/tests_integ/models/test_model_gemini.py
+++ b/tests_integ/models/test_model_gemini.py
@@ -227,6 +227,7 @@ class TestCountTokens:
         return GeminiModel(
             model_id="gemini-2.0-flash",
             client_args={"api_key": os.environ["GOOGLE_API_KEY"]},
+            use_native_token_count=True,
         )
 
     @pytest.fixture

--- a/tests_integ/models/test_model_openai.py
+++ b/tests_integ/models/test_model_openai.py
@@ -408,6 +408,7 @@ class TestOpenAIResponsesCountTokens:
         return OpenAIResponsesModel(
             model_id="gpt-4o",
             client_args={"api_key": os.environ["OPENAI_API_KEY"]},
+            use_native_token_count=True,
         )
 
     @pytest.fixture


### PR DESCRIPTION
## Description

Fix `test_count_tokens_messages_only` integration tests failing across Bedrock, Gemini, and OpenAI model test suites. The tests assert that `"native token count"` appears in `caplog.text`, but caplog was empty because the model fixtures were constructed without `use_native_token_count=True`. Without this flag, `count_tokens()` early-returns via the heuristic base class path, which never emits the expected debug log.

Added `use_native_token_count=True` to the model fixtures in all three test classes so the native token counting code path is actually exercised.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug fix

## Testing

The fix ensures the test fixtures match the code path the tests are designed to validate. These are integration tests requiring API credentials (AWS, Google, OpenAI) to run end-to-end.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.