### PR TITLE
ci: add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
     if: always()
     needs: [detect-changes, python, typescript, docs]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: re-actors/alls-green@release/v1
         with:

--- a/.github/workflows/python-check-markdown-links.yml
+++ b/.github/workflows/python-check-markdown-links.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- Add `permissions: {}` to `ci-gate` job in `ci.yml` (uses no token, so empty permissions is correct)
- Add `permissions: { contents: read, issues: write }` to `check-links` job in `python-check-markdown-links.yml`

## Test plan

- [ ] Verify CI workflow still passes (ci-gate job uses no token)
- [ ] Verify markdown link checker still works with the declared permissions