### PR TITLE
feat(strands-ts): add contextManager='auto' facade on Agent

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.context-manager.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.context-manager.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { SlidingWindowConversationManager } from '../../conversation-manager/sliding-window-conversation-manager.js'
+import { SummarizingConversationManager } from '../../conversation-manager/summarizing-conversation-manager.js'
+import { ContextOffloader } from '../../vended-plugins/context-offloader/plugin.js'
+import { InMemoryStorage } from '../../vended-plugins/context-offloader/storage.js'
+import type { Plugin } from '../../plugins/plugin.js'
+import type { LocalAgent } from '../../types/agent.js'
+
+type AgentInternals = {
+  _conversationManager: { _summaryRatio?: number; _compressionThreshold?: number }
+  _pluginRegistry: { _plugins: Map<string, Plugin>; _pending: Plugin[] }
+}
+
+function getInternals(agent: Agent): AgentInternals {
+  return agent as unknown as AgentInternals
+}
+
+class StatefulMockModel extends MockMessageModel {
+  override get stateful(): boolean {
+    return true
+  }
+}
+
+describe('Agent contextManager option', () => {
+  describe('when not set', () => {
+    it('preserves default SlidingWindowConversationManager', () => {
+      const agent = new Agent({ model: new MockMessageModel(), printer: false })
+      expect(getInternals(agent)._conversationManager).toBeInstanceOf(SlidingWindowConversationManager)
+    })
+
+    it('does not add ContextOffloader plugin', () => {
+      const agent = new Agent({ model: new MockMessageModel(), printer: false })
+      const { _plugins, _pending } = getInternals(agent)._pluginRegistry
+      const allNames = [..._plugins.keys(), ..._pending.map((p) => p.name)]
+      expect(allNames).not.toContain('strands:context-offloader')
+    })
+  })
+
+  describe('when set to "auto"', () => {
+    it('uses SummarizingConversationManager', () => {
+      const agent = new Agent({ model: new MockMessageModel(), contextManager: 'auto', printer: false })
+      expect(getInternals(agent)._conversationManager).toBeInstanceOf(SummarizingConversationManager)
+    })
+
+    it('configures summaryRatio to 0.3', () => {
+      const agent = new Agent({ model: new MockMessageModel(), contextManager: 'auto', printer: false })
+      expect(getInternals(agent)._conversationManager._summaryRatio).toBe(0.3)
+    })
+
+    it('configures proactive compression threshold to 0.85', () => {
+      const agent = new Agent({ model: new MockMessageModel(), contextManager: 'auto', printer: false })
+      expect(getInternals(agent)._conversationManager._compressionThreshold).toBe(0.85)
+    })
+
+    it('adds ContextOffloader plugin', () => {
+      const agent = new Agent({ model: new MockMessageModel(), contextManager: 'auto', printer: false })
+      const { _pending } = getInternals(agent)._pluginRegistry
+      const offloader = _pending.find((p) => p.name === 'strands:context-offloader')
+      expect(offloader).toBeDefined()
+      expect(offloader).toBeInstanceOf(ContextOffloader)
+    })
+
+    it('configures offloader maxResultTokens to 1500', () => {
+      const agent = new Agent({ model: new MockMessageModel(), contextManager: 'auto', printer: false })
+      const { _pending } = getInternals(agent)._pluginRegistry
+      const offloader = _pending.find((p) => p.name === 'strands:context-offloader') as unknown as {
+        _maxResultTokens: number
+      }
+      expect(offloader._maxResultTokens).toBe(1500)
+    })
+
+    it('configures offloader previewTokens to 750', () => {
+      const agent = new Agent({ model: new MockMessageModel(), contextManager: 'auto', printer: false })
+      const { _pending } = getInternals(agent)._pluginRegistry
+      const offloader = _pending.find((p) => p.name === 'strands:context-offloader') as unknown as {
+        _previewTokens: number
+      }
+      expect(offloader._previewTokens).toBe(750)
+    })
+
+    it('configures offloader with InMemoryStorage', () => {
+      const agent = new Agent({ model: new MockMessageModel(), contextManager: 'auto', printer: false })
+      const { _pending } = getInternals(agent)._pluginRegistry
+      const offloader = _pending.find((p) => p.name === 'strands:context-offloader') as unknown as {
+        _storage: unknown
+      }
+      expect(offloader._storage).toBeInstanceOf(InMemoryStorage)
+    })
+  })
+
+  describe('coexistence with user options', () => {
+    it('respects user-provided conversationManager', () => {
+      const userCm = new SlidingWindowConversationManager({ windowSize: 20 })
+      const agent = new Agent({
+        model: new MockMessageModel(),
+        contextManager: 'auto',
+        conversationManager: userCm,
+        printer: false,
+      })
+      expect(getInternals(agent)._conversationManager).toBe(userCm)
+    })
+
+    it('still adds ContextOffloader when user provides conversationManager', () => {
+      const userCm = new SlidingWindowConversationManager({ windowSize: 20 })
+      const agent = new Agent({
+        model: new MockMessageModel(),
+        contextManager: 'auto',
+        conversationManager: userCm,
+        printer: false,
+      })
+      const { _pending } = getInternals(agent)._pluginRegistry
+      const offloader = _pending.find((p) => p.name === 'strands:context-offloader')
+      expect(offloader).toBeDefined()
+    })
+
+    it('does not duplicate user-provided ContextOffloader', () => {
+      const userOffloader = new ContextOffloader({
+        storage: new InMemoryStorage(),
+        maxResultTokens: 3000,
+        previewTokens: 1000,
+      })
+      const agent = new Agent({
+        model: new MockMessageModel(),
+        contextManager: 'auto',
+        plugins: [userOffloader],
+        printer: false,
+      })
+      const { _pending } = getInternals(agent)._pluginRegistry
+      const offloaders = _pending.filter((p) => p.name === 'strands:context-offloader')
+      expect(offloaders).toHaveLength(1)
+      expect((offloaders[0] as unknown as { _maxResultTokens: number })._maxResultTokens).toBe(3000)
+    })
+
+    it('preserves user plugins alongside auto-configured offloader', () => {
+      const customPlugin: Plugin = {
+        name: 'my-plugin',
+        initAgent(_agent: LocalAgent) {},
+      }
+      const agent = new Agent({
+        model: new MockMessageModel(),
+        contextManager: 'auto',
+        plugins: [customPlugin],
+        printer: false,
+      })
+      const { _pending } = getInternals(agent)._pluginRegistry
+      const names = _pending.map((p) => p.name)
+      expect(names).toContain('my-plugin')
+      expect(names).toContain('strands:context-offloader')
+    })
+  })
+
+  describe('with stateful model', () => {
+    it('throws when contextManager is set', () => {
+      expect(() => new Agent({ model: new StatefulMockModel(), contextManager: 'auto', printer: false })).toThrow(
+        /stateful model/
+      )
+    })
+  })
+})

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -42,8 +42,11 @@ import { InterventionRegistry } from '../interventions/registry.js'
 import type { LifecycleObserver } from '../types/lifecycle-observer.js'
 import { PluginRegistry } from '../plugins/registry.js'
 import { SlidingWindowConversationManager } from '../conversation-manager/sliding-window-conversation-manager.js'
