### PR TITLE
docs: wrap quickstart metrics output in collapsible section

### DIFF
--- a/site/src/content/docs/user-guide/quickstart/python.mdx
+++ b/site/src/content/docs/user-guide/quickstart/python.mdx
@@ -185,11 +185,14 @@ Traces provide detailed insight into the agent's reasoning process. You can acce
 
 :::note[Example result.metrics.get_summary() output]
 
+<details>
+<summary>Click to expand</summary>
+
 ```python
 result = agent("What is the square root of 144?")
 print(result.metrics.get_summary())
 ```
-```python
+```json
 {
   "accumulated_metrics": {
     "latencyMs": 6253
@@ -342,6 +345,8 @@ print(result.metrics.get_summary())
   ]
 }
 ```
+</details>
+
 :::
 
 This observability data helps you debug agent behavior, optimize performance, and understand the agent's reasoning process. For detailed information, see [Observability](../observability-evaluation/observability.md), [Traces](../observability-evaluation/traces.md), and [Metrics](../observability-evaluation/metrics.md).


### PR DESCRIPTION
## Summary
- Wraps the large `result.metrics.get_summary()` JSON output in a `<details>` collapsible inside the existing `:::note` admonition on the Python quickstart page
- Reduces visual noise on page load while keeping the example accessible
- Fixes the output code fence language from `python` to `json`

## Verification

Compare 

https://d3ehv1nix5p99z.cloudfront.net/pr-cms-2550/docs/user-guide/quickstart/python/#understanding-what-agents-did

to 

https://strandsagents.com/docs/user-guide/quickstart/python/#understanding-what-agents-did