### PR TITLE
feat: add pr-create and pr-writer agent skills

### DIFF
--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: pr-create
+description: Creates a GitHub pull request using the gh CLI. Use when the user asks to create, open, or submit a PR on GitHub.
+---
+
+# GitHub PR Create Skill
+
+## Process
+
+### 1. Get the PR Description
+
+- Check for `.local/pr-body.md`. If it exists, re-read it fresh (the user may have edited it) and use its contents as the title and body.
+- Else if the user already generated a PR description earlier in the conversation, use that.
+- Otherwise, fall back to the `pr-writer` skill to generate the title and body.
+
+### 2. Pre-flight Checks
+
+Check for `CONTRIBUTING.md` (at the repo root or in `docs/`) and `.github/PULL_REQUEST_TEMPLATE.md`. Scan them for any recommended steps before opening a PR — common examples:
+
+- Running a linter or formatter (e.g. `npm run lint`, `cargo fmt`)
+- Running tests (e.g. `npm test`, `pytest`)
+- Building the project
+- Updating documentation or changelogs
+
+If you find any such steps, **list them and ask the user which ones they'd like you to run**. Run whichever the user approves. If any step fails, show the output and ask how to proceed before continuing.
+
+If neither file exists or they contain no actionable pre-PR steps, skip this and move on.
+
+### 3. Push the Branch
+
+```bash
+git push -u origin HEAD
+```
+
+If the push fails, show the error and stop.
+
+### 4. Create the PR
+
+Write the PR body to `.local/pr-body.md` (create `.local/` if needed) and create the PR:
+
+```bash
+gh pr create \
+  --title "<title>" \
+  --body-file .local/pr-body.md \
+  --web
+```
+
+- Do NOT pass `--repo` — let `gh` infer the upstream from the git remotes so the PR targets the correct upstream repository.
+- Always pass `--web` to open the PR in the browser for final review before submission.
+
+## Rules
+
+- Never create the PR without `--web` — the user must confirm in the browser.
+- If `gh` is not authenticated or the command fails, show the error and stop.

--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -9,7 +9,7 @@ description: Creates a GitHub pull request using the gh CLI. Use when the user a
 
 ### 1. Get the PR Description
 
-- Check for `.local/pr-body.md`. If it exists, re-read it fresh (the user may have edited it) and use its contents as the title and body.
+- Check for `.local/pr-body.md`. If it exists, re-read it fresh and sanity-check that its content matches the current branch's changes (e.g. the description references files, features, or issues consistent with the current diff). If it looks stale or unrelated to the current changes, warn the user and offer to regenerate it.
 - Else if the user already generated a PR description earlier in the conversation, use that.
 - Otherwise, fall back to the `pr-writer` skill to generate the title and body.
 
@@ -26,25 +26,23 @@ If you find any such steps, **list them and ask the user which ones they'd like 
 
 If neither file exists or they contain no actionable pre-PR steps, skip this and move on.
 
-### 3. Push the Branch
+### 3. Push the Branch (if needed)
 
-```bash
-git push -u origin HEAD
-```
-
-If the push fails, show the error and stop.
+Check whether the current branch has an upstream tracking branch with all commits pushed. If not, push before creating the PR. If the push fails, show the error and stop.
 
 ### 4. Create the PR
 
-Write the PR body to `.local/pr-body.md` (create `.local/` if needed) and create the PR:
+Ensure the final PR body is written to `.local/pr-body.md` (create `.local/` if needed), overwriting any earlier draft. Then create the PR:
 
 ```bash
 gh pr create \
   --title "<title>" \
   --body-file .local/pr-body.md \
+  --draft \
   --web
 ```
 
+- Default to `--draft`. Only omit it if the user explicitly asks for a non-draft PR.
 - Do NOT pass `--repo` — let `gh` infer the upstream from the git remotes so the PR targets the correct upstream repository.
 - Always pass `--web` to open the PR in the browser for final review before submission.
 

--- a/.agents/skills/pr-writer/SKILL.md
+++ b/.agents/skills/pr-writer/SKILL.md
@@ -28,10 +28,10 @@ Run the bundled diff script to get the base branch, commits, changed files, and 
 bash .agents/skills/pr-writer/get-diff.sh
 ```
 
-If the commit messages and diff don't provide enough context to understand the *motivation* behind the change, look at the previous 1–2 commits for additional context:
+If the commit messages and diff don't provide enough context to understand the *motivation* behind the change, look at recent commits on the branch for additional context. Use the base branch range to avoid surfacing unrelated commits from main:
 
 ```bash
