### PR TITLE
fix(structured-output): downgrade validation failure log from error to debug

### DIFF
--- a/strands-py/src/strands/tools/structured_output/structured_output_tool.py
+++ b/strands-py/src/strands/tools/structured_output/structured_output_tool.py
@@ -130,7 +130,7 @@ class StructuredOutputTool(AgentTool):
             error_message = f"Validation failed for {self._tool_name}. Please fix the following errors:\n" + "\n".join(
                 f"- {detail}" for detail in error_details
             )
-            logger.error(
+            logger.debug(
                 "tool_name=<%s> | structured output validation failed | error_message=<%s>",
                 self._tool_name,
                 error_message,


### PR DESCRIPTION
## Motivation

When structured output validation fails, the model receives the error as feedback and retries — typically succeeding on the next attempt. This is normal, expected behavior in the retry loop. However, the validation failure is currently logged at `ERROR` level, which surfaces alarming messages to users (e.g., `ERROR:strands.tools.structured_output.structured_output_tool:tool_name=<...> | structured output validation failed`) even though the system is working as designed.

Users observing these logs reasonably interpret them as something broken, when in reality it's just the self-correction mechanism doing its job.

Resolves: #2362

## Public API Changes

No public API changes. This only affects log output visibility — the validation failure message moves from `ERROR` to `DEBUG` level, so it no longer appears unless users explicitly enable debug logging.