### PR TITLE
fix(openai): read vllm reasoning deltas

### DIFF
--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -700,7 +700,11 @@ class OpenAIModel(Model):
                     continue
                 choice = event.choices[0]
 
-                if hasattr(choice.delta, "reasoning_content") and choice.delta.reasoning_content:
+                reasoning_content = getattr(choice.delta, "reasoning_content", None)
+                if not isinstance(reasoning_content, str) or not reasoning_content:
+                    reasoning_content = getattr(choice.delta, "reasoning", None)
+
+                if isinstance(reasoning_content, str) and reasoning_content:
                     chunks, data_type = self._stream_switch_content("reasoning_content", data_type)
                     for chunk in chunks:
                         yield chunk
@@ -708,7 +712,7 @@ class OpenAIModel(Model):
                         {
                             "chunk_type": "content_delta",
                             "data_type": data_type,
-                            "data": choice.delta.reasoning_content,
+                            "data": reasoning_content,
                         }
                     )
 

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1021,6 +1021,40 @@ async def test_stream(openai_client, model_id, model, agenerator, alist):
 
 
 @pytest.mark.asyncio
+async def test_stream_accepts_vllm_reasoning_delta(openai_client, model, messages, agenerator, alist):
+    reasoning_delta = unittest.mock.Mock(spec=["reasoning", "content", "tool_calls"])
+    reasoning_delta.reasoning = "\nI'm thinking"
+    reasoning_delta.content = None
+    reasoning_delta.tool_calls = None
+
+    stop_delta = unittest.mock.Mock(spec=["reasoning", "content", "tool_calls"])
+    stop_delta.reasoning = None
+    stop_delta.content = None
+    stop_delta.tool_calls = None
+
+    usage_event = unittest.mock.Mock(usage=None)
+    openai_client.chat.completions.create = unittest.mock.AsyncMock(
+        return_value=agenerator(
+            [
+                unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=reasoning_delta)]),
+                unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="stop", delta=stop_delta)]),
+                usage_event,
+            ]
+        )
+    )
+
+    response = model.stream(messages)
+
+    assert await alist(response) == [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "\nI'm thinking"}}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_stream_empty(openai_client, model_id, model, agenerator, alist):
     mock_delta = unittest.mock.Mock(content=None, tool_calls=None, reasoning_content=None)
 


### PR DESCRIPTION
﻿## Summary

Fixes #2182.

OpenAI-compatible vLLM streams can emit reasoning text on `delta.reasoning` instead of the older `delta.reasoning_content` field. The OpenAI adapter now accepts both fields and still prefers the existing `reasoning_content` path when present.

## Changes

- Read non-empty string reasoning from `delta.reasoning_content` or `delta.reasoning`.
- Keep existing text/tool streaming behavior unchanged.
- Add regression coverage for a vLLM-style `delta.reasoning` stream.

## To verify

Run from `strands-py`:

```bash
uv run pytest tests/strands/models/test_openai.py -q --basetemp .tmp/pytest-2182 -p no:cacheprovider
uv run ruff check src/strands/models/openai.py tests/strands/models/test_openai.py
python -m py_compile src/strands/models/openai.py tests/strands/models/test_openai.py
git diff --check
```

Local result on Windows: 96 passed.