-git log --format="%h %s%n%b" -2 HEAD~1
+git log --format="%h %s%n%b" $(git merge-base HEAD origin/main)..HEAD
 ```
 
 Use this only to fill in gaps — don't let older commits override what the current diff says.
@@ -44,7 +44,7 @@ Also consider the current conversation context. If the author made design decisi
 
 Read the following files — these are the **source of truth** for PR style and structure:
 
-- **PR guidelines**: `dev-docs/PR.md` (general) or `strands-py/docs/PR.md` (Python SDK). These define writing principles, anti-patterns, and checklist items. Always defer to them over general conventions.
+- **PR guidelines**: Use `strands-py/docs/PR.md` when the changes are exclusively within `strands-py/`. Otherwise use `dev-docs/PR.md`. These define writing principles, anti-patterns, and checklist items. Always defer to them over general conventions.
 - **PR template**: `.github/PULL_REQUEST_TEMPLATE.md`. This is the structural template — fill in every section it defines, in order.
 
 ### 4. Write the PR
@@ -78,4 +78,4 @@ Always prefer `gh` over manual URL construction or web scraping. If `gh` is not 
 - Fill in ALL sections of `.github/PULL_REQUEST_TEMPLATE.md`. Don't skip or rearrange them.
 - When a PR template contains checkboxes (`- [ ]`), pre-check them (`- [x]`) by default — except for any checkbox related to documentation updates or documentation examples, which should be left unchecked for the user to verify manually.
 - Output the final PR as a single markdown code block so the user can copy it directly.
-- Also write the PR body to `.local/pr-body.md` (create the `.local/` directory if it doesn't exist).
+- Also write the PR body to `.local/pr-body.md` (create the `.local/` directory if it doesn't exist). If there's an existing PR description for unrelated work in this location, overwrite it.

--- a/.agents/skills/pr-writer/SKILL.md
+++ b/.agents/skills/pr-writer/SKILL.md
@@ -42,10 +42,10 @@ Also consider the current conversation context. If the author made design decisi
 
 ### 3. Apply Project Conventions
 
-Read the following files for PR conventions and structure:
+Read the following files — these are the **source of truth** for PR style and structure:
 
-- **PR guidelines**: `dev-docs/PR.md` (general) or `strands-py/docs/PR.md` (Python SDK). Follow the writing principles, anti-patterns, and checklist items defined there.
-- **PR template**: `.github/PULL_REQUEST_TEMPLATE.md`. Use this as the structural template for the output — fill in every section it defines.
+- **PR guidelines**: `dev-docs/PR.md` (general) or `strands-py/docs/PR.md` (Python SDK). These define writing principles, anti-patterns, and checklist items. Always defer to them over general conventions.
+- **PR template**: `.github/PULL_REQUEST_TEMPLATE.md`. This is the structural template — fill in every section it defines, in order.
 
 ### 4. Write the PR
 

--- a/.agents/skills/pr-writer/SKILL.md
+++ b/.agents/skills/pr-writer/SKILL.md
@@ -28,11 +28,7 @@ Run the bundled diff script to get the base branch, commits, changed files, and 
 bash .agents/skills/pr-writer/get-diff.sh
 ```
 
-If the commit messages and diff don't provide enough context to understand the *motivation* behind the change, look at recent commits on the branch for additional context. Use the base branch range to avoid surfacing unrelated commits from main:
-
-```bash
-git log --format="%h %s%n%b" $(git merge-base HEAD origin/main)..HEAD
-```
+If the commit messages and diff don't provide enough context to understand the *motivation* behind the change, look at recent commits on the branch for additional context. Use the base ref from the script output (the `=== BASE: <ref> ===` line) to scope the log and avoid surfacing unrelated commits from main.
 
 Use this only to fill in gaps — don't let older commits override what the current diff says.
 

