### PR TITLE
feat: memory injection

### DIFF
--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -84,6 +84,10 @@
       "types": "./dist/src/vended-plugins/context-offloader/index.d.ts",
       "default": "./dist/src/vended-plugins/context-offloader/index.js"
     },
+    "./vended-plugins/context-injector": {
+      "types": "./dist/src/vended-plugins/context-injector/index.d.ts",
+      "default": "./dist/src/vended-plugins/context-injector/index.js"
+    },
     "./vended-plugins/goal": {
       "types": "./dist/src/vended-plugins/goal/index.d.ts",
       "default": "./dist/src/vended-plugins/goal/index.js"

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -344,6 +344,10 @@ export type {
   MemoryToolConfig,
   MemoryAddToolConfig,
   MemoryManagerConfig,
+  MemoryInjectionConfig,
+  InjectionConfig,
+  InjectionTrigger,
+  InjectionContext,
 } from './memory/index.js'
 export { ExtractionTrigger, InvocationTrigger, IntervalTrigger, ModelExtractor } from './memory/index.js'
 export type {

--- a/strands-ts/src/injection/__tests__/message-injection.test.ts
+++ b/strands-ts/src/injection/__tests__/message-injection.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Message, TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { foldIntoLastUserMessage, isUserTurn, resolveTrigger, createInjectionMiddleware } from '../message-injection.js'
+import type { InvokeModelContext } from '../../middleware/index.js'
+import { logger } from '../../logging/logger.js'
+
+const user = (text: string) => new Message({ role: 'user', content: [new TextBlock(text)] })
+const assistant = (text: string) => new Message({ role: 'assistant', content: [new TextBlock(text)] })
+const toolResult = () =>
+  new Message({
+    role: 'user',
+    content: [new ToolResultBlock({ toolUseId: 't1', status: 'success', content: [new TextBlock('done')] })],
+  })
+describe('foldIntoLastUserMessage', () => {
+  it('prepends the text as a leading TextBlock on the last user message, ahead of its content', () => {
+    const messages = [user('original task'), assistant('prior step'), user('next ask')]
+    const result = foldIntoLastUserMessage(messages, 'INJECTED')
+
+    expect(result).toHaveLength(3)
+    expect(result.map((m) => m.role)).toStrictEqual(['user', 'assistant', 'user'])
+    const target = result[2]!
+    expect(target.content).toHaveLength(2)
+    expect(target.content[0]).toBeInstanceOf(TextBlock)
+    expect((target.content[0] as TextBlock).text).toBe('INJECTED')
+    expect((target.content[1] as TextBlock).text).toBe('next ask')
+    // The user message stays last so the user's ask remains in the recency slot.
+    expect(result[result.length - 1]).toBe(target)
+  })
+
+  it('returns a new array and does not mutate the input or its messages', () => {
+    const original = user('ask')
+    const messages = [assistant('prior'), original]
+    const result = foldIntoLastUserMessage(messages, 'INJECTED')
+
+    expect(result).not.toBe(messages)
+    expect(messages[1]).toBe(original)
+    expect(original.content).toHaveLength(1) // untouched
+    expect(result[1]).not.toBe(original)
+  })
+
+  it('folds into a tool-result user message ahead of the tool result block', () => {
+    const messages = [user('task'), assistant('thinking'), toolResult()]
+    const result = foldIntoLastUserMessage(messages, 'INJECTED')
+
+    const target = result[2]!
+    expect(target.content[0]).toBeInstanceOf(TextBlock)
+    expect((target.content[0] as TextBlock).text).toBe('INJECTED')
+    expect(target.content[1]!.type).toBe('toolResultBlock')
+  })
+
+  it('targets the most recent user message when several exist', () => {
+    const messages = [user('first'), assistant('a'), user('second')]
+    const result = foldIntoLastUserMessage(messages, 'INJECTED')
+
+    expect((result[0]!.content[0] as TextBlock).text).toBe('first') // earlier user untouched
+    expect((result[2]!.content[0] as TextBlock).text).toBe('INJECTED')
+  })
+
+  it('preserves message metadata on the folded message', () => {
+    const tagged = new Message({
+      role: 'user',
+      content: [new TextBlock('ask')],
+      metadata: { custom: { keep: 'me' } },
+    })
+    const result = foldIntoLastUserMessage([tagged], 'INJECTED')
+    expect(result[0]!.metadata?.custom).toStrictEqual({ keep: 'me' })
+  })
+
+  it('returns the input unchanged when there is no user message', () => {
+    const messages = [assistant('only assistant')]
+    const result = foldIntoLastUserMessage(messages, 'INJECTED')
+    expect(result).toBe(messages)
+  })
+})
+
+describe('isUserTurn', () => {
+  it('is true when the last message is a plain user ask', () => {
+    expect(isUserTurn([assistant('prior').toJSON(), user('ask').toJSON()])).toBe(true)
+  })
+
+  it('is false when the last message is a user tool-result turn', () => {
+    expect(isUserTurn([user('task').toJSON(), assistant('a').toJSON(), toolResult().toJSON()])).toBe(false)
+  })
+
+  it('is false when the last message is an assistant message', () => {
+    expect(isUserTurn([user('ask').toJSON(), assistant('reply').toJSON()])).toBe(false)
+  })
+
+  it('is false for an empty conversation', () => {
+    expect(isUserTurn([])).toBe(false)
+  })
+})
+
+describe('resolveTrigger', () => {
+  it('defaults (undefined) to the userTurn policy', () => {
+    const trigger = resolveTrigger(undefined)
+    expect(trigger([user('ask').toJSON()])).toBe(true)
+    expect(trigger([toolResult().toJSON()])).toBe(false)
+  })
+
+  it("'userTurn' uses isUserTurn", () => {
+    const trigger = resolveTrigger('userTurn')
+    expect(trigger([user('ask').toJSON()])).toBe(true)
+    expect(trigger([toolResult().toJSON()])).toBe(false)
+  })
+
+  it("'everyTurn' always fires", () => {
+    const trigger = resolveTrigger('everyTurn')
+    expect(trigger([])).toBe(true)
+    expect(trigger([toolResult().toJSON()])).toBe(true)
+  })
+
+  it('uses a custom predicate', () => {
+    const trigger = resolveTrigger((messages) => messages.length >= 2)
+    expect(trigger([user('a').toJSON()])).toBe(false)
+    expect(trigger([user('a').toJSON(), assistant('b').toJSON()])).toBe(true)
+  })
+
+  it('fails open (returns false, logs) when a custom predicate throws', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const trigger = resolveTrigger(() => {
+      throw new Error('boom')
+    })
+    expect(trigger([user('ask').toJSON()])).toBe(false)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+
+describe('createInjectionMiddleware', () => {
+  // The handler is an InvokeModelStage.Input transformer: it only reads `context.messages` and spreads
+  // the rest through, so a context carrying just `messages` exercises it faithfully.
+  const ctx = (messages: Message[]) => ({ messages }) as unknown as InvokeModelContext
+
+  it('folds provide() text into the latest user message, leaving other context fields intact', async () => {
+    const handler = createInjectionMiddleware({ provide: async () => 'INJECTED' })
+    const result = await handler(ctx([assistant('prior'), user('ask')]))
+
+    expect(result.messages).toHaveLength(2)
+    const target = result.messages[1]!
+    expect((target.content[0] as TextBlock).text).toBe('INJECTED')
+    expect((target.content[1] as TextBlock).text).toBe('ask')
+  })
+
+  it('passes the conversation (as data) to provide', async () => {
+    const seen: string[] = []
+    const handler = createInjectionMiddleware({
+      provide: async (messages) => {
+        seen.push(...messages.map((m) => m.role))
+        return 'x'
+      },
+    })
+    await handler(ctx([assistant('prior'), user('ask')]))
+
+    expect(seen).toStrictEqual(['assistant', 'user'])
+  })
+
+  it('returns the context unchanged when the trigger does not fire', async () => {
+    const provide = vi.fn(async () => 'x')
+    const handler = createInjectionMiddleware({ provide }) // default 'userTurn'
+    const input = ctx([user('task'), assistant('a'), toolResult()])
+    const result = await handler(input)
+
+    expect(result).toBe(input)
+    expect(provide).not.toHaveBeenCalled()
+  })
+
+  it("'everyTurn' injects on an autonomous tool-result turn", async () => {
+    const handler = createInjectionMiddleware({ trigger: 'everyTurn', provide: async () => 'INJECTED' })
+    const result = await handler(ctx([user('task'), assistant('a'), toolResult()]))
+
+    // The most recent user message on a tool-result turn is the tool-result itself; the fold prepends
+    // ahead of its tool-result block.
+    const folded = result.messages[2]!
+    expect((folded.content[0] as TextBlock).text).toBe('INJECTED')
+    expect(folded.content[1]!.type).toBe('toolResultBlock')
+  })
+
+  it('returns the context unchanged when provide yields empty text', async () => {
+    const handler = createInjectionMiddleware({ provide: async () => '   ' })
+    const input = ctx([assistant('prior'), user('ask')])
+    const result = await handler(input)
+
+    expect(result).toBe(input)
+  })
+
+  it('fails open (returns the context unchanged, logs) when provide throws', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const handler = createInjectionMiddleware({
+      provide: async () => {
+        throw new Error('boom')
+      },
+    })
+    const input = ctx([assistant('prior'), user('ask')])
+    const result = await handler(input)
+
+    expect(result).toBe(input)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('does not mutate the original context messages', async () => {
+    const handler = createInjectionMiddleware({ provide: async () => 'INJECTED' })
+    const input = ctx([assistant('prior'), user('ask')])
+    const before = input.messages[1]!
+    await handler(input)
+
+    expect(before.content).toHaveLength(1) // the original user message is untouched
+  })
+})

--- a/strands-ts/src/injection/__tests__/message-injection.test.ts
+++ b/strands-ts/src/injection/__tests__/message-injection.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import { Message, TextBlock, ToolResultBlock } from '../../types/messages.js'
+import type { MessageData } from '../../types/messages.js'
 import { foldIntoLastUserMessage, isUserTurn, resolveTrigger, createInjectionMiddleware } from '../message-injection.js'
 import type { InvokeModelContext } from '../../middleware/index.js'
+import type { InjectionContext } from '../types.js'
+import { createMockAgent } from '../../__fixtures__/agent-helpers.js'
 import { logger } from '../../logging/logger.js'
 
 const user = (text: string) => new Message({ role: 'user', content: [new TextBlock(text)] })
@@ -11,20 +14,21 @@ const toolResult = () =>
     role: 'user',
     content: [new ToolResultBlock({ toolUseId: 't1', status: 'success', content: [new TextBlock('done')] })],
   })
+
+// resolveTrigger predicates take an InjectionContext; tests only exercise `messages`, so a minimal bag suffices.
+const injectionCtx = (messages: MessageData[]) => ({ messages }) as unknown as InjectionContext
 describe('foldIntoLastUserMessage', () => {
   it('prepends the text as a leading TextBlock on the last user message, ahead of its content', () => {
     const messages = [user('original task'), assistant('prior step'), user('next ask')]
     const result = foldIntoLastUserMessage(messages, 'INJECTED')
 
-    expect(result).toHaveLength(3)
-    expect(result.map((m) => m.role)).toStrictEqual(['user', 'assistant', 'user'])
-    const target = result[2]!
-    expect(target.content).toHaveLength(2)
-    expect(target.content[0]).toBeInstanceOf(TextBlock)
-    expect((target.content[0] as TextBlock).text).toBe('INJECTED')
-    expect((target.content[1] as TextBlock).text).toBe('next ask')
-    // The user message stays last so the user's ask remains in the recency slot.
-    expect(result[result.length - 1]).toBe(target)
+    // The earlier user/assistant turns are untouched; the last user message gains a leading INJECTED
+    // block ahead of its own content, keeping the user's ask in the recency slot.
+    expect(result.map((m) => m.toJSON())).toStrictEqual([
+      { role: 'user', content: [{ text: 'original task' }] },
+      { role: 'assistant', content: [{ text: 'prior step' }] },
+      { role: 'user', content: [{ text: 'INJECTED' }, { text: 'next ask' }] },
+    ])
   })
 
   it('returns a new array and does not mutate the input or its messages', () => {
@@ -94,26 +98,26 @@ describe('isUserTurn', () => {
 describe('resolveTrigger', () => {
   it('defaults (undefined) to the userTurn policy', () => {
     const trigger = resolveTrigger(undefined)
-    expect(trigger([user('ask').toJSON()])).toBe(true)
-    expect(trigger([toolResult().toJSON()])).toBe(false)
+    expect(trigger(injectionCtx([user('ask').toJSON()]))).toBe(true)
+    expect(trigger(injectionCtx([toolResult().toJSON()]))).toBe(false)
   })
 
   it("'userTurn' uses isUserTurn", () => {
     const trigger = resolveTrigger('userTurn')
-    expect(trigger([user('ask').toJSON()])).toBe(true)
-    expect(trigger([toolResult().toJSON()])).toBe(false)
+    expect(trigger(injectionCtx([user('ask').toJSON()]))).toBe(true)
+    expect(trigger(injectionCtx([toolResult().toJSON()]))).toBe(false)
   })
 
   it("'everyTurn' always fires", () => {
     const trigger = resolveTrigger('everyTurn')
-    expect(trigger([])).toBe(true)
-    expect(trigger([toolResult().toJSON()])).toBe(true)
+    expect(trigger(injectionCtx([]))).toBe(true)
+    expect(trigger(injectionCtx([toolResult().toJSON()]))).toBe(true)
   })
 
-  it('uses a custom predicate', () => {
-    const trigger = resolveTrigger((messages) => messages.length >= 2)
-    expect(trigger([user('a').toJSON()])).toBe(false)
-    expect(trigger([user('a').toJSON(), assistant('b').toJSON()])).toBe(true)
+  it('uses a custom predicate over the context', () => {
+    const trigger = resolveTrigger((context) => context.messages.length >= 2)
+    expect(trigger(injectionCtx([user('a').toJSON()]))).toBe(false)
+    expect(trigger(injectionCtx([user('a').toJSON(), assistant('b').toJSON()]))).toBe(true)
   })
 
   it('fails open (returns false, logs) when a custom predicate throws', () => {
@@ -121,32 +125,33 @@ describe('resolveTrigger', () => {
     const trigger = resolveTrigger(() => {
       throw new Error('boom')
     })
-    expect(trigger([user('ask').toJSON()])).toBe(false)
+    expect(trigger(injectionCtx([user('ask').toJSON()]))).toBe(false)
     expect(warn).toHaveBeenCalled()
     warn.mockRestore()
   })
 })
 
 describe('createInjectionMiddleware', () => {
-  // The handler is an InvokeModelStage.Input transformer: it only reads `context.messages` and spreads
-  // the rest through, so a context carrying just `messages` exercises it faithfully.
-  const ctx = (messages: Message[]) => ({ messages }) as unknown as InvokeModelContext
+  // The handler is an InvokeModelStage.Input transformer. It reads `context.messages` and derives the
+  // InjectionContext (appState/signal) from `context.agent`, then spreads the rest through, so a context
+  // carrying `messages` plus a mock agent exercises it faithfully.
+  const ctx = (messages: Message[]) => ({ messages, agent: createMockAgent() }) as unknown as InvokeModelContext
 
-  it('folds provide() text into the latest user message, leaving other context fields intact', async () => {
-    const handler = createInjectionMiddleware({ provide: async () => 'INJECTED' })
+  it('folds renderContent() text into the latest user message, leaving other context fields intact', async () => {
+    const handler = createInjectionMiddleware({ renderContent: async () => 'INJECTED' })
     const result = await handler(ctx([assistant('prior'), user('ask')]))
 
-    expect(result.messages).toHaveLength(2)
-    const target = result.messages[1]!
-    expect((target.content[0] as TextBlock).text).toBe('INJECTED')
-    expect((target.content[1] as TextBlock).text).toBe('ask')
+    expect(result.messages.map((m) => m.toJSON())).toStrictEqual([
+      { role: 'assistant', content: [{ text: 'prior' }] },
+      { role: 'user', content: [{ text: 'INJECTED' }, { text: 'ask' }] },
+    ])
   })
 
-  it('passes the conversation (as data) to provide', async () => {
+  it('passes an InjectionContext carrying the conversation (as data) to renderContent', async () => {
     const seen: string[] = []
     const handler = createInjectionMiddleware({
-      provide: async (messages) => {
-        seen.push(...messages.map((m) => m.role))
+      renderContent: async (context) => {
+        seen.push(...context.messages.map((m) => m.role))
         return 'x'
       },
     })
@@ -155,18 +160,37 @@ describe('createInjectionMiddleware', () => {
     expect(seen).toStrictEqual(['assistant', 'user'])
   })
 
+  it('exposes appState and the cancel signal on the InjectionContext', async () => {
+    const signal = new AbortController().signal
+    const appState = { get: () => 'stashed' }
+    const input = {
+      messages: [user('ask')],
+      agent: { appState, cancelSignal: signal },
+    } as unknown as InvokeModelContext
+    let received: { appState: unknown; signal: unknown } | undefined
+    const handler = createInjectionMiddleware({
+      renderContent: async (context) => {
+        received = { appState: context.appState, signal: context.signal }
+        return undefined
+      },
+    })
+    await handler(input)
+
+    expect(received).toStrictEqual({ appState, signal })
+  })
+
   it('returns the context unchanged when the trigger does not fire', async () => {
-    const provide = vi.fn(async () => 'x')
-    const handler = createInjectionMiddleware({ provide }) // default 'userTurn'
+    const renderContent = vi.fn(async () => 'x')
+    const handler = createInjectionMiddleware({ renderContent }) // default 'userTurn'
     const input = ctx([user('task'), assistant('a'), toolResult()])
     const result = await handler(input)
 
     expect(result).toBe(input)
-    expect(provide).not.toHaveBeenCalled()
+    expect(renderContent).not.toHaveBeenCalled()
   })
 
   it("'everyTurn' injects on an autonomous tool-result turn", async () => {
-    const handler = createInjectionMiddleware({ trigger: 'everyTurn', provide: async () => 'INJECTED' })
+    const handler = createInjectionMiddleware({ trigger: 'everyTurn', renderContent: async () => 'INJECTED' })
     const result = await handler(ctx([user('task'), assistant('a'), toolResult()]))
 
     // The most recent user message on a tool-result turn is the tool-result itself; the fold prepends
@@ -176,18 +200,18 @@ describe('createInjectionMiddleware', () => {
     expect(folded.content[1]!.type).toBe('toolResultBlock')
   })
 
-  it('returns the context unchanged when provide yields empty text', async () => {
-    const handler = createInjectionMiddleware({ provide: async () => '   ' })
+  it('returns the context unchanged when renderContent yields empty text', async () => {
+    const handler = createInjectionMiddleware({ renderContent: async () => '   ' })
     const input = ctx([assistant('prior'), user('ask')])
     const result = await handler(input)
 
     expect(result).toBe(input)
   })
 
-  it('fails open (returns the context unchanged, logs) when provide throws', async () => {
+  it('fails open (returns the context unchanged, logs) when renderContent throws', async () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
     const handler = createInjectionMiddleware({
-      provide: async () => {
+      renderContent: async () => {
         throw new Error('boom')
       },
     })
@@ -200,7 +224,7 @@ describe('createInjectionMiddleware', () => {
   })
 
   it('does not mutate the original context messages', async () => {
-    const handler = createInjectionMiddleware({ provide: async () => 'INJECTED' })
+    const handler = createInjectionMiddleware({ renderContent: async () => 'INJECTED' })
     const input = ctx([assistant('prior'), user('ask')])
     const before = input.messages[1]!
     await handler(input)

--- a/strands-ts/src/injection/__tests__/message-injection.test.ts
+++ b/strands-ts/src/injection/__tests__/message-injection.test.ts
@@ -139,7 +139,7 @@ describe('resolveTrigger', () => {
 
 describe('createInjectionMiddleware', () => {
   // The handler is an InvokeModelStage.Input transformer. It reads `context.messages` and derives the
-  // InjectionContext (appState/signal) from `context.agent`, then spreads the rest through, so a context
+  // InjectionContext (appState/agent) from `context.agent`, then spreads the rest through, so a context
   // carrying `messages` plus a mock agent exercises it faithfully.
   const ctx = (messages: Message[]) => ({ messages, agent: createMockAgent() }) as unknown as InvokeModelContext
 
@@ -166,23 +166,20 @@ describe('createInjectionMiddleware', () => {
     expect(seen).toStrictEqual(['assistant', 'user'])
   })
 
-  it('exposes appState and the cancel signal on the InjectionContext', async () => {
-    const signal = new AbortController().signal
+  it('exposes appState and the agent on the InjectionContext', async () => {
     const appState = { get: () => 'stashed' }
-    const input = {
-      messages: [user('ask')],
-      agent: { appState, cancelSignal: signal },
-    } as unknown as InvokeModelContext
-    let received: { appState: unknown; signal: unknown } | undefined
+    const agent = { appState } as unknown as InvokeModelContext['agent']
+    const input = { messages: [user('ask')], agent } as unknown as InvokeModelContext
+    let received: { appState: unknown; agent: unknown } | undefined
     const handler = createInjectionMiddleware({
       renderContent: async (context) => {
-        received = { appState: context.appState, signal: context.signal }
+        received = { appState: context.appState, agent: context.agent }
         return undefined
       },
     })
     await handler(input)
 
-    expect(received).toStrictEqual({ appState, signal })
+    expect(received).toStrictEqual({ appState, agent })
   })
 
   it('returns the context unchanged when the trigger does not fire', async () => {

--- a/strands-ts/src/injection/__tests__/message-injection.test.ts
+++ b/strands-ts/src/injection/__tests__/message-injection.test.ts
@@ -42,22 +42,28 @@ describe('foldIntoLastUserMessage', () => {
     expect(result[1]).not.toBe(original)
   })
 
-  it('folds into a tool-result user message ahead of the tool result block', () => {
-    const messages = [user('task'), assistant('thinking'), toolResult()]
-    const result = foldIntoLastUserMessage(messages, 'INJECTED')
+  it('appends after the tool result block when the target is a tool-result turn', () => {
+    const tr = toolResult()
+    const result = foldIntoLastUserMessage([user('task'), assistant('thinking'), tr], 'INJECTED')
 
-    const target = result[2]!
-    expect(target.content[0]).toBeInstanceOf(TextBlock)
-    expect((target.content[0] as TextBlock).text).toBe('INJECTED')
-    expect(target.content[1]!.type).toBe('toolResultBlock')
+    // Providers require the tool result to be the first block in the turn, so the injected text is
+    // appended rather than prepended here.
+    expect(result.map((m) => m.toJSON())).toStrictEqual([
+      { role: 'user', content: [{ text: 'task' }] },
+      { role: 'assistant', content: [{ text: 'thinking' }] },
+      { role: 'user', content: [tr.toJSON().content[0], { text: 'INJECTED' }] },
+    ])
   })
 
   it('targets the most recent user message when several exist', () => {
     const messages = [user('first'), assistant('a'), user('second')]
     const result = foldIntoLastUserMessage(messages, 'INJECTED')
 
-    expect((result[0]!.content[0] as TextBlock).text).toBe('first') // earlier user untouched
-    expect((result[2]!.content[0] as TextBlock).text).toBe('INJECTED')
+    expect(result.map((m) => m.toJSON())).toStrictEqual([
+      { role: 'user', content: [{ text: 'first' }] }, // earlier user untouched
+      { role: 'assistant', content: [{ text: 'a' }] },
+      { role: 'user', content: [{ text: 'INJECTED' }, { text: 'second' }] },
+    ])
   })
 
   it('preserves message metadata on the folded message', () => {
@@ -189,15 +195,18 @@ describe('createInjectionMiddleware', () => {
     expect(renderContent).not.toHaveBeenCalled()
   })
 
-  it("'everyTurn' injects on an autonomous tool-result turn", async () => {
+  it("'everyTurn' injects on an autonomous tool-result turn, keeping the tool result first", async () => {
     const handler = createInjectionMiddleware({ trigger: 'everyTurn', renderContent: async () => 'INJECTED' })
-    const result = await handler(ctx([user('task'), assistant('a'), toolResult()]))
+    const tr = toolResult()
+    const result = await handler(ctx([user('task'), assistant('a'), tr]))
 
-    // The most recent user message on a tool-result turn is the tool-result itself; the fold prepends
-    // ahead of its tool-result block.
-    const folded = result.messages[2]!
-    expect((folded.content[0] as TextBlock).text).toBe('INJECTED')
-    expect(folded.content[1]!.type).toBe('toolResultBlock')
+    // The most recent user message on a tool-result turn carries the tool result, which must stay the
+    // first block, so the injected text is appended after it.
+    expect(result.messages.map((m) => m.toJSON())).toStrictEqual([
+      { role: 'user', content: [{ text: 'task' }] },
+      { role: 'assistant', content: [{ text: 'a' }] },
+      { role: 'user', content: [tr.toJSON().content[0], { text: 'INJECTED' }] },
+    ])
   })
 
   it('returns the context unchanged when renderContent yields empty text', async () => {

--- a/strands-ts/src/injection/index.ts
+++ b/strands-ts/src/injection/index.ts
@@ -1,2 +1,5 @@
-export { foldIntoLastUserMessage, isUserTurn, resolveTrigger, createInjectionMiddleware } from './message-injection.js'
-export type { InjectionConfig, InjectionTrigger, InjectionMiddlewareOptions } from './types.js'
+/**
+ * Configuration types for context injection, shared by the `ContextInjector` plugin and
+ * `MemoryManager`'s `injection` config.
+ */
+export type { InjectionConfig, InjectionTrigger, InjectionContext } from './types.js'

--- a/strands-ts/src/injection/index.ts
+++ b/strands-ts/src/injection/index.ts
@@ -1,0 +1,2 @@
+export { foldIntoLastUserMessage, isUserTurn, resolveTrigger, createInjectionMiddleware } from './message-injection.js'
+export type { InjectionConfig, InjectionTrigger, InjectionMiddlewareOptions } from './types.js'

--- a/strands-ts/src/injection/message-injection.ts
+++ b/strands-ts/src/injection/message-injection.ts
@@ -1,0 +1,125 @@
+import { Message, TextBlock } from '../types/messages.js'
+import type { MessageData } from '../types/messages.js'
+import { logger } from '../logging/logger.js'
+import { normalizeError } from '../errors.js'
+import type { InvokeModelContext } from '../middleware/index.js'
+import type { InjectionMiddlewareOptions, InjectionTrigger } from './types.js'
+
+/**
+ * Whether the latest message is a fresh user ask: a `user` message carrying no tool result. This is
+ * the `'userTurn'` policy — it distinguishes a new chat ask from an autonomous tool-result turn.
+ *
+ * @param messages - The current conversation, as data
+ * @returns `true` when the latest message is a plain user ask, otherwise `false`
+ */
+export function isUserTurn(messages: MessageData[]): boolean {
+  const last = messages[messages.length - 1]
+  return !!last && last.role === 'user' && !last.content.some((block) => 'toolResult' in block)
+}
+
+/**
+ * Resolves an {@link InjectionTrigger} name or predicate into a single gate predicate.
+ *
+ * `'userTurn'` maps to {@link isUserTurn}; `'everyTurn'` to an always-true gate; a user-supplied
+ * predicate is wrapped so that a throw fails open (logs and skips injection rather than aborting the
+ * model call).
+ *
+ * @param trigger - An {@link InjectionTrigger} name, a predicate, or `undefined` (defaults to `'userTurn'`)
+ * @returns A predicate that, given the current messages, returns whether to inject this call
+ */
+export function resolveTrigger(
+  trigger: InjectionTrigger | ((messages: MessageData[]) => boolean) | undefined
+): (messages: MessageData[]) => boolean {
+  if (trigger === undefined || trigger === 'userTurn') {
+    return isUserTurn
+  }
+  if (trigger === 'everyTurn') {
+    return () => true
+  }
+  const predicate = trigger
+  return (messages) => {
+    try {
+      return predicate(messages)
+    } catch (error) {
+      logger.warn(`reason=<${normalizeError(error).message}> | injection trigger threw; skipping injection`)
+      return false
+    }
+  }
+}
+
+/**
+ * Folds `text` into the most recent `user` message as a leading {@link TextBlock}, ahead of that
+ * message's own content (block-prepend), returning a NEW array. Other messages are returned as-is.
+ *
+ * Prepending into the existing user message (rather than inserting a standalone message) keeps role
+ * alternation valid in both chat and the autonomous tool loop, and keeps the user's own ask in the
+ * recency slot — the last thing the model reads. {@link Message} fields are readonly, so the target is
+ * rebuilt as a new {@link Message}. When there is no `user` message, the input array is returned
+ * unchanged.
+ *
+ * @param messages - The conversation to fold into
+ * @param text - The text to prepend to the most recent user message
+ * @returns A new array with the folded message, or the input array when there is no user message
+ */
+export function foldIntoLastUserMessage(messages: Message[], text: string): Message[] {
+  let targetIndex = -1
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === 'user') {
+      targetIndex = i
+      break
+    }
+  }
+  if (targetIndex < 0) {
+    return messages
+  }
+
+  const target = messages[targetIndex]!
+  const folded = new Message({
+    role: target.role,
+    content: [new TextBlock(text), ...target.content],
+    ...(target.metadata !== undefined && { metadata: target.metadata }),
+  })
+
+  const result = [...messages]
+  result[targetIndex] = folded
+  return result
+}
+
+/**
+ * Builds an {@link InvokeModelStage} `Input` handler that folds {@link InjectionMiddlewareOptions.provide}'s
+ * text into the latest user message, ephemerally — the model sees the augmented input for this one call
+ * while the agent's durable history is never touched.
+ *
+ * Runs as an input-phase transformer (`(ctx) => ctx`): it gates on the resolved trigger, asks `provide`
+ * for the text, and returns a context with the folded messages. Anything that skips — the trigger not
+ * firing, `provide` returning empty, or any callback throwing — returns the context unchanged so the
+ * model call proceeds (fail open). The injected text never enters durable history because the input
+ * phase only rewrites the per-call context, not the agent's stored messages.
+ *
+ * @param opts - The trigger and `provide` callback the handler uses
+ * @returns An `InvokeModelStage.Input` handler that returns a (possibly) folded context
+ */
+export function createInjectionMiddleware(
+  opts: InjectionMiddlewareOptions
+): (context: InvokeModelContext) => Promise<InvokeModelContext> {
+  const trigger = resolveTrigger(opts.trigger)
+  return async (context) => {
+    const messages = context.messages.map((message) => message.toJSON())
+    if (!trigger(messages)) {
+      return context
+    }
+
+    let text: string | undefined
+    try {
+      text = await opts.provide(messages)
+    } catch (error) {
+      logger.warn(`reason=<${normalizeError(error).message}> | injection provide threw; skipping injection`)
+      return context
+    }
+    if (!text?.trim()) {
+      return context
+    }
+
+    return { ...context, messages: foldIntoLastUserMessage([...context.messages], text) }
+  }
+}

--- a/strands-ts/src/injection/message-injection.ts
+++ b/strands-ts/src/injection/message-injection.ts
@@ -29,7 +29,6 @@ export function createInjectionMiddleware(
     const injectionContext: InjectionContext = {
       messages: context.messages.map((message) => message.toJSON()),
       appState: agent.appState,
-      signal: agent.cancelSignal,
       agent,
     }
     if (!trigger(injectionContext)) {

--- a/strands-ts/src/injection/message-injection.ts
+++ b/strands-ts/src/injection/message-injection.ts
@@ -3,7 +3,85 @@ import type { MessageData } from '../types/messages.js'
 import { logger } from '../logging/logger.js'
 import { normalizeError } from '../errors.js'
 import type { InvokeModelContext } from '../middleware/index.js'
-import type { InjectionMiddlewareOptions, InjectionTrigger } from './types.js'
+import type { InjectionMiddlewareOptions, InjectionTrigger, InjectionContext } from './types.js'
+
+/**
+ * Builds an `InvokeModelStage` `Input` handler that folds {@link InjectionMiddlewareOptions.renderContent}'s
+ * text into the latest user message, ephemerally — the model sees the augmented input for this one call
+ * while the agent's durable history is never touched.
+ *
+ * Runs as an input-phase transformer (`(ctx) => ctx`): it gates on the resolved trigger, asks
+ * `renderContent` for the text, and returns a context with the folded messages. Anything that skips —
+ * the trigger not firing, `renderContent` returning empty, or any callback throwing — returns the
+ * context unchanged so the model call proceeds (fail open). The injected text never enters durable
+ * history because the input phase only rewrites the per-call context, not the agent's stored messages.
+ *
+ * @param opts - The trigger and `renderContent` callback the handler uses
+ * @returns An `InvokeModelStage.Input` handler that returns a (possibly) folded context
+ * @internal Delivery primitive. Reach injection through `ContextInjector` or `MemoryManager`.
+ */
+export function createInjectionMiddleware(
+  opts: InjectionMiddlewareOptions
+): (context: InvokeModelContext) => Promise<InvokeModelContext> {
+  const trigger = resolveTrigger(opts.trigger)
+  return async (context) => {
+    const agent = context.agent
+    const injectionContext: InjectionContext = {
+      messages: context.messages.map((message) => message.toJSON()),
+      appState: agent.appState,
+      signal: agent.cancelSignal,
+      agent,
+    }
+    if (!trigger(injectionContext)) {
+      return context
+    }
+
+    let text: string | undefined
+    try {
+      text = await opts.renderContent(injectionContext)
+    } catch (error) {
+      logger.warn(`reason=<${normalizeError(error).message}> | injection renderContent threw; skipping injection`)
+      return context
+    }
+    if (!text?.trim()) {
+      return context
+    }
+
+    return { ...context, messages: foldIntoLastUserMessage([...context.messages], text) }
+  }
+}
+
+/**
+ * Resolves an {@link InjectionTrigger} name or predicate into a single gate predicate over the
+ * {@link InjectionContext}.
+ *
+ * `'userTurn'` maps to {@link isUserTurn} (over `ctx.messages`); `'everyTurn'` to an always-true gate;
+ * a user-supplied predicate is wrapped so that a throw fails open (logs and skips injection rather than
+ * aborting the model call).
+ *
+ * @param trigger - An {@link InjectionTrigger} name, a predicate, or `undefined` (defaults to `'userTurn'`)
+ * @returns A predicate that, given the {@link InjectionContext}, returns whether to inject this call
+ * @internal Delivery primitive. Reach injection through `ContextInjector` or `MemoryManager`.
+ */
+export function resolveTrigger(
+  trigger: InjectionTrigger | ((context: InjectionContext) => boolean) | undefined
+): (context: InjectionContext) => boolean {
+  if (trigger === undefined || trigger === 'userTurn') {
+    return (context) => isUserTurn(context.messages)
+  }
+  if (trigger === 'everyTurn') {
+    return () => true
+  }
+  const predicate = trigger
+  return (context) => {
+    try {
+      return predicate(context)
+    } catch (error) {
+      logger.warn(`reason=<${normalizeError(error).message}> | injection trigger threw; skipping injection`)
+      return false
+    }
+  }
+}
 
 /**
  * Whether the latest message is a fresh user ask: a `user` message carrying no tool result. This is
@@ -11,40 +89,11 @@ import type { InjectionMiddlewareOptions, InjectionTrigger } from './types.js'
  *
  * @param messages - The current conversation, as data
  * @returns `true` when the latest message is a plain user ask, otherwise `false`
+ * @internal Delivery primitive. Reach injection through `ContextInjector` or `MemoryManager`.
  */
 export function isUserTurn(messages: MessageData[]): boolean {
   const last = messages[messages.length - 1]
   return !!last && last.role === 'user' && !last.content.some((block) => 'toolResult' in block)
-}
-
-/**
- * Resolves an {@link InjectionTrigger} name or predicate into a single gate predicate.
- *
- * `'userTurn'` maps to {@link isUserTurn}; `'everyTurn'` to an always-true gate; a user-supplied
- * predicate is wrapped so that a throw fails open (logs and skips injection rather than aborting the
- * model call).
- *
- * @param trigger - An {@link InjectionTrigger} name, a predicate, or `undefined` (defaults to `'userTurn'`)
- * @returns A predicate that, given the current messages, returns whether to inject this call
- */
-export function resolveTrigger(
-  trigger: InjectionTrigger | ((messages: MessageData[]) => boolean) | undefined
-): (messages: MessageData[]) => boolean {
-  if (trigger === undefined || trigger === 'userTurn') {
-    return isUserTurn
-  }
-  if (trigger === 'everyTurn') {
-    return () => true
-  }
-  const predicate = trigger
-  return (messages) => {
-    try {
-      return predicate(messages)
-    } catch (error) {
-      logger.warn(`reason=<${normalizeError(error).message}> | injection trigger threw; skipping injection`)
-      return false
-    }
-  }
 }
 
 /**
@@ -60,6 +109,7 @@ export function resolveTrigger(
  * @param messages - The conversation to fold into
  * @param text - The text to prepend to the most recent user message
  * @returns A new array with the folded message, or the input array when there is no user message
+ * @internal Delivery primitive. Reach injection through `ContextInjector` or `MemoryManager`.
  */
 export function foldIntoLastUserMessage(messages: Message[], text: string): Message[] {
   let targetIndex = -1
@@ -83,43 +133,4 @@ export function foldIntoLastUserMessage(messages: Message[], text: string): Mess
   const result = [...messages]
   result[targetIndex] = folded
   return result
-}
-
-/**
- * Builds an {@link InvokeModelStage} `Input` handler that folds {@link InjectionMiddlewareOptions.provide}'s
- * text into the latest user message, ephemerally — the model sees the augmented input for this one call
- * while the agent's durable history is never touched.
- *
- * Runs as an input-phase transformer (`(ctx) => ctx`): it gates on the resolved trigger, asks `provide`
- * for the text, and returns a context with the folded messages. Anything that skips — the trigger not
- * firing, `provide` returning empty, or any callback throwing — returns the context unchanged so the
- * model call proceeds (fail open). The injected text never enters durable history because the input
- * phase only rewrites the per-call context, not the agent's stored messages.
- *
- * @param opts - The trigger and `provide` callback the handler uses
- * @returns An `InvokeModelStage.Input` handler that returns a (possibly) folded context
- */
-export function createInjectionMiddleware(
-  opts: InjectionMiddlewareOptions
-): (context: InvokeModelContext) => Promise<InvokeModelContext> {
-  const trigger = resolveTrigger(opts.trigger)
-  return async (context) => {
-    const messages = context.messages.map((message) => message.toJSON())
-    if (!trigger(messages)) {
-      return context
-    }
-
-    let text: string | undefined
-    try {
-      text = await opts.provide(messages)
-    } catch (error) {
-      logger.warn(`reason=<${normalizeError(error).message}> | injection provide threw; skipping injection`)
-      return context
-    }
-    if (!text?.trim()) {
-      return context
-    }
-
-    return { ...context, messages: foldIntoLastUserMessage([...context.messages], text) }
-  }
 }

--- a/strands-ts/src/injection/message-injection.ts
+++ b/strands-ts/src/injection/message-injection.ts
@@ -97,17 +97,23 @@ export function isUserTurn(messages: MessageData[]): boolean {
 }
 
 /**
- * Folds `text` into the most recent `user` message as a leading {@link TextBlock}, ahead of that
- * message's own content (block-prepend), returning a NEW array. Other messages are returned as-is.
+ * Folds `text` into the most recent `user` message as a {@link TextBlock}, returning a NEW array. Other
+ * messages are returned as-is.
  *
- * Prepending into the existing user message (rather than inserting a standalone message) keeps role
- * alternation valid in both chat and the autonomous tool loop, and keeps the user's own ask in the
- * recency slot — the last thing the model reads. {@link Message} fields are readonly, so the target is
- * rebuilt as a new {@link Message}. When there is no `user` message, the input array is returned
- * unchanged.
+ * Folding into the existing user message (rather than inserting a standalone message) keeps role
+ * alternation valid in both chat and the autonomous tool loop. The block is placed to keep the message
+ * valid for the model:
+ * - A plain user ask: the text is **prepended**, leaving the user's own ask in the recency slot — the
+ *   last thing the model reads.
+ * - A tool-result turn (the message carries a `ToolResultBlock`): the text is **appended**,
+ *   because providers require the tool result to be the first content block in the turn that answers a
+ *   tool use.
+ *
+ * {@link Message} fields are readonly, so the target is rebuilt as a new {@link Message}. When there is
+ * no `user` message, the input array is returned unchanged.
  *
  * @param messages - The conversation to fold into
- * @param text - The text to prepend to the most recent user message
+ * @param text - The text to fold into the most recent user message
  * @returns A new array with the folded message, or the input array when there is no user message
  * @internal Delivery primitive. Reach injection through `ContextInjector` or `MemoryManager`.
  */
@@ -124,9 +130,14 @@ export function foldIntoLastUserMessage(messages: Message[], text: string): Mess
   }
 
   const target = messages[targetIndex]!
+  const injected = new TextBlock(text)
+  // A tool result must stay the first block in the turn that answers a tool use, so append rather than
+  // prepend when the target carries one.
+  const hasToolResult = target.content.some((block) => block.type === 'toolResultBlock')
+  const content = hasToolResult ? [...target.content, injected] : [injected, ...target.content]
   const folded = new Message({
     role: target.role,
-    content: [new TextBlock(text), ...target.content],
+    content,
     ...(target.metadata !== undefined && { metadata: target.metadata }),
   })
 

--- a/strands-ts/src/injection/types.ts
+++ b/strands-ts/src/injection/types.ts
@@ -24,8 +24,6 @@ export interface InjectionContext {
   messages: MessageData[]
   /** Durable app state shared across calls, hooks, and tools — read what a tool stashed last turn. */
   appState: StateStore
-  /** The run's cancellation signal; forward it to async I/O in `renderContent` so it aborts with the run. */
-  signal: AbortSignal
   /** The agent the injection is attached to (escape hatch for advanced consumers). */
   agent: LocalAgent
 }

--- a/strands-ts/src/injection/types.ts
+++ b/strands-ts/src/injection/types.ts
@@ -1,4 +1,6 @@
 import type { MessageData } from '../types/messages.js'
+import type { LocalAgent } from '../types/agent.js'
+import type { StateStore } from '../state-store.js'
 
 /**
  * Determines when injection runs before a model call.
@@ -14,38 +16,53 @@ import type { MessageData } from '../types/messages.js'
 export type InjectionTrigger = 'userTurn' | 'everyTurn'
 
 /**
- * Generic injection configuration shared by every injection consumer.
- *
- * Only the trigger is generic here. What text to inject (the query, result count, and rendering) is a
- * consumer concern — a memory consumer derives it from a search, while a fixed-text consumer (a
- * reminder, the date) needs none of that. Consumers extend this interface with their own knobs.
+ * The context an injection consumer receives on each model call, passed to `renderContent` and to a
+ * predicate {@link InjectionConfig.trigger}.
+ */
+export interface InjectionContext {
+  /** The current conversation, as data. */
+  messages: MessageData[]
+  /** Durable app state shared across calls, hooks, and tools — read what a tool stashed last turn. */
+  appState: StateStore
+  /** The run's cancellation signal; forward it to async I/O in `renderContent` so it aborts with the run. */
+  signal: AbortSignal
+  /** The agent the injection is attached to (escape hatch for advanced consumers). */
+  agent: LocalAgent
+}
+
+/**
+ * Configuration common to every injection consumer: when to inject. What text to inject is a consumer
+ * concern, added by the interfaces that extend this one (e.g. {@link MemoryInjectionConfig}).
  */
 export interface InjectionConfig {
   /**
    * When injection runs. An {@link InjectionTrigger} name selects a built-in policy; a predicate is
-   * the escape hatch — it receives the current messages and returns whether to inject this call. A
-   * predicate that throws fails open (injection is skipped, the model call proceeds).
+   * the escape hatch — it receives the {@link InjectionContext} and returns whether to inject this
+   * call. A predicate that throws fails open (injection is skipped, the model call proceeds).
    *
    * @defaultValue 'userTurn'
    */
-  trigger?: InjectionTrigger | ((messages: MessageData[]) => boolean)
+  trigger?: InjectionTrigger | ((context: InjectionContext) => boolean)
 }
 
 /**
  * Options for {@link createInjectionMiddleware}.
  *
  * The engine is text-in: it knows nothing about queries, search, or rendering. A consumer supplies a
- * single {@link InjectionMiddlewareOptions.provide} callback that returns the text to fold into the
- * conversation, and (optionally) a trigger that gates when to do so.
+ * single {@link InjectionMiddlewareOptions.renderContent} callback that returns the text to fold into
+ * the conversation, and (optionally) a trigger that gates when to do so.
+ *
+ * @internal Engine options. Consumers configure injection via `ContextInjectorConfig` or
+ * `MemoryInjectionConfig`, not this type.
  */
 export interface InjectionMiddlewareOptions {
   /**
    * When to inject. See {@link InjectionConfig.trigger}. Defaults to `'userTurn'`.
    */
-  trigger?: InjectionTrigger | ((messages: MessageData[]) => boolean)
+  trigger?: InjectionTrigger | ((context: InjectionContext) => boolean)
   /**
    * Returns the text to fold into the latest user message, or `undefined`/`''` to skip this call. A
    * callback that throws fails open (injection is skipped, the model call proceeds).
    */
-  provide: (messages: MessageData[]) => Promise<string | undefined>
+  renderContent: (context: InjectionContext) => Promise<string | undefined>
 }

--- a/strands-ts/src/injection/types.ts
+++ b/strands-ts/src/injection/types.ts
@@ -1,0 +1,51 @@
+import type { MessageData } from '../types/messages.js'
+
+/**
+ * Determines when injection runs before a model call.
+ *
+ * - `'userTurn'`: only when the latest message is a fresh user ask (a `user` message with no tool
+ *   result) — the common case for chat agents, where it keeps the user's ask the final message the
+ *   model sees.
+ * - `'everyTurn'`: before every model call, including mid-task tool-result turns — for autonomous
+ *   agents that should consult injected context at each step.
+ *
+ * For finer control, pass a predicate as {@link InjectionConfig.trigger} instead.
+ */
+export type InjectionTrigger = 'userTurn' | 'everyTurn'
+
+/**
+ * Generic injection configuration shared by every injection consumer.
+ *
+ * Only the trigger is generic here. What text to inject (the query, result count, and rendering) is a
+ * consumer concern — a memory consumer derives it from a search, while a fixed-text consumer (a
+ * reminder, the date) needs none of that. Consumers extend this interface with their own knobs.
+ */
+export interface InjectionConfig {
+  /**
+   * When injection runs. An {@link InjectionTrigger} name selects a built-in policy; a predicate is
+   * the escape hatch — it receives the current messages and returns whether to inject this call. A
+   * predicate that throws fails open (injection is skipped, the model call proceeds).
+   *
+   * @defaultValue 'userTurn'
+   */
+  trigger?: InjectionTrigger | ((messages: MessageData[]) => boolean)
+}
+
+/**
+ * Options for {@link createInjectionMiddleware}.
+ *
+ * The engine is text-in: it knows nothing about queries, search, or rendering. A consumer supplies a
+ * single {@link InjectionMiddlewareOptions.provide} callback that returns the text to fold into the
+ * conversation, and (optionally) a trigger that gates when to do so.
+ */
+export interface InjectionMiddlewareOptions {
+  /**
+   * When to inject. See {@link InjectionConfig.trigger}. Defaults to `'userTurn'`.
+   */
+  trigger?: InjectionTrigger | ((messages: MessageData[]) => boolean)
+  /**
+   * Returns the text to fold into the latest user message, or `undefined`/`''` to skip this call. A
+   * callback that throws fails open (injection is skipped, the model call proceeds).
+   */
+  provide: (messages: MessageData[]) => Promise<string | undefined>
+}

--- a/strands-ts/src/injection/xml.ts
+++ b/strands-ts/src/injection/xml.ts
@@ -13,7 +13,7 @@
  *
  * @param value - The raw text to escape
  * @returns The escaped text, safe to place in element content
- * @internal Use the public {@link escapeXml} alias.
+ * @internal Used by the memory default formatter
  */
 export function escapeXmlText(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
@@ -30,11 +30,3 @@ export function escapeXmlText(value: string): string {
 export function escapeXmlAttr(value: string): string {
   return escapeXmlText(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;')
 }
-
-/**
- * Escapes `&`, `<`, `>`, `"`, and `'` so a value is safe in XML **anywhere** — both element content and
- * attribute values. Exposed to consumers (e.g. a {@link ContextInjector} renderer) who render XML
- * themselves and want one helper that is safe regardless of where the value lands. Never applied
- * automatically by the injection engine — escaping is the renderer's responsibility.
- */
-export const escapeXml = escapeXmlAttr

--- a/strands-ts/src/injection/xml.ts
+++ b/strands-ts/src/injection/xml.ts
@@ -1,0 +1,39 @@
+/**
+ * Minimal XML escaping for folding untrusted text into an XML-shaped block.
+ *
+ * Memory entries and other injected content are frequently user-derived, so interpolating them raw
+ * into `<entry>…</entry>` both breaks the block structurally (a stray `</entry>` or `"`) and opens a
+ * stored-prompt-injection surface. These helpers are deliberately tiny — enough to keep a `<memory>`
+ * block well-formed, not a general-purpose serializer.
+ */
+
+/**
+ * Escapes text content for placement between XML tags: `&` (first, so later replacements are not
+ * double-escaped), then `<` and `>`.
+ *
+ * @param value - The raw text to escape
+ * @returns The escaped text, safe to place in element content
+ * @internal Use the public {@link escapeXml} alias.
+ */
+export function escapeXmlText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/**
+ * Escapes a value for placement inside a double-quoted XML attribute: the {@link escapeXmlText} rules
+ * plus `"` and `'`.
+ *
+ * @param value - The raw attribute value to escape
+ * @returns The escaped value, safe to place inside a quoted attribute
+ * @internal Default-format helper; not part of the public surface.
+ */
+export function escapeXmlAttr(value: string): string {
+  return escapeXmlText(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+}
+
+/**
+ * Convenience alias for {@link escapeXmlText}. Exposed to consumers (e.g. a {@link ContextInjector}
+ * provider) who choose to render XML themselves and want safe element content. Never applied
+ * automatically by the injection engine — escaping is the provider's responsibility.
+ */
+export const escapeXml = escapeXmlText

--- a/strands-ts/src/injection/xml.ts
+++ b/strands-ts/src/injection/xml.ts
@@ -32,8 +32,9 @@ export function escapeXmlAttr(value: string): string {
 }
 
 /**
- * Convenience alias for {@link escapeXmlText}. Exposed to consumers (e.g. a {@link ContextInjector}
- * provider) who choose to render XML themselves and want safe element content. Never applied
- * automatically by the injection engine — escaping is the provider's responsibility.
+ * Escapes `&`, `<`, `>`, `"`, and `'` so a value is safe in XML **anywhere** — both element content and
+ * attribute values. Exposed to consumers (e.g. a {@link ContextInjector} renderer) who render XML
+ * themselves and want one helper that is safe regardless of where the value lands. Never applied
+ * automatically by the injection engine — escaping is the renderer's responsibility.
  */
-export const escapeXml = escapeXmlText
+export const escapeXml = escapeXmlAttr

--- a/strands-ts/src/memory/__tests__/memory-manager.test.ts
+++ b/strands-ts/src/memory/__tests__/memory-manager.test.ts
@@ -6,6 +6,9 @@ import { tool } from '../../tools/tool-factory.js'
 import type { MemoryStore, MemoryEntry } from '../types.js'
 import type { InvokableTool, Tool } from '../../tools/tool.js'
 import { logger } from '../../logging/logger.js'
+import { Message, TextBlock, ToolUseBlock, ToolResultBlock } from '../../types/messages.js'
+import type { MessageData } from '../../types/messages.js'
+import { InvokeModelStage } from '../../middleware/index.js'
 
 function createMockStore(
   name: string,
@@ -610,6 +613,224 @@ describe('MemoryManager', () => {
     it('does not throw', () => {
       const mm = new MemoryManager({ stores: [createMockStore('test')] })
       expect(() => mm.initAgent({} as any)).not.toThrow()
+    })
+
+    it('does not register injection middleware when injection is disabled', () => {
+      const mm = new MemoryManager({ stores: [createMockStore('test')] })
+      const addMiddleware = vi.fn()
+      mm.initAgent({ addMiddleware } as any)
+      expect(addMiddleware).not.toHaveBeenCalled()
+    })
+
+    it('registers an InvokeModelStage input middleware when injection is enabled', () => {
+      const mm = new MemoryManager({ stores: [createMockStore('test')], injection: true })
+      const addMiddleware = vi.fn()
+      mm.initAgent({ addMiddleware } as any)
+
+      expect(addMiddleware).toHaveBeenCalledTimes(1)
+      expect(addMiddleware.mock.calls[0]![0]).toBe(InvokeModelStage.Input)
+      expect(typeof addMiddleware.mock.calls[0]![1]).toBe('function')
+    })
+
+    it('wires the registered middleware to the memory provide pipeline (folds a search hit)', async () => {
+      const store = createMockStore('s', { entries: [{ content: 'dark mode preferred' }] })
+      const mm = new MemoryManager({ stores: [store], injection: true })
+      const addMiddleware = vi.fn()
+      mm.initAgent({ addMiddleware } as any)
+
+      const handler = addMiddleware.mock.calls[0]![1] as (ctx: {
+        messages: Message[]
+      }) => Promise<{ messages: Message[] }>
+      const messages = [
+        new Message({ role: 'assistant', content: [new TextBlock('prior')] }),
+        new Message({ role: 'user', content: [new TextBlock('what is my plan')] }),
+      ]
+      const result = await handler({ messages })
+
+      const folded = result.messages[result.messages.length - 1]!
+      expect((folded.content[0] as TextBlock).text).toBe(
+        '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>'
+      )
+      expect(store.search).toHaveBeenCalledWith('what is my plan', { maxSearchResults: 1 })
+    })
+  })
+
+  // The injection delivery (folding text into the model input) is wired through the InvokeModelStage
+  // input middleware (see the `initAgent` tests). The memory-owned `provide` pipeline below — query
+  // derivation, search, and formatting — is exercised directly via `_provideMemoryContext`, the
+  // callback the middleware invokes.
+  describe('injection', () => {
+    const assistant = (text: string) => new Message({ role: 'assistant', content: [new TextBlock(text)] })
+    const user = (text: string) => new Message({ role: 'user', content: [new TextBlock(text)] })
+    const toolUse = () =>
+      new Message({ role: 'assistant', content: [new ToolUseBlock({ name: 'x', toolUseId: 't1', input: {} })] })
+    const toolResult = () =>
+      new Message({
+        role: 'user',
+        content: [new ToolResultBlock({ toolUseId: 't1', status: 'success', content: [new TextBlock('done')] })],
+      })
+
+    // Calls the (private) provide pipeline with the manager's resolved injection config.
+    function provide(mm: MemoryManager, messages: Message[]): Promise<string | undefined> {
+      const data = messages.map((m) => m.toJSON())
+      const config = (mm as unknown as { _injectionConfig: object | false })._injectionConfig
+      return (
+        mm as unknown as { _provideMemoryContext(m: MessageData[], c: object): Promise<string | undefined> }
+      )._provideMemoryContext(data, config === false ? {} : config)
+    }
+
+    describe('config resolution', () => {
+      const injectionConfig = (mm: MemoryManager) =>
+        (mm as unknown as { _injectionConfig: object | false })._injectionConfig
+
+      it('defaults to false (disabled) when injection is omitted', () => {
+        expect(injectionConfig(new MemoryManager({ stores: [createMockStore('s')] }))).toBe(false)
+      })
+
+      it('is false when injection is explicitly false', () => {
+        expect(injectionConfig(new MemoryManager({ stores: [createMockStore('s')], injection: false }))).toBe(false)
+      })
+
+      it('resolves to an empty config when injection is true', () => {
+        expect(injectionConfig(new MemoryManager({ stores: [createMockStore('s')], injection: true }))).toStrictEqual(
+          {}
+        )
+      })
+
+      it('passes an injection config object through unchanged', () => {
+        const cfg = { maxInjectedSearchResults: 5 }
+        expect(injectionConfig(new MemoryManager({ stores: [createMockStore('s')], injection: cfg }))).toBe(cfg)
+      })
+    })
+
+    describe('query', () => {
+      it('uses the latest user ask on a user turn (adaptive default)', async () => {
+        const store = createMockStore('s', { entries: [{ content: 'fact' }] })
+        const mm = new MemoryManager({ stores: [store], injection: true })
+
+        await provide(mm, [assistant('prior step'), user('what is my plan')])
+
+        expect(store.search).toHaveBeenCalledWith('what is my plan', { maxSearchResults: 1 })
+      })
+
+      it('uses the most recent assistant text on an autonomous (tool-result) turn', async () => {
+        const store = createMockStore('s', { entries: [{ content: 'fact' }] })
+        const mm = new MemoryManager({ stores: [store], injection: true })
+
+        await provide(mm, [user('task'), assistant('the previous step result'), toolResult()])
+
+        expect(store.search).toHaveBeenCalledWith('the previous step result', { maxSearchResults: 1 })
+      })
+
+      it('honors a custom query', async () => {
+        const store = createMockStore('s', { entries: [{ content: 'fact' }] })
+        const mm = new MemoryManager({ stores: [store], injection: { query: () => 'custom query' } })
+
+        await provide(mm, [assistant('prior'), user('ask')])
+
+        expect(store.search).toHaveBeenCalledWith('custom query', { maxSearchResults: 1 })
+      })
+
+      it('skips (returns undefined) when a custom query returns undefined', async () => {
+        const store = createMockStore('s', { entries: [{ content: 'fact' }] })
+        const mm = new MemoryManager({ stores: [store], injection: { query: () => undefined } })
+
+        await expect(provide(mm, [assistant('prior'), user('ask')])).resolves.toBeUndefined()
+        expect(store.search).not.toHaveBeenCalled()
+      })
+
+      it('fails open (returns undefined) when a custom query throws', async () => {
+        const store = createMockStore('s', { entries: [{ content: 'fact' }] })
+        const mm = new MemoryManager({
+          stores: [store],
+          injection: {
+            query: () => {
+              throw new Error('boom')
+            },
+          },
+        })
+
+        await expect(provide(mm, [assistant('prior'), user('ask')])).resolves.toBeUndefined()
+        expect(store.search).not.toHaveBeenCalled()
+      })
+
+      it('skips when the latest assistant message has no text (pure tool use)', async () => {
+        const store = createMockStore('s', { entries: [{ content: 'fact' }] })
+        const mm = new MemoryManager({ stores: [store], injection: true })
+
+        await expect(provide(mm, [toolUse(), toolResult()])).resolves.toBeUndefined()
+        expect(store.search).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('search', () => {
+      it('returns undefined when search yields no entries', async () => {
+        const store = createMockStore('s', { entries: [] })
+        const mm = new MemoryManager({ stores: [store], injection: true })
+
+        await expect(provide(mm, [assistant('prior'), user('ask')])).resolves.toBeUndefined()
+        expect(store.search).toHaveBeenCalled()
+      })
+
+      it('honors maxInjectedSearchResults and caps the rendered entries', async () => {
+        const store = createMockStore('s', {
+          entries: [{ content: 'A' }, { content: 'B' }, { content: 'C' }],
+        })
+        const mm = new MemoryManager({
+          stores: [store],
+          injection: { maxInjectedSearchResults: 2, format: (entries) => entries.map((e) => e.content).join(',') },
+        })
+
+        const text = await provide(mm, [assistant('prior'), user('ask')])
+
+        expect(store.search).toHaveBeenCalledWith('ask', { maxSearchResults: 2 })
+        expect(text).toBe('A,B')
+      })
+    })
+
+    describe('format', () => {
+      it('default renders a <memory> block with per-entry source attribution', async () => {
+        const store = createMockStore('s', { entries: [{ content: 'dark mode preferred' }] })
+        const mm = new MemoryManager({ stores: [store], injection: true })
+
+        // search() stamps storeName onto each entry, so the default format attributes the source.
+        const text = await provide(mm, [assistant('prior'), user('ask')])
+        expect(text).toBe('<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>')
+      })
+
+      it('omits the source attribute for an entry with no storeName', () => {
+        const mm = new MemoryManager({ stores: [createMockStore('s')], injection: true })
+        const text = (mm as unknown as { _defaultInjectionFormat(e: MemoryEntry[]): string })._defaultInjectionFormat([
+          { content: 'no source' },
+        ])
+        expect(text).toBe('<memory>\n<entry>no source</entry>\n</memory>')
+      })
+
+      it('honors a custom format', async () => {
+        const store = createMockStore('s', { entries: [{ content: 'A' }] })
+        const mm = new MemoryManager({
+          stores: [store],
+          injection: { format: (entries) => `[${entries.map((e) => e.content).join('|')}]` },
+        })
+
+        await expect(provide(mm, [assistant('prior'), user('ask')])).resolves.toBe('[A]')
+      })
+
+      it('fails open (returns undefined) when a custom format throws', async () => {
+        const store = createMockStore('s', { entries: [{ content: 'fact' }] })
+        const mm = new MemoryManager({
+          stores: [store],
+          injection: {
+            format: () => {
+              throw new Error('boom')
+            },
+          },
+        })
+
+        // search ran, but the format threw, so nothing is injected.
+        await expect(provide(mm, [assistant('prior'), user('ask')])).resolves.toBeUndefined()
+        expect(store.search).toHaveBeenCalled()
+      })
     })
   })
 

--- a/strands-ts/src/memory/__tests__/memory-manager.test.ts
+++ b/strands-ts/src/memory/__tests__/memory-manager.test.ts
@@ -648,10 +648,16 @@ describe('MemoryManager', () => {
       ]
       const result = await handler({ messages, agent } as unknown as InvokeModelContext)
 
-      const folded = result.messages[result.messages.length - 1]!
-      expect((folded.content[0] as TextBlock).text).toBe(
-        '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>'
-      )
+      expect(result.messages.map((m) => m.toJSON())).toStrictEqual([
+        { role: 'assistant', content: [{ text: 'prior' }] },
+        {
+          role: 'user',
+          content: [
+            { text: '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>' },
+            { text: 'what is my plan' },
+          ],
+        },
+      ])
       expect(store.search).toHaveBeenCalledWith('what is my plan', { maxSearchResults: 5 })
     })
   })

--- a/strands-ts/src/memory/__tests__/memory-manager.test.ts
+++ b/strands-ts/src/memory/__tests__/memory-manager.test.ts
@@ -9,6 +9,8 @@ import { logger } from '../../logging/logger.js'
 import { Message, TextBlock, ToolUseBlock, ToolResultBlock } from '../../types/messages.js'
 import type { MessageData } from '../../types/messages.js'
 import { InvokeModelStage } from '../../middleware/index.js'
+import type { InvokeModelContext } from '../../middleware/index.js'
+import { createMockAgent } from '../../__fixtures__/agent-helpers.js'
 
 function createMockStore(
   name: string,
@@ -618,14 +620,14 @@ describe('MemoryManager', () => {
     it('does not register injection middleware when injection is disabled', () => {
       const mm = new MemoryManager({ stores: [createMockStore('test')] })
       const addMiddleware = vi.fn()
-      mm.initAgent({ addMiddleware } as any)
+      mm.initAgent(createMockAgent({ extra: { addMiddleware } as never }))
       expect(addMiddleware).not.toHaveBeenCalled()
     })
 
     it('registers an InvokeModelStage input middleware when injection is enabled', () => {
       const mm = new MemoryManager({ stores: [createMockStore('test')], injection: true })
       const addMiddleware = vi.fn()
-      mm.initAgent({ addMiddleware } as any)
+      mm.initAgent(createMockAgent({ extra: { addMiddleware } as never }))
 
       expect(addMiddleware).toHaveBeenCalledTimes(1)
       expect(addMiddleware.mock.calls[0]![0]).toBe(InvokeModelStage.Input)
@@ -636,22 +638,21 @@ describe('MemoryManager', () => {
       const store = createMockStore('s', { entries: [{ content: 'dark mode preferred' }] })
       const mm = new MemoryManager({ stores: [store], injection: true })
       const addMiddleware = vi.fn()
-      mm.initAgent({ addMiddleware } as any)
+      const agent = createMockAgent({ extra: { addMiddleware } as never })
+      mm.initAgent(agent)
 
-      const handler = addMiddleware.mock.calls[0]![1] as (ctx: {
-        messages: Message[]
-      }) => Promise<{ messages: Message[] }>
+      const handler = addMiddleware.mock.calls[0]![1] as (ctx: InvokeModelContext) => Promise<InvokeModelContext>
       const messages = [
         new Message({ role: 'assistant', content: [new TextBlock('prior')] }),
         new Message({ role: 'user', content: [new TextBlock('what is my plan')] }),
       ]
-      const result = await handler({ messages })
+      const result = await handler({ messages, agent } as unknown as InvokeModelContext)
 
       const folded = result.messages[result.messages.length - 1]!
       expect((folded.content[0] as TextBlock).text).toBe(
         '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>'
       )
-      expect(store.search).toHaveBeenCalledWith('what is my plan', { maxSearchResults: 1 })
+      expect(store.search).toHaveBeenCalledWith('what is my plan', { maxSearchResults: 5 })
     })
   })
 
@@ -698,7 +699,7 @@ describe('MemoryManager', () => {
       })
 
       it('passes an injection config object through unchanged', () => {
-        const cfg = { maxInjectedSearchResults: 5 }
+        const cfg = { maxEntries: 5 }
         expect(injectionConfig(new MemoryManager({ stores: [createMockStore('s')], injection: cfg }))).toBe(cfg)
       })
     })
@@ -710,7 +711,7 @@ describe('MemoryManager', () => {
 
         await provide(mm, [assistant('prior step'), user('what is my plan')])
 
-        expect(store.search).toHaveBeenCalledWith('what is my plan', { maxSearchResults: 1 })
+        expect(store.search).toHaveBeenCalledWith('what is my plan', { maxSearchResults: 5 })
       })
 
       it('uses the most recent assistant text on an autonomous (tool-result) turn', async () => {
@@ -719,7 +720,7 @@ describe('MemoryManager', () => {
 
         await provide(mm, [user('task'), assistant('the previous step result'), toolResult()])
 
-        expect(store.search).toHaveBeenCalledWith('the previous step result', { maxSearchResults: 1 })
+        expect(store.search).toHaveBeenCalledWith('the previous step result', { maxSearchResults: 5 })
       })
 
       it('honors a custom query', async () => {
@@ -728,7 +729,7 @@ describe('MemoryManager', () => {
 
         await provide(mm, [assistant('prior'), user('ask')])
 
-        expect(store.search).toHaveBeenCalledWith('custom query', { maxSearchResults: 1 })
+        expect(store.search).toHaveBeenCalledWith('custom query', { maxSearchResults: 5 })
       })
 
       it('skips (returns undefined) when a custom query returns undefined', async () => {
@@ -772,13 +773,13 @@ describe('MemoryManager', () => {
         expect(store.search).toHaveBeenCalled()
       })
 
-      it('honors maxInjectedSearchResults and caps the rendered entries', async () => {
+      it('honors maxEntries and caps the rendered entries', async () => {
         const store = createMockStore('s', {
           entries: [{ content: 'A' }, { content: 'B' }, { content: 'C' }],
         })
         const mm = new MemoryManager({
           stores: [store],
-          injection: { maxInjectedSearchResults: 2, format: (entries) => entries.map((e) => e.content).join(',') },
+          injection: { maxEntries: 2, format: ({ entries }) => entries.map((e) => e.content).join(',') },
         })
 
         const text = await provide(mm, [assistant('prior'), user('ask')])
@@ -806,11 +807,21 @@ describe('MemoryManager', () => {
         expect(text).toBe('<memory>\n<entry>no source</entry>\n</memory>')
       })
 
+      it('escapes XML in entry content and source so untrusted text cannot break the block', () => {
+        const mm = new MemoryManager({ stores: [createMockStore('s')], injection: true })
+        const text = (mm as unknown as { _defaultInjectionFormat(e: MemoryEntry[]): string })._defaultInjectionFormat([
+          { content: 'a < b & c > d </entry>', storeName: 'pre"f' },
+        ])
+        expect(text).toBe(
+          '<memory>\n<entry source="pre&quot;f">a &lt; b &amp; c &gt; d &lt;/entry&gt;</entry>\n</memory>'
+        )
+      })
+
       it('honors a custom format', async () => {
         const store = createMockStore('s', { entries: [{ content: 'A' }] })
         const mm = new MemoryManager({
           stores: [store],
-          injection: { format: (entries) => `[${entries.map((e) => e.content).join('|')}]` },
+          injection: { format: ({ entries }) => `[${entries.map((e) => e.content).join('|')}]` },
         })
 
         await expect(provide(mm, [assistant('prior'), user('ask')])).resolves.toBe('[A]')

--- a/strands-ts/src/memory/index.ts
+++ b/strands-ts/src/memory/index.ts
@@ -12,7 +12,7 @@ export type {
   MemoryManagerConfig,
   MemoryInjectionConfig,
 } from './types.js'
-export type { InjectionConfig, InjectionTrigger } from '../injection/index.js'
+export type { InjectionConfig, InjectionTrigger, InjectionContext } from '../injection/index.js'
 
 export { ExtractionTrigger } from './extraction/types.js'
 export { InvocationTrigger, IntervalTrigger } from './extraction/triggers.js'

--- a/strands-ts/src/memory/index.ts
+++ b/strands-ts/src/memory/index.ts
@@ -10,7 +10,9 @@ export type {
   MemoryToolConfig,
   MemoryAddToolConfig,
   MemoryManagerConfig,
+  MemoryInjectionConfig,
 } from './types.js'
+export type { InjectionConfig, InjectionTrigger } from '../injection/index.js'
 
 export { ExtractionTrigger } from './extraction/types.js'
 export { InvocationTrigger, IntervalTrigger } from './extraction/triggers.js'

--- a/strands-ts/src/memory/memory-manager.ts
+++ b/strands-ts/src/memory/memory-manager.ts
@@ -3,6 +3,7 @@ import type { LocalAgent } from '../types/agent.js'
 import type { Tool } from '../tools/tool.js'
 import type {
   MemoryEntry,
+  MemoryInjectionConfig,
   MemoryManagerConfig,
   MemorySearchOptions,
   MemoryStore,
@@ -11,6 +12,7 @@ import type {
   MemoryAddToolConfig,
 } from './types.js'
 import type { JSONValue } from '../types/json.js'
+import type { MessageData } from '../types/messages.js'
 import { MessageAddedEvent } from '../hooks/events.js'
 import { ExtractionCoordinator } from './extraction/coordinator.js'
 import type { ExtractionTrigger } from './extraction/types.js'
@@ -18,6 +20,8 @@ import { tool } from '../tools/tool-factory.js'
 import { z } from 'zod'
 import { logger } from '../logging/logger.js'
 import { normalizeError } from '../errors.js'
+import { isUserTurn, createInjectionMiddleware } from '../injection/index.js'
+import { InvokeModelStage } from '../middleware/index.js'
 
 const SEARCH_TOOL_DESCRIPTION =
   'Search long-term memory for facts, preferences, or context from previous conversations. Use when you need background about the user or topic that may have been discussed before.'
@@ -30,6 +34,9 @@ const ADD_TOOL_DESCRIPTION =
  * Resolved by the {@link MemoryManager}.
  */
 export const DEFAULT_MAX_SEARCH_RESULTS = 3
+
+/** Default number of entries injected per model call when injection does not specify one. */
+const DEFAULT_INJECTED_SEARCH_RESULTS = 1
 
 /** Flattens nested AggregateErrors so the leaves are concrete reasons, not errors-of-errors. */
 function _flattenReasons(reasons: unknown[]): unknown[] {
@@ -85,6 +92,8 @@ export class MemoryManager implements Plugin {
   private readonly _extractionStores: MemoryStore[]
   /** Background extraction coordinator, created in {@link initAgent} when extraction is configured. */
   private _coordinator: ExtractionCoordinator | undefined
+  /** Resolved injection config, or `false` when injection is disabled. */
+  private readonly _injectionConfig: MemoryInjectionConfig | false
 
   constructor(config: MemoryManagerConfig) {
     if (config.stores.length === 0) {
@@ -149,6 +158,13 @@ export class MemoryManager implements Plugin {
       this._addToolConfig = typeof config.addToolConfig === 'object' ? config.addToolConfig : {}
       this._addToolStores = this._resolveAddToolStores(this._addToolConfig)
     }
+
+    this._injectionConfig =
+      config.injection === undefined || config.injection === false
+        ? false
+        : typeof config.injection === 'object'
+          ? config.injection
+          : {}
   }
 
   /**
@@ -181,12 +197,22 @@ export class MemoryManager implements Plugin {
   /**
    * Initializes the plugin with the agent.
    *
-   * Wires up automatic extraction for any store configured with {@link ExtractionConfig}: buffers
-   * conversation messages and attaches each store's triggers. A no-op when no store uses extraction.
+   * Wires up two independent behaviors:
+   * - **Extraction**: for any store configured with {@link ExtractionConfig}, buffers conversation
+   *   messages and attaches each store's triggers. A no-op when no store uses extraction.
+   * - **Injection**: when enabled, registers an `InvokeModelStage` middleware that folds retrieved
+   *   memory into the model input for each call without touching durable history. See
+   *   {@link _provideMemoryContext}, the `provide` callback the middleware invokes.
    *
    * @param agent - The agent this plugin is being attached to
    */
   initAgent(agent: LocalAgent): void {
+    this._initExtraction(agent)
+    this._initInjection(agent)
+  }
+
+  /** Wires background extraction for stores configured with {@link ExtractionConfig}. */
+  private _initExtraction(agent: LocalAgent): void {
     if (this._extractionStores.length === 0) {
       return
     }
@@ -207,6 +233,60 @@ export class MemoryManager implements Plugin {
   }
 
   /**
+   * Registers the injection middleware when injection is enabled. Folds retrieved memory into the
+   * model input for each call via {@link _provideMemoryContext}, without touching durable history. A
+   * no-op when injection is disabled.
+   */
+  private _initInjection(agent: LocalAgent): void {
+    const config = this._injectionConfig
+    if (config === false) {
+      return
+    }
+    agent.addMiddleware(
+      InvokeModelStage.Input,
+      createInjectionMiddleware({
+        ...(config.trigger !== undefined && { trigger: config.trigger }),
+        provide: (messages) => this._provideMemoryContext(messages, config),
+      })
+    )
+  }
+
+  /**
+   * Produces the memory context text to inject for a model call, or `undefined` to skip. This is the
+   * `provide` callback the injection middleware invokes (see {@link initAgent}).
+   *
+   * Derives a query (the configured callback or an adaptive default), searches memory, and renders the
+   * top entries. Skips silently (returns `undefined`) when no query can be derived or the search
+   * returns nothing. The rendering callback throwing fails open (returns `undefined`).
+   *
+   * @param messages - The current conversation, as data
+   * @param config - The resolved injection configuration
+   * @returns The injected text, or `undefined` when there is nothing to inject
+   */
+  private async _provideMemoryContext(
+    messages: MessageData[],
+    config: MemoryInjectionConfig
+  ): Promise<string | undefined> {
+    const query = this._resolveInjectionQuery(messages, config)
+    if (!query?.trim()) {
+      return undefined
+    }
+
+    const maxResults = config.maxInjectedSearchResults ?? DEFAULT_INJECTED_SEARCH_RESULTS
+    const entries = (await this.search(query, { maxSearchResults: maxResults })).slice(0, maxResults)
+    if (entries.length === 0) {
+      return undefined
+    }
+
+    try {
+      return (config.format ?? this._defaultInjectionFormat)(entries)
+    } catch (error) {
+      logger.warn(`reason=<${normalizeError(error).message}> | injection format threw; skipping injection`)
+      return undefined
+    }
+  }
+
+  /**
    * Saves every store's remaining messages and waits for all saves to finish. No-op when no store has
    * extraction configured.
    *
@@ -220,6 +300,63 @@ export class MemoryManager implements Plugin {
    */
   async flush(): Promise<void> {
     await this._coordinator?.flush()
+  }
+
+  /**
+   * Derives the injection search query. Uses the configured `query` callback when provided (a throw
+   * fails open, skipping injection); otherwise an adaptive default: the latest user message's text on
+   * a user turn, or the most recent assistant message's text otherwise (the previous autonomous step).
+   *
+   * @param messages - The current conversation, as data
+   * @param config - The resolved injection configuration
+   * @returns The query string, or `undefined` when none is available
+   */
+  private _resolveInjectionQuery(messages: MessageData[], config: MemoryInjectionConfig): string | undefined {
+    if (config.query) {
+      try {
+        return config.query(messages)
+      } catch (error) {
+        logger.warn(`reason=<${normalizeError(error).message}> | injection query threw; skipping injection`)
+        return undefined
+      }
+    }
+
+    const role = isUserTurn(messages) ? 'user' : 'assistant'
+    const index = this._findLastIndex(messages, (message) => message.role === role)
+    if (index < 0) {
+      return undefined
+    }
+    const text = messages[index]!.content.filter((block) => 'text' in block)
+      .map((block) => (block as { text: string }).text)
+      .join('\n')
+      .trim()
+    return text.length > 0 ? text : undefined
+  }
+
+  /**
+   * Default injection format: a `<memory>` block with one `<entry>` per result. Each entry carries a
+   * `source` attribute naming the originating store (when known) so the model can attribute memories.
+   *
+   * @param entries - The retrieved memory entries to render
+   * @returns The rendered `<memory>` block
+   */
+  private _defaultInjectionFormat(entries: MemoryEntry[]): string {
+    const items = entries.map((entry) =>
+      entry.storeName
+        ? `<entry source="${entry.storeName}">${entry.content}</entry>`
+        : `<entry>${entry.content}</entry>`
+    )
+    return `<memory>\n${items.join('\n')}\n</memory>`
+  }
+
+  /** Returns the index of the last element matching `predicate`, or -1. */
+  private _findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {
+    for (let i = items.length - 1; i >= 0; i--) {
+      if (predicate(items[i]!)) {
+        return i
+      }
+    }
+    return -1
   }
 
   /**

--- a/strands-ts/src/memory/memory-manager.ts
+++ b/strands-ts/src/memory/memory-manager.ts
@@ -20,7 +20,8 @@ import { tool } from '../tools/tool-factory.js'
 import { z } from 'zod'
 import { logger } from '../logging/logger.js'
 import { normalizeError } from '../errors.js'
-import { isUserTurn, createInjectionMiddleware } from '../injection/index.js'
+import { isUserTurn, createInjectionMiddleware } from '../injection/message-injection.js'
+import { escapeXmlText, escapeXmlAttr } from '../injection/xml.js'
 import { InvokeModelStage } from '../middleware/index.js'
 
 const SEARCH_TOOL_DESCRIPTION =
@@ -35,8 +36,15 @@ const ADD_TOOL_DESCRIPTION =
  */
 export const DEFAULT_MAX_SEARCH_RESULTS = 3
 
-/** Default number of entries injected per model call when injection does not specify one. */
-const DEFAULT_INJECTED_SEARCH_RESULTS = 1
+/**
+ * Default number of entries injected per model call when injection does not specify one.
+ *
+ * A memory store ranks by semantic (embedding) similarity, which is not the same as contextual
+ * usefulness — the top hit is not reliably the most useful entry for the turn. Injecting the top few
+ * gives the model a small candidate set to pick from rather than betting on the store's first result.
+ * Five balances that recall against context bloat; lower it for a tighter prepend.
+ */
+const DEFAULT_MAX_ENTRIES = 5
 
 /** Flattens nested AggregateErrors so the leaves are concrete reasons, not errors-of-errors. */
 function _flattenReasons(reasons: unknown[]): unknown[] {
@@ -202,7 +210,7 @@ export class MemoryManager implements Plugin {
    *   messages and attaches each store's triggers. A no-op when no store uses extraction.
    * - **Injection**: when enabled, registers an `InvokeModelStage` middleware that folds retrieved
    *   memory into the model input for each call without touching durable history. See
-   *   {@link _provideMemoryContext}, the `provide` callback the middleware invokes.
+   *   {@link _provideMemoryContext}, the `renderContent` callback the middleware invokes.
    *
    * @param agent - The agent this plugin is being attached to
    */
@@ -246,14 +254,14 @@ export class MemoryManager implements Plugin {
       InvokeModelStage.Input,
       createInjectionMiddleware({
         ...(config.trigger !== undefined && { trigger: config.trigger }),
-        provide: (messages) => this._provideMemoryContext(messages, config),
+        renderContent: (context) => this._provideMemoryContext(context.messages, config),
       })
     )
   }
 
   /**
    * Produces the memory context text to inject for a model call, or `undefined` to skip. This is the
-   * `provide` callback the injection middleware invokes (see {@link initAgent}).
+   * `renderContent` callback the injection middleware invokes (see {@link initAgent}).
    *
    * Derives a query (the configured callback or an adaptive default), searches memory, and renders the
    * top entries. Skips silently (returns `undefined`) when no query can be derived or the search
@@ -272,14 +280,14 @@ export class MemoryManager implements Plugin {
       return undefined
     }
 
-    const maxResults = config.maxInjectedSearchResults ?? DEFAULT_INJECTED_SEARCH_RESULTS
+    const maxResults = config.maxEntries ?? DEFAULT_MAX_ENTRIES
     const entries = (await this.search(query, { maxSearchResults: maxResults })).slice(0, maxResults)
     if (entries.length === 0) {
       return undefined
     }
 
     try {
-      return (config.format ?? this._defaultInjectionFormat)(entries)
+      return config.format ? config.format({ entries }) : this._defaultInjectionFormat(entries)
     } catch (error) {
       logger.warn(`reason=<${normalizeError(error).message}> | injection format threw; skipping injection`)
       return undefined
@@ -314,7 +322,7 @@ export class MemoryManager implements Plugin {
   private _resolveInjectionQuery(messages: MessageData[], config: MemoryInjectionConfig): string | undefined {
     if (config.query) {
       try {
-        return config.query(messages)
+        return config.query({ messages })
       } catch (error) {
         logger.warn(`reason=<${normalizeError(error).message}> | injection query threw; skipping injection`)
         return undefined
@@ -343,8 +351,8 @@ export class MemoryManager implements Plugin {
   private _defaultInjectionFormat(entries: MemoryEntry[]): string {
     const items = entries.map((entry) =>
       entry.storeName
-        ? `<entry source="${entry.storeName}">${entry.content}</entry>`
-        : `<entry>${entry.content}</entry>`
+        ? `<entry source="${escapeXmlAttr(entry.storeName)}">${escapeXmlText(entry.content)}</entry>`
+        : `<entry>${escapeXmlText(entry.content)}</entry>`
     )
     return `<memory>\n${items.join('\n')}\n</memory>`
   }

--- a/strands-ts/src/memory/types.ts
+++ b/strands-ts/src/memory/types.ts
@@ -209,6 +209,9 @@ export interface MemoryInjectionConfig extends InjectionConfig {
    * default injects a small candidate set rather than betting on the top hit. Raising this improves
    * recall at the cost of a larger prepend (context bloat); lower it for a tighter injection.
    *
+   * With multiple stores, results are concatenated in store-registration order with no cross-store
+   * ranking, so this cap can favor entries from earlier-registered stores.
+   *
    * @defaultValue 5
    */
   maxEntries?: number

--- a/strands-ts/src/memory/types.ts
+++ b/strands-ts/src/memory/types.ts
@@ -193,23 +193,25 @@ export interface MemoryAddToolConfig extends MemoryToolConfig {
 /**
  * Configuration for memory context injection.
  *
- * When enabled on a {@link MemoryManager}, the manager searches memory before a model call and folds
- * the top results into the most recent user message (ahead of the user's own content), so relevant
- * knowledge is present without the model choosing to search. The injected text is ephemeral: it
- * augments the model input for that call only and never persists into the durable conversation or
- * session.
+ * When enabled on a {@link MemoryManager}, the manager searches memory before a model call and makes
+ * the top results available to the model for that call, so relevant knowledge is present without the
+ * model choosing to search. The injected text is ephemeral: it augments the model input for that call
+ * only and never persists into the durable conversation or session.
  *
  * Extends the generic {@link InjectionConfig} (which carries `trigger`) with the memory-owned knobs:
- * how many entries to retrieve, how to derive the query, and how to render the results. These are
- * memory concerns and intentionally do not live on the generic injection engine.
+ * how many entries to retrieve, how to derive the query, and how to render the results.
  */
 export interface MemoryInjectionConfig extends InjectionConfig {
   /**
    * Maximum number of entries to retrieve and inject per model call.
    *
-   * @defaultValue 1
+   * A store ranks by semantic similarity, which is not the same as contextual usefulness, so the
+   * default injects a small candidate set rather than betting on the top hit. Raising this improves
+   * recall at the cost of a larger prepend (context bloat); lower it for a tighter injection.
+   *
+   * @defaultValue 5
    */
-  maxInjectedSearchResults?: number
+  maxEntries?: number
   /**
    * Derives the search query from the current conversation. Return `undefined` or an empty string to
    * skip injection for this call. A callback that throws fails open (injection is skipped).
@@ -217,15 +219,17 @@ export interface MemoryInjectionConfig extends InjectionConfig {
    * Defaults to an adaptive query: the latest user message's text on a user turn, otherwise the most
    * recent assistant message's text (the previous step on an autonomous turn).
    */
-  query?: (messages: MessageData[]) => string | undefined
+  query?: (context: { messages: MessageData[] }) => string | undefined
   /**
    * Renders retrieved entries into the injected text. A callback that throws fails open (injection is
    * skipped).
    *
    * Defaults to a `<memory>` XML block with one `<entry>` per result, carrying a `source` attribute
-   * naming the originating store (when known) so the model can attribute and weigh each memory.
+   * naming the originating store (when known) so the model can attribute and weigh each memory. The
+   * default escapes entry content and source, so a custom `format` that emits markup is responsible
+   * for its own escaping.
    */
-  format?: (entries: MemoryEntry[]) => string
+  format?: (context: { entries: MemoryEntry[] }) => string
 }
 
 /**
@@ -244,6 +248,16 @@ export interface MemoryManagerConfig {
   /**
    * Memory context injection. Defaults to `false` (opt-in). `true` uses the default injection
    * settings; pass a {@link MemoryInjectionConfig} to customize retrieval, timing, and formatting.
+   *
+   * `true` is equivalent to:
+   * ```ts
+   * {
+   *   trigger: 'userTurn',          // inject only on a fresh user ask
+   *   maxEntries: 5,                // retrieve and inject up to 5 entries
+   *   // query:  the latest user text on a user turn, else the most recent assistant text
+   *   // format: a <memory> block with one <entry source="STORE_NAME"> per result (content escaped)
+   * }
+   * ```
    */
   injection?: boolean | MemoryInjectionConfig
 }

--- a/strands-ts/src/memory/types.ts
+++ b/strands-ts/src/memory/types.ts
@@ -2,6 +2,7 @@ import type { JSONValue } from '../types/json.js'
 import type { MessageData } from '../types/messages.js'
 import type { Tool } from '../tools/tool.js'
 import type { ExtractionConfig } from './extraction/types.js'
+import type { InjectionConfig } from '../injection/index.js'
 
 /**
  * A single memory entry retrieved from or stored to a memory store.
@@ -190,6 +191,44 @@ export interface MemoryAddToolConfig extends MemoryToolConfig {
 }
 
 /**
+ * Configuration for memory context injection.
+ *
+ * When enabled on a {@link MemoryManager}, the manager searches memory before a model call and folds
+ * the top results into the most recent user message (ahead of the user's own content), so relevant
+ * knowledge is present without the model choosing to search. The injected text is ephemeral: it
+ * augments the model input for that call only and never persists into the durable conversation or
+ * session.
+ *
+ * Extends the generic {@link InjectionConfig} (which carries `trigger`) with the memory-owned knobs:
+ * how many entries to retrieve, how to derive the query, and how to render the results. These are
+ * memory concerns and intentionally do not live on the generic injection engine.
+ */
+export interface MemoryInjectionConfig extends InjectionConfig {
+  /**
+   * Maximum number of entries to retrieve and inject per model call.
+   *
+   * @defaultValue 1
+   */
+  maxInjectedSearchResults?: number
+  /**
+   * Derives the search query from the current conversation. Return `undefined` or an empty string to
+   * skip injection for this call. A callback that throws fails open (injection is skipped).
+   *
+   * Defaults to an adaptive query: the latest user message's text on a user turn, otherwise the most
+   * recent assistant message's text (the previous step on an autonomous turn).
+   */
+  query?: (messages: MessageData[]) => string | undefined
+  /**
+   * Renders retrieved entries into the injected text. A callback that throws fails open (injection is
+   * skipped).
+   *
+   * Defaults to a `<memory>` XML block with one `<entry>` per result, carrying a `source` attribute
+   * naming the originating store (when known) so the model can attribute and weigh each memory.
+   */
+  format?: (entries: MemoryEntry[]) => string
+}
+
+/**
  * Configuration for the {@link MemoryManager}.
  */
 export interface MemoryManagerConfig {
@@ -202,4 +241,9 @@ export interface MemoryManagerConfig {
    * writable stores; pass a {@link MemoryAddToolConfig} with `stores` to restrict it to specific ones.
    */
   addToolConfig?: MemoryAddToolConfig | boolean
+  /**
+   * Memory context injection. Defaults to `false` (opt-in). `true` uses the default injection
+   * settings; pass a {@link MemoryInjectionConfig} to customize retrieval, timing, and formatting.
+   */
+  injection?: boolean | MemoryInjectionConfig
 }

--- a/strands-ts/src/vended-plugins/context-injector/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-injector/__tests__/plugin.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ContextInjector } from '../plugin.js'
-import { escapeXml } from '../index.js'
 import { InvokeModelStage } from '../../../middleware/index.js'
 import { Message, TextBlock } from '../../../types/messages.js'
 import type { InvokeModelContext } from '../../../middleware/index.js'
@@ -76,13 +75,13 @@ describe('ContextInjector', () => {
       ])
     })
 
-    it('exposes appState and the cancel signal to renderContent', async () => {
+    it('exposes appState and the agent to renderContent', async () => {
       const { agent, addMiddleware } = makeAgent()
-      let sawSignal = false
+      let sawAgent = false
       let sawAppState = false
       new ContextInjector({
         renderContent: async (ctx) => {
-          sawSignal = ctx.signal === agent.cancelSignal
+          sawAgent = ctx.agent === agent
           sawAppState = ctx.appState === agent.appState
           return undefined
         },
@@ -90,7 +89,7 @@ describe('ContextInjector', () => {
       const handler = addMiddleware.mock.calls[0]![1] as (ctx: InvokeModelContext) => Promise<InvokeModelContext>
       await handler({ messages: [user('ask')], agent } as unknown as InvokeModelContext)
 
-      expect(sawSignal).toBe(true)
+      expect(sawAgent).toBe(true)
       expect(sawAppState).toBe(true)
     })
 
@@ -108,12 +107,6 @@ describe('ContextInjector', () => {
         { role: 'assistant', content: [{ text: 'prior' }] },
         { role: 'user', content: [{ text: 'ask' }] },
       ])
-    })
-  })
-
-  describe('escapeXml helper', () => {
-    it('escapes &, <, >, ", and \' so the value is safe in content or an attribute', () => {
-      expect(escapeXml('a < b & c > d " e \' f')).toBe('a &lt; b &amp; c &gt; d &quot; e &#39; f')
     })
   })
 })

--- a/strands-ts/src/vended-plugins/context-injector/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-injector/__tests__/plugin.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ContextInjector } from '../plugin.js'
+import { escapeXml } from '../index.js'
+import { InvokeModelStage } from '../../../middleware/index.js'
+import { Message, TextBlock } from '../../../types/messages.js'
+import type { InvokeModelContext } from '../../../middleware/index.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+
+const user = (text: string) => new Message({ role: 'user', content: [new TextBlock(text)] })
+const assistant = (text: string) => new Message({ role: 'assistant', content: [new TextBlock(text)] })
+
+// Builds a mock agent that captures addMiddleware registrations, with a real appState/cancelSignal.
+function makeAgent() {
+  const addMiddleware = vi.fn()
+  const agent = createMockAgent({ extra: { addMiddleware } as never })
+  return { agent, addMiddleware }
+}
+
+describe('ContextInjector', () => {
+  describe('plugin interface', () => {
+    it('defaults to the strands:context-injector name', () => {
+      expect(new ContextInjector({ renderContent: async () => 'x' }).name).toBe('strands:context-injector')
+    })
+
+    it('honors a custom name (so multiple injectors can be told apart)', () => {
+      expect(new ContextInjector({ name: 'now', renderContent: async () => 'x' }).name).toBe('now')
+    })
+
+    it('registers an InvokeModelStage input middleware on initAgent', () => {
+      const { agent, addMiddleware } = makeAgent()
+      new ContextInjector({ renderContent: async () => 'x' }).initAgent(agent)
+
+      expect(addMiddleware).toHaveBeenCalledTimes(1)
+      expect(addMiddleware.mock.calls[0]![0]).toBe(InvokeModelStage.Input)
+      expect(typeof addMiddleware.mock.calls[0]![1]).toBe('function')
+    })
+  })
+
+  describe('registered handler', () => {
+    // Runs the handler the plugin registered, with a context backed by the mock agent.
+    async function run(plugin: ContextInjector, messages: Message[]) {
+      const { agent, addMiddleware } = makeAgent()
+      plugin.initAgent(agent)
+      const handler = addMiddleware.mock.calls[0]![1] as (ctx: InvokeModelContext) => Promise<InvokeModelContext>
+      return handler({ messages, agent } as unknown as InvokeModelContext)
+    }
+
+    it('folds renderContent() text into the latest user message', async () => {
+      const result = await run(new ContextInjector({ renderContent: async () => 'INJECTED' }), [
+        assistant('prior'),
+        user('ask'),
+      ])
+      const target = result.messages[result.messages.length - 1]!
+      expect((target.content[0] as TextBlock).text).toBe('INJECTED')
+      expect((target.content[1] as TextBlock).text).toBe('ask')
+    })
+
+    it('skips on a non-user turn by default (userTurn trigger)', async () => {
+      const renderContent = vi.fn(async () => 'x')
+      const input = [user('ask'), assistant('reply')]
+      const result = await run(new ContextInjector({ renderContent }), input)
+      expect(renderContent).not.toHaveBeenCalled()
+      expect(result.messages).toBe(input)
+    })
+
+    it("'everyTurn' injects regardless of the latest role", async () => {
+      const result = await run(new ContextInjector({ trigger: 'everyTurn', renderContent: async () => 'INJECTED' }), [
+        user('ask'),
+        assistant('reply'),
+      ])
+      // No later user message than index 0, so the fold targets it.
+      expect((result.messages[0]!.content[0] as TextBlock).text).toBe('INJECTED')
+    })
+
+    it('exposes appState and the cancel signal to renderContent', async () => {
+      const { agent, addMiddleware } = makeAgent()
+      let sawSignal = false
+      let sawAppState = false
+      new ContextInjector({
+        renderContent: async (ctx) => {
+          sawSignal = ctx.signal === agent.cancelSignal
+          sawAppState = ctx.appState === agent.appState
+          return undefined
+        },
+      }).initAgent(agent)
+      const handler = addMiddleware.mock.calls[0]![1] as (ctx: InvokeModelContext) => Promise<InvokeModelContext>
+      await handler({ messages: [user('ask')], agent } as unknown as InvokeModelContext)
+
+      expect(sawSignal).toBe(true)
+      expect(sawAppState).toBe(true)
+    })
+
+    it('fails open (passes context through) when renderContent throws', async () => {
+      const result = await run(
+        new ContextInjector({
+          renderContent: async () => {
+            throw new Error('boom')
+          },
+        }),
+        [assistant('prior'), user('ask')]
+      )
+      // Unchanged: the single original user message, no injected block.
+      const target = result.messages[result.messages.length - 1]!
+      expect(target.content).toHaveLength(1)
+      expect((target.content[0] as TextBlock).text).toBe('ask')
+    })
+  })
+
+  describe('escapeXml helper', () => {
+    it('escapes &, <, > for safe element content', () => {
+      expect(escapeXml('a < b & c > d')).toBe('a &lt; b &amp; c &gt; d')
+    })
+  })
+})

--- a/strands-ts/src/vended-plugins/context-injector/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-injector/__tests__/plugin.test.ts
@@ -50,9 +50,10 @@ describe('ContextInjector', () => {
         assistant('prior'),
         user('ask'),
       ])
-      const target = result.messages[result.messages.length - 1]!
-      expect((target.content[0] as TextBlock).text).toBe('INJECTED')
-      expect((target.content[1] as TextBlock).text).toBe('ask')
+      expect(result.messages.map((m) => m.toJSON())).toStrictEqual([
+        { role: 'assistant', content: [{ text: 'prior' }] },
+        { role: 'user', content: [{ text: 'INJECTED' }, { text: 'ask' }] },
+      ])
     })
 
     it('skips on a non-user turn by default (userTurn trigger)', async () => {
@@ -69,7 +70,10 @@ describe('ContextInjector', () => {
         assistant('reply'),
       ])
       // No later user message than index 0, so the fold targets it.
-      expect((result.messages[0]!.content[0] as TextBlock).text).toBe('INJECTED')
+      expect(result.messages.map((m) => m.toJSON())).toStrictEqual([
+        { role: 'user', content: [{ text: 'INJECTED' }, { text: 'ask' }] },
+        { role: 'assistant', content: [{ text: 'reply' }] },
+      ])
     })
 
     it('exposes appState and the cancel signal to renderContent', async () => {
@@ -99,16 +103,17 @@ describe('ContextInjector', () => {
         }),
         [assistant('prior'), user('ask')]
       )
-      // Unchanged: the single original user message, no injected block.
-      const target = result.messages[result.messages.length - 1]!
-      expect(target.content).toHaveLength(1)
-      expect((target.content[0] as TextBlock).text).toBe('ask')
+      // Unchanged: the original messages, no injected block.
+      expect(result.messages.map((m) => m.toJSON())).toStrictEqual([
+        { role: 'assistant', content: [{ text: 'prior' }] },
+        { role: 'user', content: [{ text: 'ask' }] },
+      ])
     })
   })
 
   describe('escapeXml helper', () => {
-    it('escapes &, <, > for safe element content', () => {
-      expect(escapeXml('a < b & c > d')).toBe('a &lt; b &amp; c &gt; d')
+    it('escapes &, <, >, ", and \' so the value is safe in content or an attribute', () => {
+      expect(escapeXml('a < b & c > d " e \' f')).toBe('a &lt; b &amp; c &gt; d &quot; e &#39; f')
     })
   })
 })

--- a/strands-ts/src/vended-plugins/context-injector/index.ts
+++ b/strands-ts/src/vended-plugins/context-injector/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Context-injection plugin for Strands Agents.
+ *
+ * Provides the {@link ContextInjector} plugin, which folds just-in-time text into the model input
+ * before each call without touching durable history. `escapeXml` is offered for providers that render
+ * XML and want to escape untrusted content themselves — it is never applied automatically.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { ContextInjector, escapeXml } from '@strands-agents/sdk/vended-plugins/context-injector'
+ *
+ * const agent = new Agent({
+ *   model,
+ *   plugins: [
+ *     new ContextInjector({
+ *       renderContent: async ({ messages }) => `<context>${escapeXml(derive(messages))}</context>`,
+ *     }),
+ *   ],
+ * })
+ * ```
+ */
+
+export { ContextInjector } from './plugin.js'
+export type { ContextInjectorConfig } from './plugin.js'
+export type { InjectionTrigger, InjectionContext } from '../../injection/types.js'
+export { escapeXml } from '../../injection/xml.js'

--- a/strands-ts/src/vended-plugins/context-injector/index.ts
+++ b/strands-ts/src/vended-plugins/context-injector/index.ts
@@ -2,19 +2,18 @@
  * Context-injection plugin for Strands Agents.
  *
  * Provides the {@link ContextInjector} plugin, which folds just-in-time text into the model input
- * before each call without touching durable history. `escapeXml` is offered for providers that render
- * XML and want to escape untrusted content themselves — it is never applied automatically.
+ * before each call without touching durable history.
  *
  * @example
  * ```typescript
  * import { Agent } from '@strands-agents/sdk'
- * import { ContextInjector, escapeXml } from '@strands-agents/sdk/vended-plugins/context-injector'
+ * import { ContextInjector } from '@strands-agents/sdk/vended-plugins/context-injector'
  *
  * const agent = new Agent({
  *   model,
  *   plugins: [
  *     new ContextInjector({
- *       renderContent: async ({ messages }) => `<context>${escapeXml(derive(messages))}</context>`,
+ *       renderContent: async ({ messages }) => `<context>${derive(messages)}</context>`,
  *     }),
  *   ],
  * })
@@ -24,4 +23,3 @@
 export { ContextInjector } from './plugin.js'
 export type { ContextInjectorConfig } from './plugin.js'
 export type { InjectionTrigger, InjectionContext } from '../../injection/types.js'
-export { escapeXml } from '../../injection/xml.js'

--- a/strands-ts/src/vended-plugins/context-injector/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-injector/plugin.ts
@@ -1,0 +1,74 @@
+import type { Plugin } from '../../plugins/plugin.js'
+import type { LocalAgent } from '../../types/agent.js'
+import { InvokeModelStage } from '../../middleware/index.js'
+import { createInjectionMiddleware } from '../../injection/message-injection.js'
+import type { InjectionTrigger, InjectionContext } from '../../injection/types.js'
+
+/** Configuration for the {@link ContextInjector} plugin. */
+export interface ContextInjectorConfig {
+  /**
+   * Plugin name, for logging and duplicate detection. Defaults to `'strands:context-injector'`. Set a
+   * distinct name when registering more than one injector so they can be told apart.
+   */
+  name?: string
+  /**
+   * When to inject. An {@link InjectionTrigger} name selects a built-in policy (`'userTurn'` —
+   * default — or `'everyTurn'`); a predicate over the {@link InjectionContext} is the escape hatch. A
+   * predicate that throws fails open (injection is skipped).
+   *
+   * @defaultValue 'userTurn'
+   */
+  trigger?: InjectionTrigger | ((context: InjectionContext) => boolean)
+  /**
+   * Renders the text to inject for this call, or `undefined`/`''` to skip. The text reaches the model
+   * verbatim, so it is a prompt-injection surface: escape any attacker-influenced fields yourself (an
+   * `escapeXml` helper is exported alongside this plugin). A callback that throws fails open (injection
+   * is skipped, the model call proceeds).
+   */
+  renderContent: (context: InjectionContext) => Promise<string | undefined>
+}
+
+/**
+ * Plugin that injects just-in-time context into the model input before each call.
+ *
+ * Before each model call, the plugin asks {@link ContextInjectorConfig.renderContent} for text and
+ * makes it available to the model for that call, gated by {@link ContextInjectorConfig.trigger}. The
+ * injected text is ephemeral: it augments the model input for that one call and never persists into the
+ * durable conversation or session.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { ContextInjector } from '@strands-agents/sdk/vended-plugins/context-injector'
+ *
+ * const agent = new Agent({
+ *   model,
+ *   plugins: [new ContextInjector({ renderContent: async () => `<now>${new Date().toISOString()}</now>` })],
+ * })
+ * ```
+ *
+ * @remarks
+ * Multiple injectors may be registered; each contributes its text independently, in plugin-registration
+ * order.
+ */
+export class ContextInjector implements Plugin {
+  readonly name: string
+
+  private readonly _config: ContextInjectorConfig
+
+  constructor(config: ContextInjectorConfig) {
+    this.name = config.name ?? 'strands:context-injector'
+    this._config = config
+  }
+
+  initAgent(agent: LocalAgent): void {
+    const config = this._config
+    agent.addMiddleware(
+      InvokeModelStage.Input,
+      createInjectionMiddleware({
+        ...(config.trigger !== undefined && { trigger: config.trigger }),
+        renderContent: config.renderContent,
+      })
+    )
+  }
+}

--- a/strands-ts/src/vended-plugins/context-injector/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-injector/plugin.ts
@@ -21,9 +21,8 @@ export interface ContextInjectorConfig {
   trigger?: InjectionTrigger | ((context: InjectionContext) => boolean)
   /**
    * Renders the text to inject for this call, or `undefined`/`''` to skip. The text reaches the model
-   * verbatim, so it is a prompt-injection surface: escape any attacker-influenced fields yourself (an
-   * `escapeXml` helper is exported alongside this plugin). A callback that throws fails open (injection
-   * is skipped, the model call proceeds).
+   * verbatim, so it is a prompt-injection surface: escape any attacker-influenced fields yourself. A
+   * callback that throws fails open (injection is skipped, the model call proceeds).
    */
   renderContent: (context: InjectionContext) => Promise<string | undefined>
 }

--- a/strands-ts/src/vended-plugins/index.ts
+++ b/strands-ts/src/vended-plugins/index.ts
@@ -3,10 +3,11 @@
  *
  * Provides a single import path for consumers who want all built-in plugins:
  * ```typescript
- * import { AgentSkills, ContextOffloader, GoalLoop, InMemoryStorage } from '@strands-agents/sdk/vended-plugins'
+ * import { AgentSkills, ContextOffloader, ContextInjector, GoalLoop, InMemoryStorage } from '@strands-agents/sdk/vended-plugins'
  * ```
  */
 
 export * from './skills/index.js'
 export * from './context-offloader/index.js'
+export * from './context-injector/index.js'
 export * from './goal/index.js'


### PR DESCRIPTION
## Description

Adds **memory context-injection** to `MemoryManager`: configuration that lets the manager search memory before a model call and fold the top results into the model input, so relevant knowledge is present without the model having to call `search_memory` itself.

Delivery is **live**: it registers an `InvokeModelStage` input middleware (the middleware system from #2681) that folds retrieved memory into the per-call model input. The injected text is **ephemeral by design** — it augments the model input for a single call and never persists into durable history or the session, because the input phase rewrites the per-call context only, not the agent's stored messages.

The injection mechanism is generic, not memory-specific. The shared engine lives in `src/injection/` and is surfaced publicly as a vended plugin, **`ContextInjector`**: any consumer supplies a `provide(context) => Promise<string | undefined>` callback and reuses the same delivery (a clock, a sandbox descriptor, a RAG lookup). `MemoryManager`'s `injection` config is that same engine specialized to memory search. It is the first consumer. The engine itself is **text-in**: it knows nothing about queries, search, or result counts; those are consumer concerns (here, owned by memory). The delivery primitives (`createInjectionMiddleware`, `foldIntoLastUserMessage`) are kept **internal** — consumers reach injection through `ContextInjector` or `MemoryManager`, not by wiring middleware themselves.

### Public API Changes

`MemoryManagerConfig` gains an opt-in `injection` field (default `false`):

```typescript
import { Agent, MemoryManager } from '@strands-agents/sdk'

// Simplest: enable with defaults (search the latest user ask, inject up to 5 results on a user turn)
const agent = new Agent({
  model,
  memoryManager: { stores: [myStore], injection: true },
})

// Customized
const agent = new Agent({
  model,
  memoryManager: {
    stores: [myStore],
    injection: {
      trigger: 'everyTurn',           // inject before every model call, not just fresh user asks
      maxEntries: 2,                  // retrieve + inject up to 2 entries (default 5)
      query: ({ messages }) => myDerive(messages),  // override the adaptive default query
      format: ({ entries }) =>        // override the default <memory> XML rendering
        entries.map((e) => e.content).join('\n'),
    },
  },
})
```

The generic engine is also vended as a plugin for non-memory consumers:

```typescript
import { Agent } from '@strands-agents/sdk'
import { ContextInjector } from '@strands-agents/sdk/vended-plugins/context-injector'

const agent = new Agent({
  model,
  plugins: [new ContextInjector({ renderContent: async () => `<now>${new Date().toISOString()}</now>` })],
})
```

New / changed exported types:

```typescript
// Generic injection contract (reusable by any consumer)
export type InjectionTrigger = 'userTurn' | 'everyTurn'

export interface InjectionConfig {
  trigger?: InjectionTrigger | ((context: InjectionContext) => boolean)
}

// The context every injection callback receives. A bag (not positional args) so fields can be added
// later without breaking callbacks.
export interface InjectionContext {
  messages: MessageData[]   // the current conversation, as data
  appState: StateStore      // durable cross-call app state — read what a tool stashed last turn
  signal: AbortSignal       // the run's cancel signal; forward it to async I/O in renderContent()
  agent: LocalAgent         // the agent (escape hatch for advanced consumers)
}

// Memory-owned extension of the generic contract
export interface MemoryInjectionConfig extends InjectionConfig {
  maxEntries?: number
  query?: (context: { messages: MessageData[] }) => string | undefined
  format?: (context: { entries: MemoryEntry[] }) => string
}

// MemoryManagerConfig now carries:
injection?: boolean | MemoryInjectionConfig

// Generic vended plugin (from '@strands-agents/sdk/vended-plugins/context-injector')
export interface ContextInjectorConfig {
  name?: string
  trigger?: InjectionTrigger | ((context: InjectionContext) => boolean)
  renderContent: (context: InjectionContext) => Promise<string | undefined>
}
export class ContextInjector implements Plugin { ... }
export function escapeXml(value: string): string   // opt-in helper for providers that emit XML
```

`MemoryInjectionConfig`, `InjectionConfig`, `InjectionTrigger`, and `InjectionContext` are exported from the package root (`@strands-agents/sdk`); `ContextInjector`, `ContextInjectorConfig`, and `escapeXml` from the `./vended-plugins/context-injector` subpath.

Defaults, when `injection: true`:

```typescript
{
  trigger: 'userTurn',           // inject only on a fresh user ask
  maxEntries: 5,                 // retrieve and inject up to 5 entries
  // query:  the latest user text on a user turn, else the most recent assistant text
  // format: a <memory> block with one <entry source="STORE_NAME"> per result (content escaped)
}
```

- **Trigger** `'userTurn'`: inject only when the latest message is a fresh user ask (keeps the user's ask in the recency slot; valid role alternation in both chat and the tool loop). `'everyTurn'` injects before every call; a predicate over the `InjectionContext` is the escape hatch.
- **Query** (adaptive): the latest user message's text on a user turn, otherwise the most recent assistant text (the previous autonomous step).
- **Max entries** `5`: a store ranks by *semantic* (embedding) similarity, which is not the same as *contextual* usefulness — the top hit is not reliably the most useful entry for the turn. Injecting the top 5 gives the model a small candidate set to pick from rather than betting on the store's first result. Raising it improves recall at the cost of a larger prepend (context bloat); lower it for a tighter injection.
- **Format**: a `<memory>` block with one `<entry source="…">` per result, attributing the originating store. The default **escapes** entry content and the `source` attribute, so user-derived memory text cannot break the block or inject markup. A custom `format` that emits markup is responsible for its own escaping (use the exported `escapeXml` helper).

All consumer callbacks (`trigger`, `query`, `format`, `renderContent`) **fail open** — a throw logs and skips injection, and the model call proceeds.

The default rendered block looks like:

```
<memory>
<entry source="preferences">User prefers dark mode</entry>
<entry source="facts">Lives in Seattle</entry>
</memory>
```

**Customization examples for `trigger`**

```typescript
import { MemoryManager, type InjectionContext } from '@strands-agents/sdk'

// Built-in: inject before every model call (autonomous agents that should consult memory each step)
new MemoryManager({ stores: [myStore], injection: { trigger: 'everyTurn' } })

// Predicate: only inject once the conversation is long enough to benefit
new MemoryManager({
  stores: [myStore],
  injection: { trigger: ({ messages }: InjectionContext) => messages.length >= 4 },
})

// Predicate: gate on something a tool stashed in appState last turn
new MemoryManager({
  stores: [myStore],
  injection: { trigger: ({ appState }: InjectionContext) => appState.get('recallEnabled') === true },
})
```

**Customization examples for `query`**

```typescript
import { MemoryManager, type MessageData } from '@strands-agents/sdk'

// Example 1: only inject when the user explicitly asks to recall something
new MemoryManager({
  stores: [myStore],
  injection: {
    query: ({ messages }) => {
      const text = lastUserText(messages) ?? ''
      return /\b(remember|recall|last time|previously)\b/i.test(text) ? text : undefined
      //                                                                    ^ undefined => skip
    },
  },
})

// Example 2: combine the last user ask + the last assistant turn for richer retrieval
new MemoryManager({
  stores: [myStore],
  injection: {
    query: ({ messages }) => {
      const user = lastTextByRole(messages, 'user')
      const assistant = lastTextByRole(messages, 'assistant')
      return [assistant, user].filter(Boolean).join('\n') || undefined
    },
  },
})
```

**Customization examples for `format`**

```typescript
import { escapeXml } from '@strands-agents/sdk/vended-plugins/context-injector'

// bullets instead of XML
format: ({ entries }) => entries.map((e) => `- ${e.content}`).join('\n')

// natural-language preamble — frame the memories as soft context
format: ({ entries }) =>
  `Here's what you know about this user from past conversations:\n` +
  entries.map((e) => `- ${e.content}`).join('\n')

// group by source store
format: ({ entries }) => entries.map((e) => `[${e.storeName}] ${e.content}`).join('\n')

// surface a relevance score from metadata
format: ({ entries }) => entries.map((e) => `- ${e.content} (${e.metadata?.score})`).join('\n')

// custom XML — escape your own content (the default escapes; custom formatters own their escaping)
format: ({ entries }) =>
  `<context>${entries.map((e) => `<item>${escapeXml(e.content)}</item>`).join('')}</context>`
```

**Customization examples for the generic `ContextInjector`**

```typescript
import { Agent } from '@strands-agents/sdk'
import { ContextInjector, escapeXml } from '@strands-agents/sdk/vended-plugins/context-injector'

const agent = new Agent({
  model,
  plugins: [
    // a live clock, injected on every turn
    new ContextInjector({ name: 'now', trigger: 'everyTurn', renderContent: async () => `<now>${nowIso()}</now>` }),

    // a sandbox descriptor read from durable app state, cancellable on run-abort
    new ContextInjector({
      name: 'sandbox',
      renderContent: async ({ appState, signal }) =>
        `<sandbox>${escapeXml(await describeSandbox(appState, { signal }))}</sandbox>`,
    }),
  ],
})
```


## Related Issues

Builds on: #2544 (MemoryManager), #2681 (middleware system — provides the delivery seam)

## Documentation PR

todo

## Type of Change

New feature

## Testing

Unit tests cover the generic delivery primitives (`foldIntoLastUserMessage` block-prepend ordering and no-op when no user message exists, `isUserTurn`, `resolveTrigger` across modes incl. fail-open), the live `createInjectionMiddleware` handler (folds on a user turn, skips on a non-user turn, `everyTurn`, empty/whitespace text, fail-open on a throwing `provide`, no durable mutation, and that `appState`/`signal` are exposed on the `ProvideContext`), the `ContextInjector` plugin (name defaulting/override, `InvokeModelStage.Input` registration, end-to-end fold through the registered handler, fail-open), and the full memory pipeline (`_provideMemoryContext`: adaptive query on user vs. autonomous turns, custom `query`/`format`, fail-open on throwing callbacks, empty-search short-circuit, `maxInjectedSearchResults`, default-format XML escaping incl. an adversarial `</entry>`/quote breakout, config resolution for `false`/`true`/object).

Verified locally from `strands-ts/`: `tsc --noEmit --project src/tsconfig.json`, `npm run lint`, `npm run format:check` all clean; full unit suite green (3268 passed, 0 todo). This is a TypeScript SDK change.

- [ ] I ran `hatch run prepare` <!-- N/A: TypeScript SDK; ran the strands-ts equivalents above -->

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.