### PR TITLE
feat: integrate Sandbox with Agent

### DIFF
--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -6,6 +6,10 @@
   "module": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "type": "module",
+  "sideEffects": [
+    "./dist/src/index.node.js",
+    "./src/index.node.ts"
+  ],
   "files": [
     "dist",
     "README.md",
@@ -14,6 +18,7 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
+      "node": "./dist/src/index.node.js",
       "default": "./dist/src/index.js"
     },
     "./models/anthropic": {

--- a/strands-ts/src/__fixtures__/register-node-defaults.ts
+++ b/strands-ts/src/__fixtures__/register-node-defaults.ts
@@ -1,0 +1,6 @@
+import { defaultSandbox } from '../sandbox/default.js'
+import { NotASandboxLocalEnvironment } from '../sandbox/not-a-sandbox-local-environment.js'
+
+// In production, index.node.ts registers this on import. Tests don't go through that entry
+// point, so this setup file does it instead.
+defaultSandbox.set(new NotASandboxLocalEnvironment())

--- a/strands-ts/src/__tests__/default-slot.test.ts
+++ b/strands-ts/src/__tests__/default-slot.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { createDefaultSlot } from '../default-slot.js'
+import { DefaultNotConfiguredError } from '../errors.js'
+
+describe('createDefaultSlot', () => {
+  it('throws DefaultNotConfiguredError when read before configured', () => {
+    const slot = createDefaultSlot<string>('not set')
+    expect(() => slot.get()).toThrow(DefaultNotConfiguredError)
+    expect(() => slot.get()).toThrow('not set')
+  })
+
+  it('returns the configured value after set', () => {
+    const slot = createDefaultSlot<string>('not set')
+    slot.set('value')
+    expect(slot.get()).toBe('value')
+  })
+
+  it('stores falsy values that the sentinel must not confuse with unset', () => {
+    const numbers = createDefaultSlot<number>('no number')
+    numbers.set(0)
+    expect(numbers.get()).toBe(0)
+
+    const nullable = createDefaultSlot<string | null>('no value')
+    nullable.set(null)
+    expect(nullable.get()).toBeNull()
+
+    const maybe = createDefaultSlot<string | undefined>('no value')
+    maybe.set(undefined)
+    expect(maybe.get()).toBeUndefined()
+  })
+
+  it('overwrites on a subsequent set', () => {
+    const slot = createDefaultSlot<string>('not set')
+    slot.set('first')
+    slot.set('second')
+    expect(slot.get()).toBe('second')
+  })
+})

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -91,6 +91,8 @@ import { isInterruptResponseContent, type InterruptResponseContent } from '../ty
 import { takeSnapshot as takeSnapshotInternal, loadSnapshot as loadSnapshotInternal } from './snapshot.js'
 import type { TakeSnapshotOptions } from './snapshot.js'
 import type { Snapshot } from '../types/snapshot.js'
+import type { Sandbox } from '../sandbox/base.js'
+import { defaultSandbox } from '../sandbox/default.js'
 
 /**
  * Recursive type definition for nested tool arrays.
@@ -230,6 +232,20 @@ export type AgentConfig = {
    * Defaults to `'concurrent'`. See {@link ToolExecutorStrategy} for details.
    */
   toolExecutor?: ToolExecutorStrategy
+  /**
+   * Execution environment for running commands, code, and file operations.
+   * When provided, sandbox-aware tools route operations through it.
+   *
+   * Two distinct intents, even though they resolve to the same host execution
+   * in Node today:
+   * - Omitted: use the environment's default sandbox (host execution in Node).
+   *   This default is the slot reserved for richer behavior later.
+   * - `false`: explicitly opt out of a managed sandbox and run on the host.
+   *
+   * Keep `false` distinct from omitting so the opt-out stays stable even if the
+   * default changes.
+   */
+  sandbox?: Sandbox | false
 }
 
 /** Default name assigned to agents when none is provided. */
@@ -301,6 +317,18 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   public readonly memoryManager?: MemoryManager | undefined
 
