### PR TITLE
fix: preserve non-ASCII tool result text

### DIFF
--- a/strands-py/src/strands/tools/decorator.py
+++ b/strands-py/src/strands/tools/decorator.py
@@ -681,7 +681,7 @@ class DecoratedFunctionTool(AgentTool, Generic[P, R]):
                     text = str(result)
             else:
                 try:
-                    text = json.dumps(result)
+                    text = json.dumps(result, ensure_ascii=False)
                 except (TypeError, ValueError):
                     text = str(result)
 

--- a/strands-py/tests/strands/tools/test_decorator.py
+++ b/strands-py/tests/strands/tools/test_decorator.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 import strands
 from strands import Agent
@@ -601,6 +601,43 @@ async def test_tool_decorator_with_different_return_values(alist):
     result = (await alist(stream))[-1]
     assert result["tool_result"]["status"] == "success"
     assert result["tool_result"]["content"][0]["text"] == "null"
+
+
+@pytest.mark.asyncio
+async def test_tool_decorator_preserves_non_ascii_structured_return_values(alist):
+    """Test dict/list returns preserve non-ASCII text like Pydantic models."""
+
+    class Reply(BaseModel):
+        message: str
+
+    @strands.tool
+    def dict_return_tool() -> dict[str, str]:
+        """Return a dict with non-ASCII content."""
+        return {"message": "こんにちは 🌏"}
+
+    @strands.tool
+    def list_return_tool() -> list[str]:
+        """Return a list with non-ASCII content."""
+        return ["你好", "🙂"]
+
+    @strands.tool
+    def model_return_tool() -> Reply:
+        """Return a Pydantic model with non-ASCII content."""
+        return Reply(message="こんにちは 🌏")
+
+    tool_use: ToolUse = {"toolUseId": "test-id", "name": "test-tool", "input": {}}
+
+    for tool, expected_fragments in (
+        (dict_return_tool, ('"message": "こんにちは 🌏"',)),
+        (list_return_tool, ('"你好"', '"🙂"')),
+        (model_return_tool, ('"message":"こんにちは 🌏"',)),
+    ):
+        events = await alist(tool.stream(tool_use, {}))
+        text = events[-1]["tool_result"]["content"][0]["text"]
+
+        assert "\\u" not in text
+        for fragment in expected_fragments:
+            assert fragment in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
`@tool` results returned as dictionaries or lists currently escape CJK and emoji characters because the standard JSON serializer defaults to ASCII escaping, while Pydantic model returns keep UTF-8 text. This keeps structured tool-result text human-readable regardless of whether a tool returns a dict, list, or model.

## Related Issues

Resolves #2636

## Documentation PR

No documentation changes are needed for this bug fix.

## Type of Change

Bug fix

## Testing

- `uv run --extra dev pytest tests/strands/tools/test_decorator.py -vv`
- `uv run --extra dev ruff format --check src/strands/tools/decorator.py tests/strands/tools/test_decorator.py`
- `uv run --extra dev ruff check src/strands/tools/decorator.py tests/strands/tools/test_decorator.py`
- `uv run --extra dev mypy src/strands/tools/decorator.py`

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] Documentation changes are not needed for this bug fix
- [x] No new docs example is needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published, or are not needed

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
