### PR TITLE
fix: handle empty Bedrock content blocks

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -737,7 +737,8 @@ class BedrockModel(Model):
 
             return {"citationsContent": result}
 
-        raise TypeError(f"content_type=<{next(iter(content))}> | unsupported type")
+        content_type = next(iter(content), None)
+        raise TypeError(f"content_type=<{content_type}> | unsupported type")
 
     def _has_blocked_guardrail(self, guardrail_data: dict[str, Any]) -> bool:
         """Check if guardrail data contains any blocked policies.

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -1919,6 +1919,14 @@ def test_format_request_message_content_preserves_nonempty_tool_result_content(m
     assert tool_result["content"] == [{"text": "some result"}]
 
 
+def test_format_request_message_content_empty_block_raises_type_error(model):
+    """Test that empty content blocks raise the intended TypeError instead of StopIteration."""
+    messages = [{"role": "user", "content": [{}]}]
+
+    with pytest.raises(TypeError, match=r"content_type=<None> \| unsupported type"):
+        model._format_bedrock_messages(messages)
+
+
 def test_format_request_removes_status_field_when_configured(model, model_id):
     model.update_config(include_tool_result_status=False)
 


### PR DESCRIPTION
## Description

Bedrock request formatting currently raises a bare `StopIteration` when an unsupported content block is an empty dict. This makes the intended unsupported-content error much harder to catch and can surface poorly when formatting runs through thread-backed async paths.

This change keeps the existing unsupported-content behavior but makes the fallback robust for empty blocks, so callers get a descriptive `TypeError` instead of `StopIteration`. No public API changes.

This PR was AI-assisted. I reviewed the change and ran the relevant local validation.

## Related Issues

Resolves #2652

## Documentation PR

No documentation changes needed.

## Type of Change

Bug fix

## Testing

Validated locally in `strands-py/`:

- `hatch run python - <<'PY' ...` reproduced the existing `StopIteration` on main before the fix
- `hatch test tests/strands/models/test_bedrock.py -k 'empty_block or format_request_message_content'`
- `hatch test tests/strands/models/test_bedrock.py`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy hatch run hatch-static-analysis:lint-check`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy hatch run hatch-static-analysis:ruff format --check src/strands/models/bedrock.py tests/strands/models/test_bedrock.py`
- `git diff --check`

I did not run the full `hatch run prepare` because its repository-wide formatter step currently reports two pre-existing unrelated files that would be reformatted: `src/strands/tools/mcp/mcp_client.py` and `tests/strands/models/test_gemini.py`. The changed files pass the formatter check.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly, or no documentation update is needed
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.