### PR TITLE
chore: change memory store return type on add

### DIFF
--- a/strands-ts/src/memory/types.ts
+++ b/strands-ts/src/memory/types.ts
@@ -77,8 +77,12 @@ export interface MemoryStore extends MemoryStoreConfig {
   /**
    * Add content to the store. Required when `writable` is `true`; ignored otherwise.
    * A store may implement `add` while declaring `writable: false`, in which case it is never invoked.
+   *
+   * The resolved value is store-specific (e.g. a created record id or a write receipt) — each backend
+   * may return whatever shape fits it. {@link MemoryManager.add} does not consume this value (it only
+   * awaits completion); callers using a store directly can read it.
    */
-  add?(content: string, metadata?: Record<string, JSONValue>): Promise<void>
+  add?(content: string, metadata?: Record<string, JSONValue>): Promise<unknown>
   /**
    * Returns store-specific tools to register with the agent, through a {@link MemoryManager}. Registers
    * tools alongside `search_memory` / `add_memory` tools if enabled on the {@link MemoryManager}.


### PR DESCRIPTION
## Description

Widen the `MemoryStore.add` return type from `Promise<void>` to `Promise<unknown>` so each backend store implementation can resolve a value in its own format (e.g. a created record id or a write receipt) instead of being forced to discard it.

`MemoryManager.add()` keeps returning `Promise<void>` deliberately: it fans writes out across multiple, potentially heterogeneous stores via `Promise.allSettled`, so there is no single backend value to surface. Callers that use a store directly can now read whatever the backend returns. `search` and the `add_memory` tool output are unchanged. 

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

New feature

(Backward-compatible: widening the return type lets backends opt in to returning their own value; existing implementations are unaffected.)

## Testing

Verified locally in `strands-ts/`:

- `tsc --noEmit --project src/tsconfig.json` passes (exit 0) — source compiles cleanly with the widened type, including `memory-manager.ts` which ignores the return value.
- Memory unit tests pass: `npx vitest run --project unit-node src/memory` → 61 passed, vitest type-check reports no errors.
- ESLint and Prettier are clean on the edited file.

- [ ] I ran `hatch run prepare` (N/A — TypeScript change; ran `tsc`, `vitest`, `eslint`, `prettier` instead)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works (existing memory tests cover stores resolving `add`; they pass unchanged against the widened type)
- [ ] I have updated the documentation accordingly (no docs needed — backward-compatible type widening)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.