### PR TITLE
feat(context): add message pinning to conversation managers

### DIFF
--- a/strands-py/src/strands/agent/conversation_manager/pin_message.py
+++ b/strands-py/src/strands/agent/conversation_manager/pin_message.py
@@ -1,0 +1,131 @@
+"""Message pinning utilities for protecting messages from context eviction."""
+
+from ...types.content import Message, Messages
+
+
+def _get_tool_use_ids(message: Message) -> set[str]:
+    """Extract toolUseIds from toolUse or toolResult blocks in a message."""
+    ids: set[str] = set()
+    for content in message.get("content", []):
+        if isinstance(content, dict):
+            if "toolUse" in content:
+                tool_id = content["toolUse"].get("toolUseId")
+                if tool_id:
+                    ids.add(tool_id)
+            elif "toolResult" in content:
+                tool_id = content["toolResult"].get("toolUseId")
+                if tool_id:
+                    ids.add(tool_id)
+    return ids
+
+
+def _has_pinned_flag(message: Message) -> bool:
+    """Check if a message has metadata.custom.pinned set to True."""
+    metadata = message.get("metadata")
+    return metadata is not None and metadata.get("custom", {}).get("pinned") is True
+
+
+def is_pinned(messages: Messages, index: int) -> bool:
+    """Check if a message is pinned, including tool-pair partner protection.
+
+    Returns True if the message at index is pinned, or if its adjacent
+    tool-pair partner (toolUse/toolResult matched by toolUseId) is pinned.
+
+    Args:
+        messages: The full messages array.
+        index: The index to check.
+
+    Returns:
+        True if the message or its tool-pair partner is pinned.
+    """
+    if _has_pinned_flag(messages[index]):
+        return True
+
+    # Check if adjacent partner shares a toolUseId and is pinned
+    my_ids = _get_tool_use_ids(messages[index])
+    if not my_ids:
+        return False
+
+    for neighbor_index in (index - 1, index + 1):
+        if 0 <= neighbor_index < len(messages):
+            neighbor = messages[neighbor_index]
+            if _has_pinned_flag(neighbor) and my_ids & _get_tool_use_ids(neighbor):
+                return True
+
+    return False
+
+
+
+def apply_pin_first(messages: Messages, count: int) -> None:
+    """Pin the first N messages in the array permanently.
+
+    Args:
+        messages: The messages array.
+        count: Number of messages from the start to pin.
+    """
+    for i in range(min(count, len(messages))):
+        pin_message(messages, i)
+
+
+def partition_pinned(messages: Messages, start: int, end: int) -> tuple[list[Message], list[Message]]:
+    """Partition a range of messages into pinned (protected) and unpinned arrays.
+
+    Args:
+        messages: The full messages array.
+        start: Start index of the range (inclusive).
+        end: End index of the range (exclusive).
+
+    Returns:
+        A tuple of (pinned, unpinned) message lists.
+    """
+    pinned: list[Message] = []
+    unpinned: list[Message] = []
+    for i in range(start, end):
+        if is_pinned(messages, i):
+            pinned.append(messages[i])
+        else:
+            unpinned.append(messages[i])
+    return pinned, unpinned
+
+
+def pin_message(messages: Messages, index: int) -> None:
+    """Pin a message so it is protected from eviction during context reduction.
+
+    Mutates the message in place by setting metadata.custom.pinned = True.
+
+    Args:
+        messages: The messages array.
+        index: The index of the message to pin.
+    """
+    message = messages[index]
+    metadata = message.get("metadata", {})
+    custom = metadata.get("custom", {})
+    custom["pinned"] = True
+    metadata["custom"] = custom
+    message["metadata"] = metadata
+
+
+def unpin_message(messages: Messages, index: int) -> None:
+    """Unpin a message so it can be evicted during context reduction.
+
+    Mutates the message in place by removing the pinned flag from metadata.
+
+    Args:
+        messages: The messages array.
+        index: The index of the message to unpin.
+    """
+    message = messages[index]
+    metadata = message.get("metadata")
+    if metadata is None:
+        return
+
+    custom = metadata.get("custom")
+    if custom is None:
+        return
+
+    custom.pop("pinned", None)
+
+    if not custom:
+        del metadata["custom"]
+    if not metadata:
+        del message["metadata"]

--- a/strands-py/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
+++ b/strands-py/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
@@ -11,6 +11,7 @@ from ...types.content import ContentBlock, Messages
 from ...types.exceptions import ContextWindowOverflowException
 from ...types.tools import ToolResultContent
 from .conversation_manager import ConversationManager, ProactiveCompressionConfig
+from .pin_message import apply_pin_first, is_pinned
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ class SlidingWindowConversationManager(ConversationManager):
         should_truncate_results: bool = True,
         *,
         per_turn: bool | int = False,
+        pin_first: int | None = None,
         proactive_compression: bool | ProactiveCompressionConfig | None = None,
     ):
         """Initialize the sliding window conversation manager.
@@ -55,6 +57,8 @@ class SlidingWindowConversationManager(ConversationManager):
                 manage message history and prevent the agent loop from slowing down. Start with
                 per_turn=True and adjust to a specific frequency (e.g., per_turn=5) if needed
                 for performance tuning.
+            pin_first: Number of messages at the start of the conversation to permanently pin.
+                Pinned messages are protected from eviction during context reduction.
             proactive_compression: Enable proactive context compression before the model call.
                 - ``True``: compress when 70% of the context window is used (default threshold).
                 - ``{"compression_threshold": float}``: compress at the specified ratio (0, 1].
@@ -73,6 +77,8 @@ class SlidingWindowConversationManager(ConversationManager):
         self.window_size = window_size
         self.should_truncate_results = should_truncate_results
         self.per_turn = per_turn
+        self.pin_first = max(0, pin_first) if pin_first is not None else None
+        self._pin_first_applied = False
         self._model_call_count = 0
 
     def register_hooks(self, registry: "HookRegistry", **kwargs: Any) -> None:
@@ -188,10 +194,16 @@ class SlidingWindowConversationManager(ConversationManager):
         """
         messages = agent.messages
 
