### PR TITLE
feat: add middleware system for wrapping agent stages

### DIFF
--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -26,7 +26,7 @@ import {
 import type { JSONValue } from '../types/json.js'
 import { McpClient } from '../mcp.js'
 import { isValidToolName, type Tool, type ToolContext } from '../tools/tool.js'
-import type { ToolChoice } from '../tools/types.js'
+import type { ToolChoice, ToolSpec } from '../tools/types.js'
 import { systemPromptFromData } from '../types/messages.js'
 import { normalizeError, ConcurrentInvocationError, StructuredOutputError } from '../errors.js'
 import { Model } from '../models/model.js'
@@ -48,6 +48,25 @@ import { ConversationManager } from '../conversation-manager/conversation-manage
 import { ContextOffloader } from '../vended-plugins/context-offloader/plugin.js'
 import { InMemoryStorage } from '../vended-plugins/context-offloader/storage.js'
 import { HookRegistryImplementation } from '../hooks/registry.js'
+import { MiddlewareRegistry, InvokeModelStage, ExecuteToolStage, AgentStreamStage } from '../middleware/index.js'
+import type {
+  MiddlewareStage,
+  MiddlewareHandler,
+  MiddlewareInputHandler,
+  MiddlewareOutputHandler,
+  MiddlewareInputPhase,
+  MiddlewareOutputPhase,
+  MiddlewarePhaseKind,
+} from '../middleware/index.js'
+import type {
+  InvokeModelContext,
+  InvokeModelResult,
+  ExecuteToolContext,
+  ExecuteToolResult,
+  AgentStreamContext,
+  AgentStreamResult,
+  MiddlewareInterruptResult,
+} from '../middleware/index.js'
 import type { HookableEventConstructor, HookCallback, HookCallbackOptions, HookCleanup } from '../hooks/types.js'
 import {
   InitializedEvent,
@@ -69,6 +88,7 @@ import {
   ToolStreamUpdateEvent,
   InterruptEvent,
   type ModelStopData,
+  type ToolUseData,
 } from '../hooks/events.js'
 import { StructuredOutputTool, STRUCTURED_OUTPUT_TOOL_NAME } from '../tools/structured-output-tool.js'
 import { AgentAsTool } from './agent-as-tool.js'
@@ -88,7 +108,7 @@ import { CancelledError } from '../errors.js'
 import { DefaultModelRetryStrategy } from '../retry/default-model-retry-strategy.js'
 import type { RetryStrategy } from '../retry/retry-strategy.js'
 import { warnOnDuplicateRetryStrategyTypes } from '../retry/retry-strategy.js'
-import { InterruptError, InterruptState, interruptFromAgent } from '../interrupt.js'
+import { Interrupt, InterruptError, InterruptState, interruptFromAgent } from '../interrupt.js'
 import type { InterruptParams } from '../types/interrupt.js'
 import { isInterruptResponseContent, type InterruptResponseContent } from '../types/interrupt.js'
 import { takeSnapshot as takeSnapshotInternal, loadSnapshot as loadSnapshotInternal } from './snapshot.js'
@@ -297,6 +317,36 @@ const DEFAULT_AGENT_ID = 'agent'
 type ToolsExecutionResult = { message: Message; afterToolsEvent: AfterToolsEvent }
 
 /**
+ * Creates a non-mutating interrupt function for middleware contexts.
+ * Reads existing responses from state (resume case) but never writes to it.
+ * On first run (no response), throws InterruptError with a locally-created Interrupt.
+ *
+ * @param interruptState - The agent's interrupt state (read-only access)
+ * @param idPrefix - Prefix for the interrupt ID (e.g., 'middleware:agentStream')
+ */
+function createMiddlewareInterrupt(
+  interruptState: InterruptState,
+  idPrefix: string
+): <T = JSONValue>(params: InterruptParams) => MiddlewareInterruptResult<T> {
+  return <T = JSONValue>(params: InterruptParams): MiddlewareInterruptResult<T> => {
+    const interruptId = `${idPrefix}:${params.name}`
+    const existing = interruptState.interrupts[interruptId]
+    if (existing?.response !== undefined) {
+      return { response: existing.response as T }
+    }
+    if (params.response !== undefined) {
+      return { response: params.response as T }
+    }
+    const interrupt = new Interrupt({
+      id: interruptId,
+      name: params.name,
+      ...(params.reason !== undefined && { reason: params.reason }),
+    })
+    throw new InterruptError(interrupt)
+  }
+}
+
+/**
  * Orchestrates the interaction between a model, a set of tools, and MCP clients.
  * The Agent is responsible for managing the lifecycle of tools and clients
  * and invoking the core decision-making loop.
@@ -357,6 +407,7 @@ export class Agent implements LocalAgent, InvokableAgent {
   public readonly memoryManager?: MemoryManager | undefined
 
   private readonly _hooksRegistry: HookRegistryImplementation
+  private readonly _middlewareRegistry: MiddlewareRegistry
   private readonly _pluginRegistry: PluginRegistry
   private readonly _interventionRegistry: InterventionRegistry
   private _toolRegistry: ToolRegistry
@@ -424,6 +475,9 @@ export class Agent implements LocalAgent, InvokableAgent {
     this._hooksRegistry = new HookRegistryImplementation()
 
     this._interventionRegistry = new InterventionRegistry(config?.interventions ?? [], this._hooksRegistry)
+
+    // Initialize middleware registry
+    this._middlewareRegistry = new MiddlewareRegistry()
 
     // `undefined` (omitted) → install the default; `null`/`[]` → explicit opt-out.
     const retryStrategies: RetryStrategy[] =
@@ -522,6 +576,107 @@ export class Agent implements LocalAgent, InvokableAgent {
     options?: HookCallbackOptions
   ): HookCleanup {
     return this._hooksRegistry.addCallback(eventType, callback, options)
+  }
+
+  /**
+   * Register an Input phase handler that transforms context before execution.
+   * Input handlers run before Around and Output handlers.
+   *
+   * @example
+   * ```typescript
+   * agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
+   *   ...context,
+   *   systemPrompt: injectToSystemPrompt(context),
+   * }))
+   * ```
+   */
+  addMiddleware<TContext, TResult, TEvent>(
+    phase: MiddlewareInputPhase<TContext, TResult, TEvent>,
+    handler: MiddlewareInputHandler<TContext>
+  ): () => void
+  /**
+   * Register an Output phase handler that transforms the result after execution.
+   * Output handlers see the result after Around handlers complete.
+   * Execution order: Input → Around → Output.
+   *
+   * @example
+   * ```typescript
+   * agent.addMiddleware(InvokeModelStage.Output, async (result) => {
+   *   log(`Model returned stopReason=${result.result.stopReason}`)
+   *   return result
+   * })
+   * ```
+   */
+  addMiddleware<TContext, TResult, TEvent>(
+    phase: MiddlewareOutputPhase<TContext, TResult, TEvent>,
+    handler: MiddlewareOutputHandler<TResult>
+  ): () => void
+  /**
+   * Register a middleware handler for a given stage (Around phase).
+   * Middleware wraps stage execution and can intercept, transform, or short-circuit operations.
+   *
+   * @param stage - The stage token identifying the interception point
+   * @param handler - The middleware handler function (async generator)
+   * @returns A cleanup function that removes the middleware when called
+   *
+   * @example
+   * ```typescript
+   * const cleanup = agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+   *   const start = Date.now()
+   *   const result = yield* next(context)
+   *   console.log(`Model call took ${Date.now() - start}ms`)
+   *   return result
+   * })
+   *
+   * // Later, remove the middleware:
+   * cleanup()
+   * ```
+   */
+  addMiddleware<TContext, TResult, TEvent>(
+    stage: MiddlewareStage<TContext, TResult, TEvent>,
+    handler: MiddlewareHandler<TContext, TResult, TEvent>
+  ): () => void
+  addMiddleware<TContext, TResult, TEvent>(
+    stageOrPhase:
+      | MiddlewareStage<TContext, TResult, TEvent>
+      | MiddlewareInputPhase<TContext, TResult, TEvent>
+      | MiddlewareOutputPhase<TContext, TResult, TEvent>,
+    handler:
+      | MiddlewareHandler<TContext, TResult, TEvent>
+      | MiddlewareInputHandler<TContext>
+      | MiddlewareOutputHandler<TResult>
+  ): () => void {
+    if ('_phase' in stageOrPhase) {
+      const phase = stageOrPhase as { _phase: MiddlewarePhaseKind; _stage: MiddlewareStage<TContext, TResult, TEvent> }
+      const stage = phase._stage
+      switch (phase._phase) {
+        case 'input': {
+          const adapted = this._middlewareRegistry.addInput(
+            stageOrPhase as MiddlewareInputPhase<TContext, TResult, TEvent>,
+            handler as MiddlewareInputHandler<TContext>
+          )
+          return () => this._middlewareRegistry.remove(stage, adapted)
+        }
+        case 'output': {
+          const adapted = this._middlewareRegistry.addOutput(
+            stageOrPhase as MiddlewareOutputPhase<TContext, TResult, TEvent>,
+            handler as MiddlewareOutputHandler<TResult>
+          )
+          return () => this._middlewareRegistry.remove(stage, adapted)
+        }
+        case 'around': {
+          const aroundHandler = handler as MiddlewareHandler<TContext, TResult, TEvent>
+          this._middlewareRegistry.add(stage, aroundHandler)
+          return () => this._middlewareRegistry.remove(stage, aroundHandler)
+        }
+        default:
+          throw new Error(`Unknown middleware phase: ${(phase as { _phase: string })._phase}`)
+      }
+    }
+    const stage = stageOrPhase as MiddlewareStage<TContext, TResult, TEvent>
+    const aroundHandler = handler as MiddlewareHandler<TContext, TResult, TEvent>
+    this._middlewareRegistry.add(stage, aroundHandler)
+    return () => this._middlewareRegistry.remove(stage, aroundHandler)
   }
 
   public async initialize(): Promise<void> {
@@ -795,92 +950,162 @@ export class Agent implements LocalAgent, InvokableAgent {
     try {
       await this.initialize()
 
-      let currentArgs: InvokeArgs = args
+      // Process interrupt responses before middleware runs so context.interrupt() can find them
+      const interruptResponses = this._extractInterruptResponses(args)
+      if (interruptResponses.length > 0) {
+        this._interruptState.resume(interruptResponses)
+      }
 
-      // Outer loop: re-enters _stream when a hook sets AfterInvocationEvent.resume.
-      // One invocation lock spans the whole resume chain.
-      while (true) {
-        // Fresh AbortController per invocation iteration, composed with any external signal.
-        this._abortController = new AbortController()
-        this._abortSignal = options?.cancelSignal
-          ? AbortSignal.any([this._abortController.signal, options.cancelSignal])
-          : this._abortController.signal
+      const context: AgentStreamContext = {
+        agent: this,
+        args,
+        ...(options !== undefined && { options }),
+        interrupt: createMiddlewareInterrupt(this._interruptState, 'middleware:agentStream'),
+      }
 
-        const streamGenerator = this._stream(currentArgs, options)
-        let caughtError: Error | undefined
-        let lastAfterInvocation: AfterInvocationEvent | undefined
-        let iterationResult: IteratorResult<AgentStreamEvent, AgentResult>
-        try {
-          iterationResult = await streamGenerator.next()
-
-          while (!iterationResult.done) {
-            try {
-              const processed = await this._invokeCallbacks(iterationResult.value)
-              if (processed instanceof AfterInvocationEvent) {
-                lastAfterInvocation = processed
-              }
-              yield processed
-              iterationResult = await streamGenerator.next()
-            } catch (error) {
-              // Throw interrupt errors back into _stream so executeTools can store the
-              // assistant message as pending execution state for resume.
-              if (error instanceof InterruptError) {
-                iterationResult = await streamGenerator.throw(error)
-              } else {
-                throw error
-              }
-            }
+      // async function* doesn't bind lexical `this`; capture for the terminal callback.
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this
+      try {
+        const { result } = yield* this._middlewareRegistry.invoke(
+          AgentStreamStage,
+          context,
+          async function* (ctx: AgentStreamContext): AsyncGenerator<AgentStreamEvent, AgentStreamResult, undefined> {
+            const result = yield* self._streamWithResumeLoop(ctx.args, ctx.options)
+            return { result }
           }
-
-          // Suppress AgentResultEvent for resumed iterations — only the final
-          // invocation in a resume chain reports an agent result.
-          if (lastAfterInvocation?.resume === undefined) {
-            yield await this._invokeCallbacks(
-              new AgentResultEvent({
-                agent: this,
-                result: iterationResult.value,
-                invocationState: iterationResult.value.invocationState,
-              })
-            )
+        )
+        return result
+      } catch (error) {
+        if (error instanceof InterruptError) {
+          // Handles interrupts raised by AgentStreamStage middleware (before the agent loop starts).
+          // Tool/hook interrupts are caught separately in _stream() since they propagate through
+          // the agent loop and produce an AgentResult internally.
+          //
+          // We intentionally don't call _createInterruptResult() here because middleware
+          // is stateless during execution — agent state (e.g. _isInvoking) is only modified
+          // at the edges, so we construct the result directly.
+          const invocationState = options?.invocationState ?? {}
+          for (const interrupt of error.interrupts) {
+            this._interruptState.getOrCreateInterrupt(interrupt.id, interrupt.name, interrupt.reason)
           }
-        } catch (error) {
-          caughtError = error as Error
-          throw error
-        } finally {
-          // Drain _stream() so cleanup hooks and printer still fire.
-          // Yield only on error (consumer may still be iterating); on a consumer
-          // break, yielding would suspend the generator and leak the lock.
-          let drainResult = await streamGenerator.return(undefined as never)
-          while (!drainResult.done) {
-            try {
-              if (caughtError) {
-                yield await this._invokeCallbacks(drainResult.value)
-              } else {
-                await this._invokeCallbacks(drainResult.value)
-              }
-            } catch (error) {
-              logger.warn(
-                `event_type=<${drainResult.value.type}>, error=<${error}> | error invoking callbacks during cleanup`
-              )
-            }
-            drainResult = await streamGenerator.next()
+          this._interruptState.activate()
+          for (const interrupt of error.interrupts) {
+            yield new InterruptEvent({ agent: this, interrupt, invocationState })
           }
-
-          // Reset controller and signal for next iteration / invocation
-          this._abortController = new AbortController()
-          this._abortSignal = this._abortController.signal
+          return new AgentResult({
+            stopReason: 'interrupt',
+            lastMessage: new Message({ role: 'assistant', content: [] }),
+            traces: this._tracer.localTraces,
+            metrics: this._meter.metrics,
+            interrupts: this._interruptState.getUnansweredInterrupts(),
+            invocationState,
+          })
         }
-
-        // Resume only on a clean invocation — errors propagate above.
-        if (lastAfterInvocation?.resume !== undefined) {
-          currentArgs = lastAfterInvocation.resume
-          continue
-        }
-
-        return iterationResult.value
+        throw error
       }
     } finally {
       this._isInvoking = false
+    }
+  }
+
+  /**
+   * Internal stream logic with the outer resume loop.
+   * Extracted to allow AgentStreamStage middleware to wrap it as a terminal function.
+   */
+  private async *_streamWithResumeLoop(
+    args: InvokeArgs,
+    options?: InvokeOptions
+  ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
+    let currentArgs: InvokeArgs = args
+
+    // Outer loop: re-enters _stream when a hook sets AfterInvocationEvent.resume.
+    // One invocation lock spans the whole resume chain.
+    while (true) {
+      // Fresh AbortController per invocation iteration, composed with any external signal.
+      this._abortController = new AbortController()
+      this._abortSignal = options?.cancelSignal
+        ? AbortSignal.any([this._abortController.signal, options.cancelSignal])
+        : this._abortController.signal
+
+      const streamGenerator = this._stream(currentArgs, options)
+      let caughtError: Error | undefined
+      let lastAfterInvocation: AfterInvocationEvent | undefined
+      let iterationResult: IteratorResult<AgentStreamEvent, AgentResult>
+      try {
+        iterationResult = await streamGenerator.next()
+
+        while (!iterationResult.done) {
+          try {
+            const processed = await this._invokeCallbacks(iterationResult.value)
+            if (processed instanceof AfterInvocationEvent) {
+              lastAfterInvocation = processed
+            }
+            yield processed
+            iterationResult = await streamGenerator.next()
+          } catch (error) {
+            // Throw interrupt errors back into _stream so executeTools can store the
+            // assistant message as pending execution state for resume.
+            if (error instanceof InterruptError) {
+              iterationResult = await streamGenerator.throw(error)
+            } else {
+              throw error
+            }
+          }
+        }
+
+        // Suppress AgentResultEvent for resumed iterations — only the final
+        // invocation in a resume chain reports an agent result.
+        if (lastAfterInvocation?.resume === undefined) {
+          yield await this._invokeCallbacks(
+            new AgentResultEvent({
+              agent: this,
+              result: iterationResult.value,
+              invocationState: iterationResult.value.invocationState,
+            })
+          )
+        }
+      } catch (error) {
+        caughtError = error as Error
+        throw error
+      } finally {
+        // Drain _stream() so cleanup hooks and printer still fire.
+        // Yield only on error (consumer may still be iterating); on a consumer
+        // break, yielding would suspend the generator and leak the lock.
+        let drainResult = await streamGenerator.return(undefined as never)
+        while (!drainResult.done) {
+          try {
+            if (caughtError) {
+              yield await this._invokeCallbacks(drainResult.value)
+            } else {
+              await this._invokeCallbacks(drainResult.value)
+            }
+          } catch (error) {
+            logger.warn(
+              `event_type=<${drainResult.value.type}>, error=<${error}> | error invoking callbacks during cleanup`
+            )
+          }
+          drainResult = await streamGenerator.next()
+        }
+
+        // Reset controller and signal for next iteration / invocation
+        this._abortController = new AbortController()
+        this._abortSignal = this._abortController.signal
+      }
+
+      // Resume only on a clean invocation — errors propagate above.
+      if (lastAfterInvocation?.resume !== undefined) {
+        currentArgs = lastAfterInvocation.resume
+        // Apply any interrupt responses carried in the resume args so middleware
+        // sees them as answered on the next iteration.
+        const resumeInterruptResponses = this._extractInterruptResponses(currentArgs)
+        if (resumeInterruptResponses.length > 0) {
+          this._interruptState.resume(resumeInterruptResponses)
+        }
+        continue
+      }
+
+      return iterationResult.value
     }
   }
 
@@ -1018,11 +1243,10 @@ export class Agent implements LocalAgent, InvokableAgent {
     // agent loop cycles within this invocation.
     const invocationState: InvocationState = options?.invocationState ?? {}
 
-    // Handle interrupt responses if present in input
+    // Interrupt responses are already consumed in stream() before middleware
+    // runs (so middleware-level interrupt() can find them). Re-extract here
+    // to gate the "non-interrupt input while interrupted" check below.
     const interruptResponses = this._extractInterruptResponses(args)
-    if (interruptResponses.length > 0) {
-      this._interruptState.resume(interruptResponses)
-    }
 
     // Reject non-interrupt input while in interrupted state
     if (this._interruptState.activated && interruptResponses.length === 0) {
@@ -1283,6 +1507,11 @@ export class Agent implements LocalAgent, InvokableAgent {
         return result
       }
       if (error instanceof InterruptError) {
+        // Handles interrupts from tools/hooks that propagated up through the agent loop.
+        // AgentStreamStage middleware interrupts are caught separately in stream().
+        for (const interrupt of error.interrupts) {
+          this._interruptState.getOrCreateInterrupt(interrupt.id, interrupt.name, interrupt.reason)
+        }
         // Fan out one event per interrupt. Each event exposes `interrupt.source` so
         // consumers can filter by origin (tool callback vs hook callback) without
         // subscribing to separate event types.
@@ -1528,7 +1757,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       })
 
       try {
-        const result = yield* this._streamFromModel(this.messages, streamOptions, invocationState)
+        const result = yield* this._invokeModelWithMiddleware(invocationState, toolChoice)
 
         // Accumulate token usage and model latency metrics
         this._meter.updateCycle(result.metadata)
@@ -1610,6 +1839,55 @@ export class Agent implements LocalAgent, InvokableAgent {
         throw error
       }
     }
+  }
+
+  /**
+   * Invokes the model through the InvokeModelStage middleware chain.
+   * Builds an InvokeModelContext from current agent state and composes the
+   * middleware chain with a terminal function that calls _streamFromModel
+   * using context fields directly (not re-derived from the agent).
+   *
+   * @param invocationState - Per-invocation state shared across hooks and tools
+   * @param toolChoice - Optional tool choice to force specific tool usage
+   * @returns StreamAggregatedResult from the model (or middleware short-circuit)
+   */
+  private async *_invokeModelWithMiddleware(
+    invocationState: InvocationState,
+    toolChoice?: ToolChoice
+  ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
+    const context: InvokeModelContext = {
+      agent: this,
+      messages: this.messages,
+      ...(this.systemPrompt !== undefined && { systemPrompt: this.systemPrompt }),
+      toolSpecs: this._toolRegistry.list().map((tool) => tool.toolSpec),
+      ...(toolChoice !== undefined && { toolChoice }),
+      modelState: this.modelState,
+      invocationState,
+    }
+
+    // async function* doesn't bind lexical `this`; capture for the terminal callback.
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this
+    const middlewareResult = yield* this._middlewareRegistry.invoke(
+      InvokeModelStage,
+      context,
+      async function* (ctx: InvokeModelContext): AsyncGenerator<AgentStreamEvent, InvokeModelResult, undefined> {
+        const streamOptions: StreamOptions = {
+          toolSpecs: ctx.toolSpecs as ToolSpec[],
+          modelState: ctx.modelState,
+          ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),
+          ...(ctx.toolChoice && { toolChoice: ctx.toolChoice }),
+        }
+        const gen = self._streamFromModel(ctx.messages as Message[], streamOptions, ctx.invocationState)
+        let iterResult = await gen.next()
+        while (!iterResult.done) {
+          yield iterResult.value
+          iterResult = await gen.next()
+        }
+        return { result: iterResult.value }
+      }
+    )
+    return middlewareResult.result
   }
 
   /**
@@ -2060,90 +2338,9 @@ export class Agent implements LocalAgent, InvokableAgent {
         return afterToolCallEvent.result
       }
 
-      // Start tool span within loop span context
-      const toolSpan = this._tracer.startToolCallSpan({
-        tool: toolUse,
-      })
-
-      // Track tool execution time for metrics
-      const toolStartTime = Date.now()
-
-      let toolResult: ToolResultBlock
-      let error: Error | undefined
-
-      if (!effectiveTool) {
-        // Tool not found
-        toolResult = new ToolResultBlock({
-          toolUseId: toolUse.toolUseId,
-          status: 'error',
-          content: [new TextBlock(`Tool '${toolUse.name}' not found in registry`)],
-        })
-      } else {
-        // Execute tool within the tool span context
-        const toolContext: ToolContext = {
-          toolUse: {
-            name: toolUse.name,
-            toolUseId: toolUse.toolUseId,
-            input: toolUse.input,
-          },
-          agent: this,
-          invocationState,
-          interrupt: <T = JSONValue>(params: InterruptParams): T => {
-            return interruptFromAgent<T>(this, `tool:${toolUseBlock.toolUseId}:${params.name}`, params, 'tool')
-          },
-        }
-
-        try {
-          // Manually iterate tool stream to wrap each ToolStreamEvent in ToolStreamUpdateEvent.
-          // This keeps the tool authoring interface unchanged — tools construct ToolStreamEvent
-          // without knowledge of agents or hooks, and we wrap at the boundary.
-          // Tool execution is ran within the tool span's context so that
-          // downstream calls (e.g., MCP clients) can propagate trace context
-          const toolGenerator = this._tracer.withSpanContext(toolSpan, () => effectiveTool.stream(toolContext))
-          let toolNext = await this._tracer.withSpanContext(toolSpan, () => toolGenerator.next())
-          while (!toolNext.done) {
-            yield new ToolStreamUpdateEvent({ agent: this, event: toolNext.value, invocationState })
-            toolNext = await this._tracer.withSpanContext(toolSpan, () => toolGenerator.next())
-          }
-          const result = toolNext.value
-
-          if (!result) {
-            // Tool didn't return a result
-            toolResult = new ToolResultBlock({
-              toolUseId: toolUse.toolUseId,
-              status: 'error',
-              content: [new TextBlock(`Tool '${toolUse.name}' did not return a result`)],
-            })
-          } else {
-            toolResult = result
-            error = result.error
-          }
-        } catch (e) {
-          // Re-throw InterruptError to allow interrupt handling
-          if (e instanceof InterruptError) {
-            throw e
-          }
-          // Tool execution failed with error
-          error = normalizeError(e)
-          toolResult = new ToolResultBlock({
-            toolUseId: toolUse.toolUseId,
-            status: 'error',
-            content: [new TextBlock(error.message)],
-            error,
-          })
-        }
-      }
-
-      // End tool span with the raw tool result — telemetry reflects what the
-      // tool actually returned, independent of AfterToolCallEvent mutations.
-      this._tracer.endToolCallSpan(toolSpan, { toolResult, ...(error && { error }) })
-
-      // End tool metrics tracking
-      this._meter.endToolCall({
-        tool: toolUse,
-        duration: Date.now() - toolStartTime,
-        success: toolResult.status === 'success',
-      })
+      // Execute tool core logic through middleware chain
+      const toolResult = yield* this._executeToolWithMiddleware(effectiveTool, toolUse, invocationState)
+      const error = toolResult.error
 
       // Single point for AfterToolCallEvent
       const afterToolCallEvent = new AfterToolCallEvent({
@@ -2164,6 +2361,130 @@ export class Agent implements LocalAgent, InvokableAgent {
       // to ToolResultEvent and the conversation message the model will see.
       return afterToolCallEvent.result
     }
+  }
+
+  private async *_executeToolWithMiddleware(
+    tool: Tool | undefined,
+    toolUse: ToolUseData,
+    invocationState: InvocationState
+  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
+    const context: ExecuteToolContext = {
+      agent: this,
+      tool,
+      toolUse: {
+        name: toolUse.name,
+        toolUseId: toolUse.toolUseId,
+        input: toolUse.input,
+      },
+      invocationState,
+      interrupt: createMiddlewareInterrupt(this._interruptState, `middleware:executeTool:${toolUse.toolUseId}`),
+    }
+
+    // async function* doesn't bind lexical `this`; capture for the terminal callback.
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this
+    const middlewareResult = yield* this._middlewareRegistry.invoke(
+      ExecuteToolStage,
+      context,
+      async function* (ctx: ExecuteToolContext): AsyncGenerator<AgentStreamEvent, ExecuteToolResult, undefined> {
+        const result = yield* self._executeToolCore(ctx.tool, ctx.toolUse, ctx.invocationState)
+        return { result }
+      }
+    )
+    return middlewareResult.result
+  }
+
+  private async *_executeToolCore(
+    effectiveTool: Tool | undefined,
+    toolUse: ToolUseData,
+    invocationState: InvocationState
+  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
+    // Start tool span within loop span context
+    const toolSpan = this._tracer.startToolCallSpan({
+      tool: toolUse,
+    })
+
+    // Track tool execution time for metrics
+    const toolStartTime = Date.now()
+
+    let toolResult: ToolResultBlock
+    let error: Error | undefined
+
+    if (!effectiveTool) {
+      // Tool not found
+      toolResult = new ToolResultBlock({
+        toolUseId: toolUse.toolUseId,
+        status: 'error',
+        content: [new TextBlock(`Tool '${toolUse.name}' not found in registry`)],
+      })
+    } else {
+      // Execute tool within the tool span context
+      const toolContext: ToolContext = {
+        toolUse: {
+          name: toolUse.name,
+          toolUseId: toolUse.toolUseId,
+          input: toolUse.input,
+        },
+        agent: this,
+        invocationState,
+        interrupt: <T = JSONValue>(params: InterruptParams): T => {
+          return interruptFromAgent<T>(this, `tool:${toolUse.toolUseId}:${params.name}`, params, 'tool')
+        },
+      }
+
+      try {
+        // Manually iterate tool stream to wrap each ToolStreamEvent in ToolStreamUpdateEvent.
+        // This keeps the tool authoring interface unchanged — tools construct ToolStreamEvent
+        // without knowledge of agents or hooks, and we wrap at the boundary.
+        // Tool execution is ran within the tool span's context so that
+        // downstream calls (e.g., MCP clients) can propagate trace context
+        const toolGenerator = this._tracer.withSpanContext(toolSpan, () => effectiveTool.stream(toolContext))
+        let toolNext = await this._tracer.withSpanContext(toolSpan, () => toolGenerator.next())
+        while (!toolNext.done) {
+          yield new ToolStreamUpdateEvent({ agent: this, event: toolNext.value, invocationState })
+          toolNext = await this._tracer.withSpanContext(toolSpan, () => toolGenerator.next())
+        }
+        const result = toolNext.value
+
+        if (!result) {
+          // Tool didn't return a result
+          toolResult = new ToolResultBlock({
+            toolUseId: toolUse.toolUseId,
+            status: 'error',
+            content: [new TextBlock(`Tool '${toolUse.name}' did not return a result`)],
+          })
+        } else {
+          toolResult = result
+          error = result.error
+        }
+      } catch (e) {
+        // Re-throw InterruptError to allow interrupt handling
+        if (e instanceof InterruptError) {
+          throw e
+        }
+        // Tool execution failed with error
+        error = normalizeError(e)
+        toolResult = new ToolResultBlock({
+          toolUseId: toolUse.toolUseId,
+          status: 'error',
+          content: [new TextBlock(error.message)],
+          error,
+        })
+      }
+    }
+
+    // End tool span with the raw tool result — telemetry reflects what the
+    // tool actually returned, independent of AfterToolCallEvent mutations.
+    this._tracer.endToolCallSpan(toolSpan, { toolResult, ...(error && { error }) })
+
+    // End tool metrics tracking
+    this._meter.endToolCall({
+      tool: toolUse,
+      duration: Date.now() - toolStartTime,
+      success: toolResult.status === 'success',
+    })
+
+    return toolResult
   }
 
   /**

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -307,6 +307,24 @@ export { Sandbox, type ExecuteOptions } from './sandbox/base.js'
 export { PosixShellSandbox } from './sandbox/posix-shell.js'
 export type { StreamType, StreamChunk, FileInfo, OutputFile, ExecutionResult } from './sandbox/types.js'
 
+// Middleware system
+export { createStage, InvokeModelStage, ExecuteToolStage, AgentStreamStage } from './middleware/index.js'
+export type {
+  MiddlewareStage,
+  MiddlewareHandler,
+  MiddlewareNext,
+  MiddlewareHandlerOf,
+  MiddlewareNextOf,
+  InvokeModelContext,
+  InvokeModelResult,
+  ExecuteToolContext,
+  ExecuteToolResult,
+  AgentStreamContext,
+  AgentStreamResult,
+  MiddlewareInterruptResult,
+  MiddlewareInterruptible,
+} from './middleware/index.js'
+
 // Multi-agent orchestration
 export { Graph } from './multiagent/index.js'
 export { Swarm } from './multiagent/index.js'

--- a/strands-ts/src/middleware/__tests__/agent-middleware.test.ts
+++ b/strands-ts/src/middleware/__tests__/agent-middleware.test.ts
@@ -1,0 +1,1534 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Agent } from '../../agent/agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import { AgentStreamStage, ExecuteToolStage, InvokeModelStage } from '../stages.js'
+import type {
+  AgentStreamContext,
+  ExecuteToolContext,
+  InvokeModelContext,
+  ExecuteToolResult,
+  AgentStreamResult,
+} from '../stages.js'
+import type { MiddlewareHandler, MiddlewareHandlerOf } from '../types.js'
+import type { AgentStreamEvent, AgentResult, LocalAgent } from '../../types/agent.js'
+import type { Plugin } from '../../plugins/plugin.js'
+import { TextBlock, ToolResultBlock, Message } from '../../types/messages.js'
+import {
+  AfterToolCallEvent,
+  BeforeModelCallEvent,
+  AfterModelCallEvent,
+  BeforeToolCallEvent,
+  ContentBlockEvent,
+} from '../../hooks/events.js'
+import type { ToolContext } from '../../tools/tool.js'
+
+type ExecuteToolMiddleware = MiddlewareHandler<ExecuteToolContext, ExecuteToolResult, AgentStreamEvent>
+type AgentStreamMiddleware = MiddlewareHandler<AgentStreamContext, AgentStreamResult, AgentStreamEvent>
+
+describe('Agent middleware integration — InvokeModelStage', () => {
+  describe('addMiddleware registers handler and it executes on model call', () => {
+    it('middleware handler is invoked during model call', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const middlewareCalled = vi.fn()
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        middlewareCalled()
+        return yield* next(context)
+      })
+
+      await agent.invoke('Test prompt')
+
+      expect(middlewareCalled).toHaveBeenCalledOnce()
+    })
+
+    it('middleware receives InvokeModelContext with correct fields', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success' as const,
+            content: [new TextBlock('ok')],
+          })
+      )
+      const agent = new Agent({ model, tools: [tool], printer: false, systemPrompt: 'Be helpful' })
+
+      let receivedContext: InvokeModelContext | undefined
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        receivedContext = context
+        return yield* next(context)
+      })
+
+      await agent.invoke('Test prompt')
+
+      expect(receivedContext?.agent).toBe(agent)
+      expect(receivedContext).toMatchObject({
+        systemPrompt: 'Be helpful',
+        messages: expect.arrayContaining([expect.any(Message)]),
+        toolSpecs: expect.arrayContaining([expect.objectContaining({ name: 'testTool' })]),
+        modelState: expect.anything(),
+        invocationState: expect.anything(),
+      })
+    })
+
+    it('middleware result is used as the model call result', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        const result = yield* next(context)
+        return result
+      })
+
+      const result = await agent.invoke('Test prompt')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content).toEqual([new TextBlock('Hello')])
+    })
+  })
+
+  describe('middleware can short-circuit model call with synthetic result', () => {
+    it('returns synthetic result without calling the model', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Real response' })
+      const agent = new Agent({ model, printer: false })
+
+      agent.addMiddleware(
+        InvokeModelStage,
+        // eslint-disable-next-line require-yield
+        async function* () {
+          return {
+            result: {
+              message: new Message({ role: 'assistant', content: [new TextBlock('Cached response')] }),
+              stopReason: 'endTurn' as const,
+            },
+          }
+        }
+      )
+
+      const result = await agent.invoke('Test prompt')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content).toEqual([new TextBlock('Cached response')])
+    })
+
+    it('model is not called when middleware short-circuits', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Real response' })
+      const agent = new Agent({ model, printer: false })
+
+      const streamSpy = vi.spyOn(model, 'stream')
+
+      agent.addMiddleware(
+        InvokeModelStage,
+        // eslint-disable-next-line require-yield
+        async function* () {
+          return {
+            result: {
+              message: new Message({ role: 'assistant', content: [new TextBlock('Cached')] }),
+              stopReason: 'endTurn' as const,
+            },
+          }
+        }
+      )
+
+      await agent.invoke('Test prompt')
+
+      expect(streamSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('middleware can transform context (messages, toolSpecs) before model call', () => {
+    it('modified messages are passed to the model', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        const modifiedContext: InvokeModelContext = {
+          ...context,
+          messages: [...context.messages, new Message({ role: 'user', content: [new TextBlock('Injected message')] })],
+        }
+        return yield* next(modifiedContext)
+      })
+
+      const streamSpy = vi.spyOn(model, 'stream')
+
+      await agent.invoke('Test prompt')
+
+      expect(streamSpy).toHaveBeenCalled()
+      const calledMessages = streamSpy.mock.calls[0]![0]
+      expect(calledMessages.length).toBeGreaterThan(1)
+    })
+
+    it('modified toolSpecs are passed to the model', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        const modifiedContext: InvokeModelContext = {
+          ...context,
+          toolSpecs: [],
+        }
+        return yield* next(modifiedContext)
+      })
+
+      const streamSpy = vi.spyOn(model, 'stream')
+
+      await agent.invoke('Test prompt')
+
+      expect(streamSpy).toHaveBeenCalled()
+      const calledOptions = streamSpy.mock.calls[0]![1]
+      expect(calledOptions?.toolSpecs).toStrictEqual([])
+    })
+  })
+
+  describe('hooks fire around middleware', () => {
+    it('BeforeModelCallEvent fires before middleware executes', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const order: string[] = []
+
+      agent.addHook(BeforeModelCallEvent, () => {
+        order.push('beforeModelCall')
+      })
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        order.push('middleware')
+        return yield* next(context)
+      })
+
+      await agent.invoke('Test prompt')
+
+      expect(order.indexOf('beforeModelCall')).toBeLessThan(order.indexOf('middleware'))
+    })
+
+    it('AfterModelCallEvent fires after middleware completes', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const order: string[] = []
+
+      agent.addHook(AfterModelCallEvent, () => {
+        order.push('afterModelCall')
+      })
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        order.push('middleware-start')
+        const result = yield* next(context)
+        order.push('middleware-end')
+        return result
+      })
+
+      await agent.invoke('Test prompt')
+
+      expect(order.indexOf('middleware-end')).toBeLessThan(order.indexOf('afterModelCall'))
+    })
+
+    it('Before/After hooks fire even when middleware short-circuits', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const beforeCalled = vi.fn()
+      const afterCalled = vi.fn()
+
+      agent.addHook(BeforeModelCallEvent, beforeCalled)
+      agent.addHook(AfterModelCallEvent, afterCalled)
+
+      agent.addMiddleware(
+        InvokeModelStage,
+        // eslint-disable-next-line require-yield
+        async function* () {
+          return {
+            result: {
+              message: new Message({ role: 'assistant', content: [new TextBlock('Cached')] }),
+              stopReason: 'endTurn' as const,
+            },
+          }
+        }
+      )
+
+      await agent.invoke('Test prompt')
+
+      expect(beforeCalled).toHaveBeenCalled()
+      expect(afterCalled).toHaveBeenCalled()
+    })
+  })
+
+  describe('addMiddleware returns cleanup function', () => {
+    it('returns a function that removes the middleware', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'textBlock', text: 'First' })
+        .addTurn({ type: 'textBlock', text: 'Second' })
+
+      const agent = new Agent({ model, printer: false })
+
+      let middlewareCalled = false
+      const cleanup = agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        middlewareCalled = true
+        return yield* next(context)
+      })
+
+      await agent.invoke('First call')
+      expect(middlewareCalled).toBe(true)
+
+      middlewareCalled = false
+      cleanup()
+
+      await agent.invoke('Second call')
+      expect(middlewareCalled).toBe(false)
+    })
+
+    it('only removes the specific handler, not others on the same stage', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Result' })
+
+      const agent = new Agent({ model, printer: false })
+
+      const calls: string[] = []
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        calls.push('keeper')
+        return yield* next(context)
+      })
+      const cleanup = agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        calls.push('removed')
+        return yield* next(context)
+      })
+
+      cleanup()
+      await agent.invoke('Test')
+      expect(calls).toStrictEqual(['keeper'])
+    })
+  })
+
+  describe('no middleware registered', () => {
+    it('agent works correctly without any middleware', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const result = await agent.invoke('Test prompt')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content).toEqual([new TextBlock('Hello')])
+    })
+
+    it('agent with tools works correctly without middleware', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success' as const,
+            content: [new TextBlock('Tool executed')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const result = await agent.invoke('Use the tool')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content).toEqual([new TextBlock('Done')])
+    })
+
+    it('stream works correctly without middleware', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const { result } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content).toEqual([new TextBlock('Hello')])
+    })
+  })
+})
+
+describe('AgentStreamStage integration', () => {
+  describe('middleware wraps the entire agent stream', () => {
+    it('middleware executes around the full agent stream', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const callOrder: string[] = []
+
+      const middleware: AgentStreamMiddleware = async function* (context, next) {
+        callOrder.push('middleware-before')
+        const result = yield* next(context)
+        callOrder.push('middleware-after')
+        return result
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      const { result } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(callOrder).toStrictEqual(['middleware-before', 'middleware-after'])
+      expect(result.stopReason).toBe('endTurn')
+    })
+
+    it('middleware receives AgentStreamContext with agent, args, and options', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      let receivedContext: AgentStreamContext | undefined
+
+      const middleware: AgentStreamMiddleware = async function* (context, next) {
+        receivedContext = context
+        return yield* next(context)
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      await collectGenerator(agent.stream('Test prompt'))
+
+      expect(receivedContext).toBeDefined()
+      expect(receivedContext!.agent).toBe(agent)
+      expect(receivedContext!.args).toBe('Test prompt')
+    })
+
+    it('middleware receives options when provided', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      let receivedContext: AgentStreamContext | undefined
+      const options = { invocationState: { key: 'value' } }
+
+      const middleware: AgentStreamMiddleware = async function* (context, next) {
+        receivedContext = context
+        return yield* next(context)
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      await collectGenerator(agent.stream('Test prompt', options))
+
+      expect(receivedContext!.options).toBe(options)
+    })
+
+    it('middleware can short-circuit the entire agent stream', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Should not reach' })
+      const agent = new Agent({ model, printer: false })
+
+      // eslint-disable-next-line require-yield
+      const middleware: AgentStreamMiddleware = async function* () {
+        return {
+          result: {
+            stopReason: 'endTurn',
+            lastMessage: { type: 'message', role: 'assistant', content: [] },
+            metrics: { cycleCount: 0, accumulatedUsage: {}, accumulatedMetrics: {}, toolMetrics: {} },
+            invocationState: {},
+          } as unknown as AgentResult,
+        }
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      const { items, result } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(items).toStrictEqual([])
+      expect(result.stopReason).toBe('endTurn')
+    })
+
+    it('multiple middleware execute in registration order', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const callOrder: string[] = []
+
+      const outer: AgentStreamMiddleware = async function* (context, next) {
+        callOrder.push('outer-before')
+        const result = yield* next(context)
+        callOrder.push('outer-after')
+        return result
+      }
+
+      const inner: AgentStreamMiddleware = async function* (context, next) {
+        callOrder.push('inner-before')
+        const result = yield* next(context)
+        callOrder.push('inner-after')
+        return result
+      }
+
+      agent.addMiddleware(AgentStreamStage, outer)
+      agent.addMiddleware(AgentStreamStage, inner)
+
+      await collectGenerator(agent.stream('Test prompt'))
+
+      expect(callOrder).toStrictEqual(['outer-before', 'inner-before', 'inner-after', 'outer-after'])
+    })
+  })
+
+  describe('middleware can filter events from the stream', () => {
+    it('filters out specific event types', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const middleware: AgentStreamMiddleware = async function* (context, next) {
+        const gen = next(context)
+        let iterResult = await gen.next()
+        while (!iterResult.done) {
+          const event = iterResult.value
+          // Filter out modelStreamUpdate events
+          if (event.type !== 'modelStreamUpdateEvent') {
+            yield event
+          }
+          iterResult = await gen.next()
+        }
+        return iterResult.value
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      const { items } = await collectGenerator(agent.stream('Test prompt'))
+
+      const modelStreamEvents = items.filter((e: AgentStreamEvent) => e.type === 'modelStreamUpdateEvent')
+      expect(modelStreamEvents).toStrictEqual([])
+      // Other events should still be present
+      expect(items.length).toBeGreaterThan(0)
+    })
+
+    it('preserves the result when filtering events', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const middleware: AgentStreamMiddleware = async function* (context, next) {
+        const gen = next(context)
+        let iterResult = await gen.next()
+        while (!iterResult.done) {
+          const event = iterResult.value
+          if (event.type !== 'contentBlockEvent') {
+            yield event
+          }
+          iterResult = await gen.next()
+        }
+        return iterResult.value
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      const { result } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(result.stopReason).toBe('endTurn')
+    })
+
+    it('can suppress all events while still returning the result', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      // eslint-disable-next-line require-yield
+      const middleware: AgentStreamMiddleware = async function* (context, next) {
+        const gen = next(context)
+        let iterResult = await gen.next()
+        while (!iterResult.done) {
+          // Suppress all events — do not yield
+          iterResult = await gen.next()
+        }
+        return iterResult.value
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      const { items, result } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(items).toStrictEqual([])
+      expect(result.stopReason).toBe('endTurn')
+    })
+  })
+
+  describe('middleware can inject synthetic events', () => {
+    it('injects events before the stream', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const syntheticEvent = { type: 'contentBlockEvent' } as unknown as AgentStreamEvent
+
+      const middleware: AgentStreamMiddleware = async function* (context, next) {
+        yield syntheticEvent
+        return yield* next(context)
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      const { items } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(items[0]).toBe(syntheticEvent)
+      expect(items.length).toBeGreaterThan(1)
+    })
+
+    it('injects events after the stream', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const syntheticEvent = { type: 'contentBlockEvent' } as unknown as AgentStreamEvent
+
+      const middleware: AgentStreamMiddleware = async function* (context, next) {
+        const result = yield* next(context)
+        yield syntheticEvent
+        return result
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      const { items } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(items[items.length - 1]).toBe(syntheticEvent)
+    })
+
+    it('injects events alongside real events via manual iteration', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const syntheticEvent = { type: 'contentBlockEvent', synthetic: true } as unknown as AgentStreamEvent
+
+      const middleware: AgentStreamMiddleware = async function* (context, next) {
+        const gen = next(context)
+        let iterResult = await gen.next()
+        let injected = false
+        while (!iterResult.done) {
+          yield iterResult.value
+          if (!injected) {
+            yield syntheticEvent
+            injected = true
+          }
+          iterResult = await gen.next()
+        }
+        return iterResult.value
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      const { items } = await collectGenerator(agent.stream('Test prompt'))
+
+      // The synthetic event should appear after the first real event
+      expect(items[1]).toBe(syntheticEvent)
+      // Total events should include exactly one synthetic event
+      expect(items.filter((e: AgentStreamEvent) => e === syntheticEvent)).toHaveLength(1)
+    })
+
+    it('can yield events without calling next (pure synthetic stream)', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Should not reach' })
+      const agent = new Agent({ model, printer: false })
+
+      const syntheticEvent1 = { type: 'contentBlockEvent', id: 1 } as unknown as AgentStreamEvent
+      const syntheticEvent2 = { type: 'contentBlockEvent', id: 2 } as unknown as AgentStreamEvent
+
+      const middleware: AgentStreamMiddleware = async function* () {
+        yield syntheticEvent1
+        yield syntheticEvent2
+        return {
+          result: {
+            stopReason: 'endTurn',
+            lastMessage: { type: 'message', role: 'assistant', content: [] },
+            metrics: { cycleCount: 0, accumulatedUsage: {}, accumulatedMetrics: {}, toolMetrics: {} },
+            invocationState: {},
+          } as unknown as AgentResult,
+        }
+      }
+
+      agent.addMiddleware(AgentStreamStage, middleware)
+
+      const { items } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(items).toStrictEqual([syntheticEvent1, syntheticEvent2])
+    })
+  })
+
+  describe('no AgentStreamStage middleware registered', () => {
+    it('agent streams directly without middleware overhead', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const { items, result } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(items.length).toBeGreaterThan(0)
+    })
+
+    it('existing behavior is unchanged when no middleware is registered', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello world' })
+      const agent = new Agent({ model, printer: false })
+
+      const { items, result } = await collectGenerator(agent.stream('Test prompt'))
+
+      const beforeInvocation = items.find((e: AgentStreamEvent) => e.type === 'beforeInvocationEvent')
+      const afterInvocation = items.find((e: AgentStreamEvent) => e.type === 'afterInvocationEvent')
+      expect(beforeInvocation).toBeDefined()
+      expect(afterInvocation).toBeDefined()
+      expect(result.stopReason).toBe('endTurn')
+    })
+
+    it('middleware on other stages does not affect AgentStreamStage', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      // Register middleware on InvokeModelStage only
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        return yield* next(context)
+      })
+
+      const { result } = await collectGenerator(agent.stream('Test prompt'))
+
+      expect(result.stopReason).toBe('endTurn')
+    })
+  })
+})
+
+describe('ExecuteToolStage integration', () => {
+  describe('middleware executes around tool calls', () => {
+    it('middleware handler is invoked during tool execution', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: { x: 1 } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('executed')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const executionOrder: string[] = []
+
+      const middleware: ExecuteToolMiddleware = async function* (context, next) {
+        executionOrder.push('middleware:before')
+        const result = yield* next(context)
+        executionOrder.push('middleware:after')
+        return result
+      }
+
+      agent.addMiddleware(ExecuteToolStage, middleware)
+
+      await agent.invoke('Use the tool')
+
+      expect(executionOrder).toStrictEqual(['middleware:before', 'middleware:after'])
+    })
+
+    it('middleware receives ExecuteToolContext with correct fields', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: { key: 'val' } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('ok')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      let receivedContext: ExecuteToolContext | undefined
+
+      const middleware: ExecuteToolMiddleware = async function* (context, next) {
+        receivedContext = context
+        return yield* next(context)
+      }
+
+      agent.addMiddleware(ExecuteToolStage, middleware)
+
+      await agent.invoke('Use the tool')
+
+      expect(receivedContext).toBeDefined()
+      expect(receivedContext!.agent).toBe(agent)
+      expect(receivedContext!.tool).toBeDefined()
+      expect(receivedContext!.tool!.name).toBe('testTool')
+      expect(receivedContext!.toolUse).toStrictEqual({
+        name: 'testTool',
+        toolUseId: 'tool-1',
+        input: { key: 'val' },
+      })
+      expect(receivedContext!.invocationState).toBeDefined()
+    })
+
+    it('multiple middleware execute in registration order', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('ok')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const callOrder: string[] = []
+
+      const outer: ExecuteToolMiddleware = async function* (context, next) {
+        callOrder.push('outer-before')
+        const result = yield* next(context)
+        callOrder.push('outer-after')
+        return result
+      }
+
+      const inner: ExecuteToolMiddleware = async function* (context, next) {
+        callOrder.push('inner-before')
+        const result = yield* next(context)
+        callOrder.push('inner-after')
+        return result
+      }
+
+      agent.addMiddleware(ExecuteToolStage, outer)
+      agent.addMiddleware(ExecuteToolStage, inner)
+
+      await agent.invoke('Use the tool')
+
+      expect(callOrder).toStrictEqual(['outer-before', 'inner-before', 'inner-after', 'outer-after'])
+    })
+  })
+
+  describe('middleware can mock tool responses (short-circuit)', () => {
+    it('returns mock result without executing the real tool', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const toolFn = vi.fn(
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('real result')],
+          })
+      )
+
+      const tool = createMockTool('testTool', toolFn)
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      // eslint-disable-next-line require-yield
+      const middleware: ExecuteToolMiddleware = async function* (context) {
+        return {
+          result: new ToolResultBlock({
+            toolUseId: context.toolUse.toolUseId,
+            status: 'success',
+            content: [new TextBlock('mocked result')],
+          }),
+        }
+      }
+
+      agent.addMiddleware(ExecuteToolStage, middleware)
+
+      const result = await agent.invoke('Use the tool')
+
+      // The real tool function should NOT have been called
+      expect(toolFn).not.toHaveBeenCalled()
+      // The agent should still complete successfully
+      expect(result.stopReason).toBe('endTurn')
+    })
+
+    it('short-circuit result is used in the conversation', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Got the mocked data' })
+
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('real')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      // eslint-disable-next-line require-yield
+      const middleware: ExecuteToolMiddleware = async function* (context) {
+        return {
+          result: new ToolResultBlock({
+            toolUseId: context.toolUse.toolUseId,
+            status: 'success',
+            content: [new TextBlock('mocked data')],
+          }),
+        }
+      }
+
+      agent.addMiddleware(ExecuteToolStage, middleware)
+
+      await agent.invoke('Use the tool')
+
+      // The tool result message in conversation should contain the mocked result
+      const toolResultMessage = agent.messages.find(
+        (m: Message) => m.role === 'user' && m.content.some((c) => c.type === 'toolResultBlock')
+      )
+      expect(toolResultMessage).toBeDefined()
+      const toolResultBlock = toolResultMessage!.content.find((c: { type: string }) => c.type === 'toolResultBlock')
+      expect(toolResultBlock).toStrictEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('mocked data')],
+        })
+      )
+    })
+  })
+
+  describe('middleware can transform tool input via context modification', () => {
+    it('modified input reaches the tool', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: { value: 'original' } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let receivedInput: unknown
+
+      const tool = createMockTool('testTool', (context: ToolContext) => {
+        receivedInput = context.toolUse.input
+        return new ToolResultBlock({
+          toolUseId: context.toolUse.toolUseId,
+          status: 'success',
+          content: [new TextBlock('ok')],
+        })
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const middleware: ExecuteToolMiddleware = async function* (context, next) {
+        const modifiedContext: ExecuteToolContext = {
+          ...context,
+          toolUse: {
+            ...context.toolUse,
+            input: { value: 'transformed' },
+          },
+        }
+        return yield* next(modifiedContext)
+      }
+
+      agent.addMiddleware(ExecuteToolStage, middleware)
+
+      await agent.invoke('Use the tool')
+
+      expect(receivedInput).toStrictEqual({ value: 'transformed' })
+    })
+
+    it('original context is not mutated', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: { value: 'original' } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('ok')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      let originalInput: unknown
+
+      const middleware: ExecuteToolMiddleware = async function* (context, next) {
+        originalInput = context.toolUse.input
+        const modifiedContext: ExecuteToolContext = {
+          ...context,
+          toolUse: {
+            ...context.toolUse,
+            input: { value: 'modified' },
+          },
+        }
+        return yield* next(modifiedContext)
+      }
+
+      agent.addMiddleware(ExecuteToolStage, middleware)
+
+      await agent.invoke('Use the tool')
+
+      // The original context input should remain unchanged
+      expect(originalInput).toStrictEqual({ value: 'original' })
+    })
+  })
+
+  describe('hooks fire around middleware for tool execution', () => {
+    it('BeforeToolCallEvent fires before middleware, AfterToolCallEvent fires after', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('executed')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const executionOrder: string[] = []
+
+      agent.addHook(BeforeToolCallEvent, () => {
+        executionOrder.push('hook:beforeToolCall')
+      })
+
+      agent.addHook(AfterToolCallEvent, () => {
+        executionOrder.push('hook:afterToolCall')
+      })
+
+      const middleware: ExecuteToolMiddleware = async function* (context, next) {
+        executionOrder.push('middleware:before')
+        const result = yield* next(context)
+        executionOrder.push('middleware:after')
+        return result
+      }
+
+      agent.addMiddleware(ExecuteToolStage, middleware)
+
+      await agent.invoke('Use the tool')
+
+      // Hooks fire OUTSIDE middleware: Before hook → middleware → After hook
+      expect(executionOrder).toStrictEqual([
+        'hook:beforeToolCall',
+        'middleware:before',
+        'middleware:after',
+        'hook:afterToolCall',
+      ])
+    })
+
+    it('hooks fire even when middleware short-circuits', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('real')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const beforeCalled = vi.fn()
+      const afterCalled = vi.fn()
+
+      agent.addHook(BeforeToolCallEvent, beforeCalled)
+      agent.addHook(AfterToolCallEvent, afterCalled)
+
+      // eslint-disable-next-line require-yield
+      const middleware: ExecuteToolMiddleware = async function* (context) {
+        return {
+          result: new ToolResultBlock({
+            toolUseId: context.toolUse.toolUseId,
+            status: 'success',
+            content: [new TextBlock('mocked')],
+          }),
+        }
+      }
+
+      agent.addMiddleware(ExecuteToolStage, middleware)
+
+      await agent.invoke('Use the tool')
+
+      expect(beforeCalled).toHaveBeenCalled()
+      expect(afterCalled).toHaveBeenCalled()
+    })
+
+    it('AfterToolCallEvent receives the middleware result when short-circuited', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('real')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      let afterToolResult: ToolResultBlock | undefined
+
+      agent.addHook(AfterToolCallEvent, (event: AfterToolCallEvent) => {
+        afterToolResult = event.result
+      })
+
+      // eslint-disable-next-line require-yield
+      const middleware: ExecuteToolMiddleware = async function* (context) {
+        return {
+          result: new ToolResultBlock({
+            toolUseId: context.toolUse.toolUseId,
+            status: 'success',
+            content: [new TextBlock('from middleware')],
+          }),
+        }
+      }
+
+      agent.addMiddleware(ExecuteToolStage, middleware)
+
+      await agent.invoke('Use the tool')
+
+      expect(afterToolResult).toBeDefined()
+      expect(afterToolResult!.content).toStrictEqual([new TextBlock('from middleware')])
+    })
+  })
+})
+
+describe('Middleware use cases', () => {
+  describe('caching tool results', () => {
+    class ToolResultCache implements Plugin {
+      name = 'tool-result-cache'
+
+      private readonly _cache = new Map<string, ToolResultBlock>()
+
+      initAgent(agent: LocalAgent): void {
+        const cache = this._cache
+
+        agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+          const key = `${context.toolUse.name}:${JSON.stringify(context.toolUse.input)}`
+          const cached = cache.get(key)
+          if (cached) {
+            return {
+              result: new ToolResultBlock({
+                toolUseId: context.toolUse.toolUseId,
+                status: cached.status,
+                content: cached.content,
+              }),
+            }
+          }
+          const result = yield* next(context)
+          cache.set(key, result.result)
+          return result
+        })
+      }
+    }
+
+    it('returns cached result on second call, skipping real execution', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'expensiveApi', toolUseId: 'call-1', input: { query: 'weather' } })
+        .addTurn({ type: 'textBlock', text: 'First done' })
+        .addTurn({ type: 'toolUseBlock', name: 'expensiveApi', toolUseId: 'call-2', input: { query: 'weather' } })
+        .addTurn({ type: 'textBlock', text: 'Second done' })
+
+      const realCallCount = vi.fn()
+      const tool = createMockTool('expensiveApi', (ctx: ToolContext) => {
+        realCallCount()
+        return new ToolResultBlock({
+          toolUseId: ctx.toolUse.toolUseId,
+          status: 'success',
+          content: [new TextBlock('sunny, 72°F')],
+        })
+      })
+
+      const agent = new Agent({ model, tools: [tool], plugins: [new ToolResultCache()], printer: false })
+
+      await agent.invoke('What is the weather?')
+      expect(realCallCount).toHaveBeenCalledTimes(1)
+
+      await agent.invoke('What is the weather?')
+      expect(realCallCount).toHaveBeenCalledTimes(1) // cache hit
+    })
+  })
+
+  describe('auto-retrying model invocations', () => {
+    class RetryOnThrottle implements Plugin {
+      name = 'retry-on-throttle'
+
+      private readonly _maxRetries: number
+
+      constructor(maxRetries = 3) {
+        this._maxRetries = maxRetries
+      }
+
+      initAgent(agent: LocalAgent): void {
+        const maxRetries = this._maxRetries
+        agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+          for (let attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+              return yield* next(context)
+            } catch (e) {
+              const isRetryable = (e as Error).message.includes('ThrottlingException')
+              if (!isRetryable || attempt === maxRetries - 1) throw e
+              // In production: await sleep(backoff(attempt))
+            }
+          }
+          throw new Error('exhausted retries')
+        })
+      }
+    }
+
+    it('retries on transient error and succeeds on second attempt', async () => {
+      let callCount = 0
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Success after retry' })
+
+      const agent = new Agent({ model, plugins: [new RetryOnThrottle(3)], printer: false })
+
+      const originalStream = model.stream.bind(model)
+      vi.spyOn(model, 'stream').mockImplementation((...args) => {
+        callCount++
+        if (callCount === 1) throw new Error('ThrottlingException: rate limit exceeded')
+        return originalStream(...args)
+      })
+
+      const result = await agent.invoke('Hello')
+
+      expect(callCount).toBe(2)
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content).toEqual([new TextBlock('Success after retry')])
+    })
+  })
+
+  describe('stream final turn only (buffer intermediate turns)', () => {
+    class StreamFinalTurnOnly implements Plugin {
+      name = 'stream-final-turn-only'
+
+      initAgent(agent: LocalAgent): void {
+        agent.addMiddleware(AgentStreamStage, (...args) => this._handler(...args))
+      }
+
+      private async *_handler(
+        ...[context, next]: Parameters<MiddlewareHandlerOf<typeof AgentStreamStage>>
+      ): ReturnType<MiddlewareHandlerOf<typeof AgentStreamStage>> {
+        let buffer: AgentStreamEvent[] = []
+        const gen = next(context)
+        let iterResult = await gen.next()
+
+        while (!iterResult.done) {
+          const event = iterResult.value
+
+          if (event.type === 'contentBlockEvent' || event.type === 'modelStreamUpdateEvent') {
+            buffer.push(event)
+          } else if (event.type === 'afterModelCallEvent') {
+            const stopReason = (event as AfterModelCallEvent).stopData?.stopReason
+            if (stopReason === 'endTurn') {
+              for (const buffered of buffer) yield buffered
+            }
+            buffer = []
+            yield event
+          } else {
+            yield event
+          }
+
+          iterResult = await gen.next()
+        }
+
+        for (const buffered of buffer) yield buffered
+        return iterResult.value
+      }
+    }
+
+    it('suppresses content events from intermediate tool-use turns, emits only final turn', async () => {
+      const model = new MockMessageModel()
+        .addTurn([
+          { type: 'textBlock', text: 'Let me check that for you' },
+          { type: 'toolUseBlock', name: 'lookup', toolUseId: 'tool-1', input: {} },
+        ])
+        .addTurn({ type: 'textBlock', text: 'The answer is 42' })
+
+      const tool = createMockTool(
+        'lookup',
+        (ctx: ToolContext) =>
+          new ToolResultBlock({
+            toolUseId: ctx.toolUse.toolUseId,
+            status: 'success',
+            content: [new TextBlock('42')],
+          })
+      )
+
+      const agent = new Agent({ model, tools: [tool], plugins: [new StreamFinalTurnOnly()], printer: false })
+
+      const { items, result } = await collectGenerator(agent.stream('What is the meaning of life?'))
+
+      const contentEvents = items.filter((e: AgentStreamEvent) => e.type === 'contentBlockEvent')
+      expect(contentEvents).toHaveLength(1)
+      expect((contentEvents[0] as ContentBlockEvent).contentBlock).toStrictEqual(new TextBlock('The answer is 42'))
+      expect(result.stopReason).toBe('endTurn')
+    })
+
+    it('passes through all events when there is only one turn (no tool use)', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Simple answer' })
+      const agent = new Agent({ model, plugins: [new StreamFinalTurnOnly()], printer: false })
+
+      const { items, result } = await collectGenerator(agent.stream('Hello'))
+
+      const contentEvents = items.filter((e: AgentStreamEvent) => e.type === 'contentBlockEvent')
+      expect(contentEvents).toHaveLength(1)
+      expect((contentEvents[0] as ContentBlockEvent).contentBlock).toStrictEqual(new TextBlock('Simple answer'))
+      expect(result.stopReason).toBe('endTurn')
+    })
+  })
+})
+
+describe('Middleware phases (Input / Around / Output)', () => {
+  describe('InvokeModelStage.Input', () => {
+    it('transforms context before the model call', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      let receivedMessages: unknown
+
+      agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
+        ...context,
+        messages: [...context.messages, new Message({ role: 'user', content: [new TextBlock('injected')] })],
+      }))
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        receivedMessages = context.messages
+        return yield* next(context)
+      })
+
+      await agent.invoke('Original')
+
+      expect((receivedMessages as Message[]).length).toBe(2)
+      expect((receivedMessages as Message[])[1]!.content[0]).toEqual(new TextBlock('injected'))
+    })
+
+    it('runs before Around handlers regardless of registration order', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const order: string[] = []
+
+      // Register Around first, then Input
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        order.push('around')
+        return yield* next(context)
+      })
+
+      agent.addMiddleware(InvokeModelStage.Input, async (context) => {
+        order.push('input')
+        return context
+      })
+
+      await agent.invoke('Test')
+
+      expect(order).toStrictEqual(['input', 'around'])
+    })
+
+    it('multiple Input handlers compose in registration order', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const order: string[] = []
+
+      agent.addMiddleware(InvokeModelStage.Input, async (context) => {
+        order.push('input-1')
+        return context
+      })
+
+      agent.addMiddleware(InvokeModelStage.Input, async (context) => {
+        order.push('input-2')
+        return context
+      })
+
+      await agent.invoke('Test')
+
+      expect(order).toStrictEqual(['input-1', 'input-2'])
+    })
+  })
+
+  describe('InvokeModelStage.Output', () => {
+    it('transforms result after the model call', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      let outputSeen = false
+
+      agent.addMiddleware(InvokeModelStage.Output, async (result) => {
+        outputSeen = true
+        expect(result.result.stopReason).toBe('endTurn')
+        return result
+      })
+
+      await agent.invoke('Test')
+
+      expect(outputSeen).toBe(true)
+    })
+
+    it('runs after Around handlers (wraps them)', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const order: string[] = []
+
+      agent.addMiddleware(InvokeModelStage.Output, async (result) => {
+        order.push('output')
+        return result
+      })
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        order.push('around-before')
+        const result = yield* next(context)
+        order.push('around-after')
+        return result
+      })
+
+      await agent.invoke('Test')
+
+      // Output wraps Around: output sees the result after around-after
+      expect(order).toStrictEqual(['around-before', 'around-after', 'output'])
+    })
+  })
+
+  describe('InvokeModelStage (Around phase)', () => {
+    it('bare InvokeModelStage registers as Around phase and executes between Input and Output', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const order: string[] = []
+
+      agent.addMiddleware(InvokeModelStage.Input, async (context) => {
+        order.push('input')
+        return context
+      })
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        order.push('around')
+        return yield* next(context)
+      })
+
+      agent.addMiddleware(InvokeModelStage.Output, async (result) => {
+        order.push('output')
+        return result
+      })
+
+      await agent.invoke('Test prompt')
+
+      expect(order).toStrictEqual(['input', 'around', 'output'])
+    })
+  })
+
+  describe('phase ordering', () => {
+    it('Input → Around → Output execution order', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      const order: string[] = []
+
+      // Register in reverse order to prove phase ordering overrides registration order
+      agent.addMiddleware(InvokeModelStage.Output, async (result) => {
+        order.push('output')
+        return result
+      })
+
+      agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+        order.push('around')
+        return yield* next(context)
+      })
+
+      agent.addMiddleware(InvokeModelStage.Input, async (context) => {
+        order.push('input')
+        return context
+      })
+
+      await agent.invoke('Test')
+
+      expect(order).toStrictEqual(['input', 'around', 'output'])
+    })
+  })
+
+  describe('ExecuteToolStage phases', () => {
+    it('Input transforms tool context before execution', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: { x: 1 } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let receivedInput: unknown
+      const tool = createMockTool('myTool', (ctx: ToolContext) => {
+        receivedInput = ctx.toolUse.input
+        return 'ok'
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      agent.addMiddleware(ExecuteToolStage.Input, async (context) => ({
+        ...context,
+        toolUse: { ...context.toolUse, input: { x: 2 } },
+      }))
+
+      await agent.invoke('Test')
+
+      expect(receivedInput).toEqual({ x: 2 })
+    })
+  })
+
+  describe('cleanup', () => {
+    it('cleanup removes Input handler', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'textBlock', text: 'First' })
+        .addTurn({ type: 'textBlock', text: 'Second' })
+
+      const agent = new Agent({ model, printer: false })
+
+      let inputCalled = false
+      const cleanup = agent.addMiddleware(InvokeModelStage.Input, async (context) => {
+        inputCalled = true
+        return context
+      })
+
+      await agent.invoke('First')
+      expect(inputCalled).toBe(true)
+
+      inputCalled = false
+      cleanup()
+
+      await agent.invoke('Second')
+      expect(inputCalled).toBe(false)
+    })
+
+    it('cleanup removes Output handler', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'textBlock', text: 'First' })
+        .addTurn({ type: 'textBlock', text: 'Second' })
+
+      const agent = new Agent({ model, printer: false })
+
+      let outputCalled = false
+      const cleanup = agent.addMiddleware(InvokeModelStage.Output, async (result) => {
+        outputCalled = true
+        return result
+      })
+
+      await agent.invoke('First')
+      expect(outputCalled).toBe(true)
+
+      outputCalled = false
+      cleanup()
+
+      await agent.invoke('Second')
+      expect(outputCalled).toBe(false)
+    })
+  })
+
+  describe('error handling', () => {
+    it('throws on unknown phase', () => {
+      const agent = new Agent({ model: 'test', printer: false })
+      const fakePhase = { _phase: 'unknown', _stage: InvokeModelStage } as never
+
+      expect(() => agent.addMiddleware(fakePhase, (() => {}) as never)).toThrow('Unknown middleware phase: unknown')
+    })
+  })
+})

--- a/strands-ts/src/middleware/__tests__/custom-stages.test.ts
+++ b/strands-ts/src/middleware/__tests__/custom-stages.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { createStage, MiddlewareRegistry } from '../index.js'
+import type { MiddlewareHandler, MiddlewareNext } from '../types.js'
+
+// Custom stage types for testing third-party extensibility
+interface CustomContext {
+  readonly label: string
+  readonly count: number
+}
+
+interface CustomEvent {
+  readonly kind: string
+}
+
+interface CustomResult {
+  readonly summary: string
+}
+
+/**
+ * Helper to collect all yielded events and the return value from an async generator.
+ */
+async function collect<TEvent, TResult>(
+  gen: AsyncGenerator<TEvent, TResult, undefined>
+): Promise<{ events: TEvent[]; result: TResult }> {
+  const events: TEvent[] = []
+  let iterResult = await gen.next()
+  while (!iterResult.done) {
+    events.push(iterResult.value)
+    iterResult = await gen.next()
+  }
+  return { events, result: iterResult.value }
+}
+
+describe('Third-party custom stages', () => {
+  describe('createStage', () => {
+    it('returns a frozen object', () => {
+      const stage = createStage<CustomContext, CustomResult, CustomEvent>('myCustomStage')
+      expect(Object.isFrozen(stage)).toBe(true)
+    })
+
+    it('returns object with correct name property', () => {
+      const stage = createStage<CustomContext, CustomResult, CustomEvent>('myCustomStage')
+      expect(stage.name).toBe('myCustomStage')
+    })
+  })
+
+  describe('custom stage with registry', () => {
+    it('works with registry.add and compose (handlers execute correctly)', async () => {
+      const CustomStage = createStage<CustomContext, CustomResult, CustomEvent>('custom')
+      const registry = new MiddlewareRegistry()
+      const callOrder: string[] = []
+
+      const handler: MiddlewareHandler<CustomContext, CustomResult, CustomEvent> = async function* (context, next) {
+        callOrder.push('middleware')
+        yield { kind: `pre-${context.label}` }
+        const result = yield* next(context)
+        callOrder.push('middleware-after')
+        return result
+      }
+
+      registry.add(CustomStage, handler)
+
+      const terminal: MiddlewareNext<CustomContext, CustomResult, CustomEvent> = async function* (ctx) {
+        callOrder.push('terminal')
+        yield { kind: `terminal-${ctx.label}` }
+        return { summary: `done-${ctx.count}` }
+      }
+
+      const chain = registry.compose(CustomStage, terminal)
+      const { events, result } = await collect(chain({ label: 'test', count: 42 }))
+
+      expect(callOrder).toStrictEqual(['middleware', 'terminal', 'middleware-after'])
+      expect(events).toStrictEqual([{ kind: 'pre-test' }, { kind: 'terminal-test' }])
+      expect(result).toStrictEqual({ summary: 'done-42' })
+    })
+
+    it('two stages with the same name are distinct (reference identity)', async () => {
+      const StageA = createStage<CustomContext, CustomResult, CustomEvent>('shared-name')
+      const StageB = createStage<CustomContext, CustomResult, CustomEvent>('shared-name')
+
+      const registry = new MiddlewareRegistry()
+
+      const handlerA: MiddlewareHandler<CustomContext, CustomResult, CustomEvent> = async function* (context, next) {
+        yield { kind: 'from-A' }
+        return yield* next(context)
+      }
+
+      const handlerB: MiddlewareHandler<CustomContext, CustomResult, CustomEvent> = async function* (context, next) {
+        yield { kind: 'from-B' }
+        return yield* next(context)
+      }
+
+      registry.add(StageA, handlerA)
+      registry.add(StageB, handlerB)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<CustomContext, CustomResult, CustomEvent> = async function* () {
+        return { summary: 'terminal' }
+      }
+
+      // Composing for StageA should only include handlerA
+      const chainA = registry.compose(StageA, terminal)
+      const resultA = await collect(chainA({ label: 'a', count: 1 }))
+      expect(resultA.events).toStrictEqual([{ kind: 'from-A' }])
+
+      // Composing for StageB should only include handlerB
+      const chainB = registry.compose(StageB, terminal)
+      const resultB = await collect(chainB({ label: 'b', count: 2 }))
+      expect(resultB.events).toStrictEqual([{ kind: 'from-B' }])
+    })
+
+    it('custom stage middleware can be composed with a terminal and executes correctly', async () => {
+      const CustomStage = createStage<CustomContext, CustomResult, CustomEvent>('pipeline')
+      const registry = new MiddlewareRegistry()
+
+      // Register multiple middleware for the custom stage
+      const logger: MiddlewareHandler<CustomContext, CustomResult, CustomEvent> = async function* (context, next) {
+        yield { kind: 'log-start' }
+        const result = yield* next(context)
+        yield { kind: 'log-end' }
+        return result
+      }
+
+      const transformer: MiddlewareHandler<CustomContext, CustomResult, CustomEvent> = async function* (context, next) {
+        const modified = { ...context, count: context.count * 2 }
+        return yield* next(modified)
+      }
+
+      registry.add(CustomStage, logger)
+      registry.add(CustomStage, transformer)
+
+      const terminal: MiddlewareNext<CustomContext, CustomResult, CustomEvent> = async function* (ctx) {
+        yield { kind: `processed-${ctx.count}` }
+        return { summary: `result-${ctx.label}-${ctx.count}` }
+      }
+
+      const chain = registry.compose(CustomStage, terminal)
+      const { events, result } = await collect(chain({ label: 'item', count: 5 }))
+
+      expect(events).toStrictEqual([{ kind: 'log-start' }, { kind: 'processed-10' }, { kind: 'log-end' }])
+      expect(result).toStrictEqual({ summary: 'result-item-10' })
+    })
+  })
+})

--- a/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
+++ b/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../../agent/agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import { ExecuteToolStage, AgentStreamStage } from '../stages.js'
+import { TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { InterruptResponseContent } from '../../types/interrupt.js'
+import { AfterInvocationEvent, InterruptEvent } from '../../hooks/events.js'
+
+describe('Middleware interrupts', () => {
+  describe('ExecuteToolStage', () => {
+    it('middleware can raise an interrupt (agent stops with stopReason interrupt)', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'dangerousTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Should not reach' })
+
+      const tool = createMockTool('dangerousTool', () => 'executed')
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+        context.interrupt({ name: 'approve_tool', reason: 'Confirm execution?' })
+        return yield* next(context)
+      })
+
+      const result = await agent.invoke('Do the dangerous thing')
+
+      expect(result.stopReason).toBe('interrupt')
+      expect(result.interrupts).toEqual([
+        expect.objectContaining({ name: 'approve_tool', reason: 'Confirm execution?' }),
+      ])
+    })
+
+    it('middleware gets response on resume and continues execution', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'dangerousTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('dangerousTool', () => {
+        toolExecuted = true
+        return 'executed'
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+        const { response: approval } = context.interrupt<string>({ name: 'approve_tool', reason: 'Confirm?' })
+        if (approval !== 'yes') {
+          return {
+            result: new ToolResultBlock({
+              toolUseId: context.toolUse.toolUseId,
+              status: 'error',
+              content: [new TextBlock('Denied by user')],
+            }),
+          }
+        }
+        return yield* next(context)
+      })
+
+      // First invocation: interrupt fires
+      const interruptResult = await agent.invoke('Do it')
+      expect(interruptResult.stopReason).toBe('interrupt')
+      expect(toolExecuted).toBe(false)
+
+      // Resume with approval
+      const finalResult = await agent.invoke([
+        new InterruptResponseContent({
+          interruptId: interruptResult.interrupts![0]!.id,
+          response: 'yes',
+        }),
+      ])
+
+      expect(finalResult.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
+    })
+
+    it('interrupt ID includes toolUseId for disambiguation', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'unique-tool-id', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('myTool', () => 'ok')
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+        context.interrupt({ name: 'check' })
+        return yield* next(context)
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.interrupts![0]!.id).toContain('unique-tool-id')
+      expect(result.interrupts![0]!.id).toContain('check')
+    })
+
+    it('preemptive response skips the interrupt (no halt)', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('myTool', () => {
+        toolExecuted = true
+        return 'ok'
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+        // Preemptive response: returns immediately without halting
+        const { response: approval } = context.interrupt<string>({ name: 'check', response: 'pre-approved' })
+        expect(approval).toBe('pre-approved')
+        return yield* next(context)
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
+    })
+
+    it('yields InterruptEvent on the stream for ExecuteToolStage interrupts', async () => {
+      // ExecuteToolStage interrupts propagate through the agent loop and hit
+      // _stream's catch, which correctly yields InterruptEvent. This test
+      // serves as a baseline showing the expected behavior that AgentStreamStage
+      // interrupts should also follow.
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('myTool', () => 'ok')
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+        context.interrupt({ name: 'tool_gate', reason: 'confirm tool?' })
+        return yield* next(context)
+      })
+
+      const events: InterruptEvent[] = []
+      for await (const event of agent.stream('Test')) {
+        if (event instanceof InterruptEvent) events.push(event)
+      }
+
+      expect(events).toHaveLength(1)
+      expect(events[0]!.interrupt).toMatchObject({ name: 'tool_gate' })
+    })
+
+    it('context spread preserves interrupt function', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: { x: 1 } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('myTool', () => 'ok')
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+        // Spread context to modify toolUse, interrupt should still work
+        const modified = { ...context, toolUse: { ...context.toolUse, input: { x: 2 } } }
+        modified.interrupt({ name: 'after_spread' })
+        return yield* next(modified)
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('interrupt')
+      expect(result.interrupts![0]!.name).toBe('after_spread')
+    })
+  })
+
+  describe('AgentStreamStage', () => {
+    it('middleware can raise an interrupt (agent stops with stopReason interrupt)', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      // eslint-disable-next-line require-yield
+      agent.addMiddleware(AgentStreamStage, async function* (context) {
+        context.interrupt({ name: 'confirm_stream', reason: 'Are you sure?' })
+        // unreachable — interrupt() throws
+        return undefined as never
+      })
+
+      const { result } = await collectGenerator(agent.stream('Test'))
+
+      expect(result.stopReason).toBe('interrupt')
+      expect(result.interrupts).toEqual([expect.objectContaining({ name: 'confirm_stream', reason: 'Are you sure?' })])
+    })
+
+    it('middleware gets response on resume and continues', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      agent.addMiddleware(AgentStreamStage, async function* (context, next) {
+        const { response: approval } = context.interrupt<string>({ name: 'gate', reason: 'Proceed?' })
+        if (approval !== 'go') {
+          return { result: { stopReason: 'endTurn' } } as never
+        }
+        return yield* next(context)
+      })
+
+      // First: interrupt
+      const { result: interruptResult } = await collectGenerator(agent.stream('Test'))
+      expect(interruptResult.stopReason).toBe('interrupt')
+
+      // Resume
+      const { result: finalResult } = await collectGenerator(
+        agent.stream([
+          new InterruptResponseContent({
+            interruptId: interruptResult.interrupts![0]!.id,
+            response: 'go',
+          }),
+        ])
+      )
+
+      expect(finalResult.stopReason).toBe('endTurn')
+    })
+
+    it('interrupt ID uses agentStream namespace', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      // eslint-disable-next-line require-yield
+      agent.addMiddleware(AgentStreamStage, async function* (context) {
+        context.interrupt({ name: 'my_gate' })
+        return undefined as never
+      })
+
+      const { result } = await collectGenerator(agent.stream('Test'))
+
+      expect(result.interrupts![0]!.id).toContain('agentStream')
+      expect(result.interrupts![0]!.id).toContain('my_gate')
+    })
+
+    it('yields InterruptEvent on the stream for AgentStreamStage interrupts', async () => {
+      // Issue: tool/hook interrupts yield InterruptEvent on the stream, but
+      // AgentStreamStage middleware interrupts do not — stream consumers that
+      // listen for InterruptEvent will silently miss middleware-raised interrupts.
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, printer: false })
+
+      // eslint-disable-next-line require-yield
+      agent.addMiddleware(AgentStreamStage, async function* (context) {
+        context.interrupt({ name: 'stream_gate', reason: 'confirm?' })
+        return undefined as never
+      })
+
+      const events: InterruptEvent[] = []
+      for await (const event of agent.stream('Test')) {
+        if (event instanceof InterruptEvent) events.push(event)
+      }
+
+      // Expect at least one InterruptEvent, matching what tool/hook interrupts produce
+      expect(events).toHaveLength(1)
+      expect(events[0]!.interrupt).toMatchObject({ name: 'stream_gate' })
+    })
+  })
+
+  describe('resume via AfterInvocationEvent with interrupt responses', () => {
+    it('interrupt responses in resumed args are applied to interrupt state', async () => {
+      // Issue: resume() only runs once in stream() against the top-level args.
+      // When AfterInvocationEvent.resume carries interrupt-response blocks, the
+      // resume loop re-enters _stream but never re-applies resume(), so the
+      // interrupt responses are silently dropped and the middleware still sees
+      // the interrupt as unanswered.
+      //
+      // Scenario:
+      // 1. Tool middleware interrupts on first tool call
+      // 2. AfterInvocationEvent hook auto-approves by setting resume with the
+      //    interrupt response — this exercises _streamWithResumeLoop applying
+      //    interrupt responses from resume args
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done after resume' })
+
+      let toolExecCount = 0
+      const tool = createMockTool('myTool', () => {
+        toolExecCount++
+        return 'ok'
+      })
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      // Middleware that gates on approval
+      agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+        const { response: approval } = context.interrupt<string>({ name: 'gate' })
+        if (approval !== 'approved') {
+          return {
+            result: new ToolResultBlock({
+              toolUseId: context.toolUse.toolUseId,
+              status: 'error',
+              content: [new TextBlock('Denied')],
+            }),
+          }
+        }
+        return yield* next(context)
+      })
+
+      // Hook that auto-approves the interrupt on the first AfterInvocationEvent.
+      // This simulates an orchestrator that programmatically answers interrupts
+      // without requiring a new top-level invoke().
+      agent.addHook(AfterInvocationEvent, (event: AfterInvocationEvent) => {
+        const unanswered = (event.agent as Agent)._interruptState.getUnansweredInterrupts()
+        if (unanswered.length > 0) {
+          event.resume = [new InterruptResponseContent({ interruptId: unanswered[0]!.id, response: 'approved' })]
+        }
+      })
+
+      // Single invocation: middleware interrupts → AfterInvocationEvent hook
+      // sets resume with the response → _streamWithResumeLoop re-enters _stream.
+      // The bug: _interruptState.resume() was only called in stream() for the
+      // original args (which have no responses), so the resumed iteration still
+      // sees the interrupt as unanswered.
+      const result = await agent.invoke('Do it')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecCount).toBe(1)
+    })
+  })
+})

