### PR TITLE
feat(strands-py): add optional hook order

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -394,13 +394,13 @@ Most event properties are read-only to prevent unintended modifications. However
 
 By default, After event callbacks run in reverse registration order for cleanup symmetry. You can override this with explicit priority using the `order` option — lower values run first.
 
-The SDK exports convenience presets:
+The SDK exports convenience presets that mark where the SDK's own hooks run, so you can position yours relative to them:
 
-- `HookOrder.FIRST` (-100)
+- `HookOrder.SDK_FIRST` (-100) — where the SDK's earliest hooks run
 - `HookOrder.DEFAULT` (0) — implicit when no order is specified
-- `HookOrder.LAST` (100)
+- `HookOrder.SDK_LAST` (100) — where the SDK's latest hooks run
 
-These are not enforced bounds — any numeric value works.
+These are not enforced bounds — any numeric value works. Use values beyond them (e.g. `SDK_FIRST - 1`) to run before or after the SDK's hooks, or `float('-inf')`/`float('inf')` for guaranteed absolute ordering.
 
 ```python
 from strands import Agent
@@ -414,8 +414,8 @@ def early_hook(event: BeforeModelCallEvent) -> None:
 def late_hook(event: BeforeModelCallEvent) -> None:
     print("I run last")
 
-agent.add_hook(early_hook, order=HookOrder.FIRST)
-agent.add_hook(late_hook, order=HookOrder.LAST)
+agent.add_hook(early_hook, order=HookOrder.SDK_FIRST)
+agent.add_hook(late_hook, order=HookOrder.SDK_LAST)
 ```
 
 Within the same order group, Before events preserve registration order and After events reverse it.

--- a/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -392,10 +392,33 @@ Most event properties are read-only to prevent unintended modifications. However
 <Tabs>
 <Tab label="Python">
 
-After event callbacks run in reverse registration order for cleanup symmetry:
+By default, After event callbacks run in reverse registration order for cleanup symmetry. You can override this with explicit priority using the `order` option — lower values run first.
 
-- **Before**: A, B, C (registration order)
-- **After**: C, B, A (reverse registration order)
+The SDK exports convenience presets:
+
+- `HookOrder.FIRST` (-100)
+- `HookOrder.DEFAULT` (0) — implicit when no order is specified
+- `HookOrder.LAST` (100)
+
+These are not enforced bounds — any numeric value works.
+
+```python
+from strands import Agent
+from strands.hooks import BeforeModelCallEvent, HookOrder
+
+agent = Agent()
+
+def early_hook(event: BeforeModelCallEvent) -> None:
+    print("I run first")
+
+def late_hook(event: BeforeModelCallEvent) -> None:
+    print("I run last")
+
+agent.add_hook(early_hook, order=HookOrder.FIRST)
+agent.add_hook(late_hook, order=HookOrder.LAST)
+```
+
+Within the same order group, Before events preserve registration order and After events reverse it.
 
 </Tab>
 <Tab label="TypeScript">

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -730,7 +730,7 @@ class Agent(AgentBase):
         callback: HookCallback[TEvent],
         event_type: type[TEvent] | list[type[TEvent]] | None = None,
         *,
-        order: int = HookOrder.DEFAULT,
+        order: float = HookOrder.DEFAULT,
     ) -> None:
         """Register a callback function for a specific event type.
 

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -751,7 +751,7 @@ class Agent(AgentBase):
                 the callback's first parameter type hint. If a list is provided,
                 the callback is registered for each type in the list.
             order: Execution priority. Lower values execute first.
-                Use HookOrder.FIRST (-100), HookOrder.DEFAULT (0), or HookOrder.LAST (100).
+                Use HookOrder.SDK_FIRST (-100), HookOrder.DEFAULT (0), or HookOrder.SDK_LAST (100).
 
         Raises:
             ValueError: If event_type is not provided and cannot be inferred from

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -46,6 +46,7 @@ from ..hooks import (
     AgentInitializedEvent,
     BeforeInvocationEvent,
     HookCallback,
+    HookOrder,
     HookProvider,
     HookRegistry,
     MessageAddedEvent,
@@ -725,7 +726,11 @@ class Agent(AgentBase):
         self.tool_registry.cleanup()
 
     def add_hook(
-        self, callback: HookCallback[TEvent], event_type: type[TEvent] | list[type[TEvent]] | None = None
+        self,
+        callback: HookCallback[TEvent],
+        event_type: type[TEvent] | list[type[TEvent]] | None = None,
+        *,
+        order: int = HookOrder.DEFAULT,
     ) -> None:
         """Register a callback function for a specific event type.
 
