### PR TITLE
fix(media): correct MIME types for webp images and guardContent format validation

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -131,10 +131,23 @@ class AnthropicModel(Model):
             }
 
         if "image" in content:
+            # Explicit MIME type mapping for image formats that mimetypes.types_map
+            # gets wrong (e.g. webp -> application/octet-stream instead of image/webp).
+            _IMAGE_MIME_TYPES: dict[str, str] = {
+                "png": "image/png",
+                "jpg": "image/jpeg",
+                "jpeg": "image/jpeg",
+                "gif": "image/gif",
+                "webp": "image/webp",
+                "svg+xml": "image/svg+xml",
+                "bmp": "image/bmp",
+            }
+            fmt = content["image"]["format"]
+            media_type = _IMAGE_MIME_TYPES.get(fmt) or mimetypes.types_map.get(f".{fmt}", "application/octet-stream")
             return {
                 "source": {
                     "data": base64.b64encode(content["image"]["source"]["bytes"]).decode("utf-8"),
-                    "media_type": mimetypes.types_map.get(f".{content['image']['format']}", "application/octet-stream"),
+                    "media_type": media_type,
                     "type": "base64",
                 },
                 "type": "image",

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -490,12 +490,15 @@ class BedrockModel(Model):
                 if formatted_content is None:
                     continue
 
-                # Wrap text or image content in guardContent if this is the last user text/image message
+                # Wrap text or image content in guardContent if this is the last user text/image message.
+                # Bedrock GuardContent for images only supports png and jpeg formats.
                 if idx == last_user_text_idx and ("text" in formatted_content or "image" in formatted_content):
                     if "text" in formatted_content:
                         formatted_content = {"guardContent": {"text": {"text": formatted_content["text"]}}}
                     elif "image" in formatted_content:
-                        formatted_content = {"guardContent": {"image": formatted_content["image"]}}
+                        image_format = formatted_content["image"].get("format", "")
+                        if image_format in ("png", "jpeg"):
+                            formatted_content = {"guardContent": {"image": formatted_content["image"]}}
 
                 cleaned_content.append(formatted_content)
 


### PR DESCRIPTION
## Summary

Fixes #2204

Two media type handling bugs in the Python SDK that cause API errors with Bedrock and Anthropic providers:

### 1. WebP images get wrong MIME type (anthropic.py)

Python's `mimetypes.types_map` returns `"application/octet-stream"` for `.webp` instead of `"image/webp"`. This causes Anthropic API errors when sending WebP images.

**Fix:** Replace the `mimetypes.types_map` lookup with an explicit MIME type mapping for common image formats (png, jpg, jpeg, gif, webp, svg+xml, bmp), falling back to `mimetypes` for unknown formats.

### 2. guardContent wraps unsupported image formats (bedrock.py)

The guardContent wrapping logic at line 497 wraps ALL image formats, but Bedrock's `GuardrailConverseContentBlock` only supports `png` and `jpeg` images. Wrapping unsupported formats (webp, gif, etc.) causes Bedrock API validation errors.

**Fix:** Only wrap image content in guardContent when the format is `png` or `jpeg`.

### Testing

- Verified WebP images now get `"image/webp"` MIME type with Anthropic provider
- Verified guardContent is only applied for png/jpeg images with Bedrock provider
- Existing media type tests continue to pass
