### PR TITLE
fix: use separate READMEs for Python and TypeScript packages

### DIFF
--- a/.github/workflows/python-pypi-publish-on-release.yml
+++ b/.github/workflows/python-pypi-publish-on-release.yml
@@ -55,6 +55,11 @@ jobs:
             exit 1
         fi
 
+    - name: Copy root LICENSE and NOTICE
+      run: |
+        cp ../LICENSE.APACHE LICENSE
+        cp ../NOTICE .
+
     - name: Build
       run: |
         hatch build

--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -88,6 +88,10 @@ jobs:
         run: |
           # Windows typically has audio libraries available by default
           echo "Windows audio dependencies handled by PyAudio wheels"
+      - name: Copy root LICENSE and NOTICE
+        run: |
+          cp ../LICENSE.APACHE LICENSE
+          cp ../NOTICE .
       - name: Install dependencies
         run: |
           pip install --no-cache-dir hatch 'virtualenv<21'
@@ -126,6 +130,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y portaudio19-dev libasound2-dev
+
+      - name: Copy root LICENSE and NOTICE
+        run: |
+          cp ../LICENSE.APACHE LICENSE
+          cp ../NOTICE .
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,5 @@ CLAUDE.md
 # dev
 .vitest*
 
-# Files copied into strands-ts/ during prepack (originals live at repo root)
-strands-ts/README.md
+# LICENSE copied into strands-ts/ during prepack (original lives at repo root)
 strands-ts/LICENSE

--- a/strands-py/.gitignore
+++ b/strands-py/.gitignore
@@ -15,3 +15,5 @@ repl_state
 uv.lock
 .audio_cache
 CLAUDE.md
+LICENSE
+NOTICE

