### PR TITLE
feat: simplify DockerSandbox to bring-your-own-container

### DIFF
--- a/strands-ts/src/__fixtures__/test-sandbox.node.ts
+++ b/strands-ts/src/__fixtures__/test-sandbox.node.ts
@@ -1,4 +1,4 @@
-import { PosixShellSandbox, shellQuote } from '../sandbox/posix-shell.js'
+import { buildShellEnvPrefix, PosixShellSandbox, shellQuote } from '../sandbox/posix-shell.js'
 import { streamProcess } from '../sandbox/stream-process.js'
 import type { ExecuteOptions } from '../sandbox/base.js'
 import type { ExecutionResult, StreamChunk } from '../sandbox/types.js'
@@ -22,7 +22,8 @@ export class TestSandbox extends PosixShellSandbox {
     options?: ExecuteOptions
   ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
     const cwd = options?.cwd ?? this.workingDir
-    const fullCommand = `cd ${shellQuote(cwd)} && ${command}`
+    const envPrefix = buildShellEnvPrefix(options?.env)
+    const fullCommand = `cd ${shellQuote(cwd)} && ${envPrefix}${command}`
     yield* streamProcess('sh', ['-c', fullCommand], { timeout: options?.timeout, signal: options?.signal })
   }
 }

--- a/strands-ts/src/sandbox/__tests__/docker.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/docker.test.node.ts
@@ -4,7 +4,6 @@ import { streamProcess } from '../stream-process.js'
 import type { ExecutionResult } from '../types.js'
 
 const OK: ExecutionResult = { type: 'executionResult', exitCode: 0, stdout: '', stderr: '', outputFiles: [] }