--- a/strands-ts/src/middleware/__tests__/registry.test.ts
+++ b/strands-ts/src/middleware/__tests__/registry.test.ts
@@ -1,0 +1,684 @@
+import { describe, expect, it } from 'vitest'
+import { MiddlewareRegistry, createStage } from '../index.js'
+import type { MiddlewareHandler, MiddlewareNext } from '../types.js'
+import { CancelledError } from '../../errors.js'
+import { InterruptError, Interrupt } from '../../interrupt.js'
+
+// Simple test types
+interface TestContext {
+  readonly value: string
+}
+
+interface TestEvent {
+  readonly data: string
+}
+
+interface TestResult {
+  readonly output: string
+}
+
+const TestStage = createStage<TestContext, TestResult, TestEvent>('test')
+
+/**
+ * Helper to collect all yielded events and the return value from an async generator.
+ */
+async function collect<TEvent, TResult>(
+  gen: AsyncGenerator<TEvent, TResult, undefined>
+): Promise<{ events: TEvent[]; result: TResult }> {
+  const events: TEvent[] = []
+  let iterResult = await gen.next()
+  while (!iterResult.done) {
+    events.push(iterResult.value)
+    iterResult = await gen.next()
+  }
+  return { events, result: iterResult.value }
+}
+
+describe('MiddlewareRegistry', () => {
+  describe('add', () => {
+    it('stores handlers in registration order', () => {
+      const registry = new MiddlewareRegistry()
+      const callOrder: number[] = []
+
+      const handler1: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        callOrder.push(1)
+        return yield* next(context)
+      }
+
+      const handler2: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        callOrder.push(2)
+        return yield* next(context)
+      }
+
+      registry.add(TestStage, handler1)
+      registry.add(TestStage, handler2)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        callOrder.push(3)
+        return { output: 'done' }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      // Execute the chain to verify order
+      const gen = chain({ value: 'test' })
+      return collect(gen).then(() => {
+        expect(callOrder).toStrictEqual([1, 2, 3])
+      })
+    })
+  })
+
+  describe('compose', () => {
+    it('with no handlers returns terminal-equivalent function', async () => {
+      const registry = new MiddlewareRegistry()
+
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* (ctx) {
+        yield { data: `event-${ctx.value}` }
+        return { output: `result-${ctx.value}` }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      const { events, result } = await collect(chain({ value: 'hello' }))
+
+      expect(events).toStrictEqual([{ data: 'event-hello' }])
+      expect(result).toStrictEqual({ output: 'result-hello' })
+    })
+
+    it('executes handlers in registration order (outermost first)', async () => {
+      const registry = new MiddlewareRegistry()
+      const callOrder: string[] = []
+
+      const outer: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        callOrder.push('outer-before')
+        const result = yield* next(context)
+        callOrder.push('outer-after')
+        return result
+      }
+
+      const inner: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        callOrder.push('inner-before')
+        const result = yield* next(context)
+        callOrder.push('inner-after')
+        return result
+      }
+
+      registry.add(TestStage, outer)
+      registry.add(TestStage, inner)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        callOrder.push('terminal')
+        return { output: 'done' }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      await collect(chain({ value: 'test' }))
+
+      expect(callOrder).toStrictEqual(['outer-before', 'inner-before', 'terminal', 'inner-after', 'outer-after'])
+    })
+  })
+
+  describe('short-circuit behavior', () => {
+    it('does not call next handlers or terminal when middleware does not call next', async () => {
+      const registry = new MiddlewareRegistry()
+      let terminalCalled = false
+      let innerCalled = false
+
+      const shortCircuit: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* () {
+        yield { data: 'synthetic' }
+        return { output: 'short-circuited' }
+      }
+
+      const inner: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        innerCalled = true
+        return yield* next(context)
+      }
+
+      registry.add(TestStage, shortCircuit)
+      registry.add(TestStage, inner)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        terminalCalled = true
+        return { output: 'terminal' }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      const { events, result } = await collect(chain({ value: 'test' }))
+
+      expect(terminalCalled).toBe(false)
+      expect(innerCalled).toBe(false)
+      expect(events).toStrictEqual([{ data: 'synthetic' }])
+      expect(result).toStrictEqual({ output: 'short-circuited' })
+    })
+  })
+
+  describe('event pass-through via yield* next(context)', () => {
+    it('forwards all events from terminal and returns terminal result', async () => {
+      const registry = new MiddlewareRegistry()
+
+      const passThrough: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next(context)
+      }
+
+      registry.add(TestStage, passThrough)
+
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        yield { data: 'event-1' }
+        yield { data: 'event-2' }
+        yield { data: 'event-3' }
+        return { output: 'terminal-result' }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      const { events, result } = await collect(chain({ value: 'test' }))
+
+      expect(events).toStrictEqual([{ data: 'event-1' }, { data: 'event-2' }, { data: 'event-3' }])
+      expect(result).toStrictEqual({ output: 'terminal-result' })
+    })
+  })
+
+  describe('event filtering via manual iteration', () => {
+    it('only yields events matching a predicate', async () => {
+      const registry = new MiddlewareRegistry()
+
+      const filter: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        const gen = next(context)
+        let iterResult = await gen.next()
+        while (!iterResult.done) {
+          const event = iterResult.value
+          // Only forward events containing 'keep'
+          if (event.data.includes('keep')) {
+            yield event
+          }
+          iterResult = await gen.next()
+        }
+        return iterResult.value
+      }
+
+      registry.add(TestStage, filter)
+
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        yield { data: 'keep-1' }
+        yield { data: 'drop-1' }
+        yield { data: 'keep-2' }
+        yield { data: 'drop-2' }
+        return { output: 'done' }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      const { events, result } = await collect(chain({ value: 'test' }))
+
+      expect(events).toStrictEqual([{ data: 'keep-1' }, { data: 'keep-2' }])
+      expect(result).toStrictEqual({ output: 'done' })
+    })
+  })
+
+  describe('context modification flows to terminal', () => {
+    it('terminal receives modified context', async () => {
+      const registry = new MiddlewareRegistry()
+      let receivedContext: TestContext | undefined
+
+      const modifier: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        const modified = { ...context, value: 'modified' }
+        return yield* next(modified)
+      }
+
+      registry.add(TestStage, modifier)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* (ctx) {
+        receivedContext = ctx
+        return { output: ctx.value }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      const { result } = await collect(chain({ value: 'original' }))
+
+      expect(receivedContext).toStrictEqual({ value: 'modified' })
+      expect(result).toStrictEqual({ output: 'modified' })
+    })
+
+    it('each middleware can further modify context', async () => {
+      const registry = new MiddlewareRegistry()
+      let receivedContext: TestContext | undefined
+
+      const first: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next({ ...context, value: context.value + '-first' })
+      }
+
+      const second: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next({ ...context, value: context.value + '-second' })
+      }
+
+      registry.add(TestStage, first)
+      registry.add(TestStage, second)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* (ctx) {
+        receivedContext = ctx
+        return { output: ctx.value }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      const { result } = await collect(chain({ value: 'start' }))
+
+      expect(receivedContext).toStrictEqual({ value: 'start-first-second' })
+      expect(result).toStrictEqual({ output: 'start-first-second' })
+    })
+  })
+
+  describe('error propagation through chain', () => {
+    it('errors from terminal reach middleware', async () => {
+      const registry = new MiddlewareRegistry()
+      let caughtError: Error | undefined
+
+      const catcher: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          return yield* next(context)
+        } catch (error) {
+          caughtError = error as Error
+          return { output: 'recovered' }
+        }
+      }
+
+      registry.add(TestStage, catcher)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        throw new Error('terminal error')
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      const { result } = await collect(chain({ value: 'test' }))
+
+      expect(caughtError).toBeInstanceOf(Error)
+      expect(caughtError!.message).toBe('terminal error')
+      expect(result).toStrictEqual({ output: 'recovered' })
+    })
+
+    it('errors from middleware reach caller', async () => {
+      const registry = new MiddlewareRegistry()
+
+      // eslint-disable-next-line require-yield
+      const thrower: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* () {
+        throw new Error('middleware error')
+      }
+
+      registry.add(TestStage, thrower)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        return { output: 'done' }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+
+      await expect(collect(chain({ value: 'test' }))).rejects.toThrow('middleware error')
+    })
+
+    it('middleware can transform errors from next', async () => {
+      const registry = new MiddlewareRegistry()
+
+      const transformer: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          return yield* next(context)
+        } catch {
+          throw new Error('transformed error')
+        }
+      }
+
+      registry.add(TestStage, transformer)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        throw new Error('original error')
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+
+      await expect(collect(chain({ value: 'test' }))).rejects.toThrow('transformed error')
+    })
+  })
+
+  describe('CancelledError and InterruptError propagation', () => {
+    it('CancelledError propagates without being swallowed', async () => {
+      const registry = new MiddlewareRegistry()
+
+      const passThrough: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next(context)
+      }
+
+      registry.add(TestStage, passThrough)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        throw new CancelledError()
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+
+      await expect(collect(chain({ value: 'test' }))).rejects.toThrow(CancelledError)
+    })
+
+    it('InterruptError propagates without being swallowed', async () => {
+      const registry = new MiddlewareRegistry()
+
+      const passThrough: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next(context)
+      }
+
+      registry.add(TestStage, passThrough)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        throw new InterruptError(new Interrupt({ id: 'int-1', name: 'test_interrupt' }))
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+
+      await expect(collect(chain({ value: 'test' }))).rejects.toThrow(InterruptError)
+    })
+
+    it('CancelledError propagates through multiple middleware layers', async () => {
+      const registry = new MiddlewareRegistry()
+
+      const outer: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next(context)
+      }
+
+      const inner: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next(context)
+      }
+
+      registry.add(TestStage, outer)
+      registry.add(TestStage, inner)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        throw new CancelledError()
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+
+      await expect(collect(chain({ value: 'test' }))).rejects.toThrow(CancelledError)
+    })
+
+    it('InterruptError propagates through multiple middleware layers', async () => {
+      const registry = new MiddlewareRegistry()
+
+      const outer: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next(context)
+      }
+
+      const inner: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next(context)
+      }
+
+      registry.add(TestStage, outer)
+      registry.add(TestStage, inner)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        throw new InterruptError(new Interrupt({ id: 'int-1', name: 'test_interrupt' }))
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+
+      await expect(collect(chain({ value: 'test' }))).rejects.toThrow(InterruptError)
+    })
+  })
+
+  describe('try-finally guarantees', () => {
+    it('outer finally runs when inner middleware throws', async () => {
+      const registry = new MiddlewareRegistry()
+      const order: string[] = []
+
+      const outer: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          return yield* next(context)
+        } finally {
+          order.push('outer-finally')
+        }
+      }
+
+      // eslint-disable-next-line require-yield
+      const inner: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* () {
+        order.push('inner-throw')
+        throw new Error('inner exploded')
+      }
+
+      registry.add(TestStage, outer)
+      registry.add(TestStage, inner)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        return { output: 'unreachable' }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      await expect(collect(chain({ value: 'test' }))).rejects.toThrow('inner exploded')
+
+      expect(order).toStrictEqual(['inner-throw', 'outer-finally'])
+    })
+
+    it('inner finally runs when terminal throws', async () => {
+      const registry = new MiddlewareRegistry()
+      const order: string[] = []
+
+      const outer: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          return yield* next(context)
+        } finally {
+          order.push('outer-finally')
+        }
+      }
+
+      const inner: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          return yield* next(context)
+        } finally {
+          order.push('inner-finally')
+        }
+      }
+
+      registry.add(TestStage, outer)
+      registry.add(TestStage, inner)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        order.push('terminal-throw')
+        throw new Error('terminal exploded')
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      await expect(collect(chain({ value: 'test' }))).rejects.toThrow('terminal exploded')
+
+      expect(order).toStrictEqual(['terminal-throw', 'inner-finally', 'outer-finally'])
+    })
+
+    it('all finally blocks run in reverse order when terminal throws', async () => {
+      const registry = new MiddlewareRegistry()
+      const order: string[] = []
+
+      const a: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          order.push('a-enter')
+          return yield* next(context)
+        } finally {
+          order.push('a-finally')
+        }
+      }
+
+      const b: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          order.push('b-enter')
+          return yield* next(context)
+        } finally {
+          order.push('b-finally')
+        }
+      }
+
+      const c: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          order.push('c-enter')
+          return yield* next(context)
+        } finally {
+          order.push('c-finally')
+        }
+      }
+
+      registry.add(TestStage, a)
+      registry.add(TestStage, b)
+      registry.add(TestStage, c)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        throw new Error('boom')
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      await expect(collect(chain({ value: 'test' }))).rejects.toThrow('boom')
+
+      expect(order).toStrictEqual(['a-enter', 'b-enter', 'c-enter', 'c-finally', 'b-finally', 'a-finally'])
+    })
+
+    it('finally runs even when caller abandons the generator mid-stream', async () => {
+      const registry = new MiddlewareRegistry()
+      const order: string[] = []
+
+      const middleware: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          return yield* next(context)
+        } finally {
+          order.push('middleware-finally')
+        }
+      }
+
+      registry.add(TestStage, middleware)
+
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        yield { data: 'event-1' }
+        yield { data: 'event-2' }
+        yield { data: 'event-3' }
+        return { output: 'done' }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      const gen = chain({ value: 'test' })
+
+      // Only consume one event then abandon (call return to close the generator)
+      await gen.next()
+      await gen.return({ output: 'abandoned' })
+
+      expect(order).toStrictEqual(['middleware-finally'])
+    })
+
+    it('finally runs in both middleware when caller abandons mid-stream', async () => {
+      const registry = new MiddlewareRegistry()
+      const order: string[] = []
+
+      const outer: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          return yield* next(context)
+        } finally {
+          order.push('outer-finally')
+        }
+      }
+
+      const inner: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        try {
+          return yield* next(context)
+        } finally {
+          order.push('inner-finally')
+        }
+      }
+
+      registry.add(TestStage, outer)
+      registry.add(TestStage, inner)
+
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        yield { data: 'event-1' }
+        yield { data: 'event-2' }
+        return { output: 'done' }
+      }
+
+      const chain = registry.compose(TestStage, terminal)
+      const gen = chain({ value: 'test' })
+
+      await gen.next()
+      await gen.return({ output: 'abandoned' })
+
+      expect(order).toStrictEqual(['inner-finally', 'outer-finally'])
+    })
+  })
+
+  describe('remove', () => {
+    it('removes a handler so it no longer runs', async () => {
+      const registry = new MiddlewareRegistry()
+      const callOrder: number[] = []
+
+      const handler: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        callOrder.push(1)
+        return yield* next(context)
+      }
+
+      registry.add(TestStage, handler)
+      registry.remove(TestStage, handler)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        callOrder.push(2)
+        return { output: 'done' }
+      }
+
+      await collect(registry.invoke(TestStage, { value: 'test' }, terminal))
+      expect(callOrder).toStrictEqual([2])
+    })
+
+    it('only removes the first occurrence of a duplicate handler', async () => {
+      const registry = new MiddlewareRegistry()
+      let callCount = 0
+
+      const handler: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        callCount++
+        return yield* next(context)
+      }
+
+      registry.add(TestStage, handler)
+      registry.add(TestStage, handler)
+      registry.remove(TestStage, handler)
+
+      // eslint-disable-next-line require-yield
+      const terminal: MiddlewareNext<TestContext, TestResult, TestEvent> = async function* () {
+        return { output: 'done' }
+      }
+
+      await collect(registry.invoke(TestStage, { value: 'test' }, terminal))
+      expect(callCount).toBe(1)
+    })
+
+    it('is a no-op when handler was never registered', async () => {
+      const registry = new MiddlewareRegistry()
+
+      const handler: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next(context)
+      }
+
+      // Should not throw
+      registry.remove(TestStage, handler)
+    })
+
+    it('is a no-op when stage has no handlers', () => {
+      const registry = new MiddlewareRegistry()
+      const OtherStage = createStage<TestContext, TestResult, TestEvent>('other')
+
+      const handler: MiddlewareHandler<TestContext, TestResult, TestEvent> = async function* (context, next) {
+        return yield* next(context)
+      }
+
+      // Should not throw
+      registry.remove(OtherStage, handler)
+    })
+  })
+})

