### PR TITLE
feat(docs): add human in the loop

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -82,11 +82,16 @@ sidebar:
               - docs/user-guide/concepts/tools/vended-tools
           - label: Plugins
             items:
-              - docs/user-guide/concepts/plugins
+              - label: "Overview"
+                slug: docs/user-guide/concepts/plugins
               - docs/user-guide/concepts/plugins/skills
               - docs/user-guide/concepts/plugins/steering
               - docs/user-guide/concepts/plugins/context-offloader
-          - docs/user-guide/concepts/agents/interventions
+          - label: Interventions
+            items:
+              - label: "Overview"
+                slug: docs/user-guide/concepts/agents/interventions
+              - docs/user-guide/concepts/agents/human-in-the-loop
           - label: Streaming
             items:
               - docs/user-guide/concepts/streaming/async-iterators

--- a/site/src/config/tags.yml
+++ b/site/src/config/tags.yml
@@ -44,6 +44,7 @@
 - event-loop
 - failure-diagnosis
 - hooks
+- interventions
 - local-models
 - multi-agent
 - multimodal-evaluation

--- a/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop.mdx
@@ -1,0 +1,112 @@
+---
+title: Human in the Loop
+tags: [interventions, tool-execution]
+description: "Gate agent tool execution behind human approval. Configurable modes for CLI, web, and custom UIs with optional session trust."
+languages: [typescript]
+sidebar:
+  badge:
+    text: New
+    variant: tip
+---
+
+The `HumanInTheLoop` intervention handler pauses agent execution before tool calls to request human approval. It provides a configurable, drop-in way to add human oversight without writing custom interrupt logic. Pass it to `interventions` and choose how you want to collect the human's response.
+
+## How It Works
+
+The handler uses the [`confirm` action](./interventions) to pause for human input. Under the hood it builds on the SDK's [interrupt mechanism](../interrupts), but abstracts away the manual interrupt/resume loop when you provide an `ask` option.
+
+```mermaid
+flowchart LR
+    A[Tool call] --> B{Allowed?}
+    B -->|Yes| C[Execute]
+    B -->|No| D{Trusted?}
+    D -->|Yes| C
+    D -->|No| E{Human approves?}
+    E -->|Yes| C
+    E -->|No| F[Cancel]
+```
+
+## Usage
+
+### Interrupt/Resume Mode (Default)
+
+Without an `ask` option, the handler raises an interrupt and the agent pauses. The caller presents the interrupt to the user, collects their response, and resumes the agent. This is the same [interrupt/resume pattern](../interrupts#hooks) used throughout the SDK. For stateless deployments, combine with a [session manager](./session-management) to persist state between requests.
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:basic_interrupt_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:basic_interrupt"
+```
+
+### Stdio Mode
+
+For CLI applications, pass `ask: 'stdio'` to prompt the user inline via Node.js readline. The agent blocks until the user responds, so no interrupt handling is needed on the caller side.
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:stdio_mode_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:stdio_mode"
+```
+
+### Custom UI Callback
+
+For web UIs, Slack bots, or other custom interfaces, pass an async function to `ask`. The function receives a prompt string describing the tool call and must return the user's response.
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:custom_ask_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:custom_ask"
+```
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `allowedTools` | `string[]` | `undefined` | Tools that bypass approval. Supports `'*'` (all) and `'!toolName'` (negation). |
+| `enableTrust` | `boolean` | `false` | When `true`, trust responses are remembered for the session. |
+| `evaluateTrust` | Function | Accepts `'t'` or `'trust'` | Custom validator for trust responses. Only evaluated when `enableTrust` is `true`. |
+| `evaluate` | Function | Accepts `true`, `'y'`, or `'yes'` | Custom validator for approval responses. |
+| `ask` | Function or `'stdio'` | `undefined` | Pass an async function for custom UIs, `'stdio'` for CLI readline, or omit for interrupt/resume. |
+
+### Allowed Tools
+
+Use `allowedTools` to skip approval for safe, read-only tools:
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:allowed_tools_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:allowed_tools"
+```
+
+### Trust Mode
+
+When `enableTrust` is `true`, a human can respond with `'t'` or `'trust'` to approve the current tool call AND remember that decision for the rest of the session. Subsequent calls to the same tool skip the prompt entirely. Trust works in all modes: interrupt/resume, stdio, and custom callbacks.
+
+Trust state is stored in `agent.appState` and persists across turns within a session but resets when the agent is re-created. Negated tools (`'!toolName'`) cannot be trusted and always prompt.
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:trust_mode_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:trust_mode"
+```
+
+### Custom Evaluate
+
+By default, the handler accepts `true`, `'y'`, or `'yes'` as approval. Use `evaluate` to define your own approval logic, for example requiring the user to type "confirm":
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:custom_evaluate_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:custom_evaluate"
+```
+
+## When to Use
+
+Use `HumanInTheLoop` when you want tool-level approval gating with minimal code: it handles allow-lists, trust, and collection mode out of the box. Use [raw interrupts](../interrupts) when you need full control: custom interrupt shapes, multi-step interactions, or workflows beyond simple approve/deny.
+
+## Related Topics
+
+- [Interventions](./interventions): The intervention handler framework that HITL is built on
+- [Interrupts](../interrupts): Low-level interrupt/resume mechanism
+- [Agent State](./state): How trust decisions persist via `appState`
+- [Session Management](./session-management): Persisting interrupt state across sessions

--- a/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop.ts
@@ -1,0 +1,185 @@
+// @ts-nocheck
+import { Agent, tool, InterruptResponseContent } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+
+const deleteFiles = tool({
+  name: 'delete_files',
+  description: 'Delete files at the given paths',
+  inputSchema: z.object({ paths: z.array(z.string()) }),
+  callback: (input) => `Deleted ${input.paths.length} files`,
+})
+
+const readFile = tool({
+  name: 'read_file',
+  description: 'Read a file',
+  inputSchema: z.object({ path: z.string() }),
+  callback: (input) => `Contents of ${input.path}`,
+})
+
+// =====================
+// Basic (Interrupt/Resume Mode)
+// =====================
+
+async function basicInterruptExample() {
+  // --8<-- [start:basic_interrupt]
+  const deleteFiles = tool({
+    name: 'delete_files',
+    description: 'Delete files at the given paths',
+    inputSchema: z.object({ paths: z.array(z.string()) }),
+    callback: (input) => `Deleted ${input.paths.length} files`,
+  })
+
+  const agent = new Agent({
+    tools: [deleteFiles],
+    interventions: [new HumanInTheLoop()],
+  })
+
+  // Agent pauses with stopReason 'interrupt' when a tool needs approval
+  let result = await agent.invoke('Delete the temp files')
+
+  if (result.stopReason === 'interrupt') {
+    // Present the interrupt to the user (web UI, Slack, etc.)
+    console.log(result.interrupts![0].reason)
+
+    // Resume with the human's response
+    result = await agent.invoke([
+      new InterruptResponseContent({
+        interruptId: result.interrupts![0].id,
+        response: 'yes', // 'y', 'yes', or true → approved
+      }),
+    ])
+  }
+  // --8<-- [end:basic_interrupt]
+}
+
+// =====================
+// Stdio Mode
+// =====================
+
+async function stdioModeExample() {
+  // --8<-- [start:stdio_mode]
+  // const deleteFiles = tool({ ... }) — same as above
+
+  const agent = new Agent({
+    tools: [deleteFiles],
+    interventions: [new HumanInTheLoop({ ask: 'stdio' })],
+  })
+
+  await agent.invoke('Delete the temp files')
+  // Terminal prompt:
+  // Tool "delete_files" requires human approval. Input: {...} (y/n):
+  // --8<-- [end:stdio_mode]
+}
+
+// =====================
+// Custom Ask Callback
+// =====================
+
+async function customAskExample() {
+  // --8<-- [start:custom_ask]
+  // const deleteFiles = tool({ ... }) — same as above
+
+  const agent = new Agent({
+    tools: [deleteFiles],
+    interventions: [
+      new HumanInTheLoop({
+        ask: async (prompt) => {
+          // Your UI: Slack DM, web modal, push notification, etc.
+          return await askUserViaSlack(prompt)
+        },
+      }),
+    ],
+  })
+
+  await agent.invoke('Delete the temp files')
+  // --8<-- [end:custom_ask]
+}
+
+// =====================
+// Allowed Tools
+// =====================
+
+async function allowedToolsExample() {
+  // --8<-- [start:allowed_tools]
+  // const deleteFiles = tool({ ... }) — same as above
+  // const readFile = tool({ ... })
+
+  const agent = new Agent({
+    tools: [readFile, deleteFiles],
+    interventions: [
+      new HumanInTheLoop({
+        ask: 'stdio',
+        // Pattern syntax:
+        //   'read_file'             → runs without approval
+        //   '*'                     → all tools run freely (disables handler)
+        //   ['*', '!delete_files']  → all except delete_files
+        allowedTools: ['read_file'],
+      }),
+    ],
+  })
+
+  await agent.invoke('Read config.json then delete /tmp/old-logs')
+  // Only delete_files prompts; read_file executes immediately
+  // --8<-- [end:allowed_tools]
+}
+
+// =====================
+// Trust Mode
+// =====================
+
+async function trustModeExample() {
+  // --8<-- [start:trust_mode]
+  // const deleteFiles = tool({ ... }) — same as above
+
+  const agent = new Agent({
+    tools: [deleteFiles],
+    interventions: [
+      new HumanInTheLoop({
+        ask: 'stdio',
+        enableTrust: true,
+      }),
+    ],
+  })
+
+  await agent.invoke('Delete all log files in /tmp')
+  // First call: user responds 't' → approved AND remembered
+  // Subsequent calls: no prompt needed for the session
+  // --8<-- [end:trust_mode]
+}
+
+// =====================
+// Custom Evaluate (OTP example)
+// =====================
+
+async function customEvaluateExample() {
+  // --8<-- [start:custom_evaluate]
+  // const deleteFiles = tool({ ... }) — same as above
+
+  const agent = new Agent({
+    tools: [deleteFiles],
+    interventions: [
+      new HumanInTheLoop({
+        ask: 'stdio',
+        // Only approve if the user types "confirm"
+        evaluate: (response) =>
+          typeof response === 'string' && response.toLowerCase() === 'confirm',
+      }),
+    ],
+  })
+
+  await agent.invoke('Delete the temp files')
+  // Prompt: Tool "delete_files" requires human approval. Input: {...}
+  // User must type "confirm" to approve (not just "y" or "yes")
+  // --8<-- [end:custom_evaluate]
+}
+
+// Suppress unused function warnings
+void basicInterruptExample
+void stdioModeExample
+void customAskExample
+void allowedToolsExample
+void trustModeExample
+void customEvaluateExample
+
+declare function askUserViaSlack(prompt: string): Promise<string>

--- a/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop_imports.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+
+// --8<-- [start:basic_interrupt_imports]
+import { Agent, tool, InterruptResponseContent } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:basic_interrupt_imports]
+
+// --8<-- [start:stdio_mode_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:stdio_mode_imports]
+
+// --8<-- [start:custom_ask_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:custom_ask_imports]
+
+// --8<-- [start:allowed_tools_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:allowed_tools_imports]
+
+// --8<-- [start:trust_mode_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:trust_mode_imports]
+
+// --8<-- [start:custom_evaluate_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:custom_evaluate_imports]

