### PR TITLE
ci: allow design type in PR title validation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,6 +28,7 @@ jobs:
             ci
             chore
             revert
+            design
           requireScope: false
           subjectPattern: ^[a-z].+$
           subjectPatternError: |


### PR DESCRIPTION
## Description

Adds `design` to the list of allowed types in the PR Title conventional-commits
check (`.github/workflows/pr-title.yml`, the `amannn/action-semantic-pull-request`
step). Design-document PRs use a `design:` prefix (matching the `designs/` folder
convention), but the title-lint only permitted the standard Angular types
(`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`,
`chore`, `revert`), so those PRs failed the check with:

> Unknown release type "design" found in pull request title

One line added; no other behavior changes.

## Related Issues

Unblocks the title check for design-doc PRs such as #2393.

## Documentation PR

N/A

## Type of Change

Other (please describe): CI / repository tooling change

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

This change only edits a GitHub Actions workflow that validates PR titles.
## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.