### PR TITLE
docs: add security warnings to http_request and file_editor vended tools

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -37,7 +37,7 @@ Gives your agent the ability to read and modify files on disk — useful for cod
 _Supported in: Node.js only._
 
 :::caution[Security Warning]
-This tool reads and writes files at arbitrary absolute paths with the full permissions of the Node.js process. Only use with trusted input and consider running in a sandboxed environment (containers, VMs) or implementing filesystem allowlists for production.
+This tool reads and writes files at arbitrary absolute paths with the full permissions of the Node.js process. Only use with trusted input and consider running in a sandboxed environment (containers, VMs) for production.
 :::
 
 **Example:**
@@ -58,7 +58,7 @@ Lets your agent call external APIs and fetch web content. Supports all HTTP meth
 _Supported in: Node.js 20+, modern browsers._
 
 :::caution[Security Warning]
-This tool makes HTTP requests to arbitrary URLs without restrictions on destination. Only use with trusted input and consider implementing URL allowlists, blocking private network ranges, and running in sandboxed environments for production.
+This tool makes HTTP requests to arbitrary URLs without restrictions on destination. Only use with trusted input and consider running in a sandboxed environment (containers, VMs) for production.
 :::
 
 **Example:**

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -37,7 +37,7 @@ Gives your agent the ability to read and modify files on disk — useful for cod
 _Supported in: Node.js only._
 
 :::caution[Security Warning]
-This tool reads and writes files with the full permissions of the Node.js process. Only use with trusted input and consider running in a sandboxed environment for production.
+This tool reads and writes files at arbitrary absolute paths with the full permissions of the Node.js process. Only use with trusted input and consider running in a sandboxed environment (containers, VMs) or implementing filesystem allowlists for production.
 :::
 
 **Example:**
@@ -56,6 +56,10 @@ This tool reads and writes files with the full permissions of the Node.js proces
 Lets your agent call external APIs and fetch web content. Supports all HTTP methods, custom headers, and request bodies. Default timeout is 30 seconds.
 
 _Supported in: Node.js 20+, modern browsers._
+
+:::caution[Security Warning]
+This tool makes HTTP requests to arbitrary URLs without restrictions on destination. Only use with trusted input and consider implementing URL allowlists, blocking private network ranges, and running in sandboxed environments for production.
+:::
 
 **Example:**
 ```typescript

--- a/strands-ts/src/vended-tools/file-editor/README.md
+++ b/strands-ts/src/vended-tools/file-editor/README.md
@@ -2,6 +2,18 @@
 
 A filesystem editor tool for viewing, creating, and editing files programmatically. Provides string replacement, line insertion, and directory viewing with security validation.
 
+## ⚠️ Security Warning
+
+**This tool reads and writes files at arbitrary absolute paths without sandboxing or workspace restrictions.**
+
+- Only use with trusted input
+- File operations execute with the full permissions of the Node.js process
+- The tool does not restrict access to a project directory, workspace, or configured allowlist
+- For production deployments, consider running in a sandboxed environment (containers, VMs, etc.) or implementing filesystem access controls
+- Consider restricting writable paths to a specific workspace directory
+- Never expose this tool to untrusted users or untrusted prompt input without additional security measures
+- If agent tool calls may be influenced by external content (documents, web pages, user messages), implement path validation to prevent unintended file modifications
+
 ## Features
 
 - **View files** with line numbers and optional line range support

--- a/strands-ts/src/vended-tools/file-editor/README.md
+++ b/strands-ts/src/vended-tools/file-editor/README.md
@@ -8,11 +8,8 @@ A filesystem editor tool for viewing, creating, and editing files programmatical
 
 - Only use with trusted input
 - File operations execute with the full permissions of the Node.js process
-- The tool does not restrict access to a project directory, workspace, or configured allowlist
-- For production deployments, consider running in a sandboxed environment (containers, VMs, etc.) or implementing filesystem access controls
-- Consider restricting writable paths to a specific workspace directory
+- For production deployments, consider running in a sandboxed environment (containers, VMs, etc.)
 - Never expose this tool to untrusted users or untrusted prompt input without additional security measures
-- If agent tool calls may be influenced by external content (documents, web pages, user messages), implement path validation to prevent unintended file modifications
 
 ## Features
 

--- a/strands-ts/src/vended-tools/http-request/README.md
+++ b/strands-ts/src/vended-tools/http-request/README.md
@@ -2,6 +2,17 @@
 
 A cross-platform HTTP request tool for making HTTP requests to external APIs from Strands agents.
 
+## ⚠️ Security Warning
+
+**This tool makes HTTP requests to arbitrary URLs without restrictions on destination.**
+
+- Only use with trusted input
+- Requests execute with the network access of the host process
+- For production deployments, consider implementing URL allowlists to restrict accessible domains
+- Consider blocking requests to localhost, private IP ranges (10.x, 172.16-31.x, 192.168.x), link-local addresses (169.254.x), and cloud metadata endpoints (e.g., 169.254.169.254)
+- Never expose this tool to untrusted users or untrusted prompt input without additional security measures
+- If agent tool calls may be influenced by external content (documents, web pages, user messages), implement URL validation to prevent SSRF-style attacks
+
 ## Features
 
 - **All HTTP Methods**: Supports GET, POST, PUT, DELETE, PATCH, HEAD, and OPTIONS

--- a/strands-ts/src/vended-tools/http-request/README.md
+++ b/strands-ts/src/vended-tools/http-request/README.md
@@ -8,10 +8,8 @@ A cross-platform HTTP request tool for making HTTP requests to external APIs fro
 
 - Only use with trusted input
 - Requests execute with the network access of the host process
-- For production deployments, consider implementing URL allowlists to restrict accessible domains
-- Consider blocking requests to localhost, private IP ranges (10.x, 172.16-31.x, 192.168.x), link-local addresses (169.254.x), and cloud metadata endpoints (e.g., 169.254.169.254)
+- For production deployments, consider running in a sandboxed environment (containers, VMs, etc.)
 - Never expose this tool to untrusted users or untrusted prompt input without additional security measures
-- If agent tool calls may be influenced by external content (documents, web pages, user messages), implement URL validation to prevent SSRF-style attacks
 
 ## Features
 


### PR DESCRIPTION
## Motivation

The Bash vended tool includes an explicit security warning in both its README and the vended-tools documentation page, but the `http_request` and `file_editor` tools lack equivalent guidance despite also crossing important security boundaries (arbitrary network access and arbitrary filesystem writes, respectively). This adds comparable warnings so users understand the risks when exposing these tools to agents.

## Public API Changes

No public API changes. Documentation only.