@@ -745,6 +750,8 @@ class Agent(AgentBase):
                 Can be a single type, a list of types, or None to infer from
                 the callback's first parameter type hint. If a list is provided,
                 the callback is registered for each type in the list.
+            order: Execution priority. Lower values execute first.
+                Use HookOrder.FIRST (-100), HookOrder.DEFAULT (0), or HookOrder.LAST (100).
 
         Raises:
             ValueError: If event_type is not provided and cannot be inferred from
@@ -776,7 +783,7 @@ class Agent(AgentBase):
         Docs:
             https://strandsagents.com/latest/documentation/docs/user-guide/concepts/agents/hooks/
         """
-        self.hooks.add_callback(event_type, callback)
+        self.hooks.add_callback(event_type, callback, order=order)
 
     def __del__(self) -> None:
         """Clean up resources when agent is garbage collected."""

--- a/strands-py/src/strands/hooks/__init__.py
+++ b/strands-py/src/strands/hooks/__init__.py
@@ -45,7 +45,7 @@ from .events import (
     MessageAddedEvent,
     MultiAgentInitializedEvent,
 )
-from .registry import BaseHookEvent, HookCallback, HookEvent, HookProvider, HookRegistry
+from .registry import BaseHookEvent, HookCallback, HookEvent, HookOrder, HookProvider, HookRegistry
 
 __all__ = [
     "AgentInitializedEvent",
@@ -57,6 +57,7 @@ __all__ = [
     "AfterInvocationEvent",
     "MessageAddedEvent",
     "HookEvent",
+    "HookOrder",
     "HookProvider",
     "HookCallback",
     "HookRegistry",

--- a/strands-py/src/strands/hooks/registry.py
+++ b/strands-py/src/strands/hooks/registry.py
@@ -199,6 +199,7 @@ class HookRegistry:
             event_type: The lifecycle event type(s) this callback should handle.
                 Can be a single type, a list of types, or None to infer from type hints.
             callback: The callback function to invoke when events of this type occur.
+            order: Execution priority. Lower values execute first.
 
         Raises:
             ValueError: If event_type is not provided and cannot be inferred from

--- a/strands-py/src/strands/hooks/registry.py
+++ b/strands-py/src/strands/hooks/registry.py
@@ -7,10 +7,12 @@ functions, supporting both individual callback registration and bulk registratio
 via hook provider objects.
 """
 
+import bisect
 import inspect
 import logging
 from collections.abc import Awaitable, Generator
 from dataclasses import dataclass
+from itertools import groupby
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, runtime_checkable
 
 from ..interrupt import Interrupt, InterruptException
@@ -20,6 +22,25 @@ if TYPE_CHECKING:
     from ..agent import Agent
 
 logger = logging.getLogger(__name__)
+
+
+class HookOrder:
+    """Named constants for hook execution priority.
+
+    Lower values execute first. Hooks with the same order preserve registration order.
+    """
+
+    FIRST: int = -100
+    DEFAULT: int = 0
+    LAST: int = 100
+
+
+@dataclass
+class _CallbackEntry:
+    """Internal entry pairing a callback with its execution order."""
+
+    callback: "HookCallback"
+    order: int
 
 
 @dataclass
@@ -156,12 +177,14 @@ class HookRegistry:
 
     def __init__(self) -> None:
         """Initialize an empty hook registry."""