--- a/strands-py/README.md
+++ b/strands-py/README.md
@@ -1,0 +1,336 @@
+<div align="center">
+  <div>
+    <a href="https://strandsagents.com">
+      <img src="https://strandsagents.com/latest/assets/logo-github.svg" alt="Strands Agents" width="55px" height="105px">
+    </a>
+  </div>
+
+  <h1>
+    Strands Agents - Python SDK
+  </h1>
+
+  <h2>
+    A model-driven approach to building AI agents in just a few lines of code.
+  </h2>
+
+  <div align="center">
+    <a href="https://github.com/strands-agents/sdk-python/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/strands-agents/sdk-python"/></a>
+    <a href="https://github.com/strands-agents/sdk-python/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/sdk-python"/></a>
+    <a href="https://github.com/strands-agents/sdk-python/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/sdk-python"/></a>
+    <a href="https://github.com/strands-agents/sdk-python/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/sdk-python"/></a>
+    <a href="https://pypi.org/project/strands-agents/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/strands-agents"/></a>
+    <a href="https://python.org"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/strands-agents"/></a>
+    <a href="https://discord.gg/strands"><img alt="Strands Discord" src="https://img.shields.io/badge/Discord-Strands-5865F2?logo=discord&logoColor=white"/></a>
+  </div>
+  
+  <p>
+    <a href="https://strandsagents.com/">Documentation</a>
+    ◆ <a href="https://github.com/strands-agents/samples">Samples</a>
+    ◆ <a href="https://github.com/strands-agents/tools">Tools</a>
+    ◆ <a href="https://github.com/strands-agents/agent-builder">Agent Builder</a>
+    ◆ <a href="https://github.com/strands-agents/mcp-server">MCP Server</a>
+  </p>
+</div>
+
+Strands Agents is a simple yet powerful SDK that takes a model-driven approach to building and running AI agents. From simple conversational assistants to complex autonomous workflows, from local development to production deployment, Strands Agents scales with your needs.
+
+## Feature Overview
+
+- **Lightweight & Flexible**: Simple agent loop that just works and is fully customizable
+- **Model Agnostic**: Support for Amazon Bedrock, Anthropic, Gemini, LiteLLM, Llama, Ollama, OpenAI, Writer, and custom providers
+- **Advanced Capabilities**: Multi-agent systems, autonomous agents, and streaming support
+- **Built-in MCP**: Native support for Model Context Protocol (MCP) servers, enabling access to thousands of pre-built tools
+
+## Quick Start
+
+```bash
+# Install Strands Agents
+pip install strands-agents strands-agents-tools
+```
+
+```python
+from strands import Agent
+from strands_tools import calculator
+agent = Agent(tools=[calculator])
+agent("What is the square root of 1764")
+```
+
+> **Note**: For the default Amazon Bedrock model provider, you'll need AWS credentials configured and model access enabled for Claude 4 Sonnet in the us-west-2 region. See the [Quickstart Guide](https://strandsagents.com/) for details on configuring other model providers.
+
+## Installation
+
+Ensure you have Python 3.10+ installed, then:
+
+```bash
+# Create and activate virtual environment
+python -m venv .venv
+source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
+
+# Install Strands and tools
+pip install strands-agents strands-agents-tools
+```
+
+## Features at a Glance
+
+### Python-Based Tools
+
+Easily build tools using Python decorators:
+
+```python
+from strands import Agent, tool
+
+@tool
+def word_count(text: str) -> int:
+    """Count words in text.
+
+    This docstring is used by the LLM to understand the tool's purpose.
+    """
+    return len(text.split())
+
+agent = Agent(tools=[word_count])
+response = agent("How many words are in this sentence?")
+```
+
+**Hot Reloading from Directory:**
+Enable automatic tool loading and reloading from the `./tools/` directory:
+
+```python
+from strands import Agent
+
+# Agent will watch ./tools/ directory for changes
+agent = Agent(load_tools_from_directory=True)
+response = agent("Use any tools you find in the tools directory")
+```
+
+### MCP Support
+
+Seamlessly integrate Model Context Protocol (MCP) servers:
+
+```python
+from strands import Agent
+from strands.tools.mcp import MCPClient
+from mcp import stdio_client, StdioServerParameters
+
+aws_docs_client = MCPClient(
+    lambda: stdio_client(StdioServerParameters(command="uvx", args=["awslabs.aws-documentation-mcp-server@latest"]))
+)
+
+with aws_docs_client:
+   agent = Agent(tools=aws_docs_client.list_tools_sync())
+   response = agent("Tell me about Amazon Bedrock and how to use it with Python")
+```
+
+### Multiple Model Providers
+
+Support for various model providers:
+
+```python
+from strands import Agent
+from strands.models import BedrockModel
+from strands.models.ollama import OllamaModel
+from strands.models.llamaapi import LlamaAPIModel
+from strands.models.gemini import GeminiModel
+from strands.models.llamacpp import LlamaCppModel
+
+# Bedrock
+bedrock_model = BedrockModel(
+  model_id="us.amazon.nova-pro-v1:0",
+  temperature=0.3,
+  streaming=True, # Enable/disable streaming
+)
+agent = Agent(model=bedrock_model)
+agent("Tell me about Agentic AI")
+
+# Google Gemini
+gemini_model = GeminiModel(
+  client_args={
+    "api_key": "your_gemini_api_key",
+  },
+  model_id="gemini-2.5-flash",
+  params={"temperature": 0.7}
+)
+agent = Agent(model=gemini_model)
+agent("Tell me about Agentic AI")
+
+# Ollama
+ollama_model = OllamaModel(
+  host="http://localhost:11434",
+  model_id="llama3"
+)
+agent = Agent(model=ollama_model)
+agent("Tell me about Agentic AI")
+
+# Llama API
+llama_model = LlamaAPIModel(
+    model_id="Llama-4-Maverick-17B-128E-Instruct-FP8",
+)
+agent = Agent(model=llama_model)
+response = agent("Tell me about Agentic AI")
+```
+
+Built-in providers:
+ - [Amazon Bedrock](https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/)
+ - [Anthropic](https://strandsagents.com/docs/user-guide/concepts/model-providers/anthropic/)
+ - [Gemini](https://strandsagents.com/docs/user-guide/concepts/model-providers/gemini/)
+ - [Cohere](https://strandsagents.com/docs/user-guide/concepts/model-providers/cohere/)
+ - [LiteLLM](https://strandsagents.com/docs/user-guide/concepts/model-providers/litellm/)
+ - [llama.cpp](https://strandsagents.com/docs/user-guide/concepts/model-providers/llamacpp/)
+ - [LlamaAPI](https://strandsagents.com/docs/user-guide/concepts/model-providers/llamaapi/)
+ - [MistralAI](https://strandsagents.com/docs/user-guide/concepts/model-providers/mistral/)
+ - [Ollama](https://strandsagents.com/docs/user-guide/concepts/model-providers/ollama/)
+ - [OpenAI](https://strandsagents.com/docs/user-guide/concepts/model-providers/openai/)
+ - [OpenAI Responses API](https://strandsagents.com/docs/user-guide/concepts/model-providers/openai/)
+ - [SageMaker](https://strandsagents.com/docs/user-guide/concepts/model-providers/sagemaker/)
+ - [Writer](https://strandsagents.com/docs/user-guide/concepts/model-providers/writer/)
+
+Custom providers can be implemented using [Custom Providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/custom_model_provider/)
+
+### Example tools
+
+Strands offers an optional strands-agents-tools package with pre-built tools for quick experimentation:
+
+```python
+from strands import Agent
+from strands_tools import calculator
+agent = Agent(tools=[calculator])
+agent("What is the square root of 1764")
+```
+
+It's also available on GitHub via [strands-agents/tools](https://github.com/strands-agents/tools).
+
+### Bidirectional Streaming
+
+> **⚠️ Experimental Feature**: Bidirectional streaming is currently in experimental status. APIs may change in future releases as we refine the feature based on user feedback and evolving model capabilities.
+
+Build real-time voice and audio conversations with persistent streaming connections. Unlike traditional request-response patterns, bidirectional streaming maintains long-running conversations where users can interrupt, provide continuous input, and receive real-time audio responses. Get started with your first BidiAgent by following the [Quickstart](https://strandsagents.com/docs/user-guide/concepts/bidirectional-streaming/quickstart/) guide. 
+
+**Supported Model Providers:**
+- Amazon Nova Sonic (v1, v2)
+- Google Gemini Live
+- OpenAI Realtime API
+
+**Installation:**
+
+```bash
+# Server-side only (no audio I/O dependencies)
+pip install strands-agents[bidi]
+
+# With audio I/O support (includes PyAudio dependency)
+pip install strands-agents[bidi,bidi-io]
+```
+
+**Quick Example:**
+
+```python
+import asyncio
+from strands.experimental.bidi import BidiAgent
+from strands.experimental.bidi.models import BidiNovaSonicModel
+from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
+from strands.experimental.bidi.tools import stop_conversation
+from strands_tools import calculator
+
+async def main():
+    # Create bidirectional agent with Nova Sonic v2
+    model = BidiNovaSonicModel()
+    agent = BidiAgent(model=model, tools=[calculator, stop_conversation])
+
+    # Setup audio and text I/O (requires bidi-io extra)
+    audio_io = BidiAudioIO()
+    text_io = BidiTextIO()
+
+    # Run with real-time audio streaming
+    # Say "stop conversation" to gracefully end the conversation
+    await agent.run(
+        inputs=[audio_io.input()],
+        outputs=[audio_io.output(), text_io.output()]
+    )
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+> **Note**: `BidiAudioIO` and `BidiTextIO` require the `bidi-io` extra. For server-side deployments where audio I/O is handled by clients (browsers, mobile apps), install only `strands-agents[bidi]` and implement custom input/output handlers using the `BidiInput` and `BidiOutput` protocols.
+
+**Configuration Options:**
+
+```python
+from strands.experimental.bidi.models import BidiNovaSonicModel
+
+# Configure audio settings and turn detection (v2 only)
+model = BidiNovaSonicModel(
+    provider_config={
+        "audio": {
+            "input_rate": 16000,
+            "output_rate": 16000,
+            "voice": "matthew"
+        },
+        "turn_detection": {
+            "endpointingSensitivity": "MEDIUM"  # HIGH, MEDIUM, or LOW
+        },
+        "inference": {
+            "max_tokens": 2048,
+            "temperature": 0.7
+        }
+    }
+)
+
+# Configure I/O devices
+audio_io = BidiAudioIO(
+    input_device_index=0,  # Specific microphone
+    output_device_index=1,  # Specific speaker
+    input_buffer_size=10,
+    output_buffer_size=10
+)
+
+# Text input mode (type messages instead of speaking)
+text_io = BidiTextIO()
+await agent.run(
+    inputs=[text_io.input()],  # Use text input
+    outputs=[audio_io.output(), text_io.output()]
+)
+
+# Multi-modal: Both audio and text input
+await agent.run(
+    inputs=[audio_io.input(), text_io.input()],  # Speak OR type
+    outputs=[audio_io.output(), text_io.output()]
+)
+```
+
+## Documentation
+
+For detailed guidance & examples, explore our documentation:
+
+- [User Guide](https://strandsagents.com/)
+- [Quick Start Guide](https://strandsagents.com/docs/user-guide/quickstart/)
+- [Agent Loop](https://strandsagents.com/docs/user-guide/concepts/agents/agent-loop/)
+- [Examples](https://strandsagents.com/docs/examples/)
+- [API Reference](https://strandsagents.com/docs/api/python/strands.agent.agent/)
+- [Production & Deployment Guide](https://strandsagents.com/docs/user-guide/deploy/operating-agents-in-production/)
+
+## Development
+
+```bash
+pip install hatch
+hatch test        # run unit tests
+hatch fmt         # format & lint
+```
+
+## Contributing ❤️
+
+We welcome contributions! See our [Contributing Guide](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md) for details on:
+- Reporting bugs & features
+- Development setup
+- Contributing via Pull Requests
+- Code of Conduct
+- Reporting of security issues
+
+## Stay in touch with the team
+Come meet the Strands team and other users on [**Discord**](https://discord.com/invite/strands)
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/strands-agents/sdk-python/blob/main/LICENSE.APACHE) file for details.
+
+## Security
+
+See [CONTRIBUTING](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -7,9 +7,10 @@ build-backend = "hatchling.build"
 name = "strands-agents"
 dynamic = ["version"]  # Version determined by git tags
 description = "A model-driven approach to building AI agents in just a few lines of code"
-readme = "../README.md"
+readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
+license-files = ["LICENSE", "NOTICE"]
 authors = [
     {name = "AWS", email = "opensource@amazon.com"},
 ]

--- a/strands-ts/README.md
+++ b/strands-ts/README.md
@@ -1,0 +1,346 @@
+<div align="center">
+  <div>
+    <a href="https://strandsagents.com">
+      <img src="https://strandsagents.com/latest/assets/logo-github.svg" alt="Strands Agents" width="55px" height="105px">
+    </a>
+  </div>
+
+  <h1>
+    Strands Agents - TypeScript SDK
+  </h1>
+
+  <h2>
+    A model-driven approach to building AI agents in TypeScript/JavaScript.
+  </h2>
+
+  <div align="center">
+    <a href="https://github.com/strands-agents/sdk-python/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/strands-agents/sdk-python"/></a>
+    <a href="https://github.com/strands-agents/sdk-python/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/sdk-python"/></a>
+    <a href="https://github.com/strands-agents/sdk-python/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/sdk-python"/></a>
+    <a href="https://github.com/strands-agents/sdk-python/blob/main/LICENSE.APACHE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/sdk-python"/></a>
+    <a href="https://www.npmjs.com/package/@strands-agents/sdk"><img alt="NPM Version" src="https://img.shields.io/npm/v/@strands-agents/sdk"/></a>
+    <a href="https://discord.gg/strands"><img alt="Strands Discord" src="https://img.shields.io/badge/Discord-Strands-5865F2?logo=discord&logoColor=white"/></a>
+  </div>
+  
+  <p>
+    <a href="https://strandsagents.com/">Documentation</a>
+    ◆ <a href="https://github.com/strands-agents/samples">Samples</a>
+    ◆ <a href="https://github.com/strands-agents/sdk-python">Python SDK</a>
+    ◆ <a href="https://github.com/strands-agents/tools">Tools</a>
+    ◆ <a href="https://github.com/strands-agents/agent-builder">Agent Builder</a>
+    ◆ <a href="https://github.com/strands-agents/mcp-server">MCP Server</a>
+  </p>
+</div>
+
+---
+
+## Overview
+
+Strands Agents is a simple yet powerful SDK that takes a model-driven approach to building and running AI agents. The TypeScript SDK brings key features from the Python Strands framework to Node.js environments, enabling type-safe agent development for everything from simple assistants to complex workflows.
+
+### Key Features
+
+- **🪶 Lightweight & Flexible**: Simple agent loop that works seamlessly in Node.js and browser environments
+- **🔒 Type-Safe Tools**: Define tools easily using Zod schemas for robust input validation and type inference
+- **📋 Structured Output**: Get type-safe, validated responses from LLMs using Zod schemas with automatic retry on validation errors
+- **🔌 Model Agnostic**: First-class support for Amazon Bedrock and OpenAI, with extensible architecture for custom providers
+- **🔗 Built-in MCP**: Native support for Model Context Protocol (MCP) clients, enabling access to external tools and servers
+- **⚡ Streaming Support**: Real-time response streaming for better user experience
+- **🎣 Extensible Hooks**: Lifecycle hooks for monitoring and customizing agent behavior
+- **💬 Conversation Management**: Flexible strategies for managing conversation history and context windows
+- **🤝 Multi-Agent Orchestration**: Graph and Swarm patterns for coordinating multiple agents
+
+---
+
+## Quick Start
+
+### Installation
+
+Ensure you have **[Node.js 20+](https://nodejs.org/)** installed, then:
+
+```bash
+npm install @strands-agents/sdk
+```
+
+### Basic Usage
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+
+// Create agent (uses default Amazon Bedrock provider)
+const agent = new Agent()
+
+// Invoke
+const result = await agent.invoke('What is the square root of 1764?')
+console.log(result)
+```
+
+> **Note**: For the default Amazon Bedrock model provider, you'll need AWS credentials configured and model access enabled for Claude Sonnet 4 in your region.
+
+---
+
+## Core Concepts
+
+### Agents
+
+The `Agent` class is the central orchestrator that manages the interaction loop between users, models, and tools.
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+
+const agent = new Agent({
+  systemPrompt: 'You are a helpful assistant.',
+})
+```
+### Model Providers
+
+Switch between model providers easily:
+
+**Amazon Bedrock (Default)**
+
+```typescript
+import { Agent, BedrockModel } from '@strands-agents/sdk'
+
+const model = new BedrockModel({
+  region: 'us-east-1',
+  modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+  maxTokens: 4096,
+  temperature: 0.7
+})
+
+const agent = new Agent({ model })
+```
+
+**OpenAI**
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+
+// Automatically uses process.env.OPENAI_API_KEY and defaults to gpt-5.4
+const model = new OpenAIModel({ api: 'chat' })
+
+const agent = new Agent({ model })
+```
+
+### Streaming Responses
+
+Access responses as they are generated:
+
+```typescript
+const agent = new Agent()
+
+console.log('Agent response stream:')
+for await (const event of agent.stream('Tell me a story about a brave toaster.')) {
+  console.log('[Event]', event.type)
+}
+```
+
+### Tools
+
+Tools enable agents to interact with external systems and perform actions. Create type-safe tools using Zod schemas:
+
+```typescript
+import { Agent, tool } from '@strands-agents/sdk'
+import { z } from 'zod'
+
+const weatherTool = tool({
+  name: 'get_weather',
+  description: 'Get the current weather for a specific location.',
+  inputSchema: z.object({
+    location: z.string().describe('The city and state, e.g., San Francisco, CA'),
+  }),
+  callback: (input) => {
+    // input is fully typed based on the Zod schema
+    return `The weather in ${input.location} is 72°F and sunny.`
+  },
+})
+
+const agent = new Agent({
+  tools: [weatherTool],
+})
+
+await agent.invoke('What is the weather in San Francisco?')
+```
+
+**Vended Tools**: The SDK includes optional pre-built tools:
+- **Notebook Tool**: Manage text-based notebooks for persistent note-taking
+- **File Editor Tool**: Perform file system operations (read, write, edit files)
+- **HTTP Request Tool**: Make HTTP requests to external APIs
+
+
+### Structured Output
+
+Get type-safe, validated responses from LLMs by defining the expected output structure with Zod schemas. The agent automatically validates the LLM's response and retries on validation errors:
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { z } from 'zod'
+
+const PersonSchema = z.object({
+  name: z.string().describe('Name of the person'),
+  age: z.number().describe('Age of the person'),
+  occupation: z.string().describe('Occupation of the person')
+})
+
+// Configure structured output at the agent level
+const agent = new Agent({ 
+  structuredOutputSchema: PersonSchema 
+})
+
+const result = await agent.invoke('John Smith is a 30 year-old software engineer')
+
+// result.structuredOutput is fully typed based on the schema
+console.log(result.structuredOutput.name) // "John Smith"
+console.log(result.structuredOutput.age)  // 30
+```
+
+**Error handling**: The agent automatically retries with validation feedback when the LLM provides invalid output. If validation ultimately fails, a `StructuredOutputError` is thrown:
+
+```typescript
+import { StructuredOutputError } from '@strands-agents/sdk'
+
+try {
+  const result = await agent.invoke('Extract person info...')
+  console.log(result.structuredOutput)
+} catch (error) {
+  if (error instanceof StructuredOutputError) {
+    console.error('Validation failed:', error.message)
+  }
+}
+```
+
+
+### MCP Integration
+
+Seamlessly integrate Model Context Protocol (MCP) servers:
+
+```typescript
+import { Agent, McpClient } from "@strands-agents/sdk";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+// Create a client for a local MCP server
+const documentationTools = new McpClient({
+  transport: new StdioClientTransport({
+    command: "uvx",
+    args: ["awslabs.aws-documentation-mcp-server@latest"],
+  }),
+});
+
+const agent = new Agent({
+  systemPrompt: "You are a helpful assistant using MCP tools.",
+  tools: [documentationTools], // Pass the MCP client directly as a tool source
+});
+
+await agent.invoke("Use a random tool from the MCP server.");
+
+await documentationTools.disconnect();
+```
+
+### Multi-Agent Orchestration
+
+Coordinate multiple agents using built-in orchestration patterns.
+
+**Graph** — You define a deterministic execution plan. Agents run as nodes in a directed graph, with edges controlling execution order. Parallel execution is supported, and downstream nodes run once all dependencies complete.
+
+```typescript
+import { Agent, BedrockModel, Graph } from '@strands-agents/sdk'
+
+const model = new BedrockModel({ maxTokens: 1024 })
+
+const researcher = new Agent({
+  model,
+  id: 'researcher',
+  systemPrompt: 'Research the topic and provide key facts.',
+})
+
+const writer = new Agent({
+  model,
+  id: 'writer',
+  systemPrompt: 'Rewrite the research into a polished paragraph.',
+})
+
+const graph = new Graph({
+  nodes: [researcher, writer],
+  edges: [['researcher', 'writer']],
+})
+
+const result = await graph.invoke('What is the largest ocean?')
+```
+
+**Swarm** — The agents decide the routing. Each agent chooses whether to hand off to another agent or produce a final response, making the execution path dynamic and model-driven.
+
+```typescript
+import { Agent, BedrockModel, Swarm } from '@strands-agents/sdk'
+
+const model = new BedrockModel({ maxTokens: 1024 })
+
+const researcher = new Agent({
+  model,
+  id: 'researcher',
+  description: 'Researches a topic and gathers key facts.',
+  systemPrompt: 'Research the answer, then hand off to the writer.',
+})
+
+const writer = new Agent({
+  model,
+  id: 'writer',
+  description: 'Writes a polished final answer.',
+  systemPrompt: 'Write the final answer. Do not hand off.',
+})
+
+const swarm = new Swarm({
+  nodes: [researcher, writer],
+  start: 'researcher',
+  maxSteps: 4,
+})
+
+const result = await swarm.invoke('What is the largest ocean?')
+```
+
+Both patterns support streaming via `.stream()` for real-time access to handoff and node execution events. See the [examples](./examples/) directory for complete working samples.
+
+---
+
+## Documentation
+
+For detailed guidance, tutorials, and concept overviews, please visit:
+
+- **[Official Documentation](https://strandsagents.com/)**: Comprehensive guides and tutorials
+- **[API Reference](https://strandsagents.com/docs/api/typescript/)**: Complete API documentation
+- **[Examples](./examples/)**: Sample applications
+  - **[First Agent](./examples/first-agent/)**: Basic Node.js agent
+  - **[MCP](./examples/mcp/)**: MCP integration example
+  - **[Browser Agent](./examples/browser-agent/)**: Browser-based agent with DOM manipulation
+
+- **[Contributing Guide](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md)**: Development setup and guidelines
+
+---
+
+## Contributing ❤️
+
+We welcome contributions! See our [Contributing Guide](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md) for details on:
+
+- Development setup and environment
+- Testing and code quality standards
+- Pull request process
+- Code of Conduct
+- Security issue reporting
+
+---
+
+## Stay in touch with the team
+Come meet the Strands team and other users on [**Discord**](https://discord.com/invite/strands)
+
+---
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/strands-agents/sdk-python/blob/main/LICENSE.APACHE) file for details.
+
+---
+
+## Security
+
+See [CONTRIBUTING](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information on reporting security issues.
+

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -99,8 +99,8 @@
   },
   "scripts": {
     "build": "tsc --project src/tsconfig.json",
-    "prepack": "npm run build && cp ../README.md . && cp ../LICENSE.APACHE LICENSE",
-    "postpack": "rm -f README.md LICENSE",
+    "prepack": "npm run build && cp ../LICENSE.APACHE LICENSE",
+    "postpack": "rm -f LICENSE",
     "check": "npm run lint && npm run format && npm run type-check && npm run check:browser-bundle && npm run test:coverage && npm run test:package",
     "check:browser-bundle": "esbuild src/index.ts --bundle --platform=browser --format=esm --packages=external --outfile=/dev/null",
     "clean": "rm -rf node_modules dist",


### PR DESCRIPTION
## Description

The shared root README contains only Python examples, which displays incorrectly on npmjs.com for the TypeScript SDK. It also doesn't mention TypeScript features at all. Each SDK now has its own README committed in its package directory, pulled from git history (the Python one from the pre-monorepo root, the TypeScript one from sdk-typescript before the merge).

The root README stays as the monorepo landing page with the directory table. Each package README has the correct SDK title, badges, code examples, and documentation links for its ecosystem.

This also fixes the LICENSE/NOTICE bundling for the Python wheel — the CI workflows copy `LICENSE.APACHE` and `NOTICE` from the root at build time, and `pyproject.toml` now declares `license-files` so they get included in the wheel's `licenses/` directory.

Resolves: #2351

## Related Issues

#2351, #2286

## Type of Change

Bug fix

## Testing

- Built Python wheel, verified it contains `licenses/LICENSE`, `licenses/NOTICE`, and METADATA shows "Strands Agents - Python SDK" title with full markdown description
- Ran `npm pack --dry-run` in strands-ts, verified tarball contains `README.md` (11.3kB, TypeScript-specific) and `LICENSE`
- `twine check` passes for both wheel and sdist
- Pre-commit hooks pass (TS build + test suite)

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.