--- a/strands-ts/src/middleware/index.ts
+++ b/strands-ts/src/middleware/index.ts
@@ -1,0 +1,26 @@
+export type {
+  MiddlewareStage,
+  MiddlewareNext,
+  MiddlewareHandler,
+  MiddlewareHandlerOf,
+  MiddlewareNextOf,
+  MiddlewareInputHandler,
+  MiddlewareOutputHandler,
+  MiddlewareInputPhase,
+  MiddlewareAroundPhase,
+  MiddlewareOutputPhase,
+  MiddlewarePhase,
+  MiddlewarePhaseKind,
+} from './types.js'
+export { createStage, InvokeModelStage, ExecuteToolStage, AgentStreamStage } from './stages.js'
+export type {
+  InvokeModelContext,
+  InvokeModelResult,
+  ExecuteToolContext,
+  ExecuteToolResult,
+  AgentStreamContext,
+  AgentStreamResult,
+  MiddlewareInterruptResult,
+  MiddlewareInterruptible,
+} from './stages.js'
+export { MiddlewareRegistry } from './registry.js'

--- a/strands-ts/src/middleware/registry.ts
+++ b/strands-ts/src/middleware/registry.ts
@@ -1,0 +1,151 @@
+import type {
+  MiddlewareStage,
+  MiddlewareHandler,
+  MiddlewareNext,
+  MiddlewarePhaseKind,
+  MiddlewareInputPhase,
+  MiddlewareOutputPhase,
+  MiddlewareInputHandler,
+  MiddlewareOutputHandler,
+} from './types.js'
+
+/** Internal tagged handler with phase metadata for compose ordering. */
+interface TaggedHandler<TContext, TResult, TEvent> {
+  phase: MiddlewarePhaseKind
+  handler: MiddlewareHandler<TContext, TResult, TEvent>
+}
+
+/** Compose layering: input (outermost) → output → around (innermost). Execution order: input → around → output. */
+const PHASE_ORDER: Record<MiddlewarePhaseKind, number> = { input: 0, output: 1, around: 2 }
+
+/**
+ * Registry that stores middleware handlers keyed by stage tokens
+ * and composes them into execution chains with phase ordering.
+ */
+export class MiddlewareRegistry {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly _handlers: Map<MiddlewareStage<any, any, any>, TaggedHandler<any, any, any>[]>
+
+  constructor() {
+    this._handlers = new Map()
+  }
+
+  /**
+   * Register a middleware handler for a given stage (Around phase).
+   * Handlers are stored in registration order within their phase.
+   *
+   * @param stage - The stage token to register the handler for
+   * @param handler - The middleware handler function
+   */
+  add<TContext, TResult, TEvent>(
+    stage: MiddlewareStage<TContext, TResult, TEvent>,
+    handler: MiddlewareHandler<TContext, TResult, TEvent>
+  ): void {
+    const handlers = this._handlers.get(stage) ?? []
+    handlers.push({ phase: 'around', handler })
+    this._handlers.set(stage, handlers)
+  }
+
+  /**
+   * Register an Input phase handler. Transforms context before the Around chain runs.
+   * Multiple Input handlers compose in registration order (each sees the previous handler's output).
+   * Returns the adapted handler for cleanup purposes.
+   */
+  addInput<TContext, TResult, TEvent>(
+    phase: MiddlewareInputPhase<TContext, TResult, TEvent>,
+    handler: MiddlewareInputHandler<TContext>
+  ): MiddlewareHandler<TContext, TResult, TEvent> {
+    const stage = phase._stage
+    const handlers = this._handlers.get(stage) ?? []
+    const adapted: MiddlewareHandler<TContext, TResult, TEvent> = async function* (context, next) {
+      const transformed = await handler(context)
+      return yield* next(transformed)
+    }
+    handlers.push({ phase: 'input', handler: adapted })
+    this._handlers.set(stage, handlers)
+    return adapted
+  }
+
+  /**
+   * Register an Output phase handler. Transforms result after the Around chain completes.
+   * Multiple Output handlers compose in registration order (each sees the previous handler's output).
+   * Returns the adapted handler for cleanup purposes.
+   */
+  addOutput<TContext, TResult, TEvent>(
+    phase: MiddlewareOutputPhase<TContext, TResult, TEvent>,
+    handler: MiddlewareOutputHandler<TResult>
+  ): MiddlewareHandler<TContext, TResult, TEvent> {
+    const stage = phase._stage
+    const handlers = this._handlers.get(stage) ?? []
+    const adapted: MiddlewareHandler<TContext, TResult, TEvent> = async function* (context, next) {
+      const result = yield* next(context)
+      return await handler(result)
+    }
+    handlers.push({ phase: 'output', handler: adapted })
+    this._handlers.set(stage, handlers)
+    return adapted
+  }
+
+  /**
+   * Remove a previously registered middleware handler for a given stage.
+   * Removes the first occurrence of the handler (by reference equality on the adapted handler).
+   *
+   * @param stage - The stage token to remove the handler from
+   * @param handler - The middleware handler function to remove
+   */
+  remove<TContext, TResult, TEvent>(
+    stage: MiddlewareStage<TContext, TResult, TEvent>,
+    handler: MiddlewareHandler<TContext, TResult, TEvent>
+  ): void {
+    const handlers = this._handlers.get(stage)
+    if (!handlers) return
+    const idx = handlers.findIndex((h) => h.handler === handler)
+    if (idx !== -1) handlers.splice(idx, 1)
+  }
+
+  /**
+   * Compose all registered handlers for a stage into a single middleware chain.
+   * Handlers are ordered by phase (input → output → around), then by registration order within phase.
+   * First in the composed chain = outermost.
+   *
+   * @param stage - The stage token to compose handlers for
+   * @param terminal - The innermost function that performs actual stage execution
+   * @returns A single function representing the full middleware chain
+   */
+  compose<TContext, TResult, TEvent>(
+    stage: MiddlewareStage<TContext, TResult, TEvent>,
+    terminal: MiddlewareNext<TContext, TResult, TEvent>
+  ): MiddlewareNext<TContext, TResult, TEvent> {
+    const tagged = (this._handlers.get(stage) ?? []) as TaggedHandler<TContext, TResult, TEvent>[]
+
+    // Stable sort by phase: input first, output second, around last (closest to terminal)
+    const sorted = [...tagged].sort((a, b) => PHASE_ORDER[a.phase] - PHASE_ORDER[b.phase])
+
+    let current: MiddlewareNext<TContext, TResult, TEvent> = terminal
+    for (let i = sorted.length - 1; i >= 0; i--) {
+      const handler = sorted[i]!.handler
+      const next = current
+      current = (context: TContext): AsyncGenerator<TEvent, TResult, undefined> => handler(context, next)
+    }
+
+    return current
+  }
+
+  /**
+   * Compose and invoke the middleware chain for a stage in one call.
+   * Equivalent to `compose(stage, terminal)(context)` but reads more clearly at call sites.
+   *
+   * @param stage - The stage token to invoke
+   * @param context - The context to pass into the chain
+   * @param terminal - The innermost function that performs actual stage execution
+   * @returns An async generator yielding events and returning the stage result
+   */
+  invoke<TContext, TResult, TEvent>(
+    stage: MiddlewareStage<TContext, TResult, TEvent>,
+    context: TContext,
+    terminal: MiddlewareNext<TContext, TResult, TEvent>
+  ): AsyncGenerator<TEvent, TResult, undefined> {
+    const chain = this.compose(stage, terminal)
+    return chain(context)
+  }
+}

