### PR TITLE
feat: add Limits and support it during invoke/stream

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -66,7 +66,7 @@ from ..tools.registry import ToolRegistry
 from ..tools.structured_output._structured_output_context import StructuredOutputContext
 from ..tools.watcher import ToolWatcher
 from ..types._events import AgentResultEvent, EventLoopStopEvent, InitEventLoopEvent, ModelStreamChunkEvent, TypedEvent
-from ..types.agent import AgentInput, ConcurrentInvocationMode
+from ..types.agent import AgentInput, ConcurrentInvocationMode, Limits
 from ..types.content import ContentBlock, Message, Messages, SystemContentBlock
 from ..types.exceptions import ConcurrencyException, ContextWindowOverflowException
 from ..types.tools import AgentTool
@@ -472,6 +472,7 @@ class Agent(AgentBase):
         invocation_state: dict[str, Any] | None = None,
         structured_output_model: type[BaseModel] | None = None,
         structured_output_prompt: str | None = None,
+        limits: Limits | None = None,
         **kwargs: Any,
     ) -> AgentResult:
         """Process a natural language prompt through the agent's event loop.
@@ -491,6 +492,12 @@ class Agent(AgentBase):
             invocation_state: Additional parameters to pass through the event loop.
             structured_output_model: Pydantic model type(s) for structured output (overrides agent default).
             structured_output_prompt: Custom prompt for forcing structured output (overrides agent default).
+            limits: Per-invocation budget caps (turns / output_tokens / total_tokens).
+                See :class:`~strands.types.agent.Limits`. When a cap is reached, the loop
+                terminates gracefully at the next turn boundary with a corresponding
+                ``stop_reason`` (e.g. ``"limit_turns"``); no exception is raised. Token
+                caps are soft — a single oversized model response can overshoot the budget
+                by one turn, since checks run at turn boundaries, not within a model call.
             **kwargs: Additional parameters to pass through the event loop.[Deprecating]
 
         Returns:
@@ -508,6 +515,7 @@ class Agent(AgentBase):
                 invocation_state=invocation_state,
                 structured_output_model=structured_output_model,
                 structured_output_prompt=structured_output_prompt,
+                limits=limits,
                 **kwargs,
             )
         )
@@ -519,6 +527,7 @@ class Agent(AgentBase):
         invocation_state: dict[str, Any] | None = None,
         structured_output_model: type[BaseModel] | None = None,
         structured_output_prompt: str | None = None,
+        limits: Limits | None = None,
         **kwargs: Any,
     ) -> AgentResult:
         """Process a natural language prompt through the agent's event loop.
@@ -538,6 +547,12 @@ class Agent(AgentBase):
             invocation_state: Additional parameters to pass through the event loop.
             structured_output_model: Pydantic model type(s) for structured output (overrides agent default).
             structured_output_prompt: Custom prompt for forcing structured output (overrides agent default).
+            limits: Per-invocation budget caps (turns / output_tokens / total_tokens).
+                See :class:`~strands.types.agent.Limits`. When a cap is reached, the loop
+                terminates gracefully at the next turn boundary with a corresponding
+                ``stop_reason`` (e.g. ``"limit_turns"``); no exception is raised. Token
+                caps are soft — a single oversized model response can overshoot the budget
+                by one turn, since checks run at turn boundaries, not within a model call.
             **kwargs: Additional parameters to pass through the event loop.[Deprecating]
 
         Returns:
@@ -553,6 +568,7 @@ class Agent(AgentBase):
             invocation_state=invocation_state,
             structured_output_model=structured_output_model,
             structured_output_prompt=structured_output_prompt,
+            limits=limits,
             **kwargs,
         )
         async for event in events:
@@ -776,6 +792,7 @@ class Agent(AgentBase):
         invocation_state: dict[str, Any] | None = None,
         structured_output_model: type[BaseModel] | None = None,
         structured_output_prompt: str | None = None,
+        limits: Limits | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[Any]:
         """Process a natural language prompt and yield events as an async iterator.
@@ -795,6 +812,12 @@ class Agent(AgentBase):
             invocation_state: Additional parameters to pass through the event loop.
             structured_output_model: Pydantic model type(s) for structured output (overrides agent default).
             structured_output_prompt: Custom prompt for forcing structured output (overrides agent default).
+            limits: Per-invocation budget caps (turns / output_tokens / total_tokens).
+                See :class:`~strands.types.agent.Limits`. When a cap is reached, the loop
+                terminates gracefully at the next turn boundary with a corresponding
+                ``stop_reason`` (e.g. ``"limit_turns"``); no exception is raised. Token
+                caps are soft — a single oversized model response can overshoot the budget
+                by one turn, since checks run at turn boundaries, not within a model call.
             **kwargs: Additional parameters to pass to the event loop.[Deprecating]
 
         Yields:
@@ -808,6 +831,7 @@ class Agent(AgentBase):
 
         Raises:
             ConcurrencyException: If another invocation is already in progress on this agent instance.
+            TypeError: If a value in ``limits`` is not a positive integer.
             Exception: Any exceptions from the agent invocation will be propagated to the caller.
 
         Example:
@@ -817,6 +841,7 @@ class Agent(AgentBase):
                     yield event["data"]
             ```
         """