+import { SummarizingConversationManager } from '../conversation-manager/summarizing-conversation-manager.js'
 import { NullConversationManager } from '../conversation-manager/null-conversation-manager.js'
 import { ConversationManager } from '../conversation-manager/conversation-manager.js'
+import { ContextOffloader } from '../vended-plugins/context-offloader/plugin.js'
+import { InMemoryStorage } from '../vended-plugins/context-offloader/storage.js'
 import { HookRegistryImplementation } from '../hooks/registry.js'
 import type { HookableEventConstructor, HookCallback, HookCallbackOptions, HookCleanup } from '../hooks/types.js'
 import {
@@ -172,6 +175,16 @@ export type AgentConfig = {
    * Defaults to SlidingWindowConversationManager with windowSize of 40.
    */
   conversationManager?: ConversationManager
+  /**
+   * Shorthand for automatic context management. When set to 'auto', configures:
+   * - SummarizingConversationManager (summaryRatio 0.3, proactive compression at 85%)
+   * - ContextOffloader plugin (InMemoryStorage, maxResultTokens 1500, previewTokens 750)
+   *
+   * If `conversationManager` is also provided, it takes precedence.
+   * If plugins already include a ContextOffloader, no duplicate is added.
+   * Cannot be used with stateful models.
+   */
+  contextManager?: 'auto'
   /**
    * Plugins to register with the agent.
    */
@@ -338,7 +351,19 @@ export class Agent implements LocalAgent, InvokableAgent {
           'Cannot use a conversationManager with a stateful model. The model manages conversation state server-side.'
         )
       }
+      if (config?.contextManager) {
+        throw new Error(
+          'Cannot use contextManager with a stateful model. The model manages conversation state server-side.'
+        )
+      }
       this._conversationManager = new NullConversationManager()
+    } else if (config?.contextManager === 'auto') {
+      this._conversationManager =
+        config?.conversationManager ??
+        new SummarizingConversationManager({
+          summaryRatio: 0.3,
+          proactiveCompression: { compressionThreshold: 0.85 },
+        })
     } else {
       this._conversationManager =
         config?.conversationManager ?? new SlidingWindowConversationManager({ windowSize: 40 })
@@ -364,6 +389,21 @@ export class Agent implements LocalAgent, InvokableAgent {
             : [config.retryStrategy]
     warnOnDuplicateRetryStrategyTypes(retryStrategies)
 
+    // Resolve auto context management plugins
+    const contextManagerPlugins: Plugin[] = []
+    if (config?.contextManager === 'auto') {
+      const hasOffloader = (config?.plugins ?? []).some((p) => p instanceof ContextOffloader)
+      if (!hasOffloader) {
+        contextManagerPlugins.push(
+          new ContextOffloader({
+            storage: new InMemoryStorage(),
+            maxResultTokens: 1500,
+            previewTokens: 750,
+          })
+        )
+      }
+    }
+
     // Initialize plugin registry with all plugins to be initialized during initialize().
     // Ordering notes:
     // - ModelPlugin is registered last so that on AfterInvocationEvent (which uses
@@ -375,6 +415,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     this._pluginRegistry = new PluginRegistry([
       this._conversationManager,
       ...retryStrategies,
+      ...contextManagerPlugins,
       ...(config?.plugins ?? []),
       ...(config?.sessionManager ? [config.sessionManager] : []),
       new ModelPlugin(this.model),


### PR DESCRIPTION
## Description

Adds `contextManager?: 'auto'` to `AgentConfig`. When set, wires up benchmark-winning context management defaults:
- `SummarizingConversationManager` (summaryRatio 0.3, proactive compression at 85%)
- `ContextOffloader` plugin (InMemoryStorage, maxResultTokens 1500, previewTokens 750)

Coexistence rules:
- If user also provides `conversationManager`, theirs is used (offloader still added)
- If user already has a `ContextOffloader` in their plugins list, it's not duplicated
- Raises error with stateful models (they manage context server-side)

```typescript
import { Agent } from '@strands-agents/sdk'

const agent = new Agent({ model: 'us.anthropic.claude-sonnet-4-6-v1', contextManager: 'auto' })
```

## Related Issues

strands-agents/harness-sdk#2643

## Documentation PR

N/A

## Type of Change

New feature

## Testing

- [x] 14 new unit tests covering all resolution paths (default preserved, auto wiring, coexistence with user CM, user offloader dedup, user plugins preserved, stateful model rejection)
- [x] All existing agent tests pass with no regressions

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.