### PR TITLE
fix: support non-streaming OpenAI chat completions

### DIFF
--- a/strands-py/src/strands/models/litellm.py
+++ b/strands-py/src/strands/models/litellm.py
@@ -45,10 +45,12 @@ class LiteLLMModel(OpenAIModel):
             params: Model parameters (e.g., max_tokens).
                 For a complete list of supported parameters, see
                 https://docs.litellm.ai/docs/completion/input#input-params-1.
+            stream: Whether to use streaming. Defaults to True.
         """
 
         model_id: str
         params: dict[str, Any] | None
+        stream: bool
 
     def __init__(self, client_args: dict[str, Any] | None = None, **model_config: Unpack[LiteLLMConfig]) -> None:
         """Initialize provider instance.
@@ -345,14 +347,11 @@ class LiteLLMModel(OpenAIModel):
         )
         logger.debug("request=<%s>", request)
 
-        # Check if streaming is disabled in the params
-        config = self.get_config()
-        params = config.get("params") or {}
-        is_streaming = params.get("stream", True)
+        # format_request resolves streaming from the top-level `stream` config and the legacy
+        # params={"stream": ...} path, recording the effective value (and stream_options) on the request.
+        is_streaming = request["stream"]
 
         litellm_request = {**request}
-
-        litellm_request["stream"] = is_streaming
 
         logger.debug("invoking model with stream=%s", litellm_request.get("stream"))
 

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -64,10 +64,12 @@ class OpenAIModel(Model):
             params: Model parameters (e.g., max_tokens).
                 For a complete list of supported parameters, see
                 https://platform.openai.com/docs/api-reference/chat/create.
+            stream: Whether to use OpenAI chat completion streaming. Defaults to True.
         """
 
         model_id: str
         params: dict[str, Any] | None
+        stream: bool
 
     def __init__(
         self,
@@ -500,13 +502,16 @@ class OpenAIModel(Model):
             TypeError: If a message contains a content block type that cannot be converted to an OpenAI-compatible
                 format.
         """