--- a/strands-ts/src/middleware/stages.ts
+++ b/strands-ts/src/middleware/stages.ts
@@ -1,0 +1,162 @@
+import type { MiddlewareStage } from './types.js'
+import type {
+  LocalAgent,
+  AgentStreamEvent,
+  InvocationState,
+  InvokeArgs,
+  InvokeOptions,
+  AgentResult,
+} from '../types/agent.js'
+import type { Message, SystemPrompt, ToolResultBlock } from '../types/messages.js'
+import type { ToolSpec, ToolChoice } from '../tools/types.js'
+import type { StateStore } from '../state-store.js'
+import type { StreamAggregatedResult } from '../models/model.js'
+import type { ToolUseData } from '../hooks/events.js'
+import type { Tool } from '../tools/tool.js'
+import type { InterruptParams } from '../types/interrupt.js'
+import type { JSONValue } from '../types/json.js'
+
+/**
+ * Result returned by `interrupt()` in middleware contexts.
+ * Returns an object to allow future extension (e.g., cached data, metadata)
+ * without a breaking change to callers.
+ */
+export interface MiddlewareInterruptResult<T = JSONValue> {
+  /**
+   * The resolved response value from the interrupt.
+   * The generic `T` is a caller assertion — the actual value is whatever the user
+   * passed in `InterruptResponseContent.response` (a `JSONValue`). No runtime
+   * validation is performed; callers are responsible for ensuring the shape matches.
+   */
+  response: T
+}
+
+/**
+ * Interface for middleware contexts that support interrupts.
+ * Unlike the hook/tool `Interruptible`, middleware interrupts return a wrapper
+ * object to allow non-breaking additions in the future.
+ */
+export interface MiddlewareInterruptible {
+  /**
+   * Request a human-in-the-loop interrupt.
+   *
+   * On first execution (no prior response), throws `InterruptError` to halt the agent.
+   * On resume (after the user provides a response), returns the response wrapped in
+   * `MiddlewareInterruptResult`.
+   *
+   * @param params - Interrupt parameters (name, optional reason, optional preemptive response)
+   * @returns The user's response wrapped in `{ response: T }`
+   * @throws InterruptError when no response has been provided yet
+   */
+  interrupt<T = JSONValue>(params: InterruptParams): MiddlewareInterruptResult<T>
+}
+
+/**
+ * Creates a new middleware stage token with Input/Around/Output phase sub-tokens.
+ * The returned object is frozen and used as a Map key by the registry.
+ *
+ * @param name - Human-readable name for debugging/logging
+ * @returns A frozen MiddlewareStage object carrying the Context/Event/Result type parameters
+ */
+export function createStage<TContext, TResult, TEvent>(name: string): MiddlewareStage<TContext, TResult, TEvent> {
+  const stage = { name } as MiddlewareStage<TContext, TResult, TEvent>
+  const input = Object.freeze({ _phase: 'input' as const, _stage: stage })
+  const around = Object.freeze({ _phase: 'around' as const, _stage: stage })
+  const output = Object.freeze({ _phase: 'output' as const, _stage: stage })
+  return Object.freeze(Object.assign(stage, { Input: input, Around: around, Output: output }))
+}
+
+/**
+ * Context passed to model-stage middleware.
+ * All inputs to the model call are explicit — middleware can inspect and transform
+ * any of them by passing a modified context to next().
+ */
+export interface InvokeModelContext {
+  /** The agent instance (escape hatch for advanced use cases). */
+  readonly agent: LocalAgent
+  /** The messages to send to the model. */
+  readonly messages: readonly Message[]
+  /** System prompt to guide the model's behavior. */
+  readonly systemPrompt?: SystemPrompt
+  /** Tool specifications available to the model. */
+  readonly toolSpecs: readonly ToolSpec[]
+  /** Controls how the model selects tools. */
+  readonly toolChoice?: ToolChoice
+  /** Runtime state for stateful model providers. */
+  readonly modelState: StateStore
+  /** Per-invocation state shared across hooks and tools. */
+  readonly invocationState: InvocationState
+}
+
+/**
+ * Result from model-stage middleware.
+ * The return value of the async generator.
+ */
+export interface InvokeModelResult {
+  /** The aggregated result from the model stream. */
+  readonly result: StreamAggregatedResult
+}
+
+/**
+ * Context passed to tool-stage middleware.
+ * Contains everything needed to understand and potentially modify the tool call.
+ */
+export interface ExecuteToolContext extends MiddlewareInterruptible {
+  /** The agent instance (escape hatch for advanced use cases). */
+  readonly agent: LocalAgent
+  /** The resolved tool implementation, or undefined if not found. */
+  readonly tool: Tool | undefined
+  /** The tool use request (name, toolUseId, input). */
+  readonly toolUse: ToolUseData
+  /** Per-invocation state shared across hooks and tools. */
+  readonly invocationState: InvocationState
+}
+
+/**
+ * Result from tool-stage middleware.
+ * The return value of the async generator.
+ */
+export interface ExecuteToolResult {
+  /** The tool result block from execution. */
+  readonly result: ToolResultBlock
+}
+
+/**
+ * Context passed to agent-stream-stage middleware.
+ * Wraps the entire agent output stream at the outermost interception point.
+ */
+export interface AgentStreamContext extends MiddlewareInterruptible {
+  /** The agent instance (escape hatch for advanced use cases). */
+  readonly agent: LocalAgent
+  /** The invocation arguments passed to agent.stream(). */
+  readonly args: InvokeArgs
+  /** Per-invocation options (cancel signal, structured output, etc.). */
+  readonly options?: InvokeOptions
+}
+
+/**
+ * Result from agent-stream-stage middleware.
+ * The return value of the async generator.
+ */
+export interface AgentStreamResult {
+  /** The final agent result from the stream. */
+  readonly result: AgentResult
+}
+
+/**
+ * Built-in stage wrapping core model invocation.
+ * Middleware registered for this stage can rate-limit, cache, or transform model inputs.
+ */
+export const InvokeModelStage = createStage<InvokeModelContext, InvokeModelResult, AgentStreamEvent>('invokeModel')
+
+/**
+ * Built-in stage wrapping individual tool execution.
+ * Middleware registered for this stage can add telemetry, validate inputs, or mock responses.
+ */
+export const ExecuteToolStage = createStage<ExecuteToolContext, ExecuteToolResult, AgentStreamEvent>('executeTool')
+
+/**
+ * Built-in stage wrapping the entire agent output stream.
+ * Middleware registered for this stage can filter, transform, or inject events.
+ */
+export const AgentStreamStage = createStage<AgentStreamContext, AgentStreamResult, AgentStreamEvent>('agentStream')

