### PR TITLE
fix(test): drop deprecated gemini-2.0-flash override in integ tests

### DIFF
--- a/strands-ts/test/integ/models/google.test.ts
+++ b/strands-ts/test/integ/models/google.test.ts
@@ -18,7 +18,6 @@ describe.skipIf(gemini.skip)('GoogleModel Integration Tests', () => {
     describe('Configuration', () => {
       it.concurrent('respects temperature configuration', async () => {
         const provider = gemini.createModel({
-          modelId: 'gemini-2.0-flash',
           params: { temperature: 0, maxOutputTokens: 50 },
         })
 
@@ -74,7 +73,6 @@ describe.skipIf(gemini.skip)('GoogleModel Integration Tests', () => {
     describe('Content Block Lifecycle', () => {
       it.concurrent('emits complete content block lifecycle events', async () => {
         const provider = gemini.createModel({
-          modelId: 'gemini-2.0-flash',
           params: { maxOutputTokens: 50 },
         })
 
@@ -111,7 +109,6 @@ describe.skipIf(gemini.skip)('GoogleModel Integration Tests', () => {
     describe('Stop Reasons', () => {
       it.concurrent('returns endTurn stop reason for natural completion', async () => {
         const provider = gemini.createModel({
-          modelId: 'gemini-2.0-flash',
           params: { maxOutputTokens: 100 },
         })
 


### PR DESCRIPTION
## Description

Three Gemini integ tests in `strands-ts/test/integ/models/google.test.ts` pin `modelId: 'gemini-2.0-flash'`. Google removed that model, so the tests now fail with:

```
ApiError 404: This model models/gemini-2.0-flash is no longer available.
Please update your code to use a newer model for the latest features and improvements.
```

The fixture default in [strands-ts/test/integ/__fixtures__/model-providers.ts](https://github.com/strands-agents/sdk-python/blob/main/strands-ts/test/integ/__fixtures__/model-providers.ts) is already `gemini-2.5-flash` (the lightweight successor in the same `flash` tier). These three tests don't need a specific model id, so dropping the override lets them inherit the fixture default. Future deprecations only require a one-line bump in the fixture.

The fourth test in the file (`handles invalid model ID gracefully`) intentionally uses an invalid id and is unaffected.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- `hatch run prepare` (pre-commit hooks: build, unit tests, lint, format, type-check) all pass.
- The three changed tests are integration tests requiring a Gemini API key; they will be exercised by the harness-sdk CI run.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.