+        self._validate_limits(limits)
         # Conditionally acquire lock based on concurrent_invocation_mode
         # Using threading.Lock instead of asyncio.Lock because run_async() creates
         # separate event loops in different threads
@@ -853,7 +878,9 @@ class Agent(AgentBase):
 
             with trace_api.use_span(self.trace_span):
                 try:
-                    events = self._run_loop(messages, merged_state, structured_output_model, structured_output_prompt)
+                    events = self._run_loop(
+                        messages, merged_state, structured_output_model, structured_output_prompt, limits
+                    )
 
                     async for event in events:
                         event.prepare(invocation_state=merged_state)
@@ -886,6 +913,7 @@ class Agent(AgentBase):
         invocation_state: dict[str, Any],
         structured_output_model: type[BaseModel] | None = None,
         structured_output_prompt: str | None = None,
+        limits: Limits | None = None,
     ) -> AsyncGenerator[TypedEvent, None]:
         """Execute the agent's event loop with the given message and parameters.
 
@@ -894,6 +922,7 @@ class Agent(AgentBase):
             invocation_state: Additional parameters to pass to the event loop.
             structured_output_model: Optional Pydantic model type for structured output.
             structured_output_prompt: Optional custom prompt for forcing structured output.
+            limits: Optional per-invocation budget caps. See :class:`~strands.types.agent.Limits`.
 
         Yields:
             Events from the event loop cycle.
@@ -920,7 +949,7 @@ class Agent(AgentBase):
                 )
 
                 # Execute the event loop cycle with retry logic for context limits
-                events = self._execute_event_loop_cycle(invocation_state, structured_output_context)
+                events = self._execute_event_loop_cycle(invocation_state, structured_output_context, limits)
                 async for event in events:
                     # Signal from the model provider that the message sent by the user should be redacted,
                     # likely due to a guardrail.
@@ -960,7 +989,10 @@ class Agent(AgentBase):
                 current_messages = None
 
     async def _execute_event_loop_cycle(
-        self, invocation_state: dict[str, Any], structured_output_context: StructuredOutputContext | None = None
+        self,
+        invocation_state: dict[str, Any],
+        structured_output_context: StructuredOutputContext | None = None,
+        limits: Limits | None = None,
     ) -> AsyncGenerator[TypedEvent, None]:
         """Execute the event loop cycle with retry logic for context window limits.
 
@@ -971,6 +1003,7 @@ class Agent(AgentBase):
         Args:
             invocation_state: Additional parameters to pass to the event loop.
             structured_output_context: Optional structured output context for this invocation.
+            limits: Optional per-invocation budget caps. See :class:`~strands.types.agent.Limits`.
 
         Yields:
             Events of the loop cycle.
@@ -986,6 +1019,7 @@ class Agent(AgentBase):
                 agent=self,
                 invocation_state=invocation_state,
                 structured_output_context=structured_output_context,
+                limits=limits,
             )
             async for event in events:
                 yield event
@@ -998,7 +1032,7 @@ class Agent(AgentBase):
             if self._session_manager:
                 self._session_manager.sync_agent(self)
 
-            events = self._execute_event_loop_cycle(invocation_state, structured_output_context)
+            events = self._execute_event_loop_cycle(invocation_state, structured_output_context, limits)
             async for event in events:
                 yield event
 
@@ -1092,6 +1126,30 @@ class Agent(AgentBase):
                 trace_attributes["error"] = error
 
             self.tracer.end_agent_span(**trace_attributes)