--- a/strands-ts/src/middleware/types.ts
+++ b/strands-ts/src/middleware/types.ts
@@ -1,0 +1,103 @@
+/**
+ * A stage token that identifies a middleware interception point.
+ * Stages are created via `createStage()` and carry their Context/Event/Result types
+ * as generics, enabling full type inference at registration sites.
+ *
+ * Third parties can create custom stages — the SDK does not maintain a closed set.
+ */
+export interface MiddlewareStage<TContext, TResult, TEvent> {
+  /** Human-readable name for debugging and logging. */
+  readonly name: string
+  /** @internal Phantom field for type inference. Never accessed at runtime. */
+  readonly _types?: { context: TContext; event: TEvent; result: TResult }
+  /** Phase sub-token: transform context before execution. */
+  readonly Input: MiddlewareInputPhase<TContext, TResult, TEvent>
+  /** Phase sub-token: full async generator wrap (before + call next + after). */
+  readonly Around: MiddlewareAroundPhase<TContext, TResult, TEvent>
+  /** Phase sub-token: transform result after execution. */
+  readonly Output: MiddlewareOutputPhase<TContext, TResult, TEvent>
+}
+
+/** Phase ordering. Compose layering: input (outermost) → output → around (innermost). Execution order: input → around → output. */
+export type MiddlewarePhaseKind = 'input' | 'around' | 'output'
+
+/** Phase sub-token for Input handlers. */
+export interface MiddlewareInputPhase<TContext, TResult, TEvent> {
+  /** @internal */
+  readonly _phase: 'input'
+  /** @internal Back-reference to parent stage. */
+  readonly _stage: MiddlewareStage<TContext, TResult, TEvent>
+}
+
+/** Phase sub-token for Around handlers. */
+export interface MiddlewareAroundPhase<TContext, TResult, TEvent> {
+  /** @internal */
+  readonly _phase: 'around'
+  /** @internal Back-reference to parent stage. */
+  readonly _stage: MiddlewareStage<TContext, TResult, TEvent>
+}
+
+/** Phase sub-token for Output handlers. */
+export interface MiddlewareOutputPhase<TContext, TResult, TEvent> {
+  /** @internal */
+  readonly _phase: 'output'
+  /** @internal Back-reference to parent stage. */
+  readonly _stage: MiddlewareStage<TContext, TResult, TEvent>
+}
+
+/** Union of all phase sub-tokens. */
+export type MiddlewarePhase<TContext, TResult, TEvent> =
+  | MiddlewareInputPhase<TContext, TResult, TEvent>
+  | MiddlewareAroundPhase<TContext, TResult, TEvent>
+  | MiddlewareOutputPhase<TContext, TResult, TEvent>
+
+/**
+ * The `next` function passed to middleware.
+ * Returns an async generator that yields events of type TEvent and returns the stage result.
+ * Middleware can choose not to call `next` to short-circuit execution.
+ */
+export type MiddlewareNext<TContext, TResult, TEvent> = (
+  context: TContext
+) => AsyncGenerator<TEvent, TResult, undefined>
+
+/**
+ * A middleware handler function (Around phase).
+ * Receives the context and a `next` function to call the next layer.
+ * Must be an async generator that yields TEvent and returns TResult.
+ * Middleware can yield its own events, forward events from next, or suppress them.
+ */
+export type MiddlewareHandler<TContext, TResult, TEvent> = (
+  context: TContext,
+  next: MiddlewareNext<TContext, TResult, TEvent>
+) => AsyncGenerator<TEvent, TResult, undefined>
+
+/** Handler for Input phase — transforms context before execution. */
+export type MiddlewareInputHandler<TContext> = (context: TContext) => TContext | Promise<TContext>
+
+/** Handler for Output phase — transforms result after execution. */
+export type MiddlewareOutputHandler<TResult> = (result: TResult) => TResult | Promise<TResult>
+
+/**
+ * Extracts the `MiddlewareHandler` type from a stage token.
+ * Use this to type middleware methods or properties without repeating the generic parameters.
+ *
+ * @example
+ * ```typescript
+ * class MyPlugin implements Plugin {
+ *   private _handler: MiddlewareHandlerOf<typeof InvokeModelStage> = async function* (context, next) { ... }
+ * }
+ * ```
+ */
+export type MiddlewareHandlerOf<S> =
+  S extends MiddlewareStage<infer C, infer R, infer E> ? MiddlewareHandler<C, R, E> : never
+
+/**
+ * Extracts the `MiddlewareNext` type from a stage token.
+ * Use this to type the `next` parameter in standalone middleware methods.
+ *
+ * @example
+ * ```typescript
+ * private async *_handler(context: ..., next: MiddlewareNextOf<typeof AgentStreamStage>) { ... }
+ * ```
+ */
+export type MiddlewareNextOf<S> = S extends MiddlewareStage<infer C, infer R, infer E> ? MiddlewareNext<C, R, E> : never

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -26,6 +26,14 @@ import type {
   StreamEvent,
 } from '../hooks/events.js'
 import type { HookCallback, HookableEventConstructor, HookCallbackOptions, HookCleanup } from '../hooks/types.js'
