### PR TITLE
fix(strands-py-wasm): access structured-output via kebab-case attr in invoke_async

### DIFF
--- a/strands-py-wasm/src/strands/__init__.py
+++ b/strands-py-wasm/src/strands/__init__.py
@@ -1023,7 +1023,11 @@ class _AgentResultAccumulator:
             last_message=last,
             usage=stop.usage if stop is not None else None,
             metrics=None,
-            structured_output=(json.loads(stop.structured_output) if stop and stop.structured_output else None),
+            structured_output=(
+                json.loads(getattr(stop, "structured-output"))
+                if stop is not None and getattr(stop, "structured-output", None)
+                else None
+            ),
             interrupts=self._interrupts or None,
         )
 

--- a/strands-py-wasm/tests/test_agent.py
+++ b/strands-py-wasm/tests/test_agent.py
@@ -1,6 +1,6 @@
 import pytest
 
-from strands import Agent, BedrockModel, StreamEvent, StreamEvent_Stop
+from strands import Agent, AgentResult, BedrockModel, StreamEvent, StreamEvent_Stop
 
 
 @pytest.fixture
@@ -11,6 +11,13 @@ def model():
 @pytest.fixture
 def agent(model):
     return Agent(model=model)
+
+
+@pytest.mark.asyncio
+async def test_invoke_async_hello_world(agent):
+    result = await agent.invoke_async("Say hello world")
+    assert isinstance(result, AgentResult)
+    assert "hello" in str(result).lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

The `_AgentResultAccumulator.finalize()` method accessed `stop.structured_output` using Python dot notation, but the `StopEvent` from the WASM runtime is a raw wasmtime Record that stores the field under its WIT kebab-case name `structured-output`. This caused an `AttributeError` on every `invoke_async` call.

Uses `getattr(stop, "structured-output")` to access the kebab-case attribute correctly.

Also adds an `invoke_async` integration test.

## Related Issues

Tracking: https://github.com/strands-agents/sdk-typescript/pull/1102

## Type of Change

Bug fix

## Testing

- Added `test_invoke_async_hello_world` integration test that exercises `invoke_async` end-to-end
- Manually verified concurrent `invoke_async` calls via `asyncio.gather` achieve ~1.7x speedup over sequential execution

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.