### PR TITLE
fix: keep concurrent tool results in request order

### DIFF
--- a/strands-py/src/strands/tools/executors/concurrent.py
+++ b/strands-py/src/strands/tools/executors/concurrent.py
@@ -46,6 +46,7 @@ class ConcurrentToolExecutor(ToolExecutor):
         """
         task_queue: asyncio.Queue[tuple[int, Any]] = asyncio.Queue()
         task_events = [asyncio.Event() for _ in tool_uses]
+        task_results: list[list[ToolResult]] = [[] for _ in tool_uses]
         stop_event = object()
 
         tasks = []
@@ -56,7 +57,7 @@ class ConcurrentToolExecutor(ToolExecutor):
                         self._task(
                             agent,
                             tool_use,
-                            tool_results,
+                            task_results[task_id],
                             cycle_trace,
                             cycle_span,
                             invocation_state,
@@ -81,6 +82,8 @@ class ConcurrentToolExecutor(ToolExecutor):
 
                 yield event
                 task_events[task_id].set()
+            for results in task_results:
+                tool_results.extend(results)
         finally:
             for task in tasks:
                 task.cancel()

--- a/strands-py/tests/strands/tools/executors/test_concurrent.py
+++ b/strands-py/tests/strands/tools/executors/test_concurrent.py
@@ -1,5 +1,8 @@
+import asyncio
+
 import pytest
 
+import strands
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
 from strands.interrupt import Interrupt
 from strands.tools.executors import ConcurrentToolExecutor
@@ -39,6 +42,35 @@ async def test_concurrent_executor_execute(
     tru_results = sorted(tool_results, key=lambda result: result.get("toolUseId"))
     exp_results = [exp_events[0].tool_result, exp_events[1].tool_result]
     assert tru_results == exp_results
+
+
+@pytest.mark.asyncio
+async def test_concurrent_executor_preserves_tool_use_result_order(
+    executor, agent, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context, alist
+):
+    @strands.tool(name="slow_order_tool")
+    async def slow_order_tool():
+        await asyncio.sleep(0.05)
+        return "slow"
+
+    @strands.tool(name="fast_order_tool")
+    async def fast_order_tool():
+        return "fast"
+
+    agent.tool_registry.register_tool(slow_order_tool)
+    agent.tool_registry.register_tool(fast_order_tool)
+
+    tool_uses = [
+        {"name": "slow_order_tool", "toolUseId": "slow", "input": {}},
+        {"name": "fast_order_tool", "toolUseId": "fast", "input": {}},
+    ]
+    stream = executor._execute(
+        agent, tool_uses, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context
+    )
+
+    await alist(stream)
+
+    assert [result["toolUseId"] for result in tool_results] == ["slow", "fast"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿## Motivation

ConcurrentToolExecutor currently passes the same `tool_results` list into every running task. Each task appends when it finishes, so the follow-up `toolResult` message is ordered by scheduler completion instead of by the model's original `toolUse` order.

That makes prompts unstable for parallel tool calls: a fast second tool can appear before a slow first tool, breaking prompt-cache and replay determinism.

Closes #2112.

## Changes

- Give each concurrent task its own result list.
- Merge those per-task results back into the shared `tool_results` list in `tool_uses` order after all tasks finish.
- Add a regression test where the first tool intentionally finishes after the second tool, but `tool_results` still follows request order.

## Testing

- `.\.venv\Scripts\python.exe -m pytest tests\strands\tools\executors\test_concurrent.py -q`
- `.\.venv\Scripts\python.exe -m ruff check src\strands\tools\executors\concurrent.py tests\strands\tools\executors\test_concurrent.py`
- `.\.venv\Scripts\python.exe -m ruff format --check src\strands\tools\executors\concurrent.py tests\strands\tools\executors\test_concurrent.py`
- `.\.venv\Scripts\python.exe -m mypy src\strands\tools\executors\concurrent.py`
- `.\.venv\Scripts\python.exe -m py_compile src\strands\tools\executors\concurrent.py tests\strands\tools\executors\test_concurrent.py`
- `git diff --check`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