--- a/site/src/content/docs/user-guide/concepts/agents/interventions.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Interventions
 description: "A composable control layer for authorization, guardrails, and steering with typed actions, ordered evaluation, and short-circuiting."
-tags: [hooks, event-loop, tool-execution]
+tags: [interventions, hooks, event-loop, tool-execution]
 languages: [typescript]
 ---
 
@@ -98,6 +98,7 @@ Interventions return typed actions that the framework interprets. This enables:
 
 ## Related topics
 
+- [Human in the Loop](./human-in-the-loop) — Ready-to-use intervention handler for tool approval workflows
 - [Hooks](./hooks.mdx) — Low-level event callbacks for observing and modifying agent behavior
 - [Plugins](../plugins/index.mdx) — Bundle related hooks and tools into reusable modules
 - [Interrupts](../interrupts.mdx) — The interrupt/resume system that `confirm()` builds on


### PR DESCRIPTION
## Description

Adds documentation for the `HumanInTheLoop` vended intervention handler introduced in [strands-agents/sdk-typescript#1073](https://github.com/strands-agents/sdk-typescript/pull/1073).

The new page covers:
- Three collection modes: interrupt/resume (default), `ask: 'stdio'` (CLI readline), and custom async callbacks
- Configuration options: `allowedTools` (with wildcard/negation patterns), `enableTrust`, custom evaluators
- Comparison table vs raw interrupts

Also updates the sidebar navigation to group interventions as a labeled section, and adds a cross-reference from the interventions page to the new HITL page.

## Related Issues

- strands-agents/sdk-typescript#1073
- strands-agents/sdk-typescript#883
- strands-agents/docs#866

## Type of Change

- [x] New content
- [ ] Content update/revision
- [ ] Bug fix
- [ ] Other

## Testing

- Verified site builds with `npm run build` (only pre-existing image optimization warnings, no content errors)
- Navigation renders Interventions as a grouped section with Overview + Human in the Loop entries
- All internal links resolve correctly

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.