-        self._registered_callbacks: dict[type, list[HookCallback]] = {}
+        self._registered_callbacks: dict[type, list[_CallbackEntry]] = {}
 
     def add_callback(
         self,
         event_type: type[TEvent] | list[type[TEvent]] | None,
         callback: HookCallback[TEvent],
+        *,
+        order: int = HookOrder.DEFAULT,
     ) -> None:
         """Register a callback function for a specific event type.
 
@@ -227,8 +250,9 @@ class HookRegistry:
             if resolved_event_type.__name__ == "AgentInitializedEvent" and inspect.iscoroutinefunction(callback):
                 raise ValueError("AgentInitializedEvent can only be registered with a synchronous callback")
 
-            callbacks = self._registered_callbacks.setdefault(resolved_event_type, [])
-            callbacks.append(callback)
+            entries = self._registered_callbacks.setdefault(resolved_event_type, [])
+            entry = _CallbackEntry(callback=callback, order=order)
+            bisect.insort(entries, entry, key=lambda e: e.order)
 
     def _validate_event_type_list(self, event_types: list[type[TEvent]]) -> list[type[TEvent]]:
         """Validate that all types in a list are valid BaseHookEvent subclasses.
@@ -381,9 +405,12 @@ class HookRegistry:
     def get_callbacks_for(self, event: TEvent) -> Generator[HookCallback[TEvent], None, None]:
         """Get callbacks registered for the given event in the appropriate order.
 
-        This method returns callbacks in registration order for normal events,
-        or reverse registration order for events that have should_reverse_callbacks=True.
-        This enables proper cleanup ordering for teardown events.
+        For normal events, callbacks are returned in order priority (lower first),
+        with registration order preserved within the same priority.
+
+        For reversed events (should_reverse_callbacks=True), order priority still
+        applies (lower first), but within the same priority group, registration
+        order is reversed.
 
         Args:
             event: The event to get callbacks for.
@@ -400,8 +427,11 @@ class HookRegistry:
         """
         event_type = type(event)
 
-        callbacks = self._registered_callbacks.get(event_type, [])
+        entries = self._registered_callbacks.get(event_type, [])
         if event.should_reverse_callbacks:
-            yield from reversed(callbacks)
+            for _order, group in groupby(entries, key=lambda e: e.order):
+                for entry in reversed(list(group)):
+                    yield entry.callback
         else:
-            yield from callbacks
+            for entry in entries:
+                yield entry.callback

--- a/strands-py/src/strands/hooks/registry.py
+++ b/strands-py/src/strands/hooks/registry.py
@@ -40,7 +40,7 @@ class _CallbackEntry:
     """Internal entry pairing a callback with its execution order."""
 
     callback: "HookCallback"
-    order: int
+    order: float
 
 
 @dataclass
@@ -184,7 +184,7 @@ class HookRegistry:
         event_type: type[TEvent] | list[type[TEvent]] | None,
         callback: HookCallback[TEvent],
         *,
-        order: int = HookOrder.DEFAULT,
+        order: float = HookOrder.DEFAULT,
     ) -> None:
         """Register a callback function for a specific event type.
 

--- a/strands-py/src/strands/hooks/registry.py
+++ b/strands-py/src/strands/hooks/registry.py
@@ -30,9 +30,9 @@ class HookOrder:
     Lower values execute first. Hooks with the same order preserve registration order.
     """
 
-    FIRST: int = -100
+    SDK_FIRST: int = -100
     DEFAULT: int = 0
-    LAST: int = 100
+    SDK_LAST: int = 100
 
 
 @dataclass

--- a/strands-py/src/strands/multiagent/base.py
+++ b/strands-py/src/strands/multiagent/base.py
@@ -13,7 +13,7 @@ from typing import Any, Union
 
 from .._async import run_async
 from ..agent import AgentResult
-from ..hooks.registry import HookCallback
+from ..hooks.registry import HookCallback, HookOrder
 from ..interrupt import Interrupt
 from ..types.event_loop import Metrics, Usage
 from ..types.multiagent import MultiAgentInput
