### PR TITLE
docs(bedrock): document CacheConfig(strategy="auto") gap with ARN-based inference profiles

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -1028,6 +1028,43 @@ const agent = new Agent({
 Strands uses a default Claude 4 Sonnet inference model from the region of your credentials when no model is provided. So if you did not pass in any model id and are getting the above error, it's very likely due to the `region` from the credentials not supporting inference profiles.
 :::
 
+### CacheConfig with ARN-based inference profiles
+
+If you're using an ARN-based application inference profile as your `model_id` (e.g., `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123`), `CacheConfig(strategy="auto")` will not automatically enable prompt caching.
+
+**Why this happens:** The `strategy="auto"` detection checks the model ID string for `"claude"` or `"anthropic"` substrings. Cross-region inference profile ARNs (e.g., `us.anthropic.claude-sonnet-4-20250514-v1:0`) contain `"anthropic"` and are detected correctly. Application inference profiles use opaque resource IDs (`application-inference-profile/abc123`) that have no connection to the underlying model name, so detection returns `None`, caching is skipped, and Strands logs a warning: `cache_config is enabled but this model does not support automatic caching`.
+
+**Solution:** Use `strategy="anthropic"` explicitly:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.models import BedrockModel, CacheConfig
+
+bedrock_model = BedrockModel(
+    model_id="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123",
+    cache_config=CacheConfig(strategy="anthropic")
+)
+
+agent = Agent(model=bedrock_model)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+const bedrockModel = new BedrockModel({
+  modelId: 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123',
+  cacheConfig: { strategy: 'anthropic' },
+})
+
+const agent = new Agent({ model: bedrockModel })
+```
+</Tab>
+</Tabs>
+
+`strategy="anthropic"` has identical performance to `strategy="auto"` and requires no additional API calls or IAM permissions.
 
 ## Related Resources
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -1032,9 +1032,9 @@ Strands uses a default Claude 4 Sonnet inference model from the region of your c
 
 If you're using an ARN-based application inference profile as your `model_id` (e.g., `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123`), `CacheConfig(strategy="auto")` will not automatically enable prompt caching.
 
-**Why this happens:** The `strategy="auto"` detection checks the model ID string for `"claude"` or `"anthropic"` substrings. Cross-region inference profile ARNs (e.g., `us.anthropic.claude-sonnet-4-20250514-v1:0`) contain `"anthropic"` and are detected correctly. Application inference profiles use opaque resource IDs (`application-inference-profile/abc123`) that have no connection to the underlying model name, so detection returns `None`, caching is skipped, and Strands logs a warning: `cache_config is enabled but this model does not support automatic caching`.
+The `strategy="auto"` detection checks the model ID string for `"claude"` or `"anthropic"` substrings. Cross-region inference profile IDs like `us.anthropic.claude-sonnet-4-20250514-v1:0` contain `"anthropic"` and are detected correctly, but application inference profiles use opaque resource IDs (`application-inference-profile/abc123`) that carry no model name information, so detection returns `None`, caching is skipped, and Strands logs a warning: `model_id=<your-arn> | cache_config is enabled but this model does not support automatic caching`.
 
-**Solution:** Use `strategy="anthropic"` explicitly:
+Use `strategy="anthropic"` explicitly to fix this:
 
 <Tabs>
 <Tab label="Python">
@@ -1054,6 +1054,9 @@ agent = Agent(model=bedrock_model)
 <Tab label="TypeScript">
 
 ```typescript
+import { Agent } from '@strands-agents/sdk'
+import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
+
 const bedrockModel = new BedrockModel({
   modelId: 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123',
   cacheConfig: { strategy: 'anthropic' },


### PR DESCRIPTION
## Description

`CacheConfig(strategy="auto")` silently skips caching when `model_id` is an ARN-based application inference profile. The `_cache_strategy` detection checks for `"claude"` or `"anthropic"` in the model ID string. Cross-region inference profile IDs like `us.anthropic.claude-sonnet-4-20250514-v1:0` pass that check, but application inference profile ARNs are opaque resource identifiers with no model name, so detection returns `None` and caching is skipped.

This adds a troubleshooting note to the existing Bedrock model provider page explaining the root cause and documenting `strategy="anthropic"` as the fix.

## Related Issues

Fixes #2233
Fixes #2601

## Type of Change

Documentation update

## Testing

Docs-only change — no code logic modified. MDX structure validated against existing patterns in the file.

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Thanks to @mrtj for the detailed root-cause analysis in the issue.