### PR TITLE
fix: include README, LICENSE, and NOTICE in Python wheel

### DIFF
--- a/.github/workflows/python-pypi-publish-on-release.yml
+++ b/.github/workflows/python-pypi-publish-on-release.yml
@@ -55,6 +55,12 @@ jobs:
             exit 1
         fi
 
+    - name: Copy root README and LICENSE
+      run: |
+        cp ../README.md .
+        cp ../LICENSE.APACHE LICENSE
+        cp ../NOTICE .
+
     - name: Build
       run: |
         hatch build

--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -88,6 +88,11 @@ jobs:
         run: |
           # Windows typically has audio libraries available by default
           echo "Windows audio dependencies handled by PyAudio wheels"
+      - name: Copy root README and LICENSE
+        run: |
+          cp ../README.md .
+          cp ../LICENSE.APACHE LICENSE
+          cp ../NOTICE .
       - name: Install dependencies
         run: |
           pip install --no-cache-dir hatch 'virtualenv<21'
@@ -126,6 +131,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y portaudio19-dev libasound2-dev
+
+      - name: Copy root README and LICENSE
+        run: |
+          cp ../README.md .
+          cp ../LICENSE.APACHE LICENSE
+          cp ../NOTICE .
 
       - name: Install dependencies
         run: |

--- a/strands-py/.gitignore
+++ b/strands-py/.gitignore
@@ -15,3 +15,6 @@ repl_state
 uv.lock
 .audio_cache
 CLAUDE.md
+README.md
+LICENSE
+NOTICE

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -7,9 +7,10 @@ build-backend = "hatchling.build"
 name = "strands-agents"
 dynamic = ["version"]  # Version determined by git tags
 description = "A model-driven approach to building AI agents in just a few lines of code"
-readme = "../README.md"
+readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
+license-files = ["LICENSE", "NOTICE"]
 authors = [
     {name = "AWS", email = "opensource@amazon.com"},
 ]


### PR DESCRIPTION
## Description

The monorepo restructuring moved the Python package into `strands-py/` but left `pyproject.toml` pointing at `readme = "../README.md"`. While hatch can resolve that path for embedding the long description, the `LICENSE` and `NOTICE` files never get bundled into the wheel since they live at the repo root, outside the build directory.

This adopts the same pattern the TypeScript SDK already uses: copy the shared root files into the package directory at build time in CI, and gitignore the copies so they don't clutter the repo.

Resolves: #2351

## Related Issues

#2351

## Type of Change

Bug fix

## Testing

Built the wheel locally from this branch and diffed the file listing against the currently published `strands-agents==1.41.0` on PyPI. The result is structurally identical — same source files, same `licenses/LICENSE`, same `licenses/NOTICE`, same embedded README in METADATA. `twine check` passes for both wheel and sdist.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.