### PR TITLE
chore: update repository references to harness-sdk

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Strands Agents SDK Support
     # Only one repo has Discussions enabled; point users there.
-    url: https://github.com/strands-agents/sdk-python/discussions
+    url: https://github.com/strands-agents/harness-sdk/discussions
     about: Please ask and answer questions here
   - name: Strands Agents SDK Documentation
     url: https://strandsagents.com

--- a/COMPATIBILITY.MD
+++ b/COMPATIBILITY.MD
@@ -90,4 +90,4 @@ New event types added to the union don't affect existing event handling logic.
 
 ## Feedback
 
-If you have questions or concerns about this compatibility policy, please [open an issue](https://github.com/strands-agents/sdk-typescript/issues) on GitHub.
+If you have questions or concerns about this compatibility policy, please [open an issue](https://github.com/strands-agents/harness-sdk/issues) on GitHub.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
   </h2>
 
   <div align="center">
-    <a href="https://github.com/strands-agents/sdk-python/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/strands-agents/sdk-python"/></a>
-    <a href="https://github.com/strands-agents/sdk-python/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/sdk-python"/></a>
-    <a href="https://github.com/strands-agents/sdk-python/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/sdk-python"/></a>
-    <a href="https://github.com/strands-agents/sdk-python/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/sdk-python"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/harness-sdk"/></a>
     <a href="https://pypi.org/project/strands-agents/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/strands-agents"/></a>
     <a href="https://python.org"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/strands-agents"/></a>
     <a href="https://discord.gg/strands"><img alt="Strands Discord" src="https://img.shields.io/badge/Discord-Strands-5865F2?logo=discord&logoColor=white"/></a>

--- a/site/CONTRIBUTING.md
+++ b/site/CONTRIBUTING.md
@@ -73,7 +73,7 @@ reported the issue. Please try to include as much information as you can. Detail
 Looking at the existing issues is a great way to find something to contribute to. We label issues that are well-defined and ready for community contributions with the "ready for contribution" label. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
 Check our "Ready for Contribution" issues for items you can work on:
-- [SDK Issues](https://github.com/strands-agents/sdk-python/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22ready%20for%20contribution%22)
+- [SDK Issues](https://github.com/strands-agents/harness-sdk/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22ready%20for%20contribution%22)
 - [Tools Issues](https://github.com/strands-agents/tools/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22ready%20for%20contribution%22)
 
 Before starting work on any issue:

--- a/site/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md
+++ b/site/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md
@@ -290,7 +290,7 @@ aws logs tail /aws/bedrock-agentcore/runtimes/my-agent-service-XXXXXXXXXX-DEFAUL
 
 - [Full Documentation](../../../user-guide/deploy/deploy_to_bedrock_agentcore/typescript.md) - Complete deployment guide with detailed explanations
 - [Amazon Bedrock AgentCore Documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html)
-- [Strands TypeScript SDK](https://github.com/strands-agents/sdk-typescript)
+- [Strands TypeScript SDK](https://github.com/strands-agents/harness-sdk)
 - [Express.js Documentation](https://expressjs.com/)
 - [Docker Documentation](https://docs.docker.com/)
 

--- a/site/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md
+++ b/site/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md
@@ -290,7 +290,7 @@ aws logs tail /aws/bedrock-agentcore/runtimes/my-agent-service-XXXXXXXXXX-DEFAUL
 
 - [Full Documentation](../../../user-guide/deploy/deploy_to_bedrock_agentcore/typescript.md) - Complete deployment guide with detailed explanations
 - [Amazon Bedrock AgentCore Documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html)
-- [Strands TypeScript SDK](https://github.com/strands-agents/harness-sdk)
+- [Strands TypeScript SDK](https://github.com/strands-agents/harness-sdk/tree/main/strands-ts)
 - [Express.js Documentation](https://expressjs.com/)
 - [Docker Documentation](https://docs.docker.com/)
 

--- a/site/src/components/landing/HeroSection.astro
+++ b/site/src/components/landing/HeroSection.astro
@@ -86,7 +86,7 @@ await agent.invoke('Research AI agent frameworks')`
       </p>
       <div class="hero-cta">
         <a href={withBase('/docs/user-guide/quickstart/overview/')} class="cta-button primary">Get Started</a>
-        <a href="https://github.com/strands-agents/sdk-python" class="cta-button secondary">GitHub</a>
+        <a href="https://github.com/strands-agents/harness-sdk" class="cta-button secondary">GitHub</a>
       </div>
       <div class="hero-install-group">
         <div class="hero-install" data-copy="pip install strands-agents">

--- a/site/src/content/docs/community/tools/utcp.mdx
+++ b/site/src/content/docs/community/tools/utcp.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 The [Universal Tool Calling Protocol (UTCP)](https://www.utcp.io/) is a lightweight, secure, and scalable standard that enables AI agents to discover and call tools directly using their native protocols - **no wrapper servers required**. UTCP acts as a "manual" that tells agents how to call your tools directly, extending OpenAPI for AI agents while maintaining full backward compatibility.
 
-This community plugin integrates UTCP with [Strands Agents SDK](https://github.com/strands-agents/sdk-python), providing standardized tool discovery and execution capabilities.
+This community plugin integrates UTCP with Strands Agents SDK, providing standardized tool discovery and execution capabilities.
 
 ## Installation
 

--- a/site/src/content/docs/contribute/contributing/core-sdk.mdx
+++ b/site/src/content/docs/contribute/contributing/core-sdk.mdx
@@ -49,7 +49,7 @@ First, we'll clone the repository and set up the virtual environment.
 
 ```bash
 git clone https://github.com/strands-agents/harness-sdk.git
-cd sdk-python/strands-py
+cd harness-sdk/strands-py
 ```
 
 We use [hatch](https://hatch.pypa.io/) for Python development. Hatch manages virtual environments, dependencies, testing, and formatting. Enter the virtual environment and install pre-commit hooks.
@@ -93,7 +93,7 @@ First, we'll clone the repository and install dependencies.
 
 ```bash
 git clone https://github.com/strands-agents/harness-sdk.git
-cd sdk-python
+cd harness-sdk
 npm install
 ```
 

--- a/site/src/content/docs/contribute/contributing/core-sdk.mdx
+++ b/site/src/content/docs/contribute/contributing/core-sdk.mdx
@@ -12,7 +12,7 @@ This guide walks you through contributing to sdk-python and sdk-typescript. We'l
 
 Looking for a place to start? Check our issues labeled "ready for contribution"—these are well-defined and ready for community work.
 
-- [SDK issues](https://github.com/strands-agents/sdk-python/issues?q=is%3Aissue+state%3Aopen+label%3A%22ready+for+contribution%22)
+- [SDK issues](https://github.com/strands-agents/harness-sdk/issues?q=is%3Aissue+state%3Aopen+label%3A%22ready+for+contribution%22)
 
 Before starting work on any issue, check if someone is already assigned or working on it.
 
@@ -36,7 +36,7 @@ Some contributions don't fit the core SDK. Understanding this upfront saves you 
 - **Changes without tests** — Tests ensure quality and prevent regressions (documentation changes excepted)
 - **Niche features** — Features serving narrow use cases belong in extensions
 
-If you're unsure whether your contribution fits, [open a discussion](https://github.com/strands-agents/sdk-python/discussions) first. We're happy to help you find the right path.
+If you're unsure whether your contribution fits, [open a discussion](https://github.com/strands-agents/harness-sdk/discussions) first. We're happy to help you find the right path.
 
 ## Set up your development environment
 
@@ -48,7 +48,7 @@ Let's get your local environment ready for development. This process differs sli
 First, we'll clone the repository and set up the virtual environment.
 
 ```bash
-git clone https://github.com/strands-agents/sdk-python.git
+git clone https://github.com/strands-agents/harness-sdk.git
 cd sdk-python/strands-py
 ```
 
@@ -85,14 +85,14 @@ hatch run prepare           # Run all checks before committing
 
 - Use `hatch run test-integ` to run integration tests with real model providers
 - Run `hatch test --all` to test across Python 3.10-3.13
-- Check [CONTRIBUTING.md](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md) for the full development workflow
+- Check [CONTRIBUTING.md](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md) for the full development workflow
 </Tab>
 <Tab label="TypeScript">
 
 First, we'll clone the repository and install dependencies.
 
 ```bash
-git clone https://github.com/strands-agents/sdk-python.git
+git clone https://github.com/strands-agents/harness-sdk.git
 cd sdk-python
 npm install
 ```
@@ -121,7 +121,7 @@ npm run format              # Format code with Prettier
 
 - Use `npm run test:integ` to run integration tests
 - Run `npm run test:all` to test in both Node.js and browser environments
-- Check [CONTRIBUTING.md](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md) for the full development workflow
+- Check [CONTRIBUTING.md](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md) for the full development workflow
 </Tab>
 </Tabs>
 
@@ -143,4 +143,4 @@ The pre-commit hooks help catch issues before you push, but you can also run che
 ## Related guides
 
 - [Feature proposals](./feature-proposals.md) — For significant features requiring discussion
-- [Team documentation](https://github.com/strands-agents/sdk-python/tree/main/team) — Our tenets, decisions, and API review process
+- [Team documentation](https://github.com/strands-agents/harness-sdk/tree/main/team) — Our tenets, decisions, and API review process

--- a/site/src/content/docs/contribute/contributing/documentation.mdx
+++ b/site/src/content/docs/contribute/contributing/documentation.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "Documentation"
 ---
 
-Good documentation helps developers succeed with Strands. We welcome contributions that make our docs clearer, more complete, or more helpful. Our documentation lives in the `site/` directory of the [Strands SDK repository](https://github.com/strands-agents/sdk-python).
+Good documentation helps developers succeed with Strands. We welcome contributions that make our docs clearer, more complete, or more helpful. Our documentation lives in the `site/` directory of the [Strands SDK repository](https://github.com/strands-agents/harness-sdk).
 
 ## What we accept
 
@@ -24,7 +24,7 @@ Let's get the docs running locally so you can preview your changes as you work. 
 
 ```bash
 # Clone the repository
-git clone https://github.com/strands-agents/sdk-python.git
+git clone https://github.com/strands-agents/harness-sdk.git
 cd sdk-python/site
 
 # Install dependencies

--- a/site/src/content/docs/contribute/contributing/documentation.mdx
+++ b/site/src/content/docs/contribute/contributing/documentation.mdx
@@ -25,7 +25,7 @@ Let's get the docs running locally so you can preview your changes as you work. 
 ```bash
 # Clone the repository
 git clone https://github.com/strands-agents/harness-sdk.git
-cd sdk-python/site
+cd harness-sdk/site
 
 # Install dependencies
 npm install

--- a/site/src/content/docs/contribute/contributing/feature-proposals.mdx
+++ b/site/src/content/docs/contribute/contributing/feature-proposals.mdx
@@ -32,7 +32,7 @@ The design document process helps align on requirements, explore alternatives, a
 
 1. **Check the [roadmap](https://github.com/orgs/strands-agents/projects/8/views/1)** — See if your idea aligns with our direction and isn't already planned
 2. **Open an issue first** — Describe the problem you're trying to solve. We need to validate the problem is worth solving before you invest time in a detailed proposal
-3. **Create a design document** — Once we agree the problem is worth solving, submit a PR to the [`designs` folder](https://github.com/strands-agents/sdk-python/tree/main/designs) using the template there. Reference the issue in your design document
+3. **Create a design document** — Once we agree the problem is worth solving, submit a PR to the [`designs` folder](https://github.com/strands-agents/harness-sdk/tree/main/designs) using the template there. Reference the issue in your design document
 4. **Gather feedback** — We'll review and discuss with you, asking clarifying questions
 5. **Get approval** — When we merge the design document, that's your go-ahead to implement
 6. **Implement** — Follow the [SDK contribution process](./core-sdk.md)
@@ -40,11 +40,11 @@ The design document process helps align on requirements, explore alternatives, a
 
 ## Design document template
 
-See the full template in the [designs folder README](https://github.com/strands-agents/sdk-python/blob/main/designs/README.md#design-document-template).
+See the full template in the [designs folder README](https://github.com/strands-agents/harness-sdk/blob/main/designs/README.md#design-document-template).
 
 **Tips for effective proposals:**
 
 - Focus on the problem first, solution comes second
 - Include concrete examples showing current pain and proposed improvement
 - Be open to feedback, the best solution might differ from your initial idea
-- Align with our [development tenets](https://github.com/strands-agents/sdk-python/blob/main/team/TENETS.md)
+- Align with our [development tenets](https://github.com/strands-agents/harness-sdk/blob/main/team/TENETS.md)

--- a/site/src/content/docs/contribute/index.mdx
+++ b/site/src/content/docs/contribute/index.mdx
@@ -27,9 +27,7 @@ You can share your tools, model providers, hooks, and session managers with the 
 ## Community resources
 
 - [Community Catalog](../community/community-packages.md) — Discover community-built extensions
-- GitHub Discussions — Ask questions, share ideas
-  - [Python](https://github.com/strands-agents/sdk-python/discussions)
-  - [TypeScript](https://github.com/strands-agents/sdk-typescript/discussions)
+- [GitHub Discussions](https://github.com/strands-agents/harness-sdk/discussions) — Ask questions, share ideas
 - [Roadmap](https://github.com/orgs/strands-agents/projects/8/views/1) — See what we're working on
 - [Development Tenets](https://github.com/strands-agents/docs/blob/main/team/TENETS.md) — Principles that guide SDK design
 - [Decision Records](https://github.com/strands-agents/docs/blob/main/team/DECISIONS.md) — Past design decisions with rationale

--- a/site/src/content/docs/examples/python/agents_workflows.mdx
+++ b/site/src/content/docs/examples/python/agents_workflows.mdx
@@ -113,7 +113,7 @@ researcher_agent = Agent(
 )
 ```
 
-Without this suppression, the default [callback_handler](https://github.com/strands-agents/sdk-python/blob/main/src/strands/handlers/callback_handler.py) would print all outputs to stdout, creating a cluttered experience with duplicate information from each agent's thinking process and tool calls. Suppressing the output creates a clean user experience by preventing intermediate outputs while still allowing responses to be captured programmatically and enabling proper information flow between agents. Instead of verbose agent outputs, the code provides concise progress feedback through simple print statements:
+Without this suppression, the default [callback_handler](https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/handlers/callback_handler.py) would print all outputs to stdout, creating a cluttered experience with duplicate information from each agent's thinking process and tool calls. Suppressing the output creates a clean user experience by preventing intermediate outputs while still allowing responses to be captured programmatically and enabling proper information flow between agents. Instead of verbose agent outputs, the code provides concise progress feedback through simple print statements:
 
 ```python
 print("\nProcessing: '{user_input}'")

--- a/site/src/content/docs/labs/index.mdx
+++ b/site/src/content/docs/labs/index.mdx
@@ -26,4 +26,4 @@ Python functions that behave like standard functions but are evaluated by AI age
 
 ## Contributing
 
-Have an experimental idea that pushes AI agents forward? Labs is designed for innovation from across the community. Check the [contributing guide](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md) to get started.
+Have an experimental idea that pushes AI agents forward? Labs is designed for innovation from across the community. Check the [contributing guide](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md) to get started.

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -408,7 +408,7 @@ Because `BeforeModelCallEvent` triggers before every model call including calls 
 
 ### Context Window Limit
 
-The threshold check requires the model's context window size. The SDK auto-populates `contextWindowLimit` from built-in lookup tables ([Python](https://github.com/strands-agents/sdk-python/blob/main/src/strands/models/_defaults.py), [TypeScript](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/models/defaults.ts)) for known models. You can override it manually for models not in the lookup table:
+The threshold check requires the model's context window size. The SDK auto-populates `contextWindowLimit` from built-in lookup tables ([Python](https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/_defaults.py), [TypeScript](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/models/defaults.ts)) for known models. You can override it manually for models not in the lookup table:
 
 <Tabs>
 <Tab label="Python">
@@ -468,7 +468,7 @@ To create a custom conversation manager, implement the [`ConversationManager`](@
 
 4. `register_hooks` (optional): Override this method to integrate with [hooks](./hooks.md). This enables proactive context management patterns, such as trimming context before model calls. Always call `super().register_hooks` when overriding.
 
-See the [SlidingWindowConversationManager](https://github.com/strands-agents/sdk-python/blob/main/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py) implementation as a reference example.
+See the [SlidingWindowConversationManager](https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py) implementation as a reference example.
 </Tab>
 <Tab label="TypeScript">
 
@@ -492,6 +492,6 @@ For proactive management alongside overflow recovery, override `initAgent`:
 --8<-- "user-guide/concepts/agents/conversation-management.ts:custom_conversation_manager_proactive"
 ```
 
-See the [SlidingWindowConversationManager](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts) implementation as a reference example.
+See the [SlidingWindowConversationManager](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts) implementation as a reference example.
 </Tab>
 </Tabs>

--- a/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
@@ -286,7 +286,7 @@ For more complex implementations, you may want to create helper methods to organ
         return None
 ```
 
-> Note: `stream` must be implemented async. If your client does not support async invocation, you may consider wrapping the relevant calls in a thread so as not to block the async event loop. For an example on how to achieve this, you can check out the [BedrockModel](https://github.com/strands-agents/sdk-python/blob/main/src/strands/models/bedrock.py) provider implementation.
+> Note: `stream` must be implemented async. If your client does not support async invocation, you may consider wrapping the relevant calls in a thread so as not to block the async event loop. For an example on how to achieve this, you can check out the [BedrockModel](https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/bedrock.py) provider implementation.
 </Tab>
 <Tab label="TypeScript">
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
@@ -244,7 +244,7 @@ model = OpenAIResponsesModel(
 )
 
 agent = Agent(model=model)
-response = agent("Using deepwiki, what language is the strands-agents/sdk-python repo written in?")
+response = agent("Using deepwiki, what language is the strands-agents/harness-sdk repo written in?")
 ```
 </Tab>
 <Tab label="TypeScript">

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.ts
@@ -115,7 +115,7 @@ import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 
   const agent = new Agent({ model })
   const response = await agent.invoke(
-    'Using deepwiki, what language is the strands-agents/sdk-typescript repo written in?'
+    'Using deepwiki, what language is the strands-agents/harness-sdk repo written in?'
   )
   // --8<-- [end:remote_mcp]
 }

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -600,5 +600,5 @@ The A2A client tool provides three main capabilities:
 If you encounter bugs or need to request features for A2A support:
 
 1. Check the [A2A documentation](https://a2aproject.github.io/A2A/latest/) for protocol-specific issues
-2. Report Strands-specific issues on GitHub: [Python SDK](https://github.com/strands-agents/sdk-python/issues/new/choose) or [TypeScript SDK](https://github.com/strands-agents/sdk-typescript/issues/new/choose)
+2. Report Strands-specific issues on [GitHub](https://github.com/strands-agents/harness-sdk/issues/new/choose)
 3. Include relevant error messages and code samples in your reports

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -345,7 +345,7 @@ The [Teacher's Assistant](../../../../examples/python/multi_agent_example/multi_
 </Tab>
 <Tab label="TypeScript">
 
-The [Agents as Tools](https://github.com/strands-agents/sdk-typescript/tree/main/strands-ts/examples/agents-as-tools) example demonstrates an orchestrator agent that routes student queries to specialized tool agents for math, English, computer science, and general knowledge.
+The [Agents as Tools](https://github.com/strands-agents/harness-sdk/tree/main/strands-ts/examples/agents-as-tools) example demonstrates an orchestrator agent that routes student queries to specialized tool agents for math, English, computer science, and general knowledge.
 
 </Tab>
 </Tabs>

--- a/site/src/content/docs/user-guide/concepts/tools/executors.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/executors.mdx
@@ -116,4 +116,4 @@ Cancellation works identically in both modes. Call `agent.cancel()` to request c
 
 ## Custom Executors
 
-Custom tool executors are not currently supported but are planned for a future release. You can track progress on this feature at [GitHub Issue #762](https://github.com/strands-agents/sdk-python/issues/762).
+Custom tool executors are not currently supported but are planned for a future release. You can track progress on this feature at [GitHub Issue #762](https://github.com/strands-agents/harness-sdk/issues/762).

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -47,7 +47,7 @@ This tool reads and writes files at arbitrary absolute paths with the full permi
 --8<-- "user-guide/concepts/tools/vended-tools.ts:file_editor_example"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools/file-editor/README.md)
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/file-editor/README.md)
 
 ---
 
@@ -68,7 +68,7 @@ This tool makes HTTP requests to arbitrary URLs without restrictions on destinat
 --8<-- "user-guide/concepts/tools/vended-tools.ts:http_request_example"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools/http-request/README.md)
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/http-request/README.md)
 
 ---
 
@@ -92,7 +92,7 @@ _Supported in: Node.js, browsers._
 --8<-- "user-guide/concepts/tools/vended-tools.ts:notebook_state_persistence"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools/notebook/README.md)
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/notebook/README.md)
 
 ---
 
@@ -120,7 +120,7 @@ This tool executes arbitrary bash commands without sandboxing. Commands run with
 --8<-- "user-guide/concepts/tools/vended-tools.ts:bash_session"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools/bash/README.md)
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
 
 ---
 
@@ -136,7 +136,7 @@ Combine vended tools to build powerful agent workflows:
 
 ## Versioning & Maintenance
 
-Vended tools ship as part of the SDK and are updated alongside it. Report bugs and feature requests in the [TypeScript SDK GitHub repository](https://github.com/strands-agents/sdk-typescript/issues).
+Vended tools ship as part of the SDK and are updated alongside it. Report bugs and feature requests in the [TypeScript SDK GitHub repository](https://github.com/strands-agents/harness-sdk/issues).
 
 Tool names are stable and will not change. In minor versions, a tool's description, spec, or parameters may be updated to improve effectiveness — these changes are noted in SDK release notes. Pin your SDK version and test after upgrades if your workflows depend on specific tool behavior.
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -136,7 +136,7 @@ Combine vended tools to build powerful agent workflows:
 
 ## Versioning & Maintenance
 
-Vended tools ship as part of the SDK and are updated alongside it. Report bugs and feature requests in the [TypeScript SDK GitHub repository](https://github.com/strands-agents/harness-sdk/issues).
+Vended tools ship as part of the SDK and are updated alongside it. Report bugs and feature requests in the [GitHub repository](https://github.com/strands-agents/harness-sdk/issues).
 
 Tool names are stable and will not change. In minor versions, a tool's description, spec, or parameters may be updated to improve effectiveness — these changes are noted in SDK release notes. Pin your SDK version and test after upgrades if your workflows depend on specific tool behavior.
 

--- a/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/typescript.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/typescript.mdx
@@ -734,7 +734,7 @@ aws logs tail /aws/bedrock-agentcore/runtimes/my-agent-service-XXXXXXXXXX-DEFAUL
 ## Additional Resources
 
 - [Amazon Bedrock AgentCore Runtime Documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html)
-- [Strands TypeScript SDK Repository](https://github.com/strands-agents/sdk-typescript)
+- [Strands TypeScript SDK Repository](https://github.com/strands-agents/harness-sdk)
 - [Express.js Documentation](https://expressjs.com/)
 - [Docker Documentation](https://docs.docker.com/)
 - [AWS IAM Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html)

--- a/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/typescript.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/typescript.mdx
@@ -734,7 +734,7 @@ aws logs tail /aws/bedrock-agentcore/runtimes/my-agent-service-XXXXXXXXXX-DEFAUL
 ## Additional Resources
 
 - [Amazon Bedrock AgentCore Runtime Documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html)
-- [Strands TypeScript SDK Repository](https://github.com/strands-agents/harness-sdk)
+- [Strands TypeScript SDK Repository](https://github.com/strands-agents/harness-sdk/tree/main/strands-ts)
 - [Express.js Documentation](https://expressjs.com/)
 - [Docker Documentation](https://docs.docker.com/)
 - [AWS IAM Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html)

--- a/site/src/content/docs/user-guide/quickstart/typescript.mdx
+++ b/site/src/content/docs/user-guide/quickstart/typescript.mdx
@@ -192,8 +192,8 @@ See the [Async Iterators](../concepts/streaming/async-iterators.md) documentatio
 
 Ready to learn more? Check out these resources:
 
-- [Examples](https://github.com/strands-agents/sdk-typescript/tree/main/strands-ts/examples) - Examples for many use cases
-- [TypeScript SDK Repository](https://github.com/strands-agents/sdk-typescript/blob/main) - Explore the TypeScript SDK source code and contribute
+- [Examples](https://github.com/strands-agents/harness-sdk/tree/main/strands-ts/examples) - Examples for many use cases
+- [TypeScript SDK Repository](https://github.com/strands-agents/harness-sdk/blob/main) - Explore the TypeScript SDK source code and contribute
 - [Agent Loop](../concepts/agents/agent-loop.md) - Learn how Strands agents work under the hood
 - [State](../concepts/agents/state.md) - Understand how agents maintain context and state across a conversation
 - [Operating Agents in Production](../deploy/operating-agents-in-production.md) - Taking agents from development to production, operating them responsibly at scale

--- a/site/src/content/docs/user-guide/quickstart/typescript.mdx
+++ b/site/src/content/docs/user-guide/quickstart/typescript.mdx
@@ -193,7 +193,7 @@ See the [Async Iterators](../concepts/streaming/async-iterators.md) documentatio
 Ready to learn more? Check out these resources:
 
 - [Examples](https://github.com/strands-agents/harness-sdk/tree/main/strands-ts/examples) - Examples for many use cases
-- [TypeScript SDK Repository](https://github.com/strands-agents/harness-sdk/blob/main) - Explore the TypeScript SDK source code and contribute
+- [TypeScript SDK Repository](https://github.com/strands-agents/harness-sdk/tree/main/strands-ts) - Explore the TypeScript SDK source code and contribute
 - [Agent Loop](../concepts/agents/agent-loop.md) - Learn how Strands agents work under the hood
 - [State](../concepts/agents/state.md) - Understand how agents maintain context and state across a conversation
 - [Operating Agents in Production](../deploy/operating-agents-in-production.md) - Taking agents from development to production, operating them responsibly at scale

--- a/site/src/content/docs/user-guide/versioning-and-support.mdx
+++ b/site/src/content/docs/user-guide/versioning-and-support.mdx
@@ -167,13 +167,11 @@ export const deprecated_function = () => {}
 Stay up-to-date with SDK changes through these channels:
 
 * **Release Notes**: Check GitHub Releases for detailed changelogs
-    * [Python SDK](https://github.com/strands-agents/sdk-python/releases)
-    * [TypeScript SDK](https://github.com/strands-agents/sdk-typescript/releases)
+    * [Strands SDK](https://github.com/strands-agents/harness-sdk/releases)
     * [Evals SDK](https://github.com/strands-agents/evals/releases)
 * **Deprecation Warnings**: Monitor warnings in application logs
 * **GitHub Discussions**: Join conversations about proposed changes
-    * [Python Discussions](https://github.com/strands-agents/sdk-python/discussions)
-    * [TypeScript Discussions](https://github.com/strands-agents/sdk-typescript/discussions)
+    * [Strands SDK Discussions](https://github.com/strands-agents/harness-sdk/discussions)
     * [Evals Discussions](https://github.com/strands-agents/evals/discussions)
 * **Documentation**: Migration guides are published with each major release
 
@@ -183,8 +181,7 @@ The Strands SDK is an open-source project that welcomes community contributions.
 
 * **Ask Questions**: Open a GitHub Discussion in the relevant repository
 * **Report Issues**: Submit bug reports or feature requests via GitHub Issues
-    * [Python Issues](https://github.com/strands-agents/sdk-python/issues)
-    * [TypeScript Issues](https://github.com/strands-agents/sdk-typescript/issues)
+    * [Strands SDK Issues](https://github.com/strands-agents/harness-sdk/issues)
     * [Evals Issues](https://github.com/strands-agents/evals/issues)
 * **Contribute Code**: Review the [Contributing Guide](../contribute/contributing/core-sdk.md) to get started
 * **Share Feedback**: Your input on versioning and support policies helps shape the SDK's future

--- a/site/test/update-docs.test.ts
+++ b/site/test/update-docs.test.ts
@@ -55,7 +55,7 @@ See also [AgentResult](@api/python/strands.agent.agent_result#AgentResult).
     it('should not modify non-API links', () => {
       const input = `
 See the [quickstart guide](../user-guide/quickstart.md) for more info.
-Check out [GitHub](https://github.com/strands-agents/sdk-python).
+Check out [GitHub](https://github.com/strands-agents/harness-sdk).
 `
       expect(convertApiLinks(input)).toBe(input)
     })

--- a/strands-py-wasm/pyproject.toml
+++ b/strands-py-wasm/pyproject.toml
@@ -38,8 +38,8 @@ pydantic = ["pydantic>=2.4.0,<3.0.0"]
 
 
 [project.urls]
-Homepage = "https://github.com/strands-agents/sdk-python"
-"Bug Tracker" = "https://github.com/strands-agents/sdk-python/issues"
+Homepage = "https://github.com/strands-agents/harness-sdk"
+"Bug Tracker" = "https://github.com/strands-agents/harness-sdk/issues"
 Documentation = "https://strandsagents.com"
 
 

--- a/strands-py/README.md
+++ b/strands-py/README.md
@@ -14,10 +14,10 @@
   </h2>
 
   <div align="center">
-    <a href="https://github.com/strands-agents/sdk-python/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/strands-agents/sdk-python"/></a>
-    <a href="https://github.com/strands-agents/sdk-python/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/sdk-python"/></a>
-    <a href="https://github.com/strands-agents/sdk-python/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/sdk-python"/></a>
-    <a href="https://github.com/strands-agents/sdk-python/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/sdk-python"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/harness-sdk"/></a>
     <a href="https://pypi.org/project/strands-agents/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/strands-agents"/></a>
     <a href="https://python.org"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/strands-agents"/></a>
     <a href="https://discord.gg/strands"><img alt="Strands Discord" src="https://img.shields.io/badge/Discord-Strands-5865F2?logo=discord&logoColor=white"/></a>
@@ -317,7 +317,7 @@ hatch fmt         # format & lint
 
 ## Contributing ❤️
 
-We welcome contributions! See our [Contributing Guide](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md) for details on:
+We welcome contributions! See our [Contributing Guide](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md) for details on:
 - Reporting bugs & features
 - Development setup
 - Contributing via Pull Requests
@@ -329,8 +329,8 @@ Come meet the Strands team and other users on [**Discord**](https://discord.com/
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/strands-agents/sdk-python/blob/main/LICENSE.APACHE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/strands-agents/harness-sdk/blob/main/LICENSE.APACHE) file for details.
 
 ## Security
 
-See [CONTRIBUTING](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/strands-py/docs/MCP_CLIENT_ARCHITECTURE.md
+++ b/strands-py/docs/MCP_CLIENT_ARCHITECTURE.md
@@ -70,7 +70,7 @@ Once the background thread's event loop is running, we can create `asyncio.Futur
 
 ### Hanging Scenarios & Defenses
 
-**Hanging Scenario 1: Silent Exception Swallowing** ([PR #922](https://github.com/strands-agents/sdk-python/pull/922))
+**Hanging Scenario 1: Silent Exception Swallowing** ([PR #922](https://github.com/strands-agents/harness-sdk/pull/922))
 
 *Problem*: MCP SDK silently swallows server exceptions (HTTP timeouts, connection errors) without a message handler. Tool calls timeout on server side but client waits indefinitely for responses that never arrive.
 
@@ -95,7 +95,7 @@ async with ClientSession(
 
 The threading architecture makes this particularly problematic because the main thread has no way to detect that the background thread received an error - it can only wait for the Future to complete. Without the message handler, that Future never gets resolved.
 
-**Hanging Scenario 2: 5xx Server Errors** ([PR #1169](https://github.com/strands-agents/sdk-python/pull/1169))
+**Hanging Scenario 2: 5xx Server Errors** ([PR #1169](https://github.com/strands-agents/harness-sdk/pull/1169))
 
 *Problem*: When MCP servers return 5xx errors, the underlying client raises an exception that cancels all TaskGroup tasks and tears down the entire asyncio background thread. Pending tool calls hang forever waiting for responses from a dead connection.
 
@@ -116,11 +116,11 @@ async def run_async() -> T:
 
 ### Defense Against Premature Connection Collapse
 
-Before [PR #922](https://github.com/strands-agents/sdk-python/pull/922), the MCP client would never collapse connections because exceptions were silently ignored. After adding `_handle_error_message`, we introduced the risk of collapsing connections on client-side errors that should be recoverable. The challenge is ensuring we:
+Before [PR #922](https://github.com/strands-agents/harness-sdk/pull/922), the MCP client would never collapse connections because exceptions were silently ignored. After adding `_handle_error_message`, we introduced the risk of collapsing connections on client-side errors that should be recoverable. The challenge is ensuring we:
 
 1. **DO collapse** when we want to (fatal server errors)
 2. **DO NOT collapse** when we don't want to (client-side errors, orphaned responses)
-3. **DO notify users** when collapse occurs ([PR #1169](https://github.com/strands-agents/sdk-python/pull/1169) detection)
+3. **DO notify users** when collapse occurs ([PR #1169](https://github.com/strands-agents/harness-sdk/pull/1169) detection)
 
 **Non-Fatal Error Patterns**:
 ```python
@@ -142,4 +142,4 @@ Client receives a response from server with an ID it doesn't recognize (orphaned
 6. Pending operations detect collapse via `close_future` and fail with clear error
 
 **Why This Strategy Works**:
-We get the benefits of [PR #922](https://github.com/strands-agents/sdk-python/pull/922) (no hanging) while avoiding unnecessary connection collapse from recoverable client-side errors. When collapse does occur, [PR #1169](https://github.com/strands-agents/sdk-python/pull/1169) ensures users get clear error messages instead of hanging.
+We get the benefits of [PR #922](https://github.com/strands-agents/harness-sdk/pull/922) (no hanging) while avoiding unnecessary connection collapse from recoverable client-side errors. When collapse does occur, [PR #1169](https://github.com/strands-agents/harness-sdk/pull/1169) ensures users get clear error messages instead of hanging.

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -103,8 +103,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/strands-agents/sdk-python"
-"Bug Tracker" = "https://github.com/strands-agents/sdk-python/issues"
+Homepage = "https://github.com/strands-agents/harness-sdk"
+"Bug Tracker" = "https://github.com/strands-agents/harness-sdk/issues"
 Documentation = "https://strandsagents.com"
 
 

--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -69,7 +69,7 @@ def _normalize_messages(messages: Messages) -> Messages:
             has_tool_use = False
 
             # Ensure the tool-uses always have valid names before sending
-            # https://github.com/strands-agents/sdk-python/issues/1069
+            # https://github.com/strands-agents/harness-sdk/issues/1069
             for item in content:
                 if "toolUse" in item:
                     has_tool_use = True

--- a/strands-py/src/strands/hooks/registry.py
+++ b/strands-py/src/strands/hooks/registry.py
@@ -247,7 +247,7 @@ class HookRegistry:
 
         # Register callback for each event type
         for resolved_event_type in unique_event_types:
-            # Related issue: https://github.com/strands-agents/sdk-python/issues/330
+            # Related issue: https://github.com/strands-agents/harness-sdk/issues/330
             if resolved_event_type.__name__ == "AgentInitializedEvent" and inspect.iscoroutinefunction(callback):
                 raise ValueError("AgentInitializedEvent can only be registered with a synchronous callback")
 

--- a/strands-py/src/strands/models/_validation.py
+++ b/strands-py/src/strands/models/_validation.py
@@ -26,7 +26,7 @@ def validate_config_keys(config_dict: Mapping[str, Any], config_class: type) -> 
             f"Invalid configuration parameters: {sorted(invalid_keys)}."
             f"\nValid parameters are: {sorted(valid_keys)}."
             f"\n"
-            f"\nSee https://github.com/strands-agents/sdk-python/issues/815",
+            f"\nSee https://github.com/strands-agents/harness-sdk/issues/815",
             stacklevel=4,
         )
 

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -480,7 +480,7 @@ class BedrockModel(Model):
                     continue
 
                 # DeepSeek models have issues with reasoningContent
-                # TODO: Replace with systematic model configuration registry (https://github.com/strands-agents/sdk-python/issues/780)
+                # TODO: Replace with systematic model configuration registry (https://github.com/strands-agents/harness-sdk/issues/780)
                 if "deepseek" in self.config["model_id"].lower() and "reasoningContent" in content_block:
                     dropped_deepseek_reasoning_content = True
                     continue

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -241,7 +241,7 @@ class OpenAIModel(Model):
         # (image/document) content.  When all content is text, join into a
         # single string for broad compatibility with OpenAI-compatible
         # endpoints (e.g., Kimi K2.5, vLLM, Ollama).
-        # See https://github.com/strands-agents/sdk-python/issues/1696
+        # See https://github.com/strands-agents/harness-sdk/issues/1696
         merged: list[dict[str, Any]] = []
         has_non_text = False
         for content_block in contents:
@@ -379,7 +379,7 @@ class OpenAIModel(Model):
         if system_prompt and system_prompt_content is None:
             system_prompt_content = [{"text": system_prompt}]
 
-        # TODO: Handle caching blocks https://github.com/strands-agents/sdk-python/issues/1140
+        # TODO: Handle caching blocks https://github.com/strands-agents/harness-sdk/issues/1140
         return [
             {"role": "system", "content": content["text"]}
             for content in system_prompt_content or []

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -32,7 +32,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 # Validate OpenAI SDK version at import time - Responses API requires v2.0.0+
-# A major version bump is proposed in https://github.com/strands-agents/sdk-python/pull/1370
+# A major version bump is proposed in https://github.com/strands-agents/harness-sdk/pull/1370
 _MIN_OPENAI_VERSION = Version("2.0.0")
 
 try:

--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -237,7 +237,7 @@ class RepositorySessionManager(SessionManager):
                     session_message.to_message() for session_message in session_messages
                 ]
 
-                # Fix broken session histories: https://github.com/strands-agents/sdk-python/issues/859
+                # Fix broken session histories: https://github.com/strands-agents/harness-sdk/issues/859
                 agent.messages = self._fix_broken_tool_use(agent.messages)
 
         self._is_new_session = False
@@ -390,7 +390,7 @@ class RepositorySessionManager(SessionManager):
             # Restore the agents messages array
             agent.messages = [session_message.to_message() for session_message in session_messages]
 
-            # Fix broken session histories: https://github.com/strands-agents/sdk-python/issues/859
+            # Fix broken session histories: https://github.com/strands-agents/harness-sdk/issues/859
             agent.messages = self._fix_broken_tool_use(agent.messages)
 
         self._is_new_session = False

--- a/strands-py/src/strands/tools/_caller.py
+++ b/strands-py/src/strands/tools/_caller.py
@@ -133,7 +133,7 @@ class _ToolCaller:
 
                 tool_result = run_async(acall)
 
-                # TODO: https://github.com/strands-agents/sdk-python/issues/1311
+                # TODO: https://github.com/strands-agents/harness-sdk/issues/1311
                 if isinstance(self._agent, Agent):
                     self._agent.conversation_manager.apply_management(self._agent)
 

--- a/strands-py/src/strands/tools/_tool_helpers.py
+++ b/strands-py/src/strands/tools/_tool_helpers.py
@@ -4,7 +4,7 @@ from ..tools.decorator import tool
 from ..types.content import ContentBlock
 
 
-# https://github.com/strands-agents/sdk-python/issues/998
+# https://github.com/strands-agents/harness-sdk/issues/998
 @tool(name="noop", description="This is a fake tool that MUST be completely ignored.")
 def noop_tool() -> str:
     """No-op tool to satisfy tool spec requirement when tool messages are present.

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -205,7 +205,7 @@ class MCPClient(ToolProvider):
         self._log_debug_with_thread("entering MCPClient context")
         # Copy context vars to propagate to the background thread
         # This ensures that context set in the main thread is accessible in the background thread
-        # See: https://github.com/strands-agents/sdk-python/issues/1440
+        # See: https://github.com/strands-agents/harness-sdk/issues/1440
         ctx = contextvars.copy_context()
         self._background_thread = threading.Thread(target=ctx.run, args=(self._background_task,), daemon=True)
         self._background_thread.start()
@@ -968,7 +968,7 @@ class MCPClient(ToolProvider):
             raise MCPClientInitializationError("the client session was not initialized")
 
         async def run_async() -> T:
-            # Fix for strands-agents/sdk-python/issues/995 - cancel all pending invocations if/when the session closes
+            # Fix for strands-agents/harness-sdk/issues/995 - cancel all pending invocations if/when the session closes
             invoke_event = asyncio.create_task(coro)
             tasks: list[asyncio.Task | asyncio.Future] = [
                 invoke_event,

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1022,7 +1022,7 @@ def test_format_request_filters_location_source_document(model, model_id, max_to
 async def test_stream_message_stop_no_pydantic_warnings(anthropic_client, model, alist):
     """Verify no Pydantic serialization warnings are emitted for message_stop events.
 
-    Regression test for https://github.com/strands-agents/sdk-python/issues/1746.
+    Regression test for https://github.com/strands-agents/harness-sdk/issues/1746.
     """
     # Create a mock message_stop event where model_dump() would emit warnings
     # The key is that the event has a .message attribute with .stop_reason

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -808,7 +808,7 @@ async def test_stream_throttling_exception_from_event_stream_error(bedrock_clien
 
 @pytest.mark.asyncio
 async def test_stream_with_invalid_content_throws(bedrock_client, model, alist):
-    # We used to hang on None, so ensure we don't regress: https://github.com/strands-agents/sdk-python/issues/642
+    # We used to hang on None, so ensure we don't regress: https://github.com/strands-agents/harness-sdk/issues/642
     messages = [{"role": "user", "content": None}]
 
     with pytest.raises(TypeError):
@@ -1845,7 +1845,7 @@ def test_format_request_message_content_normalizes_empty_tool_result_content(mod
     Converse API, while others (e.g., Claude) accept them. The SDK should normalize empty
     content arrays to ensure cross-model compatibility.
 
-    See: https://github.com/strands-agents/sdk-python/issues/2122
+    See: https://github.com/strands-agents/harness-sdk/issues/2122
     """
     messages = [
         {"role": "user", "content": [{"text": "List tables"}]},

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -234,7 +234,7 @@ def test_format_request_tool_message_single_text_returns_string():
 def test_format_request_tool_message_multi_text_returns_joined_string():
     """Test that multi-content text results are joined into a single string.
 
-    Regression test for https://github.com/strands-agents/sdk-python/issues/1696.
+    Regression test for https://github.com/strands-agents/harness-sdk/issues/1696.
     OpenAI-compatible endpoints (e.g., Kimi K2.5, vLLM, Ollama) only correctly
     parse string content for tool messages; array format causes hallucinated results.
     """

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -289,7 +289,7 @@ def test_format_request_messages_assistant_text_uses_output_text():
 
     Regression test for multi-turn conversations failing because the OpenAI
     Responses API rejects input_text in assistant messages.
-    See: https://github.com/strands-agents/sdk-python/issues/1850
+    See: https://github.com/strands-agents/harness-sdk/issues/1850
     """
     messages = [
         {

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2451,7 +2451,7 @@ def test_find_newly_ready_nodes_only_evaluates_outbound_edges():
     Previously, it iterated over ALL nodes, which could cause nodes to fire
     before their actual dependencies completed.
 
-    See: https://github.com/strands-agents/sdk-python/issues/685
+    See: https://github.com/strands-agents/harness-sdk/issues/685
     """
     # Build a graph: A -> B -> C, D -> E (independent chain)
     node_a = GraphNode(node_id="A", executor=create_mock_agent("A"))

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_contextvar.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_contextvar.py
@@ -3,7 +3,7 @@
 This test verifies that context variables set in the main thread are
 properly propagated to the MCP client's background thread.
 
-Related: https://github.com/strands-agents/sdk-python/issues/1440
+Related: https://github.com/strands-agents/harness-sdk/issues/1440
 """
 
 import contextvars
@@ -54,7 +54,7 @@ test_contextvar: contextvars.ContextVar[str] = contextvars.ContextVar("test_cont
 def test_mcp_client_propagates_contextvars_to_background_thread(mock_transport, mock_session):
     """Test that context variables are propagated to the MCP client background thread.
 
-    This verifies the fix for https://github.com/strands-agents/sdk-python/issues/1440
+    This verifies the fix for https://github.com/strands-agents/harness-sdk/issues/1440
     where context variables set in the main thread were not accessible in the
     MCP client's background thread.
     """

--- a/strands-py/tests/strands/tools/test_decorator.py
+++ b/strands-py/tests/strands/tools/test_decorator.py
@@ -2028,7 +2028,7 @@ async def test_tool_result_event_carries_exception_assertion_error(alist):
 def test_tool_nullable_required_field_preserves_anyof():
     """Test that a required nullable field preserves anyOf so the model can pass null.
 
-    Regression test for https://github.com/strands-agents/sdk-python/issues/1525
+    Regression test for https://github.com/strands-agents/harness-sdk/issues/1525
     """
     from enum import Enum
 

--- a/strands-py/tests/strands/tools/test_decorator_pep563.py
+++ b/strands-py/tests/strands/tools/test_decorator_pep563.py
@@ -5,7 +5,7 @@ This module tests that the @tool decorator works correctly when modules use
 to be stored as string literals rather than evaluated types.
 
 This is a regression test for issue #1208:
-https://github.com/strands-agents/sdk-python/issues/1208
+https://github.com/strands-agents/harness-sdk/issues/1208
 """
 
 from __future__ import annotations

--- a/strands-py/tests_integ/models/test_model_litellm.py
+++ b/strands-py/tests_integ/models/test_model_litellm.py
@@ -283,7 +283,7 @@ async def test_cache_read_tokens_multi_turn(model):
 def test_gemini_thinking_model_tool_call(tools):
     """Test that Gemini thinking models preserve thought_signature through multi-turn tool calls.
 
-    Regression test for https://github.com/strands-agents/sdk-python/issues/1764
+    Regression test for https://github.com/strands-agents/harness-sdk/issues/1764
     """
     model = LiteLLMModel(model_id="gemini/gemini-2.5-flash", client_args={"api_key": os.environ.get("GOOGLE_API_KEY")})
     agent = Agent(model=model, tools=tools)

--- a/strands-py/tests_integ/models/test_model_openai.py
+++ b/strands-py/tests_integ/models/test_model_openai.py
@@ -206,7 +206,7 @@ def test_tool_returning_images(model, yellow_img):
     agent = Agent(model, tools=[tool_with_image_return])
     # NOTE - this currently fails with: "Invalid 'messages[3]'. Image URLs are only allowed for messages with role
     # 'user', but this message with role 'tool' contains an image URL."
-    # See https://github.com/strands-agents/sdk-python/issues/320 for additional details
+    # See https://github.com/strands-agents/harness-sdk/issues/320 for additional details
     agent("Run the the tool and analyze the image")
 
 

--- a/strands-py/tests_integ/test_invalid_tool_names.py
+++ b/strands-py/tests_integ/test_invalid_tool_names.py
@@ -14,7 +14,7 @@ def temp_dir():
 
 
 def test_invalid_tool_names_works(temp_dir):
-    # Per https://github.com/strands-agents/sdk-python/issues/1069 we want to ensure that invalid tool don't poison
+    # Per https://github.com/strands-agents/harness-sdk/issues/1069 we want to ensure that invalid tool don't poison
     # agent history either in *this* session or in when using session managers
 
     @tool

--- a/strands-ts/README.md
+++ b/strands-ts/README.md
@@ -14,10 +14,10 @@
   </h2>
 
   <div align="center">
-    <a href="https://github.com/strands-agents/sdk-python/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/strands-agents/sdk-python"/></a>
-    <a href="https://github.com/strands-agents/sdk-python/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/sdk-python"/></a>
-    <a href="https://github.com/strands-agents/sdk-python/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/sdk-python"/></a>
-    <a href="https://github.com/strands-agents/sdk-python/blob/main/LICENSE.APACHE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/sdk-python"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/blob/main/LICENSE.APACHE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/harness-sdk"/></a>
     <a href="https://www.npmjs.com/package/@strands-agents/sdk"><img alt="NPM Version" src="https://img.shields.io/npm/v/@strands-agents/sdk"/></a>
     <a href="https://discord.gg/strands"><img alt="Strands Discord" src="https://img.shields.io/badge/Discord-Strands-5865F2?logo=discord&logoColor=white"/></a>
   </div>
@@ -25,7 +25,7 @@
   <p>
     <a href="https://strandsagents.com/">Documentation</a>
     ◆ <a href="https://github.com/strands-agents/samples">Samples</a>
-    ◆ <a href="https://github.com/strands-agents/sdk-python">Python SDK</a>
+    ◆ <a href="https://github.com/strands-agents/harness-sdk">Python SDK</a>
     ◆ <a href="https://github.com/strands-agents/tools">Tools</a>
     ◆ <a href="https://github.com/strands-agents/agent-builder">Agent Builder</a>
     ◆ <a href="https://github.com/strands-agents/mcp-server">MCP Server</a>
@@ -313,13 +313,13 @@ For detailed guidance, tutorials, and concept overviews, please visit:
   - **[MCP](./examples/mcp/)**: MCP integration example
   - **[Browser Agent](./examples/browser-agent/)**: Browser-based agent with DOM manipulation
 
-- **[Contributing Guide](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md)**: Development setup and guidelines
+- **[Contributing Guide](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md)**: Development setup and guidelines
 
 ---
 
 ## Contributing ❤️
 
-We welcome contributions! See our [Contributing Guide](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md) for details on:
+We welcome contributions! See our [Contributing Guide](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md) for details on:
 
 - Development setup and environment
 - Testing and code quality standards
@@ -336,11 +336,11 @@ Come meet the Strands team and other users on [**Discord**](https://discord.com/
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/strands-agents/sdk-python/blob/main/LICENSE.APACHE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/strands-agents/harness-sdk/blob/main/LICENSE.APACHE) file for details.
 
 ---
 
 ## Security
 
-See [CONTRIBUTING](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information on reporting security issues.
+See [CONTRIBUTING](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information on reporting security issues.
 

--- a/strands-ts/README.md
+++ b/strands-ts/README.md
@@ -25,7 +25,7 @@
   <p>
     <a href="https://strandsagents.com/">Documentation</a>
     ◆ <a href="https://github.com/strands-agents/samples">Samples</a>
-    ◆ <a href="https://github.com/strands-agents/harness-sdk">Python SDK</a>
+    ◆ <a href="https://github.com/strands-agents/harness-sdk/tree/main/strands-py">Python SDK</a>
     ◆ <a href="https://github.com/strands-agents/tools">Tools</a>
     ◆ <a href="https://github.com/strands-agents/agent-builder">Agent Builder</a>
     ◆ <a href="https://github.com/strands-agents/mcp-server">MCP Server</a>

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1333,7 +1333,7 @@ describe('Agent', () => {
     })
 
     it('does not send assistant-ended conversation when forcing structured output retry', async () => {
-      // Regression for https://github.com/strands-agents/sdk-typescript/issues/1039
+      // Regression for https://github.com/strands-agents/harness-sdk/issues/1039
       // When the model responds with plain text instead of calling the structured output tool,
       // the forced-retry model call must not see a conversation ending with an assistant message.
       // Bedrock/Anthropic-family models reject assistant message prefill.

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1333,7 +1333,7 @@ describe('Agent', () => {
     })
 
     it('does not send assistant-ended conversation when forcing structured output retry', async () => {
-      // Regression for https://github.com/strands-agents/harness-sdk/issues/1039
+      // Regression for https://github.com/strands-agents/sdk-typescript/issues/1039
       // When the model responds with plain text instead of calling the structured output tool,
       // the forced-retry model call must not see a conversation ending with an assistant message.
       // Bedrock/Anthropic-family models reject assistant message prefill.

--- a/strands-ts/test/integ/__fixtures__/model-providers.ts
+++ b/strands-ts/test/integ/__fixtures__/model-providers.ts
@@ -15,7 +15,7 @@ import { createOpenAI } from '@ai-sdk/openai'
  * Feature support flags for model providers.
  * Used to conditionally run tests based on model capabilities.
  *
- * TODO: after https://github.com/strands-agents/harness-sdk/issues/780 this config should be in src not test
+ * TODO: after https://github.com/strands-agents/sdk-typescript/issues/780 this config should be in src not test
  */
 export interface ProviderFeatures {
   reasoning: boolean

--- a/strands-ts/test/integ/__fixtures__/model-providers.ts
+++ b/strands-ts/test/integ/__fixtures__/model-providers.ts
@@ -15,7 +15,7 @@ import { createOpenAI } from '@ai-sdk/openai'
  * Feature support flags for model providers.
  * Used to conditionally run tests based on model capabilities.
  *
- * TODO: after https://github.com/strands-agents/sdk-python/issues/780 this config should be in src not test
+ * TODO: after https://github.com/strands-agents/harness-sdk/issues/780 this config should be in src not test
  */
 export interface ProviderFeatures {
   reasoning: boolean

--- a/strands-ts/test/integ/__fixtures__/model-providers.ts
+++ b/strands-ts/test/integ/__fixtures__/model-providers.ts
@@ -15,7 +15,7 @@ import { createOpenAI } from '@ai-sdk/openai'
  * Feature support flags for model providers.
  * Used to conditionally run tests based on model capabilities.
  *
- * TODO: after https://github.com/strands-agents/sdk-typescript/issues/780 this config should be in src not test
+ * TODO: after https://github.com/strands-agents/sdk-python/issues/780 this config should be in src not test
  */
 export interface ProviderFeatures {
   reasoning: boolean

--- a/strands-wasm/README.md
+++ b/strands-wasm/README.md
@@ -23,7 +23,7 @@ In WIT terminology, the WASM component is the "guest" and Python is the "host". 
 ### First-time setup
 
 ```bash
-git clone https://github.com/strands-agents/sdk-python.git
+git clone https://github.com/strands-agents/harness-sdk.git
 cd sdk-python
 npm install
 npm run dev -- bootstrap

--- a/strands-wasm/README.md
+++ b/strands-wasm/README.md
@@ -24,7 +24,7 @@ In WIT terminology, the WASM component is the "guest" and Python is the "host". 
 
 ```bash
 git clone https://github.com/strands-agents/harness-sdk.git
-cd sdk-python
+cd harness-sdk
 npm install
 npm run dev -- bootstrap
 ```


### PR DESCRIPTION
## Summary

- Updates all GitHub URL references from `strands-agents/sdk-python` and `strands-agents/sdk-typescript` to `strands-agents/harness-sdk` across READMEs, docs, source comments, and issue templates
- Fixes `cd` commands in contributor docs to match the new clone directory name (`harness-sdk` instead of `sdk-python`)
- Consolidates duplicate Python/TypeScript entries that now point to the same monorepo (versioning docs, discussions links, issue links)
- Fixes source file paths in doc links to use the monorepo `strands-py/` prefix

AFAICT, integ tests failures are unrelated and are just timing out

## What's unchanged

- Build tooling (clone scripts, typedoc config, API generation, CI workflows) — left for a follow-up
- Design docs (`designs/`) — historical records
- Blog posts (`site/src/content/blog/`) — historical announcements (GitHub redirects handle old URLs)

## Test plan

- [x] Python lint (ruff) passes
- [x] Python unit tests pass (1826 tests)
- [x] TypeScript build passes
- [x] TypeScript check (lint + typecheck) passes
- [x] CI passes on PR