### PR TITLE
chore: address fast-follow items from docs monorepo merge

### DIFF
--- a/.github/workflows/docs-deploy-preview.yml
+++ b/.github/workflows/docs-deploy-preview.yml
@@ -79,7 +79,7 @@ jobs:
         run: npm run cms:build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_DEPLOY_ROLE }}
           role-session-name: GitHubActions-Docs-${{ env.RUN_ID }}

--- a/.github/workflows/docs-strands-command.yml
+++ b/.github/workflows/docs-strands-command.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Run Strands Agent
         id: agent-runner

--- a/designs/README.md
+++ b/designs/README.md
@@ -23,7 +23,7 @@ Skip the design process for bug fixes, small improvements, documentation updates
 ## How to submit a feature proposal
 
 1. **Check the [roadmap](https://github.com/orgs/strands-agents/projects/8/views/1)** — See if your idea aligns with our direction
-2. **Fork the [docs repository](https://github.com/strands-agents/docs)**
+2. **Fork the [sdk-python repository](https://github.com/strands-agents/sdk-python)**
 3. **Create your design** — Add a new file: `designs/NNNN-feature-name.md` using the template below
 4. **Submit a pull request** — We'll review and discuss
 5. **Iterate based on feedback** — Address comments and questions


### PR DESCRIPTION
## Description

> **Note:** This is also a test PR to verify behavior. 

Fast-follow fixes from the docs monorepo merge (#2339). Addresses three items flagged during review:

- Bump `aws-actions/configure-aws-credentials` from `@v4` to `@v6` in `docs-deploy-preview.yml` for consistency with the rest of the repo
- Align `docs-strands-command.yml` to Node 22 (all other docs workflows already use 22)
- Fix stale reference in `designs/README.md` that still pointed to the now-merged `strands-agents/docs` repo

## Related Issues

#2339

## Documentation PR

N/A

## Type of Change

Other (please describe): Post-merge cleanup from monorepo convergence

## Testing

No functional changes — action version bumps, Node version alignment, and a docs link fix.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.