### PR TITLE
fix(gemini): handle safety-blocked metadata

### DIFF
--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -420,14 +420,18 @@ class GeminiModel(Model):
                         return {"messageStop": {"stopReason": "tool_use"}}
                     case "MAX_TOKENS":
                         return {"messageStop": {"stopReason": "max_tokens"}}
+                    case "SAFETY":
+                        return {"messageStop": {"stopReason": "guardrail_intervened"}}
                     case _:
                         return {"messageStop": {"stopReason": "end_turn"}}
 
             case "metadata":
+                input_tokens = event["data"].prompt_token_count or 0
+                total_tokens = event["data"].total_token_count or 0
                 usage_data: Usage = {
-                    "inputTokens": event["data"].prompt_token_count,
-                    "outputTokens": event["data"].total_token_count - event["data"].prompt_token_count,
-                    "totalTokens": event["data"].total_token_count,
+                    "inputTokens": input_tokens,
+                    "outputTokens": max(0, total_tokens - input_tokens),
+                    "totalTokens": total_tokens,
                 }
 
                 if cached := event["data"].cached_content_token_count:

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -620,6 +620,29 @@ def test_format_chunk_metadata_with_zero_cached_tokens(model):
     }
 
 
+def test_format_chunk_metadata_with_missing_token_counts(model):
+    event = {
+        "chunk_type": "metadata",
+        "data": genai.types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=None,
+            total_token_count=None,
+        ),
+    }
+
+    result = model._format_chunk(event)
+
+    assert result == {
+        "metadata": {
+            "usage": {
+                "inputTokens": 0,
+                "outputTokens": 0,
+                "totalTokens": 0,
+            },
+            "metrics": {"latencyMs": 0},
+        },
+    }
+
+
 @pytest.mark.asyncio
 async def test_stream_response_tool_use(gemini_client, model, messages, agenerator, alist):
     gemini_client.aio.models.generate_content_stream.return_value = agenerator(
@@ -844,6 +867,35 @@ async def test_stream_response_max_tokens(gemini_client, model, messages, agener
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "max_tokens"}},
         {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
+    ]
+    assert tru_chunks == exp_chunks
+
+
+@pytest.mark.asyncio
+async def test_stream_response_safety_block_with_missing_counts(
+    gemini_client, model, messages, agenerator, alist
+):
+    gemini_client.aio.models.generate_content_stream.return_value = agenerator(
+        [
+            genai.types.GenerateContentResponse(
+                candidates=[
+                    genai.types.Candidate(
+                        finish_reason="SAFETY",
+                    ),
+                ],
+                usage_metadata=genai.types.GenerateContentResponseUsageMetadata(
+                    prompt_token_count=None,
+                    total_token_count=None,
+                ),
+            ),
+        ]
+    )
+
+    tru_chunks = await alist(model.stream(messages))
+    exp_chunks = [
+        {"messageStart": {"role": "assistant"}},
+        {"messageStop": {"stopReason": "guardrail_intervened"}},
+        {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}, "metrics": {"latencyMs": 0}}},
     ]
     assert tru_chunks == exp_chunks
 


### PR DESCRIPTION
﻿## Summary

Fixes #2347.

This makes the Gemini adapter tolerate safety-blocked responses where Google returns `usage_metadata` with missing token counts. It also maps Gemini's `SAFETY` finish reason to `guardrail_intervened`, matching the guardrail stop reason used elsewhere in Strands.

## Changes

- Default missing Gemini token counts to zero before computing usage metadata.
- Clamp computed output tokens at zero for defensive consistency.
- Map `SAFETY` message stops to `guardrail_intervened`.
- Add regression coverage for metadata-only safety-blocked responses.

## To verify

Run from `strands-py`:

```bash
uv run pytest tests/strands/models/test_gemini.py -q --basetemp .tmp/pytest-2347 -p no:cacheprovider
uv run ruff check src/strands/models/gemini.py tests/strands/models/test_gemini.py
python -m py_compile src/strands/models/gemini.py tests/strands/models/test_gemini.py
git diff --check
```

Local result on Windows: 56 passed.
