### PR TITLE
fix: surface MaxTokensError when max_tokens truncates tool input JSON

### DIFF
--- a/strands-ts/src/models/__tests__/model.test.ts
+++ b/strands-ts/src/models/__tests__/model.test.ts
@@ -323,19 +323,41 @@ describe('Model', () => {
         )
       })
 
-      it('preserves SyntaxError instead of overwriting with MaxTokensError when tool input JSON is malformed', async () => {
+      it('throws MaxTokensError when contentBlockStop arrives with truncated tool input JSON and stopReason is maxTokens', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
           yield {
             type: 'modelContentBlockStartEvent',
-            start: { type: 'toolUseStart', toolUseId: 'tool1', name: 'get_weather' },
+            start: { type: 'toolUseStart', toolUseId: 't', name: 'tool' },
+          }
+          yield {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'toolUseInputDelta', input: '{"field": "value"' },
+          }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelMessageStopEvent', stopReason: 'maxTokens' }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        await expect(async () => await collectGenerator(provider.streamAggregated(messages))).rejects.toThrow(
+          MaxTokensError
+        )
+      })
+
+      it('surfaces SyntaxError as cause when tool input JSON is malformed and stopReason is not maxTokens', async () => {
+        const provider = new TestModelProvider(async function* () {
+          yield { type: 'modelMessageStartEvent', role: 'assistant' }
+          yield {
+            type: 'modelContentBlockStartEvent',
+            start: { type: 'toolUseStart', toolUseId: 't', name: 'tool' },
           }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'toolUseInputDelta', input: '{invalid json' },
           }
           yield { type: 'modelContentBlockStopEvent' }
-          yield { type: 'modelMessageStopEvent', stopReason: 'maxTokens' }
+          yield { type: 'modelMessageStopEvent', stopReason: 'toolUse' }
         })
 
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
@@ -346,6 +368,34 @@ describe('Model', () => {
         } catch (error) {
           expect(error).toBeInstanceOf(ModelError)
           expect(error).not.toBeInstanceOf(MaxTokensError)
+          expect((error as ModelError).message).toBe('unable to parse tool input JSON')
+          expect((error as ModelError).cause).toBeInstanceOf(SyntaxError)
+        }
+      })
+
+      it('attaches SyntaxError as cause when stream ends without a stop event after malformed tool input', async () => {
+        const provider = new TestModelProvider(async function* () {
+          yield { type: 'modelMessageStartEvent', role: 'assistant' }
+          yield {
+            type: 'modelContentBlockStartEvent',
+            start: { type: 'toolUseStart', toolUseId: 't', name: 'tool' },
+          }
+          yield {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'toolUseInputDelta', input: '{invalid json' },
+          }
+          yield { type: 'modelContentBlockStopEvent' }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        try {
+          await collectGenerator(provider.streamAggregated(messages))
+          expect.fail('Expected error to be thrown')
+        } catch (error) {
+          expect(error).toBeInstanceOf(ModelError)
+          expect(error).not.toBeInstanceOf(MaxTokensError)
+          expect((error as ModelError).message).toBe('Stream ended without completing a message')
           expect((error as ModelError).cause).toBeInstanceOf(SyntaxError)
         }
       })

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -349,6 +349,7 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
       let finalStopReason: StopReason | null = null
       let metadata: ModelMetadataEvent | undefined = undefined
       let redactionMessage: string | undefined = undefined
+      let toolInputParseError: SyntaxError | undefined = undefined
 
       for await (const event_data of this.stream(messages, options)) {
         const event = this._convert_to_class_event(event_data)
@@ -425,8 +426,8 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
               yield block
             } catch (e: unknown) {
               if (e instanceof SyntaxError) {
-                logger.error('unable to parse JSON string', e)
-                throw e
+                logger.error('unable to parse tool input JSON', e)
+                toolInputParseError = e
               }
             }
             break
@@ -471,7 +472,10 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
 
       if (!stoppedMessage || !finalStopReason) {
         // If we exit the loop without completing a message or stop reason, throw an error
-        throw new ModelError('Stream ended without completing a message')
+        throw new ModelError(
+          'Stream ended without completing a message',
+          toolInputParseError ? { cause: toolInputParseError } : undefined
+        )
       }
 
       // Attach metadata after redaction so it applies to the final message.
@@ -493,6 +497,10 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
           'Model reached maximum token limit. This is an unrecoverable state that requires intervention.',
           stoppedMessage
         )
+      }
+
+      if (toolInputParseError !== undefined) {
+        throw new ModelError('unable to parse tool input JSON', { cause: toolInputParseError })
       }
 
       // Return the final message with stop reason and optional metadata


### PR DESCRIPTION
## Description

Port of [strands-agents/sdk-typescript#1065](https://github.com/strands-agents/sdk-typescript/pull/1065) by @cmbullock.
Resolves : https://github.com/strands-agents/harness-sdk/issues/2451

When a model hits the `max_tokens` limit mid-stream, the tool input JSON can be truncated and fail `JSON.parse`. Previously the resulting `SyntaxError` was thrown immediately from `streamAggregated`, masking the more actionable `MaxTokensError` that the `maxTokens` stop reason is supposed to surface.

The fix defers the tool input parse error instead of throwing it inline, then resolves precedence after the stop reason is known:

- `stopReason === 'maxTokens'` → `MaxTokensError` (the real, actionable failure).
- any other stop reason → `ModelError('unable to parse tool input JSON')` with the `SyntaxError` attached as `cause`.
- stream ends without a stop event → `ModelError('Stream ended without completing a message')` with the `SyntaxError` attached as `cause`.


## Type of Change

Bug fix

## Testing

`npm run test -w strands-ts` — full unit suite passes (lint, format, and type-check included via the prepare checks).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