+  private readonly _sandbox: Sandbox | false | undefined
+
+  /**
+   * Execution environment for running commands, code, and file operations.
+   *
+   * @throws DefaultNotConfiguredError if no sandbox is configured for this
+   * environment (e.g. browsers, where no host default is registered).
+   */
+  get sandbox(): Sandbox {
+    return this._sandbox || defaultSandbox.get()
+  }
+
   private readonly _hooksRegistry: HookRegistryImplementation
   private readonly _pluginRegistry: PluginRegistry
   private readonly _interventionRegistry: InterventionRegistry
@@ -342,6 +370,7 @@ export class Agent implements LocalAgent, InvokableAgent {
         : config?.memoryManager
           ? new MemoryManager(config.memoryManager)
           : undefined
+    this._sandbox = config?.sandbox
 
     if (typeof config?.model === 'string') {
       this.model = new BedrockModel({ modelId: config.model })

--- a/strands-ts/src/default-slot.ts
+++ b/strands-ts/src/default-slot.ts
@@ -1,0 +1,22 @@
+import { DefaultNotConfiguredError } from './errors.js'
+
+export interface DefaultSlot<T> {
+  set(value: T): void
+  get(): T
+}
+
+export function createDefaultSlot<T>(errorMessage: string): DefaultSlot<T> {
+  // A unique sentinel for "unset" so any value of T -- including undefined or
+  // null -- can be stored and read back without colliding with the empty state.
+  const EMPTY = Symbol('empty')
+  let value: T | typeof EMPTY = EMPTY
+  return {
+    set(v): void {
+      value = v
+    },
+    get(): T {
+      if (value === EMPTY) throw new DefaultNotConfiguredError(errorMessage)
+      return value
+    },
+  }
+}

--- a/strands-ts/src/errors.ts
+++ b/strands-ts/src/errors.ts
@@ -242,3 +242,15 @@ export class CancelledError extends Error {
     this.name = 'CancelledError'
   }
 }
+
+/**
+ * Thrown when a default value is read before one has been configured.
+ *
+ * Catch it to distinguish a missing-default condition from other runtime errors.
+ */
+export class DefaultNotConfiguredError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DefaultNotConfiguredError'
+  }
+}

--- a/strands-ts/src/index.node.ts
+++ b/strands-ts/src/index.node.ts
@@ -1,0 +1,10 @@
+// Node entry point (selected by the "node" export condition in package.json).
+// Registers Node-specific defaults, then re-exports the full public API.
+// This is a load-bearing side effect -- do NOT mark this module side-effect-free
+// or bundlers will tree-shake the registrations.
+import { defaultSandbox } from './sandbox/default.js'
+import { NotASandboxLocalEnvironment } from './sandbox/not-a-sandbox-local-environment.js'
+
+defaultSandbox.set(new NotASandboxLocalEnvironment())
+
+export * from './index.js'

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -37,6 +37,7 @@ export {
   ToolValidationError,
   StructuredOutputError,
   ToolNotFoundError,
+  DefaultNotConfiguredError,
 } from './errors.js'
 
 // Interrupt system

--- a/strands-ts/src/sandbox/__tests__/default.test.browser.ts
+++ b/strands-ts/src/sandbox/__tests__/default.test.browser.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { Agent } from '../../agent/agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+
+// The unit-browser project has no setupFiles registering a default sandbox,
+// mirroring a real browser where index.node.ts never loads.
+describe('Agent.sandbox getter (browser)', () => {
+  it('throws when unconfigured because no default sandbox is registered', () => {
+    expect(() => new Agent({ model: new MockMessageModel() }).sandbox).toThrow('No Sandbox configured')
+  })
+})