-        # window_size=0 means "remove all messages" (matches TypeScript SDK behaviour)
+        # Pin first N messages permanently (only on first reduction)
+        if self.pin_first and not self._pin_first_applied:
+            apply_pin_first(messages, self.pin_first)
+            self._pin_first_applied = True
+
+        # window_size=0 means "remove all non-pinned messages"
         if self.window_size == 0:
-            self.removed_message_count += len(messages)
-            messages[:] = []
+            pinned = [messages[i] for i in range(len(messages)) if is_pinned(messages, i)]
+            self.removed_message_count += len(messages) - len(pinned)
+            messages[:] = pinned
             return
 
         # Try to truncate the tool result first (only for reactive overflow, not proactive compression)
@@ -273,11 +285,24 @@ class SlidingWindowConversationManager(ConversationManager):
                 )
                 return
 
-        # trim_index represents the number of messages being removed from the agents messages array
-        self.removed_message_count += trim_index
+        # Collect non-pinned indices in [0, trim_index) to remove
+        indices_to_remove = [i for i in range(trim_index) if not is_pinned(messages, i)]
 
-        # Overwrite message history
-        messages[:] = messages[trim_index:]
+        if not indices_to_remove:
+            if e is not None:
+                raise ContextWindowOverflowException("Unable to trim conversation context!") from e
+            logger.warning(
+                "window_size=<%s>, message_count=<%s> | all messages in trim range are pinned, unable to reduce",
+                self.window_size,
+                len(messages),
+            )
+            return
+
+        self.removed_message_count += len(indices_to_remove)
+
+        # Remove in reverse order to keep indices stable
+        for i in reversed(indices_to_remove):
+            del messages[i]
 
     def _truncate_tool_results(self, messages: Messages, msg_idx: int) -> bool:
         """Truncate tool results and replace image blocks in a message to reduce context size.
@@ -362,7 +387,7 @@ class SlidingWindowConversationManager(ConversationManager):
         """Find the index of the oldest message containing tool results.
 
         Iterates from oldest to newest so that truncation targets the least-recent
-        (and therefore least relevant) tool results first.
+        (and therefore least relevant) tool results first. Skips pinned messages.
 
         Args:
             messages: The conversation message history.
@@ -370,8 +395,9 @@ class SlidingWindowConversationManager(ConversationManager):
         Returns:
             Index of the oldest message with tool results, or None if no such message exists.
         """
-        # Iterate from oldest to newest
         for idx in range(len(messages)):
+            if is_pinned(messages, idx):
+                continue
             current_message = messages[idx]
             for content in current_message.get("content", []):
                 if isinstance(content, dict) and "toolResult" in content:

--- a/strands-py/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
+++ b/strands-py/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
@@ -13,6 +13,7 @@ from ...types.content import Message
 from ...types.exceptions import ContextWindowOverflowException
 from ...types.tools import AgentTool
 from .conversation_manager import ConversationManager, ProactiveCompressionConfig
+from .pin_message import apply_pin_first, partition_pinned
 
 if TYPE_CHECKING:
     from ..agent import Agent
@@ -66,6 +67,7 @@ class SummarizingConversationManager(ConversationManager):
         summarization_agent: Optional["Agent"] = None,
         summarization_system_prompt: str | None = None,
         *,
+        pin_first: int | None = None,
         proactive_compression: bool | ProactiveCompressionConfig | None = None,
     ):
         """Initialize the summarizing conversation manager.
@@ -79,6 +81,8 @@ class SummarizingConversationManager(ConversationManager):
                 If provided, this agent can use tools as part of the summarization process.
             summarization_system_prompt: Optional system prompt override for summarization.
                 If None, uses the default summarization prompt.
+            pin_first: Number of messages at the start of the conversation to permanently pin.
+                Pinned messages are protected from summarization and compacted to the front.
             proactive_compression: Enable proactive context compression before the model call.
                 - ``True``: compress when 70% of the context window is used (default threshold).
                 - ``{"compression_threshold": float}``: compress at the specified ratio (0, 1].
@@ -95,6 +99,8 @@ class SummarizingConversationManager(ConversationManager):
         self.preserve_recent_messages = preserve_recent_messages
         self.summarization_agent = summarization_agent
         self.summarization_system_prompt = summarization_system_prompt
+        self.pin_first = max(0, pin_first) if pin_first is not None else None
+        self._pin_first_applied = False
         self._summary_message: Message | None = None
 
     @override
@@ -187,21 +193,32 @@ class SummarizingConversationManager(ConversationManager):
         if messages_to_summarize_count <= 0:
             raise ContextWindowOverflowException("Cannot summarize: insufficient messages for summarization")
 
-        # Extract messages to summarize
-        messages_to_summarize = agent.messages[:messages_to_summarize_count]
+        # Pin first N messages permanently (only on first reduction)
+        if self.pin_first and not self._pin_first_applied:
+            apply_pin_first(agent.messages, self.pin_first)
+            self._pin_first_applied = True
+
+        # Partition [0, messages_to_summarize_count) into pinned (preserve) and non-pinned (summarize)
+        protected_to_preserve, to_summarize = partition_pinned(agent.messages, 0, messages_to_summarize_count)
+
+        if not to_summarize:
+            raise ContextWindowOverflowException(
+                "Cannot summarize: all messages in summarize range are pinned"
+            )
+
         remaining_messages = agent.messages[messages_to_summarize_count:]
 
         # Keep track of the number of messages that have been summarized thus far.
-        self.removed_message_count += len(messages_to_summarize)
+        self.removed_message_count += len(to_summarize)
         # If there is a summary message, don't count it in the removed_message_count.
         if self._summary_message:
             self.removed_message_count -= 1
 
         # Generate summary
