### PR TITLE
docs: remove unnecessary model IDs from examples, rely on built-in defaults

### DIFF
--- a/site/src/content/docs/contribute/contributing/documentation.mdx
+++ b/site/src/content/docs/contribute/contributing/documentation.mdx
@@ -100,10 +100,8 @@ agent("Hello, world!")
 
 # Then show configuration
 from strands import Agent
-from strands.models import BedrockModel
 
 agent = Agent(
-    model=BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514"),
     system_prompt="You are a helpful assistant."
 )
 agent("What's the weather like?")

--- a/site/src/content/docs/contribute/contributing/documentation.ts
+++ b/site/src/content/docs/contribute/contributing/documentation.ts
@@ -1,5 +1,5 @@
 // --8<-- [start:basic_agent]
-import { Agent, BedrockModel } from '@strands-agents/sdk'
+import { Agent } from '@strands-agents/sdk'
 
 // Good: Start simple
 const agent = new Agent()
@@ -7,7 +7,6 @@ await agent.invoke('Hello, world!')
 
 // Then show configuration
 const configuredAgent = new Agent({
-  model: new BedrockModel({ modelId: 'us.anthropic.claude-sonnet-4-20250514' }),
   systemPrompt: 'You are a helpful assistant.',
 })
 await configuredAgent.invoke("What's the weather like?")

--- a/site/src/content/docs/labs/ai-functions.mdx
+++ b/site/src/content/docs/labs/ai-functions.mdx
@@ -37,7 +37,7 @@ from strands.models.bedrock import BedrockModel
 from strands.models.openai import OpenAIModel
 
 # Use Claude Sonnet on Amazon Bedrock (default if `model` is not specified)
-model = BedrockModel(model_id="anthropic.claude-sonnet-4-20250514-v1:0")
+model = BedrockModel()
 
 # Or use a different provider and model
 model = OpenAIModel(client_args={"api_key": "<KEY>"}, model_id="gpt-4o")

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -285,7 +285,7 @@ from strands.models import AnthropicModel
 
 # Create a cheaper, faster model for summarization tasks
 summarization_model = AnthropicModel(
-    model_id="claude-3-5-haiku-20241022",  # More cost-effective for summarization
+    model_id="claude-haiku-4-5-20251001",  # More cost-effective for summarization
     max_tokens=1000,
     params={"temperature": 0.1}  # Low temperature for consistent summaries
 )
@@ -339,10 +339,8 @@ Pass `proactive_compression` to any built-in conversation manager. Use `True` fo
 ```python
 from strands import Agent
 from strands.agent.conversation_manager import SlidingWindowConversationManager
-from strands.models.bedrock import BedrockModel
 
 agent = Agent(
-    model=BedrockModel(model_id="anthropic.claude-sonnet-4-6-v1:0"),
     conversation_manager=SlidingWindowConversationManager(
         window_size=50,
         proactive_compression={"compression_threshold": 0.7},
@@ -355,10 +353,8 @@ agent = Agent(
 ```python
 from strands import Agent
 from strands.agent.conversation_manager import SummarizingConversationManager
