### PR TITLE
feat(strands-py): add Sandbox core abstraction (TS→Python port, core only 1/N)

### DIFF
--- a/strands-py/src/strands/sandbox/__init__.py
+++ b/strands-py/src/strands/sandbox/__init__.py
@@ -17,6 +17,13 @@ Concrete shell backends (Docker, SSH) and the Agent↔Sandbox integration are
 intentionally out of scope for this "core only (1/N)" port; they follow as
 separate PRs mirroring the corresponding TypeScript modules.
 
+.. note::
+   Per the "Prefer Flat Namespaces Over Nested Modules" decision record, the
+   commonly-used symbols here will be re-exported from the top-level ``strands``
+   package. That re-export is deferred to the Agent↔Sandbox integration
+   follow-up (where the public surface stabilizes), so it is not added in this
+   core-only PR.
+
 Example:
     A minimal shell-backed sandbox needs only ``execute_streaming``::
 

--- a/strands-py/src/strands/sandbox/__init__.py
+++ b/strands-py/src/strands/sandbox/__init__.py
@@ -1,0 +1,44 @@
+"""Sandbox abstraction for agent code-execution environments.
+
+A :class:`Sandbox` provides the runtime context where tools execute code, run
+commands, and interact with a filesystem. This module ports the *core* sandbox
+interface from ``strands-ts/src/sandbox/`` (the behavioral oracle):
+
+- :class:`Sandbox` — the abstract base with streaming primitives and
+  non-streaming/text convenience wrappers.
+- :class:`PosixShellSandbox` — an abstract sandbox that implements file and code
+  operations via shell commands; subclasses implement only
+  :meth:`~strands.sandbox.base.Sandbox.execute_streaming`.
+- Data types: :class:`StreamChunk`, :class:`FileInfo`, :class:`OutputFile`,
+  :class:`ExecutionResult`, and the :data:`StreamType` literal.
+- :data:`LANGUAGE_PATTERN` — interpreter-name validation pattern.
+
+Concrete shell backends (Docker, SSH) and the Agent↔Sandbox integration are
+intentionally out of scope for this "core only (1/N)" port; they follow as
+separate PRs mirroring the corresponding TypeScript modules.
+
+Example:
+    A minimal shell-backed sandbox needs only ``execute_streaming``::
+
+        from strands.sandbox import PosixShellSandbox
+
+        class MyShellSandbox(PosixShellSandbox):
+            async def execute_streaming(self, command, *, timeout=None, cwd=None, env=None, **kwargs):
+                ...  # spawn a process, yield StreamChunk(s), then an ExecutionResult
+"""
+
+from .base import Sandbox
+from .constants import LANGUAGE_PATTERN
+from .shell import PosixShellSandbox
+from .types import ExecutionResult, FileInfo, OutputFile, StreamChunk, StreamType
+
+__all__ = [
+    "ExecutionResult",
+    "FileInfo",
+    "LANGUAGE_PATTERN",
+    "OutputFile",
+    "PosixShellSandbox",
+    "Sandbox",
+    "StreamChunk",
+    "StreamType",
+]