@@ -255,7 +255,9 @@ class MultiAgentBase(ABC):
         """Restore orchestrator state from a session dict."""
         raise NotImplementedError
 
-    def add_hook(self, callback: HookCallback, event_type: type | list[type] | None = None) -> None:
+    def add_hook(
+        self, callback: HookCallback, event_type: type | list[type] | None = None, *, order: int = HookOrder.DEFAULT
+    ) -> None:
         """Register a hook callback with the orchestrator.
 
         Subclasses that support hooks should override this method to register
@@ -266,6 +268,7 @@ class MultiAgentBase(ABC):
             event_type: The class type(s) of events this callback should handle.
                 Can be a single type, a list of types, or None to infer from
                 the callback's first parameter type hint.
+            order: Execution priority. Lower values execute first.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement add_hook() to support plugins")
 

--- a/strands-py/src/strands/multiagent/base.py
+++ b/strands-py/src/strands/multiagent/base.py
@@ -256,7 +256,7 @@ class MultiAgentBase(ABC):
         raise NotImplementedError
 
     def add_hook(
-        self, callback: HookCallback, event_type: type | list[type] | None = None, *, order: int = HookOrder.DEFAULT
+        self, callback: HookCallback, event_type: type | list[type] | None = None, *, order: float = HookOrder.DEFAULT
     ) -> None:
         """Register a hook callback with the orchestrator.
 

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -496,7 +496,7 @@ class Graph(MultiAgentBase):
         run_async(lambda: self.hooks.invoke_callbacks_async(MultiAgentInitializedEvent(self)))
 
     def add_hook(
-        self, callback: HookCallback, event_type: type | list[type] | None = None, *, order: int = HookOrder.DEFAULT
+        self, callback: HookCallback, event_type: type | list[type] | None = None, *, order: float = HookOrder.DEFAULT
     ) -> None:
         """Register a hook callback with the graph.
 

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -35,7 +35,7 @@ from ..hooks.events import (
     BeforeNodeCallEvent,
     MultiAgentInitializedEvent,
 )
-from ..hooks.registry import HookCallback, HookProvider, HookRegistry
+from ..hooks.registry import HookCallback, HookOrder, HookProvider, HookRegistry
 from ..interrupt import Interrupt, _InterruptState
 from ..plugins.multiagent_plugin import MultiAgentPlugin
 from ..plugins.multiagent_registry import _MultiAgentPluginRegistry
@@ -495,7 +495,9 @@ class Graph(MultiAgentBase):
 
         run_async(lambda: self.hooks.invoke_callbacks_async(MultiAgentInitializedEvent(self)))
 
-    def add_hook(self, callback: HookCallback, event_type: type | list[type] | None = None) -> None:
+    def add_hook(
+        self, callback: HookCallback, event_type: type | list[type] | None = None, *, order: int = HookOrder.DEFAULT
+    ) -> None:
         """Register a hook callback with the graph.
 
         Args:
@@ -503,8 +505,9 @@ class Graph(MultiAgentBase):
             event_type: The class type(s) of events this callback should handle.
                 Can be a single type, a list of types, or None to infer from
                 the callback's first parameter type hint.
+            order: Execution priority. Lower values execute first.
         """
-        self.hooks.add_callback(event_type, callback)
+        self.hooks.add_callback(event_type, callback, order=order)
 
     def __call__(
         self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any

--- a/strands-py/src/strands/multiagent/swarm.py
+++ b/strands-py/src/strands/multiagent/swarm.py
@@ -316,7 +316,7 @@ class Swarm(MultiAgentBase):
         run_async(lambda: self.hooks.invoke_callbacks_async(MultiAgentInitializedEvent(self)))
 
     def add_hook(
-        self, callback: HookCallback, event_type: type | list[type] | None = None, *, order: int = HookOrder.DEFAULT
+        self, callback: HookCallback, event_type: type | list[type] | None = None, *, order: float = HookOrder.DEFAULT
     ) -> None:
         """Register a hook callback with the swarm.
 