--- a/strands-ts/src/sandbox/__tests__/default.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/default.test.node.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { Agent } from '../../agent/agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { NotASandboxLocalEnvironment } from '../not-a-sandbox-local-environment.js'
+import { defaultSandbox } from '../default.js'
+
+describe('default sandbox registry', () => {
+  it('returns the instance registered by the setup file', () => {
+    expect(defaultSandbox.get()).toBeInstanceOf(NotASandboxLocalEnvironment)
+  })
+})
+
+describe('Agent.sandbox getter', () => {
+  it('returns the configured sandbox when one is provided', () => {
+    const sandbox = new NotASandboxLocalEnvironment()
+    expect(new Agent({ model: new MockMessageModel(), sandbox }).sandbox).toBe(sandbox)
+  })
+
+  it('falls back to the registered default when unconfigured', () => {
+    expect(new Agent({ model: new MockMessageModel() }).sandbox).toBeInstanceOf(NotASandboxLocalEnvironment)
+  })
+
+  it('treats sandbox: false the same as unconfigured', () => {
+    expect(new Agent({ model: new MockMessageModel(), sandbox: false }).sandbox).toBeInstanceOf(
+      NotASandboxLocalEnvironment
+    )
+  })
+})

--- a/strands-ts/src/sandbox/__tests__/not-a-sandbox-local-environment.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/not-a-sandbox-local-environment.test.node.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import { NotASandboxLocalEnvironment } from '../not-a-sandbox-local-environment.js'
+
+const TEST_DIR = '/tmp/strands-test-not-a-sandbox'
+// Written relative (resolved against process.cwd()) to exercise _resolvePath; cleaned up below.
+const REL_NAME = 'strands-not-a-sandbox-rel-probe.txt'
+const REL_ABS = path.join(process.cwd(), REL_NAME)
+
+describe.skipIf(process.platform === 'win32')('NotASandboxLocalEnvironment', () => {
+  let sandbox: NotASandboxLocalEnvironment
+
+  beforeEach(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true })
+    fs.mkdirSync(TEST_DIR, { recursive: true })
+    sandbox = new NotASandboxLocalEnvironment()
+  })
+
+  afterEach(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true })
+    fs.rmSync(REL_ABS, { force: true })
+  })
+
+  describe('execute', () => {
+    it('runs a command on the host', async () => {
+      const result = await sandbox.execute('echo hello')
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('hello\n')
+    })
+
+    it('respects the cwd option', async () => {
+      const result = await sandbox.execute('pwd', { cwd: TEST_DIR })
+      expect(result.stdout.trim()).toBe(TEST_DIR)
+    })
+
+    it('reports a non-zero exit code and stderr from a failing command', async () => {
+      const result = await sandbox.execute('echo oops >&2; exit 3')
+      expect(result.exitCode).toBe(3)
+      expect(result.stderr).toBe('oops\n')
+    })
+
+    it('applies the env option', async () => {
+      const result = await sandbox.execute('echo "$GREETING"', { env: { GREETING: 'hi' } })
+      expect(result.stdout).toBe('hi\n')
+    })
+  })
+
+  describe('executeCode', () => {
+    it('runs code through the named interpreter', async () => {
+      const result = await sandbox.executeCode('print(2 + 2)', 'python3', { cwd: TEST_DIR })
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('4\n')
+    })
+
+    it('rejects a language with invalid characters', async () => {
+      await expect(sandbox.executeCode('x', '../../bin/sh')).rejects.toThrow('invalid characters')
+    })
+
+    it('applies the env option', async () => {
+      const result = await sandbox.executeCode('import os; print(os.environ["GREETING"])', 'python3', {
+        env: { GREETING: 'hi' },
+      })
+      expect(result.stdout).toBe('hi\n')
+    })
+  })
+
+  describe('read/write (native fs)', () => {
+    it('text file roundtrip via absolute path', async () => {
+      const file = path.join(TEST_DIR, 'note.txt')
+      await sandbox.writeText(file, 'hello host')
+      expect(await sandbox.readText(file)).toBe('hello host')
+    })
+
+    it('binary roundtrip preserves all byte values', async () => {
+      const file = path.join(TEST_DIR, 'all-bytes.bin')
+      const bytes = new Uint8Array(256)
+      for (let i = 0; i < 256; i++) bytes[i] = i
+      await sandbox.writeFile(file, bytes)
+      expect(Array.from(await sandbox.readFile(file))).toStrictEqual(Array.from(bytes))
+    })
+
+    it('creates missing parent directories on write', async () => {
+      const file = path.join(TEST_DIR, 'deep/nested/file.txt')
+      await sandbox.writeText(file, 'deep')
+      expect(await sandbox.readText(file)).toBe('deep')
+    })
+
+    it('throws when reading a nonexistent file', async () => {
+      await expect(sandbox.readFile(path.join(TEST_DIR, 'nope.txt'))).rejects.toThrow()
+    })
+  })
+
+  describe('removeFile', () => {
+    it('removes a file', async () => {
+      const file = path.join(TEST_DIR, 'delete-me.txt')
+      await sandbox.writeText(file, 'bye')
+      await sandbox.removeFile(file)
+      await expect(sandbox.readFile(file)).rejects.toThrow()
+    })
+
+    it('throws on a nonexistent file', async () => {
+      await expect(sandbox.removeFile(path.join(TEST_DIR, 'nope.txt'))).rejects.toThrow()
+    })
+  })
+
+  describe('listFiles', () => {
+    it('returns entries sorted by name with isDir and size metadata', async () => {
+      await sandbox.writeText(path.join(TEST_DIR, 'c.txt'), 'cc')
+      await sandbox.writeText(path.join(TEST_DIR, 'a.txt'), 'a')
+      await sandbox.writeText(path.join(TEST_DIR, 'b.txt'), 'bbb')
+      fs.mkdirSync(path.join(TEST_DIR, 'sub'))
+
+      const files = await sandbox.listFiles(TEST_DIR)
+      expect(files.map((f) => f.name)).toStrictEqual(['a.txt', 'b.txt', 'c.txt', 'sub'])
+
+      const a = files.find((f) => f.name === 'a.txt')
+      expect(a?.isDir).toBe(false)
+      expect(a?.size).toBe(1)
+      expect(files.find((f) => f.name === 'sub')?.isDir).toBe(true)
+    })
+
+    it('throws on a nonexistent directory', async () => {
+      await expect(sandbox.listFiles(path.join(TEST_DIR, 'no-such-dir'))).rejects.toThrow()
+    })
+  })
+
+  describe('_resolvePath (relative vs absolute)', () => {
+    it('writes absolute paths as-is', async () => {
+      const file = path.join(TEST_DIR, 'abs.txt')
+      await sandbox.writeText(file, 'absolute')
+      expect(fs.readFileSync(file, 'utf8')).toBe('absolute')
+    })
+
+    it('resolves relative paths against process.cwd()', async () => {
+      await sandbox.writeText(REL_NAME, 'relative')
+      expect(fs.readFileSync(REL_ABS, 'utf8')).toBe('relative')
+    })
+  })
+})

