### PR TITLE
fix(telemetry): make MetricsClient singleton thread-safe

### DIFF
--- a/strands-py/src/strands/telemetry/metrics.py
+++ b/strands-py/src/strands/telemetry/metrics.py
@@ -1,6 +1,7 @@
 """Utilities for collecting and reporting performance metrics in the SDK."""
 
 import logging
+import threading
 import time
 import uuid
 from collections.abc import Iterable
@@ -548,9 +549,13 @@ class MetricsClient:
 
     The actual metrics export destination (console, OTLP endpoint, etc.) is configured
     through OpenTelemetry SDK configuration by users, not by this client.
+
+    This class uses a thread-safe double-checked locking pattern to ensure safe
+    concurrent initialization across multiple threads.
     """
 
     _instance: Optional["MetricsClient"] = None
+    _lock: threading.Lock = threading.Lock()
     meter: Meter
     event_loop_cycle_count: Counter
     event_loop_start_cycle: Counter
@@ -570,11 +575,16 @@ class MetricsClient:
     def __new__(cls) -> "MetricsClient":
         """Create or return the singleton instance of MetricsClient.
 
+        Uses double-checked locking to ensure thread safety without
+        acquiring the lock on every access after initialization.
+
         Returns:
             The single MetricsClient instance.
         """
         if cls._instance is None:
-            cls._instance = super().__new__(cls)
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
         return cls._instance
 
     def __init__(self) -> None:
@@ -582,14 +592,20 @@ class MetricsClient:
 
         This method only runs once due to the singleton pattern.
         Sets up the OpenTelemetry meter and creates metric instruments.
+        Uses a lock to prevent concurrent initialization races.
         """
         if hasattr(self, "meter"):
             return
 
-        logger.info("Creating Strands MetricsClient")
-        meter_provider: metrics_api.MeterProvider = metrics_api.get_meter_provider()
-        self.meter = meter_provider.get_meter(__name__)
-        self.create_instruments()
+        with self._lock:
+            # Double-check after acquiring the lock
+            if hasattr(self, "meter"):
+                return
+
+            logger.info("Creating Strands MetricsClient")
+            meter_provider: metrics_api.MeterProvider = metrics_api.get_meter_provider()
+            self.meter = meter_provider.get_meter(__name__)
+            self.create_instruments()
 
     def create_instruments(self) -> None:
         """Create and initialize all OpenTelemetry metric instruments."""

--- a/strands-py/tests/strands/telemetry/test_metrics.py
+++ b/strands-py/tests/strands/telemetry/test_metrics.py
@@ -503,6 +503,44 @@ def test_use_ProxyMeter_if_no_global_meter_provider():
     assert isinstance(metrics_client.meter, _ProxyMeter)
 
 
+def test_metrics_client_singleton_is_thread_safe():
+    """Test that MetricsClient singleton is safe under concurrent access.
+
+    Multiple threads creating MetricsClient simultaneously should all get the same
+    fully-initialized instance without AttributeError on instrument attributes.
+    """
+    import concurrent.futures
+    import threading
+
+    # Reset the singleton so threads race to create it
+    strands.telemetry.metrics.MetricsClient._instance = None
+
+    num_threads = 20
+    barrier = threading.Barrier(num_threads)
+    instances = []
+    errors = []
+
+    def create_and_use_client():
+        try:
+            # Synchronize all threads to maximize contention
+            barrier.wait()
+            client = MetricsClient()
+            # Access an instrument attribute that would fail if initialization is incomplete
+            _ = client.event_loop_cycle_count
+            instances.append(client)
+        except Exception as e:
+            errors.append(e)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = [executor.submit(create_and_use_client) for _ in range(num_threads)]
+        concurrent.futures.wait(futures)
+
+    assert not errors, f"Threads raised errors: {errors}"
+    assert len(instances) == num_threads
+    # All threads should have received the same singleton instance
+    assert all(inst is instances[0] for inst in instances)
+
+
 def test_latest_agent_invocation_property(usage, event_loop_metrics, mock_get_meter_provider):
     """Test the latest_agent_invocation property getter"""
     # Initially, no invocations exist


### PR DESCRIPTION
## Motivation

The `MetricsClient` singleton uses a pattern where `__new__` creates the instance and `__init__` sets up OpenTelemetry instruments. Without synchronization, concurrent threads can observe a partially-initialized instance — one thread creates the object while another thread gets that same object before `create_instruments()` has assigned all the counter/histogram attributes. This causes intermittent `AttributeError` crashes when running multiple agents in parallel via `ThreadPoolExecutor`.

Resolves: #2342

## Public API Changes

No public API changes. The fix is internal to `MetricsClient`'s initialization logic. Existing single-threaded and multi-threaded usage continues to work identically — the singleton is simply safe to access concurrently now.

## Use Cases

- **Concurrent agent execution**: Running multiple `Agent` instances in a `ThreadPoolExecutor` without needing to manually pre-initialize `MetricsClient()` on the main thread first.

## Description
Add threading.Lock with double-checked locking to MetricsClient's __new__ and __init__ methods to prevent race conditions when multiple threads concurrently initialize the singleton. Without this fix, concurrent agent invocations can intermittently raise AttributeError when accessing instrument attributes before create_instruments() completes.

## Type of Change

Bug fix

## Testing

Tested locally via new unit test and existing integration tests.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly --> NO CHANGE
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