--- a/.agents/skills/pr-writer/SKILL.md
+++ b/.agents/skills/pr-writer/SKILL.md
@@ -70,7 +70,7 @@ Always prefer `gh` over manual URL construction or web scraping. If `gh` is not 
 - If you're uncertain about the motivation, scope, or intent of a change, **ask the user** rather than guessing. A question is always better than a wrong description.
 - Never list every file changed — that's what the diff view is for.
 - If the diff is trivial (typo fix, dependency bump), keep the description proportionally short.
-- Follow the writing principles and anti-patterns defined in `dev-docs/PR.md`.
+- Follow the writing principles and anti-patterns defined in the PR guidelines file selected in step 3.
 - Fill in ALL sections of `.github/PULL_REQUEST_TEMPLATE.md`. Don't skip or rearrange them.
 - When a PR template contains checkboxes (`- [ ]`), pre-check them (`- [x]`) by default — except for any checkbox related to documentation updates or documentation examples, which should be left unchecked for the user to verify manually.
 - Output the final PR as a single markdown code block so the user can copy it directly.

--- a/.agents/skills/pr-writer/SKILL.md
+++ b/.agents/skills/pr-writer/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: pr-writer
+description: Generates pull request titles and descriptions. Use when the user asks to write, draft, or generate a PR, pull request, or merge request description.
+---
+
+# PR Writer Skill
+
+## Persona
+
+You are a senior engineer with 10+ years of experience. You don't pad PRs with filler. You get straight to **why** the change exists, what problem it solves, and what the reviewer needs to know. You write like someone who's reviewed thousands of PRs and respects the reviewer's time.
+
+## Process
+
+When asked to generate a PR description, follow these steps in order:
+
+### 1. Check for Staged Changes
+
+Run `git diff --cached --stat` to check for staged but uncommitted changes.
+
+- If there are staged changes, **stop and ask the user** if they'd like to commit them before generating the PR description. Do not proceed until the user confirms.
+- If there are no staged changes, continue.
+
+### 2. Gather Context
+
+Run the bundled diff script to get the base branch, commits, changed files, and full diff:
+
+```bash
+bash .agents/skills/pr-writer/get-diff.sh
+```
+
+If the commit messages and diff don't provide enough context to understand the *motivation* behind the change, look at the previous 1–2 commits for additional context:
+
+```bash
+git log --format="%h %s%n%b" -2 HEAD~1
+```
+
+Use this only to fill in gaps — don't let older commits override what the current diff says.
+
+If commit messages reference a GitHub issue (e.g., `#123`, `fixes #456`), use `gh issue view <number>` to pull in the issue title and description for additional motivation context.
+
+Also consider the current conversation context. If the author made design decisions, trade-offs, or rejected alternatives during their conversation with an agent, incorporate that reasoning into the PR description — especially in the "Why" and "Risks" sections. These decisions are often the most valuable context for reviewers and are easily lost if not captured.
+
+### 3. Apply Project Conventions
+
+Read the following files for PR conventions and structure:
+
+- **PR guidelines**: `dev-docs/PR.md` (general) or `strands-py/docs/PR.md` (Python SDK). Follow the writing principles, anti-patterns, and checklist items defined there.
+- **PR template**: `.github/PULL_REQUEST_TEMPLATE.md`. Use this as the structural template for the output — fill in every section it defines.
+
+### 4. Write the PR
+
+Apply these rules:
+
+- **Title**: Must follow Conventional Commits format: `<type>(<optional scope>): <subject>`. The subject must start with a lowercase letter. Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `design`. Example: `feat(agents): add streaming support for tool results`.
+- **Why**: Lead with the motivation. What broke, what was missing, what's the business/user need. This is the most important part.
+- **What**: Concise summary of the approach. Not a file-by-file changelog — the diff already shows that. Explain the design decision.
+- **Risks / Callouts**: Anything the reviewer should scrutinize. Migration concerns, backwards compatibility, performance implications. Omit this section if there's genuinely nothing to flag.
+
+## Retrieving Information from GitHub
+
+When you need to retrieve information from GitHub (e.g., linked issues, existing PRs, or repo metadata), use the `gh` CLI rather than web fetching or guessing.
+
+Useful commands:
+
+- `gh issue view <number>` — get details of a linked issue for motivation/context
+- `gh pr list` — check for existing PRs on the current branch
+- `gh pr view <number>` — view an existing PR's details
+
+Always prefer `gh` over manual URL construction or web scraping. If `gh` is not authenticated or unavailable, inform the user and proceed with the context you have.
+
+## Rules
+
+- Never invent changes that aren't in the diff.
+- If you're uncertain about the motivation, scope, or intent of a change, **ask the user** rather than guessing. A question is always better than a wrong description.
+- Never list every file changed — that's what the diff view is for.
+- If the diff is trivial (typo fix, dependency bump), keep the description proportionally short.
+- Follow the writing principles and anti-patterns defined in `dev-docs/PR.md`.
+- Fill in ALL sections of `.github/PULL_REQUEST_TEMPLATE.md`. Don't skip or rearrange them.
+- When a PR template contains checkboxes (`- [ ]`), pre-check them (`- [x]`) by default — except for any checkbox related to documentation updates or documentation examples, which should be left unchecked for the user to verify manually.
+- Output the final PR as a single markdown code block so the user can copy it directly.
+- Also write the PR body to `.local/pr-body.md` (create the `.local/` directory if it doesn't exist).

--- a/.agents/skills/pr-writer/get-diff.sh
+++ b/.agents/skills/pr-writer/get-diff.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find the closest base ref from common branch names across all remotes and local refs.
+
+candidates=()
+for ref in main master; do
+  # Check local branch
+  if git rev-parse --verify "$ref" &>/dev/null; then
+    candidates+=("$ref")
+  fi
+  # Check all remote tracking refs (e.g. origin/main, upstream/main)
+  for remote_ref in $(git for-each-ref --format='%(refname:short)' "refs/remotes/*/$ref" 2>/dev/null); do
+    candidates+=("$remote_ref")
+  done
+done
+
+if [[ ${#candidates[@]} -eq 0 ]]; then
+  echo "ERROR: No base branch found." >&2
+  exit 1
+fi
+
+BASE="${candidates[0]}"
+best_distance=$(git rev-list --count "$BASE"..HEAD 2>/dev/null || echo 999999)
+
+for ref in "${candidates[@]:1}"; do
+  distance=$(git rev-list --count "$ref"..HEAD 2>/dev/null || echo 999999)
+  if [[ "$distance" -lt "$best_distance" ]]; then
+    BASE="$ref"
+    best_distance="$distance"
+  fi
+done
+
+echo "=== BASE: $BASE ==="
+echo "=== BRANCH: $(git branch --show-current) ==="
+echo ""
+echo "=== COMMITS ==="
+git log "$BASE"..HEAD --oneline
+echo ""
+echo "=== CHANGED FILES ==="
+git diff "$BASE"...HEAD --name-status
+echo ""
+echo "=== DIFF ==="
+git diff "$BASE"...HEAD

--- a/.agents/skills/pr-writer/get-diff.sh
+++ b/.agents/skills/pr-writer/get-diff.sh
@@ -31,6 +31,11 @@ for ref in "${candidates[@]:1}"; do
   fi
 done
 
+if [[ "$best_distance" -eq 0 ]]; then
+  echo "ERROR: HEAD has no commits ahead of $BASE. Nothing to diff." >&2
+  exit 1
+fi
+
 echo "=== BASE: $BASE ==="
 echo "=== BRANCH: $(git branch --show-current) ==="
 echo ""
@@ -39,6 +44,9 @@ git log "$BASE"..HEAD --oneline
 echo ""
 echo "=== CHANGED FILES ==="
 git diff "$BASE"...HEAD --name-status
+echo ""
+echo "=== DIFF STAT ==="
+git diff "$BASE"...HEAD --stat
 echo ""
 echo "=== DIFF ==="
 git diff "$BASE"...HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,5 @@ CLAUDE.md
 
 # dev
 .vitest*
+.local/
 


### PR DESCRIPTION
## Description

Adds `pr-create` and `pr-writer` agent skills to streamline PR authoring for contributors. The `pr-writer` skill generates PR descriptions following this repo's conventions (Conventional Commits title format, `dev-docs/PR.md` writing principles, and the GitHub PR template). The `pr-create` skill orchestrates the full flow: description generation, pre-flight checks, push, and `gh pr create --web`.

Both skills use `.local/pr-body.md` as the scratch file for PR bodies, which is now gitignored.

## Related Issues

N/A

## Documentation PR

N/A — these are internal agent skills, not user-facing documentation.

## Type of Change

New feature

## Testing

Tested by invoking both skills in a live Claude Code session on this branch.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
