### PR TITLE
fix: address CodeQL static analysis findings in JS/TS

### DIFF
--- a/site/docs/examples/typescript/deploy_to_bedrock_agentcore/invoke.ts
+++ b/site/docs/examples/typescript/deploy_to_bedrock_agentcore/invoke.ts
@@ -11,7 +11,7 @@ const client = new BedrockAgentCoreClient({
 
 const input = {
   // Generate unique session ID
-  runtimeSessionId: 'test-session-' + Date.now() + '-' + Math.random().toString(36).substring(7),
+  runtimeSessionId: 'test-session-' + Date.now() + '-' + crypto.randomUUID().slice(0, 7),
   // Replace with your actual runtime ARN
   agentRuntimeArn:
     'arn:aws:bedrock-agentcore:ap-southeast-2:YOUR_ACCOUNT_ID:runtime/my-agent-service-XXXXXXXXXX',

--- a/site/scripts/astro-broken-links-checker-check-links.js
+++ b/site/scripts/astro-broken-links-checker-check-links.js
@@ -168,13 +168,16 @@ export async function checkLinksInHtml(
 }
 
 function isValidUrl(url) {
-  // Skip mailto:, tel:, javascript:, and empty links
+  // Skip non-HTTP schemes and empty links
+  const lower = url.toLowerCase().trim();
   return !(
-    url.startsWith('mailto:') ||
-    url.startsWith('tel:') ||
-    url.startsWith('javascript:') ||
-    url.startsWith('#') ||
-    url.trim() === ''
+    lower.startsWith('mailto:') ||
+    lower.startsWith('tel:') ||
+    lower.startsWith('javascript:') ||
+    lower.startsWith('vbscript:') ||
+    lower.startsWith('data:') ||
+    lower.startsWith('#') ||
+    lower === ''
   );
 }
 

--- a/site/src/content/docs/user-guide/concepts/streaming/async-iterators.ts
+++ b/site/src/content/docs/user-guide/concepts/streaming/async-iterators.ts
@@ -35,6 +35,8 @@ async function expressExample() {
     console.log(`Got Request: ${JSON.stringify(req.body)}`)
     const { prompt } = req.body as PromptRequest
 
+    res.setHeader('Content-Type', 'application/x-ndjson')
+
     const agent = new Agent({
       tools: [notebook],
       printer: false,

--- a/site/test/update-docs.test.ts
+++ b/site/test/update-docs.test.ts
@@ -12,7 +12,7 @@ describe('API link conversion', () => {
   function convertApiLinks(content: string): string {
     // Match markdown links with potentially nested brackets in the text
     // This handles cases like [`list[ToolSpec]`](url)
-    const markdownLinkPattern = /\[([^\]]*(?:\[[^\]]*\][^\]]*)*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+    const markdownLinkPattern = /\[((?:[^\[\]]|\[[^\]]*\])*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
 
     return content.replace(markdownLinkPattern, (match, text, url) => {
       if (isOldApiLink(url)) {

--- a/strands-ts/src/vended-plugins/context-offloader/search.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/search.ts
@@ -45,14 +45,11 @@ function searchByPattern(
   scopeLabel: string
 ): string {
   let regex: RegExp
-  const safeInput =
-    pattern.length > MAX_PATTERN_LENGTH
-      ? pattern.slice(0, MAX_PATTERN_LENGTH).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      : pattern
+  const truncated = pattern.length > MAX_PATTERN_LENGTH ? pattern.slice(0, MAX_PATTERN_LENGTH) : pattern
   try {
-    regex = new RegExp(safeInput)
+    regex = new RegExp(truncated)
   } catch {
-    regex = new RegExp(safeInput.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    regex = new RegExp(truncated.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
   }
 
   const matchedSet = new Set<number>()


### PR DESCRIPTION
## Summary

- Replace `Math.random()` with `crypto.randomUUID()` for session ID generation in bedrock agentcore example
- Add `data:` and `vbscript:` to URL scheme blocklist in link checker; normalize to lowercase before comparison
- Set `Content-Type: application/x-ndjson` header on streaming response in async-iterators example
- Rewrite markdown link regex in `update-docs.test.ts` to avoid catastrophic backtracking (uses `(?:[^\[\]]|\[[^\]]*\])*` instead of nested `[^\]]*` groups)
- Fix double-escaping in context-offloader `search.ts`: only escape regex metacharacters in the catch fallback path, not preemptively on truncation

## Test plan

- [ ] Verify `site/test/update-docs.test.ts` tests still pass
- [ ] Verify link checker still correctly identifies broken links
- [ ] Verify bedrock agentcore example TypeScript compiles