+
+    @staticmethod
+    def _validate_limits(limits: Limits | None) -> None:
+        """Validate per-invocation budget caps before any model work begins.
+
+        Each cap, when set, must be a positive ``int``. Booleans are rejected because
+        ``bool`` is a subclass of ``int`` in Python and ``True``/``False`` would
+        otherwise pass through as ``1``/``0``, silently no-op'ing or tripping
+        immediately.
+
+        Args:
+            limits: The caps to validate, or ``None`` to skip.
+
+        Raises:
+            TypeError: If any value is not a positive int.
+        """
+        if not limits:
+            return
+        for key in ("turns", "output_tokens", "total_tokens"):
+            if key not in limits:
+                continue
+            value = limits[key]  # type: ignore[literal-required]
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise TypeError(f"limits[{key!r}] must be a positive int, got {value!r}")
 
     def _initialize_system_prompt(
         self, system_prompt: str | list[SystemContentBlock] | None

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1147,7 +1147,7 @@ class Agent(AgentBase):
         for key in ("turns", "output_tokens", "total_tokens"):
             if key not in limits:
                 continue
-            value = limits[key]  # type: ignore[literal-required]
+            value = limits[key]
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 raise TypeError(f"limits[{key!r}] must be a positive int, got {value!r}")
 

--- a/strands-py/src/strands/agent/conversation_manager/conversation_manager.py
+++ b/strands-py/src/strands/agent/conversation_manager/conversation_manager.py
@@ -89,9 +89,7 @@ class ConversationManager(ABC, HookProvider):
             threshold = None
 
         if threshold is not None and (threshold <= 0 or threshold > 1):
-            raise ValueError(
-                f"compression_threshold must be between 0 (exclusive) and 1 (inclusive), got {threshold}"
-            )
+            raise ValueError(f"compression_threshold must be between 0 (exclusive) and 1 (inclusive), got {threshold}")
 
         self.removed_message_count = 0
         self._compression_threshold = threshold

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -32,6 +32,7 @@ from ..types._events import (
     ToolResultMessageEvent,
     TypedEvent,
 )
+from ..types.agent import Limits
 from ..types.content import Message, Messages
 from ..types.exceptions import (
     ContextWindowOverflowException,
@@ -53,6 +54,42 @@ logger = logging.getLogger(__name__)
 MAX_ATTEMPTS = 6
 INITIAL_DELAY = 4
 MAX_DELAY = 240  # 4 minutes
+
+
+def _check_limits(agent: "Agent", limits: Limits | None) -> StopReason | None:
+    """Evaluate per-invocation budget caps against the current invocation's metrics.
+
+    Reads from ``EventLoopMetrics.latest_agent_invocation`` (scoped to the current
+    invocation) so caps don't fire prematurely on the second invoke against a reused
+    agent. Priority on simultaneous trip: turns -> total_tokens -> output_tokens.
+
+    Args:
+        agent: The agent whose metrics to read.
+        limits: The configured caps, or ``None`` for no caps.
+
+    Returns:
+        The matching ``StopReason`` if a cap has been reached, otherwise ``None``.
+    """
+    if not limits:
+        return None
+    invocation = agent.event_loop_metrics.latest_agent_invocation
+    if invocation is None:
+        return None
+
+    cycle_count = len(invocation.cycles)
+    output_tokens = invocation.usage.get("outputTokens", 0)
+    total_tokens = invocation.usage.get("totalTokens", 0)
+
+    turns_cap = limits.get("turns")
+    if turns_cap is not None and cycle_count >= turns_cap:
+        return "limit_turns"
+    total_cap = limits.get("total_tokens")
+    if total_cap is not None and total_tokens >= total_cap:
+        return "limit_total_tokens"
+    output_cap = limits.get("output_tokens")
+    if output_cap is not None and output_tokens >= output_cap:
+        return "limit_output_tokens"
+    return None
 
 
 def _has_tool_use_in_latest_message(messages: "Messages") -> bool:
@@ -121,6 +158,7 @@ async def event_loop_cycle(
     agent: "Agent",
     invocation_state: dict[str, Any],
     structured_output_context: StructuredOutputContext | None = None,
+    limits: Limits | None = None,
 ) -> AsyncGenerator[TypedEvent, None]:
     """Execute a single cycle of the event loop.
 
@@ -143,6 +181,9 @@ async def event_loop_cycle(
             - event_loop_cycle_id: Unique ID for this cycle
             - event_loop_cycle_span: Current tracing Span for this cycle
         structured_output_context: Optional context for structured output management.
+        limits: Optional per-invocation budget caps. Checked at the top of this cycle
+            (after tools from the previous cycle have run to completion). See
+            :class:`~strands.types.agent.Limits`.
 
     Yields:
         Model and tool stream events. The last event is a tuple containing:
@@ -157,6 +198,20 @@ async def event_loop_cycle(
         ContextWindowOverflowException: If the input is too large for the model
     """
     structured_output_context = structured_output_context or StructuredOutputContext()
+
+    # Caps are positive and use >= semantics, so a trip implies at least one prior cycle
+    # ran — meaning agent.messages[-1] exists.
+    limit_stop_reason = _check_limits(agent, limits)
+    if limit_stop_reason is not None:
+        if "request_state" not in invocation_state:
+            invocation_state["request_state"] = {}
+        yield EventLoopStopEvent(
+            limit_stop_reason,
+            agent.messages[-1],
+            agent.event_loop_metrics,
+            invocation_state["request_state"],
+        )
+        return
 
     # Initialize cycle state
     invocation_state["event_loop_cycle_id"] = uuid.uuid4()
@@ -234,6 +289,7 @@ async def event_loop_cycle(
                     invocation_state=invocation_state,
                     tracer=tracer,
                     structured_output_context=structured_output_context,
+                    limits=limits,
                 )
                 async for tool_event in tool_events:
                     yield tool_event
@@ -257,7 +313,10 @@ async def event_loop_cycle(
 
                 tracer.end_event_loop_cycle_span(cycle_span, message)
                 events = recurse_event_loop(
-                    agent=agent, invocation_state=invocation_state, structured_output_context=structured_output_context
+                    agent=agent,
+                    invocation_state=invocation_state,
+                    structured_output_context=structured_output_context,
+                    limits=limits,
                 )
                 async for typed_event in events:
                     yield typed_event
@@ -286,6 +345,7 @@ async def recurse_event_loop(
     agent: "Agent",
     invocation_state: dict[str, Any],
     structured_output_context: StructuredOutputContext | None = None,
+    limits: Limits | None = None,
 ) -> AsyncGenerator[TypedEvent, None]:
     """Make a recursive call to event_loop_cycle with the current state.
 
@@ -295,6 +355,7 @@ async def recurse_event_loop(
         agent: Agent for which the recursive call is being made.
         invocation_state: Arguments to pass through event_loop_cycle
         structured_output_context: Optional context for structured output management.
+        limits: Optional per-invocation budget caps. See :class:`~strands.types.agent.Limits`.
 
     Yields:
         Results from event_loop_cycle where the last result contains:
@@ -313,7 +374,10 @@ async def recurse_event_loop(
     yield StartEvent()
 
     events = event_loop_cycle(
-        agent=agent, invocation_state=invocation_state, structured_output_context=structured_output_context
+        agent=agent,
+        invocation_state=invocation_state,
+        structured_output_context=structured_output_context,
+        limits=limits,
     )
     async for event in events:
         yield event
@@ -497,6 +561,7 @@ async def _handle_tool_execution(
     invocation_state: dict[str, Any],
     tracer: Tracer,
     structured_output_context: StructuredOutputContext,
+    limits: Limits | None = None,
 ) -> AsyncGenerator[TypedEvent, None]:
     """Handles the execution of tools requested by the model during an event loop cycle.
 
@@ -510,6 +575,7 @@ async def _handle_tool_execution(
         invocation_state: Additional keyword arguments, including request state.
         tracer: Tracer instance for span management.
         structured_output_context: Optional context for structured output management.
+        limits: Optional per-invocation budget caps. See :class:`~strands.types.agent.Limits`.
 
     Yields:
         Tool stream events along with events yielded from a recursive call to the event loop. The last event is a tuple
@@ -641,7 +707,10 @@ async def _handle_tool_execution(
         return
 
     events = recurse_event_loop(
-        agent=agent, invocation_state=invocation_state, structured_output_context=structured_output_context
+        agent=agent,
+        invocation_state=invocation_state,
+        structured_output_context=structured_output_context,
+        limits=limits,
     )
     async for event in events:
         yield event

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -852,13 +852,9 @@ class BedrockModel(Model):
             logger.debug("model_id=<%s>, total_tokens=<%d> | native token count", self.config["model_id"], total_tokens)
             return total_tokens
         except Exception as e:
-            if (
-                isinstance(e, ClientError)
-                and e.response.get("Error", {}).get("Code") == "AccessDeniedException"
-            ):
+            if isinstance(e, ClientError) and e.response.get("Error", {}).get("Code") == "AccessDeniedException":
                 logger.warning(
-                    "model_id=<%s> | bedrock:CountTokens permission denied,"
-                    " falling back to heuristic estimation: %s",
+                    "model_id=<%s> | bedrock:CountTokens permission denied, falling back to heuristic estimation: %s",
                     model_id,
                     e,
                 )

--- a/strands-py/src/strands/types/__init__.py
+++ b/strands-py/src/strands/types/__init__.py
@@ -1,6 +1,7 @@
 """SDK type definitions."""
 
 from ._snapshot import Snapshot
+from .agent import Limits
 from .collections import PaginatedList
 
-__all__ = ["PaginatedList", "Snapshot"]
+__all__ = ["Limits", "PaginatedList", "Snapshot"]

--- a/strands-py/src/strands/types/agent.py
+++ b/strands-py/src/strands/types/agent.py
@@ -6,10 +6,47 @@ This module defines the types used for an Agent.
 from enum import Enum
 from typing import TypeAlias
 
+from typing_extensions import TypedDict
+
 from .content import ContentBlock, Messages
 from .interrupt import InterruptResponseContent
 
 AgentInput: TypeAlias = str | list[ContentBlock] | list[InterruptResponseContent] | Messages | None
+
+
+class Limits(TypedDict, total=False):
+    """Per-invocation budget caps for the agent loop.
+
+    Each cap, when set, bounds a single ``invoke_async`` / ``stream_async`` call only;
+    counters are not cumulative across reuses of the same agent. Caps are checked at
+    the top of each loop iteration, so tools requested by the previous turn always run
+    to completion before a cap fires and ``agent.messages`` remains in a reinvokable state.
+
+    Each cap, when set, must be a positive ``int``. Omit any field (or pass ``limits=None``)
+    for no limit on that dimension.
+
+    Priority on simultaneous trip (highest first): ``turns``, ``total_tokens``,
+    ``output_tokens``. The corresponding ``stop_reason`` is ``"limit_turns"``,
+    ``"limit_total_tokens"``, or ``"limit_output_tokens"``.
+
+    Attributes:
+        turns: Maximum number of agent loop iterations (turns). One turn is one model
+            call plus any tool execution that follows. Counted against
+            ``len(metrics.latest_agent_invocation.cycles)``.
+        output_tokens: Maximum cumulative model-generated tokens, summed across every
+            model call in the loop (``metrics.latest_agent_invocation.usage["outputTokens"]``).
+            Distinct from per-call provider-level caps, which bound a single model call's
+            output. Soft cap: a single oversized response can overshoot the budget;
+            checked at turn boundaries, not within an individual model call.
+        total_tokens: Maximum cumulative input + output tokens
+            (``metrics.latest_agent_invocation.usage["totalTokens"]``). Each model call's
+            input includes prior turns, so this counter compounds across the run and
+            approximates total token spend. Soft cap, same caveat as ``output_tokens``.
+    """
+
+    turns: int
+    output_tokens: int
+    total_tokens: int
 
 
 class ConcurrentInvocationMode(str, Enum):

--- a/strands-py/src/strands/types/event_loop.py
+++ b/strands-py/src/strands/types/event_loop.py
@@ -43,6 +43,9 @@ StopReason = Literal[
     "end_turn",
     "guardrail_intervened",
     "interrupt",
+    "limit_output_tokens",
+    "limit_total_tokens",
+    "limit_turns",
     "max_tokens",
     "stop_sequence",
     "tool_use",
@@ -55,7 +58,10 @@ StopReason = Literal[
 - "end_turn": Normal completion of the response
 - "guardrail_intervened": Guardrail system intervened
 - "interrupt": Agent was interrupted for human input
-- "max_tokens": Maximum token limit reached
+- "limit_output_tokens": Agent loop stopped because the ``limits["output_tokens"]`` cap was reached
+- "limit_total_tokens": Agent loop stopped because the ``limits["total_tokens"]`` cap was reached
+- "limit_turns": Agent loop stopped because the ``limits["turns"]`` cap was reached
+- "max_tokens": The model provider's per-call output cap was reached
 - "stop_sequence": Stop sequence encountered
 - "tool_use": Model requested to use a tool
 """

--- a/strands-py/tests/fixtures/mocked_model_provider.py
+++ b/strands-py/tests/fixtures/mocked_model_provider.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from strands.models import Model
 from strands.types.content import Message, Messages
-from strands.types.event_loop import StopReason
+from strands.types.event_loop import StopReason, Usage
 from strands.types.streaming import StreamEvent
 from strands.types.tools import ToolSpec
 
@@ -24,10 +24,22 @@ class MockedModelProvider(Model):
     This class simulates a model provider by returning pre-defined agent responses
     in sequence. It implements the Model interface methods and provides functionality
     to stream mock responses as events.
+
+    Optionally accepts a parallel sequence of per-response ``Usage`` to drive
+    metrics-dependent test paths (e.g. per-invocation token-budget caps).
     """
 
-    def __init__(self, agent_responses: Sequence[Message | RedactionMessage]):
+    def __init__(
+        self,
+        agent_responses: Sequence[Message | RedactionMessage],
+        usages: Sequence[Usage] | None = None,
+    ):
+        if usages is not None and len(usages) != len(agent_responses):
+            raise ValueError(
+                f"usages length ({len(usages)}) must match agent_responses length ({len(agent_responses)})"
+            )
         self.agent_responses = [*agent_responses]
+        self.usages: list[Usage] | None = [*usages] if usages is not None else None
         self.index = 0
 
     def format_chunk(self, event: Any) -> StreamEvent:
@@ -63,13 +75,18 @@ class MockedModelProvider(Model):
         system_prompt_content=None,
         **kwargs: Any,
     ) -> AsyncGenerator[Any, None]:
-        events = self.map_agent_message_to_events(self.agent_responses[self.index])
+        usage = self.usages[self.index] if self.usages is not None else None
+        events = self.map_agent_message_to_events(self.agent_responses[self.index], usage=usage)
         for event in events:
             yield event
 
         self.index += 1
 
-    def map_agent_message_to_events(self, agent_message: Message | RedactionMessage) -> Iterable[dict[str, Any]]:
+    def map_agent_message_to_events(
+        self,
+        agent_message: Message | RedactionMessage,
+        usage: Usage | None = None,
+    ) -> Iterable[dict[str, Any]]:
         stop_reason: StopReason = "end_turn"
         yield {"messageStart": {"role": "assistant"}}
         if agent_message.get("redactedAssistantContent"):
@@ -106,3 +123,5 @@ class MockedModelProvider(Model):
                     yield {"contentBlockStop": {}}
 
         yield {"messageStop": {"stopReason": stop_reason}}
+        if usage is not None:
+            yield {"metadata": {"usage": usage, "metrics": {"latencyMs": 0}}}

--- a/strands-py/tests/strands/agent/test_agent_limits.py
+++ b/strands-py/tests/strands/agent/test_agent_limits.py
@@ -1,0 +1,248 @@
+"""Tests for per-invocation budget caps via the ``limits`` kwarg."""
+
+from collections.abc import Sequence
+
+import pytest
+
+from strands import Agent, tool
+from strands.hooks import AfterInvocationEvent, BeforeInvocationEvent
+from strands.types.event_loop import Usage
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+TOOL_USE_RESPONSE_1 = {
+    "role": "assistant",
+    "content": [{"toolUse": {"toolUseId": "tool-1", "name": "loop", "input": {}}}],
+}
+TOOL_USE_RESPONSE_2 = {
+    "role": "assistant",
+    "content": [{"toolUse": {"toolUseId": "tool-2", "name": "loop", "input": {}}}],
+}
+
+
+@tool
+def loop() -> str:
+    """A passthrough tool used to drive multi-turn loops in tests."""
+    return "ok"
+
+
+def _usage(input_tokens: int, output_tokens: int) -> Usage:
+    return Usage(
+        inputTokens=input_tokens,
+        outputTokens=output_tokens,
+        totalTokens=input_tokens + output_tokens,
+    )
+
+
+def _agent(responses: Sequence[dict], usages: Sequence[Usage] | None = None) -> Agent:
+    return Agent(
+        model=MockedModelProvider(list(responses), list(usages) if usages is not None else None),
+        tools=[loop],
+    )
+
+
+@pytest.mark.asyncio
+async def test_limit_turns_bails_after_cycle_completes():
+    """With turns=1, the first tool round trip runs but the second model call is skipped."""
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(10, 5), _usage(20, 5)],
+    )
+
+    result = await agent.invoke_async("go", limits={"turns": 1})
+
+    assert result.stop_reason == "limit_turns"
+    # Tools from cycle 1 ran; cycle 2 was skipped, so only one model call's usage is recorded.
+    assert result.metrics.latest_agent_invocation is not None
+    assert len(result.metrics.latest_agent_invocation.cycles) == 1
+    assert result.metrics.latest_agent_invocation.usage["outputTokens"] == 5
+    # lastMessage should be the user toolResult (tools were processed before the cap fired).
+    assert result.message["role"] == "user"
+    assert any("toolResult" in block for block in result.message["content"])
+
+
+@pytest.mark.asyncio
+async def test_generous_limits_does_not_trip():
+    final_response = {"role": "assistant", "content": [{"text": "done"}]}
+    agent = Agent(model=MockedModelProvider([final_response], [_usage(5, 5)]))
+
+    result = await agent.invoke_async("go", limits={"turns": 5, "output_tokens": 1000, "total_tokens": 1000})
+
+    assert result.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_limit_output_tokens_trips_when_cumulative_meets_cap():
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(10, 60), _usage(10, 60)],
+    )
+
+    result = await agent.invoke_async("go", limits={"output_tokens": 100})
+
+    assert result.stop_reason == "limit_output_tokens"
+    assert result.metrics.latest_agent_invocation is not None
+    assert len(result.metrics.latest_agent_invocation.cycles) == 2
+
+
+@pytest.mark.asyncio
+async def test_limit_output_tokens_uses_at_least_semantics():
+    """Stops when count exactly equals the cap (>= semantics)."""
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(10, 100), _usage(10, 100)],
+    )
+
+    result = await agent.invoke_async("go", limits={"output_tokens": 100})
+
+    assert result.stop_reason == "limit_output_tokens"
+    assert len(result.metrics.latest_agent_invocation.cycles) == 1
+
+
+@pytest.mark.asyncio
+async def test_limit_total_tokens_trips_when_cumulative_meets_cap():
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(200, 100), _usage(200, 100)],
+    )
+
+    result = await agent.invoke_async("go", limits={"total_tokens": 500})
+
+    assert result.stop_reason == "limit_total_tokens"
+    assert len(result.metrics.latest_agent_invocation.cycles) == 2
+
+
+@pytest.mark.asyncio
+async def test_end_turn_wins_when_model_finishes_on_the_same_cycle_a_cap_would_trip():
+    final = {"role": "assistant", "content": [{"text": "final answer"}]}
+    agent = Agent(model=MockedModelProvider([final], [_usage(300, 300)]))
+
+    result = await agent.invoke_async("go", limits={"total_tokens": 500})
+
+    assert result.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_simultaneous_trip_priority_turns_wins():
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(100, 100), _usage(100, 100)],
+    )
+
+    result = await agent.invoke_async("go", limits={"turns": 1, "total_tokens": 1, "output_tokens": 1})
+
+    assert result.stop_reason == "limit_turns"
+
+
+@pytest.mark.asyncio
+async def test_simultaneous_trip_priority_total_over_output():
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(100, 100), _usage(100, 100)],
+    )
+
+    result = await agent.invoke_async("go", limits={"total_tokens": 1, "output_tokens": 1})
+
+    assert result.stop_reason == "limit_total_tokens"
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_output_tokens_when_no_higher_priority_cap_set():
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(100, 100), _usage(100, 100)],
+    )
+
+    result = await agent.invoke_async("go", limits={"output_tokens": 1})
+
+    assert result.stop_reason == "limit_output_tokens"
+
+
+@pytest.mark.asyncio
+async def test_limits_are_per_invocation_not_lifetime():
+    """A reused agent gets a fresh budget on each invoke; the cap doesn't leak across calls."""
+    final = {"role": "assistant", "content": [{"text": "done"}]}
+    agent = Agent(model=MockedModelProvider([final, final], [_usage(10, 50), _usage(10, 50)]))
+
+    r1 = await agent.invoke_async("go", limits={"output_tokens": 75})
+    assert r1.stop_reason == "end_turn"
+    assert len(r1.metrics.latest_agent_invocation.cycles) == 1
+
+    r2 = await agent.invoke_async("go again", limits={"output_tokens": 75})
+    assert r2.stop_reason == "end_turn"
+    assert len(r2.metrics.latest_agent_invocation.cycles) == 1
+
+
+@pytest.mark.parametrize(
+    "limits",
+    [
+        {"turns": -1},
+        {"turns": 0},
+        {"output_tokens": 0},
+        {"total_tokens": -5},
+        {"turns": True},  # bool subclasses int; should still be rejected
+    ],
+)
+@pytest.mark.asyncio
+async def test_invalid_limits_raise_type_error(limits):
+    final = {"role": "assistant", "content": [{"text": "never reached"}]}
+    agent = Agent(model=MockedModelProvider([final]))
+
+    with pytest.raises(TypeError):
+        await agent.invoke_async("go", limits=limits)
+
+
+@pytest.mark.asyncio
+async def test_limits_propagate_through_stream_async():
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(10, 5), _usage(10, 5)],
+    )
+
+    result = None
+    async for event in agent.stream_async("go", limits={"turns": 1}):
+        if "result" in event:
+            result = event["result"]
+
+    assert result is not None
+    assert result.stop_reason == "limit_turns"
+
+
+def test_limits_propagate_through_call():
+    """The sync ``__call__`` path also accepts and applies ``limits``."""
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(10, 5), _usage(10, 5)],
+    )
+
+    result = agent("go", limits={"turns": 1})
+
+    assert result.stop_reason == "limit_turns"
+
+
+@pytest.mark.asyncio
+async def test_empty_limits_dict_is_no_op():
+    """``limits={}`` carries no caps and behaves identically to ``limits=None``."""
+    final = {"role": "assistant", "content": [{"text": "done"}]}
+    agent = Agent(model=MockedModelProvider([final], [_usage(5, 5)]))
+
+    result = await agent.invoke_async("go", limits={})
+
+    assert result.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_invocation_hooks_fire_when_limit_trips():
+    """``BeforeInvocationEvent`` / ``AfterInvocationEvent`` fire even on a graceful cap-trip."""
+    agent = _agent(
+        [TOOL_USE_RESPONSE_1, TOOL_USE_RESPONSE_2],
+        usages=[_usage(10, 5), _usage(10, 5)],
+    )
+
+    seen: list[str] = []
+    agent.add_hook(lambda event: seen.append("before"), BeforeInvocationEvent)
+    agent.add_hook(lambda event: seen.append("after"), AfterInvocationEvent)
+
+    result = await agent.invoke_async("go", limits={"turns": 1})
+
+    assert result.stop_reason == "limit_turns"
+    assert seen == ["before", "after"]

