### PR TITLE
ci: add automated issue labeling workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug in the Strands Agents SDK
 title: "[BUG] "
-labels: ["bug", "triage"]
+labels: ["triage"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/content_addition.yml
+++ b/.github/ISSUE_TEMPLATE/content_addition.yml
@@ -1,7 +1,7 @@
 name: Content Addition
 description: Suggest new content for the documentation
 title: "[NEW CONTENT] "
-labels: ["documentation", "enhancement"]
+labels: ["documentation"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yml
@@ -1,7 +1,7 @@
 name: Documentation Improvement
 description: Suggest improvements to the documentation
 title: "[DOCS] "
-labels: ["documentation", "enhancement"]
+labels: ["documentation"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/documentation_question.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_question.yml
@@ -1,7 +1,7 @@
 name: Documentation Question
 description: Ask a question about the documentation
 title: "[QUESTION] "
-labels: ["documentation", "question"]
+labels: ["documentation"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or enhancement for Strands Agents SDK
 title: "[FEATURE] "
-labels: ["enhancement", "triage"]
+labels: ["triage"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/technical_correction.yml
+++ b/.github/ISSUE_TEMPLATE/technical_correction.yml
@@ -1,7 +1,7 @@
 name: Technical Correction
 description: Report technical inaccuracies in the documentation
 title: "[CORRECTION] "
-labels: ["documentation", "bug"]
+labels: ["documentation"]
 assignees: []
 body:
   - type: markdown

--- a/.github/labelers/area.yml
+++ b/.github/labelers/area.yml
@@ -8,8 +8,9 @@ instructions: |
   Provider-specific bugs (Bedrock, OpenAI, Anthropic, Gemini, Ollama, etc.) belong to area-model.
   Issues about hook lifecycle events belong to area-hooks even if they mention tools or agents.
   Guardrails and content filtering belong to area-interventions, not area-hooks.
-  Documentation content issues belong to docs, not area-devx.
-  Session persistence/storage issues belong to area-sessions. Context window/token management belongs to area-context.
+  Documentation content issues belong to documentation, not area-devx.
+  Storage backend implementation issues (S3, DynamoDB, file) belong to area-persistence. Session lifecycle and interface issues belong to area-sessions.
+  Context window/token management belongs to area-context.
   General agent class behavior (invocation, streaming, result handling) belongs to area-agent.
 
 labels:
@@ -55,5 +56,5 @@ labels:
     description: "Structured output API, JSON schema enforcement, Pydantic output models, deterministic response formatting"
   area-tool:
     description: "Tool behavior, tool definitions, tool execution, @tool decorator, tool results, tool validation"
-  docs:
+  documentation:
     description: "Documentation changes, improvements, additions, content updates, site improvements, examples, guides"

--- a/.github/labelers/area.yml
+++ b/.github/labelers/area.yml
@@ -1,0 +1,42 @@
+# .github/labelers/area.yml
+# Classifies issues by technical area/subsystem.
+
+instructions: |
+  This is the Strands Agents SDK repository (Python + TypeScript monorepo).
+  CI dependency bumps (dependabot, renovate) should be labeled area-community.
+
+labels:
+  area-a2a:
+    description: "Agent-to-Agent protocol, A2AAgent, A2AClient, A2AServer, agent cards"
+  area-async:
+    description: "Asynchronous flows, multi-threading, asyncio, concurrent execution, event loops"
+  area-bidirectional-streaming:
+    description: "Bidirectional streaming, BidiAgent, real-time audio/video, WebRTC, WebSocket, Nova Sonic"
+  area-community:
+    description: "Community health, monorepo consolidation, contributor guides, governance, CI dependency bumps"
+  area-config:
+    description: "Config-based agents, agent config files, mcp-config, declarative definitions"
+  area-context:
+    description: "Conversation management, context windows, context reduction, sliding window, token management"
+  area-devx:
+    description: "Developer experience, better APIs, ergonomics, helper methods, error messages, usability"
+  area-hil:
+    description: "Human-in-the-loop, interrupt/resume, suspend/resume, approval workflows"
+  area-hooks:
+    description: "Hook events, hook registry, callbacks, lifecycle events, BeforeEvent/AfterEvent"
+  area-language:
+    description: "New language SDKs (Ruby, .NET, Rust, Go, etc.)"
+  area-mcp:
+    description: "Model Context Protocol, MCP servers/clients/transport/tools"
+  area-multiagent:
+    description: "Multi-agent patterns, swarm, graph, orchestrator, agent-as-tool, arena"
+  area-otel:
+    description: "OpenTelemetry, tracing, metrics, spans, observability, OTLP"
+  area-persistence:
+    description: "Session storage, checkpointing, S3SessionManager, DynamoDB sessions, state serialization"
+  area-provider:
+    description: "Model providers (Bedrock, OpenAI, Anthropic, Ollama, LiteLLM, SageMaker, vLLM, Mistral)"
+  area-structured-output:
+    description: "Structured output API, JSON schema enforcement, Pydantic output models"
+  area-tool:
+    description: "Tool behavior, tool definitions, tool execution, @tool decorator, tool results"

--- a/.github/labelers/area.yml
+++ b/.github/labelers/area.yml
@@ -7,6 +7,8 @@ instructions: |
   MCP tools should be labeled area-mcp, not area-tool.
   Provider-specific async/streaming bugs belong to area-provider, not area-async.
   Issues about hook lifecycle events belong to area-hooks even if they mention tools or agents.
+  Guardrails and content filtering belong to area-interventions, not area-hooks.
+  Documentation content issues belong to docs, not area-devx.
 
 labels:
   area-a2a:
@@ -41,5 +43,11 @@ labels:
     description: "Model providers (Bedrock, OpenAI, Anthropic, Ollama, LiteLLM, SageMaker, vLLM, Mistral)"
   area-structured-output:
     description: "Structured output API, JSON schema enforcement, Pydantic output models"
+  area-interventions:
+    description: "Guardrails, input/output filtering, content moderation, safety controls"
+  area-server:
+    description: "Strands Server, sandbox, runtime container, execution boundaries, credential injection"
   area-tool:
     description: "Tool behavior, tool definitions, tool execution, @tool decorator, tool results"
+  docs:
+    description: "Documentation changes, content updates, site improvements, examples"

--- a/.github/labelers/area.yml
+++ b/.github/labelers/area.yml
@@ -56,4 +56,4 @@ labels:
   area-tool:
     description: "Tool behavior, tool definitions, tool execution, @tool decorator, tool results, tool validation"
   docs:
-    description: "Documentation changes, content updates, site improvements, API reference, examples, guides"
+    description: "Documentation changes, improvements, additions, content updates, site improvements, examples, guides"

--- a/.github/labelers/area.yml
+++ b/.github/labelers/area.yml
@@ -4,6 +4,9 @@
 instructions: |
   This is the Strands Agents SDK repository (Python + TypeScript monorepo).
   CI dependency bumps (dependabot, renovate) should be labeled area-community.
+  MCP tools should be labeled area-mcp, not area-tool.
+  Provider-specific async/streaming bugs belong to area-provider, not area-async.
+  Issues about hook lifecycle events belong to area-hooks even if they mention tools or agents.
 
 labels:
   area-a2a:

--- a/.github/labelers/area.yml
+++ b/.github/labelers/area.yml
@@ -5,49 +5,55 @@ instructions: |
   This is the Strands Agents SDK repository (Python + TypeScript monorepo).
   CI dependency bumps (dependabot, renovate) should be labeled area-community.
   MCP tools should be labeled area-mcp, not area-tool.
-  Provider-specific async/streaming bugs belong to area-provider, not area-async.
+  Provider-specific bugs (Bedrock, OpenAI, Anthropic, Gemini, Ollama, etc.) belong to area-model.
   Issues about hook lifecycle events belong to area-hooks even if they mention tools or agents.
   Guardrails and content filtering belong to area-interventions, not area-hooks.
   Documentation content issues belong to docs, not area-devx.
+  Session persistence/storage issues belong to area-sessions. Context window/token management belongs to area-context.
+  General agent class behavior (invocation, streaming, result handling) belongs to area-agent.
 
 labels:
   area-a2a:
-    description: "Agent-to-Agent protocol, A2AAgent, A2AClient, A2AServer, agent cards"
+    description: "Agent-to-Agent protocol, A2AAgent, A2AClient, A2AServer, agent cards, cross-agent communication"
+  area-agent:
+    description: "Core agent class, agent invocation, agent lifecycle, streaming responses, AgentResult, system prompt"
   area-async:
-    description: "Asynchronous flows, multi-threading, asyncio, concurrent execution, event loops"
+    description: "Asynchronous flows, multi-threading, asyncio, concurrent execution, event loops, non-blocking operations"
   area-bidirectional-streaming:
-    description: "Bidirectional streaming, BidiAgent, real-time audio/video, WebRTC, WebSocket, Nova Sonic"
+    description: "Bidirectional streaming, BidiAgent, real-time audio/video, WebRTC, WebSocket, Nova Sonic, voice agents"
   area-community:
-    description: "Community health, monorepo consolidation, contributor guides, governance, CI dependency bumps"
+    description: "Community health, monorepo consolidation, contributor guides, governance, CI dependency bumps, release process"
   area-config:
-    description: "Config-based agents, agent config files, mcp-config, declarative definitions"
+    description: "Config-based agents, agent config files, mcp-config, declarative agent/graph/swarm definitions from YAML"
   area-context:
-    description: "Conversation management, context windows, context reduction, sliding window, token management"
+    description: "Conversation management, context windows, context reduction, sliding window, token management, compression strategies"
   area-devx:
-    description: "Developer experience, better APIs, ergonomics, helper methods, error messages, usability"
+    description: "Developer experience improvements, better APIs, ergonomics, helper methods, error messages, SDK usability"
   area-hil:
-    description: "Human-in-the-loop, interrupt/resume, suspend/resume, approval workflows"
+    description: "Human-in-the-loop, interrupt/resume, suspend/resume, approval workflows, callback-based tool execution"
   area-hooks:
-    description: "Hook events, hook registry, callbacks, lifecycle events, BeforeEvent/AfterEvent"
-  area-language:
-    description: "New language SDKs (Ruby, .NET, Rust, Go, etc.)"
-  area-mcp:
-    description: "Model Context Protocol, MCP servers/clients/transport/tools"
-  area-multiagent:
-    description: "Multi-agent patterns, swarm, graph, orchestrator, agent-as-tool, arena"
-  area-otel:
-    description: "OpenTelemetry, tracing, metrics, spans, observability, OTLP"
-  area-persistence:
-    description: "Session storage, checkpointing, S3SessionManager, DynamoDB sessions, state serialization"
-  area-provider:
-    description: "Model providers (Bedrock, OpenAI, Anthropic, Ollama, LiteLLM, SageMaker, vLLM, Mistral)"
-  area-structured-output:
-    description: "Structured output API, JSON schema enforcement, Pydantic output models"
+    description: "Hook events, hook registry, callbacks, lifecycle events, BeforeEvent/AfterEvent, Plugin protocol"
   area-interventions:
-    description: "Guardrails, input/output filtering, content moderation, safety controls"
+    description: "Guardrails, input/output filtering, content moderation, safety controls, Bedrock Guardrails integration"
+  area-language:
+    description: "New language SDKs (Ruby, .NET, Rust, Go, etc.) or language-specific development"
+  area-mcp:
+    description: "Model Context Protocol, MCP servers, MCP clients, MCP transport, MCP tools, Streamable HTTP"
+  area-model:
+    description: "Model providers (Bedrock, OpenAI, Anthropic, Gemini, Ollama, LiteLLM, SageMaker, vLLM, Mistral), model config, caching"
+  area-multiagent:
+    description: "Multi-agent patterns, swarm, graph, orchestrator, agent-as-tool, arena, agent coordination, GraphNode"
+  area-otel:
+    description: "OpenTelemetry, tracing, metrics, spans, observability, OTLP export, telemetry instrumentation"
+  area-persistence:
+    description: "Session storage backends, checkpointing, S3SessionManager, DynamoDB sessions, state serialization"
   area-server:
-    description: "Strands Server, sandbox, runtime container, execution boundaries, credential injection"
+    description: "Strands Server, sandbox, runtime container, execution boundaries, credential injection, blast radius"
+  area-sessions:
+    description: "Session management, session lifecycle, session ID handling, session state, SessionManager interface"
+  area-structured-output:
+    description: "Structured output API, JSON schema enforcement, Pydantic output models, deterministic response formatting"
   area-tool:
-    description: "Tool behavior, tool definitions, tool execution, @tool decorator, tool results"
+    description: "Tool behavior, tool definitions, tool execution, @tool decorator, tool results, tool validation"
   docs:
-    description: "Documentation changes, content updates, site improvements, examples"
+    description: "Documentation changes, content updates, site improvements, API reference, examples, guides"

--- a/.github/labelers/language.yml
+++ b/.github/labelers/language.yml
@@ -6,6 +6,7 @@ instructions: |
   This is a monorepo with Python and TypeScript SDKs.
   Look for language-specific keywords: Python paths (strands-py/, .py files, pip, pyproject.toml),
   TypeScript paths (strands-ts/, .ts files, npm, package.json).
+  If the issue clearly targets both languages equally, prefer the language where the bug or feature originates.
   If the issue is language-agnostic or unclear, do not assign a label.
 
 labels:

--- a/.github/labelers/language.yml
+++ b/.github/labelers/language.yml
@@ -12,5 +12,5 @@ instructions: |
 labels:
   python:
     description: "Issue relates to the Python SDK (strands-py/, .py files, pip, pyproject.toml)"
-  javascript:
-    description: "Issue relates to the TypeScript/JavaScript SDK (strands-ts/, .ts files, npm, package.json)"
+  typescript:
+    description: "Issue relates to the TypeScript SDK (strands-ts/, .ts files, npm, package.json)"

--- a/.github/labelers/language.yml
+++ b/.github/labelers/language.yml
@@ -1,0 +1,15 @@
+# .github/labelers/language.yml
+# Identifies which SDK language the issue relates to.
+# Use max_labels: 1 since most issues target one language.
+
+instructions: |
+  This is a monorepo with Python and TypeScript SDKs.
+  Look for language-specific keywords: Python paths (strands-py/, .py files, pip, pyproject.toml),
+  TypeScript paths (strands-ts/, .ts files, npm, package.json).
+  If the issue is language-agnostic or unclear, do not assign a label.
+
+labels:
+  lang-python:
+    description: "Issue relates to the Python SDK (strands-py/, .py files, pip, pyproject.toml)"
+  lang-typescript:
+    description: "Issue relates to the TypeScript SDK (strands-ts/, .ts files, npm, package.json)"

--- a/.github/labelers/language.yml
+++ b/.github/labelers/language.yml
@@ -8,6 +8,7 @@ instructions: |
   TypeScript paths (strands-ts/, .ts files, npm, package.json).
   If the issue clearly targets both languages equally, prefer the language where the bug or feature originates.
   If the issue is language-agnostic or unclear, do not assign a label.
+  Issues about general agent behavior, documentation content, or feature requests without language-specific file paths or package managers should not receive a language label.
 
 labels:
   python:

--- a/.github/labelers/language.yml
+++ b/.github/labelers/language.yml
@@ -9,7 +9,7 @@ instructions: |
   If the issue is language-agnostic or unclear, do not assign a label.
 
 labels:
-  lang-python:
+  python:
     description: "Issue relates to the Python SDK (strands-py/, .py files, pip, pyproject.toml)"
-  lang-typescript:
-    description: "Issue relates to the TypeScript SDK (strands-ts/, .ts files, npm, package.json)"
+  javascript:
+    description: "Issue relates to the TypeScript/JavaScript SDK (strands-ts/, .ts files, npm, package.json)"

--- a/.github/labelers/type.yml
+++ b/.github/labelers/type.yml
@@ -1,0 +1,18 @@
+# .github/labelers/type.yml
+# Classifies issues by type (bug, feature, etc.)
+# Use max_labels: 1 in the workflow since these are mutually exclusive.
+
+instructions: |
+  Choose exactly one type. If the title starts with [BUG] it is a bug.
+  If the title starts with [FEATURE] it is an enhancement.
+  CI/dependency PRs that open as issues are chores.
+
+labels:
+  bug:
+    description: "Something is broken or not working as documented"
+  enhancement:
+    description: "New feature request or improvement to existing functionality"
+  question:
+    description: "User asking for help, clarification, or how to do something"
+  chore:
+    description: "Maintenance tasks, dependency updates, CI changes, refactoring with no user-facing impact"

--- a/.github/labelers/type.yml
+++ b/.github/labelers/type.yml
@@ -6,6 +6,7 @@ instructions: |
   Choose exactly one type. If the title starts with [BUG] it is a bug.
   If the title starts with [FEATURE] it is an enhancement.
   CI/dependency PRs that open as issues are chores.
+  Documentation improvements or corrections are bugs. Requests for new docs or content additions are enhancements. Documentation questions are questions.
 
 labels:
   bug:

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,55 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  id-token: write
+  contents: read
+
+jobs:
+  label-area:
+    name: "Label: Area"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/labelers
+          sparse-checkout-cone-mode: false
+      - uses: strands-agents/devtools/issue-labeler@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          config_path: '.github/labelers/area.yml'
+
+  label-type:
+    name: "Label: Type"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/labelers
+          sparse-checkout-cone-mode: false
+      - uses: strands-agents/devtools/issue-labeler@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          config_path: '.github/labelers/type.yml'
+          max_labels: '1'
+
+  label-language:
+    name: "Label: Language"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/labelers
+          sparse-checkout-cone-mode: false
+      - uses: strands-agents/devtools/issue-labeler@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          config_path: '.github/labelers/language.yml'
+          max_labels: '1'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -2,7 +2,7 @@ name: Issue Labeler
 
 on:
   issues:
-    types: [opened, edited]
+    types: [opened]
 
 permissions:
   issues: write
@@ -19,6 +19,7 @@ jobs:
         with:
           sparse-checkout: .github/labelers
           sparse-checkout-cone-mode: false
+      # max_labels omitted: issues may span multiple areas
       - uses: strands-agents/devtools/issue-labeler@main
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}


### PR DESCRIPTION
## Description

Adds automated issue labeling using the shared `issue-labeler` action from devtools. Three independent labelers run in parallel on every issue open:

1. **Area** — classifies by technical subsystem (area-model, area-mcp, area-tool, area-agent, etc.)
2. **Type** — classifies as bug, enhancement, question, or chore (mutually exclusive)
3. **Language** — identifies whether the issue targets Python or TypeScript

Each labeler has its own config in `.github/labelers/` defining the valid label set and classification instructions. The LLM output is validated against these configs so it can only apply labels that exist in the allowlist.

## Related Issues

Depends on https://github.com/strands-agents/devtools/pull/55

## Type of Change

New feature

## Testing

- Tested classification logic locally against ~488 open issues
- Verified allowlist validation rejects arbitrary LLM output
- Confirmed parallel job execution doesn't cause label conflicts

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.