-        return {
+        params = dict(cast(dict[str, Any], self.config.get("params") or {}))
+        stream = bool(self.config.get("stream", params.pop("stream", True)))
+        stream_options = params.pop("stream_options", {"include_usage": True})
+
+        request = {
             "messages": self.format_request_messages(
                 messages, system_prompt, system_prompt_content=system_prompt_content
             ),
             "model": self.config["model_id"],
-            "stream": True,
-            "stream_options": {"include_usage": True},
+            "stream": stream,
             "tools": [
                 {
                     "type": "function",
@@ -519,8 +524,13 @@ class OpenAIModel(Model):
                 for tool_spec in tool_specs or []
             ],
             **(self._format_request_tool_choice(tool_choice)),
-            **cast(dict[str, Any], self.config.get("params", {})),
+            **params,
         }
+
+        if stream:
+            request["stream_options"] = stream_options
+
+        return request
 
     def format_chunk(self, event: dict[str, Any], **kwargs: Any) -> StreamEvent:
         """Format an OpenAI response event into a standardized message chunk.
@@ -600,6 +610,44 @@ class OpenAIModel(Model):
 
             case _:
                 raise RuntimeError(f"chunk_type=<{event['chunk_type']} | unknown type")
+
+    def _format_non_streaming_response(self, response: Any) -> list[StreamEvent]:
+        """Convert a non-streaming OpenAI chat completion into Strands stream events."""
+        chunks = [self.format_chunk({"chunk_type": "message_start"})]
+        choices = getattr(response, "choices", None) or []
+        choice = choices[0] if choices else None
+        message = getattr(choice, "message", None)
+
+        reasoning_content = getattr(message, "reasoning_content", None) or getattr(message, "reasoning", None)
+        if reasoning_content:
+            chunks.append(self.format_chunk({"chunk_type": "content_start", "data_type": "reasoning_content"}))
+            chunks.append(
+                self.format_chunk(
+                    {"chunk_type": "content_delta", "data_type": "reasoning_content", "data": reasoning_content}
+                )
+            )
+            chunks.append(self.format_chunk({"chunk_type": "content_stop", "data_type": "reasoning_content"}))
+
+        if content := getattr(message, "content", None):
+            chunks.append(self.format_chunk({"chunk_type": "content_start", "data_type": "text"}))
+            chunks.append(self.format_chunk({"chunk_type": "content_delta", "data_type": "text", "data": content}))
+            chunks.append(self.format_chunk({"chunk_type": "content_stop", "data_type": "text"}))
+
+        for tool_call in getattr(message, "tool_calls", None) or []:
+            chunks.append(self.format_chunk({"chunk_type": "content_start", "data_type": "tool", "data": tool_call}))
+            chunks.append(self.format_chunk({"chunk_type": "content_delta", "data_type": "tool", "data": tool_call}))
+            chunks.append(self.format_chunk({"chunk_type": "content_stop", "data_type": "tool"}))
+
+        chunks.append(
+            self.format_chunk(
+                {"chunk_type": "message_stop", "data": getattr(choice, "finish_reason", None) or "end_turn"}
+            )
+        )
+
+        if usage := getattr(response, "usage", None):
+            chunks.append(self.format_chunk({"chunk_type": "metadata", "data": usage}))
+
+        return chunks
 
     @asynccontextmanager
     async def _get_client(self) -> AsyncIterator[Any]:
@@ -686,6 +734,11 @@ class OpenAIModel(Model):
                     raise ContextWindowOverflowException(error_message) from e
                 # Re-raise other APIError exceptions
                 raise
+
+            if not request["stream"]:
+                for chunk in self._format_non_streaming_response(response):
+                    yield chunk
+                return
 
             logger.debug("got response from model")
             yield self.format_chunk({"chunk_type": "message_start"})

--- a/strands-py/tests/strands/models/test_litellm.py
+++ b/strands-py/tests/strands/models/test_litellm.py
@@ -556,7 +556,7 @@ async def test_stream_non_streaming(litellm_acompletion, api_key, model_id, alis
         "model": model_id,
         "messages": [{"role": "user", "content": [{"text": "What is 123981723 + 234982734?", "type": "text"}]}],
         "stream": False,  # Verify that stream=False was passed to litellm
-        "stream_options": {"include_usage": True},
+        # stream_options is only sent for streaming requests
         "tools": [],
     }
     litellm_acompletion.assert_called_once_with(**expected_request)

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -661,6 +661,31 @@ def test_format_request(model, messages, tool_specs, system_prompt):
     assert tru_request == exp_request
 
 
+def test_format_request_can_disable_stream(openai_client, model_id, messages):
+    _ = openai_client
+    model = OpenAIModel(model_id=model_id, stream=False, params={"max_tokens": 1})
+
+    tru_request = model.format_request(messages)
+    exp_request = {
+        "messages": [{"role": "user", "content": [{"text": "test", "type": "text"}]}],
+        "model": model_id,
+        "stream": False,
+        "tools": [],
+        "max_tokens": 1,
+    }
+    assert tru_request == exp_request
+
+
+def test_format_request_respects_legacy_stream_param(openai_client, model_id, messages):
+    _ = openai_client
+    model = OpenAIModel(model_id=model_id, params={"max_tokens": 1, "stream": False})
+
+    tru_request = model.format_request(messages)
+
+    assert tru_request["stream"] is False
+    assert "stream_options" not in tru_request
+
+
 def test_format_request_with_tool_choice_auto(model, messages, tool_specs, system_prompt):
     tool_choice = {"auto": {}}
     tru_request = model.format_request(messages, tool_specs, system_prompt, tool_choice)
@@ -1141,6 +1166,41 @@ async def test_stream_with_empty_choices(openai_client, model, agenerator, alist
         "tools": [],
     }
     openai_client.chat.completions.create.assert_called_once_with(**expected_request)
+
+
+@pytest.mark.asyncio
+async def test_stream_can_use_non_streaming_chat_completion(openai_client, model_id, messages, alist):
+    mock_usage = unittest.mock.Mock(prompt_tokens=7, completion_tokens=3, total_tokens=10, prompt_tokens_details=None)
+    mock_message = unittest.mock.Mock(content="done", tool_calls=None, reasoning_content=None, reasoning=None)
+    mock_choice = unittest.mock.Mock(message=mock_message, finish_reason="stop")
+    mock_response = unittest.mock.Mock(choices=[mock_choice], usage=mock_usage)
+
+    openai_client.chat.completions.create = unittest.mock.AsyncMock(return_value=mock_response)
+    model = OpenAIModel(model_id=model_id, stream=False, params={"max_tokens": 1})
+
+    tru_events = await alist(model.stream(messages))
+    exp_events = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": "done"}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10},
+                "metrics": {"latencyMs": 0},
+            }
+        },
+    ]
+
+    assert tru_events == exp_events
+    openai_client.chat.completions.create.assert_called_once_with(
+        max_tokens=1,
+        model=model_id,
+        messages=[{"role": "user", "content": [{"text": "test", "type": "text"}]}],
+        stream=False,
+        tools=[],
+    )
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests_integ/models/test_model_openai.py
+++ b/strands-py/tests_integ/models/test_model_openai.py
@@ -128,6 +128,25 @@ async def test_agent_invoke_async(agent, model):
     assert all(string in text for string in ["12:00", "sunny"])
 
 
+def test_agent_invoke_non_streaming_with_tools(tools):
+    """Integration test for non-streaming (stream=False) chat completions that invoke tools.
+
+    Verifies that when streaming is disabled, the OpenAI provider converts the completion
+    into Strands stream events and that tool calls still execute end-to-end.
+    """
+    model = OpenAIModel(
+        model_id="gpt-4o",
+        client_args={"api_key": os.getenv("OPENAI_API_KEY")},
+        stream=False,
+    )
+    agent = Agent(model=model, tools=tools)
+
+    result = agent("What is the time and weather in New York?")
+    text = result.message["content"][0]["text"].lower()
+
+    assert all(string in text for string in ["12:00", "sunny"])
+
+
 @pytest.mark.asyncio
 async def test_agent_stream_async(agent, model):
     stream = agent.stream_async("What is the time and weather in New York?")


### PR DESCRIPTION
﻿## Summary

Fixes #778.

OpenAIModel now accepts `stream=False` as a model config option and keeps the older `params={"stream": False}` path working. When a non-streaming chat completion is requested, the provider converts the returned completion into the same Strands stream events that callers already consume.

## To verify

- `python -m pytest tests\strands\models\test_openai.py -q`
- `python -m ruff check src\strands\models\openai.py tests\strands\models\test_openai.py`
- `python -m ruff format --check src\strands\models\openai.py tests\strands\models\test_openai.py`
- `git diff --check`