--- a/strands-py/src/strands/multiagent/swarm.py
+++ b/strands-py/src/strands/multiagent/swarm.py
@@ -35,7 +35,7 @@ from ..hooks.events import (
     BeforeNodeCallEvent,
     MultiAgentInitializedEvent,
 )
-from ..hooks.registry import HookCallback, HookProvider, HookRegistry
+from ..hooks.registry import HookCallback, HookOrder, HookProvider, HookRegistry
 from ..interrupt import Interrupt, _InterruptState
 from ..plugins.multiagent_plugin import MultiAgentPlugin
 from ..plugins.multiagent_registry import _MultiAgentPluginRegistry
@@ -315,7 +315,9 @@ class Swarm(MultiAgentBase):
         self._inject_swarm_tools()
         run_async(lambda: self.hooks.invoke_callbacks_async(MultiAgentInitializedEvent(self)))
 
-    def add_hook(self, callback: HookCallback, event_type: type | list[type] | None = None) -> None:
+    def add_hook(
+        self, callback: HookCallback, event_type: type | list[type] | None = None, *, order: int = HookOrder.DEFAULT
+    ) -> None:
         """Register a hook callback with the swarm.
 
         Args:
@@ -323,8 +325,9 @@ class Swarm(MultiAgentBase):
             event_type: The class type(s) of events this callback should handle.
                 Can be a single type, a list of types, or None to infer from
                 the callback's first parameter type hint.
+            order: Execution priority. Lower values execute first.
         """
-        self.hooks.add_callback(event_type, callback)
+        self.hooks.add_callback(event_type, callback, order=order)
 
     def __call__(
         self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any

--- a/strands-py/tests/strands/agent/hooks/test_hook_registry.py
+++ b/strands-py/tests/strands/agent/hooks/test_hook_registry.py
@@ -58,7 +58,7 @@ def test_add_callback(hook_registry, normal_event):
     hook_registry.add_callback(NormalTestEvent, callback)
 
     assert NormalTestEvent in hook_registry._registered_callbacks
-    assert callback in hook_registry._registered_callbacks[NormalTestEvent]
+    assert any(e.callback is callback for e in hook_registry._registered_callbacks[NormalTestEvent])
 
 
 def test_add_multiple_callbacks_same_event(hook_registry, normal_event):
@@ -70,8 +70,8 @@ def test_add_multiple_callbacks_same_event(hook_registry, normal_event):
     hook_registry.add_callback(NormalTestEvent, callback2)
 
     assert len(hook_registry._registered_callbacks[NormalTestEvent]) == 2
-    assert callback1 in hook_registry._registered_callbacks[NormalTestEvent]
-    assert callback2 in hook_registry._registered_callbacks[NormalTestEvent]
+    assert any(e.callback is callback1 for e in hook_registry._registered_callbacks[NormalTestEvent])
+    assert any(e.callback is callback2 for e in hook_registry._registered_callbacks[NormalTestEvent])
 
 
 def test_add_hook(hook_registry):

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -2629,7 +2629,7 @@ def test_agent_add_hook_delegates_to_hooks_add_callback():
     # Spy on the hooks.add_callback method
     with unittest.mock.patch.object(agent.hooks, "add_callback") as mock_add_callback:
         agent.add_hook(callback, BeforeInvocationEvent)
-        mock_add_callback.assert_called_once_with(BeforeInvocationEvent, callback)
+        mock_add_callback.assert_called_once_with(BeforeInvocationEvent, callback, order=0)
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/hooks/test_registry.py
+++ b/strands-py/tests/strands/hooks/test_registry.py
@@ -325,8 +325,8 @@ def test_lower_order_runs_first(registry, agent):
     order = []
 
     registry.add_callback(BeforeModelCallEvent, lambda e: order.append("default"), order=HookOrder.DEFAULT)
-    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("first"), order=HookOrder.FIRST)
-    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("last"), order=HookOrder.LAST)
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("first"), order=HookOrder.SDK_FIRST)
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("last"), order=HookOrder.SDK_LAST)
 
     registry.invoke_callbacks(BeforeModelCallEvent(agent=agent))
     assert order == ["first", "default", "last"]