--- a/strands-ts/src/sandbox/default.ts
+++ b/strands-ts/src/sandbox/default.ts
@@ -1,0 +1,6 @@
+import type { Sandbox } from './base.js'
+import { createDefaultSlot } from '../default-slot.js'
+
+export const defaultSandbox = createDefaultSlot<Sandbox>(
+  'No Sandbox configured. Pass a `sandbox` to the Agent to use sandbox features in this environment.'
+)

--- a/strands-ts/src/sandbox/not-a-sandbox-local-environment.ts
+++ b/strands-ts/src/sandbox/not-a-sandbox-local-environment.ts
@@ -1,0 +1,84 @@
+import { readFile, writeFile, unlink, mkdir, readdir, stat } from 'fs/promises'
+import { dirname, isAbsolute, join } from 'path'
+import { Sandbox } from './base.js'
+import type { ExecuteOptions } from './base.js'
+import { LANGUAGE_PATTERN } from './constants.js'
+import { streamProcess } from './stream-process.js'
+import type { ExecutionResult, FileInfo, StreamChunk } from './types.js'
+import { buildShellEnvPrefix, shellQuote } from './posix-shell.js'
+
+/**
+ * Runs on the host with no isolation. Used as the default when no sandbox is configured.
+ */
+export class NotASandboxLocalEnvironment extends Sandbox {
+  private _resolvePath(path: string): string {
+    return isAbsolute(path) ? path : join(process.cwd(), path)
+  }
+
+  async *executeStreaming(
+    command: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    const cwd = options?.cwd ?? process.cwd()
+    yield* streamProcess('sh', ['-c', `cd ${shellQuote(cwd)} && ${buildShellEnvPrefix(options?.env)}${command}`], {
+      timeout: options?.timeout,
+      signal: options?.signal,
+    })
+  }
+
+  async *executeCodeStreaming(
+    code: string,
+    language: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    if (!LANGUAGE_PATTERN.test(language)) {
+      throw new Error(`language parameter contains invalid characters: ${language}`)
+    }
+    const cwd = options?.cwd ?? process.cwd()
+    const encoded = btoa(Array.from(new TextEncoder().encode(code), (b) => String.fromCharCode(b)).join(''))
+    const eof = `STRANDS_EOF_${crypto.randomUUID().slice(0, 16)}`
+    yield* streamProcess(
+      'sh',
+      [
+        '-c',
+        `cd ${shellQuote(cwd)} && ${buildShellEnvPrefix(options?.env)}base64 -d << '${eof}' | ${language}\n${encoded}\n${eof}`,
+      ],
+      {
+        timeout: options?.timeout,
+        signal: options?.signal,
+        enoentMessage: `Language interpreter not found: ${language}`,
+      }
+    )
+  }
+
+  async readFile(path: string): Promise<Uint8Array> {
+    return readFile(this._resolvePath(path))
+  }
+
+  async writeFile(path: string, content: Uint8Array): Promise<void> {
+    const fullPath = this._resolvePath(path)
+    await mkdir(dirname(fullPath), { recursive: true })
+    await writeFile(fullPath, content)
+  }
+
+  async removeFile(path: string): Promise<void> {
+    await unlink(this._resolvePath(path))
+  }
+
+  async listFiles(path: string): Promise<FileInfo[]> {
+    const fullPath = this._resolvePath(path)
+    const entries = await readdir(fullPath, { withFileTypes: true })
+    const results: FileInfo[] = []
+
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      try {
+        const entryStat = await stat(join(fullPath, entry.name))
+        results.push({ name: entry.name, isDir: entryStat.isDirectory(), size: entryStat.size })
+      } catch {
+        results.push({ name: entry.name })
+      }
+    }
+
+    return results
+  }
+}

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -1,3 +1,4 @@
+import type { Sandbox } from '../sandbox/base.js'
 import type { StateStore } from '../state-store.js'
 import type { ContentBlock, ContentBlockData, Message, MessageData, StopReason, SystemPrompt } from './messages.js'
 import type { Interrupt } from '../interrupt.js'