-        self._summary_message = self._generate_summary(messages_to_summarize, agent)
+        self._summary_message = self._generate_summary(to_summarize, agent)
 
-        # Replace the summarized messages with the summary
-        agent.messages[:] = [self._summary_message] + remaining_messages
+        # Replace summarized range with protected messages + summary + remaining
+        agent.messages[:] = protected_to_preserve + [self._summary_message] + remaining_messages
 
     def _generate_summary(self, messages: list[Message], agent: "Agent") -> Message:
         """Generate a summary of the provided messages.
@@ -362,3 +379,4 @@ class SummarizingConversationManager(ConversationManager):
             raise ContextWindowOverflowException("Unable to trim conversation context!")
 
         return split_point
+

--- a/strands-py/tests/strands/agent/test_conversation_manager.py
+++ b/strands-py/tests/strands/agent/test_conversation_manager.py
@@ -1034,3 +1034,103 @@ def test_sliding_window_proactive_compression_no_trim_below():
     registry.invoke_callbacks(event)
 
     assert len(agent.messages) == 2
+
+
+# --- pin_first tests ---
+
+
+def test_pin_first_protects_first_n_messages_from_trimming():
+    manager = SlidingWindowConversationManager(window_size=2, should_truncate_results=False, pin_first=2)
+    messages = [
+        {"role": "user", "content": [{"text": "first"}]},
+        {"role": "assistant", "content": [{"text": "second"}]},
+        {"role": "user", "content": [{"text": "third"}]},
+        {"role": "assistant", "content": [{"text": "fourth"}]},
+        {"role": "user", "content": [{"text": "fifth"}]},
+        {"role": "assistant", "content": [{"text": "sixth"}]},
+    ]
+    agent = _make_mock_agent(messages=messages)
+    manager.reduce_context(agent)
+
+    texts = [m["content"][0]["text"] for m in agent.messages]
+    assert "first" in texts
+    assert "second" in texts
+    assert "third" not in texts
+    assert "fourth" not in texts
+
+
+def test_pin_first_returns_without_trimming_when_all_in_range_are_pinned():
+    manager = SlidingWindowConversationManager(window_size=2, should_truncate_results=False, pin_first=4)
+    messages = [
+        {"role": "user", "content": [{"text": "a"}]},
+        {"role": "assistant", "content": [{"text": "b"}]},
+        {"role": "user", "content": [{"text": "c"}]},
+        {"role": "assistant", "content": [{"text": "d"}]},
+    ]
+    agent = _make_mock_agent(messages=messages)
+    manager.reduce_context(agent)
+
+    assert len(agent.messages) == 4
+
+
+def test_pin_first_with_window_size_zero_preserves_pinned():
+    manager = SlidingWindowConversationManager(window_size=0, should_truncate_results=False, pin_first=2)
+    messages = [
+        {"role": "user", "content": [{"text": "first"}]},
+        {"role": "assistant", "content": [{"text": "second"}]},
+        {"role": "user", "content": [{"text": "third"}]},
+        {"role": "assistant", "content": [{"text": "fourth"}]},
+    ]
+    agent = _make_mock_agent(messages=messages)
+    manager.reduce_context(agent)
+
+    texts = [m["content"][0]["text"] for m in agent.messages]
+    assert texts == ["first", "second"]
+
+
+def test_pin_first_only_applies_once():
+    manager = SlidingWindowConversationManager(window_size=4, should_truncate_results=False, pin_first=2)
+    messages = [
+        {"role": "user", "content": [{"text": "first"}]},
+        {"role": "assistant", "content": [{"text": "second"}]},
+        {"role": "user", "content": [{"text": "third"}]},
+        {"role": "assistant", "content": [{"text": "fourth"}]},
+        {"role": "user", "content": [{"text": "fifth"}]},
+        {"role": "assistant", "content": [{"text": "sixth"}]},
+    ]
+    agent = _make_mock_agent(messages=messages)
+
+    # First reduction
+    manager.reduce_context(agent)
+    # Verify pin was applied
+    assert agent.messages[0].get("metadata", {}).get("custom", {}).get("pinned") is True
+
+    # Second reduction — should not re-apply (flag is set)
+    agent.messages.extend([
+        {"role": "user", "content": [{"text": "seventh"}]},
+        {"role": "assistant", "content": [{"text": "eighth"}]},
+    ])
+    manager.reduce_context(agent)
+    # Still works without error
+    assert "first" in [m["content"][0]["text"] for m in agent.messages]
+
+
+def test_pinned_message_in_middle_survives_trimming():
+    from strands.agent.conversation_manager.pin_message import pin_message
+
+    manager = SlidingWindowConversationManager(window_size=4, should_truncate_results=False)
+    messages = [
+        {"role": "user", "content": [{"text": "first"}]},
+        {"role": "assistant", "content": [{"text": "second"}]},
+        {"role": "user", "content": [{"text": "pinned-middle"}]},
+        {"role": "assistant", "content": [{"text": "fourth"}]},
+        {"role": "user", "content": [{"text": "fifth"}]},
+        {"role": "assistant", "content": [{"text": "sixth"}]},
+    ]
+    pin_message(messages, 2)
+    agent = _make_mock_agent(messages=messages)
+    manager.reduce_context(agent)
+
+    texts = [m["content"][0]["text"] for m in agent.messages]
+    assert "pinned-middle" in texts
+    assert "first" not in texts

--- a/strands-py/tests/strands/agent/test_pin_message.py
+++ b/strands-py/tests/strands/agent/test_pin_message.py
@@ -1,0 +1,108 @@
+"""Tests for message pinning utilities."""
+
+from strands.agent.conversation_manager.pin_message import is_pinned, pin_message, unpin_message
+
+
+def make_message(text, role="user", metadata=None):
+    msg = {"role": role, "content": [{"text": text}]}
+    if metadata is not None:
+        msg["metadata"] = metadata
+    return msg
+
+
+class TestIsPinned:
+    def test_returns_false_for_unpinned(self):
+        messages = [make_message("hello")]
+        assert is_pinned(messages, 0) is False
+
+    def test_returns_false_for_empty_custom(self):
+        messages = [make_message("hello", metadata={"custom": {}})]
+        assert is_pinned(messages, 0) is False
+
+    def test_returns_true_for_pinned(self):
+        messages = [make_message("hello", metadata={"custom": {"pinned": True}})]
+        assert is_pinned(messages, 0) is True
+
+    def test_returns_false_for_explicitly_unpinned(self):
+        messages = [make_message("hello", metadata={"custom": {"pinned": False}})]
+        assert is_pinned(messages, 0) is False
+
+
+class TestPinMessage:
+    def test_sets_pinned_true(self):
+        messages = [make_message("important")]
+        pin_message(messages, 0)
+        assert is_pinned(messages, 0) is True
+
+    def test_preserves_existing_metadata(self):
+        messages = [make_message("important", metadata={"usage": {"inputTokens": 10}})]
+        pin_message(messages, 0)
+        assert messages[0]["metadata"]["usage"] == {"inputTokens": 10}
+        assert is_pinned(messages, 0) is True
+
+    def test_preserves_existing_custom_fields(self):
+        messages = [make_message("important", metadata={"custom": {"myField": "value"}})]
+        pin_message(messages, 0)
+        assert messages[0]["metadata"]["custom"]["myField"] == "value"
+        assert is_pinned(messages, 0) is True
+
+
+class TestUnpinMessage:
+    def test_removes_pinned_flag(self):
+        messages = [make_message("important")]
+        pin_message(messages, 0)
+        unpin_message(messages, 0)
+        assert is_pinned(messages, 0) is False
+
+    def test_preserves_other_custom_fields(self):
+        messages = [make_message("important", metadata={"custom": {"pinned": True, "other": "keep"}})]
+        unpin_message(messages, 0)
+        assert is_pinned(messages, 0) is False
+        assert messages[0]["metadata"]["custom"]["other"] == "keep"
+
+    def test_removes_metadata_when_nothing_remains(self):
+        messages = [make_message("hello")]
+        pin_message(messages, 0)
+        unpin_message(messages, 0)
+        assert "metadata" not in messages[0]
+
+    def test_preserves_non_custom_metadata(self):
+        messages = [make_message("important", metadata={"usage": {"inputTokens": 10}, "custom": {"pinned": True}})]
+        unpin_message(messages, 0)
+        assert messages[0]["metadata"]["usage"] == {"inputTokens": 10}
+        assert is_pinned(messages, 0) is False
+
+
+class TestToolPairPartnerProtection:
+    def test_tool_result_partner_of_pinned_tool_use(self):
+        tool_result = {
+            "toolUseId": "id-1",
+            "content": [{"text": "result"}],
+            "status": "success",
+        }
+        messages = [
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "id-1", "name": "test", "input": {}}}]},
+            {"role": "user", "content": [{"toolResult": tool_result}]},
+            make_message("other"),
+        ]
+        pin_message(messages, 0)
+        assert is_pinned(messages, 1) is True
+
+    def test_tool_use_partner_of_pinned_tool_result(self):
+        tool_result = {
+            "toolUseId": "id-1",
+            "content": [{"text": "result"}],
+            "status": "success",
+        }
+        messages = [
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "id-1", "name": "test", "input": {}}}]},
+            {"role": "user", "content": [{"toolResult": tool_result}]},
+            make_message("other"),
+        ]
+        pin_message(messages, 1)
+        assert is_pinned(messages, 0) is True
+
+    def test_unrelated_message_next_to_pinned_is_not_pinned(self):
+        messages = [make_message("a"), make_message("b")]
+        pin_message(messages, 0)
+        assert is_pinned(messages, 1) is False

--- a/strands-ts/src/conversation-manager/__tests__/pin.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/pin.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { pinMessage, unpinMessage, isPinned } from '../pin-message.js'
+import { Message, TextBlock, ToolUseBlock, ToolResultBlock } from '../../types/messages.js'
+
+function makeMessage(text: string, metadata?: Record<string, unknown>): Message {
+  return new Message({
+    role: 'user',
+    content: [new TextBlock(text)],
+    ...(metadata !== undefined ? { metadata: metadata as any } : {}),
+  })
+}
+
+describe('isPinned', () => {
+  it('returns false for message without metadata', () => {
+    expect(isPinned([makeMessage('hello')], 0)).toBe(false)
+  })
+
+  it('returns false for message with empty custom', () => {
+    expect(isPinned([makeMessage('hello', { custom: {} })], 0)).toBe(false)
+  })
+
+  it('returns true for message with custom.pinned = true', () => {
+    expect(isPinned([makeMessage('hello', { custom: { pinned: true } })], 0)).toBe(true)
+  })
+
+  it('returns false for message with custom.pinned = false', () => {
+    expect(isPinned([makeMessage('hello', { custom: { pinned: false } })], 0)).toBe(false)
+  })
+})
+
+describe('pinMessage', () => {
+  it('sets pinned = true in custom metadata', () => {
+    const messages = [makeMessage('important')]
+    pinMessage(messages, 0)
+
+    expect(isPinned(messages, 0)).toBe(true)
+    expect(messages[0]!.role).toBe('user')
+  })
+
+  it('preserves existing metadata', () => {
+    const messages = [makeMessage('important', { usage: { inputTokens: 10, outputTokens: 5 } })]
+    pinMessage(messages, 0)
+
+    expect(messages[0]!.metadata?.usage).toEqual({ inputTokens: 10, outputTokens: 5 })
+    expect(isPinned(messages, 0)).toBe(true)
+  })
+
+  it('preserves existing custom fields', () => {
+    const messages = [makeMessage('important', { custom: { myField: 'value' } })]
+    pinMessage(messages, 0)
+
+    expect(messages[0]!.metadata?.custom?.myField).toBe('value')
+    expect(isPinned(messages, 0)).toBe(true)
+  })
+})
+
+describe('unpinMessage', () => {
+  it('removes pinned from custom metadata', () => {
+    const messages = [makeMessage('important')]
+    pinMessage(messages, 0)
+    unpinMessage(messages, 0)
+
+    expect(isPinned(messages, 0)).toBe(false)
+  })
+
+  it('preserves other custom fields', () => {
+    const messages = [makeMessage('important', { custom: { pinned: true, other: 'keep' } })]
+    unpinMessage(messages, 0)
+
+    expect(isPinned(messages, 0)).toBe(false)
+    expect(messages[0]!.metadata?.custom?.other).toBe('keep')
+  })
+
+  it('removes metadata entirely when nothing remains', () => {
+    const messages = [makeMessage('hello')]
+    pinMessage(messages, 0)
+    unpinMessage(messages, 0)
+
+    expect(messages[0]!.metadata).toBeUndefined()
+  })
+
+  it('preserves non-custom metadata fields', () => {
+    const messages = [
+      makeMessage('important', { usage: { inputTokens: 10, outputTokens: 5 }, custom: { pinned: true } }),
+    ]
+    unpinMessage(messages, 0)
+
+    expect(messages[0]!.metadata?.usage).toEqual({ inputTokens: 10, outputTokens: 5 })
+    expect(isPinned(messages, 0)).toBe(false)
+  })
+})
+
+describe('isPinned with messages array', () => {
+  it('returns false for unpinned message', () => {
+    const messages = [makeMessage('a'), makeMessage('b')]
+    expect(isPinned(messages, 0)).toBe(false)
+  })
+
+  it('returns true for pinned message', () => {
+    const messages = [makeMessage('a'), makeMessage('b')]
+    pinMessage(messages, 0)
+    expect(isPinned(messages, 0)).toBe(true)
+  })
+
+  it('returns true for toolResult whose toolUse partner is pinned', () => {
+    const messages = [
+      new Message({
+        role: 'assistant',
+        content: [new ToolUseBlock({ toolUseId: 'id-1', name: 'test', input: {} })],
+      }),
+      new Message({
+        role: 'user',
+        content: [new ToolResultBlock({ toolUseId: 'id-1', content: [new TextBlock('result')], status: 'success' })],
+      }),
+      makeMessage('other'),
+    ]
+    pinMessage(messages, 0)
+
+    expect(isPinned(messages, 1)).toBe(true)
+  })
+
+  it('returns true for toolUse whose toolResult partner is pinned', () => {
+    const messages = [
+      new Message({
+        role: 'assistant',
+        content: [new ToolUseBlock({ toolUseId: 'id-1', name: 'test', input: {} })],
+      }),
+      new Message({
+        role: 'user',
+        content: [new ToolResultBlock({ toolUseId: 'id-1', content: [new TextBlock('result')], status: 'success' })],
+      }),
+      makeMessage('other'),
+    ]
+    pinMessage(messages, 1)
+
+    expect(isPinned(messages, 0)).toBe(true)
+  })
+
+  it('returns false for unrelated message next to pinned', () => {
+    const messages = [makeMessage('a'), makeMessage('b')]
+    pinMessage(messages, 0)
+    expect(isPinned(messages, 1)).toBe(false)
+  })
+})

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -1211,4 +1211,61 @@ describe('SlidingWindowConversationManager', () => {
       expect(mockAgent.messages).toHaveLength(2)
     })
   })
+
+  describe('pinFirst', () => {
+    it('protects first N messages from trimming', async () => {
+      // windowSize 2 on 6 messages: trimIndex = 4, but first 2 are pinned
+      const manager = new SlidingWindowConversationManager({ windowSize: 2, pinFirst: 2 })
+      const mockAgent = createMockAgent({
+        messages: [
+          new Message({ role: 'user', content: [new TextBlock('first')] }),
+          new Message({ role: 'assistant', content: [new TextBlock('second')] }),
+          new Message({ role: 'user', content: [new TextBlock('third')] }),
+          new Message({ role: 'assistant', content: [new TextBlock('fourth')] }),
+          new Message({ role: 'user', content: [new TextBlock('fifth')] }),
+          new Message({ role: 'assistant', content: [new TextBlock('sixth')] }),
+        ],
+      })
+
+      await triggerSlidingWindow(manager, mockAgent)
+
+      const texts = mockAgent.messages.map((m) => (m.content[0] as TextBlock).text)
+      expect(texts).toEqual(['first', 'second', 'fifth', 'sixth'])
+    })
+
+    it('returns false when all messages in trim range are protected', () => {
+      const manager = new SlidingWindowConversationManager({ windowSize: 2, pinFirst: 4 })
+      const mockAgent = createMockAgent({
+        messages: [
+          new Message({ role: 'user', content: [new TextBlock('a')] }),
+          new Message({ role: 'assistant', content: [new TextBlock('b')] }),
+          new Message({ role: 'user', content: [new TextBlock('c')] }),
+          new Message({ role: 'assistant', content: [new TextBlock('d')] }),
+        ],
+      })
+
+      const result = manager.reduce({ agent: mockAgent, model: {} as any })
+      expect(result).toBe(false)
+    })
+
+    it('pinned message in middle of window survives trimming', async () => {
+      const { pinMessage } = await import('../pin-message.js')
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('first')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('second')] }),
+        new Message({ role: 'user', content: [new TextBlock('pinned-middle')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('fourth')] }),
+        new Message({ role: 'user', content: [new TextBlock('fifth')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('sixth')] }),
+      ]
+      pinMessage(messages, 2)
+      const manager = new SlidingWindowConversationManager({ windowSize: 4 })
+      const mockAgent = createMockAgent({ messages })
+
+      await triggerSlidingWindow(manager, mockAgent)
+
+      const texts = mockAgent.messages.map((m) => (m.content[0] as TextBlock).text)
+      expect(texts).toEqual(['pinned-middle', 'fourth', 'fifth', 'sixth'])
+    })
+  })
 })

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -406,4 +406,75 @@ describe('SummarizingConversationManager', () => {
       expect(mockAgent.messages).toHaveLength(20)
     })
   })
+
+  describe('pinFirst', () => {
+    it('protects first N messages from summarization', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary' })
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        pinFirst: 2,
+      })
+
+      const agent = createMockAgent({
+        messages: [
+          textMsg('user', 'protected-1'),
+          textMsg('assistant', 'protected-2'),
+          textMsg('user', 'summarize-me'),
+          textMsg('assistant', 'summarize-me-too'),
+          textMsg('user', 'recent-1'),
+          textMsg('assistant', 'recent-2'),
+        ],
+      })
+
+      await manager.reduce({ agent, model: model as unknown as Model })
+
+      const texts = agent.messages.map((m) => (m.content[0] as TextBlock).text)
+      expect(texts).toEqual(['protected-1', 'protected-2', 'Summary', 'summarize-me-too', 'recent-1', 'recent-2'])
+    })
+
+    it('returns false when all messages in summary range are protected', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary' })
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.3,
+        preserveRecentMessages: 2,
+        pinFirst: 10,
+      })
+
+      const agent = createMockAgent({ messages: makeMessages(6) })
+      const result = await manager.reduce({ agent, model: model as unknown as Model })
+      expect(result).toBe(false)
+    })
+
+    it('pinned message in middle survives summarization', async () => {
+      const { pinMessage } = await import('../pin-message.js')
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary' })
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+      })
+
+      const messages = [
+        textMsg('user', 'old-1'),
+        textMsg('assistant', 'pinned-middle'),
+        textMsg('user', 'old-3'),
+        textMsg('assistant', 'old-4'),
+        textMsg('user', 'recent-1'),
+        textMsg('assistant', 'recent-2'),
+      ]
+      pinMessage(messages, 1)
+      const agent = createMockAgent({ messages })
+
+      await manager.reduce({ agent, model: model as unknown as Model })
+
+      const texts = agent.messages.map((m) => (m.content[0] as TextBlock).text)
+      expect(texts).toEqual(['pinned-middle', 'Summary', 'old-4', 'recent-1', 'recent-2'])
+    })
+  })
 })

--- a/strands-ts/src/conversation-manager/pin-message.ts
+++ b/strands-ts/src/conversation-manager/pin-message.ts
@@ -1,0 +1,111 @@
+import { Message, type ToolUseBlock, type ToolResultBlock } from '../types/messages.js'
+
+/**
+ * Check if a message is pinned, including tool-pair partner protection.
+ * Returns `true` if the message at `index` is pinned, or if it is the
+ * adjacent tool-pair partner (toolUse/toolResult) of a pinned message,
+ * matched by toolUseId.
+ *
+ * @param messages - The full messages array.
+ * @param index - The index to check.
+ * @returns `true` if the message or its tool-pair partner is pinned.
+ */
+export function isPinned(messages: Message[], index: number): boolean {
+  const msg = messages[index]!
+
+  if (msg.metadata?.custom?.pinned === true) return true
+
+  // Tool-pair partner protection: if this is a toolResult, check if prev toolUse is pinned
+  const toolResultBlocks = msg.content.filter((b): b is ToolResultBlock => b.type === 'toolResultBlock')
+  if (toolResultBlocks.length > 0 && index > 0) {
+    const prev = messages[index - 1]!
+    if (prev.metadata?.custom?.pinned === true) {
+      const resultIds = new Set(toolResultBlocks.map((b) => b.toolUseId))
+      if (prev.content.some((b) => b.type === 'toolUseBlock' && resultIds.has((b as ToolUseBlock).toolUseId))) {
+        return true
+      }
+    }
+  }
+
+  // Tool-pair partner protection: if this is a toolUse, check if next toolResult is pinned
+  const toolUseBlocks = msg.content.filter((b): b is ToolUseBlock => b.type === 'toolUseBlock')
+  if (toolUseBlocks.length > 0 && index + 1 < messages.length) {
+    const next = messages[index + 1]!
+    if (next.metadata?.custom?.pinned === true) {
+      const useIds = new Set(toolUseBlocks.map((b) => b.toolUseId))
+      if (next.content.some((b) => b.type === 'toolResultBlock' && useIds.has((b as ToolResultBlock).toolUseId))) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+/**
+ * Pin a message so it is protected from eviction during context reduction.
+ * Mutates the message in place by setting `metadata.custom.pinned = true`.
+ *
+ * @param messages - The messages array containing the message to pin.
+ * @param index - The index of the message to pin.
+ */
+export function pinMessage(messages: Message[], index: number): void {
+  const message = messages[index]!
+  message.metadata = {
+    ...message.metadata,
+    custom: { ...message.metadata?.custom, pinned: true },
+  }
+}
+
+/**
+ * Pin the first N messages in the array permanently.
+ *
+ * @param messages - The messages array.
+ * @param count - Number of messages from the start to pin.
+ */
+export function applyPinFirst(messages: Message[], count: number): void {
+  for (let i = 0; i < Math.min(count, messages.length); i++) {
+    pinMessage(messages, i)
+  }
+}
+
+/**
+ * Partition a range of messages into pinned (protected) and unpinned arrays.
+ *
+ * @param messages - The full messages array.
+ * @param start - Start index of the range (inclusive).
+ * @param end - End index of the range (exclusive).
+ * @returns A tuple of [pinned, unpinned] message arrays.
+ */
+export function partitionPinned(messages: Message[], start: number, end: number): [Message[], Message[]] {
+  const pinned: Message[] = []
+  const unpinned: Message[] = []
+  for (let i = start; i < end; i++) {
+    if (isPinned(messages, i)) {
+      pinned.push(messages[i]!)
+    } else {
+      unpinned.push(messages[i]!)
+    }
+  }
+  return [pinned, unpinned]
+}
+
+/**
+ * Unpin a message so it can be evicted during context reduction.
+ * Mutates the message in place by removing the `pinned` flag from metadata.
+ *
+ * @param messages - The messages array containing the message to unpin.
+ * @param index - The index of the message to unpin.
+ */
+export function unpinMessage(messages: Message[], index: number): void {
+  const message = messages[index]!
+  const { pinned: _, ...restCustom } = message.metadata?.custom ?? {}
+  const { custom: __, ...restMetadata } = message.metadata ?? {}
+  const hasCustom = Object.keys(restCustom).length > 0
+  const hasMetadata = hasCustom || Object.keys(restMetadata).length > 0
+  if (hasMetadata) {
+    message.metadata = { ...restMetadata, ...(hasCustom ? { custom: restCustom } : {}) }
+  } else {
+    delete message.metadata
+  }
+}

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -14,6 +14,7 @@ import {
   type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions,
 } from './conversation-manager.js'
+import { isPinned, applyPinFirst } from './pin-message.js'
 import { logger } from '../logging/logger.js'
 
 const PRESERVE_CHARS = 200
@@ -103,6 +104,12 @@ export type SlidingWindowConversationManagerConfig = {
    * - `false` or omitted: disabled, only reactive overflow recovery is used.
    */
   proactiveCompression?: boolean | ProactiveCompressionConfig
+
+  /**
+   * Number of messages at the start of the conversation to permanently pin.
+   * Pinned messages are protected from eviction during context reduction.
+   */
+  pinFirst?: number
 }
 
 /**
@@ -121,6 +128,8 @@ export type SlidingWindowConversationManagerConfig = {
 export class SlidingWindowConversationManager extends ConversationManager {
   private readonly _windowSize: number
   private readonly _shouldTruncateResults: boolean
+  private readonly _pinFirst: number | undefined
+  private _pinFirstApplied = false
 
   /**
    * Unique identifier for this conversation manager.
@@ -136,6 +145,7 @@ export class SlidingWindowConversationManager extends ConversationManager {
     super(config)
     this._windowSize = config?.windowSize ?? 40
     this._shouldTruncateResults = config?.shouldTruncateResults ?? true
+    this._pinFirst = config?.pinFirst != null ? Math.max(0, config.pinFirst) : undefined
   }
 
   /**
@@ -204,6 +214,12 @@ export class SlidingWindowConversationManager extends ConversationManager {
    * @returns `true` if any reduction occurred, `false` otherwise.
    */
   private _reduceContext(messages: Message[], _error?: Error): boolean {
+    // Pin first N messages permanently (only on first reduction)
+    if (this._pinFirst && !this._pinFirstApplied) {
+      applyPinFirst(messages, this._pinFirst)
+      this._pinFirstApplied = true
+    }
+
     // Only truncate tool results when handling a context overflow error, not for window size enforcement
     const oldestMessageIdxWithToolResults = this._findOldestMessageWithToolResults(messages)
     if (_error && oldestMessageIdxWithToolResults !== undefined && this._shouldTruncateResults) {
@@ -264,8 +280,24 @@ export class SlidingWindowConversationManager extends ConversationManager {
       return false
     }
 
-    // trimIndex is guaranteed to be < messages.length here, so splice always removes at least one message
-    messages.splice(0, trimIndex)
+    // Collect non-pinned indices in [0, trimIndex) to remove
+    const indicesToRemove: number[] = []
+    for (let i = 0; i < trimIndex; i++) {
+      if (isPinned(messages, i)) continue
+      indicesToRemove.push(i)
+    }
+
+    if (indicesToRemove.length === 0) {
+      logger.warn(
+        `window_size=<${this._windowSize}>, messages=<${messages.length}> | all messages in trim range are protected, unable to reduce`
+      )
+      return false
+    }
+
+    // Remove in reverse order to keep indices stable
+    for (let i = indicesToRemove.length - 1; i >= 0; i--) {
+      messages.splice(indicesToRemove[i]!, 1)
+    }
     return true
   }
 
@@ -449,10 +481,9 @@ export class SlidingWindowConversationManager extends ConversationManager {
    */
   private _findOldestMessageWithToolResults(messages: Message[]): number | undefined {
     for (let idx = 0; idx < messages.length; idx++) {
-      const currentMessage = messages[idx]!
+      if (isPinned(messages, idx)) continue
 
-      const hasToolResult = currentMessage.content.some((block) => block.type === 'toolResultBlock')
-
+      const hasToolResult = messages[idx]!.content.some((block) => block.type === 'toolResultBlock')
       if (hasToolResult) {
         return idx
       }

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -13,6 +13,7 @@ import {
   type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions,
 } from './conversation-manager.js'
+import { applyPinFirst, partitionPinned } from './pin-message.js'
 import { logger } from '../logging/logger.js'
 import { normalizeError } from '../errors.js'
 import type { Model } from '../models/model.js'
@@ -83,6 +84,12 @@ export type SummarizingConversationManagerConfig = {
    * - `false` or omitted: disabled, only reactive overflow recovery is used.
    */
   proactiveCompression?: boolean | ProactiveCompressionConfig
+
+  /**
+   * Number of messages at the start of the conversation to permanently pin.
+   * Pinned messages are protected from summarization and compacted to the front.
+   */
+  pinFirst?: number
 }
 
 /**
@@ -99,6 +106,8 @@ export class SummarizingConversationManager extends ConversationManager {
   private readonly _summaryRatio: number
   private readonly _preserveRecentMessages: number
   private readonly _summarizationSystemPrompt: string
+  private readonly _pinFirst: number | undefined
+  private _pinFirstApplied = false
 
   constructor(config?: SummarizingConversationManagerConfig) {
     super(config)
@@ -107,6 +116,7 @@ export class SummarizingConversationManager extends ConversationManager {
     this._summaryRatio = Math.max(0.1, Math.min(0.8, config?.summaryRatio ?? 0.3))
     this._preserveRecentMessages = config?.preserveRecentMessages ?? 10
     this._summarizationSystemPrompt = config?.summarizationSystemPrompt ?? DEFAULT_SUMMARIZATION_PROMPT
+    this._pinFirst = config?.pinFirst != null ? Math.max(0, config.pinFirst) : undefined
   }
 
   /**
@@ -164,13 +174,25 @@ export class SummarizingConversationManager extends ConversationManager {
     // Adjust split point to avoid breaking tool use/result pairs
     messagesToSummarizeCount = this._adjustSplitPointForToolPairs(messages, messagesToSummarizeCount)
 
-    const messagesToSummarize = messages.slice(0, messagesToSummarizeCount)
+    // Pin first N messages permanently (only on first reduction)
+    if (this._pinFirst && !this._pinFirstApplied) {
+      applyPinFirst(messages, this._pinFirst)
+      this._pinFirstApplied = true
+    }
+
+    // Partition [0, messagesToSummarizeCount) into pinned (preserve) and non-pinned (summarize)
+    const [protectedToPreserve, toSummarize] = partitionPinned(messages, 0, messagesToSummarizeCount)
+
+    if (toSummarize.length === 0) {
+      logger.warn(`messages=<${messages.length}> | all messages in summarize range are protected, unable to reduce`)
+      return false
+    }
 
     // Generate summary via model call
-    const summaryMessage = await this._generateSummary(messagesToSummarize, model)
+    const summaryMessage = await this._generateSummary(toSummarize, model)
 
-    // Replace summarized messages with the summary
-    messages.splice(0, messagesToSummarizeCount, summaryMessage)
+    // Replace summarized range with protected messages + summary
+    messages.splice(0, messagesToSummarizeCount, ...protectedToPreserve, summaryMessage)
 
     return true
   }

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -72,7 +72,7 @@ export class Message implements JSONSerializable<MessageData> {
   /**
    * Optional metadata, not sent to model providers.
    */
-  readonly metadata?: MessageMetadata
+  metadata?: MessageMetadata
 
   constructor(data: { role: Role; content: ContentBlock[]; metadata?: MessageMetadata }) {
     this.role = data.role


### PR DESCRIPTION
### Description

Adds opt-in message pinning to conversation managers in both TypeScript and Python SDKs. Pinned messages are protected from eviction during context reduction — they survive both sliding-window trimming and summarization.

### What's included
- `pin_message`/`unpin_message`/`is_pinned` utility functions (stores pin state in `metadata.custom.pinned`)
- `pin_message(messages, index)` mutates in place — designed for future agentic tool use
- `is_pinned` handles tool-pair partner protection (adjacent toolUse/toolResult matched by toolUseId)
- `pinFirst` config on both conversation managers — permanently pins the first N messages on first reduction
- `SlidingWindowConversationManager` skips pinned messages during trimming and tool-result truncation
- `SummarizingConversationManager` excludes pinned messages from summarization, compacting them to the front before the summary message
- `Message.metadata` is now writable (was `readonly` in TS — not a breaking change, SDK already mutated it post-construction)

### API Surface

**TypeScript:**
```typescript
// Config (on both SlidingWindowConversationManager and SummarizingConversationManager)
pinFirst?: number  // permanently pin first N messages
```

**Python:**
```python
# Config (on both SlidingWindowConversationManager and SummarizingConversationManager)
pin_first: int | None  # permanently pin first N messages
```

### Usage

**TypeScript:**
```typescript
import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'

// Protect first message (e.g. system context)
const agent = new Agent({
  conversationManager: new SlidingWindowConversationManager({ pinFirst: 1 }),
})

// Pin programmatically (for agentic use)
import { pinMessage } from './conversation-manager/pin-message.js'
pinMessage(agent.messages, 3)  // pin message at index 3
```

**Python:**
```python
from strands import Agent
from strands.agent.conversation_manager import SlidingWindowConversationManager
from strands.agent.conversation_manager.pin_message import pin_message

# Protect first message
agent = Agent(conversation_manager=SlidingWindowConversationManager(pin_first=1))

# Pin programmatically
pin_message(agent.messages, 3)
```

### File structure

**TypeScript:**
```
conversation-manager/
  pin-message.ts        — utilities (isPinned, pinMessage, unpinMessage)
  __tests__/
    pin.test.ts
```

**Python:**
```
agent/conversation_manager/
  pin_message.py        — utilities (is_pinned, pin_message, unpin_message)
```

## Related Issues

strands-agents/docs#831

## Documentation PR

TK in context facade docs PR

## Type of Change

New feature

## Testing

How have you tested the change?

**TypeScript:**
- [x] I ran `npm run check` (build + test:coverage + lint + format + type-check)
- [x] Unit tests for `pinMessage`/`unpinMessage`/`isPinned` (16 tests)
- [x] Integration tests for `pinFirst` config on both managers
- [x] All existing sliding-window tests pass (50 tests)
- [x] All existing summarizing tests pass (15 tests)
- [x] Tests use `toEqual` on full resulting arrays

**Python:**
- [x] Unit tests for `pin_message`/`unpin_message`/`is_pinned` (14 tests)
- [x] All existing sliding-window tests pass (64 tests)
- [x] All existing summarizing tests pass (38 tests)
- [x] `hatch fmt --linter --check` passes

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.