@@ -361,8 +361,8 @@ def test_after_events_lower_order_still_runs_first(registry, agent):
 
     registry.add_callback(AfterModelCallEvent, lambda e: order.append("default_a"))
     registry.add_callback(AfterModelCallEvent, lambda e: order.append("default_b"))
-    registry.add_callback(AfterModelCallEvent, lambda e: order.append("first"), order=HookOrder.FIRST)
-    registry.add_callback(AfterModelCallEvent, lambda e: order.append("last"), order=HookOrder.LAST)
+    registry.add_callback(AfterModelCallEvent, lambda e: order.append("first"), order=HookOrder.SDK_FIRST)
+    registry.add_callback(AfterModelCallEvent, lambda e: order.append("last"), order=HookOrder.SDK_LAST)
 
     registry.invoke_callbacks(AfterModelCallEvent(agent=agent))
     # Lower order first, but within same group registration order is reversed

--- a/strands-py/tests/strands/hooks/test_registry.py
+++ b/strands-py/tests/strands/hooks/test_registry.py
@@ -9,9 +9,15 @@ from strands.hooks import (
     BeforeInvocationEvent,
     BeforeModelCallEvent,
     BeforeToolCallEvent,
+    HookOrder,
     HookRegistry,
 )
 from strands.interrupt import Interrupt, _InterruptState
+
+
+def _has_callback(registry, event_type, callback):
+    """Check if a callback is registered for an event type."""
+    return any(entry.callback is callback for entry in registry._registered_callbacks.get(event_type, []))
 
 
 @pytest.fixture
@@ -108,7 +114,7 @@ def test_hook_registry_add_callback_infers_event_type(registry):
 
     # Verify callback was registered
     assert BeforeInvocationEvent in registry._registered_callbacks
-    assert typed_callback in registry._registered_callbacks[BeforeInvocationEvent]
+    assert _has_callback(registry, BeforeInvocationEvent, typed_callback)
 
 
 def test_hook_registry_add_callback_raises_error_no_type_hint(registry):
@@ -150,7 +156,7 @@ def test_hook_registry_add_callback_infers_event_type_when_callback_provided_wit
     registry.add_callback(None, typed_callback)
 
     assert BeforeInvocationEvent in registry._registered_callbacks
-    assert typed_callback in registry._registered_callbacks[BeforeInvocationEvent]
+    assert _has_callback(registry, BeforeInvocationEvent, typed_callback)
 
 
 def test_hook_registry_add_callback_with_explicit_event_type_and_callback(registry):
