### PR TITLE
docs: document per-invocation limits feature

### DIFF
--- a/.agents/references/voice-guide.md
+++ b/.agents/references/voice-guide.md
@@ -324,6 +324,8 @@ Strands ships both a Python and TypeScript SDK. Most doc pages show code in both
 
 **Prose between tabs should be language-neutral.** Don't write "Pass the `retry_strategy` parameter..." when the tabs show both Python and TypeScript. Write "Configure a retry strategy:" and let the code speak for itself. Language-specific parameter names belong in the code blocks, not in the prose.
 
+**Never name the language inside its own tab.** The reader selected the tab; they know which language they're reading. State facts directly without prefixing the language name. The tab itself provides that context.
+
 #### Where divergence content lives in the page structure
 
 The page's heading structure should read the same in both languages. A reader on either tab should see the same table of contents. Divergence is content, not structure — keep it **inside the existing `<Tab>`**: same heading on both sides, with per-tab prose and code carrying the difference.

--- a/.agents/skills/docs-reviewer/SKILL.md
+++ b/.agents/skills/docs-reviewer/SKILL.md
@@ -27,7 +27,7 @@ Reference `../../references/voice-guide.md` for the full layer definitions. Chec
 - **Narrative flow:** Start with why the topic matters and what use-case problems it solves. Throughout, show how to implement using Strands SDK in a self-contained, concise way.
 - **Framing:** Does the first sentence of every section describe the developer's goal? Flag sections leading with API descriptions.
 - **Register:** Is the tone appropriate for the content type?
-- **Constraints:** Scan for banned phrases, em-dashes, passive voice, hedging. Apply type-aware overrides (passive in reference is fine; longer sentences in explanation are fine).
+- **Constraints:** Scan for banned phrases, em-dashes, passive voice, hedging. Apply type-aware overrides (passive in reference is fine; longer sentences in explanation are fine). Flag any prose inside a `<Tab>` that names the language of that tab (e.g., "Python requires..." inside the Python tab, "In TypeScript..." inside the TypeScript tab). The reader chose the tab; they know what language they're reading.
 - **Authenticity:** Structural variety, visible editorial choices, concision.
 
 ### 2. Terminology Consistency

--- a/.agents/skills/docs-writer/SKILL.md
+++ b/.agents/skills/docs-writer/SKILL.md
@@ -69,6 +69,7 @@ Then self-check against hard constraints:
 - Terminology matches the lock file
 - Code examples are contextually complete (imports present, runnable)
 - Code examples use proper backtick formatting
+- Never name the language inside its own tab. The reader selected the tab; they already know. State facts directly without prefixing the language name.
 
 ### Step 4b: Verify code accuracy
 

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -95,7 +95,9 @@ Each model invocation ends with a stop reason that determines what happens next:
 - **Content filtered**: The response was blocked by safety mechanisms.
 - **Guardrail intervention**: A guardrail policy stopped generation.
 
-The limit stop reasons indicate graceful budget exhaustion. The agent's message history remains in a valid state, and you can reinvoke with a higher budget or different prompt. Both content filtered and guardrail intervention terminate the loop and should be handled according to application requirements.
+The limit stop reasons indicate graceful budget exhaustion. The agent's message history remains in a valid state, and you can reinvoke with a higher budget or different prompt.
+
+Both content filtered and guardrail intervention terminate the loop and should be handled according to application requirements.
 
 ### Extending the Loop
 
@@ -210,8 +212,7 @@ tokens, or total tokens. All three are optional.
   ```
 
   The same parameter works with `invoke_async` and
-  `stream_async`. Python requires each cap to be a positive
-  `int` (booleans are rejected).
+  `stream_async`. Each cap must be a positive `int`.
 
   </Tab>
   <Tab label="TypeScript">
@@ -220,8 +221,8 @@ tokens, or total tokens. All three are optional.
   --8<-- "user-guide/concepts/agents/agent-loop.ts:limits_basic"
   ```
 
