### PR TITLE
chore(site): update GitHub dropdown to harness-sdk and add evals

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -306,12 +306,15 @@ github:
   sections:
     - title: SDKs
       links:
-        - label: sdk-python
-          href: https://github.com/strands-agents/sdk-python
+        - label: Python SDK
+          href: https://github.com/strands-agents/harness-sdk/tree/main/strands-py
           icon: PY
-        - label: sdk-typescript
-          href: https://github.com/strands-agents/sdk-typescript
+        - label: TypeScript SDK
+          href: https://github.com/strands-agents/harness-sdk/tree/main/strands-ts
           icon: TS
+        - label: Evals SDK
+          href: https://github.com/strands-agents/evals
+          icon: EV
     - title: Organizations
       links:
         - label: strands-agents


### PR DESCRIPTION
## Description

Add the [evals](https://github.com/strands-agents/evals) repository to the GitHub dropdown on the docs site, under the "SDKs" section alongside `harness-sdk`.

## Related Issues

N/A

## Type of Change

Documentation update

## Testing

Verified the YAML structure is valid and the `GitHubDropdown.astro` component iterates over sections/links without any additional configuration needed.

- [x] Site-only change — `hatch run prepare` not applicable

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
