### PR TITLE
chore(docs): remove duplicate community callouts from xAI provider page

### DIFF
--- a/site/src/content/docs/community/model-providers/xai.mdx
+++ b/site/src/content/docs/community/model-providers/xai.mdx
@@ -15,17 +15,6 @@ redirectFrom:
   - docs/user-guide/concepts/model-providers/xai
 ---
 
-:::note[Community Contribution]
-This is a community-maintained package that is not owned or supported by the Strands team. Validate and review 
-the package before using it in your project.
-
-Have your own integration? [We'd love to add it here too!](https://github.com/strands-agents/docs/issues/new?assignees=&labels=enhancement&projects=&template=content_addition.yml&title=%5BContent+Addition%5D%3A+)
-:::
-
-:::note[Language Support]
-This provider is only supported in Python.
-:::
-
 [xAI](https://x.ai/) is an AI company that develops the Grok family of large language models with advanced reasoning capabilities. The [`strands-xai`](https://pypi.org/project/strands-xai/) package ([GitHub](https://github.com/Cerrix/strands-xai)) provides a community-maintained integration for the Strands Agents SDK, enabling seamless use of xAI's Grok models with powerful server-side tools including real-time X platform access, web search, and code execution.
 
 ## Installation


### PR DESCRIPTION
## Description

Remove duplicate "Community Contribution" and "Language Support" callout notes from the xAI community provider page. These were manually added to the markdown body, but the site already auto-generates them via the `MarkdownContent.astro` override when `community: true` is set in frontmatter. This results in the notes appearing twice on the rendered page.

## Related Issues

N/A

## Type of Change

Documentation update

## Testing

Verified that the `MarkdownContent.astro` component renders the community aside automatically for all pages with `community: true` frontmatter, and that no other community provider pages have this duplication.

- [x] I ran `hatch run prepare`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.