### PR TITLE
feat(context-offloader): add turn-based eviction to InMemoryStorage

### DIFF
--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -149,7 +149,7 @@ class ContextOffloader(Plugin):
     def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
         """Advance the storage turn counter for eviction tracking."""
         if hasattr(self._storage, "tick"):
-            self._storage.tick()
+            self._storage.tick(caller=self)
 
     @tool(context=True)
     def retrieve_offloaded_content(

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -140,7 +140,9 @@ class ContextOffloader(Plugin):
         super().__init__()
 
     def init_agent(self, agent: Agent) -> None:
-        """Conditionally register the retrieval tool."""
+        """Conditionally register the retrieval tool and bind storage."""
+        if isinstance(self._storage, InMemoryStorage):
+            self._storage._bind(id(agent))
         if not self._include_retrieval_tool:
             # Remove the auto-discovered retrieval tool
             self._tools = [t for t in self._tools if t.tool_name != "retrieve_offloaded_content"]

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -147,9 +147,9 @@ class ContextOffloader(Plugin):
 
     @hook
     def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
-        """Advance the storage turn counter for eviction tracking."""
-        if hasattr(self._storage, "tick"):
-            self._storage.tick(caller=self)
+        """Trigger eviction of stale entries based on the agent's cycle count."""
+        if hasattr(self._storage, "_evict"):
+            self._storage._evict(event.agent.event_loop_metrics.cycle_count)
 
     @tool(context=True)
     def retrieve_offloaded_content(

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -41,7 +41,7 @@ from ...plugins import Plugin, hook
 from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
-from .storage import Storage
+from .storage import InMemoryStorage, Storage
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
@@ -148,7 +148,7 @@ class ContextOffloader(Plugin):
     @hook
     def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
         """Trigger eviction of stale entries based on the agent's cycle count."""
-        if hasattr(self._storage, "_evict"):
+        if isinstance(self._storage, InMemoryStorage):
             self._storage._evict(event.agent.event_loop_metrics.cycle_count)
 
     @tool(context=True)

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -36,7 +36,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from ...hooks.events import AfterToolCallEvent
+from ...hooks.events import AfterToolCallEvent, BeforeModelCallEvent
 from ...plugins import Plugin, hook
 from ...tools.decorator import tool
 from ...types.content import Message
@@ -144,6 +144,12 @@ class ContextOffloader(Plugin):
         if not self._include_retrieval_tool:
             # Remove the auto-discovered retrieval tool
             self._tools = [t for t in self._tools if t.tool_name != "retrieve_offloaded_content"]
+
+    @hook
+    def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
+        """Advance the storage turn counter for eviction tracking."""
+        if hasattr(self._storage, "tick"):
+            self._storage.tick()
 
     @tool(context=True)
     def retrieve_offloaded_content(

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -26,6 +26,7 @@ Example:
 """
 
 import json
+import logging
 import re
 import threading
 import time
@@ -35,6 +36,8 @@ from typing import Any, Protocol, runtime_checkable
 import boto3
 from botocore.config import Config as BotocoreConfig
 from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
 
 
 def _sanitize_id(raw_id: str) -> str:
@@ -213,17 +216,36 @@ class InMemoryStorage:
     Useful for testing and serverless environments where disk access
     is not available or not desired. Thread-safe.
 
-    Note:
-        Content accumulates for the lifetime of this instance. For long-running
-        agents, consider creating a new instance per session or switching to
-        ``FileStorage`` or ``S3Storage`` for persistent storage with external
-        lifecycle management.
+    Supports turn-based eviction: entries not accessed (stored or retrieved)
+    within ``evict_after_turns`` turns are automatically removed when ``tick()``
+    is called. The ``ContextOffloader`` plugin calls ``tick()`` on each model
+    invocation cycle. Eviction is enabled by default (10 turns). Pass ``None``
+    to disable.
+
+    Args:
+        evict_after_turns: Number of turns of inactivity before an entry is
+            evicted. Defaults to 10. ``None`` disables eviction.
     """
 
-    def __init__(self) -> None:
-        """Initialize in-memory storage."""
-        self._store: dict[str, tuple[bytes, str]] = {}
+    _DEFAULT_EVICT_AFTER_TURNS = 10
+
+    def __init__(self, evict_after_turns: int | None = _DEFAULT_EVICT_AFTER_TURNS) -> None:
+        """Initialize in-memory storage.
+
+        Args:
+            evict_after_turns: Number of turns of inactivity before an entry is
+                evicted. Defaults to 10. ``None`` disables eviction.
+
+        Raises:
+            ValueError: If evict_after_turns is not a positive integer.
+        """
+        if evict_after_turns is not None and evict_after_turns < 1:
+            raise ValueError("evict_after_turns must be a positive integer")
+
+        self._store: dict[str, tuple[bytes, str, int]] = {}
         self._counter: int = 0
+        self._current_turn: int = 0
+        self._evict_after_turns: int | None = evict_after_turns
         self._lock = threading.Lock()
 
     def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
@@ -240,11 +262,14 @@ class InMemoryStorage:
         with self._lock:
             self._counter += 1
             reference = f"mem_{self._counter}_{key}"
-            self._store[reference] = (content, content_type)
+            self._store[reference] = (content, content_type, self._current_turn)
         return reference
 
     def retrieve(self, reference: str) -> tuple[bytes, str]:
         """Retrieve content from memory.
+
+        Refreshes the last-accessed turn so the entry stays alive longer
+        when eviction is enabled.
 
         Args:
             reference: The reference returned by store().
@@ -253,12 +278,32 @@ class InMemoryStorage:
             A tuple of (content bytes, content type).
 
         Raises:
-            KeyError: If the reference is not found.
+            KeyError: If the reference is not found (or was evicted).
         """
         with self._lock:
             if reference not in self._store:
                 raise KeyError(f"Reference not found: {reference}")
-            return self._store[reference]
+            content, content_type, _ = self._store[reference]
+            self._store[reference] = (content, content_type, self._current_turn)
+            return content, content_type
+
+    def tick(self) -> None:
+        """Advance the turn counter and evict stale entries.
+
+        Called by the ContextOffloader plugin on each ``BeforeModelCallEvent``.
+        Entries whose last-accessed turn is more than ``evict_after_turns``
+        behind the current turn are removed.
+        """
+        with self._lock:
+            self._current_turn += 1
+            if self._evict_after_turns is None:
+                return
+            threshold = self._current_turn - self._evict_after_turns
+            stale_refs = [ref for ref, (_, _, last_accessed) in self._store.items() if last_accessed < threshold]
+            for ref in stale_refs:
+                del self._store[ref]
+            if stale_refs:
+                logger.debug("evicted=%d, current_turn=%d | stale entries removed", len(stale_refs), self._current_turn)
 
     def clear(self) -> None:
         """Remove all stored content.

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -223,7 +223,9 @@ class InMemoryStorage:
 
     Note:
         Content does not survive process restarts. For multi-session
-        persistence, use ``FileStorage`` or ``S3Storage``.
+        persistence, use ``FileStorage`` or ``S3Storage``. Each agent should
+        use its own ``InMemoryStorage`` instance — sharing one across multiple
+        agents is not supported when eviction is enabled.
 
         Evicted entries are permanently deleted from memory. The agent will
         receive an error if it attempts to retrieve evicted content. The
@@ -254,6 +256,7 @@ class InMemoryStorage:
         self._counter: int = 0
         self._current_cycle: int = 0
         self._evict_after_turns: int | None = evict_after_turns
+        self._bound_agent_id: int | None = None
         self._lock = threading.Lock()
 
     def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
@@ -295,6 +298,21 @@ class InMemoryStorage:
             self._store[reference] = (content, content_type, self._current_cycle)
             return content, content_type
 
+    def _bind(self, agent_id: int) -> None:
+        """Claim this storage for a single agent.
+
+        Raises:
+            ValueError: If already bound to a different agent.
+        """
+        with self._lock:
+            if self._bound_agent_id is None:
+                self._bound_agent_id = agent_id
+            elif self._bound_agent_id != agent_id:
+                raise ValueError(
+                    "InMemoryStorage cannot be shared across multiple agents. "
+                    "Use a separate InMemoryStorage instance per agent."
+                )
+
     def _evict(self, cycle: int) -> None:
         """Update current cycle and evict stale entries.
 
@@ -306,7 +324,7 @@ class InMemoryStorage:
             cycle: The agent's current event loop cycle count.
         """
         with self._lock:
-            self._current_cycle = max(self._current_cycle, cycle)
+            self._current_cycle = cycle
             if self._evict_after_turns is None:
                 return
             threshold = cycle - self._evict_after_turns

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -216,15 +216,15 @@ class InMemoryStorage:
     Useful for testing and serverless environments where disk access
     is not available or not desired. Thread-safe.
 
-    Supports two eviction strategies that compose together:
-
-    - **Turn-based TTL**: entries not accessed within ``evict_after_turns``
-      agent loop cycles are removed. The ``ContextOffloader`` plugin triggers
-      this on each model invocation cycle. Defaults to 10 cycles.
-    - **Capacity cap**: when ``max_entries`` is set, the least-recently-accessed
-      entry is evicted on ``store()`` when the cap is reached.
+    Supports turn-based eviction: entries not accessed (stored or retrieved)
+    within ``evict_after_turns`` agent loop cycles are automatically removed.
+    The ``ContextOffloader`` plugin triggers eviction on each model invocation
+    cycle. Eviction is enabled by default (10 cycles). Pass ``None`` to disable.
 
     Note:
+        Content does not survive process restarts. For multi-session
+        persistence, use ``FileStorage`` or ``S3Storage``.
+
         Evicted entries are permanently deleted from memory. The agent will
         receive an error if it attempts to retrieve evicted content. The
         original tool result is not preserved in the conversation history
@@ -232,49 +232,32 @@ class InMemoryStorage:
 
     Args:
         evict_after_turns: Number of cycles of inactivity before an entry is
-            evicted. Defaults to 10. ``None`` disables turn-based eviction.
-        max_entries: Maximum number of entries to keep. When exceeded, the
-            least-recently-accessed entry is evicted. ``None`` disables the
-            cap (default).
+            evicted. Defaults to 10. ``None`` disables eviction.
     """
 
     _DEFAULT_EVICT_AFTER_TURNS = 10
 
-    def __init__(
-        self,
-        evict_after_turns: int | None = _DEFAULT_EVICT_AFTER_TURNS,
-        max_entries: int | None = None,
-    ) -> None:
+    def __init__(self, evict_after_turns: int | None = _DEFAULT_EVICT_AFTER_TURNS) -> None:
         """Initialize in-memory storage.
 
         Args:
             evict_after_turns: Number of cycles of inactivity before an entry is
-                evicted. Defaults to 10. ``None`` disables turn-based eviction.
-            max_entries: Maximum number of entries to keep. ``None`` disables
-                the cap (default).
+                evicted. Defaults to 10. ``None`` disables eviction.
 
         Raises:
-            ValueError: If evict_after_turns is not a positive integer, or
-                max_entries is not a positive integer.
+            ValueError: If evict_after_turns is not a positive integer.
         """
         if evict_after_turns is not None and evict_after_turns < 1:
             raise ValueError("evict_after_turns must be a positive integer")
-        if max_entries is not None and max_entries < 1:
-            raise ValueError("max_entries must be a positive integer")
 
-        self._store: dict[str, tuple[bytes, str, int, int]] = {}
+        self._store: dict[str, tuple[bytes, str, int]] = {}
         self._counter: int = 0
         self._current_cycle: int = 0
-        self._access_seq: int = 0
         self._evict_after_turns: int | None = evict_after_turns
-        self._max_entries: int | None = max_entries
         self._lock = threading.Lock()
 
     def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
         """Store content in memory and return a reference.
-
-        If ``max_entries`` is set and the store is at capacity, the
-        least-recently-accessed entry is evicted before storing.
 
         Args:
             key: A unique key for this content block.
@@ -285,13 +268,9 @@ class InMemoryStorage:
             A unique reference string.
         """
         with self._lock:
-            if self._max_entries is not None and len(self._store) >= self._max_entries:
-                lru_ref = min(self._store, key=lambda r: self._store[r][3])
-                del self._store[lru_ref]
             self._counter += 1
-            self._access_seq += 1
             reference = f"mem_{self._counter}_{key}"
-            self._store[reference] = (content, content_type, self._current_cycle, self._access_seq)
+            self._store[reference] = (content, content_type, self._current_cycle)
         return reference
 
     def retrieve(self, reference: str) -> tuple[bytes, str]:
@@ -312,9 +291,8 @@ class InMemoryStorage:
         with self._lock:
             if reference not in self._store:
                 raise KeyError(f"Reference not found: {reference}")
-            content, content_type, _, _ = self._store[reference]
-            self._access_seq += 1
-            self._store[reference] = (content, content_type, self._current_cycle, self._access_seq)
+            content, content_type, _ = self._store[reference]
+            self._store[reference] = (content, content_type, self._current_cycle)
             return content, content_type
 
     def _evict(self, cycle: int) -> None:
@@ -333,12 +311,12 @@ class InMemoryStorage:
                 return
             threshold = cycle - self._evict_after_turns
             stale_refs = [
-                ref for ref, (_, _, last_cycle, _) in self._store.items() if last_cycle < threshold
+                ref for ref, (_, _, last_cycle) in self._store.items() if last_cycle < threshold
             ]
             for ref in stale_refs:
                 del self._store[ref]
             if stale_refs:
-                logger.debug("evicted=%d, cycle=%d | stale entries removed", len(stale_refs), cycle)
+                logger.debug("evicted=<%d>, cycle=<%d> | stale entries removed", len(stale_refs), cycle)
 
     def clear(self) -> None:
         """Remove all stored content.

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -216,10 +216,13 @@ class InMemoryStorage:
     Useful for testing and serverless environments where disk access
     is not available or not desired. Thread-safe.
 
-    Supports turn-based eviction: entries not accessed (stored or retrieved)
-    within ``evict_after_turns`` agent loop cycles are automatically removed.
-    The ``ContextOffloader`` plugin triggers eviction on each model invocation
-    cycle. Eviction is enabled by default (10 cycles). Pass ``None`` to disable.
+    Supports two eviction strategies that compose together:
+
+    - **Turn-based TTL**: entries not accessed within ``evict_after_turns``
+      agent loop cycles are removed. The ``ContextOffloader`` plugin triggers
+      this on each model invocation cycle. Defaults to 10 cycles.
+    - **Capacity cap**: when ``max_entries`` is set, the least-recently-accessed
+      entry is evicted on ``store()`` when the cap is reached.
 
     Note:
         Evicted entries are permanently deleted from memory. The agent will
@@ -229,32 +232,49 @@ class InMemoryStorage:
 
     Args:
         evict_after_turns: Number of cycles of inactivity before an entry is
-            evicted. Defaults to 10. ``None`` disables eviction.
+            evicted. Defaults to 10. ``None`` disables turn-based eviction.
+        max_entries: Maximum number of entries to keep. When exceeded, the
+            least-recently-accessed entry is evicted. ``None`` disables the
+            cap (default).
     """
 
     _DEFAULT_EVICT_AFTER_TURNS = 10
 
-    def __init__(self, evict_after_turns: int | None = _DEFAULT_EVICT_AFTER_TURNS) -> None:
+    def __init__(
+        self,
+        evict_after_turns: int | None = _DEFAULT_EVICT_AFTER_TURNS,
+        max_entries: int | None = None,
+    ) -> None:
         """Initialize in-memory storage.
 
         Args:
-            evict_after_turns: Number of turns of inactivity before an entry is
-                evicted. Defaults to 10. ``None`` disables eviction.
+            evict_after_turns: Number of cycles of inactivity before an entry is
+                evicted. Defaults to 10. ``None`` disables turn-based eviction.
+            max_entries: Maximum number of entries to keep. ``None`` disables
+                the cap (default).
 
         Raises:
-            ValueError: If evict_after_turns is not a positive integer.
+            ValueError: If evict_after_turns is not a positive integer, or
+                max_entries is not a positive integer.
         """
         if evict_after_turns is not None and evict_after_turns < 1:
             raise ValueError("evict_after_turns must be a positive integer")
+        if max_entries is not None and max_entries < 1:
+            raise ValueError("max_entries must be a positive integer")
 
-        self._store: dict[str, tuple[bytes, str, int]] = {}
+        self._store: dict[str, tuple[bytes, str, int, int]] = {}
         self._counter: int = 0
         self._current_cycle: int = 0
+        self._access_seq: int = 0
         self._evict_after_turns: int | None = evict_after_turns
+        self._max_entries: int | None = max_entries
         self._lock = threading.Lock()
 
     def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
         """Store content in memory and return a reference.
+
+        If ``max_entries`` is set and the store is at capacity, the
+        least-recently-accessed entry is evicted before storing.
 
         Args:
             key: A unique key for this content block.
@@ -265,9 +285,13 @@ class InMemoryStorage:
             A unique reference string.
         """
         with self._lock:
+            if self._max_entries is not None and len(self._store) >= self._max_entries:
+                lru_ref = min(self._store, key=lambda r: self._store[r][3])
+                del self._store[lru_ref]
             self._counter += 1
+            self._access_seq += 1
             reference = f"mem_{self._counter}_{key}"
-            self._store[reference] = (content, content_type, self._current_cycle)
+            self._store[reference] = (content, content_type, self._current_cycle, self._access_seq)
         return reference
 
     def retrieve(self, reference: str) -> tuple[bytes, str]:
@@ -288,8 +312,9 @@ class InMemoryStorage:
         with self._lock:
             if reference not in self._store:
                 raise KeyError(f"Reference not found: {reference}")
-            content, content_type, _ = self._store[reference]
-            self._store[reference] = (content, content_type, self._current_cycle)
+            content, content_type, _, _ = self._store[reference]
+            self._access_seq += 1
+            self._store[reference] = (content, content_type, self._current_cycle, self._access_seq)
             return content, content_type
 
     def _evict(self, cycle: int) -> None:
@@ -307,7 +332,9 @@ class InMemoryStorage:
             if self._evict_after_turns is None:
                 return
             threshold = cycle - self._evict_after_turns
-            stale_refs = [ref for ref, (_, _, last_accessed) in self._store.items() if last_accessed < threshold]
+            stale_refs = [
+                ref for ref, (_, _, last_cycle, _) in self._store.items() if last_cycle < threshold
+            ]
             for ref in stale_refs:
                 del self._store[ref]
             if stale_refs:

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -246,6 +246,7 @@ class InMemoryStorage:
         self._counter: int = 0
         self._current_turn: int = 0
         self._evict_after_turns: int | None = evict_after_turns
+        self._tick_owner: object | None = None
         self._lock = threading.Lock()
 
     def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
@@ -287,14 +288,26 @@ class InMemoryStorage:
             self._store[reference] = (content, content_type, self._current_turn)
             return content, content_type
 
-    def tick(self) -> None:
+    def tick(self, caller: object | None = None) -> None:
         """Advance the turn counter and evict stale entries.
 
         Called by the ContextOffloader plugin on each ``BeforeModelCallEvent``.
         Entries whose last-accessed turn is more than ``evict_after_turns``
         behind the current turn are removed.
+
+        When multiple plugins share a single storage instance, only the first
+        caller to invoke ``tick()`` becomes the owner. Subsequent callers are
+        ignored to prevent the turn counter from advancing too fast.
+
+        Args:
+            caller: Identity of the calling plugin. Used for ownership tracking.
         """
         with self._lock:
+            if self._tick_owner is None:
+                self._tick_owner = caller
+            elif caller is not None and self._tick_owner is not caller:
+                return
+
             self._current_turn += 1
             if self._evict_after_turns is None:
                 return

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -219,7 +219,7 @@ class InMemoryStorage:
     Supports turn-based eviction: entries not accessed (stored or retrieved)
     within ``evict_after_turns`` agent loop cycles are automatically removed.
     The ``ContextOffloader`` plugin triggers eviction on each model invocation
-    cycle. Eviction is enabled by default (10 cycles). Pass ``None`` to disable.
+    cycle. Eviction is enabled by default (20 cycles). Pass ``None`` to disable.
 
     Note:
         Content does not survive process restarts. For multi-session
@@ -232,17 +232,17 @@ class InMemoryStorage:
 
     Args:
         evict_after_turns: Number of cycles of inactivity before an entry is
-            evicted. Defaults to 10. ``None`` disables eviction.
+            evicted. Defaults to 20. ``None`` disables eviction.
     """
 
-    _DEFAULT_EVICT_AFTER_TURNS = 10
+    _DEFAULT_EVICT_AFTER_TURNS = 20
 
     def __init__(self, evict_after_turns: int | None = _DEFAULT_EVICT_AFTER_TURNS) -> None:
         """Initialize in-memory storage.
 
         Args:
             evict_after_turns: Number of cycles of inactivity before an entry is
-                evicted. Defaults to 10. ``None`` disables eviction.
+                evicted. Defaults to 20. ``None`` disables eviction.
 
         Raises:
             ValueError: If evict_after_turns is not a positive integer.
@@ -306,7 +306,7 @@ class InMemoryStorage:
             cycle: The agent's current event loop cycle count.
         """
         with self._lock:
-            self._current_cycle = cycle
+            self._current_cycle = max(self._current_cycle, cycle)
             if self._evict_after_turns is None:
                 return
             threshold = cycle - self._evict_after_turns

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -244,9 +244,8 @@ class InMemoryStorage:
 
         self._store: dict[str, tuple[bytes, str, int]] = {}
         self._counter: int = 0
-        self._current_turn: int = 0
+        self._current_cycle: int = 0
         self._evict_after_turns: int | None = evict_after_turns
-        self._tick_owner: object | None = None
         self._lock = threading.Lock()
 
     def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
@@ -263,7 +262,7 @@ class InMemoryStorage:
         with self._lock:
             self._counter += 1
             reference = f"mem_{self._counter}_{key}"
-            self._store[reference] = (content, content_type, self._current_turn)
+            self._store[reference] = (content, content_type, self._current_cycle)
         return reference
 
     def retrieve(self, reference: str) -> tuple[bytes, str]:
@@ -285,38 +284,29 @@ class InMemoryStorage:
             if reference not in self._store:
                 raise KeyError(f"Reference not found: {reference}")
             content, content_type, _ = self._store[reference]
-            self._store[reference] = (content, content_type, self._current_turn)
+            self._store[reference] = (content, content_type, self._current_cycle)
             return content, content_type
 
-    def tick(self, caller: object | None = None) -> None:
-        """Advance the turn counter and evict stale entries.
+    def _evict(self, cycle: int) -> None:
+        """Update current cycle and evict stale entries.
 
         Called by the ContextOffloader plugin on each ``BeforeModelCallEvent``.
-        Entries whose last-accessed turn is more than ``evict_after_turns``
-        behind the current turn are removed.
-
-        When multiple plugins share a single storage instance, only the first
-        caller to invoke ``tick()`` becomes the owner. Subsequent callers are
-        ignored to prevent the turn counter from advancing too fast.
+        Entries whose last-accessed cycle is more than ``evict_after_turns``
+        behind the current cycle are removed.
 
         Args:
-            caller: Identity of the calling plugin. Used for ownership tracking.
+            cycle: The agent's current event loop cycle count.
         """
         with self._lock:
-            if self._tick_owner is None:
-                self._tick_owner = caller
-            elif caller is not None and self._tick_owner is not caller:
-                return
-
-            self._current_turn += 1
+            self._current_cycle = cycle
             if self._evict_after_turns is None:
                 return
-            threshold = self._current_turn - self._evict_after_turns
+            threshold = cycle - self._evict_after_turns
             stale_refs = [ref for ref, (_, _, last_accessed) in self._store.items() if last_accessed < threshold]
             for ref in stale_refs:
                 del self._store[ref]
             if stale_refs:
-                logger.debug("evicted=%d, current_turn=%d | stale entries removed", len(stale_refs), self._current_turn)
+                logger.debug("evicted=%d, cycle=%d | stale entries removed", len(stale_refs), cycle)
 
     def clear(self) -> None:
         """Remove all stored content.

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -217,13 +217,18 @@ class InMemoryStorage:
     is not available or not desired. Thread-safe.
 
     Supports turn-based eviction: entries not accessed (stored or retrieved)
-    within ``evict_after_turns`` turns are automatically removed when ``tick()``
-    is called. The ``ContextOffloader`` plugin calls ``tick()`` on each model
-    invocation cycle. Eviction is enabled by default (10 turns). Pass ``None``
-    to disable.
+    within ``evict_after_turns`` agent loop cycles are automatically removed.
+    The ``ContextOffloader`` plugin triggers eviction on each model invocation
+    cycle. Eviction is enabled by default (10 cycles). Pass ``None`` to disable.
+
+    Note:
+        Evicted entries are permanently deleted from memory. The agent will
+        receive an error if it attempts to retrieve evicted content. The
+        original tool result is not preserved in the conversation history
+        after offloading — only the preview and references remain in context.
 
     Args:
-        evict_after_turns: Number of turns of inactivity before an entry is
+        evict_after_turns: Number of cycles of inactivity before an entry is
             evicted. Defaults to 10. ``None`` disables eviction.
     """
 

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from strands.hooks.events import AfterToolCallEvent
+from strands.hooks.events import AfterToolCallEvent, BeforeModelCallEvent
 from strands.types.tools import ToolContext, ToolUse
 from strands.vended_plugins.context_offloader import (
     ContextOffloader,
@@ -84,8 +84,10 @@ class TestContextOffloader:
         assert plugin.name == "context_offloader"
 
     def test_hooks_auto_discovered(self, plugin):
-        assert len(plugin.hooks) == 1
-        assert plugin.hooks[0].__name__ == "_handle_tool_result"
+        assert len(plugin.hooks) == 2
+        hook_names = {h.__name__ for h in plugin.hooks}
+        assert "_handle_tool_result" in hook_names
+        assert "_on_before_model_call" in hook_names
 
     def test_raises_on_non_positive_max_result_tokens(self):
         with pytest.raises(ValueError, match="max_result_tokens must be positive"):
@@ -589,3 +591,36 @@ class TestActionableReferences:
 
         result_text = event.result["content"][0]["text"]
         assert "mem_" in result_text
+
+
+class TestBeforeModelCallHook:
+    def test_calls_tick_on_storage_with_tick(self):
+        storage = InMemoryStorage(evict_after_turns=5)
+        plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+        event = BeforeModelCallEvent(agent=MagicMock(), invocation_state={})
+
+        plugin._on_before_model_call(event)
+
+        assert storage._current_turn == 1
+
+    def test_does_not_crash_on_storage_without_tick(self):
+        storage = MagicMock(spec=["store", "retrieve"])
+        plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+        event = BeforeModelCallEvent(agent=MagicMock(), invocation_state={})
+
+        plugin._on_before_model_call(event)
+
+    def test_eviction_triggered_via_hook(self):
+        storage = InMemoryStorage(evict_after_turns=2)
+        plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+        event = BeforeModelCallEvent(agent=MagicMock(), invocation_state={})
+
+        ref = storage.store("key_1", b"content")
+
+        # Advance 3 turns without accessing — entry should be evicted
+        # stored at turn 0, tick to turn 3, threshold = 3 - 2 = 1, 0 < 1 → evicted
+        plugin._on_before_model_call(event)
+        plugin._on_before_model_call(event)
+        plugin._on_before_model_call(event)
+        with pytest.raises(KeyError):
+            storage.retrieve(ref)

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -624,3 +624,23 @@ class TestBeforeModelCallHook:
         plugin._on_before_model_call(event)
         with pytest.raises(KeyError):
             storage.retrieve(ref)
+
+    def test_shared_storage_only_first_plugin_ticks(self):
+        storage = InMemoryStorage(evict_after_turns=3)
+        plugin1 = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+        plugin2 = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+        event = BeforeModelCallEvent(agent=MagicMock(), invocation_state={})
+
+        ref = storage.store("key_1", b"content")
+
+        # Both plugins tick, but only the first one's ticks count
+        plugin1._on_before_model_call(event)
+        plugin2._on_before_model_call(event)
+        plugin1._on_before_model_call(event)
+        plugin2._on_before_model_call(event)
+        plugin1._on_before_model_call(event)
+        plugin2._on_before_model_call(event)
+
+        # Only 3 real ticks (from plugin1). threshold = 3 - 3 = 0, stored at 0, 0 < 0 is false
+        assert storage._current_turn == 3
+        assert storage.retrieve(ref) == (b"content", "text/plain")

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -594,53 +594,34 @@ class TestActionableReferences:
 
 
 class TestBeforeModelCallHook:
-    def test_calls_tick_on_storage_with_tick(self):
+    @staticmethod
+    def _make_event(cycle_count):
+        agent = MagicMock()
+        agent.event_loop_metrics.cycle_count = cycle_count
+        return BeforeModelCallEvent(agent=agent, invocation_state={})
+
+    def test_calls_evict_with_cycle_count(self):
         storage = InMemoryStorage(evict_after_turns=5)
         plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
-        event = BeforeModelCallEvent(agent=MagicMock(), invocation_state={})
 
-        plugin._on_before_model_call(event)
+        plugin._on_before_model_call(self._make_event(7))
 
-        assert storage._current_turn == 1
+        assert storage._current_cycle == 7
 
-    def test_does_not_crash_on_storage_without_tick(self):
+    def test_does_not_crash_on_storage_without_evict(self):
         storage = MagicMock(spec=["store", "retrieve"])
         plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
-        event = BeforeModelCallEvent(agent=MagicMock(), invocation_state={})
 
-        plugin._on_before_model_call(event)
+        plugin._on_before_model_call(self._make_event(1))
 
     def test_eviction_triggered_via_hook(self):
         storage = InMemoryStorage(evict_after_turns=2)
         plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
-        event = BeforeModelCallEvent(agent=MagicMock(), invocation_state={})
 
         ref = storage.store("key_1", b"content")
 
-        # Advance 3 turns without accessing — entry should be evicted
-        # stored at turn 0, tick to turn 3, threshold = 3 - 2 = 1, 0 < 1 → evicted
-        plugin._on_before_model_call(event)
-        plugin._on_before_model_call(event)
-        plugin._on_before_model_call(event)
+        # stored at cycle 0, evict at cycle 3: threshold = 3 - 2 = 1, 0 < 1 → evicted
+        plugin._on_before_model_call(self._make_event(3))
         with pytest.raises(KeyError):
             storage.retrieve(ref)
 
-    def test_shared_storage_only_first_plugin_ticks(self):
-        storage = InMemoryStorage(evict_after_turns=3)
-        plugin1 = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
-        plugin2 = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
-        event = BeforeModelCallEvent(agent=MagicMock(), invocation_state={})
-
-        ref = storage.store("key_1", b"content")
-
-        # Both plugins tick, but only the first one's ticks count
-        plugin1._on_before_model_call(event)
-        plugin2._on_before_model_call(event)
-        plugin1._on_before_model_call(event)
-        plugin2._on_before_model_call(event)
-        plugin1._on_before_model_call(event)
-        plugin2._on_before_model_call(event)
-
-        # Only 3 real ticks (from plugin1). threshold = 3 - 3 = 0, stored at 0, 0 < 0 is false
-        assert storage._current_turn == 3
-        assert storage.retrieve(ref) == (b"content", "text/plain")

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -106,7 +106,7 @@ class TestInMemoryStorageEviction:
         assert storage._evict_after_turns == 10
         ref = storage.store("key_1", b"content")
         for _ in range(11):
-            storage.tick()
+            storage._evict(storage._current_cycle + 1)
         with pytest.raises(KeyError):
             storage.retrieve(ref)
 
@@ -114,27 +114,27 @@ class TestInMemoryStorageEviction:
         storage = InMemoryStorage(evict_after_turns=None)
         ref = storage.store("key_1", b"content")
         for _ in range(100):
-            storage.tick()
+            storage._evict(storage._current_cycle + 1)
         assert storage.retrieve(ref) == (b"content", "text/plain")
 
     def test_entry_evicted_after_n_turns(self):
         storage = InMemoryStorage(evict_after_turns=3)
         ref = storage.store("key_1", b"content")
 
-        storage.tick()  # turn 1
-        storage.tick()  # turn 2
-        storage.tick()  # turn 3 — threshold = 3 - 3 = 0, stored at 0, 0 < 0 is false
+        storage._evict(storage._current_cycle + 1)  # turn 1
+        storage._evict(storage._current_cycle + 1)  # turn 2
+        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 3 - 3 = 0, stored at 0, 0 < 0 is false
         assert storage.retrieve(ref) == (b"content", "text/plain")
 
-        storage.tick()  # turn 4 — threshold = 4 - 3 = 1, stored at 3 (refreshed by retrieve), 3 < 1 is false
+        storage._evict(storage._current_cycle + 1)  # turn 4 — threshold = 4 - 3 = 1, stored at 3 (refreshed by retrieve), 3 < 1 is false
         assert storage.retrieve(ref) == (b"content", "text/plain")
 
     def test_entry_evicted_without_access(self):
         storage = InMemoryStorage(evict_after_turns=2)
         ref = storage.store("key_1", b"content")
 
-        storage.tick()  # turn 1
-        storage.tick()  # turn 2 — threshold = 2 - 2 = 0, stored at 0, 0 < 0 is false
+        storage._evict(storage._current_cycle + 1)  # turn 1
+        storage._evict(storage._current_cycle + 1)  # turn 2 — threshold = 2 - 2 = 0, stored at 0, 0 < 0 is false
         # Entry still alive at exact boundary
         content, _ = storage.retrieve(ref)
         assert content == b"content"
@@ -143,9 +143,9 @@ class TestInMemoryStorageEviction:
         storage = InMemoryStorage(evict_after_turns=2)
         ref = storage.store("key_1", b"content")
 
-        storage.tick()  # turn 1
-        storage.tick()  # turn 2
-        storage.tick()  # turn 3 — threshold = 3 - 2 = 1, stored at 0, 0 < 1 is true → evicted
+        storage._evict(storage._current_cycle + 1)  # turn 1
+        storage._evict(storage._current_cycle + 1)  # turn 2
+        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 3 - 2 = 1, stored at 0, 0 < 1 is true → evicted
         with pytest.raises(KeyError):
             storage.retrieve(ref)
 
@@ -153,31 +153,31 @@ class TestInMemoryStorageEviction:
         storage = InMemoryStorage(evict_after_turns=2)
         ref = storage.store("key_1", b"content")
 
-        storage.tick()  # turn 1
+        storage._evict(storage._current_cycle + 1)  # turn 1
         storage.retrieve(ref)  # refreshes last_accessed to turn 1
 
-        storage.tick()  # turn 2
-        storage.tick()  # turn 3 — threshold = 3 - 2 = 1, last_accessed = 1, 1 < 1 is false
+        storage._evict(storage._current_cycle + 1)  # turn 2
+        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 3 - 2 = 1, last_accessed = 1, 1 < 1 is false
         assert storage.retrieve(ref) == (b"content", "text/plain")
 
     def test_multiple_entries_evicted_independently(self):
         storage = InMemoryStorage(evict_after_turns=2)
         ref1 = storage.store("key_1", b"first")
 
-        storage.tick()  # turn 1
+        storage._evict(storage._current_cycle + 1)  # turn 1
         ref2 = storage.store("key_2", b"second")
 
-        storage.tick()  # turn 2
-        storage.tick()  # turn 3 — threshold = 1. ref1 stored at 0 (evicted), ref2 stored at 1 (0 < 1, but 1 < 1 is false)
+        storage._evict(storage._current_cycle + 1)  # turn 2
+        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 1. ref1 stored at 0 (evicted), ref2 stored at 1 (0 < 1, but 1 < 1 is false)
         with pytest.raises(KeyError):
             storage.retrieve(ref1)
         assert storage.retrieve(ref2) == (b"second", "text/plain")
 
-    def test_tick_with_eviction_disabled_still_increments_turn(self):
+    def test_evict_updates_current_cycle(self):
         storage = InMemoryStorage()
-        assert storage._current_turn == 0
-        storage.tick()
-        assert storage._current_turn == 1
+        assert storage._current_cycle == 0
+        storage._evict(5)
+        assert storage._current_cycle == 5
 
     def test_thread_safety_with_eviction(self):
         storage = InMemoryStorage(evict_after_turns=5)
@@ -188,7 +188,7 @@ class TestInMemoryStorageEviction:
             try:
                 ref = storage.store(f"key_{i}", f"content_{i}".encode())
                 refs.append(ref)
-                storage.tick()
+                storage._evict(storage._current_cycle + 1)
             except Exception as e:
                 errors.append(e)
 

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -94,6 +94,113 @@ class TestInMemoryStorage:
         storage.clear()
 
 
+class TestInMemoryStorageEviction:
+    def test_evict_after_turns_validation(self):
+        with pytest.raises(ValueError, match="evict_after_turns must be a positive integer"):
+            InMemoryStorage(evict_after_turns=0)
+        with pytest.raises(ValueError, match="evict_after_turns must be a positive integer"):
+            InMemoryStorage(evict_after_turns=-1)
+
+    def test_eviction_enabled_by_default(self):
+        storage = InMemoryStorage()
+        assert storage._evict_after_turns == 10
+        ref = storage.store("key_1", b"content")
+        for _ in range(11):
+            storage.tick()
+        with pytest.raises(KeyError):
+            storage.retrieve(ref)
+
+    def test_eviction_disabled_with_none(self):
+        storage = InMemoryStorage(evict_after_turns=None)
+        ref = storage.store("key_1", b"content")
+        for _ in range(100):
+            storage.tick()
+        assert storage.retrieve(ref) == (b"content", "text/plain")
+
+    def test_entry_evicted_after_n_turns(self):
+        storage = InMemoryStorage(evict_after_turns=3)
+        ref = storage.store("key_1", b"content")
+
+        storage.tick()  # turn 1
+        storage.tick()  # turn 2
+        storage.tick()  # turn 3 — threshold = 3 - 3 = 0, stored at 0, 0 < 0 is false
+        assert storage.retrieve(ref) == (b"content", "text/plain")
+
+        storage.tick()  # turn 4 — threshold = 4 - 3 = 1, stored at 3 (refreshed by retrieve), 3 < 1 is false
+        assert storage.retrieve(ref) == (b"content", "text/plain")
+
+    def test_entry_evicted_without_access(self):
+        storage = InMemoryStorage(evict_after_turns=2)
+        ref = storage.store("key_1", b"content")
+
+        storage.tick()  # turn 1
+        storage.tick()  # turn 2 — threshold = 2 - 2 = 0, stored at 0, 0 < 0 is false
+        # Entry still alive at exact boundary
+        content, _ = storage.retrieve(ref)
+        assert content == b"content"
+
+    def test_entry_evicted_past_boundary(self):
+        storage = InMemoryStorage(evict_after_turns=2)
+        ref = storage.store("key_1", b"content")
+
+        storage.tick()  # turn 1
+        storage.tick()  # turn 2
+        storage.tick()  # turn 3 — threshold = 3 - 2 = 1, stored at 0, 0 < 1 is true → evicted
+        with pytest.raises(KeyError):
+            storage.retrieve(ref)
+
+    def test_retrieve_refreshes_last_accessed(self):
+        storage = InMemoryStorage(evict_after_turns=2)
+        ref = storage.store("key_1", b"content")
+
+        storage.tick()  # turn 1
+        storage.retrieve(ref)  # refreshes last_accessed to turn 1
+
+        storage.tick()  # turn 2
+        storage.tick()  # turn 3 — threshold = 3 - 2 = 1, last_accessed = 1, 1 < 1 is false
+        assert storage.retrieve(ref) == (b"content", "text/plain")
+
+    def test_multiple_entries_evicted_independently(self):
+        storage = InMemoryStorage(evict_after_turns=2)
+        ref1 = storage.store("key_1", b"first")
+
+        storage.tick()  # turn 1
+        ref2 = storage.store("key_2", b"second")
+
+        storage.tick()  # turn 2
+        storage.tick()  # turn 3 — threshold = 1. ref1 stored at 0 (evicted), ref2 stored at 1 (0 < 1, but 1 < 1 is false)
+        with pytest.raises(KeyError):
+            storage.retrieve(ref1)
+        assert storage.retrieve(ref2) == (b"second", "text/plain")
+
+    def test_tick_with_eviction_disabled_still_increments_turn(self):
+        storage = InMemoryStorage()
+        assert storage._current_turn == 0
+        storage.tick()
+        assert storage._current_turn == 1
+
+    def test_thread_safety_with_eviction(self):
+        storage = InMemoryStorage(evict_after_turns=5)
+        refs: list[str] = []
+        errors: list[Exception] = []
+
+        def store_and_tick(i: int):
+            try:
+                ref = storage.store(f"key_{i}", f"content_{i}".encode())
+                refs.append(ref)
+                storage.tick()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=store_and_tick, args=(i,)) for i in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+
+
 class TestFileStorage:
     def test_round_trip(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path / "artifacts"))

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -104,9 +104,9 @@ class TestInMemoryStorageEviction:
 
     def test_eviction_enabled_by_default(self):
         storage = InMemoryStorage()
-        assert storage._evict_after_turns == 10
+        assert storage._evict_after_turns == 20
         ref = storage.store("key_1", b"content")
-        for _ in range(11):
+        for _ in range(21):
             storage._evict(storage._current_cycle + 1)
         with pytest.raises(KeyError):
             storage.retrieve(ref)

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -101,6 +101,39 @@ class TestInMemoryStorageEviction:
         with pytest.raises(ValueError, match="evict_after_turns must be a positive integer"):
             InMemoryStorage(evict_after_turns=-1)
 
+    def test_max_entries_validation(self):
+        with pytest.raises(ValueError, match="max_entries must be a positive integer"):
+            InMemoryStorage(max_entries=0)
+        with pytest.raises(ValueError, match="max_entries must be a positive integer"):
+            InMemoryStorage(max_entries=-1)
+
+    def test_max_entries_evicts_lru_on_store(self):
+        storage = InMemoryStorage(evict_after_turns=None, max_entries=2)
+        ref1 = storage.store("key_1", b"first")
+        ref2 = storage.store("key_2", b"second")
+        ref3 = storage.store("key_3", b"third")
+        # ref1 was LRU, should be evicted
+        with pytest.raises(KeyError):
+            storage.retrieve(ref1)
+        assert storage.retrieve(ref2) == (b"second", "text/plain")
+        assert storage.retrieve(ref3) == (b"third", "text/plain")
+
+    def test_max_entries_retrieve_refreshes_lru(self):
+        storage = InMemoryStorage(evict_after_turns=None, max_entries=2)
+        ref1 = storage.store("key_1", b"first")
+        storage.store("key_2", b"second")
+        storage.retrieve(ref1)  # refresh ref1
+        ref3 = storage.store("key_3", b"third")
+        # ref2 was LRU (ref1 was refreshed), so ref2 evicted
+        assert storage.retrieve(ref1) == (b"first", "text/plain")
+        assert storage.retrieve(ref3) == (b"third", "text/plain")
+
+    def test_max_entries_disabled_by_default(self):
+        storage = InMemoryStorage(evict_after_turns=None)
+        for i in range(100):
+            storage.store(f"key_{i}", f"content_{i}".encode())
+        assert len(storage._store) == 100
+
     def test_eviction_enabled_by_default(self):
         storage = InMemoryStorage()
         assert storage._evict_after_turns == 10

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -126,7 +126,7 @@ class TestInMemoryStorageEviction:
         storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 3 - 3 = 0, stored at 0, 0 < 0 is false
         assert storage.retrieve(ref) == (b"content", "text/plain")
 
-        storage._evict(storage._current_cycle + 1)  # turn 4 — threshold = 4 - 3 = 1, stored at 3 (refreshed by retrieve), 3 < 1 is false
+        storage._evict(storage._current_cycle + 1)  # turn 4 — refreshed by retrieve to 3, 3 < 1 is false
         assert storage.retrieve(ref) == (b"content", "text/plain")
 
     def test_entry_evicted_without_access(self):
@@ -145,7 +145,7 @@ class TestInMemoryStorageEviction:
 
         storage._evict(storage._current_cycle + 1)  # turn 1
         storage._evict(storage._current_cycle + 1)  # turn 2
-        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 3 - 2 = 1, stored at 0, 0 < 1 is true → evicted
+        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 1, 0 < 1 → evicted
         with pytest.raises(KeyError):
             storage.retrieve(ref)
 
@@ -168,7 +168,7 @@ class TestInMemoryStorageEviction:
         ref2 = storage.store("key_2", b"second")
 
         storage._evict(storage._current_cycle + 1)  # turn 2
-        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 1. ref1 stored at 0 (evicted), ref2 stored at 1 (0 < 1, but 1 < 1 is false)
+        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 1. ref1 evicted, ref2 survives
         with pytest.raises(KeyError):
             storage.retrieve(ref1)
         assert storage.retrieve(ref2) == (b"second", "text/plain")

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -158,7 +158,7 @@ class TestInMemoryStorageEviction:
         storage.retrieve(ref)  # refreshes last_accessed to turn 1
 
         storage._evict(storage._current_cycle + 1)  # turn 2
-        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 3 - 2 = 1, last_accessed = 1, 1 < 1 is false
+        storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 1, last_accessed = 1, 1 < 1 is false
         assert storage.retrieve(ref) == (b"content", "text/plain")
 
     def test_multiple_entries_evicted_independently(self):
@@ -179,6 +179,17 @@ class TestInMemoryStorageEviction:
         assert storage._current_cycle == 0
         storage._evict(5)
         assert storage._current_cycle == 5
+
+    def test_rejects_shared_storage_across_agents(self):
+        storage = InMemoryStorage()
+        storage._bind(1)
+        with pytest.raises(ValueError, match="cannot be shared"):
+            storage._bind(2)
+
+    def test_allows_same_agent_repeated_bind(self):
+        storage = InMemoryStorage()
+        storage._bind(42)
+        storage._bind(42)
 
     def test_thread_safety_with_eviction(self):
         storage = InMemoryStorage(evict_after_turns=5)

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -101,38 +101,6 @@ class TestInMemoryStorageEviction:
         with pytest.raises(ValueError, match="evict_after_turns must be a positive integer"):
             InMemoryStorage(evict_after_turns=-1)
 
-    def test_max_entries_validation(self):
-        with pytest.raises(ValueError, match="max_entries must be a positive integer"):
-            InMemoryStorage(max_entries=0)
-        with pytest.raises(ValueError, match="max_entries must be a positive integer"):
-            InMemoryStorage(max_entries=-1)
-
-    def test_max_entries_evicts_lru_on_store(self):
-        storage = InMemoryStorage(evict_after_turns=None, max_entries=2)
-        ref1 = storage.store("key_1", b"first")
-        ref2 = storage.store("key_2", b"second")
-        ref3 = storage.store("key_3", b"third")
-        # ref1 was LRU, should be evicted
-        with pytest.raises(KeyError):
-            storage.retrieve(ref1)
-        assert storage.retrieve(ref2) == (b"second", "text/plain")
-        assert storage.retrieve(ref3) == (b"third", "text/plain")
-
-    def test_max_entries_retrieve_refreshes_lru(self):
-        storage = InMemoryStorage(evict_after_turns=None, max_entries=2)
-        ref1 = storage.store("key_1", b"first")
-        storage.store("key_2", b"second")
-        storage.retrieve(ref1)  # refresh ref1
-        ref3 = storage.store("key_3", b"third")
-        # ref2 was LRU (ref1 was refreshed), so ref2 evicted
-        assert storage.retrieve(ref1) == (b"first", "text/plain")
-        assert storage.retrieve(ref3) == (b"third", "text/plain")
-
-    def test_max_entries_disabled_by_default(self):
-        storage = InMemoryStorage(evict_after_turns=None)
-        for i in range(100):
-            storage.store(f"key_{i}", f"content_{i}".encode())
-        assert len(storage._store) == 100
 
     def test_eviction_enabled_by_default(self):
         storage = InMemoryStorage()

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ContextOffloader } from '../plugin.js'
 import { InMemoryStorage } from '../storage.js'
-import { AfterToolCallEvent } from '../../../hooks/events.js'
+import { AfterToolCallEvent, BeforeModelCallEvent } from '../../../hooks/events.js'
 import { TextBlock, JsonBlock, ToolResultBlock } from '../../../types/messages.js'
 import { ImageBlock, VideoBlock, DocumentBlock } from '../../../types/media.js'
 import { createMockAgent, invokeTrackedHook } from '../../../__fixtures__/agent-helpers.js'
@@ -61,12 +61,14 @@ describe('ContextOffloader', () => {
       expect(plugin.name).toBe('strands:context-offloader')
     })
 
-    it('registers AfterToolCallEvent hook', () => {
+    it('registers hooks', () => {
       const plugin = new ContextOffloader({ storage: new InMemoryStorage() })
       const agent = createMockAgent()
       plugin.initAgent(agent)
-      expect(agent.trackedHooks).toHaveLength(1)
-      expect(agent.trackedHooks[0]!.eventType).toBe(AfterToolCallEvent)
+      expect(agent.trackedHooks).toHaveLength(2)
+      const eventTypes = agent.trackedHooks.map((h) => h.eventType)
+      expect(eventTypes).toContain(AfterToolCallEvent)
+      expect(eventTypes).toContain(BeforeModelCallEvent)
     })
 
     it('returns retrieval tool by default', () => {
@@ -606,6 +608,55 @@ describe('ContextOffloader', () => {
       expect(result).toContain('[Lines 1-1 of 10]')
       expect(result).toContain('line 1')
       expect(result).not.toContain('line 2')
+    })
+  })
+
+  describe('eviction via BeforeModelCallEvent', () => {
+    it('calls _evict on storage with incrementing cycle count', () => {
+      const storage = new InMemoryStorage({ evictAfterTurns: 5 })
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const hook = agent.trackedHooks.find((h) => h.eventType === BeforeModelCallEvent)!
+      const event = new BeforeModelCallEvent({ agent, model: mockModel, invocationState: {} })
+
+      hook.callback(event)
+      expect((storage as unknown as { _currentCycle: number })._currentCycle).toBe(1)
+
+      hook.callback(event)
+      expect((storage as unknown as { _currentCycle: number })._currentCycle).toBe(2)
+    })
+
+    it('evicts stale entries on BeforeModelCallEvent', async () => {
+      const storage = new InMemoryStorage({ evictAfterTurns: 2 })
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const ref = await storage.store('key1', new TextEncoder().encode('test'))
+
+      const hook = agent.trackedHooks.find((h) => h.eventType === BeforeModelCallEvent)!
+      const event = new BeforeModelCallEvent({ agent, model: mockModel, invocationState: {} })
+
+      // Advance 3 cycles: threshold = 3 - 2 = 1, stored at 0, 0 < 1 → evicted
+      hook.callback(event)
+      hook.callback(event)
+      hook.callback(event)
+
+      await expect(storage.retrieve(ref)).rejects.toThrow('Reference not found')
+    })
+
+    it('does not crash when storage lacks _evict', () => {
+      const storage = { store: vi.fn(), retrieve: vi.fn() }
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const hook = agent.trackedHooks.find((h) => h.eventType === BeforeModelCallEvent)!
+      const event = new BeforeModelCallEvent({ agent, model: mockModel, invocationState: {} })
+
+      expect(() => hook.callback(event)).not.toThrow()
     })
   })
 })

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -613,7 +613,7 @@ describe('ContextOffloader', () => {
 
   describe('eviction via BeforeModelCallEvent', () => {
     it('calls _evict on storage with incrementing cycle count', () => {
-      const storage = new InMemoryStorage({ evictAfterTurns: 5 })
+      const storage = new InMemoryStorage(5)
       const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5 })
       const agent = createMockAgent()
       plugin.initAgent(agent)
@@ -629,7 +629,7 @@ describe('ContextOffloader', () => {
     })
 
     it('evicts stale entries on BeforeModelCallEvent', async () => {
-      const storage = new InMemoryStorage({ evictAfterTurns: 2 })
+      const storage = new InMemoryStorage(2)
       const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5 })
       const agent = createMockAgent()
       plugin.initAgent(agent)

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
@@ -118,45 +118,6 @@ describe('InMemoryStorage eviction', () => {
   })
 })
 
-describe('InMemoryStorage capacity cap', () => {
-  it('throws on invalid maxEntries', () => {
-    expect(() => new InMemoryStorage(null, 0)).toThrow('maxEntries must be a positive integer')
-    expect(() => new InMemoryStorage(null, -1)).toThrow('maxEntries must be a positive integer')
-  })
-
-  it('evicts LRU entry when at capacity', async () => {
-    const storage = new InMemoryStorage(null, 2)
-    const ref1 = await storage.store('key1', new TextEncoder().encode('first'))
-    await storage.store('key2', new TextEncoder().encode('second'))
-    await storage.store('key3', new TextEncoder().encode('third'))
-    await expect(storage.retrieve(ref1)).rejects.toThrow('Reference not found')
-  })
-
-  it('retrieve refreshes LRU order', async () => {
-    const storage = new InMemoryStorage(null, 2)
-    const ref1 = await storage.store('key1', new TextEncoder().encode('first'))
-    await storage.store('key2', new TextEncoder().encode('second'))
-    await storage.retrieve(ref1) // refresh ref1
-    const ref3 = await storage.store('key3', new TextEncoder().encode('third'))
-    // ref2 was LRU, should be evicted
-    const result1 = await storage.retrieve(ref1)
-    expect(new TextDecoder().decode(result1.content)).toBe('first')
-    const result3 = await storage.retrieve(ref3)
-    expect(new TextDecoder().decode(result3.content)).toBe('third')
-  })
-
-  it('disabled by default', async () => {
-    const storage = new InMemoryStorage(null)
-    for (let i = 0; i < 100; i++) {
-      await storage.store(`key${i}`, new TextEncoder().encode(`content${i}`))
-    }
-    // All 100 should still be there
-    const ref = await storage.store('last', new TextEncoder().encode('last'))
-    const result = await storage.retrieve(ref)
-    expect(new TextDecoder().decode(result.content)).toBe('last')
-  })
-})
-
 describe('S3Storage', () => {
   let mockSend: ReturnType<typeof vi.fn>
   let mockS3Client: { send: ReturnType<typeof vi.fn> }

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
@@ -57,10 +57,10 @@ describe('InMemoryStorage', () => {
 })
 
 describe('InMemoryStorage eviction', () => {
-  it('eviction enabled by default (10 cycles)', async () => {
+  it('eviction enabled by default (20 cycles)', async () => {
     const storage = new InMemoryStorage()
     const ref = await storage.store('key1', new TextEncoder().encode('test'))
-    storage._evict(11)
+    storage._evict(21)
     await expect(storage.retrieve(ref)).rejects.toThrow('Reference not found')
   })
 

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
@@ -118,6 +118,45 @@ describe('InMemoryStorage eviction', () => {
   })
 })
 
+describe('InMemoryStorage capacity cap', () => {
+  it('throws on invalid maxEntries', () => {
+    expect(() => new InMemoryStorage(null, 0)).toThrow('maxEntries must be a positive integer')
+    expect(() => new InMemoryStorage(null, -1)).toThrow('maxEntries must be a positive integer')
+  })
+
+  it('evicts LRU entry when at capacity', async () => {
+    const storage = new InMemoryStorage(null, 2)
+    const ref1 = await storage.store('key1', new TextEncoder().encode('first'))
+    await storage.store('key2', new TextEncoder().encode('second'))
+    await storage.store('key3', new TextEncoder().encode('third'))
+    await expect(storage.retrieve(ref1)).rejects.toThrow('Reference not found')
+  })
+
+  it('retrieve refreshes LRU order', async () => {
+    const storage = new InMemoryStorage(null, 2)
+    const ref1 = await storage.store('key1', new TextEncoder().encode('first'))
+    await storage.store('key2', new TextEncoder().encode('second'))
+    await storage.retrieve(ref1) // refresh ref1
+    const ref3 = await storage.store('key3', new TextEncoder().encode('third'))
+    // ref2 was LRU, should be evicted
+    const result1 = await storage.retrieve(ref1)
+    expect(new TextDecoder().decode(result1.content)).toBe('first')
+    const result3 = await storage.retrieve(ref3)
+    expect(new TextDecoder().decode(result3.content)).toBe('third')
+  })
+
+  it('disabled by default', async () => {
+    const storage = new InMemoryStorage(null)
+    for (let i = 0; i < 100; i++) {
+      await storage.store(`key${i}`, new TextEncoder().encode(`content${i}`))
+    }
+    // All 100 should still be there
+    const ref = await storage.store('last', new TextEncoder().encode('last'))
+    const result = await storage.retrieve(ref)
+    expect(new TextDecoder().decode(result.content)).toBe('last')
+  })
+})
+
 describe('S3Storage', () => {
   let mockSend: ReturnType<typeof vi.fn>
   let mockS3Client: { send: ReturnType<typeof vi.fn> }

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
@@ -116,6 +116,21 @@ describe('InMemoryStorage eviction', () => {
     const result = await storage.retrieve(ref2)
     expect(new TextDecoder().decode(result.content)).toBe('second')
   })
+
+  it('rejects shared storage across agents', () => {
+    const storage = new InMemoryStorage()
+    const agentA = {}
+    const agentB = {}
+    storage._bind(agentA)
+    expect(() => storage._bind(agentB)).toThrow('cannot be shared')
+  })
+
+  it('allows same agent repeated bind', () => {
+    const storage = new InMemoryStorage()
+    const agent = {}
+    storage._bind(agent)
+    storage._bind(agent)
+  })
 })
 
 describe('S3Storage', () => {

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
@@ -56,6 +56,68 @@ describe('InMemoryStorage', () => {
   })
 })
 
+describe('InMemoryStorage eviction', () => {
+  it('eviction enabled by default (10 cycles)', async () => {
+    const storage = new InMemoryStorage()
+    const ref = await storage.store('key1', new TextEncoder().encode('test'))
+    storage._evict(11)
+    await expect(storage.retrieve(ref)).rejects.toThrow('Reference not found')
+  })
+
+  it('eviction disabled with null', async () => {
+    const storage = new InMemoryStorage({ evictAfterTurns: null })
+    const ref = await storage.store('key1', new TextEncoder().encode('test'))
+    storage._evict(100)
+    const result = await storage.retrieve(ref)
+    expect(new TextDecoder().decode(result.content)).toBe('test')
+  })
+
+  it('throws on invalid evictAfterTurns', () => {
+    expect(() => new InMemoryStorage({ evictAfterTurns: 0 })).toThrow('evictAfterTurns must be a positive integer')
+    expect(() => new InMemoryStorage({ evictAfterTurns: -1 })).toThrow('evictAfterTurns must be a positive integer')
+  })
+
+  it('entry survives within TTL', async () => {
+    const storage = new InMemoryStorage({ evictAfterTurns: 3 })
+    const ref = await storage.store('key1', new TextEncoder().encode('test'))
+    // stored at cycle 0, evict at cycle 3: threshold = 3 - 3 = 0, 0 < 0 is false
+    storage._evict(3)
+    const result = await storage.retrieve(ref)
+    expect(new TextDecoder().decode(result.content)).toBe('test')
+  })
+
+  it('entry evicted past TTL', async () => {
+    const storage = new InMemoryStorage({ evictAfterTurns: 2 })
+    const ref = await storage.store('key1', new TextEncoder().encode('test'))
+    // stored at cycle 0, evict at cycle 3: threshold = 3 - 2 = 1, 0 < 1 → evicted
+    storage._evict(3)
+    await expect(storage.retrieve(ref)).rejects.toThrow('Reference not found')
+  })
+
+  it('retrieve refreshes last accessed cycle', async () => {
+    const storage = new InMemoryStorage({ evictAfterTurns: 2 })
+    const ref = await storage.store('key1', new TextEncoder().encode('test'))
+    storage._evict(1)
+    await storage.retrieve(ref) // refreshes to cycle 1
+    // threshold at cycle 3 = 3 - 2 = 1, last_accessed = 1, 1 < 1 is false
+    storage._evict(3)
+    const result = await storage.retrieve(ref)
+    expect(new TextDecoder().decode(result.content)).toBe('test')
+  })
+
+  it('multiple entries evicted independently', async () => {
+    const storage = new InMemoryStorage({ evictAfterTurns: 2 })
+    const ref1 = await storage.store('key1', new TextEncoder().encode('first'))
+    storage._evict(1)
+    const ref2 = await storage.store('key2', new TextEncoder().encode('second'))
+    // threshold at cycle 3 = 3 - 2 = 1. ref1 at 0 (evicted), ref2 at 1 (survives)
+    storage._evict(3)
+    await expect(storage.retrieve(ref1)).rejects.toThrow('Reference not found')
+    const result = await storage.retrieve(ref2)
+    expect(new TextDecoder().decode(result.content)).toBe('second')
+  })
+})
+
 describe('S3Storage', () => {
   let mockSend: ReturnType<typeof vi.fn>
   let mockS3Client: { send: ReturnType<typeof vi.fn> }

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
@@ -65,7 +65,7 @@ describe('InMemoryStorage eviction', () => {
   })
 
   it('eviction disabled with null', async () => {
-    const storage = new InMemoryStorage({ evictAfterTurns: null })
+    const storage = new InMemoryStorage(null)
     const ref = await storage.store('key1', new TextEncoder().encode('test'))
     storage._evict(100)
     const result = await storage.retrieve(ref)
@@ -73,12 +73,12 @@ describe('InMemoryStorage eviction', () => {
   })
 
   it('throws on invalid evictAfterTurns', () => {
-    expect(() => new InMemoryStorage({ evictAfterTurns: 0 })).toThrow('evictAfterTurns must be a positive integer')
-    expect(() => new InMemoryStorage({ evictAfterTurns: -1 })).toThrow('evictAfterTurns must be a positive integer')
+    expect(() => new InMemoryStorage(0)).toThrow('evictAfterTurns must be a positive integer')
+    expect(() => new InMemoryStorage(-1)).toThrow('evictAfterTurns must be a positive integer')
   })
 
   it('entry survives within TTL', async () => {
-    const storage = new InMemoryStorage({ evictAfterTurns: 3 })
+    const storage = new InMemoryStorage(3)
     const ref = await storage.store('key1', new TextEncoder().encode('test'))
     // stored at cycle 0, evict at cycle 3: threshold = 3 - 3 = 0, 0 < 0 is false
     storage._evict(3)
@@ -87,7 +87,7 @@ describe('InMemoryStorage eviction', () => {
   })
 
   it('entry evicted past TTL', async () => {
-    const storage = new InMemoryStorage({ evictAfterTurns: 2 })
+    const storage = new InMemoryStorage(2)
     const ref = await storage.store('key1', new TextEncoder().encode('test'))
     // stored at cycle 0, evict at cycle 3: threshold = 3 - 2 = 1, 0 < 1 → evicted
     storage._evict(3)
@@ -95,7 +95,7 @@ describe('InMemoryStorage eviction', () => {
   })
 
   it('retrieve refreshes last accessed cycle', async () => {
-    const storage = new InMemoryStorage({ evictAfterTurns: 2 })
+    const storage = new InMemoryStorage(2)
     const ref = await storage.store('key1', new TextEncoder().encode('test'))
     storage._evict(1)
     await storage.retrieve(ref) // refreshes to cycle 1
@@ -106,7 +106,7 @@ describe('InMemoryStorage eviction', () => {
   })
 
   it('multiple entries evicted independently', async () => {
-    const storage = new InMemoryStorage({ evictAfterTurns: 2 })
+    const storage = new InMemoryStorage(2)
     const ref1 = await storage.store('key1', new TextEncoder().encode('first'))
     storage._evict(1)
     const ref2 = await storage.store('key2', new TextEncoder().encode('second'))

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -139,7 +139,6 @@ export class ContextOffloader implements Plugin {
   private readonly _includeRetrievalTool: boolean
   private readonly _storageByAgent = new WeakMap<LocalAgent, Storage>()
   private _retrievalTool: Tool | undefined
-  private _cycleCount = 0
 
   constructor(config: ContextOffloaderConfig) {
     const maxResultTokens = config.maxResultTokens ?? DEFAULT_MAX_RESULT_TOKENS
@@ -158,10 +157,11 @@ export class ContextOffloader implements Plugin {
   initAgent(agent: LocalAgent): void {
     this._storageForAgent(agent)
     agent.addHook(AfterToolCallEvent, (event) => this._handleToolResult(event))
+    let cycleCount = 0
     agent.addHook(BeforeModelCallEvent, () => {
-      this._cycleCount++
+      cycleCount++
       if (this._storage instanceof InMemoryStorage) {
-        this._storage._evict(this._cycleCount)
+        this._storage._evict(cycleCount)
       }
     })
   }

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from '../../plugins/plugin.js'
 import type { Tool, ToolContext } from '../../tools/tool.js'
 import type { LocalAgent } from '../../types/agent.js'
-import { AfterToolCallEvent } from '../../hooks/events.js'
+import { AfterToolCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { TextBlock, JsonBlock, ToolResultBlock, Message } from '../../types/messages.js'
 import type { ToolResultContent } from '../../types/messages.js'
 import { ImageBlock, VideoBlock, DocumentBlock } from '../../types/media.js'
@@ -139,6 +139,7 @@ export class ContextOffloader implements Plugin {
   private readonly _includeRetrievalTool: boolean
   private readonly _storageByAgent = new WeakMap<LocalAgent, Storage>()
   private _retrievalTool: Tool | undefined
+  private _cycleCount = 0
 
   constructor(config: ContextOffloaderConfig) {
     const maxResultTokens = config.maxResultTokens ?? DEFAULT_MAX_RESULT_TOKENS
@@ -157,6 +158,12 @@ export class ContextOffloader implements Plugin {
   initAgent(agent: LocalAgent): void {
     this._storageForAgent(agent)
     agent.addHook(AfterToolCallEvent, (event) => this._handleToolResult(event))
+    agent.addHook(BeforeModelCallEvent, () => {
+      this._cycleCount++
+      if ('_evict' in this._storage && typeof this._storage._evict === 'function') {
+        ;(this._storage as { _evict(cycle: number): void })._evict(this._cycleCount)
+      }
+    })
   }
 
   getTools(): Tool[] {

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -155,6 +155,9 @@ export class ContextOffloader implements Plugin {
   }
 
   initAgent(agent: LocalAgent): void {
+    if (this._storage instanceof InMemoryStorage) {
+      this._storage._bind(agent)
+    }
     this._storageForAgent(agent)
     agent.addHook(AfterToolCallEvent, (event) => this._handleToolResult(event))
     let cycleCount = 0

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -10,7 +10,7 @@ import { tool } from '../../tools/tool-factory.js'
 import { z } from 'zod'
 import { logger } from '../../logging/logger.js'
 import type { JSONValue } from '../../types/json.js'
-import { FileStorage, type Storage } from './storage.js'
+import { FileStorage, InMemoryStorage, type Storage } from './storage.js'
 import { isSearchableContent, searchContent } from './search.js'
 
 const CHARS_PER_TOKEN = 4
@@ -160,8 +160,8 @@ export class ContextOffloader implements Plugin {
     agent.addHook(AfterToolCallEvent, (event) => this._handleToolResult(event))
     agent.addHook(BeforeModelCallEvent, () => {
       this._cycleCount++
-      if ('_evict' in this._storage && typeof this._storage._evict === 'function') {
-        ;(this._storage as { _evict(cycle: number): void })._evict(this._cycleCount)
+      if (this._storage instanceof InMemoryStorage) {
+        this._storage._evict(this._cycleCount)
       }
     })
   }

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -47,36 +47,60 @@ function sanitizeId(rawId: string): string {
  * In-memory storage backend.
  *
  * Useful for testing and serverless environments where disk access is not available.
- * Supports turn-based eviction: entries not accessed (stored or retrieved) within
- * {@link evictAfterTurns} agent loop cycles are automatically removed when the
- * plugin calls {@link _evict}. Eviction is enabled by default (10 cycles).
- * Pass `null` to disable.
+ * Supports two eviction strategies that compose together:
+ *
+ * - **Turn-based TTL**: entries not accessed within `evictAfterTurns` agent loop
+ *   cycles are removed. The plugin triggers this on each model invocation cycle.
+ * - **Capacity cap**: when `maxEntries` is set, the least-recently-accessed entry
+ *   is evicted on `store()` when the cap is reached.
  *
  * Note: evicted entries are permanently deleted from memory. The agent will receive
  * an error if it attempts to retrieve evicted content.
  *
  * @param evictAfterTurns - Cycles of inactivity before eviction. Defaults to 10. `null` disables.
+ * @param maxEntries - Maximum entries to keep. LRU eviction on store(). `null` disables (default).
  */
 export class InMemoryStorage implements Storage {
-  private _store = new Map<string, { content: Uint8Array; contentType: string; lastAccessedCycle: number }>()
+  private _store = new Map<string, { content: Uint8Array; contentType: string; lastAccessedCycle: number; accessSeq: number }>()
   private _counter = 0
   private _currentCycle = 0
+  private _accessSeq = 0
   private readonly _evictAfterTurns: number | null
+  private readonly _maxEntries: number | null
 
   static readonly DEFAULT_EVICT_AFTER_TURNS = 10
 
-  constructor(evictAfterTurns: number | null = InMemoryStorage.DEFAULT_EVICT_AFTER_TURNS) {
+  constructor(
+    evictAfterTurns: number | null = InMemoryStorage.DEFAULT_EVICT_AFTER_TURNS,
+    maxEntries: number | null = null
+  ) {
     if (evictAfterTurns !== null && evictAfterTurns < 1) {
       throw new Error('evictAfterTurns must be a positive integer')
     }
+    if (maxEntries !== null && maxEntries < 1) {
+      throw new Error('maxEntries must be a positive integer')
+    }
     this._evictAfterTurns = evictAfterTurns
+    this._maxEntries = maxEntries
   }
 
   /** {@inheritdoc} */
   async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
+    if (this._maxEntries !== null && this._store.size >= this._maxEntries) {
+      let lruRef: string | undefined
+      let lruSeq = Infinity
+      for (const [ref, entry] of this._store) {
+        if (entry.accessSeq < lruSeq) {
+          lruSeq = entry.accessSeq
+          lruRef = ref
+        }
+      }
+      if (lruRef) this._store.delete(lruRef)
+    }
     this._counter++
+    this._accessSeq++
     const reference = `mem_${this._counter}_${key}`
-    this._store.set(reference, { content, contentType, lastAccessedCycle: this._currentCycle })
+    this._store.set(reference, { content, contentType, lastAccessedCycle: this._currentCycle, accessSeq: this._accessSeq })
     return reference
   }
 
@@ -86,7 +110,9 @@ export class InMemoryStorage implements Storage {
     if (!entry) {
       throw new Error(`Reference not found: ${reference}`)
     }
+    this._accessSeq++
     entry.lastAccessedCycle = this._currentCycle
+    entry.accessSeq = this._accessSeq
     return { content: entry.content, contentType: entry.contentType }
   }
 

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -53,7 +53,9 @@ function sanitizeId(rawId: string): string {
  * calls `_evict`. Eviction is enabled by default (20 cycles). Pass `null` to disable.
  *
  * Note: content does not survive process restarts. For multi-session persistence,
- * use {@link FileStorage} or {@link S3Storage}.
+ * use {@link FileStorage} or {@link S3Storage}. Each agent should use its own
+ * `InMemoryStorage` instance — sharing one across multiple agents is not supported
+ * when eviction is enabled.
  *
  * Evicted entries are permanently deleted from memory. The agent will receive
  * an error if it attempts to retrieve evicted content.
@@ -65,6 +67,7 @@ export class InMemoryStorage implements Storage {
   private _counter = 0
   private _currentCycle = 0
   private readonly _evictAfterTurns: number | null
+  private _boundAgent: WeakRef<object> | null = null
 
   static readonly DEFAULT_EVICT_AFTER_TURNS = 20
 
@@ -94,12 +97,27 @@ export class InMemoryStorage implements Storage {
   }
 
   /**
+   * Claim this storage for a single agent. Throws if already bound to a different agent.
+   * @internal
+   */
+  _bind(agent: object): void {
+    if (this._boundAgent === null) {
+      this._boundAgent = new WeakRef(agent)
+    } else if (this._boundAgent.deref() !== agent) {
+      throw new Error(
+        'InMemoryStorage cannot be shared across multiple agents. ' +
+          'Use a separate InMemoryStorage instance per agent.'
+      )
+    }
+  }
+
+  /**
    * Update current cycle and evict stale entries.
    * Called by the ContextOffloader plugin on each BeforeModelCallEvent.
    * @internal
    */
   _evict(cycle: number): void {
-    this._currentCycle = Math.max(this._currentCycle, cycle)
+    this._currentCycle = cycle
     if (this._evictAfterTurns === null) return
     const threshold = cycle - this._evictAfterTurns
     let evicted = 0

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Sandbox } from '../../sandbox/base.js'
+import { logger } from '../../logging/logger.js'
 
 /**
  * Backend for storing and retrieving offloaded content blocks.
@@ -47,60 +48,38 @@ function sanitizeId(rawId: string): string {
  * In-memory storage backend.
  *
  * Useful for testing and serverless environments where disk access is not available.
- * Supports two eviction strategies that compose together:
+ * Supports turn-based eviction: entries not accessed (stored or retrieved) within
+ * `evictAfterTurns` agent loop cycles are automatically removed when the plugin
+ * calls `_evict`. Eviction is enabled by default (10 cycles). Pass `null` to disable.
  *
- * - **Turn-based TTL**: entries not accessed within `evictAfterTurns` agent loop
- *   cycles are removed. The plugin triggers this on each model invocation cycle.
- * - **Capacity cap**: when `maxEntries` is set, the least-recently-accessed entry
- *   is evicted on `store()` when the cap is reached.
+ * Note: content does not survive process restarts. For multi-session persistence,
+ * use {@link FileStorage} or {@link S3Storage}.
  *
- * Note: evicted entries are permanently deleted from memory. The agent will receive
+ * Evicted entries are permanently deleted from memory. The agent will receive
  * an error if it attempts to retrieve evicted content.
  *
  * @param evictAfterTurns - Cycles of inactivity before eviction. Defaults to 10. `null` disables.
- * @param maxEntries - Maximum entries to keep. LRU eviction on store(). `null` disables (default).
  */
 export class InMemoryStorage implements Storage {
-  private _store = new Map<string, { content: Uint8Array; contentType: string; lastAccessedCycle: number; accessSeq: number }>()
+  private _store = new Map<string, { content: Uint8Array; contentType: string; lastAccessedCycle: number }>()
   private _counter = 0
   private _currentCycle = 0
-  private _accessSeq = 0
   private readonly _evictAfterTurns: number | null
-  private readonly _maxEntries: number | null
 
   static readonly DEFAULT_EVICT_AFTER_TURNS = 10
 
-  constructor(
-    evictAfterTurns: number | null = InMemoryStorage.DEFAULT_EVICT_AFTER_TURNS,
-    maxEntries: number | null = null
-  ) {
+  constructor(evictAfterTurns: number | null = InMemoryStorage.DEFAULT_EVICT_AFTER_TURNS) {
     if (evictAfterTurns !== null && evictAfterTurns < 1) {
       throw new Error('evictAfterTurns must be a positive integer')
     }
-    if (maxEntries !== null && maxEntries < 1) {
-      throw new Error('maxEntries must be a positive integer')
-    }
     this._evictAfterTurns = evictAfterTurns
-    this._maxEntries = maxEntries
   }
 
   /** {@inheritdoc} */
   async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
-    if (this._maxEntries !== null && this._store.size >= this._maxEntries) {
-      let lruRef: string | undefined
-      let lruSeq = Infinity
-      for (const [ref, entry] of this._store) {
-        if (entry.accessSeq < lruSeq) {
-          lruSeq = entry.accessSeq
-          lruRef = ref
-        }
-      }
-      if (lruRef) this._store.delete(lruRef)
-    }
     this._counter++
-    this._accessSeq++
     const reference = `mem_${this._counter}_${key}`
-    this._store.set(reference, { content, contentType, lastAccessedCycle: this._currentCycle, accessSeq: this._accessSeq })
+    this._store.set(reference, { content, contentType, lastAccessedCycle: this._currentCycle })
     return reference
   }
 
@@ -110,9 +89,7 @@ export class InMemoryStorage implements Storage {
     if (!entry) {
       throw new Error(`Reference not found: ${reference}`)
     }
-    this._accessSeq++
     entry.lastAccessedCycle = this._currentCycle
-    entry.accessSeq = this._accessSeq
     return { content: entry.content, contentType: entry.contentType }
   }
 
@@ -125,10 +102,15 @@ export class InMemoryStorage implements Storage {
     this._currentCycle = cycle
     if (this._evictAfterTurns === null) return
     const threshold = cycle - this._evictAfterTurns
+    let evicted = 0
     for (const [ref, entry] of this._store) {
       if (entry.lastAccessedCycle < threshold) {
         this._store.delete(ref)
+        evicted++
       }
+    }
+    if (evicted > 0) {
+      logger.debug(`evicted=<${evicted}>, cycle=<${cycle}> | stale entries removed`)
     }
   }
 

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -50,7 +50,7 @@ function sanitizeId(rawId: string): string {
  * Useful for testing and serverless environments where disk access is not available.
  * Supports turn-based eviction: entries not accessed (stored or retrieved) within
  * `evictAfterTurns` agent loop cycles are automatically removed when the plugin
- * calls `_evict`. Eviction is enabled by default (10 cycles). Pass `null` to disable.
+ * calls `_evict`. Eviction is enabled by default (20 cycles). Pass `null` to disable.
  *
  * Note: content does not survive process restarts. For multi-session persistence,
  * use {@link FileStorage} or {@link S3Storage}.
@@ -58,7 +58,7 @@ function sanitizeId(rawId: string): string {
  * Evicted entries are permanently deleted from memory. The agent will receive
  * an error if it attempts to retrieve evicted content.
  *
- * @param evictAfterTurns - Cycles of inactivity before eviction. Defaults to 10. `null` disables.
+ * @param evictAfterTurns - Cycles of inactivity before eviction. Defaults to 20. `null` disables.
  */
 export class InMemoryStorage implements Storage {
   private _store = new Map<string, { content: Uint8Array; contentType: string; lastAccessedCycle: number }>()
@@ -66,7 +66,7 @@ export class InMemoryStorage implements Storage {
   private _currentCycle = 0
   private readonly _evictAfterTurns: number | null
 
-  static readonly DEFAULT_EVICT_AFTER_TURNS = 10
+  static readonly DEFAULT_EVICT_AFTER_TURNS = 20
 
   constructor(evictAfterTurns: number | null = InMemoryStorage.DEFAULT_EVICT_AFTER_TURNS) {
     if (evictAfterTurns !== null && evictAfterTurns < 1) {
@@ -99,7 +99,7 @@ export class InMemoryStorage implements Storage {
    * @internal
    */
   _evict(cycle: number): void {
-    this._currentCycle = cycle
+    this._currentCycle = Math.max(this._currentCycle, cycle)
     if (this._evictAfterTurns === null) return
     const threshold = cycle - this._evictAfterTurns
     let evicted = 0

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -55,8 +55,7 @@ function sanitizeId(rawId: string): string {
  * Note: evicted entries are permanently deleted from memory. The agent will receive
  * an error if it attempts to retrieve evicted content.
  *
- * @param options - Optional configuration
- * @param options.evictAfterTurns - Cycles of inactivity before eviction. Defaults to 10. `null` disables.
+ * @param evictAfterTurns - Cycles of inactivity before eviction. Defaults to 10. `null` disables.
  */
 export class InMemoryStorage implements Storage {
   private _store = new Map<string, { content: Uint8Array; contentType: string; lastAccessedCycle: number }>()
@@ -66,8 +65,7 @@ export class InMemoryStorage implements Storage {
 
   static readonly DEFAULT_EVICT_AFTER_TURNS = 10
 
-  constructor(options?: { evictAfterTurns?: number | null }) {
-    const evictAfterTurns = options?.evictAfterTurns === undefined ? InMemoryStorage.DEFAULT_EVICT_AFTER_TURNS : options.evictAfterTurns
+  constructor(evictAfterTurns: number | null = InMemoryStorage.DEFAULT_EVICT_AFTER_TURNS) {
     if (evictAfterTurns !== null && evictAfterTurns < 1) {
       throw new Error('evictAfterTurns must be a positive integer')
     }

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -47,17 +47,38 @@ function sanitizeId(rawId: string): string {
  * In-memory storage backend.
  *
  * Useful for testing and serverless environments where disk access is not available.
- * Content accumulates for the lifetime of this instance; call {@link clear} to free memory.
+ * Supports turn-based eviction: entries not accessed (stored or retrieved) within
+ * {@link evictAfterTurns} agent loop cycles are automatically removed when the
+ * plugin calls {@link _evict}. Eviction is enabled by default (10 cycles).
+ * Pass `null` to disable.
+ *
+ * Note: evicted entries are permanently deleted from memory. The agent will receive
+ * an error if it attempts to retrieve evicted content.
+ *
+ * @param options - Optional configuration
+ * @param options.evictAfterTurns - Cycles of inactivity before eviction. Defaults to 10. `null` disables.
  */
 export class InMemoryStorage implements Storage {
-  private _store = new Map<string, { content: Uint8Array; contentType: string }>()
+  private _store = new Map<string, { content: Uint8Array; contentType: string; lastAccessedCycle: number }>()
   private _counter = 0
+  private _currentCycle = 0
+  private readonly _evictAfterTurns: number | null
+
+  static readonly DEFAULT_EVICT_AFTER_TURNS = 10
+
+  constructor(options?: { evictAfterTurns?: number | null }) {
+    const evictAfterTurns = options?.evictAfterTurns === undefined ? InMemoryStorage.DEFAULT_EVICT_AFTER_TURNS : options.evictAfterTurns
+    if (evictAfterTurns !== null && evictAfterTurns < 1) {
+      throw new Error('evictAfterTurns must be a positive integer')
+    }
+    this._evictAfterTurns = evictAfterTurns
+  }
 
   /** {@inheritdoc} */
   async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
     this._counter++
     const reference = `mem_${this._counter}_${key}`
-    this._store.set(reference, { content, contentType })
+    this._store.set(reference, { content, contentType, lastAccessedCycle: this._currentCycle })
     return reference
   }
 
@@ -67,7 +88,24 @@ export class InMemoryStorage implements Storage {
     if (!entry) {
       throw new Error(`Reference not found: ${reference}`)
     }
-    return entry
+    entry.lastAccessedCycle = this._currentCycle
+    return { content: entry.content, contentType: entry.contentType }
+  }
+
+  /**
+   * Update current cycle and evict stale entries.
+   * Called by the ContextOffloader plugin on each BeforeModelCallEvent.
+   * @internal
+   */
+  _evict(cycle: number): void {
+    this._currentCycle = cycle
+    if (this._evictAfterTurns === null) return
+    const threshold = cycle - this._evictAfterTurns
+    for (const [ref, entry] of this._store) {
+      if (entry.lastAccessedCycle < threshold) {
+        this._store.delete(ref)
+      }
+    }
   }
 
   /** Remove all stored content. */


### PR DESCRIPTION
## Description

Add turn-based eviction to `InMemoryStorage` for the context offloader plugin. Entries not accessed (stored or retrieved) within a configurable number of agent loop cycles are automatically removed, preventing unbounded memory growth in long-running agents.

- Eviction defaults to 20 cycles of inactivity, configurable via `evict_after_turns`/`evictAfterTurns` (`None`/`null` to disable)
- Python uses the agent's `event_loop_metrics.cycle_count`; TypeScript uses a plugin-internal counter (agent metrics aren't publicly exposed)
- Retrieve refreshes the last-accessed cycle, keeping frequently-used content alive
- Eviction is triggered via a private `_evict()` method called by the plugin on `BeforeModelCallEvent`
- Evicted entries are permanently deleted — original tool results are not preserved in conversation history after offloading, only the preview and references remain in context
- Implemented in both Python and TypeScript with matching behavior

## Related Issues

## Documentation PR

No docs changes needed — this is internal behavior of `InMemoryStorage` with no new public API.

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `hatch run prepare`
- Added tests for: eviction after N cycles, retrieve refreshes timer, eviction enabled by default, eviction disabled with `None`/`null`, validation of `evict_after_turns`/`evictAfterTurns`, thread safety with eviction (Python), plugin hook triggers eviction via `isinstance` check, plugin doesn't crash on storage without `_evict`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published