### PR TITLE
feat(bidi/openai): support image input via BidiImageInputEvent

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/openai_realtime.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai_realtime.py
@@ -24,6 +24,7 @@ from ..types.events import (
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
     BidiConnectionStartEvent,
+    BidiImageInputEvent,
     BidiInputEvent,
     BidiInterruptionEvent,
     BidiOutputEvent,
@@ -712,7 +713,7 @@ class BidiOpenAIRealtimeModel(BidiModel):
             content: Typed event (BidiTextInputEvent, BidiAudioInputEvent, BidiImageInputEvent, or ToolResultEvent).
 
         Raises:
-            ValueError: If content type not supported (e.g., image content).
+            ValueError: If content type not supported.
         """
         if not self._connection_id:
             raise RuntimeError("model not started | call start before sending")
@@ -722,6 +723,8 @@ class BidiOpenAIRealtimeModel(BidiModel):
             await self._send_text_content(content.text)
         elif isinstance(content, BidiAudioInputEvent):
             await self._send_audio_content(content)
+        elif isinstance(content, BidiImageInputEvent):
+            await self._send_image_content(content)
         elif isinstance(content, ToolResultEvent):
             tool_result = content.get("tool_result")
             if tool_result:
@@ -733,6 +736,22 @@ class BidiOpenAIRealtimeModel(BidiModel):
         """Internal: Send audio content to OpenAI for processing."""
         # Audio is already base64 encoded in the event
         await self._send_event({"type": "input_audio_buffer.append", "audio": audio_input.audio})
+
+    async def _send_image_content(self, image_input: BidiImageInputEvent) -> None:
+        """Internal: Send image content to OpenAI for processing.
+
+        Sends the image as an ``input_image`` content block on a user message via
+        ``conversation.item.create``. Image data is encoded as a ``data:`` URL using
+        the event's MIME type and base64 payload, matching the format documented for
+        OpenAI's Realtime API image input on ``gpt-realtime`` models.
+        """
+        data_url = f"data:{image_input.mime_type};base64,{image_input.image}"
+        item_data = {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_image", "image_url": data_url}],
+        }
+        await self._send_event({"type": "conversation.item.create", "item": item_data})
 
     async def _send_text_content(self, text: str) -> None:
         """Internal: Send text content to OpenAI for processing."""

--- a/strands-py/tests/strands/experimental/bidi/models/test_openai_realtime.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_openai_realtime.py
@@ -478,15 +478,28 @@ async def test_send_edge_cases(mock_websockets_connect, model):
         await model.send(text_input)
     mock_ws.send.assert_not_called()
 
-    # Test image input (not supported, base64 encoded, no encoding parameter)
+    # Test image input (sent as input_image content block on user message)
     await model.start()
+    mock_ws.send.reset_mock()
     image_b64 = base64.b64encode(b"image_bytes").decode("utf-8")
     image_input = BidiImageInputEvent(
         image=image_b64,
         mime_type="image/jpeg",
     )
-    with pytest.raises(ValueError, match=r"content not supported"):
-        await model.send(image_input)
+    await model.send(image_input)
+
+    # Verify exactly one event was sent: a conversation.item.create with input_image
+    image_calls = [json.loads(call[0][0]) for call in mock_ws.send.call_args_list]
+    image_creates = [m for m in image_calls if m.get("type") == "conversation.item.create"]
+    assert len(image_creates) == 1, "expected exactly one conversation.item.create for image"
+    image_item = image_creates[0].get("item", {})
+    assert image_item.get("type") == "message"
+    assert image_item.get("role") == "user"
+    assert image_item.get("content") == [
+        {"type": "input_image", "image_url": f"data:image/jpeg;base64,{image_b64}"}
+    ]
+    # Image input must NOT auto-trigger a response — caller decides when to commit.
+    assert not any(m.get("type") == "response.create" for m in image_calls)
 
     await model.stop()
 


### PR DESCRIPTION
## Summary

Adds image-input support to `BidiOpenAIRealtimeModel`, bringing it to parity with `BidiGeminiLiveModel` which already handles `BidiImageInputEvent`.

Previously, sending a `BidiImageInputEvent` to the OpenAI realtime model raised `ValueError: content not supported`. OpenAI's Realtime API on `gpt-realtime` models *does* accept image inputs as `input_image` content blocks on `conversation.item.create` - this PR wires that up.

## Motivation

We're building voice agents where the user says *"look at me"* / *"what's on my whiteboard?"* and we want to inject a captured camera frame straight into the realtime model's multimodal context, then let it reply in audio.

Gemini Live works out of the box. For OpenAI we had to monkeypatch `BidiOpenAIRealtimeModel.send()` from outside the SDK - this PR upstreams the fix.

## Changes

**`src/strands/experimental/bidi/models/openai_realtime.py`**
- Import `BidiImageInputEvent`.
- Dispatch it in `send()` to a new `_send_image_content()` method.
- `_send_image_content()` encodes the image as a `data:` URL (`data:<mime>;base64,<b64>`) and emits a single `conversation.item.create` event with `role=user` and an `input_image` content block.
- Does **not** auto-trigger `response.create` — caller decides when to commit (mirrors the audio/buffered semantics rather than text/auto-reply, which matches typical streaming-vision use cases where you send N frames then a follow-up text/audio prompt).

**`tests/strands/experimental/bidi/models/test_openai_realtime.py`**
- The existing case that asserted `BidiImageInputEvent` raises `ValueError` is replaced with one that verifies the new wire format and that no implicit `response.create` is sent.

## Wire format

```json
{
  "type": "conversation.item.create",
  "item": {
    "type": "message",
    "role": "user",
    "content": [
      {
        "type": "input_image",
        "image_url": "data:image/jpeg;base64,<...>"
      }
    ]
  }
}
```

This matches OpenAI's documented format for image inputs on `gpt-realtime`.

## Tests

```
hatch fmt --formatter
hatch fmt --linter           # All checks passed!
hatch test tests/strands/experimental/bidi/models/test_openai_realtime.py
# 27 passed in 5.21s
```

The broader `tests/strands/experimental/bidi/` suite passes except for unrelated pre-existing failures from optional deps (`aws_sdk_bedrock_runtime` for Nova Sonic, `pyaudio` for audio I/O) — none touched by this change.

## Tenets alignment

- **Composability**: matches Gemini Live's behavior, same event type, same shape.
- **The obvious path is the happy path**: `agent.send(BidiImageInputEvent(...))` Just Works on OpenAI now.
- **Embrace common standards**: uses OpenAI's own documented `input_image` block + `data:` URL.

## Checklist

- [x] Code follows existing patterns (mirrors `_send_audio_content` / `_send_text_content`).
- [x] Formatter (`hatch fmt --formatter`) clean.
- [x] Linter + mypy (`hatch fmt --linter`) clean.
- [x] Unit tests updated and passing.
- [x] No public API changes other than removing the previous `ValueError`.
