### PR TITLE
feat(strands-py-wasm): make get/set app state sync

### DIFF
--- a/strands-py-wasm/src/strands/__init__.py
+++ b/strands-py-wasm/src/strands/__init__.py
@@ -23,6 +23,7 @@ from dataclasses import asdict, is_dataclass
 from typing import Any, Protocol, TypeVar, get_type_hints, runtime_checkable
 
 from strands import _marshalling, types
+from strands._runtime import _AgentRuntime
 
 # First-class types users construct when wiring up an agent. Anything reached
 # only through return values or pattern matching (StreamEvent, Interrupt,
@@ -428,23 +429,12 @@ class Agent:
             app_state=json.dumps(app_state) if app_state else None,
             model_state=json.dumps(model_state) if model_state else None,
         )
-        self._runtime: Any = None
+        self._runtime = _AgentRuntime(self)
+        self._runtime.init()
 
     @property
     def config(self) -> types.AgentConfig:
         return self._config
-
-    def _ensure_runtime(self) -> Any:
-        if self._runtime is None:
-            from ._runtime import _AgentRuntime
-
-            self._runtime = _AgentRuntime(self)
-        return self._runtime
-
-    async def _ensure_runtime_async(self) -> Any:
-        rt = self._ensure_runtime()
-        await rt.async_init()
-        return rt
 
     def _lookup_tool(self, name: str) -> DecoratedTool:
         for t in self._tools:
@@ -476,9 +466,8 @@ class Agent:
         structured_output_schema: str | None = None,
     ) -> AsyncIterator[types.StreamEvent]:
         """Yield :class:`StreamEvent` arms as the agent runs."""
-        runtime = await self._ensure_runtime_async()
         args = self._build_invoke_args(prompt, tools, tool_choice, structured_output_schema)
-        stream = await runtime.generate(args)
+        stream = await self._runtime.generate(args)
         async for event in stream:
             yield event
 
@@ -533,31 +522,29 @@ class Agent:
 
     def cancel(self) -> None:
         """Cancel the in-flight invocation. Fire-and-forget."""
-        if self._runtime is not None:
-            self._runtime.cancel()
+        self._runtime.cancel()
 
     async def respond(self, interrupt_id: str, response: Any) -> None:
-        runtime = await self._ensure_runtime_async()
         payload = response if isinstance(response, str) else json.dumps(response)
-        await runtime.respond(types.RespondArgs(interrupt_id=interrupt_id, response=payload))
+        await self._runtime.respond(types.RespondArgs(interrupt_id=interrupt_id, response=payload))
 
     async def get_messages(self) -> list[types.Message]:
-        return await (await self._ensure_runtime_async()).get_messages()
+        return await self._runtime.get_messages()
 
     async def set_messages(self, messages: list[types.Message]) -> None:
-        await (await self._ensure_runtime_async()).set_messages(messages)
+        await self._runtime.set_messages(messages)
 
-    async def get_app_state(self) -> dict[str, Any]:
-        return await (await self._ensure_runtime_async()).get_app_state()
+    def get_app_state(self) -> dict[str, Any]:
+        return self._runtime.get_app_state()
 
-    async def set_app_state(self, state: dict[str, Any]) -> None:
-        await (await self._ensure_runtime_async()).set_app_state(state)
+    def set_app_state(self, state: dict[str, Any]) -> None:
+        self._runtime.set_app_state(state)
 
     async def get_model_state(self) -> dict[str, Any]:
-        return await (await self._ensure_runtime_async()).get_model_state()
+        return await self._runtime.get_model_state()
 
     async def set_model_state(self, state: dict[str, Any]) -> None:
-        await (await self._ensure_runtime_async()).set_model_state(state)
+        await self._runtime.set_model_state(state)
 
 
 class _AgentResultAccumulator:

--- a/strands-py-wasm/src/strands/_runtime.py
+++ b/strands-py-wasm/src/strands/_runtime.py
@@ -339,10 +339,8 @@ class _AgentRuntime:
         self._handle: ResourceAny | None = None
         self._current_response: ResourceAny | None = None
 
-    async def async_init(self) -> None:
-        if self._handle is not None:
-            return
-        self._handle = await self._funcs.constructor.call_async(self._store, self._agent._config)
+    def init(self) -> None:
+        self._handle = self._funcs.constructor(self._store, self._agent._config)
         self._funcs.constructor.post_return(self._store)
 
     async def generate(self, args: _t.InvokeArgs) -> EventStream:
@@ -381,14 +379,14 @@ class _AgentRuntime:
         self._funcs.set_messages.post_return(self._store)
         _raise_on_err(res)
 
-    async def get_app_state(self) -> dict[str, Any]:
-        raw = await self._funcs.get_app_state.call_async(self._store, self._handle)
+    def get_app_state(self) -> dict[str, Any]:
+        raw = self._funcs.get_app_state(self._store, self._handle)
         self._funcs.get_app_state.post_return(self._store)
         return json.loads(raw) if raw else {}
 
-    async def set_app_state(self, state: dict[str, Any]) -> None:
+    def set_app_state(self, state: dict[str, Any]) -> None:
         payload = json.dumps(state)
-        res = await self._funcs.set_app_state.call_async(self._store, self._handle, payload)
+        res = self._funcs.set_app_state(self._store, self._handle, payload)
         self._funcs.set_app_state.post_return(self._store)
         _raise_on_err(res)
 

--- a/strands-py-wasm/tests/test_agent.py
+++ b/strands-py-wasm/tests/test_agent.py
@@ -19,3 +19,9 @@ async def test_stream_async_hello_world(agent):
         assert isinstance(event, types.StreamEvent)
 
     assert isinstance(event, types.StreamEvent.Stop)
+
+
+def test_app_state(agent):
+    assert agent.get_app_state() == {}
+    agent.set_app_state({"foo": "bar", "count": 1})
+    assert agent.get_app_state() == {"foo": "bar", "count": 1}


### PR DESCRIPTION
## Description

Make `Agent.get_app_state` and `Agent.set_app_state` synchronous on `strands-py-wasm`. The underlying WIT exports (`get-app-state`, `set-app-state`) are non-suspending, so they can be invoked through wasmtime-py's sync FFI path under the existing `Config.async_allow_sync = True`. The TS host implementation backs them with in-memory `StateStore` operations (`entry.ts:591-604`), which never await, so there is no risk of trapping on a sync-called suspension.

While here, simplify the runtime lifecycle:
- Drop `_AgentRuntime.async_init` and the three `Agent._ensure_runtime*` helpers.
- Construct `_AgentRuntime` and call its sync `init` eagerly from `Agent.__init__`. The WIT `[constructor]agent` is also non-suspending, so it is safe to invoke sync.
- All async methods (`stream_async`, `invoke_async`, `respond`, `get_messages`, `set_messages`, `get/set_model_state`) now go directly through `self._runtime` instead of an ensure-helper.

Net: -32 / +26 lines, three ensure helpers and one async-init method gone, one fewer code path to reason about.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

New feature

## Testing

Added an integ test in `strands-py-wasm/tests/test_agent.py::test_app_state` that round-trips through the new sync API: asserts the default state is empty, writes via `set_app_state`, and reads back via `get_app_state`.

Local run:

\`\`\`
$ pytest tests/ -v
tests/test_agent.py::test_stream_async_hello_world PASSED
tests/test_agent.py::test_app_state PASSED
tests/test_tools.py::test_decorated_tool_invocation PASSED
\`\`\`

- [ ] I ran \`hatch run prepare\`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.