### PR TITLE
fix: add maintain role to auto-strands-review allowed-roles

### DIFF
--- a/.github/workflows/auto-strands-review.yml
+++ b/.github/workflows/auto-strands-review.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           skip-check: false
           username: ${{ github.event.pull_request.user.login || 'invalid' }}
-          allowed-roles: 'triage,write,admin'
+          allowed-roles: 'triage,write,maintain,admin'
 
   trigger-review:
     name: Trigger Strands Review


### PR DESCRIPTION
## Description

The `auto-strands-review.yml` workflow's authorization-check rejects users with the `maintain` role because it's missing from the `allowed-roles` list. This causes every PR from maintainers to require manual environment approval before the auto-review can trigger.

All other workflows in this repo (`strands-command.yml`, `python-integration-test.yml`, `typescript-integration-test.yml`) already include `maintain` — this was simply missed when the auto-review workflow was added.

## Related Issues

Observed on PR #2615 — the workflow was stuck waiting for manual approval because the PR author has the `maintain` role.

## Type of Change

Bug fix

## Testing

- Verified via workflow logs that the authorization-check correctly resolves the `maintain` role but rejects it due to the allowlist
- Confirmed the other three workflows in this repo already include `maintain` and work correctly for maintainers

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.