--- a/strands-py/tests/strands/agent/test_conversation_manager.py
+++ b/strands-py/tests/strands/agent/test_conversation_manager.py
@@ -983,9 +983,7 @@ def test_proactive_compression_exception_swallowed():
 def test_proactive_compression_true_default_threshold_behavior():
     """proactive_compression=True uses 0.7 — triggered at 0.7+ but not below."""
     manager = _MinimalManager(proactive_compression=True)
-    agent = _make_mock_agent(
-        messages=[{"role": "user", "content": [{"text": "msg"}]}], context_window_limit=1000
-    )
+    agent = _make_mock_agent(messages=[{"role": "user", "content": [{"text": "msg"}]}], context_window_limit=1000)
     registry = HookRegistry()
     manager.register_hooks(registry)
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3505,8 +3505,7 @@ class TestCountTokens:
         self, model_with_client, bedrock_client, messages, caplog
     ):
         error_message = (
-            "User: arn:aws:sts::123456789012:assumed-role/role is not authorized"
-            " to perform: bedrock:CountTokens"
+            "User: arn:aws:sts::123456789012:assumed-role/role is not authorized to perform: bedrock:CountTokens"
         )
         bedrock_client.count_tokens.side_effect = ClientError(
             {"Error": {"Code": "AccessDeniedException", "Message": error_message}},


### PR DESCRIPTION
## Description

## Motivation

An agent loop today runs until the model stops requesting tools, a hook halts it, or it's cancelled. There's no caller-side guardrail on cost or runaway behavior — anyone wanting to bound a run has to wire a hook themselves or wrap the call in a timeout that races against the model rather than terminating cleanly at a turn boundary. This adds first-class, per-invocation budget caps so callers can put a ceiling on a single `invoke_async` / `stream_async` without fighting the loop.

Ports the equivalent TypeScript feature merged in strands-agents/sdk-typescript#1106.

## Public API Changes

`Agent.__call__`, `Agent.invoke_async`, and `Agent.stream_async` accept an optional `limits` argument with three caps:

```python
# Cap loop iterations
result = await agent.invoke_async("Plan a trip", limits={"turns": 5})
if result.stop_reason == "limit_turns":
    ...

# Cap cumulative model-generated tokens across the loop
result = await agent.invoke_async("Summarize", limits={"output_tokens": 10_000})
if result.stop_reason == "limit_output_tokens":
    ...

# Cap cumulative input + output tokens (compounds across turns; approximates billed spend)
result = await agent.invoke_async("Research X", limits={"total_tokens": 100_000})

# Combine
result = await agent.invoke_async("Plan a trip", limits={
    "turns": 10, "output_tokens": 50_000, "total_tokens": 200_000,
})
```

When a cap is reached the loop terminates gracefully at the next turn boundary and returns an `AgentResult` with one of three new `stop_reason` values: `"limit_turns"`, `"limit_output_tokens"`, `"limit_total_tokens"`. No exception is raised — this mirrors how `"cancelled"` already works, and leaves `result.message` and `result.metrics` accessible.

The existing `"max_tokens"` reason (and `MaxTokensReachedException`) is unchanged. That one signals the model provider's per-call output cap and still raises; the new caller-set caps are graceful.

Caps are scoped to a single invocation — counters reset on each `invoke_async` / `stream_async` call against the same agent. Tools requested by the previous turn always run to completion before a cap fires, so `agent.messages` stays in a state the agent can be reinvoked from. On simultaneous trip the priority is `turns` → `total_tokens` → `output_tokens`, giving the most informative reason in the result. Caps are soft: a single oversized model response can overshoot the budget by one turn, since checks happen at turn boundaries, not within an individual model call.

Each cap, when set, must be a positive `int`; invalid values raise `TypeError` at the start of the invocation. Backward compatible — omitting `limits` preserves prior behavior.

### Why a `limits` dict instead of top-level kwargs

Grouping under `limits` keeps the top-level kwarg surface stable as future caps (wall-clock, cost, etc.) are added. The stop reasons keep a `limit_` prefix rather than collapsing to a single `"limit_exceeded"` so granular telemetry / log buckets are preserved — callers shouldn't have to derive which cap tripped from `result.metrics` plus the `limits` they passed in.

## Use Cases

- **Cost ceilings on user-facing agents** — bound an interactive turn so a misbehaving model can't burn an unbounded number of tokens before the user sees a response.
- **Eval / batch harnesses** — give every run a fixed `turns` budget so a single stuck agent doesn't pin a worker.
- **Cheap timeouts at turn boundaries** — terminate cleanly with a real `stop_reason` instead of cancelling mid-stream.

## Related Issues

#2124 

## Documentation PR

N/A — will follow up.

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