--- a/strands-py/src/strands/sandbox/base.py
+++ b/strands-py/src/strands/sandbox/base.py
@@ -1,0 +1,308 @@
+"""Base sandbox interface.
+
+Defines the abstract :class:`Sandbox` class that all sandbox implementations
+must extend. The class provides six abstract operations (command execution,
+code execution, and file I/O) and convenience wrappers for common patterns.
+
+Mirrors ``strands-ts/src/sandbox/base.ts``. The streaming methods
+(:meth:`Sandbox.execute_streaming`, :meth:`Sandbox.execute_code_streaming`) are
+the abstract primitives; the non-streaming convenience methods
+(:meth:`Sandbox.execute`, :meth:`Sandbox.execute_code`) consume the stream and
+return the final :class:`ExecutionResult`.
+
+Idiomatic divergences from the TypeScript oracle (see PR description):
+
+- TS's ``ExecuteOptions`` *options object* (``timeout``, ``cwd``, ``signal``,
+  ``env``) becomes Python keyword arguments (``timeout``, ``cwd``, ``env``),
+  matching how the rest of ``strands-py`` models call options.
+- TS's ``AbortSignal`` cancellation maps to asyncio task cancellation — the
+  Pythonic way to cancel an in-flight coroutine/generator — rather than an
+  explicit signal parameter.
+- TS's discriminated union (``type: 'streamChunk' | 'executionResult'``) is
+  discriminated in Python with ``isinstance`` checks on the dataclasses.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from .types import ExecutionResult, FileInfo, StreamChunk
+
+logger = logging.getLogger(__name__)
+
+
+class Sandbox(ABC):
+    """Abstract execution environment.
+
+    A Sandbox provides the runtime context where tools execute code, run
+    commands, and interact with a filesystem. Multiple tools share the same
+    Sandbox instance, giving them a common working directory and filesystem.
+
+    Streaming methods (:meth:`execute_streaming`, :meth:`execute_code_streaming`)
+    are the abstract primitives. Non-streaming convenience methods
+    (:meth:`execute`, :meth:`execute_code`) consume the stream and return the
+    final result.
+
+    All abstract methods accept ``**kwargs`` for forward compatibility — new
+    parameters with defaults can be added in future versions without breaking
+    existing implementations.
+
+    Example:
+        Non-streaming (common case)::
+
+            result = await sandbox.execute("echo hello")
+            print(result.stdout)
+
+        Streaming with stdout/stderr distinction::
+
+            async for chunk in sandbox.execute_streaming("echo hello"):
+                if isinstance(chunk, StreamChunk):
+                    print(f"[{chunk.stream_type}] {chunk.data}", end="")
+                elif isinstance(chunk, ExecutionResult):
+                    print(f"Exit code: {chunk.exit_code}")
+    """
+
+    # ---- Streaming methods (abstract primitives) ----
+
+    @abstractmethod
+    async def execute_streaming(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        """Execute a shell command, streaming output.
+
+        Yields :class:`StreamChunk` objects for stdout and stderr as output
+        arrives. The final yield is an :class:`ExecutionResult` with the exit
+        code and complete output.
+
+        Args:
+            command: The shell command to execute.
+            timeout: Maximum execution time in seconds. ``None`` means no timeout.
+            cwd: Working directory for execution. ``None`` means use the sandbox
+                default.
+            env: Environment variables to set for this command. Built-in
+                sandboxes always apply these, though the mechanism differs;
+                custom implementations must handle ``env`` explicitly or it has
+                no effect.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Yields:
+            :class:`StreamChunk` objects for output, then a final
+            :class:`ExecutionResult`.
+        """
+        ...
+        # Establishes this as an async generator function for type checkers.
+        # Concrete subclasses must yield at least one ExecutionResult.
+        yield  # type: ignore[misc]  # pragma: no cover
+
+    @abstractmethod
+    async def execute_code_streaming(
+        self,
+        code: str,
+        language: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        """Execute source code via a language interpreter, streaming output.
+
+        Args:
+            code: The source code to execute.
+            language: The interpreter to use (e.g., ``"python3"``, ``"node"``).
+            timeout: Maximum execution time in seconds. ``None`` means no timeout.
+            cwd: Working directory for execution. ``None`` means use the sandbox
+                default.
+            env: Environment variables to set for this execution.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Yields:
+            :class:`StreamChunk` objects for output, then a final
+            :class:`ExecutionResult`.
+        """
+        ...
+        yield  # type: ignore[misc]  # pragma: no cover
+
+    @abstractmethod
+    async def read_file(self, path: str, **kwargs: Any) -> bytes:
+        """Read a file from the sandbox filesystem as raw bytes.
+
+        Returns ``bytes`` to support both text and binary files. Use
+        :meth:`read_text` for a convenience wrapper that decodes to a string.
+
+        Args:
+            path: Path to the file to read.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Returns:
+            The file contents as raw bytes.
+
+        Raises:
+            FileNotFoundError: If the file does not exist or cannot be read.
+        """
+        ...
+
+    @abstractmethod
+    async def write_file(self, path: str, content: bytes, **kwargs: Any) -> None:
+        """Write raw bytes to a file in the sandbox filesystem.
+
+        Implementations should create parent directories if they do not exist.
+        Use :meth:`write_text` for a convenience wrapper that encodes a string.
+
+        Args:
+            path: Path to the file to write.
+            content: The content to write.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        ...
+
+    @abstractmethod
+    async def remove_file(self, path: str, **kwargs: Any) -> None:
+        """Remove a file from the sandbox filesystem.
+
+        Args:
+            path: Path to the file to remove.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
+        ...
+
+    @abstractmethod
+    async def list_files(self, path: str, **kwargs: Any) -> list[FileInfo]:
+        """List files in a sandbox directory.
+
+        Returns :class:`FileInfo` entries with name, ``is_dir``, and ``size``
+        metadata. Fields ``is_dir`` and ``size`` may be ``None`` if the backend
+        cannot determine them.
+
+        Args:
+            path: Path to the directory to list.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Returns:
+            A list of :class:`FileInfo` entries for the directory contents.
+
+        Raises:
+            FileNotFoundError: If the directory does not exist.
+        """
+        ...
+
+    # ---- Non-streaming convenience methods ----
+
+    async def execute(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Execute a shell command and return the result.
+
+        Consumes :meth:`execute_streaming` and returns the final
+        :class:`ExecutionResult`. Use :meth:`execute_streaming` when you need to
+        process output as it arrives.
+
+        Args:
+            command: The shell command to execute.
+            timeout: Maximum execution time in seconds. ``None`` means no timeout.
+            cwd: Working directory for execution. ``None`` means use the sandbox
+                default.
+            env: Environment variables to set for this command.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Returns:
+            The execution result with exit code and output.
+
+        Raises:
+            RuntimeError: If ``execute_streaming`` did not yield an
+                :class:`ExecutionResult`.
+        """
+        async for chunk in self.execute_streaming(command, timeout=timeout, cwd=cwd, env=env, **kwargs):
+            if isinstance(chunk, ExecutionResult):
+                return chunk
+        raise RuntimeError("execute_streaming() did not yield an ExecutionResult")
+
+    async def execute_code(
+        self,
+        code: str,
+        language: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Execute source code and return the result.
+
+        Consumes :meth:`execute_code_streaming` and returns the final
+        :class:`ExecutionResult`. Use :meth:`execute_code_streaming` when you
+        need to process output as it arrives.
+
+        Args:
+            code: The source code to execute.
+            language: The interpreter to use.
+            timeout: Maximum execution time in seconds. ``None`` means no timeout.
+            cwd: Working directory for execution. ``None`` means use the sandbox
+                default.
+            env: Environment variables to set for this execution.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Returns:
+            The execution result with exit code and output.
+
+        Raises:
+            RuntimeError: If ``execute_code_streaming`` did not yield an
+                :class:`ExecutionResult`.
+        """
+        async for chunk in self.execute_code_streaming(code, language, timeout=timeout, cwd=cwd, env=env, **kwargs):
+            if isinstance(chunk, ExecutionResult):
+                return chunk
+        raise RuntimeError("execute_code_streaming() did not yield an ExecutionResult")
+
+    # ---- Text convenience methods ----
+
+    async def read_text(self, path: str, encoding: str = "utf-8", **kwargs: Any) -> str:
+        """Read a text file from the sandbox filesystem.
+
+        Convenience wrapper over :meth:`read_file` that decodes bytes as UTF-8
+        (by default). For other encodings, call :meth:`read_file` and decode
+        manually.
+
+        Args:
+            path: Path to the file to read.
+            encoding: Text encoding to use. Defaults to UTF-8.
+            **kwargs: Additional keyword arguments passed to :meth:`read_file`.
+
+        Returns:
+            The file contents decoded as a string.
+        """
+        return (await self.read_file(path, **kwargs)).decode(encoding)
+
+    async def write_text(self, path: str, content: str, encoding: str = "utf-8", **kwargs: Any) -> None:
+        """Write a text file to the sandbox filesystem.
+
+        Convenience wrapper over :meth:`write_file` that encodes a string as
+        UTF-8 (by default). For other encodings, encode manually and call
+        :meth:`write_file`.
+
+        Args:
+            path: Path to the file to write.
+            content: The text content to write.
+            encoding: Text encoding to use. Defaults to UTF-8.
+            **kwargs: Additional keyword arguments passed to :meth:`write_file`.
+        """
+        await self.write_file(path, content.encode(encoding), **kwargs)

--- a/strands-py/src/strands/sandbox/constants.py
+++ b/strands-py/src/strands/sandbox/constants.py
@@ -1,0 +1,19 @@
+"""Validation patterns for sandbox inputs.
+
+Mirrors ``strands-ts/src/sandbox/constants.ts``. These patterns reject inputs
+that could break out of the intended shell context (path separators, spaces,
+shell metacharacters), providing defense-in-depth for shell-based sandboxes.
+"""
+
+import re
+
+#: Pattern for validating language/interpreter names.
+#: Allows alphanumeric characters, dots, hyphens, and underscores. Rejects path
+#: separators, spaces, and shell metacharacters to prevent injection.
+LANGUAGE_PATTERN = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+#: Pattern for validating environment variable names: a leading letter or
+#: underscore, followed by letters, digits, or underscores (valid POSIX names).
+#: Names outside this set are rejected to prevent shell-syntax injection where a
+#: key is interpolated into a command, and to fail with a clear error otherwise.
+ENV_KEY_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")

--- a/strands-py/src/strands/sandbox/constants.py
+++ b/strands-py/src/strands/sandbox/constants.py
@@ -1,8 +1,14 @@
-"""Validation patterns for sandbox inputs.
+r"""Validation patterns for sandbox inputs.
 
 Mirrors ``strands-ts/src/sandbox/constants.ts``. These patterns reject inputs
 that could break out of the intended shell context (path separators, spaces,
 shell metacharacters), providing defense-in-depth for shell-based sandboxes.
+
+Match these with :meth:`re.Pattern.fullmatch` (not :meth:`re.match`): Python's
+``$`` also matches just before a trailing ``\n``, so ``re.match`` would accept
+e.g. ``"python3\n"`` and let a newline-separated second statement slip through.
+``fullmatch`` reproduces the JavaScript ``/^...$/.test()`` semantics of the
+``strands-ts`` oracle, which anchors to the true end of the string.
 """
 
 import re

--- a/strands-py/src/strands/sandbox/shell.py
+++ b/strands-py/src/strands/sandbox/shell.py
@@ -1,0 +1,238 @@
+"""Shell sandbox with default implementations for file and code operations.
+
+Subclasses only need to implement :meth:`PosixShellSandbox.execute_streaming` —
+all other operations are implemented by running shell commands through it. Use
+this for remote environments where only shell access is available (Docker
+containers, SSH connections, cloud runtimes).
+
+Mirrors ``strands-ts/src/sandbox/posix-shell.ts``.
+"""
+
+import base64
+import logging
+import uuid
+from abc import ABC
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from .base import Sandbox
+from .constants import ENV_KEY_PATTERN, LANGUAGE_PATTERN
+from .types import ExecutionResult, FileInfo, StreamChunk
+
+logger = logging.getLogger(__name__)
+
+
+def shell_quote(value: str) -> str:
+    r"""Shell-escape a string for safe inclusion in a shell command.
+
+    Wraps the value in single quotes and escapes any embedded single quotes
+    using the ``'\''`` pattern. Single quotes disable all shell expansion
+    (variables, backticks, globbing), making this safe against injection.
+
+    Args:
+        value: The string to escape.
+
+    Returns:
+        The shell-escaped string wrapped in single quotes.
+    """
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+def validate_env_keys(env: dict[str, str]) -> None:
+    """Validate environment variable names against :data:`ENV_KEY_PATTERN`.
+
+    Args:
+        env: Mapping of environment variable names to values.
+
+    Raises:
+        ValueError: If any key is not a valid POSIX environment variable name.
+    """
+    for key in env:
+        if not ENV_KEY_PATTERN.match(key):
+            raise ValueError(f"Invalid environment variable name: {key}")
+
+
+def build_shell_env_prefix(env: dict[str, str] | None = None) -> str:
+    """Build a shell ``export KEY=VALUE && ...`` prefix, or ``""`` when empty.
+
+    Keys are validated; values are :func:`shell_quote`d. Used by shell-string
+    backends (e.g. SSH); backends that set env via native flags (e.g. Docker's
+    ``-e``) call :func:`validate_env_keys` directly.
+
+    Uses ``export`` rather than an ``env KEY=VALUE`` command wrapper so the
+    variables are set in the shell itself and inherited by every stage of a
+    pipeline. ``execute_code`` runs ``base64 ... | <lang>``, and an ``env``
+    wrapper would only bind the left side of the pipe, never reaching the
+    interpreter. The trailing ``&&`` keeps the surrounding
+    ``cd ... && <prefix><command>`` chain fail-fast.
+
+    Args:
+        env: Mapping of environment variable names to values.
+
+    Returns:
+        The shell ``export ... && `` prefix, or an empty string when ``env`` is
+        ``None`` or empty.
+
+    Raises:
+        ValueError: If any key is not a valid POSIX environment variable name.
+    """
+    if not env:
+        return ""
+    validate_env_keys(env)
+    assignments = " ".join(f"{key}={shell_quote(value)}" for key, value in env.items())
+    return f"export {assignments} && "
+
+
+def _eof_marker() -> str:
+    """Generate a unique heredoc EOF marker, mirroring the TS ``STRANDS_EOF_`` token."""
+    return f"STRANDS_EOF_{uuid.uuid4().hex[:16]}"
+
+
+class PosixShellSandbox(Sandbox, ABC):
+    """Abstract sandbox that provides shell-based defaults for file and code operations.
+
+    Assumes a POSIX-compatible shell (sh/bash) on the target.
+
+    Subclasses only need to implement :meth:`execute_streaming`. The remaining
+    operations — ``execute_code_streaming``, ``read_file``, ``write_file``,
+    ``remove_file``, and ``list_files`` — are implemented via shell commands
+    piped through :meth:`execute_streaming`.
+
+    Subclasses may override any method with a native implementation for better
+    performance or to handle edge cases (e.g., binary-safe file transfer via
+    Docker stdin pipes, or native API calls for cloud backends).
+
+    Subclasses must apply ``env`` in :meth:`execute_streaming` or it has no
+    effect: backends that build a shell-command string prepend
+    :func:`build_shell_env_prefix`; backends that set env via process flags
+    (e.g. Docker's ``-e``) call :func:`validate_env_keys` and pass the values
+    directly.
+    """
+
+    async def execute_code_streaming(
+        self,
+        code: str,
+        language: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        """Execute code by piping it to a language interpreter over the shell.
+
+        The code is base64-encoded and decoded inside a quoted heredoc on the
+        target, then piped to the interpreter (``base64 -d << 'EOF' | <lang>``).
+        This transports arbitrary source — including shell metacharacters,
+        quotes, and newlines — without injection risk. The ``language`` is
+        validated against :data:`LANGUAGE_PATTERN` first.
+
+        Args:
+            code: The source code to execute.
+            language: The interpreter to use (e.g., ``"python3"``, ``"node"``).
+            timeout: Maximum execution time in seconds. ``None`` means no timeout.
+            cwd: Working directory for execution.
+            env: Environment variables to set for this execution.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Yields:
+            :class:`StreamChunk` objects for output, then a final
+            :class:`ExecutionResult`.
+
+        Raises:
+            ValueError: If ``language`` contains invalid characters.
+        """
+        if not LANGUAGE_PATTERN.match(language):
+            raise ValueError(f"language parameter contains invalid characters: {language}")
+        encoded = base64.b64encode(code.encode()).decode("ascii")
+        eof = _eof_marker()
+        command = f"base64 -d << '{eof}' | {language}\n{encoded}\n{eof}"
+        async for chunk in self.execute_streaming(command, timeout=timeout, cwd=cwd, env=env, **kwargs):
+            yield chunk
+
+    async def read_file(self, path: str, **kwargs: Any) -> bytes:
+        """Read a file as raw bytes via base64 over the shell.
+
+        Args:
+            path: Path to the file to read.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Returns:
+            The file contents as raw bytes.
+
+        Raises:
+            FileNotFoundError: If the file does not exist or cannot be read.
+        """
+        result = await self.execute(f"base64 < {shell_quote(path)}")
+        if result.exit_code != 0:
+            raise FileNotFoundError(result.stderr or f"Failed to read file: {path}")
+        # base64 output is ASCII-safe text; strip whitespace (line wrapping) and decode.
+        return base64.b64decode("".join(result.stdout.split()))
+
+    async def write_file(self, path: str, content: bytes, **kwargs: Any) -> None:
+        """Write raw bytes to a file via base64 over the shell.
+
+        Parent directories are created via ``mkdir -p``. The base64-encoded
+        content is decoded inside a quoted heredoc on the target, preserving
+        arbitrary binary content.
+
+        Args:
+            path: Path to the file to write.
+            content: The content to write.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        encoded = base64.b64encode(content).decode("ascii")
+        quoted = shell_quote(path)
+        eof = _eof_marker()
+        cmd = f"mkdir -p \"$(dirname {quoted})\" && base64 -d << '{eof}' > {quoted}\n{encoded}\n{eof}"
+        result = await self.execute(cmd)
+        if result.exit_code != 0:
+            raise OSError(result.stderr or f"Failed to write file: {path}")
+
+    async def remove_file(self, path: str, **kwargs: Any) -> None:
+        """Remove a file via ``rm`` over the shell.
+
+        Args:
+            path: Path to the file to remove.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
+        result = await self.execute(f"rm {shell_quote(path)}")
+        if result.exit_code != 0:
+            raise FileNotFoundError(result.stderr or f"Failed to remove file: {path}")
+
+    async def list_files(self, path: str, **kwargs: Any) -> list[FileInfo]:
+        """List directory contents via ``ls -1ap`` parsing.
+
+        Args:
+            path: Path to the directory to list.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Returns:
+            A list of :class:`FileInfo` entries (``size`` is always ``None`` for
+            this shell-based listing).
+
+        Raises:
+            FileNotFoundError: If the directory does not exist (or ``path`` is
+                not a directory).
+        """
+        quoted = shell_quote(path)
+        result = await self.execute(f"test -d {quoted} || exit 1; env QUOTING_STYLE=literal ls -1ap {quoted}")
+        if result.exit_code != 0:
+            raise FileNotFoundError(result.stderr or f"Failed to list directory: {path}")
+
+        entries: list[FileInfo] = []
+        for raw in result.stdout.split("\n"):
+            line = raw.rstrip("\r")
+            if not line or line in ("./", "../"):
+                continue
+            is_dir = line.endswith("/")
+            name = line[:-1] if is_dir else line
+            if name:
+                entries.append(FileInfo(name=name, is_dir=is_dir))
+        return entries

--- a/strands-py/src/strands/sandbox/shell.py
+++ b/strands-py/src/strands/sandbox/shell.py
@@ -48,7 +48,7 @@ def validate_env_keys(env: dict[str, str]) -> None:
         ValueError: If any key is not a valid POSIX environment variable name.
     """
     for key in env:
-        if not ENV_KEY_PATTERN.match(key):
+        if not ENV_KEY_PATTERN.fullmatch(key):
             raise ValueError(f"Invalid environment variable name: {key}")
 
 
@@ -142,7 +142,7 @@ class PosixShellSandbox(Sandbox, ABC):
         Raises:
             ValueError: If ``language`` contains invalid characters.
         """
-        if not LANGUAGE_PATTERN.match(language):
+        if not LANGUAGE_PATTERN.fullmatch(language):
             raise ValueError(f"language parameter contains invalid characters: {language}")
         encoded = base64.b64encode(code.encode()).decode("ascii")
         eof = _eof_marker()

--- a/strands-py/src/strands/sandbox/shell.py
+++ b/strands-py/src/strands/sandbox/shell.py
@@ -10,6 +10,7 @@ Mirrors ``strands-ts/src/sandbox/posix-shell.ts``.
 
 import base64
 import logging
+import shlex
 import uuid
 from abc import ABC
 from collections.abc import AsyncGenerator
@@ -20,22 +21,6 @@ from .constants import ENV_KEY_PATTERN, LANGUAGE_PATTERN
 from .types import ExecutionResult, FileInfo, StreamChunk
 
 logger = logging.getLogger(__name__)
-
-
-def shell_quote(value: str) -> str:
-    r"""Shell-escape a string for safe inclusion in a shell command.
-
-    Wraps the value in single quotes and escapes any embedded single quotes
-    using the ``'\''`` pattern. Single quotes disable all shell expansion
-    (variables, backticks, globbing), making this safe against injection.
-
-    Args:
-        value: The string to escape.
-
-    Returns:
-        The shell-escaped string wrapped in single quotes.
-    """
-    return "'" + value.replace("'", "'\\''") + "'"
 
 
 def validate_env_keys(env: dict[str, str]) -> None:
@@ -55,9 +40,9 @@ def validate_env_keys(env: dict[str, str]) -> None:
 def build_shell_env_prefix(env: dict[str, str] | None = None) -> str:
     """Build a shell ``export KEY=VALUE && ...`` prefix, or ``""`` when empty.
 
-    Keys are validated; values are :func:`shell_quote`d. Used by shell-string
-    backends (e.g. SSH); backends that set env via native flags (e.g. Docker's
-    ``-e``) call :func:`validate_env_keys` directly.
+    Keys are validated; values are escaped with :func:`shlex.quote`. Used by
+    shell-string backends (e.g. SSH); backends that set env via native flags
+    (e.g. Docker's ``-e``) call :func:`validate_env_keys` directly.
 
     Uses ``export`` rather than an ``env KEY=VALUE`` command wrapper so the
     variables are set in the shell itself and inherited by every stage of a
@@ -79,7 +64,7 @@ def build_shell_env_prefix(env: dict[str, str] | None = None) -> str:
     if not env:
         return ""
     validate_env_keys(env)
-    assignments = " ".join(f"{key}={shell_quote(value)}" for key, value in env.items())
+    assignments = " ".join(f"{key}={shlex.quote(value)}" for key, value in env.items())
     return f"export {assignments} && "
 
 
@@ -102,11 +87,18 @@ class PosixShellSandbox(Sandbox, ABC):
     performance or to handle edge cases (e.g., binary-safe file transfer via
     Docker stdin pipes, or native API calls for cloud backends).
 
-    Subclasses must apply ``env`` in :meth:`execute_streaming` or it has no
-    effect: backends that build a shell-command string prepend
-    :func:`build_shell_env_prefix`; backends that set env via process flags
-    (e.g. Docker's ``-e``) call :func:`validate_env_keys` and pass the values
-    directly.
+    Subclasses are responsible for honoring the execution options in
+    :meth:`execute_streaming`, or they have no effect:
+
+    - ``env`` — backends that build a shell-command string prepend
+      :func:`build_shell_env_prefix`; backends that set env via process flags
+      (e.g. Docker's ``-e``) call :func:`validate_env_keys` and pass the values
+      directly. An implementation that ignores ``env`` will silently drop the
+      caller's variables.
+    - ``timeout`` — the base class does not enforce a timeout; a subclass that
+      does not wire ``timeout`` into its process supervision will silently run
+      without any time limit.
+    - ``cwd`` — similarly must be applied by the subclass.
     """
 
     async def execute_code_streaming(
@@ -162,12 +154,18 @@ class PosixShellSandbox(Sandbox, ABC):
 
         Raises:
             FileNotFoundError: If the file does not exist or cannot be read.
+            OSError: If the command succeeds but its output is not valid base64
+                (e.g. a shell profile or locale warning prepended text to stdout).
         """
-        result = await self.execute(f"base64 < {shell_quote(path)}")
+        result = await self.execute(f"base64 < {shlex.quote(path)}")
         if result.exit_code != 0:
             raise FileNotFoundError(result.stderr or f"Failed to read file: {path}")
         # base64 output is ASCII-safe text; strip whitespace (line wrapping) and decode.
-        return base64.b64decode("".join(result.stdout.split()))
+        try:
+            # binascii.Error (raised by b64decode on malformed input) subclasses ValueError.
+            return base64.b64decode("".join(result.stdout.split()))
+        except ValueError as e:
+            raise OSError(f"Failed to decode base64 contents of file: {path}") from e
 
     async def write_file(self, path: str, content: bytes, **kwargs: Any) -> None:
         """Write raw bytes to a file via base64 over the shell.
@@ -185,7 +183,7 @@ class PosixShellSandbox(Sandbox, ABC):
             OSError: If the file cannot be written.
         """
         encoded = base64.b64encode(content).decode("ascii")
-        quoted = shell_quote(path)
+        quoted = shlex.quote(path)
         eof = _eof_marker()
         cmd = f"mkdir -p \"$(dirname {quoted})\" && base64 -d << '{eof}' > {quoted}\n{encoded}\n{eof}"
         result = await self.execute(cmd)
@@ -202,7 +200,7 @@ class PosixShellSandbox(Sandbox, ABC):
         Raises:
             FileNotFoundError: If the file does not exist.
         """
-        result = await self.execute(f"rm {shell_quote(path)}")
+        result = await self.execute(f"rm {shlex.quote(path)}")
         if result.exit_code != 0:
             raise FileNotFoundError(result.stderr or f"Failed to remove file: {path}")
 
@@ -221,7 +219,7 @@ class PosixShellSandbox(Sandbox, ABC):
             FileNotFoundError: If the directory does not exist (or ``path`` is
                 not a directory).
         """
-        quoted = shell_quote(path)
+        quoted = shlex.quote(path)
         result = await self.execute(f"test -d {quoted} || exit 1; env QUOTING_STYLE=literal ls -1ap {quoted}")
         if result.exit_code != 0:
             raise FileNotFoundError(result.stderr or f"Failed to list directory: {path}")

--- a/strands-py/src/strands/sandbox/types.py
+++ b/strands-py/src/strands/sandbox/types.py
@@ -1,0 +1,87 @@
+"""Data types for the sandbox abstraction.
+
+These types represent the inputs and outputs of sandbox operations — execution
+results, file metadata, and streaming chunks. They mirror the structural
+interfaces in ``strands-ts/src/sandbox/types.ts`` using idiomatic Python
+dataclasses (the TypeScript discriminator fields such as ``type: 'streamChunk'``
+are replaced by ``isinstance`` checks, the Pythonic way to discriminate a union).
+"""
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+StreamType = Literal["stdout", "stderr"]
+"""Type of a streaming output chunk — distinguishes stdout from stderr."""
+
+
+@dataclass
+class StreamChunk:
+    """A typed chunk of streaming output from command or code execution.
+
+    Allows consumers to distinguish stdout from stderr during streaming,
+    enabling richer UIs and more precise output handling.
+
+    Attributes:
+        data: The text content of the chunk.
+        stream_type: Whether this chunk is from stdout or stderr.
+    """
+
+    data: str
+    stream_type: StreamType = "stdout"
+
+
+@dataclass
+class FileInfo:
+    """Metadata about a file or directory in a sandbox.
+
+    Provides minimal structured information that lets tools distinguish files
+    from directories and report sizes. ``is_dir`` and ``size`` are ``None`` when
+    the backend cannot determine them accurately (rather than guessing).
+
+    Attributes:
+        name: The file or directory name (not the full path).
+        is_dir: Whether this entry is a directory. ``None`` if unknown.
+        size: File size in bytes. ``None`` if unknown.
+    """
+
+    name: str
+    is_dir: bool | None = None
+    size: int | None = None
+
+
+@dataclass
+class OutputFile:
+    """A file produced as output by code execution.
+
+    Used to carry binary artifacts (images, charts, PDFs, compiled files) from
+    sandbox execution back to the agent. Shell-based sandboxes typically return
+    an empty list. Jupyter-backed or API-backed sandboxes can populate this with
+    generated artifacts.
+
+    Attributes:
+        name: Filename (e.g., ``"plot.png"``).
+        content: Raw file content as bytes.
+        mime_type: MIME type of the content (e.g., ``"image/png"``).
+    """
+
+    name: str
+    content: bytes
+    mime_type: str = "application/octet-stream"
+
+
+@dataclass
+class ExecutionResult:
+    """Result of command or code execution in a sandbox.
+
+    Attributes:
+        exit_code: The exit code of the command or code execution.
+        stdout: Standard output captured from execution.
+        stderr: Standard error captured from execution.
+        output_files: Files produced by the execution (e.g., images, charts).
+            Shell-based sandboxes typically return an empty list.
+    """
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    output_files: list[OutputFile] = field(default_factory=list)

--- a/strands-py/tests/strands/sandbox/test_shell.py
+++ b/strands-py/tests/strands/sandbox/test_shell.py
@@ -209,6 +209,16 @@ def test_build_shell_env_prefix_rejects_invalid_names():
         build_shell_env_prefix({"BAD-KEY": "v"})
 
 
+def test_build_shell_env_prefix_rejects_trailing_newline_in_key():
+    # Regression: a trailing newline in an env key is a shell statement
+    # separator. Python's `$` would match before it (unlike JS), so the
+    # validator must full-string match to reject `FOO\n` and friends.
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        build_shell_env_prefix({"FOO\n": "v"})
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        validate_env_keys({"FOO\nBAR": "v"})
+
+
 def test_validate_env_keys_accepts_valid_posix_names():
     validate_env_keys({"FOO": "1", "_bar": "2", "BAZ_99": "3"})  # no raise
 
@@ -276,6 +286,18 @@ async def test_language_rejects_shell_metacharacters(sandbox):
 async def test_language_rejects_spaces(sandbox):
     with pytest.raises(ValueError, match="invalid characters"):
         await sandbox.execute_code("x", "python -c")
+
+
+@pytest.mark.asyncio
+async def test_language_rejects_trailing_newline(sandbox):
+    # Regression: Python's `$` matches before a trailing newline, unlike JS's
+    # `/^...$/.test()`. The validator must use full-string matching so a
+    # trailing newline (a shell statement separator) cannot smuggle a second
+    # command past `LANGUAGE_PATTERN`.
+    with pytest.raises(ValueError, match="invalid characters"):
+        await sandbox.execute_code("x", "python3\n")
+    with pytest.raises(ValueError, match="invalid characters"):
+        await sandbox.execute_code("x", "python3\nrm -rf /")
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/sandbox/test_shell.py
+++ b/strands-py/tests/strands/sandbox/test_shell.py
@@ -1,0 +1,566 @@
+"""Tests for the shell-based sandbox core (``strands.sandbox``).
+
+Mirrors ``strands-ts/src/sandbox/__tests__/posix-shell.test.node.ts`` and its
+``TestSandbox`` fixture, plus the security/adversarial cases recovered from the
+prior Python sandbox attempt (PR #2198). Exercises the real
+:class:`~strands.sandbox.shell.PosixShellSandbox` code paths: base64 file
+transport, shell quoting, ``ls`` parsing, language validation, env handling,
+timeout, and cancellation.
+
+These tests spawn ``sh`` and require a POSIX shell, so they are skipped on
+Windows.
+"""
+
+import asyncio
+import os
+import sys
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+
+from strands.sandbox import (
+    ExecutionResult,
+    FileInfo,
+    PosixShellSandbox,
+    StreamChunk,
+)
+from strands.sandbox.shell import (
+    build_shell_env_prefix,
+    shell_quote,
+    validate_env_keys,
+)
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell required")
+
+_SIGNAL_BASE = 128
+
+
+async def _stream_process(
+    program: str,
+    args: list[str],
+    *,
+    timeout: float | None = None,
+) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+    """Spawn a process and stream stdout/stderr, yielding a final result.
+
+    Python equivalent of the TypeScript ``streamProcess`` helper. Yields
+    :class:`StreamChunk` objects as output arrives, then a final
+    :class:`ExecutionResult`. Signal termination maps to ``128 + signal``;
+    a timeout terminates the process and raises ``TimeoutError``.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        program,
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    queue: asyncio.Queue[StreamChunk | None] = asyncio.Queue()
+    out_buf: list[str] = []
+    err_buf: list[str] = []
+
+    async def pump(stream: asyncio.StreamReader, stream_type: str, buf: list[str]) -> None:
+        while True:
+            data = await stream.read(65536)
+            if not data:
+                break
+            text = data.decode(errors="replace")
+            buf.append(text)
+            await queue.put(StreamChunk(data=text, stream_type=stream_type))  # type: ignore[arg-type]
+
+    assert proc.stdout is not None and proc.stderr is not None
+    pumps = asyncio.gather(
+        pump(proc.stdout, "stdout", out_buf),
+        pump(proc.stderr, "stderr", err_buf),
+    )
+
+    async def waiter() -> None:
+        await pumps
+        await proc.wait()
+        await queue.put(None)
+
+    waiter_task = asyncio.ensure_future(waiter())
+
+    try:
+        while True:
+            if timeout is not None:
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    raise TimeoutError(f"Execution timed out after {timeout} seconds") from None
+            else:
+                item = await queue.get()
+            if item is None:
+                break
+            yield item
+
+        returncode = proc.returncode if proc.returncode is not None else 1
+        if returncode < 0:
+            exit_code = _SIGNAL_BASE + (-returncode)
+        else:
+            exit_code = returncode
+        yield ExecutionResult(
+            exit_code=exit_code,
+            stdout="".join(out_buf),
+            stderr="".join(err_buf),
+        )
+    finally:
+        if proc.returncode is None:
+            proc.kill()
+        waiter_task.cancel()
+
+
+class _ShellTestSandbox(PosixShellSandbox):
+    """Concrete sandbox that runs commands in a working directory via ``sh -c``.
+
+    Mirrors the TypeScript ``TestSandbox`` fixture so the same
+    :class:`PosixShellSandbox` code paths (base64 transport, shell quoting,
+    ``ls`` parsing) are exercised.
+    """
+
+    def __init__(self, working_dir: str) -> None:
+        self.working_dir = working_dir
+
+    async def execute_streaming(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        target_cwd = cwd if cwd is not None else self.working_dir
+        env_prefix = build_shell_env_prefix(env)
+        full_command = f"cd {shell_quote(target_cwd)} && {env_prefix}{command}"
+        async for chunk in _stream_process("sh", ["-c", full_command], timeout=timeout):
+            yield chunk
+
+
+@pytest.fixture
+def sandbox(tmp_path) -> _ShellTestSandbox:
+    return _ShellTestSandbox(str(tmp_path))
+
+
+# ---- execute (via shell commands) ----
+
+
+@pytest.mark.asyncio
+async def test_execute_runs_a_command(sandbox):
+    result = await sandbox.execute("echo hello")
+    assert result.exit_code == 0
+    assert result.stdout == "hello\n"
+
+
+@pytest.mark.asyncio
+async def test_execute_runs_in_working_dir(sandbox, tmp_path):
+    result = await sandbox.execute("pwd")
+    assert os.path.basename(str(tmp_path)) in result.stdout.strip()
+
+
+@pytest.mark.asyncio
+async def test_execute_respects_cwd_option(sandbox):
+    result = await sandbox.execute("pwd", cwd="/tmp")
+    assert result.stdout.strip().endswith("/tmp")
+
+
+# ---- env option (via build_shell_env_prefix) ----
+
+
+@pytest.mark.asyncio
+async def test_env_passes_vars_to_command(sandbox):
+    result = await sandbox.execute("printenv FOO", env={"FOO": "hello", "BAR": "world"})
+    assert result.stdout.strip() == "hello"
+
+
+@pytest.mark.asyncio
+async def test_env_values_are_not_evaluated(sandbox):
+    result = await sandbox.execute("printenv FOO", env={"FOO": "$(whoami)"})
+    assert result.stdout.strip() == "$(whoami)"
+
+
+@pytest.mark.asyncio
+async def test_env_rejects_invalid_var_names(sandbox):
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        await sandbox.execute("echo hi", env={"BAD-KEY": "v"})
+
+
+# ---- build_shell_env_prefix ----
+
+
+def test_build_shell_env_prefix_empty():
+    assert build_shell_env_prefix() == ""
+    assert build_shell_env_prefix({}) == ""
+
+
+def test_build_shell_env_prefix_uses_export_with_fail_fast_separator():
+    # `export ... &&` (not `env ... `) is what lets env reach the right side of
+    # the `base64 ... | <interpreter>` pipe in execute_code. Locking the format.
+    assert build_shell_env_prefix({"FOO": "bar", "BAZ": "qux"}) == "export FOO='bar' BAZ='qux' && "
+
+
+def test_build_shell_env_prefix_quotes_values():
+    assert build_shell_env_prefix({"FOO": "$(whoami)"}) == "export FOO='$(whoami)' && "
+
+
+def test_build_shell_env_prefix_rejects_invalid_names():
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        build_shell_env_prefix({"BAD-KEY": "v"})
+
+
+def test_validate_env_keys_accepts_valid_posix_names():
+    validate_env_keys({"FOO": "1", "_bar": "2", "BAZ_99": "3"})  # no raise
+
+
+# ---- execute_code (via base64 heredoc) ----
+
+
+@pytest.mark.asyncio
+async def test_execute_code_runs_python(sandbox):
+    result = await sandbox.execute_code("print(2 + 2)", "python3")
+    assert result.exit_code == 0
+    assert result.stdout == "4\n"
+
+
+@pytest.mark.asyncio
+async def test_execute_code_handles_double_quotes(sandbox):
+    result = await sandbox.execute_code("print('hello \"world\"')", "python3")
+    assert result.stdout == 'hello "world"\n'
+
+
+@pytest.mark.asyncio
+async def test_execute_code_handles_single_quotes(sandbox):
+    result = await sandbox.execute_code('print("it\'s working")', "python3")
+    assert result.stdout == "it's working\n"
+
+
+@pytest.mark.asyncio
+async def test_execute_code_passes_env_to_interpreter(sandbox):
+    result = await sandbox.execute_code('import os; print(os.environ["FOO"])', "python3", env={"FOO": "from-env"})
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "from-env"
+
+
+@pytest.mark.asyncio
+async def test_execute_code_passes_env_literally(sandbox):
+    result = await sandbox.execute_code('import os; print(os.environ["FOO"])', "python3", env={"FOO": "$(whoami)"})
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "$(whoami)"
+
+
+@pytest.mark.asyncio
+async def test_execute_code_handles_shell_metacharacters(sandbox):
+    # Code containing shell metacharacters must reach the interpreter verbatim.
+    result = await sandbox.execute_code("print('$(rm -rf /) `whoami` && || $HOME')", "python3")
+    assert result.exit_code == 0
+    assert result.stdout == "$(rm -rf /) `whoami` && || $HOME\n"
+
+
+# ---- language validation (security) ----
+
+
+@pytest.mark.asyncio
+async def test_language_rejects_path_traversal(sandbox):
+    with pytest.raises(ValueError, match="invalid characters"):
+        await sandbox.execute_code("x", "../../../bin/sh")
+
+
+@pytest.mark.asyncio
+async def test_language_rejects_shell_metacharacters(sandbox):
+    with pytest.raises(ValueError, match="invalid characters"):
+        await sandbox.execute_code("x", "python;rm -rf /")
+
+
+@pytest.mark.asyncio
+async def test_language_rejects_spaces(sandbox):
+    with pytest.raises(ValueError, match="invalid characters"):
+        await sandbox.execute_code("x", "python -c")
+
+
+@pytest.mark.asyncio
+async def test_language_allows_valid_interpreters(sandbox):
+    result = await sandbox.execute_code('print("safe")', "python3")
+    assert result.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_language_allows_dots_and_hyphens(sandbox):
+    # Valid pattern, but the binary doesn't exist -> shell returns 127.
+    result = await sandbox.execute_code("x", "fake-lang.99")
+    assert result.exit_code == 127
+
+
+# ---- read/write (via base64 encoding over shell) ----
+
+
+@pytest.mark.asyncio
+async def test_text_file_roundtrip(sandbox):
+    await sandbox.write_text("test.txt", "hello shell")
+    assert await sandbox.read_text("test.txt") == "hello shell"
+
+
+@pytest.mark.asyncio
+async def test_binary_file_roundtrip(sandbox):
+    data = bytes([0, 1, 2, 127, 128, 254, 255])
+    await sandbox.write_file("binary.bin", data)
+    assert await sandbox.read_file("binary.bin") == data
+
+
+@pytest.mark.asyncio
+async def test_all_256_byte_values_roundtrip(sandbox):
+    data = bytes(range(256))
+    await sandbox.write_file("all-bytes.bin", data)
+    assert await sandbox.read_file("all-bytes.bin") == data
+
+
+@pytest.mark.asyncio
+async def test_write_creates_parent_directories(sandbox):
+    await sandbox.write_text("deep/nested/file.txt", "deep")
+    assert await sandbox.read_text("deep/nested/file.txt") == "deep"
+
+
+@pytest.mark.asyncio
+async def test_handles_unicode_content(sandbox):
+    content = "日本語 🚀 émojis"
+    await sandbox.write_text("unicode.txt", content)
+    assert await sandbox.read_text("unicode.txt") == content
+
+
+@pytest.mark.asyncio
+async def test_handles_shell_metacharacters_in_content(sandbox):
+    content = "$(rm -rf /) `whoami` && || $HOME"
+    await sandbox.write_text("meta.txt", content)
+    assert await sandbox.read_text("meta.txt") == content
+
+
+@pytest.mark.asyncio
+async def test_empty_content_roundtrip(sandbox):
+    await sandbox.write_file("empty.txt", b"")
+    assert await sandbox.read_file("empty.txt") == b""
+
+
+@pytest.mark.asyncio
+async def test_read_nonexistent_file_raises(sandbox):
+    with pytest.raises(FileNotFoundError):
+        await sandbox.read_file("nope.txt")
+
+
+# ---- remove ----
+
+
+@pytest.mark.asyncio
+async def test_remove_file(sandbox):
+    await sandbox.write_text("delete-me.txt", "bye")
+    await sandbox.remove_file("delete-me.txt")
+    with pytest.raises(FileNotFoundError):
+        await sandbox.read_file("delete-me.txt")
+
+
+@pytest.mark.asyncio
+async def test_remove_nonexistent_file_raises(sandbox):
+    with pytest.raises(FileNotFoundError):
+        await sandbox.remove_file("nope.txt")
+
+
+# ---- list (via ls -1ap parsing) ----
+
+
+@pytest.mark.asyncio
+async def test_list_directory_contents(sandbox):
+    await sandbox.write_text("a.txt", "a")
+    await sandbox.write_text("b.txt", "b")
+    names = [f.name for f in await sandbox.list_files(".")]
+    assert "a.txt" in names
+    assert "b.txt" in names
+
+
+@pytest.mark.asyncio
+async def test_list_identifies_directories(sandbox):
+    await sandbox.execute("mkdir -p subdir")
+    files = await sandbox.list_files(".")
+    subdir = next((f for f in files if f.name == "subdir"), None)
+    assert subdir is not None
+    assert subdir.is_dir is True
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_dot_entries(sandbox):
+    await sandbox.write_text("file.txt", "")
+    names = [f.name for f in await sandbox.list_files(".")]
+    assert "." not in names
+    assert ".." not in names
+
+
+@pytest.mark.asyncio
+async def test_list_nonexistent_directory_raises(sandbox):
+    with pytest.raises(FileNotFoundError):
+        await sandbox.list_files("/tmp/nonexistent-dir-xyz-12345")
+
+
+@pytest.mark.asyncio
+async def test_list_on_file_raises(sandbox):
+    await sandbox.write_text("not-a-dir.txt", "hello")
+    with pytest.raises(FileNotFoundError):
+        await sandbox.list_files("not-a-dir.txt")
+
+
+# ---- shell_quote ----
+
+
+def test_shell_quote_wraps_in_single_quotes():
+    assert shell_quote("hello") == "'hello'"
+
+
+def test_shell_quote_escapes_embedded_single_quotes():
+    assert shell_quote("it's") == "'it'\\''s'"
+
+
+def test_shell_quote_neutralizes_command_substitution():
+    assert shell_quote("$(whoami)") == "'$(whoami)'"
+
+
+@pytest.mark.asyncio
+async def test_paths_with_spaces(sandbox):
+    await sandbox.execute('mkdir -p "with spaces"')
+    await sandbox.write_text("with spaces/file.txt", "spaced")
+    assert await sandbox.read_text("with spaces/file.txt") == "spaced"
+
+
+@pytest.mark.asyncio
+async def test_paths_with_single_quotes(sandbox):
+    await sandbox.execute('mkdir -p "it\'s"')
+    await sandbox.write_text("it's/file.txt", "quoted")
+    assert await sandbox.read_text("it's/file.txt") == "quoted"
+
+
+# ---- timeout ----
+
+
+@pytest.mark.asyncio
+async def test_timeout_kills_process(sandbox):
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    with pytest.raises(TimeoutError, match="timed out"):
+        await sandbox.execute("sleep 60", timeout=0.2)
+    assert loop.time() - start < 5
+
+
+@pytest.mark.asyncio
+async def test_timeout_allows_fast_commands(sandbox):
+    result = await sandbox.execute("echo fast", timeout=5)
+    assert result.exit_code == 0
+    assert result.stdout == "fast\n"
+
+
+# ---- cancellation (Pythonic equivalent of AbortSignal) ----
+
+
+@pytest.mark.asyncio
+async def test_cancellation_kills_process(sandbox):
+    task = asyncio.ensure_future(sandbox.execute("sleep 60"))
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# ---- concurrent execution ----
+
+
+@pytest.mark.asyncio
+async def test_concurrent_commands(sandbox):
+    results = await asyncio.gather(
+        sandbox.execute("echo one"),
+        sandbox.execute("echo two"),
+        sandbox.execute("echo three"),
+    )
+    assert sorted(r.stdout.strip() for r in results) == ["one", "three", "two"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_file_writes(sandbox):
+    await asyncio.gather(
+        sandbox.write_text("a.txt", "aaa"),
+        sandbox.write_text("b.txt", "bbb"),
+        sandbox.write_text("c.txt", "ccc"),
+    )
+    a, b, c = await asyncio.gather(
+        sandbox.read_text("a.txt"),
+        sandbox.read_text("b.txt"),
+        sandbox.read_text("c.txt"),
+    )
+    assert (a, b, c) == ("aaa", "bbb", "ccc")
+
+
+# ---- streaming ----
+
+
+@pytest.mark.asyncio
+async def test_streaming_yields_chunks_then_result(sandbox):
+    chunks = [chunk async for chunk in sandbox.execute_streaming("echo hello")]
+    stream_chunks = [c for c in chunks if isinstance(c, StreamChunk)]
+    results = [c for c in chunks if isinstance(c, ExecutionResult)]
+    assert len(stream_chunks) > 0
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_chunk_carries_stdout_type(sandbox):
+    chunks = [chunk async for chunk in sandbox.execute_streaming("echo hi")]
+    stdout_chunks = [c for c in chunks if isinstance(c, StreamChunk) and c.stream_type == "stdout"]
+    assert any("hi" in c.data for c in stdout_chunks)
+
+
+# ---- exit codes ----
+
+
+@pytest.mark.asyncio
+async def test_command_not_found_returns_127(sandbox):
+    result = await sandbox.execute("nonexistent_binary_xyz_12345")
+    assert result.exit_code == 127
+
+
+@pytest.mark.asyncio
+async def test_signal_termination_maps_to_128_plus_signal(sandbox):
+    # sh -c 'kill -9 $$' sends SIGKILL (9) to itself -> 128 + 9 = 137.
+    result = await sandbox.execute("kill -9 $$")
+    assert result.exit_code == 137
+
+
+@pytest.mark.asyncio
+async def test_exit_codes_preserved(sandbox):
+    for code in (0, 1, 2, 42, 255):
+        result = await sandbox.execute(f"exit {code}")
+        assert result.exit_code == code
+
+
+# ---- convenience method wiring (base.Sandbox) ----
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_first_execution_result():
+    class _Fake(PosixShellSandbox):
+        async def execute_streaming(self, command, **kwargs):
+            yield StreamChunk(data="partial", stream_type="stdout")
+            yield ExecutionResult(exit_code=0, stdout="done", stderr="")
+
+    result = await _Fake().execute("noop")
+    assert isinstance(result, ExecutionResult)
+    assert result.stdout == "done"
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_if_no_execution_result():
+    class _Fake(PosixShellSandbox):
+        async def execute_streaming(self, command, **kwargs):
+            yield StreamChunk(data="only-chunk", stream_type="stdout")
+
+    with pytest.raises(RuntimeError, match="did not yield an ExecutionResult"):
+        await _Fake().execute("noop")
+
+
+def test_file_info_defaults():
+    info = FileInfo(name="x")
+    assert info.is_dir is None
+    assert info.size is None

--- a/strands-py/tests/strands/sandbox/test_shell.py
+++ b/strands-py/tests/strands/sandbox/test_shell.py
@@ -13,6 +13,7 @@ Windows.
 
 import asyncio
 import os
+import shlex
 import sys
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -27,7 +28,6 @@ from strands.sandbox import (
 )
 from strands.sandbox.shell import (
     build_shell_env_prefix,
-    shell_quote,
     validate_env_keys,
 )
 
@@ -46,8 +46,13 @@ async def _stream_process(
 
     Python equivalent of the TypeScript ``streamProcess`` helper. Yields
     :class:`StreamChunk` objects as output arrives, then a final
-    :class:`ExecutionResult`. Signal termination maps to ``128 + signal``;
-    a timeout terminates the process and raises ``TimeoutError``.
+    :class:`ExecutionResult`. Signal termination maps to ``128 + signal``.
+
+    ``timeout`` here is an *idle* timeout: it fires when no output (chunk or
+    completion) arrives within ``timeout`` seconds, not when total wall-clock
+    execution exceeds it. A process that emits output steadily would never trip
+    it. This is sufficient for the test fixture; concrete backends that reuse
+    this pattern should document/enforce whichever semantics they intend.
     """
     proc = await asyncio.create_subprocess_exec(
         program,
@@ -84,6 +89,7 @@ async def _stream_process(
     try:
         while True:
             if timeout is not None:
+                # Idle timeout: bounds the wait for the *next* item, not the total runtime.
                 try:
                     item = await asyncio.wait_for(queue.get(), timeout=timeout)
                 except asyncio.TimeoutError:
@@ -133,7 +139,7 @@ class _ShellTestSandbox(PosixShellSandbox):
     ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
         target_cwd = cwd if cwd is not None else self.working_dir
         env_prefix = build_shell_env_prefix(env)
-        full_command = f"cd {shell_quote(target_cwd)} && {env_prefix}{command}"
+        full_command = f"cd {shlex.quote(target_cwd)} && {env_prefix}{command}"
         async for chunk in _stream_process("sh", ["-c", full_command], timeout=timeout):
             yield chunk
 
@@ -197,7 +203,7 @@ def test_build_shell_env_prefix_empty():
 def test_build_shell_env_prefix_uses_export_with_fail_fast_separator():
     # `export ... &&` (not `env ... `) is what lets env reach the right side of
     # the `base64 ... | <interpreter>` pipe in execute_code. Locking the format.
-    assert build_shell_env_prefix({"FOO": "bar", "BAZ": "qux"}) == "export FOO='bar' BAZ='qux' && "
+    assert build_shell_env_prefix({"FOO": "bar", "BAZ": "qux"}) == "export FOO=bar BAZ=qux && "
 
 
 def test_build_shell_env_prefix_quotes_values():
@@ -368,6 +374,19 @@ async def test_read_nonexistent_file_raises(sandbox):
         await sandbox.read_file("nope.txt")
 
 
+@pytest.mark.asyncio
+async def test_read_file_invalid_base64_raises_oserror(sandbox, monkeypatch):
+    # If the command exits 0 but stdout is not valid base64 (e.g. a shell
+    # profile/locale warning prepended text), surface a clear OSError naming the
+    # path instead of leaking a cryptic binascii.Error from deep in the stack.
+    async def fake_execute(self, command, **kwargs):
+        return ExecutionResult(exit_code=0, stdout="not%%valid base64!!", stderr="")
+
+    monkeypatch.setattr(PosixShellSandbox, "execute", fake_execute, raising=True)
+    with pytest.raises(OSError, match="Failed to decode base64 contents of file: weird.bin"):
+        await sandbox.read_file("weird.bin")
+
+
 # ---- remove ----
 
 
@@ -427,19 +446,20 @@ async def test_list_on_file_raises(sandbox):
         await sandbox.list_files("not-a-dir.txt")
 
 
-# ---- shell_quote ----
+# ---- shell quoting (stdlib shlex.quote) ----
+# We delegate shell-escaping to the stdlib `shlex.quote` (tenet #6: embrace
+# common standards) instead of a hand-rolled quoter. These pin the security
+# properties we rely on: command substitution and embedded quotes are neutralized.
 
 
-def test_shell_quote_wraps_in_single_quotes():
-    assert shell_quote("hello") == "'hello'"
+def test_shlex_quote_neutralizes_command_substitution():
+    assert shlex.quote("$(whoami)") == "'$(whoami)'"
 
 
-def test_shell_quote_escapes_embedded_single_quotes():
-    assert shell_quote("it's") == "'it'\\''s'"
-
-
-def test_shell_quote_neutralizes_command_substitution():
-    assert shell_quote("$(whoami)") == "'$(whoami)'"
+def test_shlex_quote_escapes_embedded_single_quotes():
+    # shlex closes the quote, inserts an escaped quote, and reopens: 'it'"'"'s'.
+    # Shell-equivalent to the '\'' idiom; both render the literal string it's.
+    assert shlex.quote("it's") == "'it'\"'\"'s'"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

This PR ports the **core** Sandbox abstraction from the `strands-ts` reference implementation into `strands-py`, under `strands-py/src/strands/sandbox/`. It is a **cross-language parity port**: the behavior is derived from the TypeScript oracle, then re-expressed idiomatically in Python.

### Behavioral oracle

The source of truth is the TypeScript sandbox **public barrel** `strands-ts/src/sandbox/index.ts` in this monorepo, which exports exactly:

```ts
export { Sandbox, type ExecuteOptions } from './base.js'
export { PosixShellSandbox } from './posix-shell.js'
export type { StreamType, StreamChunk, FileInfo, OutputFile, ExecutionResult } from './types.js'
export { LANGUAGE_PATTERN } from './constants.js'
```

The Python module mirrors this barrel one-to-one (`strands/sandbox/__init__.py`), porting:

- **`Sandbox`** (ABC) — two abstract streaming primitives (`execute_streaming`, `execute_code_streaming`), abstract file I/O (`read_file`, `write_file`, `remove_file`, `list_files`), and non-streaming/text convenience wrappers (`execute`, `execute_code`, `read_text`, `write_text`).
- **`PosixShellSandbox`** — shell-based defaults: base64-heredoc code execution, base64 file read/write with `mkdir -p`, `rm`, and `ls -1ap` parsing. Subclasses implement only `execute_streaming`.
- **Data types** — `StreamChunk`, `FileInfo`, `OutputFile`, `ExecutionResult`, and the `StreamType` literal (as dataclasses + a `Literal`).
- **`LANGUAGE_PATTERN`** — interpreter-name validation, plus the internal `ENV_KEY_PATTERN` and the `shell_quote` / `validate_env_keys` / `build_shell_env_prefix` helpers.

Docker/SSH concrete backends, the `stream-process` event-pump, and the Agent↔Sandbox integration are **deliberately out of scope** for this "core only (1/N)" PR (see Scope below).

### Prior-history note (what happened to the earlier Python sandbox attempt)

A previous Python sandbox attempt — tracked around **PR #2198** ("feat: add Sandbox abstraction - core only (1/N)") — was **merged to a `feature/sandbox` branch ONLY, never to `main`**. It used the **pre-monorepo path** `src/strands/sandbox/`. Since then the design has evolved (it now lives in the monorepo and the TypeScript implementation is the canonical reference). **This port follows the CURRENT `strands-ts` oracle, not that stale attempt** — though its adversarial/security tests were cross-referenced when mirroring coverage.

### Accepted Python↔TypeScript divergences

These are intentional, idiomatic translations (behavior preserved, surface adapted to Python):

| TypeScript (oracle) | Python (this port) | Rationale |
|---|---|---|
| `ExecuteOptions` options-object | keyword args `timeout` / `cwd` / `env` | matches `strands-py` call-option style |
| `AbortSignal` cancellation | `asyncio` task cancellation | Pythonic cancellation; no explicit `signal` param in the core ABC |
| discriminated-union `type` tag (`'streamChunk'` / `'executionResult'`) | `isinstance()` checks on `@dataclass` types | no redundant tag field in Python |
| `Uint8Array` | `bytes` | native binary type |
| camelCase (`executeStreaming`, `isDir`, `streamType`, `outputFiles`) | snake_case (`execute_streaming`, `is_dir`, `stream_type`, `output_files`) | PEP 8 |
| `throw new Error(...)` | `FileNotFoundError` / `OSError` / `ValueError` / `RuntimeError` | idiomatic, specific exception types |
| `re` via JS `/^...$/.test()` | **`re.fullmatch`** on `^...$` patterns | **see below** |

**Iteration-1 divergence note (security-relevant):** Python's `$` in a regex matches **just before a trailing `\n`**, unlike JavaScript's `/^...$/.test()` which anchors to the true end of the string. Using `re.match` on the `$`-anchored `LANGUAGE_PATTERN` / `ENV_KEY_PATTERN` would have **accepted** `language="python3\n"` and env key `"FOO\n"` (a trailing newline is a shell statement separator) while the TS oracle rejects them. Both validator call sites use **`re.fullmatch`** to reproduce the JS semantics; the gotcha is documented in `constants.py` and covered by two dedicated regression tests.

### Scope — "core only (1/N)" + follow-ups

This PR is the first in a series. Out of scope here, to follow as separate PRs mirroring the corresponding TypeScript work:

- Concrete **Docker / SSH** sandbox implementations (+ the `stream-process` helper).
- **Agent↔Sandbox integration** (tracks TS `strands-agents/harness-sdk#2563`).
- **Vended sandbox tools** (tracks TS `strands-agents/harness-sdk#2649`).

## Related Issues

Parity-port tracking issue: `agent-of-mkmeral/strands-coder-private#248`.

## Documentation PR

No user-facing docs required for this internal core abstraction (no public package export surface changes beyond the new `strands.sandbox` module, which is documented via module/class docstrings). Docs will accompany the Agent-integration follow-up.

## Type of Change

New feature

## Review Loop Summary

This PR went through a fresh-context pre-PR review loop (`task-pre-pr-review`, max 3 iterations) before being opened. State was tracked in the `REVIEW_LOOP_248` repo variable.

| Iteration | Actor | Run | Findings / Action |
|---|---|---|---|
| 0 | porter | [27133074838](https://github.com/agent-of-mkmeral/strands-coder-private/actions/runs/27133074838) | Initial port of `strands-ts/src/sandbox/` core → `strands-py/src/strands/sandbox/`: `Sandbox` ABC + `PosixShellSandbox` + types + `LANGUAGE_PATTERN`, 55 mirrored tests incl. security/adversarial. |
| 1 | reviewer | [27134301661](https://github.com/agent-of-mkmeral/strands-coder-private/actions/runs/27134301661) | 🔴 **Found & fixed:** `re.match` vs JS `$` transliteration bug in `LANGUAGE_PATTERN`/`ENV_KEY_PATTERN` — trailing-newline bypass in a security-sensitive validator. Switched both call sites to `re.fullmatch`, documented the gotcha in `constants.py`, added 2 regression tests (verified to fail on the old `.match` code). 57 tests. |
| 2 | reviewer (this PR) | [27134910228](https://github.com/agent-of-mkmeral/strands-coder-private/actions/runs/27134910228) | **Converged — ZERO 🔴 / ZERO 🟡.** Independently re-derived parity vs the TS oracle for the whole core. Confirmed both validator call sites use `fullmatch`; grepped for any other `.match`/`.search` validator sites (none); empirically re-verified the iteration-1 regression tests genuinely fail when reverted to `.match` and pass with `fullmatch`. lint + mypy (5 files) + 57 tests all green. Opening the PR. |

## Remaining Findings

None blocking. One 🟢 cosmetic nit was considered and dismissed as a non-issue: `list_files` strips trailing CR with `str.rstrip("\r")` (removes all trailing CRs) where the TS oracle uses `replace(/\r$/, '')` (removes at most one). This can only differ for a filename literally containing a CR byte under CRLF line endings, which POSIX `ls -1ap` never emits (POSIX uses LF). No behavioral impact; not filed.

## Testing

Readiness was run from `strands-py/` (with the runner's ambient `OTEL_*` env unset, which otherwise breaks the hatch-test env at import — an env artifact, not a code defect):

- `hatch run lint` → **All checks passed!**
- `hatch run hatch-static-analysis:mypy ./src/strands/sandbox` → **Success: no issues found in 5 source files**
- `hatch test tests/strands/sandbox/test_shell.py` → **57 passed**

The Python tests mirror `strands-ts/src/sandbox/__tests__/posix-shell.test.node.ts` and its `TestSandbox` fixture (ported to `_ShellTestSandbox` + `_stream_process`), and cover: streaming primitives + non-streaming/text wrappers; base64-heredoc code exec; base64 binary/all-256-byte/unicode file roundtrip with `mkdir -p`; `rm`; `ls -1ap` parsing (excludes `./`/`../`, trailing-slash dir detection); `export K=V && ` env prefix with shell-quoting + `ENV_KEY` validation; `shell_quote` single-quote wrapping + `'\''` escaping; `LANGUAGE_PATTERN` injection rejection (path traversal, `;`, spaces, **trailing newline**); env-name injection; shell-metacharacter content/path safety; command-substitution neutralization; timeout; asyncio cancellation; exit-code/signal mapping (127, 128+signal).

- [x] I ran `hatch run prepare` (scoped: lint + mypy + sandbox tests — all green). Note: `hatch run format` flags two **unrelated** pre-existing files (`src/strands/tools/mcp/mcp_client.py`, `tests/strands/models/test_gemini.py`) as drift on `main`; those are not part of this diff and were left untouched.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (module/class/method docstrings)
- [x] I have added an appropriate example to the documentation to outline the feature (see `strands/sandbox/__init__.py` and `Sandbox` docstrings)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

cc @mkmeral @gautamsirdeshmukh (gautamsirdeshmukh owns the sandbox workstream — TS #2563/#2649).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Opened by an autonomous Strands agent after a fresh-context pre-PR review loop converged.