-const FAIL: ExecutionResult = { type: 'executionResult', exitCode: 1, stdout: '', stderr: 'boom', outputFiles: [] }
 
 vi.mock('../stream-process.js', () => ({
   streamProcess: vi.fn(async function* () {
@@ -12,123 +11,85 @@ vi.mock('../stream-process.js', () => ({
   }),
 }))
 
-const findRunArgs = (): string[] => {
-  const call = vi.mocked(streamProcess).mock.calls.find(([, args]) => args[0] === 'run')
-  if (!call) throw new Error('docker run was never called')
-  return call[1]
-}
-
 describe('DockerSandbox', () => {
   beforeEach(() => {
     vi.mocked(streamProcess).mockClear()
   })
 
-  it('throws when a volume mount exposes a sensitive host path', () => {
-    expect(() => new DockerSandbox({ image: 'alpine', volumes: ['/etc:/mnt/etc'] })).toThrow(/sensitive host path/)
-  })
+  describe('executeStreaming', () => {
+    it('terminates flags with -- so a dash-prefixed container is not parsed as a flag', async () => {
+      const sandbox = new DockerSandbox({ container: '--privileged' })
+      await sandbox.execute('echo hi')
 
-  it('allows dangerous mounts when allowDangerousMounts is true', () => {
-    expect(
-      () => new DockerSandbox({ image: 'alpine', volumes: ['/etc:/mnt/etc'], allowDangerousMounts: true })
-    ).not.toThrow()
-  })
-
-  it('catches path traversal attempts in volume mounts', () => {
-    expect(() => new DockerSandbox({ image: 'alpine', volumes: ['/var/../etc:/mnt'] })).toThrow(/sensitive host path/)
-  })
-
-  it('does not throw for safe volume mounts', () => {
-    expect(() => new DockerSandbox({ image: 'alpine', volumes: ['/opt/myproject:/app'] })).not.toThrow()
-  })
-
-  it('runs the container as a non-root user by default', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await sandbox.start()
-
-    const args = findRunArgs()
-    const userIdx = args.indexOf('--user')
-    expect(args[userIdx + 1]).toBe('1000:1000')
-  })
-
-  it('drops all capabilities and disables new privileges by default', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await sandbox.start()
-
-    const args = findRunArgs()
-    expect(args).toEqual(expect.arrayContaining(['--cap-drop', 'ALL', '--security-opt', 'no-new-privileges']))
-  })
-
-  it('omits cap-drop and no-new-privileges when allowPrivilegeEscalation is true', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine', allowPrivilegeEscalation: true })
-    await sandbox.start()
-
-    const args = findRunArgs()
-    expect(args).not.toContain('--cap-drop')
-    expect(args).not.toContain('no-new-privileges')
-  })
-
-  it('throws a clear error when the Docker daemon is unavailable', async () => {
-    vi.mocked(streamProcess).mockImplementationOnce(async function* () {
-      yield FAIL
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      expect(args.slice(-5)).toStrictEqual(['--', '--privileged', 'sh', '-c', 'echo hi'])
     })
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await expect(sandbox.start()).rejects.toThrow(/Docker is not available/)
-  })
 
-  it('throws when executeStreaming is called before start()', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await expect(sandbox.execute('echo hi')).rejects.toThrow(/not running.*start\(\)/)
-  })
+    it('omits --user and -w when user and workingDir are unset', async () => {
+      const sandbox = new DockerSandbox({ container: 'my-container' })
+      await sandbox.execute('echo hi')
 
-  it('removes the container on stop()', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine', name: 'test-stop' })
-    await sandbox.start()
-    vi.mocked(streamProcess).mockClear()
-    await sandbox.stop()
-
-    expect(streamProcess).toHaveBeenCalledWith('docker', ['rm', '-f', 'test-stop'], {
-      enoentMessage: 'docker is not installed or not on PATH',
+      expect(streamProcess).toHaveBeenCalledWith('docker', ['exec', '--', 'my-container', 'sh', '-c', 'echo hi'], {
+        timeout: undefined,
+        signal: undefined,
+        enoentMessage: 'docker is not installed or not on PATH',
+      })
     })
-  })
 
-  it('passes resource limits to docker run', async () => {
-    const sandbox = new DockerSandbox({
-      image: 'alpine',
-      memory: '512m',
-      cpus: 1.5,
-      pidsLimit: 100,
-      network: 'none',
+    it('uses custom user and workingDir', async () => {
+      const sandbox = new DockerSandbox({ container: 'my-container', user: 'root', workingDir: '/app' })
+      await sandbox.execute('ls')
+
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      expect(args).toStrictEqual(['exec', '--user', 'root', '-w', '/app', '--', 'my-container', 'sh', '-c', 'ls'])
     })
-    await sandbox.start()
 
-    const args = findRunArgs()
-    expect(args).toEqual(
-      expect.arrayContaining(['--memory', '512m', '--cpus', '1.5', '--pids-limit', '100', '--network', 'none'])
-    )
-  })
+    it('cwd option overrides workingDir', async () => {
+      const sandbox = new DockerSandbox({ container: 'my-container', workingDir: '/app' })
+      await sandbox.execute('pwd', { cwd: '/override' })
 
-  it('executes commands via docker exec with correct args', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine', name: 'test-exec' })
-    await sandbox.start()
-    vi.mocked(streamProcess).mockClear()
-    await sandbox.execute('echo hi')
-
-    expect(streamProcess).toHaveBeenCalledWith('docker', ['exec', 'test-exec', 'sh', '-c', "cd '/tmp' && echo hi"], {
-      timeout: undefined,
-      signal: undefined,
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      expect(args).toStrictEqual(['exec', '-w', '/override', '--', 'my-container', 'sh', '-c', 'pwd'])
     })
-  })
 
-  it('resets _running on start() failure so retry is possible', async () => {
-    vi.mocked(streamProcess).mockImplementationOnce(async function* () {
-      yield FAIL
-    })
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await expect(sandbox.start()).rejects.toThrow(/Docker is not available/)
+    it('forwards timeout and signal to streamProcess', async () => {
+      const sandbox = new DockerSandbox({ container: 'my-container' })
+      const controller = new AbortController()
+      await sandbox.execute('sleep 10', { timeout: 5, signal: controller.signal })
 
-    vi.mocked(streamProcess).mockImplementation(async function* () {
-      yield OK
+      const opts = vi.mocked(streamProcess).mock.calls[0]![2]
+      expect(opts).toStrictEqual({
+        timeout: 5,
+        signal: controller.signal,
+        enoentMessage: 'docker is not installed or not on PATH',
+      })
     })
-    await sandbox.start()
+
+    it('passes env vars as -e flags before container ID', async () => {
+      const sandbox = new DockerSandbox({ container: 'my-container' })
+      await sandbox.execute('echo $FOO', { env: { FOO: 'bar', BAZ: 'qux' } })
+
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      expect(args).toStrictEqual([
+        'exec',
+        '-e',
+        'FOO=bar',
+        '-e',
+        'BAZ=qux',
+        '--',
+        'my-container',
+        'sh',
+        '-c',
+        'echo $FOO',
+      ])
+    })
+
+    it('rejects invalid env var names', async () => {
+      const sandbox = new DockerSandbox({ container: 'my-container' })
+
+      await expect(sandbox.execute('cmd', { env: { 'FOO=bar BAZ': 'val' } })).rejects.toThrow(
+        'Invalid environment variable name'
+      )
+    })
   })
 })

--- a/strands-ts/src/sandbox/__tests__/posix-shell.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/posix-shell.test.node.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'fs'
 import { TestSandbox } from '../../__fixtures__/test-sandbox.node.js'
+import { buildShellEnvPrefix } from '../posix-shell.js'
 import { streamProcess } from '../stream-process.js'
 import type { ExecutionResult, StreamChunk } from '../types.js'
 
@@ -37,6 +38,45 @@ describe.skipIf(process.platform === 'win32')('PosixShellSandbox', () => {
     })
   })
 
+  describe('env option (via buildEnvPrefix)', () => {
+    it('passes env vars to the command', async () => {
+      const result = await sandbox.execute('printenv FOO', { env: { FOO: 'hello', BAR: 'world' } })
+      expect(result.stdout.trim()).toBe('hello')
+    })
+
+    it('shell-quotes env values so they are not evaluated', async () => {
+      const result = await sandbox.execute('printenv FOO', { env: { FOO: '$(whoami)' } })
+      expect(result.stdout.trim()).toBe('$(whoami)')
+    })
+
+    it('rejects invalid env var names', async () => {
+      await expect(sandbox.execute('echo hi', { env: { 'BAD-KEY': 'v' } })).rejects.toThrow(
+        'Invalid environment variable name'
+      )
+    })
+  })
+
+  describe('buildShellEnvPrefix', () => {
+    it('returns an empty string when there are no env vars', () => {
+      expect(buildShellEnvPrefix()).toBe('')
+      expect(buildShellEnvPrefix({})).toBe('')
+    })
+
+    it('uses export so vars are inherited across a pipeline, with a fail-fast && separator', () => {
+      // `export ... &&` (not `env ... `) is what lets env reach the right side of the
+      // `base64 ... | <interpreter>` pipe in executeCode. Locking the exact format.
+      expect(buildShellEnvPrefix({ FOO: 'bar', BAZ: 'qux' })).toBe("export FOO='bar' BAZ='qux' && ")
+    })
+
+    it('shell-quotes values so they are not evaluated', () => {
+      expect(buildShellEnvPrefix({ FOO: '$(whoami)' })).toBe("export FOO='$(whoami)' && ")
+    })
+
+    it('throws on invalid env var names', () => {
+      expect(() => buildShellEnvPrefix({ 'BAD-KEY': 'v' })).toThrow('Invalid environment variable name')
+    })
+  })
+
   describe('executeCode (via shell quoting)', () => {
     it('runs python code through shell', async () => {
       const result = await sandbox.executeCode('print(2 + 2)', 'python3')
@@ -52,6 +92,22 @@ describe.skipIf(process.platform === 'win32')('PosixShellSandbox', () => {
     it('handles code with single quotes', async () => {
       const result = await sandbox.executeCode('print("it\'s working")', 'python3')
       expect(result.stdout).toBe("it's working\n")
+    })
+
+    it('passes env vars through to the interpreter', async () => {
+      const result = await sandbox.executeCode('import os; print(os.environ["FOO"])', 'python3', {
+        env: { FOO: 'from-env' },
+      })
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout.trim()).toBe('from-env')
+    })
+
+    it('passes env values to the interpreter literally, without shell evaluation', async () => {
+      const result = await sandbox.executeCode('import os; print(os.environ["FOO"])', 'python3', {
+        env: { FOO: '$(whoami)' },
+      })
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout.trim()).toBe('$(whoami)')
     })
   })
 

--- a/strands-ts/src/sandbox/__tests__/ssh.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/ssh.test.node.ts
@@ -129,8 +129,17 @@ describe('SshSandbox', () => {
       }
 
       const args = vi.mocked(streamProcess).mock.calls[0]![1]
-      expect(args).toContain('StrictHostKeyChecking=no')
-      expect(args).not.toContain('StrictHostKeyChecking=accept-new')
+      expect(args).toStrictEqual([
+        '-o',
+        'StrictHostKeyChecking=no',
+        '-o',
+        'BatchMode=yes',
+        '-p',
+        '22',
+        '--',
+        'h',
+        "cd '/w' && ls",
+      ])
     })
 
     it('includes identity file when provided', async () => {
@@ -145,9 +154,19 @@ describe('SshSandbox', () => {
       }
 
       const args = vi.mocked(streamProcess).mock.calls[0]![1]
-      const idx = args.indexOf('-i')
-      expect(idx).toBeGreaterThan(-1)
-      expect(args[idx + 1]).toBe('/home/user/.ssh/key')
+      expect(args).toStrictEqual([
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'BatchMode=yes',
+        '-p',
+        '22',
+        '-i',
+        '/home/user/.ssh/key',
+        '--',
+        'h',
+        "cd '/w' && ls",
+      ])
     })
 
     it('uses custom port', async () => {
@@ -158,9 +177,17 @@ describe('SshSandbox', () => {
       }
 
       const args = vi.mocked(streamProcess).mock.calls[0]![1]
-      const idx = args.indexOf('-p')
-      expect(idx).toBeGreaterThan(-1)
-      expect(args[idx + 1]).toBe('2222')
+      expect(args).toStrictEqual([
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'BatchMode=yes',
+        '-p',
+        '2222',
+        '--',
+        'h',
+        "cd '/w' && ls",
+      ])
     })
 
     it('appends user sshOptions as -o flags', async () => {
@@ -175,7 +202,21 @@ describe('SshSandbox', () => {
       }
 
       const args = vi.mocked(streamProcess).mock.calls[0]![1]
-      expect(args).toEqual(expect.arrayContaining(['-o', 'ConnectTimeout=5', '-o', 'ServerAliveInterval=30']))
+      expect(args).toStrictEqual([
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'BatchMode=yes',
+        '-p',
+        '22',
+        '-o',
+        'ConnectTimeout=5',
+        '-o',
+        'ServerAliveInterval=30',
+        '--',
+        'h',
+        "cd '/w' && ls",
+      ])
     })
 
     it('quotes cwd with single quotes', async () => {
@@ -186,7 +227,17 @@ describe('SshSandbox', () => {
       }
 
       const args = vi.mocked(streamProcess).mock.calls[0]![1]
-      expect(args[args.length - 1]).toContain("cd '/path/with spaces/and'\\''quotes'")
+      expect(args).toStrictEqual([
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'BatchMode=yes',
+        '-p',
+        '22',
+        '--',
+        'h',
+        "cd '/path/with spaces/and'\\''quotes' && ls",
+      ])
     })
 
     it('uses cwd option when provided', async () => {
@@ -197,7 +248,17 @@ describe('SshSandbox', () => {
       }
 
       const args = vi.mocked(streamProcess).mock.calls[0]![1]
-      expect(args[args.length - 1]).toContain("cd '/override'")
+      expect(args).toStrictEqual([
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'BatchMode=yes',
+        '-p',
+        '22',
+        '--',
+        'h',
+        "cd '/override' && ls",
+      ])
     })
 
     it('forwards timeout and signal to streamProcess', async () => {
@@ -214,6 +275,37 @@ describe('SshSandbox', () => {
         signal: controller.signal,
         enoentMessage: 'ssh is not installed or not on PATH',
       })
+    })
+
+    it('prefixes command with env vars when provided', async () => {
+      const sandbox = new SshSandbox({ host: 'h', workingDir: '/w' })
+
+      for await (const _ of sandbox.executeStreaming('echo $FOO', { env: { FOO: 'bar', BAZ: 'qux' } })) {
+        // consume
+      }
+
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      expect(args).toStrictEqual([
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        'BatchMode=yes',
+        '-p',
+        '22',
+        '--',
+        'h',
+        "cd '/w' && export FOO='bar' BAZ='qux' && echo $FOO",
+      ])
+    })
+
+    it('rejects invalid env var names', async () => {
+      const sandbox = new SshSandbox({ host: 'h', workingDir: '/w' })
+
+      await expect(async () => {
+        for await (const _ of sandbox.executeStreaming('cmd', { env: { 'FOO=bar BAZ': 'val' } })) {
+          // consume
+        }
+      }).rejects.toThrow('Invalid environment variable name')
     })
   })
 })

--- a/strands-ts/src/sandbox/base.ts
+++ b/strands-ts/src/sandbox/base.ts
@@ -18,6 +18,12 @@ export interface ExecuteOptions {
   cwd?: string | undefined
   /** Abort signal to cancel execution. The process is killed when the signal fires. */
   signal?: AbortSignal | undefined
+  /**
+   * Environment variables to set for this command. Built-in sandboxes always apply these,
+   * though the mechanism differs (Docker `-e` flags, SSH `env` prefix); custom `Sandbox`
+   * implementations must handle env explicitly or it has no effect.
+   */
+  env?: Record<string, string> | undefined
 }
 
 /**
@@ -41,7 +47,7 @@ export abstract class Sandbox {
    * exit code and complete output.
    *
    * @param command - The shell command to execute.
-   * @param options - Execution options (timeout, cwd).
+   * @param options - Execution options.
    * @returns Async iterable yielding StreamChunks followed by a final ExecutionResult.
    */
   abstract executeStreaming(command: string, options?: ExecuteOptions): AsyncIterable<StreamChunk | ExecutionResult>
@@ -51,7 +57,7 @@ export abstract class Sandbox {
    *
    * @param code - The source code to execute.
    * @param language - The interpreter to use (e.g., `"python3"`, `"node"`).
-   * @param options - Execution options (timeout, cwd).
+   * @param options - Execution options.
    * @returns Async iterable yielding StreamChunks followed by a final ExecutionResult.
    */
   abstract executeCodeStreaming(
@@ -113,7 +119,7 @@ export abstract class Sandbox {
    * Use `executeStreaming` when you need to process output as it arrives.
    *
    * @param command - The shell command to execute.
-   * @param options - Execution options (timeout, cwd).
+   * @param options - Execution options.
    * @returns The execution result with exit code and output.
    */
   async execute(command: string, options?: ExecuteOptions): Promise<ExecutionResult> {
@@ -133,7 +139,7 @@ export abstract class Sandbox {
    *
    * @param code - The source code to execute.
    * @param language - The interpreter to use.
-   * @param options - Execution options (timeout, cwd).
+   * @param options - Execution options.
    * @returns The execution result with exit code and output.
    */
   async executeCode(code: string, language: string, options?: ExecuteOptions): Promise<ExecutionResult> {

--- a/strands-ts/src/sandbox/constants.ts
+++ b/strands-ts/src/sandbox/constants.ts
@@ -4,3 +4,11 @@
  * Rejects path separators, spaces, and shell metacharacters to prevent injection.
  */
 export const LANGUAGE_PATTERN = /^[a-zA-Z0-9._-]+$/
+
+/**
+ * Regex pattern for validating environment variable names: a leading letter or
+ * underscore, followed by letters, digits, or underscores (valid POSIX names).
+ * Names outside this set are rejected to prevent shell-syntax injection where a
+ * key is interpolated into a command, and to fail with a clear error otherwise.
+ */
+export const ENV_KEY_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/

--- a/strands-ts/src/sandbox/docker.ts
+++ b/strands-ts/src/sandbox/docker.ts
@@ -1,230 +1,79 @@
 /**
- * Docker sandbox — executes commands inside a Docker container via `docker exec`.
+ * Docker sandbox — executes commands in a Docker container via `docker exec`.
  */
 
-import { randomUUID } from 'crypto'
-import path from 'path'
 import type { ExecuteOptions } from './base.js'
-import { PosixShellSandbox, shellQuote } from './posix-shell.js'
+import { PosixShellSandbox, validateEnvKeys } from './posix-shell.js'
 import { streamProcess } from './stream-process.js'
 import type { ExecutionResult, StreamChunk } from './types.js'
-
-// Host paths that bypass container isolation when bind-mounted. Covers system
-// directories, runtime sockets, and user data that would expose the host to
-// LLM-generated commands running inside the container.
-const DANGEROUS_MOUNTS = [
-  '/',
-  '/boot',
-  '/dev',
-  '/etc',
-  '/home',
-  '/lib',
-  '/lib64',
-  '/proc',
-  '/root',
-  '/run',
-  '/sys',
-  '/tmp',
-  '/usr',
-  '/var/run',
-]
-
-// Windows drive roots (C:, D:) are flagged; POSIX paths are checked against DANGEROUS_MOUNTS.
-// Docker volume format: host:container[:options]. Windows paths (C:\...) have a colon after
-// the drive letter, so the separator search starts at index 2 to avoid splitting on it.
-function isHostPathDangerous(vol: string): boolean {
-  const sep = vol.indexOf(':', /^[a-zA-Z]:[/\\]/.test(vol) ? 2 : 0)
-  let hostPath = (sep > 0 ? vol.slice(0, sep) : vol).replace(/[/\\]+$/, '') || '/'
-  if (hostPath.startsWith('/')) hostPath = path.posix.normalize(hostPath).replace(/\/+$/, '') || '/'
-  return /^[a-zA-Z]:$/.test(hostPath) || DANGEROUS_MOUNTS.some((d) => hostPath === d || hostPath.startsWith(d + '/'))
-}
-
-async function dockerCmd(args: string[]): Promise<ExecutionResult> {
-  for await (const chunk of streamProcess('docker', args, {
-    enoentMessage: 'docker is not installed or not on PATH',
-  })) {
-    if (chunk.type === 'executionResult') return chunk
-  }
-  throw new Error(`docker command did not produce a result: docker ${args.join(' ')}`)
-}
 
 /**
  * Options for constructing a {@link DockerSandbox}.
  */
 export interface DockerSandboxOptions {
-  /** Docker image to use (e.g., `"python:3.12"`, `"node:20-alpine"`). */
-  image: string
+  /** ID or name of a running Docker container. */
+  container: string
   /**
-   * Working directory inside the container. Defaults to `"/tmp"`.
+   * Working directory for executed commands. If omitted, no `-w` flag is set and
+   * commands run in the container's configured working directory.
    *
-   * `/tmp` is used because the default non-root user (`1000:1000`) with `--cap-drop ALL`
-   * cannot create or chown directories. `/tmp` is world-writable on every standard base image.
-   * If you specify a custom path, it must already exist in the image and be writable by `user`.
+   * Set this to run elsewhere; the path must exist and be writable by the effective {@link user}.
    */
   workingDir?: string
-  /** Container name. Auto-generated if not provided. */
-  name?: string
   /**
-   * Volume mounts in `"host:container"` format.
+   * User to run commands as, in `"uid"`, `"uid:gid"`, or `"name"` form. If omitted,
+   * no `--user` flag is set and commands run as the container's configured user.
    *
-   * By default, mounts exposing sensitive host paths (`/`, `/etc`, `/proc`, `/sys`,
-   * `/var/run`, etc.) throw at construction time. Set {@link allowDangerousMounts}
-   * to bypass validation.
-   */
-  volumes?: string[]
-  /** Environment variables to set in the container. */
-  env?: Record<string, string>
-  /** Memory limit (e.g., `"512m"`, `"2g"`). */
-  memory?: string
-  /** CPU limit (e.g., `1.5` for one and a half cores). */
-  cpus?: number
-  /** Maximum number of PIDs in the container. Prevents fork bombs. */
-  pidsLimit?: number
-  /** Docker network mode. Use `"none"` to disable network access. */
-  network?: string
-  /**
-   * User to run as inside the container. Defaults to `"1000:1000"` (non-root).
-   * Pass `"root"` to run as root.
+   * Set this to override the container's identity, e.g. `"root"` or `"1000:1000"`.
    */
   user?: string
-  /**
-   * Allow mounting sensitive host paths.
-   *
-   * When `false` (default), volumes exposing dangerous host paths throw at construction time.
-   * When `true`, all volume mounts are permitted without validation.
-   */
-  allowDangerousMounts?: boolean
-  /**
-   * Allow privilege escalation inside the container.
-   *
-   * When `false` (default), applies `--cap-drop ALL` and `--security-opt no-new-privileges`
-   * to prevent setuid escalation and drop all Linux capabilities.
-   */
-  allowPrivilegeEscalation?: boolean
 }
 
-/**
- * Execute commands inside a Docker container.
- *
- * The container is created on {@link start} and destroyed on {@link stop}.
- * All sandbox operations route through `docker exec`.
- */
+/** Execute commands in a Docker container via `docker exec`. */
 export class DockerSandbox extends PosixShellSandbox {
-  readonly image: string
-  readonly workingDir: string
-  private readonly _name: string
-  private readonly _volumes: string[]
-  private readonly _env: Record<string, string>
-  private readonly _memory: string | undefined
-  private readonly _cpus: number | undefined
-  private readonly _pidsLimit: number | undefined
-  private readonly _network: string | undefined
-  private readonly _user: string
-  private readonly _allowPrivilegeEscalation: boolean
-  private _running = false
+  readonly container: string
+  readonly workingDir: string | undefined
+  private readonly _user: string | undefined
 
   constructor(options: DockerSandboxOptions) {
     super()
-    this.image = options.image
-    // /tmp is world-writable on all base images — works with non-root user + cap-drop ALL.
-    this.workingDir = options.workingDir ?? '/tmp'
-    this._name = options.name ?? `strands-sandbox-${randomUUID()}`
-    this._volumes = options.volumes ?? []
-    if (!options.allowDangerousMounts) {
-      for (const vol of this._volumes) {
-        if (isHostPathDangerous(vol)) {
-          throw new Error(
-            `Volume "${vol}" mounts a sensitive host path. ` + 'Set allowDangerousMounts: true to bypass validation.'
-          )
-        }
-      }
-    }
-    this._env = options.env ?? {}
-    this._memory = options.memory
-    this._cpus = options.cpus
-    this._pidsLimit = options.pidsLimit
-    this._network = options.network
-    // Non-root by default to limit blast radius of container escapes and in-container misbehavior.
-    this._user = options.user ?? '1000:1000'
-    this._allowPrivilegeEscalation = options.allowPrivilegeEscalation ?? false
-  }
-
-  /**
-   * Create and start the Docker container.
-   *
-   * @throws If Docker is not available or the container fails to start.
-   */
-  async start(): Promise<void> {
-    if (this._running) return
-    this._running = true
-
-    try {
-      const info = await dockerCmd(['info'])
-      if (info.exitCode !== 0) {
-        throw new Error('Docker is not available. Ensure Docker is installed and running.')
-      }
-
-      const args: string[] = ['run', '-d', '--rm', '--name', this._name, '-w', this.workingDir]
-
-      for (const vol of this._volumes) {
-        args.push('-v', vol)
-      }
-      for (const [key, value] of Object.entries(this._env)) {
-        args.push('-e', `${key}=${value}`)
-      }
-      if (this._memory !== undefined) args.push('--memory', this._memory)
-      if (this._cpus !== undefined) args.push('--cpus', String(this._cpus))
-      if (this._pidsLimit !== undefined) args.push('--pids-limit', String(this._pidsLimit))
-      if (this._network !== undefined) args.push('--network', this._network)
-      args.push('--user', this._user)
-      if (!this._allowPrivilegeEscalation) {
-        args.push('--cap-drop', 'ALL')
-        args.push('--security-opt', 'no-new-privileges')
-      }
-
-      // docker run requires the image name after all flags. Furthermore, '--' terminates
-      // flag parsing so the image is always treated as a positional argument. Without
-      // this, an image like '--privileged' would be parsed as a flag, overriding --cap-drop ALL.
-      args.push('--', this.image, 'tail', '-f', '/dev/null')
-
-      const result = await dockerCmd(args)
-      if (result.exitCode !== 0) {
-        throw new Error(`Failed to start Docker container "${this._name}": ${result.stderr}`)
-      }
-    } catch (err) {
-      this._running = false
-      throw err
-    }
-  }
-
-  /** Stop and remove the Docker container. */
-  async stop(): Promise<void> {
-    if (!this._running) return
-    try {
-      await dockerCmd(['rm', '-f', this._name])
-    } finally {
-      this._running = false
-    }
+    this.container = options.container
+    this.workingDir = options.workingDir
+    this._user = options.user
   }
 
   async *executeStreaming(
     command: string,
     options?: ExecuteOptions
   ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
-    if (!this._running) {
-      throw new Error(`Docker container "${this._name}" is not running. Call start() before executing commands.`)
-    }
+    const args = ['exec']
+
+    // Unset user/cwd defer to the container's own configuration.
+    if (this._user !== undefined) args.push('--user', this._user)
 
     const cwd = options?.cwd ?? this.workingDir
-    const execCommand = `cd ${shellQuote(cwd)} && ${command}`
+    if (cwd !== undefined) args.push('-w', cwd)
 
-    yield* streamProcess('docker', ['exec', this._name, 'sh', '-c', execCommand], {
+    if (options?.env) {
+      validateEnvKeys(options.env)
+      for (const [key, val] of Object.entries(options.env)) {
+        // Values are passed as process argv (not through a shell), so no escaping is
+        // needed -- Docker stores them verbatim. This is why values aren't shell-quoted
+        // here, unlike the SSH backend which builds a shell command string.
+        args.push('-e', `${key}=${val}`)
+      }
+    }
+
+    // docker exec requires the container and command after all flags. Furthermore, '--'
+    // terminates flag parsing so the container is always treated as a positional argument.
+    // Without this, a name like '--privileged' would be parsed as a flag, overriding the
+    // exec options above.
+    args.push('--', this.container, 'sh', '-c', command)
+
+    yield* streamProcess('docker', args, {
       timeout: options?.timeout,
       signal: options?.signal,
+      enoentMessage: 'docker is not installed or not on PATH',
     })
-  }
-
-  async [Symbol.asyncDispose](): Promise<void> {
-    await this.stop()
   }
 }

--- a/strands-ts/src/sandbox/posix-shell.ts
+++ b/strands-ts/src/sandbox/posix-shell.ts
@@ -9,7 +9,7 @@
 
 import { Sandbox } from './base.js'
 import type { ExecuteOptions } from './base.js'
-import { LANGUAGE_PATTERN } from './constants.js'
+import { ENV_KEY_PATTERN, LANGUAGE_PATTERN } from './constants.js'
 import type { ExecutionResult, FileInfo, StreamChunk } from './types.js'
 
 /**
@@ -27,6 +27,37 @@ export function shellQuote(value: string): string {
 }
 
 /**
+ * Validate environment variable names against {@link ENV_KEY_PATTERN}.
+ * @throws If any key is not a valid POSIX environment variable name.
+ */
+export function validateEnvKeys(env: Record<string, string>): void {
+  for (const key of Object.keys(env)) {
+    if (!ENV_KEY_PATTERN.test(key)) {
+      throw new Error(`Invalid environment variable name: ${key}`)
+    }
+  }
+}
+
+/**
+ * Build a shell `export KEY=VALUE && ...` prefix for a command, or `''` when there are none.
+ * Keys are validated; values are {@link shellQuote}d. Used by shell-string backends (e.g. SSH);
+ * backends that set env via native flags (e.g. Docker's `-e`) call {@link validateEnvKeys} directly.
+ *
+ * Uses `export` rather than an `env KEY=VALUE` command wrapper so the variables are set in the
+ * shell itself and inherited by every stage of a pipeline. `executeCode` runs `base64 ... | <lang>`,
+ * and an `env` wrapper would only bind the left side of the pipe, never reaching the interpreter.
+ * The trailing `&&` keeps the surrounding `cd ... && <prefix><command>` chain fail-fast.
+ */
+export function buildShellEnvPrefix(env?: Record<string, string>): string {
+  if (!env || Object.keys(env).length === 0) {
+    return ''
+  }
+  validateEnvKeys(env)
+  const assignments = Object.entries(env).map(([k, v]) => `${k}=${shellQuote(v)}`)
+  return `export ${assignments.join(' ')} && `
+}
+
+/**
  * Abstract sandbox that provides shell-based defaults for file and code operations.
  * Assumes a POSIX-compatible shell (sh/bash) on the target.
  *
@@ -38,6 +69,11 @@ export function shellQuote(value: string): string {
  * Subclasses may override any method with a native implementation for
  * better performance or to handle edge cases (e.g., binary-safe file
  * transfer via Docker stdin pipes, or native API calls for cloud backends).
+ *
+ * Subclasses must apply `options.env` in `executeStreaming` or it has no effect:
+ * backends that build a shell-command string prepend {@link buildShellEnvPrefix};
+ * backends that set env via process flags (e.g. Docker's `-e`) call
+ * {@link validateEnvKeys} and pass the values directly.
  */
 export abstract class PosixShellSandbox extends Sandbox {
   async *executeCodeStreaming(

--- a/strands-ts/src/sandbox/ssh.ts
+++ b/strands-ts/src/sandbox/ssh.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ExecuteOptions } from './base.js'
-import { PosixShellSandbox, shellQuote } from './posix-shell.js'
+import { buildShellEnvPrefix, PosixShellSandbox, shellQuote } from './posix-shell.js'
 import { streamProcess } from './stream-process.js'
 import type { ExecutionResult, StreamChunk } from './types.js'
 
@@ -117,7 +117,8 @@ export class SshSandbox extends PosixShellSandbox {
     options?: ExecuteOptions
   ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
     const cwd = options?.cwd ?? this.workingDir
-    const remoteCommand = `cd ${shellQuote(cwd)} && ${command}`
+    const envPrefix = buildShellEnvPrefix(options?.env)
+    const remoteCommand = `cd ${shellQuote(cwd)} && ${envPrefix}${command}`
 
     const sshArgs: string[] = [
       '-o',

--- a/strands-ts/test/integ/sandbox/docker.test.node.ts
+++ b/strands-ts/test/integ/sandbox/docker.test.node.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, afterEach } from 'vitest'
-import { spawnSync } from 'child_process'
-import fs from 'fs'
-import os from 'os'
-import path from 'path'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execSync, spawnSync } from 'child_process'
 import { DockerSandbox } from '../../../src/sandbox/docker.js'
+
+// Unique suffix so concurrent runs (CI matrix, or local + CI) don't collide on the container name.
+const CONTAINER_NAME = `strands-integ-docker-sandbox-${Math.random().toString(16).slice(2, 8)}`
 
 function dockerAvailable(): boolean {
   if (process.platform === 'win32') return false
@@ -11,37 +11,18 @@ function dockerAvailable(): boolean {
 }
 
 describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
-  let sandbox: DockerSandbox | undefined
-
-  afterEach(async () => {
-    if (sandbox) {
-      await sandbox.stop()
-      sandbox = undefined
-    }
+  beforeAll(() => {
+    spawnSync('docker', ['rm', '-f', CONTAINER_NAME], { stdio: 'pipe' })
+    // alpine (busybox) is tiny and ships sh + base64, all these tests need; executeCode runs via sh.
+    execSync(`docker run -d --name ${CONTAINER_NAME} alpine:latest tail -f /dev/null`, { stdio: 'pipe' })
   })
 
-  it('start() creates a container, stop() removes it', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest', name: 'strands-integ-lifecycle' })
-    await sandbox.start()
-
-    const ps = spawnSync('docker', ['ps', '--filter', 'name=strands-integ-lifecycle', '--format', '{{.Names}}'], {
-      encoding: 'utf-8',
-    })
-    expect(ps.stdout.trim()).toBe('strands-integ-lifecycle')
-
-    await sandbox.stop()
-
-    const psAfter = spawnSync(
-      'docker',
-      ['ps', '-a', '--filter', 'name=strands-integ-lifecycle', '--format', '{{.Names}}'],
-      { encoding: 'utf-8' }
-    )
-    expect(psAfter.stdout.trim()).toBe('')
+  afterAll(() => {
+    spawnSync('docker', ['rm', '-f', CONTAINER_NAME], { stdio: 'pipe' })
   })
 
   it('runs commands and captures stdout, stderr, and exit code', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest' })
-    await sandbox.start()
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME })
 
     const result = await sandbox.execute('echo hello && echo err >&2')
     expect(result).toStrictEqual({
@@ -53,21 +34,25 @@ describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
     })
 
     const failed = await sandbox.execute('exit 42')
-    expect(failed.exitCode).toBe(42)
+    expect(failed).toStrictEqual({
+      type: 'executionResult',
+      exitCode: 42,
+      stdout: '',
+      stderr: '',
+      outputFiles: [],
+    })
   })
 
-  it('runs python via executeCode', async () => {
-    sandbox = new DockerSandbox({ image: 'python:3.12-slim' })
-    await sandbox.start()
+  it('runs code via executeCode', async () => {
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME })
 
-    const result = await sandbox.executeCode('print(6 * 7)', 'python3')
+    const result = await sandbox.executeCode('echo $((6 * 7))', 'sh')
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toBe('42\n')
   })
 
   it('round-trips text and binary files', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest' })
-    await sandbox.start()
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME })
 
     await sandbox.writeText('greeting.txt', 'hello docker')
     expect(await sandbox.readText('greeting.txt')).toBe('hello docker')
@@ -78,8 +63,7 @@ describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
   })
 
   it('lists and removes files', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest' })
-    await sandbox.start()
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME })
 
     await sandbox.writeText('a.txt', 'a')
     await sandbox.writeText('b.txt', 'b')
@@ -92,43 +76,59 @@ describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
     await expect(sandbox.readFile('a.txt')).rejects.toThrow()
   })
 
-  it('mounts host volumes when configured', async () => {
-    const hostDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strands-integ-vol-'))
-    fs.writeFileSync(path.join(hostDir, 'file.txt'), 'from-host\n')
+  it('respects custom workingDir', async () => {
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME, workingDir: '/opt' })
 
-    try {
-      sandbox = new DockerSandbox({
-        image: 'alpine:latest',
-        volumes: [`${hostDir}:/mnt/shared`],
-        allowDangerousMounts: true,
-      })
-      await sandbox.start()
-
-      const result = await sandbox.execute('cat /mnt/shared/file.txt')
-      expect(result.stdout.trim()).toBe('from-host')
-    } finally {
-      fs.rmSync(hostDir, { recursive: true, force: true })
-    }
+    const result = await sandbox.execute('pwd')
+    expect(result.stdout.trim()).toBe('/opt')
   })
 
-  it('passes environment variables into the container', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest', env: { MY_VAR: 'hello-env' } })
-    await sandbox.start()
+  it('respects per-command cwd override', async () => {
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME })
 
-    const result = await sandbox.execute('echo $MY_VAR')
-    expect(result.stdout.trim()).toBe('hello-env')
+    const result = await sandbox.execute('pwd', { cwd: '/usr' })
+    expect(result.stdout.trim()).toBe('/usr')
   })
 
-  it('files inside the container do not exist on the host', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest' })
-    await sandbox.start()
+  it('kills command on timeout', async () => {
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME })
 
-    const marker = `strands-isolation-${Date.now()}`
-    await sandbox.writeText(marker, 'sandbox-only')
+    await expect(sandbox.execute('sleep 60', { timeout: 0.5 })).rejects.toThrow('timed out')
+  })
 
-    const content = await sandbox.readText(marker)
-    expect(content).toBe('sandbox-only')
+  it('kills command on abort signal', async () => {
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME })
+    const controller = new AbortController()
+    const promise = sandbox.execute('sleep 60', { signal: controller.signal })
+    setTimeout(() => controller.abort(), 100)
 
-    expect(fs.existsSync(`/tmp/${marker}`)).toBe(false)
+    await expect(promise).rejects.toThrow('aborted')
+  })
+
+  it('passes env vars to the command', async () => {
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME })
+
+    const result = await sandbox.execute('echo $MY_VAR', { env: { MY_VAR: 'hello-from-env' } })
+    expect(result.stdout.trim()).toBe('hello-from-env')
+  })
+
+  it('passes env values with shell metacharacters literally, without expansion', async () => {
+    const sandbox = new DockerSandbox({ container: CONTAINER_NAME })
+
+    // `-e KEY=VALUE` is argv, not shell input, so Docker stores the value verbatim.
+    // `printenv` reads the variable without a shell touching the value, isolating the
+    // Docker layer: any expansion of `$(whoami)`/`$HOME` here would be a real bug.
+    const value = '$(whoami) $HOME `id`'
+    const result = await sandbox.execute('printenv MY_VAR', { env: { MY_VAR: value } })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.trim()).toBe(value)
+  })
+
+  it('returns error for non-existent container', async () => {
+    const sandbox = new DockerSandbox({ container: 'nonexistent123' })
+
+    const result = await sandbox.execute('echo hi')
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/No such container/)
   })
 })


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Simplify `DockerSandbox` to "bring-your-own-container" (thin docker exec wrapper). The SDK no longer manages container lifecycle, security policies, volumes, or resource limits. Users create and configure their container externally then pass the container name/ID.

Removed:
- Lifecycle control: `start()`/`stop()` methods, AsyncDisposable usage
- Low-level params: `image`, `name`, `volumes`, `env`, `memory`, `cpus`, `pidsLimit`, network options
- Various now-obsolete internal helper methods and security checks

Added:

- Flag-injection safety via a `--` separator before the container ID in `docker exec`, so a name like `--privileged` is never parsed as a flag
- `env?: Record<string, string>` on base `ExecuteOptions` interface for per-command environment variables (Docker uses `-e` flags, SSH uses `env` prefix)

What remains from before:
- `containerId` (required, exposed as public readonly), `workingDir`, `user`
- Single `executeStreaming` method that shells out to `docker exec`

## Related Issues

<!-- Link to related issues using #issue-number format -->

Updates https://github.com/strands-agents/sdk-typescript/pull/1110

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

Not yet

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

(breaking) change

## Testing

How have you tested the change?

- [x] I ran the relevant checks (`npm run check` for TypeScript)
- [x] Unit + integration tests 

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
