### PR TITLE
fix: report OpenAI Responses cached tokens

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -55,6 +55,7 @@ import openai  # noqa: E402 - must import after version check
 
 from ..types.citations import WebLocationDict  # noqa: E402
 from ..types.content import ContentBlock, Messages, Role, SystemContentBlock  # noqa: E402
+from ..types.event_loop import Usage  # noqa: E402
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException  # noqa: E402
 from ..types.streaming import StreamEvent  # noqa: E402
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse  # noqa: E402
@@ -837,13 +838,20 @@ class OpenAIResponsesModel(Model):
 
             case "metadata":
                 # Responses API uses input_tokens/output_tokens naming convention
+                usage_data: Usage = {
+                    "inputTokens": getattr(event["data"], "input_tokens", 0),
+                    "outputTokens": getattr(event["data"], "output_tokens", 0),
+                    "totalTokens": getattr(event["data"], "total_tokens", 0),
+                }
+
+                if tokens_details := getattr(event["data"], "input_tokens_details", None):
+                    cached = getattr(tokens_details, "cached_tokens", None)
+                    if isinstance(cached, int) and cached:
+                        usage_data["cacheReadInputTokens"] = cached
+
                 return {
                     "metadata": {
-                        "usage": {
-                            "inputTokens": getattr(event["data"], "input_tokens", 0),
-                            "outputTokens": getattr(event["data"], "output_tokens", 0),
-                            "totalTokens": getattr(event["data"], "total_tokens", 0),
-                        },
+                        "usage": usage_data,
                         "metrics": {
                             "latencyMs": 0,  # TODO
                         },

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -484,6 +484,45 @@ def test_format_chunk_unknown_type(model):
         model._format_chunk(event)
 
 
+def test_format_chunk_metadata_with_cache_tokens(model):
+    """Test _format_chunk for metadata with cache tokens present."""
+    mock_usage = unittest.mock.Mock()
+    mock_usage.input_tokens = 100
+    mock_usage.output_tokens = 50
+    mock_usage.total_tokens = 150
+
+    mock_tokens_details = unittest.mock.Mock()
+    mock_tokens_details.cached_tokens = 25
+    mock_usage.input_tokens_details = mock_tokens_details
+
+    event = {"chunk_type": "metadata", "data": mock_usage}
+
+    result = model._format_chunk(event)
+
+    assert result["metadata"]["usage"]["inputTokens"] == 100
+    assert result["metadata"]["usage"]["outputTokens"] == 50
+    assert result["metadata"]["usage"]["totalTokens"] == 150
+    assert result["metadata"]["usage"]["cacheReadInputTokens"] == 25
+
+
+def test_format_chunk_metadata_with_zero_cached_tokens(model):
+    """Test _format_chunk for metadata when cached_tokens is 0."""
+    mock_usage = unittest.mock.Mock()
+    mock_usage.input_tokens = 100
+    mock_usage.output_tokens = 50
+    mock_usage.total_tokens = 150
+
+    mock_tokens_details = unittest.mock.Mock()
+    mock_tokens_details.cached_tokens = 0
+    mock_usage.input_tokens_details = mock_tokens_details
+
+    event = {"chunk_type": "metadata", "data": mock_usage}
+
+    result = model._format_chunk(event)
+
+    assert "cacheReadInputTokens" not in result["metadata"]["usage"]
+
+
 @pytest.mark.asyncio
 async def test_stream(openai_client, model_id, model, agenerator, alist):
     # Mock response events

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -497,12 +497,17 @@ def test_format_chunk_metadata_with_cache_tokens(model):
 
     event = {"chunk_type": "metadata", "data": mock_usage}
 
-    result = model._format_chunk(event)
-
-    assert result["metadata"]["usage"]["inputTokens"] == 100
-    assert result["metadata"]["usage"]["outputTokens"] == 50
-    assert result["metadata"]["usage"]["totalTokens"] == 150
-    assert result["metadata"]["usage"]["cacheReadInputTokens"] == 25
+    assert model._format_chunk(event) == {
+        "metadata": {
+            "usage": {
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 150,
+                "cacheReadInputTokens": 25,
+            },
+            "metrics": {"latencyMs": 0},
+        },
+    }
 
 
 def test_format_chunk_metadata_with_zero_cached_tokens(model):
@@ -518,9 +523,38 @@ def test_format_chunk_metadata_with_zero_cached_tokens(model):
 
     event = {"chunk_type": "metadata", "data": mock_usage}
 
-    result = model._format_chunk(event)
+    assert model._format_chunk(event) == {
+        "metadata": {
+            "usage": {
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 150,
+            },
+            "metrics": {"latencyMs": 0},
+        },
+    }
 
-    assert "cacheReadInputTokens" not in result["metadata"]["usage"]
+
+def test_format_chunk_metadata_without_token_details(model):
+    """Test _format_chunk for metadata when input token details are absent."""
+    mock_usage = unittest.mock.Mock()
+    mock_usage.input_tokens = 100
+    mock_usage.output_tokens = 50
+    mock_usage.total_tokens = 150
+    mock_usage.input_tokens_details = None
+
+    event = {"chunk_type": "metadata", "data": mock_usage}
+
+    assert model._format_chunk(event) == {
+        "metadata": {
+            "usage": {
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 150,
+            },
+            "metrics": {"latencyMs": 0},
+        },
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`OpenAIResponsesModel` now carries prompt-cache reads from `usage.input_tokens_details.cached_tokens` into `cacheReadInputTokens`, matching the existing Chat Completions model behavior. This lets agent metrics and telemetry report OpenAI Responses API cache reads when OpenAI returns them.

No public API changes. The existing usage metadata shape already supports `cacheReadInputTokens`; this fills the missing provider mapping.

This PR was AI-assisted. I reviewed the change and ran the relevant local validation.

## Related Issues

Resolves #2407

## Documentation PR

No documentation changes needed.

## Type of Change

Bug fix

## Testing

Validated locally in `strands-py/`:

- `hatch test tests/strands/models/test_openai_responses.py -k 'metadata_with_cache_tokens or metadata_with_zero_cached_tokens'` first reproduced the missing `cacheReadInputTokens` behavior before the implementation, then passed after the fix
- `hatch test tests/strands/models/test_openai_responses.py`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy hatch run hatch-static-analysis:lint-check`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy hatch run hatch-static-analysis:ruff format --check src/strands/models/openai_responses.py tests/strands/models/test_openai_responses.py`
- `git diff --check`

I did not run the full `hatch run prepare` because its repository-wide formatter step currently reports two pre-existing unrelated files that would be reformatted: `src/strands/tools/mcp/mcp_client.py` and `tests/strands/models/test_gemini.py`. The changed files pass the formatter check.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly, or no documentation update is needed
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.