@@ -162,7 +168,7 @@ def test_hook_registry_add_callback_with_explicit_event_type_and_callback(regist
     registry.add_callback(BeforeInvocationEvent, callback)
 
     assert BeforeInvocationEvent in registry._registered_callbacks
-    assert callback in registry._registered_callbacks[BeforeInvocationEvent]
+    assert _has_callback(registry, BeforeInvocationEvent, callback)
 
 
 # ========== Tests for union type support ==========
@@ -179,8 +185,8 @@ def test_hook_registry_add_callback_infers_union_types_pipe_syntax(registry):
     # Callback should be registered for both event types
     assert BeforeModelCallEvent in registry._registered_callbacks
     assert AfterModelCallEvent in registry._registered_callbacks
-    assert union_callback in registry._registered_callbacks[BeforeModelCallEvent]
-    assert union_callback in registry._registered_callbacks[AfterModelCallEvent]
+    assert _has_callback(registry, BeforeModelCallEvent, union_callback)
+    assert _has_callback(registry, AfterModelCallEvent, union_callback)
 
 
 def test_hook_registry_add_callback_infers_union_types_union_syntax(registry):
@@ -194,8 +200,8 @@ def test_hook_registry_add_callback_infers_union_types_union_syntax(registry):
     # Callback should be registered for both event types
     assert BeforeModelCallEvent in registry._registered_callbacks
     assert AfterModelCallEvent in registry._registered_callbacks
-    assert union_callback in registry._registered_callbacks[BeforeModelCallEvent]
-    assert union_callback in registry._registered_callbacks[AfterModelCallEvent]
+    assert _has_callback(registry, BeforeModelCallEvent, union_callback)
+    assert _has_callback(registry, AfterModelCallEvent, union_callback)
 
 
 def test_hook_registry_add_callback_union_with_none_raises_error(registry):
@@ -230,9 +236,9 @@ def test_hook_registry_add_callback_union_multiple_types(registry):
     assert BeforeModelCallEvent in registry._registered_callbacks
     assert AfterModelCallEvent in registry._registered_callbacks
     assert BeforeInvocationEvent in registry._registered_callbacks
-    assert multi_union_callback in registry._registered_callbacks[BeforeModelCallEvent]
-    assert multi_union_callback in registry._registered_callbacks[AfterModelCallEvent]
-    assert multi_union_callback in registry._registered_callbacks[BeforeInvocationEvent]
+    assert _has_callback(registry, BeforeModelCallEvent, multi_union_callback)
+    assert _has_callback(registry, AfterModelCallEvent, multi_union_callback)
+    assert _has_callback(registry, BeforeInvocationEvent, multi_union_callback)
 
 
 # ========== Tests for list of types support ==========
@@ -249,8 +255,8 @@ def test_hook_registry_add_callback_with_list_of_types(registry):
     # Callback should be registered for both event types
     assert BeforeModelCallEvent in registry._registered_callbacks
     assert AfterModelCallEvent in registry._registered_callbacks
-    assert my_callback in registry._registered_callbacks[BeforeModelCallEvent]
-    assert my_callback in registry._registered_callbacks[AfterModelCallEvent]
+    assert _has_callback(registry, BeforeModelCallEvent, my_callback)
+    assert _has_callback(registry, AfterModelCallEvent, my_callback)
 
 
 def test_hook_registry_add_callback_with_list_deduplicates(registry):
@@ -309,3 +315,55 @@ async def test_hook_registry_union_callback_invoked_for_each_type(registry, agen
     after_event = AfterModelCallEvent(agent=agent)
     await registry.invoke_callbacks_async(after_event)
     assert call_count["after"] == 1
+
+
+# ========== Tests for hook ordering ==========
+
+
+def test_lower_order_runs_first(registry, agent):
+    """Test that lower order values execute first."""
+    order = []
+
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("default"), order=HookOrder.DEFAULT)
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("first"), order=HookOrder.FIRST)
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("last"), order=HookOrder.LAST)
+
+    registry.invoke_callbacks(BeforeModelCallEvent(agent=agent))
+    assert order == ["first", "default", "last"]
+
+
+def test_same_order_preserves_registration_order(registry, agent):
+    """Test that callbacks with the same order preserve registration order."""
+    order = []
+
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("a"))
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("b"))
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("c"))
+
+    registry.invoke_callbacks(BeforeModelCallEvent(agent=agent))
+    assert order == ["a", "b", "c"]
+
+
+def test_negative_order_runs_before_default(registry, agent):
+    """Test that negative order runs before default."""
+    order = []
+
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("default"))
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("early"), order=-50)
+
+    registry.invoke_callbacks(BeforeModelCallEvent(agent=agent))
+    assert order == ["early", "default"]
+
+
+def test_after_events_lower_order_still_runs_first(registry, agent):
+    """Test that for After events, lower order still runs first across groups."""
+    order = []
+
+    registry.add_callback(AfterModelCallEvent, lambda e: order.append("default_a"))
+    registry.add_callback(AfterModelCallEvent, lambda e: order.append("default_b"))
+    registry.add_callback(AfterModelCallEvent, lambda e: order.append("first"), order=HookOrder.FIRST)
+    registry.add_callback(AfterModelCallEvent, lambda e: order.append("last"), order=HookOrder.LAST)
+
+    registry.invoke_callbacks(AfterModelCallEvent(agent=agent))
+    # Lower order first, but within same group registration order is reversed
+    assert order == ["first", "default_b", "default_a", "last"]

