### PR TITLE
feat(strands-py-wasm): wire vended tools through the WASM guest

### DIFF
--- a/strands-py-wasm/src/strands/__init__.py
+++ b/strands-py-wasm/src/strands/__init__.py
@@ -38,6 +38,13 @@ from strands.types import (  # noqa: F401
     SummarizingConversationManager,
 )
 
+# Built-in tools the agent can invoke. Drop one of these into
+# ``Agent(vended_tools=[...])``.
+bash = types.VendedTool.Bash()
+file_editor = types.VendedTool.FileEditor()
+http_request = types.VendedTool.HttpRequest()
+notebook = types.VendedTool.Notebook()
+
 
 class StrandsError(Exception):
     """Base class for all SDK-raised errors."""
@@ -375,7 +382,7 @@ class Agent:
         system_prompt: PromptInput | None = None,
         tools: list[DecoratedTool] | None = None,
         agent_tools: list[types.AgentAsToolConfig] | None = None,
-        vended_tools: list[types.VendedToolInput] | None = None,
+        vended_tools: list[types.VendedTool] | None = None,
         vended_plugins: list[types.VendedPluginInput] | None = None,
         mcp_clients: list[types.McpClientConfig] | None = None,
         name: str | None = None,
@@ -397,9 +404,6 @@ class Agent:
         if name is not None or id is not None or description is not None:
             identity = types.AgentIdentity(name=name, id=id, description=description)
 
