### PR TITLE
ci: verify docs/typescript/python CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,4 @@ jobs:
         with:
           allowed-skips: python, typescript, docs
           jobs: ${{ toJSON(needs) }}
+


### PR DESCRIPTION
## Summary
- Adds trailing newline to `ci.yml` to trigger all three CI path filters (python, typescript, docs)
- Purpose: verify that docs, TypeScript, and Python CI workflows run successfully

## Test plan
- [ ] CI Gate passes (all three sub-workflows triggered and green)
- [ ] Close PR after verification