-from strands.models.bedrock import BedrockModel
 
 agent = Agent(
-    model=BedrockModel(model_id="anthropic.claude-sonnet-4-6-v1:0"),
     conversation_manager=SummarizingConversationManager(
         proactive_compression=True,
     ),

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -147,9 +147,6 @@ Format as bullet points without conversational language.
 async function proactiveSlidingWindow() {
   // --8<-- [start:proactive_sliding_window]
   const agent = new Agent({
-    model: new BedrockModel({
-      modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    }),
     conversationManager: new SlidingWindowConversationManager({
       windowSize: 50,
       proactiveCompression: { compressionThreshold: 0.7 },
@@ -161,9 +158,6 @@ async function proactiveSlidingWindow() {
 async function proactiveSummarizing() {
   // --8<-- [start:proactive_summarizing]
   const agent = new Agent({
-    model: new BedrockModel({
-      modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    }),
     conversationManager: new SummarizingConversationManager({
       proactiveCompression: true,
     }),

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
@@ -44,13 +44,9 @@ import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 // --8<-- [end:summarizing_conversation_manager_advanced_imports]
 
 // --8<-- [start:proactive_sliding_window_imports]
-import {
-  Agent,
-  BedrockModel,
-  SlidingWindowConversationManager,
-} from '@strands-agents/sdk'
+import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
 // --8<-- [end:proactive_sliding_window_imports]
 
 // --8<-- [start:proactive_summarizing_imports]
-import { Agent, BedrockModel, SummarizingConversationManager } from '@strands-agents/sdk'
+import { Agent, SummarizingConversationManager } from '@strands-agents/sdk'
 // --8<-- [end:proactive_summarizing_imports]

--- a/site/src/content/docs/user-guide/concepts/model-providers/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/index.mdx
@@ -92,9 +92,7 @@ from strands.models.bedrock import BedrockModel
 from strands.models.openai import OpenAIModel
 
 # Use Bedrock
-bedrock_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0"
-)
+bedrock_model = BedrockModel()
 agent = Agent(model=bedrock_model)
 response = agent("What can you help me with?")
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/index.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/index.ts
@@ -12,9 +12,7 @@ import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 async function basicUsage() {
   // --8<-- [start:basic_usage]
   // Use Bedrock
-  const bedrockModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
-  })
+  const bedrockModel = new BedrockModel()
   let agent = new Agent({ model: bedrockModel })
   let response = await agent.invoke('What can you help me with?')
 

--- a/site/src/content/docs/user-guide/evals-sdk/simulators/tool_simulation.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/simulators/tool_simulation.mdx
@@ -289,12 +289,12 @@ Specify a different model for simulation inference:
 
 ```python
 # Via model ID string (Bedrock)
-tool_simulator = ToolSimulator(model="anthropic.claude-3-5-sonnet-20241022-v2:0")
+tool_simulator = ToolSimulator(model="anthropic.claude-haiku-4-5-20251001-v1:0")
 
 # Via Strands Model provider
 from strands.models import BedrockModel
 
-model = BedrockModel(model_id="anthropic.claude-3-5-sonnet-20241022-v2:0")
+model = BedrockModel(model_id="anthropic.claude-haiku-4-5-20251001-v1:0")
 tool_simulator = ToolSimulator(model=model)
 ```
 

--- a/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
@@ -149,7 +149,7 @@ DEBUG | strands.event_loop.error_handler | message_index=<5> | found message wit
 Logs related to interactions with foundation models:
 
 ```
-DEBUG | strands.models.bedrock | config=<{'model_id': 'us.anthropic.claude-4-sonnet-20250219-v1:0'}> | initializing
+DEBUG | strands.models.bedrock | config=<{'model_id': 'global.anthropic.claude-sonnet-4-6'}> | initializing
 WARNING | strands.models.bedrock | bedrock threw context window overflow error
 DEBUG | strands.models.bedrock | Found blocked output guardrail. Redacting output.
 ```
@@ -174,7 +174,7 @@ WARN choice=<null> | invalid choice format in openai chunk
 WARN tool_call=<{"type":"function","id":"xyz"}> | received tool call with invalid index
 
 # Bedrock-specific logs
-DEBUG model_id=<us.anthropic.claude-sonnet-4-20250514-v1:0>, include_tool_result_status=<true> | auto-detected includeToolResultStatus
+DEBUG model_id=<global.anthropic.claude-sonnet-4-6>, include_tool_result_status=<true> | auto-detected includeToolResultStatus
 WARN block_key=<unknown_key> | skipping unsupported block key
 WARN event_type=<unknown_type> | unsupported bedrock event type
 ```

--- a/site/src/content/docs/user-guide/quickstart/python.mdx
+++ b/site/src/content/docs/user-guide/quickstart/python.mdx
@@ -401,7 +401,7 @@ from strands import Agent
 agent = Agent()
 
 print(agent.model.config)
-# {'model_id': 'us.anthropic.claude-sonnet-4-20250514-v1:0'}
+# {'model_id': 'global.anthropic.claude-sonnet-4-6'}
 ```
 
 You can specify a different model in two ways:

--- a/site/src/content/docs/user-guide/safety-security/guardrails.mdx
+++ b/site/src/content/docs/user-guide/safety-security/guardrails.mdx
@@ -33,7 +33,6 @@ from strands.models import BedrockModel
 
 # Create a Bedrock model with guardrail configuration
 bedrock_model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     guardrail_id="your-guardrail-id",         # Your Bedrock guardrail ID
     guardrail_version="1",                    # Guardrail version
     guardrail_trace="enabled",                # Enable trace info for debugging


### PR DESCRIPTION
## Motivation

Documentation examples reference explicit model IDs even when the example's purpose has nothing to do with model configuration (e.g., tracing setup, conversation management, guardrails, contributing guidelines). This creates unnecessary maintenance work every time default models change and clutters examples with irrelevant configuration that distracts from the actual topic being demonstrated.

Resolves #2573

## Changes

**Removed unnecessary model_id parameters** from 12 files where the example focus is not on model selection:
- Contributing documentation examples now use the default model instead of specifying an explicit ID
- Conversation management proactive compression examples no longer include model configuration (the topic is compression, not model choice)
- Model providers overview page uses `BedrockModel()` for the Bedrock example (demonstrates simplicity of defaults)
- Guardrails page focuses on guardrail config only
- AI functions lab page uses `BedrockModel()` for the default example
- Quickstart config output updated to reflect current default

**Updated stale model references** where an explicit ID is still warranted:
- `claude-3-5-sonnet-20241022-v2:0` → `claude-haiku-4-5-20251001-v1:0` in tool simulation custom model example
- `claude-3-5-haiku-20241022` → `claude-haiku-4-5-20251001` in summarization model example

**Updated output examples** (log messages) to reflect the current default model ID (`global.anthropic.claude-sonnet-4-6`).

**Kept explicit model_ids** where they serve a purpose:
- Model provider pages (showing how to configure each provider)
- Examples using non-default providers (OpenAI, Anthropic direct, LiteLLM, community providers)
- Examples where a specific model is chosen for cost/capability reasons (e.g., cheaper model for summarization)
- Production deployment guides (should pin specific versions)
- Custom model sections in eval SDK

## Verification

- All 316 site tests pass
- TypeScript type checking passes (`tsc --noEmit`)
- Prettier formatting passes on all modified TS files