### PR TITLE
fix: scope authorization-check job permissions to contents: read

### DIFF
--- a/.github/workflows/auto-strands-review.yml
+++ b/.github/workflows/auto-strands-review.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   authorization-check:
     name: Check access
-    permissions: read-all
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -12,7 +12,8 @@ on:
 jobs:
   authorization-check:
     name: Check access
-    permissions: read-all
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -24,7 +24,8 @@ jobs:
   authorization-check:
     if: startsWith(github.event.comment.body, '/strands') || github.event_name == 'workflow_dispatch'
     name: Check access
-    permissions: read-all
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -17,7 +17,8 @@ on:
 jobs:
   authorization-check:
     name: Check access
-    permissions: read-all
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}


### PR DESCRIPTION
## Summary

- Replace `permissions: read-all` with explicit `contents: read` on all four authorization-check jobs across workflows
- Affected workflows: `strands-command.yml`, `python-integration-test.yml`, `typescript-integration-test.yml`, `auto-strands-review.yml`
- The authorization-check action only requires repository read access (checkout + `repos.getCollaboratorPermissionLevel` API call)

## Test plan

- [ ] Verify authorization-check jobs still pass on PRs from collaborators (auto-approve path)
- [ ] Verify authorization-check jobs still require manual-approval for non-collaborators