--- a/strands-py/tests/strands/plugins/test_multiagent_plugin.py
+++ b/strands-py/tests/strands/plugins/test_multiagent_plugin.py
@@ -245,7 +245,7 @@ def test_registry_hooks_are_bound_to_instance(mock_orchestrator, registry):
     registry.add_and_init(plugin)
 
     mock_event = unittest.mock.MagicMock(spec=BeforeNodeCallEvent)
-    mock_orchestrator.hooks._registered_callbacks[BeforeNodeCallEvent][0](mock_event)
+    mock_orchestrator.hooks._registered_callbacks[BeforeNodeCallEvent][0].callback(mock_event)
 
     assert plugin.events_received == [mock_event]
 

--- a/strands-py/tests/strands/plugins/test_plugin_base_class.py
+++ b/strands-py/tests/strands/plugins/test_plugin_base_class.py
@@ -512,8 +512,8 @@ class TestPluginBoundMethods:
 
         # Call the registered hook and verify it accesses the correct instance
         mock_event = unittest.mock.MagicMock(spec=BeforeModelCallEvent)
-        callbacks = list(mock_agent.hooks._registered_callbacks.get(BeforeModelCallEvent, []))
-        callbacks[0](mock_event)
+        entries = list(mock_agent.hooks._registered_callbacks.get(BeforeModelCallEvent, []))
+        entries[0].callback(mock_event)
 
         assert len(plugin.events_received) == 1
         assert plugin.events_received[0] is mock_event

--- a/strands-py/tests/strands/vended_plugins/steering/core/test_handler.py
+++ b/strands-py/tests/strands/vended_plugins/steering/core/test_handler.py
@@ -281,9 +281,9 @@ async def test_context_callbacks_receive_steering_context():
     event.tool_use = {"name": "test_tool", "input": {}}
 
     # Call all callbacks, handling both sync and async
-    for cb in callbacks:
+    for entry in callbacks:
         try:
-            result = await cb(event)
+            result = await entry.callback(event)
             if inspect.iscoroutine(result):
                 await result
         except Exception:


### PR DESCRIPTION
## Description

Adds an optional `order` parameter to `add_callback` and `add_hook` methods that controls hook execution priority. Lower values execute first, with named constants: `HookOrder.SDK_FIRST` (-100), `HookOrder.DEFAULT` (0), `HookOrder.SDK_LAST` (100).

Hooks with the same order preserve registration order. For After* events (reversed), lower order still runs first across groups, with registration order reversed within same group.

Port of strands-agents/sdk-typescript#1005.

### Usage

```python
from strands import Agent
from strands.hooks import BeforeModelCallEvent, HookOrder

agent = Agent()

def early_hook(event: BeforeModelCallEvent) -> None:
    print("I run first")

def late_hook(event: BeforeModelCallEvent) -> None:
    print("I run last")

agent.add_hook(early_hook, order=HookOrder.SDK_FIRST)
agent.add_hook(late_hook, order=HookOrder.SDK_LAST)

# Arbitrary numeric values work too
agent.add_hook(my_hook, order=-50)

# float('-inf') / float('inf') for guaranteed absolute ordering
agent.add_hook(always_first, order=float('-inf'))
```

## Related Issues

strands-agents/sdk-typescript#1005

## Documentation PR

Documentation included in this PR — updated the Python tab under "Callback Ordering" in `site/src/content/docs/user-guide/concepts/agents/hooks.mdx`.

## Type of Change

New feature

## Testing

- [x] New unit tests for ordering behavior (lower order first, same order FIFO, negative order, After event semantics)
- [x] All existing hook registry tests pass
- [x] Plugin and steering tests updated for internal storage change
- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.