-        wrapped_vended_tools = (
-            [_marshalling.wrap(v, _marshalling.VENDED_TOOL_ARM_BY_TYPE) for v in vended_tools] if vended_tools else None
-        )
         wrapped_vended_plugins = (
             [_marshalling.wrap(p, _marshalling.VENDED_PLUGIN_ARM_BY_TYPE) for p in vended_plugins]
             if vended_plugins
@@ -413,7 +417,7 @@ class Agent:
             system_prompt=(_marshalling.coerce_prompt(system_prompt) if system_prompt is not None else None),
             tools=[t.to_spec() for t in self._tools] or None,
             agent_tools=agent_tools,
-            vended_tools=wrapped_vended_tools,
+            vended_tools=vended_tools,
             vended_plugins=wrapped_vended_plugins,
             mcp_clients=mcp_clients,
             identity=identity,

--- a/strands-py-wasm/src/strands/_generated/__init__.py
+++ b/strands-py-wasm/src/strands/_generated/__init__.py
@@ -24,7 +24,7 @@ from .strands_agent.snapshot_storage import DeleteSessionArgs, ListSnapshotIdsAr
 from .strands_agent.snapshot_trigger_handler import TriggerError, TriggerParams
 from .strands_agent.streaming import AfterInvocationData, AfterModelCallData, AfterToolCallData, AgentLoopMetrics, AgentMetrics, AgentResultData, AgentTrace, BeforeInvocationData, BeforeModelCallData, BeforeToolCallData, ContentBlockData, HookRedaction, InputRedaction, Interrupt, InvocationMetrics, MessageAddedData, MetadataEvent, ModelMessageData, ModelStopData, ModelStreamUpdateData, OutputRedaction, RedactionEvent, StopEvent, StopReason, StreamError, StreamEvent, ToolMetrics, ToolResultData, ToolStreamUpdateData, ToolUseData, ToolsBatchData, TraceMetadataEntry
 from .strands_agent.tools import AgentAsToolConfig, CallToolArgs, ToolChoice, ToolError, ToolEventStream, ToolSpec, ToolStreamEvent
-from .strands_agent.vended import AgentSkills, BashTool, ContextOffloader, FileEditorTool, HttpRequestTool, NotebookTool, SkillSource, VendedPlugin, VendedTool
+from .strands_agent.vended import AgentSkills, ContextOffloader, SkillSource, VendedPlugin, VendedTool
 from .wasi_clocks.monotonic_clock import Duration, Instant
 from .wasi_clocks.wall_clock import Datetime
 from .wasi_io.error import Error
@@ -60,7 +60,6 @@ __all__ = [
     'AnthropicModel',
     'AttributeValue',
     'BackoffStrategy',
-    'BashTool',
     'BedrockModel',
     'BeforeInvocationData',
     'BeforeModelCallData',
@@ -100,7 +99,6 @@ __all__ = [
     'Error',
     'EventStream',
     'ExponentialBackoff',
-    'FileEditorTool',
     'FileStorage',
     'GoogleModel',
     'GraphConfig',
@@ -112,7 +110,6 @@ __all__ = [
     'HandoffEvent',
     'HookRedaction',
     'HttpHeader',
-    'HttpRequestTool',
     'HttpTransport',
     'ImageBlock',
     'ImageSource',
@@ -158,7 +155,6 @@ __all__ = [
     'NodeKind',
     'NodeResult',
     'NodeStartData',
-    'NotebookTool',
     'OpenaiModel',
     'OrchestrationStatus',
     'OutputRedaction',

--- a/strands-py-wasm/src/strands/_generated/strands_agent/vended.py
+++ b/strands-py-wasm/src/strands/_generated/strands_agent/vended.py
@@ -11,31 +11,6 @@ from wasmtime.component import Variant as _WitVariant
 from wasmtime.component import VariantCase as _WitVariantCase
 
 
-@dataclass(kw_only=True)
-class BashTool:
-    """Bash tool configuration."""
-    default_timeout_s: int | None
-
-
-@dataclass(kw_only=True)
-class FileEditorTool:
-    """File editor tool configuration."""
-    workspace_root: str | None
-
-
-@dataclass(kw_only=True)
-class HttpRequestTool:
-    """HTTP request tool configuration."""
-    allowed_hosts: list[str]
-    max_response_bytes: int
-
-
-@dataclass(kw_only=True)
-class NotebookTool:
-    """Notebook tool configuration."""
-    workspace_root: str | None
-
-
 class VendedTool:
     """Built-in tools."""
     if TYPE_CHECKING:
@@ -63,7 +38,7 @@ class _VendedTool_HttpRequest(_WitVariantCase, VendedTool):
 VendedTool.HttpRequest = _VendedTool_HttpRequest  # type: ignore[attr-defined]
 
 class _VendedTool_Notebook(_WitVariantCase, VendedTool):
-    """Read and execute Jupyter notebook cells."""
+    """Read and write named text notebooks stored in agent state."""
     tag = 'notebook'
 VendedTool.Notebook = _VendedTool_Notebook  # type: ignore[attr-defined]
 

--- a/strands-py-wasm/src/strands/_marshalling.py
+++ b/strands-py-wasm/src/strands/_marshalling.py
@@ -47,13 +47,6 @@ CM_ARM_BY_TYPE: dict[type, type] = {
     types.SummarizingConversationManager: types.ConversationManagerConfig.Summarizing,
 }
 
-VENDED_TOOL_ARM_BY_TYPE: dict[type, type] = {
-    types.BashTool: types.VendedTool.Bash,
-    types.FileEditorTool: types.VendedTool.FileEditor,
-    types.HttpRequestTool: types.VendedTool.HttpRequest,
-    types.NotebookTool: types.VendedTool.Notebook,
-}
-
 VENDED_PLUGIN_ARM_BY_TYPE: dict[type, type] = {
     types.AgentSkills: types.VendedPlugin.Skills,
     types.ContextOffloader: types.VendedPlugin.ContextOffloader,

--- a/strands-py-wasm/src/strands/types.py
+++ b/strands-py-wasm/src/strands/types.py
@@ -34,7 +34,6 @@ from strands._generated.strands_agent.vended import (
     AgentSkills,
     ContextOffloader,
     VendedPlugin,
-    VendedTool,
 )
 
 ModelInput = ModelConfig | BedrockModel | AnthropicModel | OpenaiModel | GoogleModel | CustomModel

--- a/strands-py-wasm/src/strands/types.py
+++ b/strands-py-wasm/src/strands/types.py
@@ -32,18 +32,13 @@ from strands._generated.strands_agent.models import (
 )
 from strands._generated.strands_agent.vended import (
     AgentSkills,
-    BashTool,
     ContextOffloader,
-    FileEditorTool,
-    HttpRequestTool,
-    NotebookTool,
     VendedPlugin,
     VendedTool,
 )
 
 ModelInput = ModelConfig | BedrockModel | AnthropicModel | OpenaiModel | GoogleModel | CustomModel
 ConversationManagerInput = ConversationManagerConfig | SlidingWindowConversationManager | SummarizingConversationManager
-VendedToolInput = VendedTool | BashTool | FileEditorTool | HttpRequestTool | NotebookTool
 VendedPluginInput = VendedPlugin | AgentSkills | ContextOffloader
 
 _DROPPED: set[str] = {
@@ -62,6 +57,5 @@ __all__ = sorted(  # pyright: ignore[reportUnsupportedDunderAll]
         "ConversationManagerInput",
         "ModelInput",
         "VendedPluginInput",
-        "VendedToolInput",
     }
 )

--- a/strands-py-wasm/tests/test_tools.py
+++ b/strands-py-wasm/tests/test_tools.py
@@ -1,6 +1,6 @@
 import pytest
 
-from strands import Agent, BedrockModel, tool
+from strands import Agent, BedrockModel, http_request, notebook, tool, types
 
 
 @pytest.fixture
@@ -23,7 +23,61 @@ def agent(model, weather_tool):
     return Agent(model=model, tools=[weather_tool])
 
 
+@pytest.fixture
+def http_request_agent(model):
+    return Agent(model=model, vended_tools=[http_request])
+
+
+@pytest.fixture
+def notebook_agent(model):
+    return Agent(model=model, vended_tools=[notebook])
+
+
 @pytest.mark.asyncio
 async def test_decorated_tool_invocation(agent):
     result = await agent.invoke_async("What is the weather in Seattle?")
     assert "72" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_http_request_tool_invocation(http_request_agent):
+    tools_called: list[str] = []
+    last_message: types.Message | None = None
+    async for event in http_request_agent.stream_async(
+        "Use the http_request tool to GET https://httpbin.org/base64/c3RyYW5kcw== "
+        "and tell me the exact decoded text from the response body."
+    ):
+        if isinstance(event, types.StreamEvent.BeforeToolCall):
+            tools_called.append(event.value.tool_use.name)
+        elif isinstance(event, types.StreamEvent.MessageAdded):
+            last_message = event.value.message
+
+    assert "http_request" in tools_called, f"tools called: {tools_called}"
+
+    assert last_message is not None
+    text_blocks = [b.payload.text for b in last_message.content if b.tag == "text"]
+    # /base64/c3RyYW5kcw== returns the literal body "strands".
+    assert any("strands" in t.lower() for t in text_blocks)
+
+
+@pytest.mark.asyncio
+async def test_notebook_tool_invocation(notebook_agent):
+    tools_called: list[str] = []
+    last_message: types.Message | None = None
+    async for event in notebook_agent.stream_async(
+        "Use the notebook tool to create a notebook named 'todo' with the line 'buy milk'. "
+        "Then read it back and tell me what's in it."
+    ):
+        if isinstance(event, types.StreamEvent.BeforeToolCall):
+            tools_called.append(event.value.tool_use.name)
+        elif isinstance(event, types.StreamEvent.MessageAdded):
+            last_message = event.value.message
+
+    assert "notebook" in tools_called, f"tools called: {tools_called}"
+
+    notebooks = (await notebook_agent.get_app_state()).get("notebooks")
+    assert notebooks == {"default": "", "todo": "buy milk"}, f"got: {notebooks!r}"
+
+    assert last_message is not None
+    text_blocks = [b.payload.text for b in last_message.content if b.tag == "text"]
+    assert any("milk" in t.lower() for t in text_blocks)

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -16,6 +16,7 @@
 /// <reference path="./generated/interfaces/strands-agent-sessions.d.ts" />
 /// <reference path="./generated/interfaces/strands-agent-conversation.d.ts" />
 /// <reference path="./generated/interfaces/strands-agent-tool-provider.d.ts" />
+/// <reference path="./generated/interfaces/strands-agent-vended.d.ts" />
 
 import type { AgentConfig, InvokeArgs, RespondArgs, AgentError } from 'strands:agent/api@0.1.0'
 import type {
@@ -34,9 +35,12 @@ import type {
 } from 'strands:agent/streaming@0.1.0'
 import type { ModelConfig as WitModelConfig, ModelParams as WitModelParams } from 'strands:agent/models@0.1.0'
 import type { ToolSpec, ToolChoice as WitToolChoice } from 'strands:agent/tools@0.1.0'
+import type { VendedTool as WitVendedTool } from 'strands:agent/vended@0.1.0'
 
 import { callTool } from 'strands:agent/tool-provider@0.1.0'
-import { Agent, FunctionTool, SessionManager, FileStorage } from '@strands-agents/sdk'
+import { Agent, FunctionTool, SessionManager, FileStorage, Tool } from '@strands-agents/sdk'
+import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 import { S3Storage } from '@strands-agents/sdk/session/s3-storage'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
@@ -69,6 +73,8 @@ import {
   SummarizingConversationManager,
 } from '@strands-agents/sdk'
 import { z } from 'zod'
+
+import './polyfills/abort-signal.js'
 
 //
 // --- logging + error helpers --------------------------------------------
@@ -182,7 +188,7 @@ function mapToolResultContent(block: ToolResultContent): WitToolResultContent {
   const payload = JSON.parse(JSON.stringify(block))
   switch (block.type) {
     case 'textBlock': return { tag: 'text', val: payload } as WitToolResultContent
-    case 'jsonBlock': return { tag: 'json', val: payload } as WitToolResultContent
+    case 'jsonBlock': return { tag: 'json', val: { json: JSON.stringify(payload.json) } } as WitToolResultContent
     case 'imageBlock': return { tag: 'image', val: payload.image } as WitToolResultContent
     case 'videoBlock': return { tag: 'video', val: payload.video } as WitToolResultContent
     case 'documentBlock': return { tag: 'document', val: payload.document } as WitToolResultContent
@@ -381,9 +387,36 @@ function createModel(config?: WitModelConfig, params?: WitModelParams): Model<Ba
   }
 }
 
+/**
+ * Map each `vended-tool` arm to its TS implementation.
+ *
+ * `notebook` and `http-request` run in the WASM guest. `bash` and
+ * `file-editor` import Node-only APIs (`child_process`, `fs`) and throw at
+ * agent construction time so failure is immediate and traceable, rather than
+ * surfacing mid-conversation when the model picks the tool.
+ */
+function createVendedTools(vendedTools: WitVendedTool[] | undefined): Tool[] {
+  if (!vendedTools) return []
+  return vendedTools.map((vt) => {
+    switch (vt.tag) {
+      case 'notebook':
+        return notebook
+      case 'http-request':
+        return httpRequest
+      case 'bash':
+      case 'file-editor':
+        throw new Error(`vended-tool '${vt.tag}' is not yet supported.`)
+      default: {
+        vt satisfies never
+        throw new Error(`Unknown vended-tool arm`)
+      }
+    }
+  })
+}
+
 /** Convert WIT ToolSpecs into TS FunctionTools that call back to the host. */
-function createTools(specs: ToolSpec[] | undefined): FunctionTool[] | undefined {
-  if (!specs || specs.length === 0) return undefined
+function createTools(specs: ToolSpec[] | undefined): FunctionTool[] {
+  if (!specs) return []
 
   return specs.map(
     (spec) =>
@@ -532,12 +565,12 @@ function invokeInputFromWit(input: PromptInput): SdkInvokeArgs {
 
 class AgentImpl {
   private agent: Agent
-  private defaultTools: FunctionTool[] | undefined
+  private defaultTools: Tool[]
   private sessionManager: SessionManager | undefined
 
   constructor(config: AgentConfig) {
     const model = createModel(config.model, config.modelParams)
-    this.defaultTools = createTools(config.tools)
+    this.defaultTools = [...createTools(config.tools), ...createVendedTools(config.vendedTools)]
     this.sessionManager = createSessionManager(config)
 
     this.agent = new Agent({
@@ -553,9 +586,8 @@ class AgentImpl {
 
   generate(args: InvokeArgs): ResponseStreamImpl {
     if (args.tools) {
-      const requestTools = createTools(args.tools)
       this.agent.toolRegistry.clear()
-      if (requestTools) this.agent.toolRegistry.add(requestTools)
+      this.agent.toolRegistry.add(createTools(args.tools))
     }
 
     let originalModel: Model<BaseModelConfig> | undefined
@@ -672,14 +704,14 @@ class ResponseStreamImpl {
   private generator: AsyncGenerator<AgentStreamEvent, AgentResult | undefined, undefined>
   private interruptResolve: ((payload: string) => void) | null = null
   private agent: Agent
-  private defaultTools: FunctionTool[] | undefined
+  private defaultTools: Tool[]
   private originalModel: Model<BaseModelConfig> | undefined
   private pendingStop: WitStreamEvent | undefined
 
   constructor(
     agent: Agent,
     input: PromptInput,
-    defaultTools?: FunctionTool[],
+    defaultTools: Tool[],
     originalModel?: Model<BaseModelConfig>,
     structuredOutputSchema?: z.ZodSchema
   ) {
@@ -692,7 +724,7 @@ class ResponseStreamImpl {
   private restoreDefaults(): void {
     if (this.originalModel) this.agent.model = this.originalModel
     this.agent.toolRegistry.clear()
-    if (this.defaultTools) this.agent.toolRegistry.add(this.defaultTools)
+    this.agent.toolRegistry.add(this.defaultTools)
   }
 
   /** @internal Drains both the SDK iterator and any pending terminal stop. */

--- a/strands-wasm/polyfills/abort-signal.ts
+++ b/strands-wasm/polyfills/abort-signal.ts
@@ -1,0 +1,13 @@
+/**
+ * Workaround for https://github.com/bytecodealliance/StarlingMonkey/issues/309.
+ * If the host's `AbortSignal.any` is broken, replace it. Delete this file
+ * once the minimum supported StarlingMonkey version ships the upstream fix.
+ */
+
+const probe = AbortSignal.any([new AbortController().signal])
+if (probe.aborted) {
+  const original = AbortSignal.any
+  AbortSignal.any = (signals: Iterable<AbortSignal>): AbortSignal =>
+    // @ts-expect-error broken host expects varargs; we adapt by spreading.
+    original.call(AbortSignal, ...signals)
+}

--- a/wit/vended.wit
+++ b/wit/vended.wit
@@ -7,42 +7,13 @@ interface vended {
   /// Built-in tools.
   variant vended-tool {
     /// Run shell commands in a persistent bash session.
-    bash(bash-tool),
+    bash,
     /// Create, view, and edit files on disk.
-    file-editor(file-editor-tool),
+    file-editor,
     /// Make HTTP requests.
-    http-request(http-request-tool),
-    /// Read and execute Jupyter notebook cells.
-    notebook(notebook-tool),
-  }
-
-  /// Bash tool configuration.
-  record bash-tool {
-    /// Default timeout for `execute` calls, in seconds.
-    default-timeout-s: option<s32>,
-  }
-
-  /// File editor tool configuration.
-  record file-editor-tool {
-    /// Directory outside of which the tool refuses to operate. Absent
-    /// permits any path the sandbox grants.
-    workspace-root: option<string>,
-  }
-
-  /// HTTP request tool configuration.
-  record http-request-tool {
-    /// Hosts the tool is allowed to reach. Empty permits any host the
-    /// sandbox permits.
-    allowed-hosts: list<string>,
-    /// Upper bound on response size, in bytes. 0 means unbounded.
-    max-response-bytes: u64,
-  }
-
-  /// Notebook tool configuration.
-  record notebook-tool {
-    /// Directory outside of which the tool refuses to operate. Absent
-    /// permits any path the sandbox grants.
-    workspace-root: option<string>,
+    http-request,
+    /// Read and write named text notebooks stored in agent state.
+    notebook,
   }
 
   /// Location of a skill definition on disk.


### PR DESCRIPTION
## Description

Wires the four vended tools through the WASM guest so a Python (`strands-py-wasm`) user can opt into them via `Agent(vended_tools=[...])`:

```python
from strands import Agent, BedrockModel, http_request, notebook

agent = Agent(model=BedrockModel(...), vended_tools=[notebook, http_request])
```

`notebook` and `http_request` run end-to-end inside the WASM guest. `bash` and `file_editor` throw at agent construction time because their TS implementations import Node-only APIs (`child_process`, `fs`) that StarlingMonkey doesn't expose. See #2421 for the gap log.

Key changes:

- `wit/vended.wit`: simplify `vended-tool` to unit-arm variants. The existing payload records advertised configuration the TS singletons don't accept (see #2425 "Out of scope: vended-tool configurability").
- `strands-py-wasm/src/strands/__init__.py`: export four module-level variant-arm singletons (`bash`, `file_editor`, `http_request`, `notebook`); drop the public `*Tool` payload dataclasses.
- `strands-wasm/entry.ts`: add `createVendedTools` mapping arms to TS singletons, throwing at construction for the unsupported arms; merge with decorated tools. Fix `mapToolResultContent`'s `jsonBlock` arm to satisfy the `json-block.json: string` WIT contract (was passing an object).
- `strands-wasm/polyfills/abort-signal.ts`: new side-effect polyfill for [bytecodealliance/StarlingMonkey#309](https://github.com/bytecodealliance/StarlingMonkey/issues/309). `AbortSignal.any` returns a pre-aborted signal in StarlingMonkey; spread the iterable into varargs so the broken impl iterates the args correctly. Self-removing (probe-then-replace) once upstream lands the fix.
- `strands-py-wasm/tests/test_tools.py`: integration tests for `notebook` and `http_request`.

## Related Issues

Closes #2425

## Documentation PR

N/A

## Type of Change

New feature

## Testing

- `cd strands-py-wasm && pytest tests/` — 4 passed (decorated tool, hello world, http_request, notebook).
- `notebook` test asserts `agent.get_app_state()['notebooks'] == {"default": "", "todo": "buy milk"}` after the model invokes the tool, plus that the result reaches the assistant message.
- `http_request` test fetches `https://httpbin.org/base64/c3RyYW5kcw==` (returns the literal body `strands`) and asserts the model surfaces it.
- Requires the wasmtime patch in [pgrayy/wasm-deps#4](https://github.com/pgrayy/wasm-deps/pull/4) so `AbortSignal.timeout` doesn't panic the host (no Tokio reactor on the calling thread). Will be picked up automatically once wasm-deps publishes a new wheel; until then, smoke-tested locally with the rebuilt dylib.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.