### PR TITLE
fix: include json blocks in counting tokens

### DIFF
--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -59,9 +59,12 @@ def _count_content_block_tokens(
 
     if "toolResult" in block:
         tool_result = block["toolResult"]
+        # image/document items are binary and intentionally not counted by the heuristic
         for item in tool_result.get("content", []):
             if "text" in item:
                 total += count_text(item["text"])
+            if "json" in item:
+                total += count_json(item["json"])
 
     if "reasoningContent" in block:
         reasoning = block["reasoningContent"]

--- a/strands-py/tests/strands/models/test_model.py
+++ b/strands-py/tests/strands/models/test_model.py
@@ -1,3 +1,5 @@
+import json
+import math
 from unittest.mock import MagicMock
 
 import pytest
@@ -314,6 +316,53 @@ async def test_count_tokens_tool_result_block(model):
     ]
     result = await model.count_tokens(messages=messages)
     assert result == 4  # ceil(16/4)
+
+
+@pytest.mark.asyncio
+async def test_count_tokens_tool_result_with_json(model):
+    obj = {"x": "lorem ipsum " * 1000}
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "123",
+                        "content": [{"json": obj}],
+                        "status": "success",
+                    }
+                }
+            ],
+        }
+    ]
+    result = await model.count_tokens(messages=messages)
+    assert result == math.ceil(len(json.dumps(obj)) / 2)
+    assert result > 0
+
+
+@pytest.mark.asyncio
+async def test_count_tokens_tool_result_with_text_and_json(model):
+    text = "Here is the data"
+    obj = {"key": "value", "count": 42}
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "123",
+                        "content": [
+                            {"text": text},
+                            {"json": obj},
+                        ],
+                        "status": "success",
+                    }
+                }
+            ],
+        }
+    ]
+    result = await model.count_tokens(messages=messages)
+    assert result == math.ceil(len(text) / 4) + math.ceil(len(json.dumps(obj)) / 2)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

The heuristic `count_tokens` estimator silently returned `0` for tool results that use `json` content blocks. `_count_content_block_tokens` in `strands-py/src/strands/models/model.py` only counted `text` items inside a `toolResult` content list; the `json` branch was missing, even though the `count_json` callable is already passed into the function and used elsewhere (e.g. `toolUse.input`).

This breaks the `ContextOffloader` plugin's threshold check (`token_count <= self._max_result_tokens`) whenever native token counting is unavailable and the code falls back to the heuristic (e.g. `bedrock:CountTokens` IAM denied, model not on the CountTokens allowlist, or network failure). With a `0` estimate the threshold always passes and offloading never triggers, making the plugin a silent no-op for JSON tool results.

This PR adds the missing `json` handling in the `toolResult` loop, mirroring how `toolUse.input` is counted (`json.dumps(obj) / 2` heuristic), plus a brief comment noting that `image`/`document` items are binary and intentionally not counted by the heuristic. 

## Related Issues

Fixes #2635

## Documentation PR

No documentation changes required. 

## Type of Change

Bug fix

## Testing

Added two regression tests in `strands-py/tests/strands/models/test_model.py` alongside the existing `test_count_tokens_tool_result_*` tests:

- `test_count_tokens_tool_result_with_json` — a `toolResult` whose content is a single `{"json": {...}}` block; asserts the count equals `ceil(len(json.dumps(obj)) / 2)` and is non-zero.
- `test_count_tokens_tool_result_with_text_and_json` — a `toolResult` mixing `text` and `json` blocks; asserts the count equals the sum of both heuristics.

All 34 tests in `test_model.py` pass. `hatch fmt --linter --check` passes (ruff + mypy, no new warnings). The issue's reproduction snippet now returns `6005` (previously `0`).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.