### PR TITLE
fix: preserve non-ASCII text in provider tool-result and tool-call serialization

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -162,7 +162,7 @@ class AnthropicModel(Model):
             return {
                 "content": [
                     self._format_request_message_content(
-                        {"text": json.dumps(tool_result_content["json"])}
+                        {"text": json.dumps(tool_result_content["json"], ensure_ascii=False)}
                         if "json" in tool_result_content
                         else cast(ContentBlock, tool_result_content)
                     )

--- a/strands-py/src/strands/models/llamaapi.py
+++ b/strands-py/src/strands/models/llamaapi.py
@@ -131,7 +131,7 @@ class LlamaAPIModel(Model):
         """
         return {
             "function": {
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
                 "name": tool_use["name"],
             },
             "id": tool_use["toolUseId"],
@@ -149,7 +149,7 @@ class LlamaAPIModel(Model):
         contents = cast(
             list[ContentBlock],
             [
-                {"text": json.dumps(content["json"])} if "json" in content else content
+                {"text": json.dumps(content["json"], ensure_ascii=False)} if "json" in content else content
                 for content in tool_result["content"]
             ],
         )

--- a/strands-py/src/strands/models/llamacpp.py
+++ b/strands-py/src/strands/models/llamacpp.py
@@ -256,7 +256,7 @@ class LlamaCppModel(Model):
         """
         return {
             "function": {
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
                 "name": tool_use["name"],
             },
             "id": tool_use["toolUseId"],
@@ -273,7 +273,7 @@ class LlamaCppModel(Model):
             llama.cpp compatible tool message.
         """
         contents = [
-            {"text": json.dumps(content["json"])} if "json" in content else content
+            {"text": json.dumps(content["json"], ensure_ascii=False)} if "json" in content else content
             for content in tool_result["content"]
         ]
 

--- a/strands-py/src/strands/models/mistral.py
+++ b/strands-py/src/strands/models/mistral.py
@@ -158,7 +158,7 @@ class MistralModel(Model):
         return {
             "function": {
                 "name": tool_use["name"],
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
             },
             "id": tool_use["toolUseId"],
             "type": "function",
@@ -176,7 +176,7 @@ class MistralModel(Model):
         content_parts: list[str] = []
         for content in tool_result["content"]:
             if "json" in content:
-                content_parts.append(json.dumps(content["json"]))
+                content_parts.append(json.dumps(content["json"], ensure_ascii=False))
             elif "text" in content:
                 content_parts.append(content["text"])
 

--- a/strands-py/src/strands/models/ollama.py
+++ b/strands-py/src/strands/models/ollama.py
@@ -140,7 +140,7 @@ class OllamaModel(Model):
                 for formatted_tool_result_content in self._format_request_message_contents(
                     "tool",
                     (
-                        {"text": json.dumps(tool_result_content["json"])}
+                        {"text": json.dumps(tool_result_content["json"], ensure_ascii=False)}
                         if "json" in tool_result_content
                         else cast(ContentBlock, tool_result_content)
                     ),

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -211,7 +211,7 @@ class OpenAIModel(Model):
         """
         return {
             "function": {
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
                 "name": tool_use["name"],
             },
             "id": tool_use["toolUseId"],
@@ -232,7 +232,7 @@ class OpenAIModel(Model):
         contents = cast(
             list[ContentBlock],
             [
-                {"text": json.dumps(content["json"])} if "json" in content else content
+                {"text": json.dumps(content["json"], ensure_ascii=False)} if "json" in content else content
                 for content in tool_result["content"]
             ],
         )

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -694,7 +694,7 @@ class OpenAIResponsesModel(Model):
             "type": "function_call",
             "call_id": tool_use["toolUseId"],
             "name": tool_use["name"],
-            "arguments": json.dumps(tool_use["input"]),
+            "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
         }
 
     @classmethod
@@ -720,7 +720,7 @@ class OpenAIResponsesModel(Model):
 
         for content in tool_result["content"]:
             if "json" in content:
-                output_parts.append({"type": "input_text", "text": json.dumps(content["json"])})
+                output_parts.append({"type": "input_text", "text": json.dumps(content["json"], ensure_ascii=False)})
             elif "text" in content:
                 output_parts.append({"type": "input_text", "text": content["text"]})
             elif "image" in content:

--- a/strands-py/src/strands/models/sagemaker.py
+++ b/strands-py/src/strands/models/sagemaker.py
@@ -519,7 +519,7 @@ class SageMakerAIModel(OpenAIModel):
         content_parts = []
         for content in tool_result["content"]:
             if "json" in content:
-                content_parts.append(json.dumps(content["json"]))
+                content_parts.append(json.dumps(content["json"], ensure_ascii=False))
             elif "text" in content:
                 content_parts.append(content["text"])
             else:

--- a/strands-py/src/strands/models/writer.py
+++ b/strands-py/src/strands/models/writer.py
@@ -167,7 +167,7 @@ class WriterModel(Model):
         """
         return {
             "function": {
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
                 "name": tool_use["name"],
             },
             "id": tool_use["toolUseId"],
@@ -186,7 +186,7 @@ class WriterModel(Model):
         contents = cast(
             list[ContentBlock],
             [
-                {"text": json.dumps(content["json"])} if "json" in content else content
+                {"text": json.dumps(content["json"], ensure_ascii=False)} if "json" in content else content
                 for content in tool_result["content"]
             ],
         )

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -293,6 +293,45 @@ def test_format_request_with_reasoning(model, model_id, max_tokens):
     assert tru_request == exp_request
 
 
+def test_format_request_with_tool_result_preserves_non_ascii(model, model_id, max_tokens):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "c1",
+                        "status": "success",
+                        "content": [{"json": {"city": "東京"}}],
+                    }
+                }
+            ],
+        }
+    ]
+
+    tru_request = model.format_request(messages)
+    exp_request = {
+        "max_tokens": max_tokens,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "content": [{"text": '{"city": "東京"}', "type": "text"}],
+                        "is_error": False,
+                        "tool_use_id": "c1",
+                        "type": "tool_result",
+                    }
+                ],
+            }
+        ],
+        "model": model_id,
+        "tools": [],
+    }
+
+    assert tru_request == exp_request
+
+
 def test_format_request_with_tool_use(model, model_id, max_tokens):
     messages = [
         {

--- a/strands-py/tests/strands/models/test_llamaapi.py
+++ b/strands-py/tests/strands/models/test_llamaapi.py
@@ -136,6 +136,72 @@ def test_format_request_with_image(model, model_id):
     assert tru_request == exp_request
 
 
+def test_format_request_with_tool_use_preserves_non_ascii(model, model_id):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": "c1", "name": "search", "input": {"query": "東京"}}}],
+        },
+    ]
+
+    tru_request = model.format_request(messages)
+    exp_request = {
+        "messages": [
+            {
+                "content": "",
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "search",
+                            "arguments": '{"query": "東京"}',
+                        },
+                        "id": "c1",
+                    }
+                ],
+            }
+        ],
+        "model": model_id,
+        "stream": True,
+        "tools": [],
+    }
+
+    assert tru_request == exp_request
+
+
+def test_format_request_with_tool_result_preserves_non_ascii(model, model_id):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "c1",
+                        "status": "success",
+                        "content": [{"json": {"city": "東京"}}],
+                    }
+                }
+            ],
+        }
+    ]
+
+    tru_request = model.format_request(messages)
+    exp_request = {
+        "messages": [
+            {
+                "content": [{"text": '{"city": "東京"}', "type": "text"}],
+                "role": "tool",
+                "tool_call_id": "c1",
+            },
+        ],
+        "model": model_id,
+        "stream": True,
+        "tools": [],
+    }
+
+    assert tru_request == exp_request
+
+
 def test_format_request_with_tool_result(model, model_id):
     messages = [
         {

--- a/strands-py/tests/strands/models/test_llamacpp.py
+++ b/strands-py/tests/strands/models/test_llamacpp.py
@@ -172,6 +172,41 @@ def test_format_request_with_all_new_params() -> None:
     assert extra["samplers"] == ["top_k", "tfs_z", "typical_p"]
 
 
+def test_format_tool_call_preserves_non_ascii() -> None:
+    """Tool-call arguments must keep non-ASCII text (no \\uXXXX escaping)."""
+    model = LlamaCppModel()
+    tool_use = {"toolUseId": "c1", "name": "search", "input": {"query": "東京"}}
+
+    tru_result = model._format_tool_call(tool_use)
+    exp_result = {
+        "function": {
+            "arguments": '{"query": "東京"}',
+            "name": "search",
+        },
+        "id": "c1",
+        "type": "function",
+    }
+    assert tru_result == exp_result
+
+
+def test_format_tool_message_preserves_non_ascii() -> None:
+    """Tool-result JSON content must keep non-ASCII text (no \\uXXXX escaping)."""
+    model = LlamaCppModel()
+    tool_result = {
+        "toolUseId": "c1",
+        "status": "success",
+        "content": [{"json": {"city": "東京"}}],
+    }
+
+    tru_result = model._format_tool_message(tool_result)
+    exp_result = {
+        "role": "tool",
+        "tool_call_id": "c1",
+        "content": [{"text": '{"city": "東京"}', "type": "text"}],
+    }
+    assert tru_result == exp_result
+
+
 def test_format_request_with_tools() -> None:
     """Test request formatting with tool specifications."""
     model = LlamaCppModel()

--- a/strands-py/tests/strands/models/test_mistral.py
+++ b/strands-py/tests/strands/models/test_mistral.py
@@ -155,6 +155,74 @@ def test_format_request_with_system_prompt(model, messages, model_id, system_pro
     assert actual_request == exp_request
 
 
+def test_format_request_with_tool_use_preserves_non_ascii(model, model_id):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": "c1", "name": "search", "input": {"query": "東京"}}}],
+        },
+    ]
+
+    actual_request = model.format_request(messages)
+    exp_request = {
+        "model": model_id,
+        "messages": [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "search",
+                            "arguments": '{"query": "東京"}',
+                        },
+                        "id": "c1",
+                        "type": "function",
+                    }
+                ],
+            }
+        ],
+        "max_tokens": 100,
+        "stream": True,
+    }
+
+    assert actual_request == exp_request
+
+
+def test_format_request_with_tool_result_preserves_non_ascii(model, model_id):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "c1",
+                        "status": "success",
+                        "content": [{"json": {"city": "東京"}}],
+                    }
+                }
+            ],
+        }
+    ]
+
+    actual_request = model.format_request(messages)
+    exp_request = {
+        "model": model_id,
+        "messages": [
+            {
+                "role": "tool",
+                "name": "c1",
+                "content": '{"city": "東京"}',
+                "tool_call_id": "c1",
+            }
+        ],
+        "max_tokens": 100,
+        "stream": True,
+    }
+
+    assert actual_request == exp_request
+
+
 def test_format_request_with_tool_use(model, model_id):
     messages = [
         {

--- a/strands-py/tests/strands/models/test_ollama.py
+++ b/strands-py/tests/strands/models/test_ollama.py
@@ -126,6 +126,39 @@ def test_format_request_with_image(model, model_id):
     assert tru_request == exp_request
 
 
+def test_format_request_with_tool_result_preserves_non_ascii(model, model_id):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "c1",
+                        "status": "success",
+                        "content": [{"json": {"city": "東京"}}],
+                    }
+                }
+            ],
+        }
+    ]
+
+    tru_request = model.format_request(messages)
+    exp_request = {
+        "messages": [
+            {
+                "role": "tool",
+                "content": '{"city": "東京"}',
+            },
+        ],
+        "model": model_id,
+        "options": {},
+        "stream": True,
+        "tools": [],
+    }
+
+    assert tru_request == exp_request
+
+
 def test_format_request_with_tool_use(model, model_id):
     messages = [
         {

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -179,6 +179,41 @@ def test_format_request_message_content_unsupported_type():
         OpenAIModel.format_request_message_content(content)
 
 
+def test_format_request_message_tool_call_preserves_non_ascii():
+    tool_use = {
+        "input": {"query": "東京"},
+        "name": "search",
+        "toolUseId": "c1",
+    }
+
+    tru_result = OpenAIModel.format_request_message_tool_call(tool_use)
+    exp_result = {
+        "function": {
+            "arguments": '{"query": "東京"}',
+            "name": "search",
+        },
+        "id": "c1",
+        "type": "function",
+    }
+    assert tru_result == exp_result
+
+
+def test_format_request_tool_message_preserves_non_ascii():
+    tool_result = {
+        "content": [{"json": {"city": "東京"}}],
+        "status": "success",
+        "toolUseId": "c1",
+    }
+
+    tru_result = OpenAIModel.format_request_tool_message(tool_result)
+    exp_result = {
+        "content": '{"city": "東京"}',
+        "role": "tool",
+        "tool_call_id": "c1",
+    }
+    assert tru_result == exp_result
+
+
 def test_format_request_message_tool_call():
     tool_use = {
         "input": {"expression": "2+2"},

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -152,6 +152,39 @@ def test_format_request_message_content_unsupported_type():
         OpenAIResponsesModel._format_request_message_content(content)
 
 
+def test_format_request_message_tool_call_preserves_non_ascii():
+    tool_use = {
+        "input": {"query": "東京"},
+        "name": "search",
+        "toolUseId": "c1",
+    }
+
+    tru_result = OpenAIResponsesModel._format_request_message_tool_call(tool_use)
+    exp_result = {
+        "type": "function_call",
+        "call_id": "c1",
+        "name": "search",
+        "arguments": '{"query": "東京"}',
+    }
+    assert tru_result == exp_result
+
+
+def test_format_request_tool_message_preserves_non_ascii():
+    tool_result = {
+        "content": [{"json": {"city": "東京"}}],
+        "status": "success",
+        "toolUseId": "c1",
+    }
+
+    tru_result = OpenAIResponsesModel._format_request_tool_message(tool_result)
+    exp_result = {
+        "type": "function_call_output",
+        "call_id": "c1",
+        "output": '{"city": "東京"}',
+    }
+    assert tru_result == exp_result
+
+
 def test_format_request_message_tool_call():
     tool_use = {
         "input": {"expression": "2+2"},

--- a/strands-py/tests/strands/models/test_sagemaker.py
+++ b/strands-py/tests/strands/models/test_sagemaker.py
@@ -87,6 +87,23 @@ def system_prompt() -> str:
     return "You are a helpful assistant."
 
 
+def test_format_request_tool_message_preserves_non_ascii():
+    """Tool-result JSON content must keep non-ASCII text (no \\uXXXX escaping)."""
+    tool_result = {
+        "toolUseId": "c1",
+        "status": "success",
+        "content": [{"json": {"city": "東京"}}],
+    }
+
+    tru_result = SageMakerAIModel.format_request_tool_message(tool_result)
+    exp_result = {
+        "role": "tool",
+        "tool_call_id": "c1",
+        "content": '{"city": "東京"}',
+    }
+    assert tru_result == exp_result
+
+
 class TestSageMakerAIModel:
     """Test suite for SageMakerAIModel."""
 

--- a/strands-py/tests/strands/models/test_writer.py
+++ b/strands-py/tests/strands/models/test_writer.py
@@ -114,6 +114,70 @@ def test_format_request_with_system_prompt(model, messages, model_id, stream_opt
     assert request == exp_request
 
 
+def test_format_request_with_tool_use_preserves_non_ascii(model, model_id, stream_options):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": "c1", "name": "search", "input": {"query": "東京"}}}],
+        },
+    ]
+
+    request = model.format_request(messages)
+    exp_request = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {"arguments": '{"query": "東京"}', "name": "search"},
+                        "id": "c1",
+                        "type": "function",
+                    }
+                ],
+            },
+        ],
+        "model": model_id,
+        "stream_options": stream_options,
+        "stream": True,
+    }
+
+    assert request == exp_request
+
+
+def test_format_request_with_tool_result_preserves_non_ascii(model, model_id, stream_options):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "c1",
+                        "status": "success",
+                        "content": [{"json": {"city": "東京"}}],
+                    }
+                }
+            ],
+        }
+    ]
+
+    request = model.format_request(messages)
+    exp_request = {
+        "messages": [
+            {
+                "role": "tool",
+                "content": [{"text": '{"city": "東京"}', "type": "text"}],
+                "tool_call_id": "c1",
+            },
+        ],
+        "model": model_id,
+        "stream_options": stream_options,
+        "stream": True,
+    }
+
+    assert request == exp_request
+
+
 def test_format_request_with_tool_use(model, model_id, stream_options):
     messages = [
         {


### PR DESCRIPTION
## Description

Provider request formatting serialized tool-result `{"json": ...}` content blocks and tool-call arguments with `json.dumps(...)`, which defaults to `ensure_ascii=True` and escapes non-ASCII (CJK, emoji) to `\uXXXX` in the request sent to the model. This adds `ensure_ascii=False` to those calls so non-Latin text is preserved — matching what the SDK already does in `telemetry/tracer.py` and the session managers, and complementing #2653 which fixed the same issue in the `@tool` decorator.

Two model-visible paths are fixed:

- Tool-result `{"json": ...}` content blocks (Anthropic + OpenAI-family providers)
- Tool-call argument serialization (OpenAI-family providers)

Out of scope (intentionally unchanged):

- **Gemini and Bedrock** pass these as native structures (no `json.dumps`), so they are unaffected.
- **Streaming-delta serializations** round-trip through `json.loads` in the event loop, so escaping there is a no-op.
- Log-only / token-estimate `json.dumps` calls.

This mirrors an established convention in the repo: #37 already added `ensure_ascii=False` to the telemetry tracer, and `tests/strands/telemetry/test_tracer.py::test_serialize_non_ascii_characters` locks in "non-ASCII is preserved" as intended behavior.

## Related Issues

Closes #2660. Follow-up to #2636; complements #2653.

## Documentation PR

No documentation changes are needed for this bug fix.

## Type of Change

Bug fix

## Testing

- Added per-provider unit tests asserting non-ASCII is preserved, using exact-equality on the formatted request and mirroring each provider's existing format tests.
- `hatch test tests/strands/models/` → 781 passed
- `hatch fmt --formatter` / `hatch fmt --linter` → clean
- `mypy ./src` → introduces no new errors

- [x] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] Documentation changes are not needed for this bug fix
- [x] No new docs example is needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published, or are not needed

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