@@ -261,6 +262,14 @@ export interface LocalAgent {
    * The tool registry for registering tools with the agent.
    */
   readonly toolRegistry: ToolRegistry
+
+  /**
+   * Execution environment for running commands, code, and file operations.
+   *
+   * @throws DefaultNotConfiguredError if no sandbox is configured for this
+   * environment (e.g. browsers, where no host default is registered).
+   */
+  readonly sandbox: Sandbox
 
   /**
    * The model provider used by the agent for inference.

--- a/strands-ts/test/packages/cjs-module/cjs.js
+++ b/strands-ts/test/packages/cjs-module/cjs.js
@@ -19,12 +19,8 @@ async function main() {
     notebook: barrelNotebook,
   } = await import('@strands-agents/sdk/vended-tools')
 
-  const {
-    AgentSkills,
-    ContextOffloader,
-    GoalLoop,
-    InMemoryStorage,
-  } = await import('@strands-agents/sdk/vended-plugins')
+  const { AgentSkills, ContextOffloader, GoalLoop, InMemoryStorage } =
+    await import('@strands-agents/sdk/vended-plugins')
 
   const { GoalLoop: GoalLoopFromSubpath } = await import('@strands-agents/sdk/vended-plugins/goal')
 
@@ -72,6 +68,11 @@ async function main() {
     throw new Error('Tool was not correctly added to the agent')
   }
 
+  // The Node entry (exports.node -> index.node.js) must register the host default
+  // sandbox; this getter throws if it didn't.
+  void agent.sandbox
+  console.log('✓ Node default sandbox registered')
+
   const tools = { notebook, fileEditor, httpRequest, bash }
   for (const tool of Object.values(tools)) {
     if (!(tool instanceof Tool)) {
@@ -85,7 +86,12 @@ async function main() {
   console.log('✓ Model subpath exports verified')
 
   // Verify barrel exports match individual subpath exports
-  if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+  if (
+    barrelBash !== bash ||
+    barrelFileEditor !== fileEditor ||
+    barrelHttpRequest !== httpRequest ||
+    barrelNotebook !== notebook
+  ) {
     throw new Error('Barrel vended-tools exports do not match individual subpath exports')
   }
   console.log('✓ Barrel vended-tools exports verified')

--- a/strands-ts/test/packages/esm-module/esm.js
+++ b/strands-ts/test/packages/esm-module/esm.js
@@ -17,12 +17,7 @@ import {
   notebook as barrelNotebook,
 } from '@strands-agents/sdk/vended-tools'
 
-import {
-  AgentSkills,
-  ContextOffloader,
-  GoalLoop,
-  InMemoryStorage,
-} from '@strands-agents/sdk/vended-plugins'
+import { AgentSkills, ContextOffloader, GoalLoop, InMemoryStorage } from '@strands-agents/sdk/vended-plugins'
 
 import { GoalLoop as GoalLoopFromSubpath } from '@strands-agents/sdk/vended-plugins/goal'
 
@@ -82,6 +77,11 @@ if (agent.tools.length == 0) {
   throw new Error('Tool was not correctly added to the agent')
 }
 
+// The Node entry (exports.node -> index.node.js) must register the host default
+// sandbox; this getter throws if it didn't.
+void agent.sandbox
+console.log('✓ Node default sandbox registered')
+
 async function validateScratchpad() {
   let context = { agent: agent }
   notebook.invoke(
@@ -128,7 +128,12 @@ if (BedrockFromSubpath !== BedrockModel) {
 console.log('✓ Model subpath exports verified')
 
 // Verify barrel exports match individual subpath exports
-if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+if (
+  barrelBash !== bash ||
+  barrelFileEditor !== fileEditor ||
+  barrelHttpRequest !== httpRequest ||
+  barrelNotebook !== notebook
+) {
   throw new Error('Barrel vended-tools exports do not match individual subpath exports')
 }
 console.log('✓ Barrel vended-tools exports verified')

--- a/strands-ts/vitest.config.ts
+++ b/strands-ts/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     projects: [
       {
         test: {
+          setupFiles: ['./src/__fixtures__/register-node-defaults.ts'],
           include: [
             'src/**/__tests__/**/*.test.ts',
             'src/**/__tests__/**/*.test.node.ts',


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Adds the [Sandbox](https://github.com/strands-agents/sdk-python/blob/main/strands-ts/src/sandbox/base.ts) as a first-class parameter on `Agent`.

> In Node, agents get a host-execution fallback automatically via a "node" export condition in package.json that loads index.node.ts. In browsers, accessing agent.sandbox without explicit configuration throws. 

> To make this Node/browser bundler compatible fallback split possible, we (also) introduce `createDefaultSlot<T>()` as a reusable primitive for environment-conditional defaults.

This is the third PR split off from https://github.com/strands-agents/sdk-typescript/pull/1011, preceded by the base interface merged in https://github.com/strands-agents/sdk-typescript/pull/1090 and Docker/SSH implementations merged in https://github.com/strands-agents/sdk-typescript/pull/1110.

## Developer Experience

Explicitly Configured Sandbox
```
const agent = new Agent({
  model: new BedrockModel(),
  sandbox: new DockerSandbox({ containerId: 'my-container' }),
})

agent.sandbox // DockerSandbox
```

Node: works without configuration (falls back to host-level execution)
```
const agent = new Agent({ model: new BedrockModel() })

agent.sandbox // NotASandboxLocalEnvironment
```

Browser: throws if not explicitly configured
```
...
agent.sandbox // throws DefaultNotConfiguredError
```


## Related Issues

<!-- Link to related issues using #issue-number format -->

- https://github.com/strands-agents/sdk-typescript/pull/1011 (parent mega-PR)
- https://github.com/strands-agents/sdk-typescript/pull/1090 (base Sandbox / PosixShellSandbox interfaces)
- https://github.com/strands-agents/sdk-typescript/pull/1110 (Docker / SSH implementations)

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

Not yet

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran all tests + added several

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