-  The same option works with `stream`. TypeScript requires each
-  cap to be a positive finite number.
+  The same option works with `stream`. Each cap must be a
+  positive finite number.
 
   </Tab>
 </Tabs>

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -87,12 +87,15 @@ Each model invocation ends with a stop reason that determines what happens next:
 - **End turn**: The model has finished its response and has no further actions to take. This is the normal successful termination. The loop exits and returns the model's final message.
 - **Tool use**: The model wants to execute one or more tools before continuing. The loop executes the requested tools, appends the results to the conversation history, and invokes the model again.
 - **Cancelled**: The agent was stopped externally via `agent.cancel()`. See [Cancellation](#cancellation) below.
+- **Limit turns** (`limit_turns` / `limitTurns`): The per-invocation turn budget was exhausted. See [Invocation Limits](#invocation-limits).
+- **Limit total tokens** (`limit_total_tokens` / `limitTotalTokens`): The cumulative token budget was exhausted. See [Invocation Limits](#invocation-limits).
+- **Limit output tokens** (`limit_output_tokens` / `limitOutputTokens`): The output token budget was exhausted. See [Invocation Limits](#invocation-limits).
 - **Max tokens**: The model's response was truncated because it hit the token limit. This is unrecoverable within the current loop. The model cannot continue from a partial response, and the loop terminates with an error.
 - **Stop sequence**: The model encountered a configured stop sequence. Like end turn, this terminates the loop normally.
 - **Content filtered**: The response was blocked by safety mechanisms.
 - **Guardrail intervention**: A guardrail policy stopped generation.
 
-Both content filtered and guardrail intervention terminate the loop and should be handled according to application requirements.
+The limit stop reasons indicate graceful budget exhaustion. The agent's message history remains in a valid state, and you can reinvoke with a higher budget or different prompt. Both content filtered and guardrail intervention terminate the loop and should be handled according to application requirements.
 
 ### Extending the Loop
 
@@ -176,6 +179,66 @@ The `agent.cancel()` method provides a way to stop the loop from outside, such a
   ```
   </Tab>
 </Tabs>
+
+### Invocation Limits
+
+To cap how much work an agent does in a single invocation, pass
+a `limits` object. You can bound turns (loop iterations), output
+tokens, or total tokens. All three are optional.
+
+<Tabs>
+  <Tab label="Python">
+
+  ```python
+  from strands import Agent
+
+  agent = Agent()
+
+  result = agent(
+      "Summarize this document",
+      limits={
+          "turns": 5,
+          "output_tokens": 2000,
+          "total_tokens": 10000,
+      },
+  )
+
+  if result.stop_reason == "limit_turns":
+      print("Hit turn budget")
+  elif result.stop_reason == "limit_total_tokens":
+      print("Hit token budget")
+  ```
+
+  The same parameter works with `invoke_async` and
+  `stream_async`. Python requires each cap to be a positive
+  `int` (booleans are rejected).
+
+  </Tab>
+  <Tab label="TypeScript">
+
+  ```typescript
+  --8<-- "user-guide/concepts/agents/agent-loop.ts:limits_basic"
+  ```
+
+  The same option works with `stream`. TypeScript requires each
+  cap to be a positive finite number.
+
+  </Tab>
+</Tabs>
+
+Limits are checked at the top of each loop iteration, not
+mid-call. A single turn can overshoot the token budget, but the
+check fires before the next turn starts. Tools requested by the
+previous turn always run to completion before the limit check
+fires. The agent's message history stays in a valid,
+reinvokable state.
+
+Limits apply to the current invocation only. A reused agent
+starts each call with fresh counters.
+
+When multiple caps trip simultaneously, the reported stop reason
+follows priority order: turns, then total tokens, then output
+tokens.
 
 ## Common Problems
 

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.ts
@@ -41,3 +41,23 @@ const controllerResult = await agent.invoke('Hello', {
   cancelSignal: controller.signal,
 })
 // --8<-- [end:cancel_external_signal]
+
+async function limitsExample() {
+  // --8<-- [start:limits_basic]
+  const agent = new Agent()
+
+  const result = await agent.invoke('Summarize this document', {
+    limits: {
+      turns: 5,
+      outputTokens: 2000,
+      totalTokens: 10000,
+    },
+  })
+
+  if (result.stopReason === 'limitTurns') {
+    console.log('Hit turn budget')
+  } else if (result.stopReason === 'limitTotalTokens') {
+    console.log('Hit token budget')
+  }
+  // --8<-- [end:limits_basic]
+}


### PR DESCRIPTION
## Motivation

The per-invocation limits feature shipped in sdk-typescript#1106 and sdk-python#2360 but has no documentation on the docs site. Developers have no way to discover how to cap turns, output tokens, or total tokens during agent execution.

## Public API Changes

No public API changes. This PR documents existing SDK functionality.

## Documentation PR

Documents the `limits` parameter added to `invoke`/`stream` in both SDKs:

```python
result = agent("Summarize this", limits={"turns": 5, "output_tokens": 2000})
```

```typescript
const result = await agent.invoke('Summarize this', {
  limits: { turns: 5, outputTokens: 2000 },
})
```

## Type of Change

Documentation update

## Testing

- [x] Verified all code examples against SDK source (local clones via `npm run sdk:clone`)
- [x] Verified stop reason strings match `StopReason` types in both SDKs
- [x] Verified behavioral claims (check timing, priority order, per-invocation scoping) against implementation

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings