### PR TITLE
fix(tests): fix flaky tests to accept string or number

### DIFF
--- a/tests_integ/models/test_model_mantle.py
+++ b/tests_integ/models/test_model_mantle.py
@@ -40,13 +40,13 @@ def test_chat_completions_agent_invoke(chat_completions_model):
     """OpenAIModel (Chat Completions) reaches Mantle via bedrock_mantle_config."""
     agent = Agent(model=chat_completions_model, system_prompt="Reply in one short sentence.", callback_handler=None)
     result = agent("What is 2+2?")
-    assert "4" in str(result)
+    assert "4" in str(result) or "four" in str(result).lower()
 
 
 def test_agent_invoke(model):
     agent = Agent(model=model, system_prompt="Reply in one short sentence.", callback_handler=None)
     result = agent("What is 2+2?")
-    assert "4" in str(result)
+    assert "4" in str(result) or "four" in str(result).lower()
 
 
 def test_responses_server_side_conversation(stateful_model):


### PR DESCRIPTION
## Description

Fix flaky assertion in `test_chat_completions_agent_invoke` — the model sometimes responds with the word "four" instead of the digit "4" when asked "What is 2+2?". The assertion now accepts either form.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.