### PR TITLE
fix: preserve concurrent tool result order

### DIFF
--- a/strands-py/src/strands/tools/executors/concurrent.py
+++ b/strands-py/src/strands/tools/executors/concurrent.py
@@ -49,6 +49,7 @@ class ConcurrentToolExecutor(ToolExecutor):
         stop_event = object()
 
         tasks = []
+        ordered_tool_results: list[list[ToolResult]] = [[] for _ in tool_uses]
         try:
             for task_id, tool_use in enumerate(tool_uses):
                 tasks.append(
@@ -56,7 +57,7 @@ class ConcurrentToolExecutor(ToolExecutor):
                         self._task(
                             agent,
                             tool_use,
-                            tool_results,
+                            ordered_tool_results[task_id],
                             cycle_trace,
                             cycle_span,
                             invocation_state,
@@ -81,6 +82,9 @@ class ConcurrentToolExecutor(ToolExecutor):
 
                 yield event
                 task_events[task_id].set()
+
+            for task_results in ordered_tool_results:
+                tool_results.extend(task_results)
         finally:
             for task in tasks:
                 task.cancel()

--- a/strands-py/tests/strands/tools/executors/test_concurrent.py
+++ b/strands-py/tests/strands/tools/executors/test_concurrent.py
@@ -1,5 +1,8 @@
+import asyncio
+
 import pytest
 
+import strands
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
 from strands.interrupt import Interrupt
 from strands.tools.executors import ConcurrentToolExecutor
@@ -39,6 +42,35 @@ async def test_concurrent_executor_execute(
     tru_results = sorted(tool_results, key=lambda result: result.get("toolUseId"))
     exp_results = [exp_events[0].tool_result, exp_events[1].tool_result]
     assert tru_results == exp_results
+
+
+@pytest.mark.asyncio
+async def test_concurrent_executor_keeps_tool_result_order(
+    executor, agent, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context, alist
+):
+    @strands.tool(name="slow_order_tool")
+    async def slow_order_tool():
+        await asyncio.sleep(0.05)
+        return "slow"
+
+    @strands.tool(name="fast_order_tool")
+    async def fast_order_tool():
+        return "fast"
+
+    agent.tool_registry.register_tool(slow_order_tool)
+    agent.tool_registry.register_tool(fast_order_tool)
+
+    tool_uses = [
+        {"name": "slow_order_tool", "toolUseId": "slow-id", "input": {}},
+        {"name": "fast_order_tool", "toolUseId": "fast-id", "input": {}},
+    ]
+    stream = executor._execute(
+        agent, tool_uses, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context
+    )
+
+    await alist(stream)
+
+    assert [result["toolUseId"] for result in tool_results] == ["slow-id", "fast-id"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿## Description
ConcurrentToolExecutor used to append results into the shared `tool_results` list as each async task completed. That made prompt-cache breakpoint order depend on tool runtime instead of the original `toolUse` order.

This keeps each task's results local while the concurrent queue runs, then merges them back in the original tool-use order after the queue drains. Event streaming still happens as tasks finish; only the final `tool_results` ordering changes.

## Related Issues

Fixes #2112

## Documentation PR

No documentation PR. This is a bug fix for existing executor behavior.

## Type of Change

Bug fix

## Testing

- `uv run --extra dev pytest tests/strands/tools/executors/test_concurrent.py -q`
- `uv run --extra dev pytest tests/strands/tools/executors -q`
- `uv run --extra dev ruff format --check src/strands/tools/executors/concurrent.py tests/strands/tools/executors/test_concurrent.py`
- `uv run --extra dev ruff check src/strands/tools/executors/concurrent.py tests/strands/tools/executors/test_concurrent.py`
- `git diff --check`

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly, or no documentation change is needed
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published, or no dependent changes are needed

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
