### PR TITLE
fix: forward OpenAI Responses parse params

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -488,10 +488,13 @@ class OpenAIResponsesModel(Model):
         """
         async with openai.AsyncOpenAI(**self._resolve_client_args()) as client:
             try:
+                request = self._format_request(prompt, system_prompt=system_prompt)
+                parse_kwargs = {key: value for key, value in request.items() if key not in {"model", "input", "stream"}}
                 response = await client.responses.parse(
                     model=self.get_config()["model_id"],
-                    input=self._format_request(prompt, system_prompt=system_prompt)["input"],
+                    input=request["input"],
                     text_format=output_model,
+                    **parse_kwargs,
                 )
             except openai.BadRequestError as e:
                 if hasattr(e, "code") and e.code == "context_length_exceeded":

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -743,6 +743,29 @@ async def test_structured_output(openai_client, model, test_output_model_cls, al
 
 
 @pytest.mark.asyncio
+async def test_structured_output_forwards_formatted_request_params(
+    openai_client, model_id, test_output_model_cls, alist
+):
+    model = OpenAIResponsesModel(
+        model_id=model_id,
+        params={"max_output_tokens": 1000, "reasoning": {"effort": "high"}},
+    )
+    messages = [{"role": "user", "content": [{"text": "Generate a person"}]}]
+    mock_response = unittest.mock.Mock(output_parsed=test_output_model_cls(name="John", age=30))
+
+    openai_client.responses.parse = unittest.mock.AsyncMock(return_value=mock_response)
+
+    await alist(model.structured_output(test_output_model_cls, messages, system_prompt="Follow the schema"))
+
+    _, kwargs = openai_client.responses.parse.call_args
+    assert kwargs["max_output_tokens"] == 1000
+    assert kwargs["reasoning"] == {"effort": "high"}
+    assert kwargs["instructions"] == "Follow the schema"
+    assert kwargs["store"] is False
+    assert "stream" not in kwargs
+
+
+@pytest.mark.asyncio
 async def test_stream_context_overflow_exception(openai_client, model, messages):
     """Test that OpenAI context overflow errors are properly converted to ContextWindowOverflowException."""
     mock_error = openai.BadRequestError(


### PR DESCRIPTION
﻿## Motivation

`OpenAIResponsesModel.structured_output()` builds the request through `_format_request()`, but then only forwards `input` to `client.responses.parse()`. That drops regular Responses API parameters from model config, including `max_output_tokens`, `reasoning`, and system `instructions`.

Closes #1908.

## Changes

- Build the structured-output parse request from the full `_format_request()` result.
- Continue passing `model`, `input`, and `text_format` explicitly.
- Exclude `stream`, since `_format_request()` sets it for streaming calls and `responses.parse()` should not receive it.
- Add regression coverage for `max_output_tokens`, `reasoning`, `instructions`, and `store`.

## Testing

- `.\.venv\Scripts\python.exe -m pytest tests\strands\models\test_openai_responses.py::test_structured_output tests\strands\models\test_openai_responses.py::test_structured_output_forwards_formatted_request_params -q`
- `.\.venv\Scripts\python.exe -m ruff check src\strands\models\openai_responses.py tests\strands\models\test_openai_responses.py`
- `.\.venv\Scripts\python.exe -m ruff format --check src\strands\models\openai_responses.py tests\strands\models\test_openai_responses.py`
- `.\.venv\Scripts\python.exe -m mypy src\strands\models\openai_responses.py`
- `.\strands-py\.venv\Scripts\python.exe -m py_compile strands-py\src\strands\models\openai_responses.py strands-py\tests\strands\models\test_openai_responses.py`
- `git diff --check`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