+import type {
+  MiddlewareStage,
+  MiddlewareHandler,
+  MiddlewareInputPhase,
+  MiddlewareOutputPhase,
+  MiddlewareInputHandler,
+  MiddlewareOutputHandler,
+} from '../middleware/types.js'
 import type { ToolRegistry } from '../registry/tool-registry.js'
 import type { Model } from '../models/model.js'
 import type { z } from 'zod'
@@ -341,6 +349,27 @@ export interface LocalAgent {
    * @param snapshot - The snapshot to restore from
    */
   loadSnapshot(snapshot: Snapshot): void
+
+  /**
+   * Register a middleware handler for a given stage or phase.
+   * Middleware wraps stage execution and can intercept, transform, or short-circuit operations.
+   *
+   * @param stageOrPhase - A stage token (Around) or phase sub-token (.Input / .Output)
+   * @param handler - Async generator for Around, plain async function for Input/Output
+   * @returns A cleanup function that removes the middleware when called
+   */
+  addMiddleware<TContext, TResult, TEvent>(
+    phase: MiddlewareInputPhase<TContext, TResult, TEvent>,
+    handler: MiddlewareInputHandler<TContext>
+  ): () => void
+  addMiddleware<TContext, TResult, TEvent>(
+    phase: MiddlewareOutputPhase<TContext, TResult, TEvent>,
+    handler: MiddlewareOutputHandler<TResult>
+  ): () => void
+  addMiddleware<TContext, TResult, TEvent>(
+    stage: MiddlewareStage<TContext, TResult, TEvent>,
+    handler: MiddlewareHandler<TContext, TResult, TEvent>
+  ): () => void
 }
 
 /**


### PR DESCRIPTION
Migrated to https://github.com/strands-agents/harness-sdk/pull/2681 to cut down on un-needed history

-----

Port of strands-agents/sdk-typescript#1068 into the mono-repo.

Original author: @zastrowm

-----

## Summary

Adds a middleware system that wraps agent stages using async generator handlers. Middleware controls flow (retry, cache, transform, short-circuit).

**Public API:** `agent.addMiddleware(stage, handler)` — returns a cleanup function.

Three built-in stages: `InvokeModelStage`, `ExecuteToolStage`, `AgentStreamStage`. 

## Motivation

Hooks let you observe operations and set flags, but they don't let you wrap them. If you want to do something both before and after a model call (timing it, adding a span, catching errors), hooks force you to manage state across two separate callbacks. With middleware you can wrap the entire invocation keeping state within your callback:

```typescript
agent.addMiddleware(InvokeModelStage, async function* (context, next) {
  const start = Date.now()
  const result = yield* next(context)
  metrics.record(Date.now() - start)
  return result
})
```

Beyond the before/after pattern, middleware also makes several other use cases much more natural to express: caching, input transformation, short-circuiting, and error handling. All of these are awkward or impossible with hooks alone.

## Public API Changes

```typescript
import { Agent, InvokeModelStage, ExecuteToolStage, AgentStreamStage, createStage } from '@strands-agents/sdk'
import type { MiddlewareStage, MiddlewareHandler, MiddlewareNext } from '@strands-agents/sdk'

const agent = new Agent({ model, tools })

// Register middleware for any built-in stage
agent.addMiddleware(InvokeModelStage, async function* (context, next) {
  // pre-processing: inspect or transform context
  const modified = { ...context, messages: sanitize(context.messages) }
  // call next layer (or don't, to short-circuit)
  const result = yield* next(modified)
  // post-processing: inspect or transform result
  return result
})
```

Three stages ship with the SDK:

| Stage              | Wraps                                                     | Context fields                                            |
| ------------------ | --------------------------------------------------------- | --------------------------------------------------------- |
| `InvokeModelStage` | Model call (between Before/AfterModelCallEvent)           | messages, systemPrompt, toolSpecs, toolChoice, modelState |
| `ExecuteToolStage` | Single tool execution (between Before/AfterToolCallEvent) | tool, toolUse (name, id, input)                           |
| `AgentStreamStage` | Full `agent.stream()` output                              | args, options                                             |

Handlers are async generators and simple pass-through is `return yield* next(context)`. Manual iteration of `next()` allows real-time event filtering or injection while not calling `next` at all short-circuits the operation.

## Plugin Examples

```typescript
class ToolResultCache implements Plugin {
  name = 'tool-result-cache'
  private readonly _cache = new Map<string, ToolResultBlock>()

  initAgent(agent: LocalAgent): void {
    const cache = this._cache
    agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
      const key = `${context.toolUse.name}:${JSON.stringify(context.toolUse.input)}`
      const cached = cache.get(key)
      if (cached) return { result: new ToolResultBlock({ toolUseId: context.toolUse.toolUseId, status: cached.status, content: cached.content }) }
      const result = yield* next(context)
      cache.set(key, result.result)
      return result
    })
  }
}
```

```typescript
class RetryOnThrottle implements Plugin {
  name = 'retry-on-throttle'
  initAgent(agent: LocalAgent): void {
    agent.addMiddleware(InvokeModelStage, async function* (context, next) {
      for (let attempt = 0; attempt < 3; attempt++) {
        try { return yield* next(context) }
        catch (e) {
          if (!(e as Error).message.includes('ThrottlingException') || attempt === 2) throw e
        }
      }
      throw new Error('exhausted retries')
    })
  }
}
```

```typescript
class SystemPromptInjector implements Plugin {
  name = 'system-prompt-injector'
  constructor(private readonly _suffix: string) {}

  initAgent(agent: LocalAgent): void {
    const suffix = this._suffix
    agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
      ...context,
      systemPrompt: `${context.systemPrompt ?? ''}\n\n${suffix}`.trim(),
    }))
  }
}

// Usage: inject safety guidelines into every model call
const agent = new Agent({
  model,
  systemPrompt: 'You are a helpful assistant.',
  plugins: [new SystemPromptInjector('Always cite your sources.')],
})
```

## Middleware Interrupts

Middleware contexts expose `interrupt()` for human-in-the-loop gating:

```typescript
agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
  const { response } = context.interrupt<string>({ name: 'approve', reason: 'Confirm?' })
  if (response !== 'yes') return { result: new ToolResultBlock({ ... }) }
  return yield* next(context)
})
```

Returns `MiddlewareInterruptResult<T>` (wrapper) — allows non-breaking additions (cached data, metadata) as the interrupt system evolves.

## Phase Sub-Stages (Input / Around / Output)

Each stage exposes three phases with a fixed execution order in order to solve the middleware ordering problem without explicit priority numbers:

- `Input`: Modifies the input of the phase as a pure function - take in the original input, return the modified input
- `Output`: Modifies the output of the phase as a pure function - take in the original output, return the modified output
- `Around`: Wrape the entire invocation of the stage - this is more akin to traditional middleware from express or other frameworks

```typescript
// Input: transform context before execution (plain async function)
agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
  ...context,
  systemPrompt: injectToSystemPrompt(context),
}))

// Output: transform result after execution (plain async function)
agent.addMiddleware(InvokeModelStage.Output, async (result) => {
  log(`stopReason=${result.result.stopReason}`)
  return result
})

// Around: full async generator wrap (same as just providing `InvokeModelStage`)
agent.addMiddleware(InvokeModelStage.Around, async function* (context, next) {
  return yield* next(context)
})
```

**Execution order is fixed:** all Input → all Output → all Around → terminal. A retry plugin on `.Around` always retries the full chain including Input transforms. A response logger on `.Output` never needs to coordinate registration order with a system prompt injector on `.Input`.

## Key Decisions

- **First registered = outermost**: follows existing middleware conventions (from Express/Koa)
- **Phase ordering is fixed**: Input/Output/Around reduces the need for explicit priority management (for now - we'll probably need to add it later)
- **Hooks fire unconditionally before/after middleware**: existing behavior is unchanged
- **Result wrapper types** (`InvokeModelResult`, etc.): allows future extension of middleware return values, including returning values "up the chain"
- **`readonly` arrays** on `InvokeModelContext`: enforce immutable-context pattern at the type level

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] Tests prove the fix is effective / feature works
- [x] No new warnings
- [ ] Documentation update (pending)

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
