### PR TITLE
fix: handle empty Bedrock content blocks

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -737,7 +737,8 @@ class BedrockModel(Model):
 
             return {"citationsContent": result}
 
-        raise TypeError(f"content_type=<{next(iter(content))}> | unsupported type")
+        content_type = next(iter(content), None)
+        raise TypeError(f"content_type=<{content_type}> | unsupported type")
 
     def _has_blocked_guardrail(self, guardrail_data: dict[str, Any]) -> bool:
         """Check if guardrail data contains any blocked policies.

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -1894,6 +1894,13 @@ def test_format_request_message_content_does_not_mutate_empty_tool_result(model,
     assert original_content == [], "Original empty content list should not be mutated"
 
 
+def test_format_request_message_content_empty_block_raises_type_error(model, model_id):
+    messages = [{"role": "user", "content": [{}]}]
+
+    with pytest.raises(TypeError, match="content_type=<None> \\| unsupported type"):
+        model._format_bedrock_messages(messages)
+
+
 def test_format_request_message_content_preserves_nonempty_tool_result_content(model, model_id):
     """Test that _format_request_message_content does not modify non-empty toolResult content."""
     messages = [


### PR DESCRIPTION
Fixes #2652.

## Summary
- avoid calling `next(iter(content))` without a default for unsupported Bedrock content blocks
- make an empty content block raise the intended descriptive `TypeError` instead of leaking `StopIteration`
- add a regression test through `_format_bedrock_messages`, matching the reported history-path failure

## To verify
- `$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m pytest tests\strands\models\test_bedrock.py -q -k "empty_block or empty_tool_result"`
- `$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m pytest tests\strands\models\test_bedrock.py -q`
- `$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m py_compile src\strands\models\bedrock.py tests\strands\models\test_bedrock.py`
- `$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m ruff check src\strands\models\bedrock.py tests\strands\models\test_bedrock.py`
- `git diff --check`

Local note: this Windows environment has an older editable Strands checkout on `sys.path`, so the validation commands set `PYTHONPATH=./src` to force imports from this worktree.
