### PR TITLE
fix: workflow_dispatch step for python wasm release

### DIFF
--- a/.github/workflows/python-wasm-pypi-publish-on-release.yml
+++ b/.github/workflows/python-wasm-pypi-publish-on-release.yml
@@ -39,7 +39,7 @@ jobs:
         package-manager-cache: false
 
     - name: Install dependencies
-      run: npm ci
+      run: npm install
 
     - name: Build TypeScript SDK
       run: npm run build -w strands-ts


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
The `workflow_dispatch` failed for python wasm release. More details [here](https://github.com/strands-agents/sdk-python/actions/runs/26830425262/job/79109852165). The build failed in CI because `npm ci` didn't install a linux-specific native dependency. 

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
