### PR TITLE
ci: use env var for repository name in integration test workflow

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -102,6 +102,8 @@ jobs:
           name: test-results
 
       - name: Publish test metrics to CloudWatch
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           pip install --no-cache-dir boto3
-          python .github/scripts/upload-integ-test-metrics.py test-results.xml ${{ github.event.repository.name }}
+          python .github/scripts/upload-integ-test-metrics.py test-results.xml "$REPO_NAME"


### PR DESCRIPTION
## Summary

- Move `github.event.repository.name` from inline expression interpolation to an `env:` block variable in the integration test metrics upload step
- Aligns with the convention used elsewhere in the project's workflows

## Test plan

- [ ] Verify integration test workflow still uploads metrics to CloudWatch after merge