### PR TITLE
fix(openai-responses): prevent tool list mutation across API calls

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -549,7 +549,12 @@ class OpenAIResponsesModel(Model):
 
         # Add tools if provided
         if tool_specs:
-            # Merge with any built-in tools (e.g. web_search) already in the request from params
+            # Merge with any built-in tools (e.g. web_search) already in the request from params.
+            # Shallow-copy the existing list (if any) to avoid mutating self.config["params"]["tools"]
+            # via the shared reference created by ** unpacking above.
+            # See: strands-agents/sdk-python#2405
+            if "tools" in request:
+                request["tools"] = list(request["tools"])
             request.setdefault("tools", []).extend(
                 {
                     "type": "function",

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -549,21 +549,22 @@ class OpenAIResponsesModel(Model):
 
         # Add tools if provided
         if tool_specs:
-            # Merge with any built-in tools (e.g. web_search) already in the request from params.
-            # Shallow-copy the existing list (if any) to avoid mutating self.config["params"]["tools"]
-            # via the shared reference created by ** unpacking above.
-            # See: strands-agents/sdk-python#2405
-            if "tools" in request:
-                request["tools"] = list(request["tools"])
-            request.setdefault("tools", []).extend(
-                {
-                    "type": "function",
-                    "name": tool_spec["name"],
-                    "description": tool_spec.get("description", ""),
-                    "parameters": tool_spec["inputSchema"]["json"],
-                }
-                for tool_spec in tool_specs
-            )
+            # Merge function tools with any built-in tools (e.g. web_search) carried in from params.
+            # Build a new list rather than extending in place: ** unpacking above aliases
+            # self.config["params"]["tools"] by reference, so mutating it would duplicate every tool
+            # spec into the stored config on each call.
+            request["tools"] = [
+                *request.get("tools", []),
+                *(
+                    {
+                        "type": "function",
+                        "name": tool_spec["name"],
+                        "description": tool_spec.get("description", ""),
+                        "parameters": tool_spec["inputSchema"]["json"],
+                    }
+                    for tool_spec in tool_specs
+                ),
+            ]
             request.update(self._format_request_tool_choice(tool_choice))
 
         return request

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1016,6 +1016,20 @@ def test_format_request_merges_builtin_tools_with_function_tools(messages, tool_
     ]
 
 
+def test_format_request_does_not_mutate_params_tools_across_calls(messages, tool_specs):
+    """Repeated _format_request calls must not mutate self.config["params"]["tools"]."""
+    model = OpenAIResponsesModel(
+        model_id="gpt-4o",
+        params={"tools": [{"type": "web_search"}]},
+    )
+
+    first = model._format_request(messages, tool_specs)
+    second = model._format_request(messages, tool_specs)
+
+    assert second["tools"] == first["tools"]
+    assert model.config["params"]["tools"] == [{"type": "web_search"}]
+
+
 def test_format_request_builtin_tools_without_function_tools(messages):
     """Test that built-in tools from params are preserved when no function tools are provided."""
     model = OpenAIResponsesModel(


### PR DESCRIPTION
## Summary

Fixes #2405

`OpenAIResponsesModel._format_request` shallow-copies `self.config["params"]` via `**` unpacking into the `request` dict. When `params` contains a `"tools"` key, `request["tools"]` and `self.config["params"]["tools"]` become the **same list object**.

The subsequent `request.setdefault("tools", []).extend(...)` then permanently mutates `self.config["params"]["tools"]`, adding a duplicate copy of every tool spec on each API call. With 10 tools, after 5 calls the tools list grows from 10 to 15 entries.

## Fix

Shallow-copy the existing tools list before extending when it already exists in the request from `params` unpacking:

```python
if "tools" in request:
    request["tools"] = list(request["tools"])
request.setdefault("tools", []).extend(...)
```

This ensures `.extend()` operates on a fresh list, leaving `self.config["params"]["tools"]` untouched.

## Testing

- Verified with the reproduction script from the issue: tool list no longer grows across API calls
- Existing `_format_request` tests continue to pass
