### PR TITLE
docs: clarify summary_ratio replaces oldest messages

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -153,7 +153,7 @@ The [`SummarizingConversationManager`](@api/python/strands.agent.conversation_ma
 
 Configuration parameters:
 
-- **`summary_ratio`** (float, default: 0.3): Percentage of messages to summarize when reducing context (clamped between 0.1 and 0.8)
+- **`summary_ratio`** (float, default: 0.3): Percentage of the oldest messages to summarize and replace when reducing context (clamped between 0.1 and 0.8)
 - **`preserve_recent_messages`** (int, default: 10): Minimum number of recent messages to always keep
 - **`summarization_agent`** (Agent, optional): Custom agent for generating summaries. If not provided, uses the main agent instance. Cannot be used together with `summarization_system_prompt`.
 - **`summarization_system_prompt`** (str, optional): Custom system prompt for summarization. If not provided, uses a default prompt that creates structured bullet-point summaries focusing on key topics, tools used, and technical information in third-person format. Cannot be used together with `summarization_agent`.
@@ -211,7 +211,7 @@ from strands.agent.conversation_manager import SummarizingConversationManager
 
 # Create the summarizing conversation manager with default settings
 conversation_manager = SummarizingConversationManager(
-    summary_ratio=0.3,  # Summarize 30% of messages when context reduction is needed
+    summary_ratio=0.3,  # Summarize and replace the oldest 30% of messages when context reduction is needed
     preserve_recent_messages=10,  # Always keep 10 most recent messages
 )
 


### PR DESCRIPTION
## Summary
- clarify that `summary_ratio` summarizes and replaces the oldest messages during context reduction
- update the Python example comment to match the actual behavior
- recreate the docs clarification requested after `strands-agents/docs#871` because the docs repo was migrated into this monorepo

## Validation
- `npx --yes prettier@3.6.2 --check src/content/docs/user-guide/concepts/agents/conversation-management.mdx`
- `git diff --check`

## Notes
- I did not run the full `site` test/typecheck suite in this environment because the docs package expects generated SDK artifacts under `site/.build/` from the repo's SDK sync workflow.
