### PR TITLE
feat: add memory manager (python)

### DIFF
--- a/strands-py/src/strands/__init__.py
+++ b/strands-py/src/strands/__init__.py
@@ -4,6 +4,14 @@ from . import agent, models, telemetry, types
 from .agent.agent import Agent
 from .agent.base import AgentBase
 from .event_loop._retry import ModelRetryStrategy
+from .memory import (
+    MemoryAddToolConfig,
+    MemoryEntry,
+    MemoryManager,
+    MemoryStore,
+    MemoryStoreError,
+    MemoryToolConfig,
+)
 from .plugins import MultiAgentPlugin, Plugin
 from .tools.decorator import tool
 from .types._snapshot import Snapshot
@@ -16,6 +24,12 @@ __all__ = [
     "AgentSkills",
     "agent",
     "models",
+    "MemoryAddToolConfig",
+    "MemoryEntry",
+    "MemoryManager",
+    "MemoryStore",
+    "MemoryStoreError",
+    "MemoryToolConfig",
     "ModelRetryStrategy",
     "MultiAgentPlugin",
     "Plugin",

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -54,6 +54,7 @@ from ..hooks import (
 )
 from ..hooks.registry import TEvent
 from ..interrupt import _InterruptState
+from ..memory.memory_manager import MemoryManager
 from ..models.bedrock import BedrockModel
 from ..models.model import Model, _ModelPlugin
 from ..plugins import Plugin
@@ -144,6 +145,7 @@ class Agent(AgentBase):
         plugins: list[Plugin] | None = None,
         hooks: list[HookProvider | HookCallback] | None = None,
         session_manager: SessionManager | None = None,
+        memory_manager: MemoryManager | None = None,
         structured_output_prompt: str | None = None,
         tool_executor: ToolExecutor | None = None,
         retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
@@ -203,6 +205,9 @@ class Agent(AgentBase):
                 Defaults to None.
             session_manager: Manager for handling agent sessions including conversation history and state.
                 If provided, enables session-based persistence and state management.
+            memory_manager: Manager for cross-session memory retrieval and storage.
+                Manages one or more memory stores and exposes search/add tools to the agent.
+                Defaults to None.
             structured_output_prompt: Custom prompt message used when forcing structured output.
                 When using structured output, if the model doesn't automatically use the output tool,
                 the agent sends a follow-up message to request structured formatting. This parameter
@@ -356,6 +361,9 @@ class Agent(AgentBase):
         if self._session_manager:
             self.hooks.add_hook(self._session_manager)
 
+        # Memory management is registered as a plugin below, after built-in and user plugins.
+        self.memory_manager = memory_manager
+
         # Allow conversation_managers to subscribe to hooks
         self.hooks.add_hook(self.conversation_manager)
 
@@ -381,6 +389,9 @@ class Agent(AgentBase):
         if plugins:
             for plugin in plugins:
                 self._plugin_registry.add_and_init(plugin)
+
+        if self.memory_manager is not None:
+            self._plugin_registry.add_and_init(self.memory_manager)
 
         self.hooks.invoke_callbacks(AgentInitializedEvent(agent=self))
 

--- a/strands-py/src/strands/memory/__init__.py
+++ b/strands-py/src/strands/memory/__init__.py
@@ -1,0 +1,33 @@
+"""Memory module.
+
+This module provides cross-session memory management for agents. The
+:class:`MemoryManager` manages one or more :class:`MemoryStore` backends and exposes
+``search_memory`` / ``add_memory`` tools for agent-driven recall and persistence,
+plus programmatic ``search`` / ``add`` methods.
+
+Example:
+    ```python
+    from strands import Agent
+    from strands.memory import MemoryManager
+
+    agent = Agent(memory_manager=MemoryManager(stores=[my_store], add_tool_config=True))
+    ```
+"""
+
+from .memory_manager import MemoryManager
+from .types import (
+    MemoryAddToolConfig,
+    MemoryEntry,
+    MemoryStore,
+    MemoryStoreError,
+    MemoryToolConfig,
+)
+
+__all__ = [
+    "MemoryAddToolConfig",
+    "MemoryEntry",
+    "MemoryManager",
+    "MemoryStore",
+    "MemoryStoreError",
+    "MemoryToolConfig",
+]

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -1,0 +1,540 @@
+"""MemoryManager primitive for cross-session agent memory.
+
+This module provides the :class:`MemoryManager`, a :class:`~strands.plugins.Plugin`
+that manages one or more :class:`~strands.memory.types.MemoryStore` backends and
+exposes ``search_memory`` / ``add_memory`` tools for agent-driven recall and
+persistence, plus programmatic :meth:`MemoryManager.search` / :meth:`MemoryManager.add`
+methods. Any tools the stores themselves provide (via
+:meth:`MemoryStore.get_tools`) are registered alongside these.
+
+Example:
+    ```python
+    from strands import Agent
+    from strands.memory import MemoryManager
+
+    # Agent gains search_memory (+ add_memory) tools
+    agent = Agent(memory_manager=MemoryManager(stores=[my_store], add_tool_config=True))
+
+    # Programmatic access via the instance
+    manager = MemoryManager(stores=[my_store], add_tool_config=True)
+    agent = Agent(memory_manager=manager)
+    await manager.search("user preferences")
+    await manager.add("User prefers dark mode")
+    ```
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+from ..hooks.events import AfterInvocationEvent
+from ..plugins import Plugin, hook
+from ..tools.decorator import DecoratedFunctionTool, tool
+from .types import (
+    MemoryAddToolConfig,
+    MemoryEntry,
+    MemoryStore,
+    MemoryStoreError,
+    MemoryToolConfig,
+)
+
+if TYPE_CHECKING:
+    from ..agent.agent import Agent
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_SEARCH_RESULTS = 3
+"""Default maximum results per store when neither the caller nor the store specifies one."""
+
+_SEARCH_TOOL_DESCRIPTION = (
+    "Search long-term memory for facts, preferences, or context from previous conversations. "
+    "Use when you need background about the user or topic that may have been discussed before."
+)
+
+_ADD_TOOL_DESCRIPTION = (
+    "Add facts, preferences, or decisions to long-term memory so they are remembered across "
+    "conversations. Use when the user shares something worth recalling later."
+)
+
+
+def _flatten_reasons(reasons: list[Exception]) -> list[Exception]:
+    """Flatten nested :class:`MemoryStoreError`s so the leaves are concrete reasons.
+
+    Args:
+        reasons: A list of exceptions, some of which may be aggregate errors.
+
+    Returns:
+        A flat list with concrete (non-aggregate) exceptions as leaves.
+    """
+    flat: list[Exception] = []
+    for reason in reasons:
+        if isinstance(reason, MemoryStoreError) and reason.errors:
+            flat.extend(_flatten_reasons(reason.errors))
+        else:
+            flat.append(reason)
+    return flat
+
+
+def _entry_to_dict(entry: MemoryEntry) -> dict[str, Any]:
+    """Convert a memory entry to a JSON-serializable dict, omitting empty fields."""
+    result: dict[str, Any] = {"content": entry.content}
+    if entry.store_name:
+        result["store_name"] = entry.store_name
+    if entry.metadata:
+        result["metadata"] = entry.metadata
+    return result
+
+
+class MemoryManager(Plugin):
+    """Provides cross-session memory retrieval and storage for agents.
+
+    Manages one or more :class:`~strands.memory.types.MemoryStore` backends, exposing
+    ``search_memory`` and ``add_memory`` tools for agent-driven recall and persistence.
+    Any tools the stores themselves provide (via :meth:`MemoryStore.get_tools`) are
+    registered alongside these.
+
+    The manager is a :class:`~strands.plugins.Plugin`: pass it to an agent via the
+    dedicated ``memory_manager`` parameter (``Agent(memory_manager=...)``), which
+    registers its tools and its write-drain hook.
+
+    Example:
+        ```python
+        from strands import Agent
+        from strands.memory import MemoryManager
+
+        manager = MemoryManager(stores=[my_store], add_tool_config=True)
+        agent = Agent(memory_manager=manager)
+        await manager.search("user preferences")
+        ```
+    """
+
+    name = "strands.memory_manager"
+
+    def __init__(
+        self,
+        stores: list[MemoryStore],
+        *,
+        search_tool_config: bool | MemoryToolConfig = True,
+        add_tool_config: bool | MemoryAddToolConfig = False,
+    ) -> None:
+        """Initialize the memory manager.
+
+        Args:
+            stores: One or more memory stores to manage.
+            search_tool_config: Search tool configuration. ``True`` (default) registers
+                the ``search_memory`` tool with default name/description; pass a
+                :class:`~strands.memory.types.MemoryToolConfig` to customize, or ``False``
+                to disable the tool.
+            add_tool_config: Add tool configuration. ``False`` (default) disables the
+                ``add_memory`` tool. ``True`` lets the tool write to all writable stores;
+                pass a :class:`~strands.memory.types.MemoryAddToolConfig` to customize the
+                name/description, restrict it to specific stores, or control write awaiting.
+
+        Raises:
+            ValueError: If ``stores`` is empty, two stores share a name, a writable store
+                does not implement ``add``, the add tool is enabled with no writable stores,
+                or ``add_tool_config.stores`` references an unknown or read-only store.
+        """
+        if not stores:
+            raise ValueError("MemoryManager requires at least one store")
+
+        seen_names: set[str] = set()
+        for store in stores:
+            if store.name in seen_names:
+                raise ValueError(f"MemoryManager: duplicate store name '{store.name}'")
+            seen_names.add(store.name)
+
+            if store.writable and type(store).add is MemoryStore.add:
+                raise ValueError(f"MemoryManager: store '{store.name}' is writable but does not implement add")
+
+        self._stores = list(stores)
+        self._search_stores = self._stores
+        # All writable stores: the unscoped target set for the programmatic add() method.
+        self._add_stores = [s for s in self._stores if s.writable]
+        self._pending_writes: set[asyncio.Task[None]] = set()
+
+        self._search_tool_config: MemoryToolConfig | None
+        if search_tool_config is False:
+            self._search_tool_config = None
+        elif isinstance(search_tool_config, MemoryToolConfig):
+            self._search_tool_config = search_tool_config
+        else:
+            self._search_tool_config = MemoryToolConfig()
+
+        self._add_tool_config: MemoryAddToolConfig | None
+        if add_tool_config is False:
+            self._add_tool_config = None
+            self._add_tool_stores: list[MemoryStore] = []
+        else:
+            if not self._add_stores:
+                raise ValueError("MemoryManager: add_tool_config is enabled but no stores are writable")
+            self._add_tool_config = (
+                add_tool_config if isinstance(add_tool_config, MemoryAddToolConfig) else MemoryAddToolConfig()
+            )
+            self._add_tool_stores = self._resolve_add_tool_stores(self._add_tool_config)
+
+        # Pre-seed the dynamically named tools so Plugin.__init__ skips auto-discovery
+        # (the @tool/@hook scan only finds class-level decorated members; these are built here).
+        self._tools: list[DecoratedFunctionTool] = []
+        if self._search_tool_config is not None:
+            self._tools.append(self._create_search_tool(self._search_tool_config))
+        if self._add_tool_config is not None:
+            self._tools.append(self._create_add_tool(self._add_tool_config, self._add_tool_stores))
+
+        super().__init__()
+
+    def _resolve_add_tool_stores(self, config: MemoryAddToolConfig) -> list[MemoryStore]:
+        """Resolve the writable stores the ``add_memory`` tool may write to.
+
+        When ``config.stores`` is given, each entry (a store name or a
+        :class:`MemoryStore` instance) must resolve by name to a configured, writable
+        store (else raises). Omitted means all writable stores.
+
+        Args:
+            config: The add tool configuration.
+
+        Returns:
+            The list of writable stores the add tool is scoped to.
+
+        Raises:
+            ValueError: If a named store is not configured or is not writable.
+        """
+        if config.stores is None:
+            return self._add_stores
+
+        names = [s if isinstance(s, str) else s.name for s in config.stores]
+
+        resolved: list[MemoryStore] = []
+        for name in dict.fromkeys(names):
+            found = self._find_store(name)
+            if found is None:
+                raise ValueError(f"MemoryManager: add_tool_config store '{name}' not found")
+            if not found.writable:
+                raise ValueError(f"MemoryManager: add_tool_config store '{name}' is not writable")
+            resolved.append(found)
+        return resolved
+
+    def _find_store(self, name: str) -> MemoryStore | None:
+        """Return the configured store with the given name, or None."""
+        return next((s for s in self._stores if s.name == name), None)
+
+    def init_agent(self, agent: Agent) -> None:
+        """Register any store-provided tools with the agent.
+
+        The manager's own ``search_memory`` / ``add_memory`` tools are auto-registered
+        via the plugin's :attr:`tools`. Store-provided tools are registered here so they
+        are not constrained by the plugin's tool list type.
+
+        Args:
+            agent: The agent this manager is being attached to.
+        """
+        for store in self._stores:
+            store_tools = store.get_tools()
+            if store_tools:
+                agent.tool_registry.process_tools(list(store_tools))
+
+    @hook
+    async def _drain_pending_writes(self, event: AfterInvocationEvent) -> None:
+        """Await fire-and-forget memory writes so they survive event-loop teardown.
+
+        Strands runs invocations through ``run_async``, which can create and close an
+        event loop per call. Draining here guarantees dispatched writes complete before
+        the invocation returns rather than being cancelled at loop teardown.
+
+        Args:
+            event: The after-invocation event (unused).
+        """
+        if not self._pending_writes:
+            return
+        await asyncio.gather(*list(self._pending_writes), return_exceptions=True)
+
+    async def search(
+        self,
+        query: str,
+        *,
+        max_search_results: int | None = None,
+        stores: list[str] | None = None,
+    ) -> list[MemoryEntry]:
+        """Search stores for entries matching the query.
+
+        This method is unscoped, with full access to all configured stores. When
+        ``stores`` is omitted, all stores are searched; when provided, only the named
+        stores are searched. Per-store failures are logged and skipped. Each returned
+        entry is attributed to its source store via :attr:`MemoryEntry.store_name`.
+
+        Args:
+            query: The search query string.
+            max_search_results: Maximum results per store. Overrides each store's own
+                default; falls back to the store default, then the SDK default of 3.
+            stores: Filter to specific stores by name. Omit to search all.
+
+        Returns:
+            A list of memory entries from matching stores.
+
+        Raises:
+            ValueError: If a named store does not exist.
+        """
+        logger.debug(
+            "query=<%s>, max_search_results=<%s>, stores=<%s> | searching stores",
+            query,
+            max_search_results,
+            stores,
+        )
+
+        target_stores = self._resolve_named_stores(stores) if stores is not None else self._stores
+
+        settled = await asyncio.gather(
+            *(
+                store.search(
+                    query,
+                    max_search_results=(
+                        max_search_results
+                        if max_search_results is not None
+                        else store.max_search_results
+                        if store.max_search_results is not None
+                        else DEFAULT_MAX_SEARCH_RESULTS
+                    ),
+                )
+                for store in target_stores
+            ),
+            return_exceptions=True,
+        )
+
+        results: list[MemoryEntry] = []
+        for store, outcome in zip(target_stores, settled, strict=True):
+            if isinstance(outcome, BaseException):
+                logger.warning("store=<%s>, reason=<%s> | store search failed", store.name, outcome)
+                continue
+            for entry in outcome:
+                results.append(replace(entry, store_name=store.name))
+
+        logger.debug("results=<%d> | search complete", len(results))
+        return results
+
+    async def add(
+        self,
+        content: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+        stores: list[str] | None = None,
+    ) -> None:
+        """Add content to writable stores.
+
+        This method is unscoped, with full access to all configured writable stores.
+        Target stores are validated first (an unknown or read-only named store raises),
+        then the writes are awaited: per-store failures are logged, and a
+        :class:`MemoryStoreError` is raised if any store fails.
+
+        Args:
+            content: The text content to add.
+            metadata: Optional metadata to associate with the entry.
+            stores: Filter to specific writable stores by name. Omit to write to all
+                writable stores.
+
+        Raises:
+            ValueError: If a named store does not exist, is read-only, or no writable
+                store matched.
+            MemoryStoreError: If one or more store writes fail.
+        """
+        if stores is not None:
+            writable_stores: list[MemoryStore] = []
+            for name in dict.fromkeys(stores):
+                found = self._find_store(name)
+                if found is None:
+                    raise ValueError(f"MemoryManager: store '{name}' not found")
+                if not found.writable:
+                    raise ValueError(f"MemoryManager: store '{name}' is read-only")
+                writable_stores.append(found)
+        else:
+            writable_stores = self._add_stores
+
+        if not writable_stores:
+            raise ValueError("MemoryManager: no writable store matched")
+
+        settled = await asyncio.gather(
+            *(store.add(content, metadata) for store in writable_stores),
+            return_exceptions=True,
+        )
+
+        failures: list[Exception] = []
+        failed_names: list[str] = []
+        for store, outcome in zip(writable_stores, settled, strict=True):
+            if isinstance(outcome, Exception):
+                logger.warning("store=<%s>, reason=<%s> | store write failed", store.name, outcome)
+                failures.append(outcome)
+                failed_names.append(store.name)
+
+        if failures:
+            raise MemoryStoreError(
+                f"MemoryManager: store writes failed: {', '.join(failed_names)}",
+                errors=failures,
+            )
+
+    def _resolve_named_stores(self, names: list[str]) -> list[MemoryStore]:
+        """Resolve store names to configured stores, deduping and preserving order.
+
+        Args:
+            names: Store names to resolve.
+
+        Returns:
+            The resolved stores.
+
+        Raises:
+            ValueError: If a name does not match a configured store.
+        """
+        resolved: list[MemoryStore] = []
+        for name in dict.fromkeys(names):
+            found = self._find_store(name)
+            if found is None:
+                raise ValueError(f"MemoryManager: store '{name}' not found")
+            resolved.append(found)
+        return resolved
+
+    def _resolve_tool_targets(self, scoped_names: list[str], requested: list[str] | None) -> list[str]:
+        """Resolve the store names a tool callback should target against its scoped set.
+
+        - Omitting ``requested`` (or an empty list) targets all scoped stores.
+        - In-scope names are kept; out-of-scope names are dropped with a warning.
+        - When every requested name is out of scope, raises so the model receives an
+          actionable error (the tool layer turns this into a model-visible result).
+
+        Args:
+            scoped_names: Store names available to this tool.
+            requested: Store names the model asked for, if any.
+
+        Returns:
+            A non-empty list of in-scope store names to target.
+
+        Raises:
+            ValueError: If every requested name is out of scope.
+        """
+        if not requested:
+            return scoped_names
+
+        in_scope = [name for name in requested if name in scoped_names]
+        out_of_scope = [name for name in requested if name not in scoped_names]
+
+        if not in_scope:
+            raise ValueError(
+                f"MemoryManager: requested=<{', '.join(requested)}> | "
+                f"none of the requested memory stores are available; available stores: {', '.join(scoped_names)}"
+            )
+
+        if out_of_scope:
+            logger.warning(
+                "requested=<%s> | ignoring memory stores outside this tool's scope",
+                ", ".join(out_of_scope),
+            )
+
+        return in_scope
+
+    def _create_search_tool(self, config: MemoryToolConfig) -> DecoratedFunctionTool:
+        """Build the ``search_memory`` tool, scoped to all searchable stores."""
+        description = config.description or _SEARCH_TOOL_DESCRIPTION
+        store_descriptions = [f"- {s.name}: {s.description}" for s in self._search_stores if s.description]
+        if store_descriptions:
+            description += "\n\nAvailable memory stores:\n" + "\n".join(store_descriptions)
+            description += (
+                "\n\nYou can target one or more memory stores by name if you know which domains are "
+                "relevant, or omit the stores parameter to search all."
+            )
+
+        scoped_names = [s.name for s in self._search_stores]
+        manager = self
+
+        async def search_memory(
+            query: str,
+            max_search_results: int | None = None,
+            stores: list[str] | None = None,
+        ) -> dict[str, Any]:
+            """Search long-term memory for relevant entries.
+
+            Args:
+                query: What to search for.
+                max_search_results: Maximum number of results per store.
+                stores: Filter to specific stores by name. Omit to search all available stores.
+            """
+            targets = manager._resolve_tool_targets(scoped_names, stores)
+            results = await manager.search(query, max_search_results=max_search_results, stores=targets)
+            return {"results": [_entry_to_dict(entry) for entry in results]}
+
+        return tool(name=config.name or "search_memory", description=description)(search_memory)
+
+    def _create_add_tool(self, config: MemoryAddToolConfig, stores: list[MemoryStore]) -> DecoratedFunctionTool:
+        """Build the ``add_memory`` tool, scoped to its writable store allowlist."""
+        description = config.description or _ADD_TOOL_DESCRIPTION
+        store_descriptions = [f"- {s.name}: {s.description}" for s in stores if s.description]
+        if store_descriptions:
+            description += "\n\nAvailable writable stores:\n" + "\n".join(store_descriptions)
+            description += (
+                "\n\nYou can target a specific store by name to route facts to the right place, "
+                "or omit to add to all available writable stores."
+            )
+
+        scoped_names = [s.name for s in stores]
+        wait_for_writes = config.wait_for_writes
+        manager = self
+
+        async def add_memory(
+            entries: list[str],
+            stores: list[str] | None = None,
+        ) -> dict[str, Any]:
+            """Add one or more entries to long-term memory.
+
+            Args:
+                entries: Data to add to long-term memory.
+                stores: Target specific stores by name. Omit to add to all writable stores.
+            """
+            if not entries:
+                raise ValueError("MemoryManager: entries must not be empty")
+
+            targets = manager._resolve_tool_targets(scoped_names, stores)
+
+            if not wait_for_writes:
+                # Fire-and-forget: dispatch without awaiting so the agent loop is not blocked.
+                # Failures are logged; pending writes are drained at the end of the invocation.
+                for content in entries:
+                    manager._dispatch_write(content, targets)
+                return {"accepted": len(entries)}
+
+            # Await mode: surface failures to the model with concrete reasons.
+            settled = await asyncio.gather(
+                *(manager.add(content, stores=targets) for content in entries),
+                return_exceptions=True,
+            )
+            failures = [outcome for outcome in settled if isinstance(outcome, Exception)]
+            if failures:
+                reasons = _flatten_reasons(failures)
+                raise MemoryStoreError(
+                    f"MemoryManager: failed to add {len(failures)} of {len(entries)} entries: "
+                    + "; ".join(str(reason) for reason in reasons),
+                    errors=reasons,
+                )
+
+            return {"stored": len(entries)}
+
+        return tool(name=config.name or "add_memory", description=description)(add_memory)
+
+    def _dispatch_write(self, content: str, stores: list[str]) -> None:
+        """Dispatch a fire-and-forget write, holding a strong task reference.
+
+        The event loop keeps only a weak reference to tasks, so the reference is held in
+        :attr:`_pending_writes` (and discarded on completion) to prevent mid-flight GC.
+
+        Args:
+            content: The text content to add.
+            stores: The target store names.
+        """
+        task = asyncio.create_task(self._safe_write(content, stores))
+        self._pending_writes.add(task)
+        task.add_done_callback(self._pending_writes.discard)
+
+    async def _safe_write(self, content: str, stores: list[str]) -> None:
+        """Run a write, swallowing and logging any failure (fire-and-forget mode)."""
+        try:
+            await self.add(content, stores=stores)
+        except Exception:
+            logger.warning("stores=<%s> | fire-and-forget memory write failed", ", ".join(stores), exc_info=True)

--- a/strands-py/src/strands/memory/types.py
+++ b/strands-py/src/strands/memory/types.py
@@ -1,0 +1,193 @@
+"""Type definitions and interfaces for the memory module.
+
+This module defines the data types and the ``MemoryStore`` interface that the
+:class:`~strands.memory.memory_manager.MemoryManager` builds on. A memory store
+is a searchable (and optionally writable) backend for an agent's long-term
+memory; concrete stores subclass :class:`MemoryStore`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..types.tools import AgentTool
+
+
+@dataclass
+class MemoryEntry:
+    """A single memory entry retrieved from or stored to a memory store.
+
+    Attributes:
+        content: The textual content of this memory entry.
+        store_name: Name of the store this entry came from. Populated by
+            :meth:`MemoryManager.search` so callers (and the model, via
+            ``search_memory``) can tell which store produced each result and refine
+            targeting. Stores need not set this themselves.
+        metadata: Optional metadata (e.g., score, source, id, timestamp).
+    """
+
+    content: str
+    store_name: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class MemoryStore(ABC):
+    """Interface for a memory store backend.
+
+    Every store is searchable; the ``writable`` flag declares whether it also
+    accepts writes, which is how the :class:`~strands.memory.memory_manager.MemoryManager`
+    decides where to route them. ``search_memory`` can query all stores, while
+    ``add_memory`` can only write to ``writable`` stores.
+
+    Concrete stores subclass this and implement :meth:`search`. Writable stores
+    (``writable=True``) must additionally override :meth:`add`.
+
+    Example:
+        ```python
+        from strands.memory import MemoryEntry, MemoryStore
+
+
+        class MyStore(MemoryStore):
+            def __init__(self) -> None:
+                super().__init__(name="my-store", writable=True)
+                self._entries: list[str] = []
+
+            async def search(self, query, *, max_search_results=None):
+                return [MemoryEntry(content=e) for e in self._entries if query in e]
+
+            async def add(self, content, metadata=None):
+                self._entries.append(content)
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        writable: bool = False,
+        description: str | None = None,
+        max_search_results: int | None = None,
+    ) -> None:
+        """Initialize the memory store.
+
+        Args:
+            name: Identifier for this store, used to target specific stores in the
+                search/add tools. Must be unique within a ``MemoryManager``.
+            writable: Whether this store accepts writes. When True, the subclass
+                must override :meth:`add`. Defaults to False.
+            description: Human-readable description of what this store contains.
+                Included in tool descriptions when present.
+            max_search_results: Default maximum number of results this store returns
+                per search, used when a caller does not pass a per-call
+                ``max_search_results``.
+        """
+        self.name = name
+        self.writable = writable
+        self.description = description
+        self.max_search_results = max_search_results
+
+    @abstractmethod
+    async def search(self, query: str, *, max_search_results: int | None = None) -> list[MemoryEntry]:
+        """Search the store for entries matching the query, ordered by relevance.
+
+        Args:
+            query: The search query string.
+            max_search_results: Maximum number of results to return from this store.
+
+        Returns:
+            A list of matching memory entries.
+        """
+        ...
+
+    async def add(self, content: str, metadata: dict[str, Any] | None = None) -> None:
+        """Add content to the store.
+
+        Must be overridden by stores that declare ``writable=True``. The default
+        implementation raises, so a writable store that forgets to implement it
+        fails loudly.
+
+        Args:
+            content: The text content to add.
+            metadata: Optional metadata to associate with the entry.
+
+        Raises:
+            NotImplementedError: If the store does not override this method.
+        """
+        raise NotImplementedError(f"store '{self.name}' does not implement add")
+
+    def get_tools(self) -> list[AgentTool]:
+        """Return store-specific tools to register with the agent.
+
+        Registered alongside the manager's ``search_memory`` / ``add_memory`` tools.
+        Override to expose backend-specific capabilities (e.g. a store-native query
+        tool). Optional; mirrors :meth:`Plugin.tools`.
+
+        Returns:
+            A list of tools provided by this store. Empty by default.
+        """
+        return []
+
+
+@dataclass
+class MemoryToolConfig:
+    """Configuration for customizing a memory tool's name or description.
+
+    Attributes:
+        name: Custom tool name. Defaults to the tool's standard name when None.
+        description: Custom tool description. Defaults to the tool's standard
+            description when None.
+    """
+
+    name: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class MemoryAddToolConfig(MemoryToolConfig):
+    """Configuration for the ``add_memory`` tool.
+
+    Extends :class:`MemoryToolConfig` with an explicit allowlist of stores the tool
+    may write to and a flag controlling whether writes are awaited.
+
+    Attributes:
+        stores: The writable stores the ``add_memory`` tool may write to, given as
+            store names or :class:`MemoryStore` instances. Each must be a configured,
+            writable store. Omit to allow all writable stores.
+        wait_for_writes: Whether the tool waits for store writes before returning to
+            the model. Defaults to True.
+
+            - True (default): waits for writes. The tool returns ``{"stored": N}`` on
+              success, or surfaces a failure to the model if any store write fails.
+            - False: fire-and-forget. The tool returns ``{"accepted": N}`` once writes
+              are dispatched (so a slow backend never blocks the agent loop); per-store
+              failures are logged. Dispatched writes are drained at the end of the agent
+              invocation so they are not lost to event-loop teardown.
+    """
+
+    stores: list[str | MemoryStore] | None = field(default=None)
+    wait_for_writes: bool = True
+
+
+class MemoryStoreError(Exception):
+    """Raised when one or more memory store operations fail.
+
+    Aggregates the underlying per-store errors (the Python analogue of an
+    ``AggregateError``), since the standard library ``ExceptionGroup`` is only
+    available on Python 3.11+.
+
+    Attributes:
+        errors: The underlying exceptions raised by individual stores.
+    """
+
+    def __init__(self, message: str, errors: list[Exception] | None = None) -> None:
+        """Initialize the error.
+
+        Args:
+            message: A human-readable summary, typically naming the failed stores.
+            errors: The underlying per-store exceptions, if any.
+        """
+        super().__init__(message)
+        self.errors = errors if errors is not None else []

--- a/strands-py/tests/strands/memory/test_memory_manager.py
+++ b/strands-py/tests/strands/memory/test_memory_manager.py
@@ -1,0 +1,640 @@
+"""Tests for the MemoryManager primitive and the MemoryStore interface."""
+
+import json
+import logging
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+import strands
+from strands import Agent
+from strands.hooks.events import AfterInvocationEvent
+from strands.memory import (
+    MemoryAddToolConfig,
+    MemoryEntry,
+    MemoryManager,
+    MemoryStore,
+    MemoryStoreError,
+    MemoryToolConfig,
+)
+from strands.tools.decorator import DecoratedFunctionTool
+from strands.types.tools import AgentTool
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+class FakeStore(MemoryStore):
+    """In-memory store with spy-able search/add for tests."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        writable: bool = False,
+        description: str | None = None,
+        max_search_results: int | None = None,
+        entries: list[MemoryEntry] | None = None,
+        tools: list[AgentTool] | None = None,
+    ) -> None:
+        super().__init__(
+            name=name,
+            writable=writable,
+            description=description,
+            max_search_results=max_search_results,
+        )
+        self._entries = entries if entries is not None else []
+        self._tools = tools
+        self.search = AsyncMock(return_value=self._entries)  # type: ignore[method-assign]
+        if writable:
+            self.add = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    async def search(self, query: str, *, max_search_results: int | None = None) -> list[MemoryEntry]:  # noqa: D102
+        return self._entries
+
+    async def add(self, content: str, metadata: dict[str, Any] | None = None) -> None:  # noqa: D102
+        return None
+
+    def get_tools(self) -> list[AgentTool]:  # noqa: D102
+        return self._tools if self._tools is not None else []
+
+
+class WritableNoAddStore(MemoryStore):
+    """A store that claims writable=True but never overrides add (an error)."""
+
+    async def search(self, query: str, *, max_search_results: int | None = None) -> list[MemoryEntry]:  # noqa: D102
+        return []
+
+
+def _named_tool(name: str) -> DecoratedFunctionTool:
+    @strands.tool(name=name, description=f"test tool {name}")
+    def _t() -> str:
+        return "ok"
+
+    return _t
+
+
+def _search_tool(manager: MemoryManager) -> DecoratedFunctionTool:
+    return next(t for t in manager.tools if t.tool_name == "search_memory")
+
+
+def _add_tool(manager: MemoryManager) -> DecoratedFunctionTool:
+    return next(t for t in manager.tools if t.tool_name == "add_memory")
+
+
+async def _invoke(tool: DecoratedFunctionTool, alist, **tool_input: Any) -> dict[str, Any]:
+    """Invoke a tool via its stream and return the final ToolResult."""
+    events = await alist(tool.stream({"toolUseId": "t", "input": tool_input}, {}))
+    return events[-1].tool_result
+
+
+# --- Group A: constructor validation -------------------------------------------------
+
+
+class TestConstructorValidation:
+    def test_empty_stores_raises(self):
+        with pytest.raises(ValueError, match="at least one store"):
+            MemoryManager(stores=[])
+
+    def test_creates_instance_with_valid_config(self):
+        manager = MemoryManager(stores=[FakeStore("test")])
+        assert manager.name == "strands.memory_manager"
+
+    def test_duplicate_store_name_raises(self):
+        with pytest.raises(ValueError, match="duplicate store name 'dup'"):
+            MemoryManager(stores=[FakeStore("dup"), FakeStore("dup")])
+
+    def test_writable_without_add_raises(self):
+        with pytest.raises(ValueError, match="writable but does not implement add"):
+            MemoryManager(stores=[WritableNoAddStore(name="broken", writable=True)])
+
+    def test_add_tool_enabled_without_writable_store_raises(self):
+        with pytest.raises(ValueError, match="no stores are writable"):
+            MemoryManager(stores=[FakeStore("a")], add_tool_config=True)
+
+    def test_add_tool_config_unknown_store_raises(self):
+        with pytest.raises(ValueError, match="add_tool_config store 'nope' not found"):
+            MemoryManager(
+                stores=[FakeStore("a", writable=True)],
+                add_tool_config=MemoryAddToolConfig(stores=["nope"]),
+            )
+
+    def test_add_tool_config_readonly_store_raises(self):
+        with pytest.raises(ValueError, match="add_tool_config store 'readonly' is not writable"):
+            MemoryManager(
+                stores=[FakeStore("a", writable=True), FakeStore("readonly")],
+                add_tool_config=MemoryAddToolConfig(stores=["readonly"]),
+            )
+
+    def test_add_tool_config_accepts_store_instances(self):
+        personal = FakeStore("personal", writable=True)
+        team = FakeStore("team", writable=True)
+        manager = MemoryManager(stores=[personal, team], add_tool_config=MemoryAddToolConfig(stores=[personal]))
+        assert [s.name for s in manager._add_tool_stores] == ["personal"]
+
+    def test_add_tool_config_stray_instance_raises(self):
+        configured = FakeStore("configured", writable=True)
+        stray = FakeStore("stray", writable=True)
+        with pytest.raises(ValueError, match="add_tool_config store 'stray' not found"):
+            MemoryManager(stores=[configured], add_tool_config=MemoryAddToolConfig(stores=[stray]))
+
+
+# --- Group B: tool registration & plugin wiring --------------------------------------
+
+
+class TestTools:
+    def test_registers_search_tool_by_default(self):
+        manager = MemoryManager(stores=[FakeStore("test")])
+        assert [t.tool_name for t in manager.tools] == ["search_memory"]
+
+    def test_registers_add_tool_when_enabled(self):
+        manager = MemoryManager(stores=[FakeStore("test", writable=True)], add_tool_config=True)
+        assert [t.tool_name for t in manager.tools] == ["search_memory", "add_memory"]
+
+    def test_no_add_tool_by_default(self):
+        manager = MemoryManager(stores=[FakeStore("test", writable=True)])
+        assert [t.tool_name for t in manager.tools] == ["search_memory"]
+
+    def test_no_tools_when_both_disabled(self):
+        manager = MemoryManager(
+            stores=[FakeStore("test", writable=True)],
+            search_tool_config=False,
+            add_tool_config=False,
+        )
+        assert manager.tools == []
+
+    def test_custom_tool_names(self):
+        manager = MemoryManager(
+            stores=[FakeStore("test", writable=True)],
+            search_tool_config=MemoryToolConfig(name="recall"),
+            add_tool_config=MemoryAddToolConfig(name="remember"),
+        )
+        assert [t.tool_name for t in manager.tools] == ["recall", "remember"]
+
+    def test_search_tool_includes_store_descriptions(self):
+        manager = MemoryManager(stores=[FakeStore("personal", description="User preferences")])
+        desc = _search_tool(manager).tool_spec["description"]
+        assert "personal: User preferences" in desc
+        assert "target one or more memory stores by name" in desc
+
+    def test_add_tool_includes_store_descriptions(self):
+        manager = MemoryManager(
+            stores=[FakeStore("notes", writable=True, description="Personal notes")],
+            add_tool_config=True,
+        )
+        desc = _add_tool(manager).tool_spec["description"]
+        assert "notes: Personal notes" in desc
+        assert "target a specific store by name" in desc
+
+    def test_drain_hook_discovered(self):
+        manager = MemoryManager(stores=[FakeStore("test")])
+        assert [getattr(h, "__name__", h) for h in manager.hooks] == ["_drain_pending_writes"]
+
+    def test_search_tool_input_schema_props(self):
+        manager = MemoryManager(stores=[FakeStore("test")])
+        props = _search_tool(manager).tool_spec["inputSchema"]["json"]["properties"]
+        assert set(props) == {"query", "max_search_results", "stores"}
+
+    def test_add_tool_input_schema_props(self):
+        manager = MemoryManager(stores=[FakeStore("test", writable=True)], add_tool_config=True)
+        props = _add_tool(manager).tool_spec["inputSchema"]["json"]["properties"]
+        assert set(props) == {"entries", "stores"}
+
+
+class TestStoreProvidedTools:
+    def test_store_tools_registered_via_init_agent(self):
+        store = FakeStore("kb", tools=[_named_tool("kb_query")])
+        agent = Agent(memory_manager=MemoryManager(stores=[store]))
+        assert "kb_query" in agent.tool_names
+        assert "search_memory" in agent.tool_names
+
+    def test_store_tools_registered_even_with_no_manager_tools(self):
+        store = FakeStore("kb", tools=[_named_tool("kb_query")])
+        agent = Agent(memory_manager=MemoryManager(stores=[store], search_tool_config=False))
+        assert "kb_query" in agent.tool_names
+        assert "search_memory" not in agent.tool_names
+
+
+# --- Group C: programmatic search() --------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSearch:
+    async def test_queries_all_stores_and_concatenates(self):
+        a = FakeStore("a", entries=[MemoryEntry(content="fact one")])
+        b = FakeStore("b", entries=[MemoryEntry(content="fact two")])
+        manager = MemoryManager(stores=[a, b])
+
+        results = await manager.search("query")
+        assert results == [
+            MemoryEntry(content="fact one", store_name="a"),
+            MemoryEntry(content="fact two", store_name="b"),
+        ]
+
+    async def test_resolves_store_max_search_results_when_caller_omits(self):
+        store = FakeStore("a", max_search_results=5)
+        manager = MemoryManager(stores=[store])
+
+        await manager.search("query")
+        store.search.assert_called_once_with("query", max_search_results=5)
+
+    async def test_forwards_explicit_max_search_results(self):
+        store = FakeStore("a", max_search_results=5)
+        manager = MemoryManager(stores=[store])
+
+        await manager.search("query", max_search_results=2)
+        store.search.assert_called_once_with("query", max_search_results=2)
+
+    async def test_falls_back_to_sdk_default_limit(self):
+        store = FakeStore("a")
+        manager = MemoryManager(stores=[store])
+
+        await manager.search("query")
+        store.search.assert_called_once_with("query", max_search_results=3)
+
+    async def test_filters_to_named_stores(self):
+        personal = FakeStore("personal", entries=[MemoryEntry(content="personal fact")])
+        team = FakeStore("team", entries=[MemoryEntry(content="team fact")])
+        manager = MemoryManager(stores=[personal, team])
+
+        results = await manager.search("query", stores=["personal"])
+        assert results == [MemoryEntry(content="personal fact", store_name="personal")]
+        team.search.assert_not_called()
+
+    async def test_gracefully_handles_store_failures(self, caplog):
+        failing = FakeStore("failing")
+        failing.search = AsyncMock(side_effect=RuntimeError("network error"))
+        ok = FakeStore("ok", entries=[MemoryEntry(content="fact")])
+        manager = MemoryManager(stores=[failing, ok])
+
+        with caplog.at_level(logging.WARNING):
+            results = await manager.search("query")
+        assert results == [MemoryEntry(content="fact", store_name="ok")]
+        assert "failing" in caplog.text
+
+    async def test_searches_all_when_stores_omitted(self):
+        a = FakeStore("a", entries=[MemoryEntry(content="one")])
+        b = FakeStore("b", entries=[MemoryEntry(content="two")])
+        manager = MemoryManager(stores=[a, b])
+
+        results = await manager.search("query")
+        assert {e.store_name for e in results} == {"a", "b"}
+
+    async def test_searches_none_when_stores_empty(self):
+        a = FakeStore("a", entries=[MemoryEntry(content="one")])
+        b = FakeStore("b", entries=[MemoryEntry(content="two")])
+        manager = MemoryManager(stores=[a, b])
+
+        results = await manager.search("query", stores=[])
+        assert results == []
+        a.search.assert_not_called()
+        b.search.assert_not_called()
+
+    async def test_unknown_named_store_raises(self):
+        store = FakeStore("personal")
+        manager = MemoryManager(stores=[store])
+
+        with pytest.raises(ValueError, match="store 'nonexistent' not found"):
+            await manager.search("query", stores=["nonexistent"])
+        store.search.assert_not_called()
+
+
+# --- Group D: programmatic add() -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAdd:
+    async def test_writes_to_all_writable_stores(self):
+        a = FakeStore("a", writable=True)
+        b = FakeStore("b", writable=True)
+        manager = MemoryManager(stores=[a, b])
+
+        await manager.add("user likes coffee")
+        a.add.assert_called_once_with("user likes coffee", None)
+        b.add.assert_called_once_with("user likes coffee", None)
+
+    async def test_passes_metadata(self):
+        store = FakeStore("a", writable=True)
+        manager = MemoryManager(stores=[store])
+
+        await manager.add("fact", metadata={"source": "user"})
+        store.add.assert_called_once_with("fact", {"source": "user"})
+
+    async def test_filters_to_named_stores(self):
+        personal = FakeStore("personal", writable=True)
+        team = FakeStore("team", writable=True)
+        manager = MemoryManager(stores=[personal, team])
+
+        await manager.add("pref", stores=["personal"])
+        personal.add.assert_called_once_with("pref", None)
+        team.add.assert_not_called()
+
+    async def test_dedupes_duplicate_store_names(self):
+        store = FakeStore("personal", writable=True)
+        manager = MemoryManager(stores=[store])
+
+        await manager.add("fact", stores=["personal", "personal"])
+        store.add.assert_called_once()
+
+    async def test_no_writable_store_matched_raises(self):
+        manager = MemoryManager(stores=[FakeStore("a")])
+        with pytest.raises(ValueError, match="no writable store matched"):
+            await manager.add("fact")
+
+    async def test_unknown_named_store_raises(self):
+        manager = MemoryManager(stores=[FakeStore("a", writable=True)])
+        with pytest.raises(ValueError, match="store 'nonexistent' not found"):
+            await manager.add("fact", stores=["nonexistent"])
+
+    async def test_readonly_named_store_raises(self):
+        manager = MemoryManager(stores=[FakeStore("readonly")])
+        with pytest.raises(ValueError, match="store 'readonly' is read-only"):
+            await manager.add("fact", stores=["readonly"])
+
+    async def test_partial_failure_raises_aggregate(self, caplog):
+        failing = FakeStore("failing", writable=True)
+        failing.add = AsyncMock(side_effect=RuntimeError("write error"))
+        ok = FakeStore("ok", writable=True)
+        manager = MemoryManager(stores=[failing, ok])
+
+        with caplog.at_level(logging.WARNING), pytest.raises(MemoryStoreError, match="store writes failed: failing"):
+            await manager.add("fact")
+        ok.add.assert_called_once_with("fact", None)
+
+
+# --- Group E: search_memory tool scoping --------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSearchToolScoping:
+    async def test_searches_all_when_omitted(self, alist):
+        personal = FakeStore("personal", entries=[MemoryEntry(content="p")])
+        team = FakeStore("team", entries=[MemoryEntry(content="t")])
+        manager = MemoryManager(stores=[personal, team])
+
+        await _invoke(_search_tool(manager), alist, query="q")
+        personal.search.assert_called()
+        team.search.assert_called()
+
+    async def test_empty_stores_treated_as_all(self, alist):
+        personal = FakeStore("personal", entries=[MemoryEntry(content="p")])
+        team = FakeStore("team", entries=[MemoryEntry(content="t")])
+        manager = MemoryManager(stores=[personal, team])
+
+        await _invoke(_search_tool(manager), alist, query="q", stores=[])
+        personal.search.assert_called()
+        team.search.assert_called()
+
+    async def test_targets_only_requested_in_scope(self, alist):
+        personal = FakeStore("personal", entries=[MemoryEntry(content="p")])
+        team = FakeStore("team", entries=[MemoryEntry(content="t")])
+        manager = MemoryManager(stores=[personal, team])
+
+        await _invoke(_search_tool(manager), alist, query="q", stores=["personal"])
+        personal.search.assert_called()
+        team.search.assert_not_called()
+
+    async def test_result_attributes_each_entry(self, alist):
+        personal = FakeStore("personal", entries=[MemoryEntry(content="personal fact")])
+        team = FakeStore("team", entries=[MemoryEntry(content="team fact")])
+        manager = MemoryManager(stores=[personal, team])
+
+        result = await _invoke(_search_tool(manager), alist, query="q")
+        payload = json.loads(result["content"][0]["text"])
+        assert payload == {
+            "results": [
+                {"content": "personal fact", "store_name": "personal"},
+                {"content": "team fact", "store_name": "team"},
+            ]
+        }
+
+    async def test_keeps_valid_warns_on_out_of_scope(self, alist, caplog):
+        personal = FakeStore("personal", entries=[MemoryEntry(content="p")])
+        team = FakeStore("team", entries=[MemoryEntry(content="t")])
+        manager = MemoryManager(stores=[personal, team])
+
+        with caplog.at_level(logging.WARNING):
+            await _invoke(_search_tool(manager), alist, query="q", stores=["personal", "nonexistent"])
+        personal.search.assert_called()
+        team.search.assert_not_called()
+        assert "nonexistent" in caplog.text
+
+    async def test_all_out_of_scope_returns_error_result(self, alist):
+        personal = FakeStore("personal", entries=[MemoryEntry(content="p")])
+        manager = MemoryManager(stores=[personal])
+
+        result = await _invoke(_search_tool(manager), alist, query="q", stores=["nonexistent"])
+        assert result["status"] == "error"
+        assert "none of the requested memory stores are available" in result["content"][0]["text"]
+        personal.search.assert_not_called()
+
+    async def test_underlying_failure_still_returns_partial_success(self, alist):
+        failing = FakeStore("failing")
+        failing.search = AsyncMock(side_effect=RuntimeError("boom"))
+        ok = FakeStore("ok", entries=[MemoryEntry(content="fact")])
+        manager = MemoryManager(stores=[failing, ok])
+
+        result = await _invoke(_search_tool(manager), alist, query="q")
+        assert result["status"] == "success"
+        payload = json.loads(result["content"][0]["text"])
+        assert payload == {"results": [{"content": "fact", "store_name": "ok"}]}
+
+
+# --- Group F: add_memory tool scoping & write modes ---------------------------------
+
+
+@pytest.mark.asyncio
+class TestAddToolScoping:
+    async def test_writes_all_writable_when_omitted(self, alist):
+        personal = FakeStore("personal", writable=True)
+        team = FakeStore("team", writable=True)
+        manager = MemoryManager(stores=[personal, team], add_tool_config=True)
+
+        await _invoke(_add_tool(manager), alist, entries=["fact"])
+        personal.add.assert_called_once_with("fact", None)
+        team.add.assert_called_once_with("fact", None)
+
+    async def test_empty_stores_treated_as_all(self, alist):
+        personal = FakeStore("personal", writable=True)
+        team = FakeStore("team", writable=True)
+        manager = MemoryManager(stores=[personal, team], add_tool_config=True)
+
+        await _invoke(_add_tool(manager), alist, entries=["fact"], stores=[])
+        personal.add.assert_called()
+        team.add.assert_called()
+
+    async def test_scoped_to_add_tool_config_stores(self, alist):
+        personal = FakeStore("personal", writable=True)
+        team = FakeStore("team", writable=True)
+        manager = MemoryManager(stores=[personal, team], add_tool_config=MemoryAddToolConfig(stores=["personal"]))
+
+        await _invoke(_add_tool(manager), alist, entries=["fact"])
+        personal.add.assert_called_once_with("fact", None)
+        team.add.assert_not_called()
+
+    async def test_rejects_writable_store_excluded_from_allowlist(self, alist):
+        personal = FakeStore("personal", writable=True)
+        extraction_only = FakeStore("extraction-only", writable=True)
+        manager = MemoryManager(
+            stores=[personal, extraction_only],
+            add_tool_config=MemoryAddToolConfig(stores=["personal"]),
+        )
+
+        result = await _invoke(_add_tool(manager), alist, entries=["fact"], stores=["extraction-only"])
+        assert result["status"] == "error"
+        assert "none of the requested memory stores are available" in result["content"][0]["text"]
+        extraction_only.add.assert_not_called()
+
+    async def test_excludes_readonly_stores_from_scope(self, alist):
+        personal = FakeStore("personal", writable=True)
+        readonly = FakeStore("readonly")
+        manager = MemoryManager(stores=[personal, readonly], add_tool_config=True)
+
+        result = await _invoke(_add_tool(manager), alist, entries=["fact"], stores=["readonly"])
+        assert result["status"] == "error"
+        assert "none of the requested memory stores are available" in result["content"][0]["text"]
+        personal.add.assert_not_called()
+
+    async def test_keeps_valid_warns_on_out_of_scope(self, alist, caplog):
+        personal = FakeStore("personal", writable=True)
+        team = FakeStore("team", writable=True)
+        manager = MemoryManager(stores=[personal, team], add_tool_config=True)
+
+        with caplog.at_level(logging.WARNING):
+            await _invoke(_add_tool(manager), alist, entries=["fact"], stores=["personal", "nonexistent"])
+        personal.add.assert_called_once_with("fact", None)
+        team.add.assert_not_called()
+        assert "nonexistent" in caplog.text
+
+    async def test_all_out_of_scope_returns_error(self, alist):
+        personal = FakeStore("personal", writable=True)
+        manager = MemoryManager(stores=[personal], add_tool_config=True)
+
+        result = await _invoke(_add_tool(manager), alist, entries=["fact"], stores=["nonexistent"])
+        assert result["status"] == "error"
+        assert "none of the requested memory stores are available" in result["content"][0]["text"]
+        personal.add.assert_not_called()
+
+    async def test_empty_entries_rejected(self, alist):
+        personal = FakeStore("personal", writable=True)
+        manager = MemoryManager(stores=[personal], add_tool_config=True)
+
+        result = await _invoke(_add_tool(manager), alist, entries=[])
+        assert result["status"] == "error"
+        personal.add.assert_not_called()
+
+    async def test_returns_stored_count_by_default(self, alist):
+        store = FakeStore("notes", writable=True)
+        manager = MemoryManager(stores=[store], add_tool_config=True)
+
+        result = await _invoke(_add_tool(manager), alist, entries=["a", "b"])
+        assert result["status"] == "success"
+        assert json.loads(result["content"][0]["text"]) == {"stored": 2}
+
+    async def test_failure_returns_error_with_concrete_reasons(self, alist):
+        failing = FakeStore("failing", writable=True)
+        failing.add = AsyncMock(side_effect=RuntimeError("write error"))
+        manager = MemoryManager(stores=[failing], add_tool_config=True)
+
+        result = await _invoke(_add_tool(manager), alist, entries=["a", "b"])
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "failed to add 2 of 2 entries" in text
+        assert "write error" in text
+
+    async def test_wait_for_writes_false_returns_accepted(self, alist):
+        store = FakeStore("notes", writable=True)
+        manager = MemoryManager(stores=[store], add_tool_config=MemoryAddToolConfig(wait_for_writes=False))
+
+        result = await _invoke(_add_tool(manager), alist, entries=["a", "b"])
+        assert result["status"] == "success"
+        assert json.loads(result["content"][0]["text"]) == {"accepted": 2}
+
+        # Drain dispatched writes and confirm they landed.
+        await manager._drain_pending_writes(AfterInvocationEvent(agent=None))
+        assert store.add.call_count == 2
+
+    async def test_wait_for_writes_false_swallows_failures(self, alist, caplog):
+        failing = FakeStore("failing", writable=True)
+        failing.add = AsyncMock(side_effect=RuntimeError("write error"))
+        manager = MemoryManager(stores=[failing], add_tool_config=MemoryAddToolConfig(wait_for_writes=False))
+
+        with caplog.at_level(logging.WARNING):
+            result = await _invoke(_add_tool(manager), alist, entries=["a", "b"])
+            assert json.loads(result["content"][0]["text"]) == {"accepted": 2}
+            await manager._drain_pending_writes(AfterInvocationEvent(agent=None))
+        assert "fire-and-forget memory write failed" in caplog.text
+
+
+# --- Group G: Agent integration ------------------------------------------------------
+
+
+class TestAgentIntegration:
+    def test_registers_memory_tools_on_agent(self):
+        agent = Agent(memory_manager=MemoryManager(stores=[FakeStore("test", writable=True)], add_tool_config=True))
+        assert "search_memory" in agent.tool_names
+        assert "add_memory" in agent.tool_names
+
+    def test_passes_through_instance_unchanged(self):
+        manager = MemoryManager(stores=[FakeStore("test")])
+        agent = Agent(memory_manager=manager)
+        assert agent.memory_manager is manager
+
+    def test_memory_manager_none_when_not_configured(self):
+        agent = Agent()
+        assert agent.memory_manager is None
+
+    def test_name_collision_raises(self):
+        # Two managers register under the same plugin name on one agent.
+        manager = MemoryManager(stores=[FakeStore("a")])
+        with pytest.raises(ValueError, match="already registered"):
+            Agent(memory_manager=manager, plugins=[MemoryManager(stores=[FakeStore("b")])])
+
+
+@pytest.mark.asyncio
+class TestDrainOnInvocation:
+    async def test_pending_writes_drained_after_invocation(self, alist):
+        store = FakeStore("notes", writable=True)
+        manager = MemoryManager(stores=[store], add_tool_config=MemoryAddToolConfig(wait_for_writes=False))
+        tool_use = {"name": "add_memory", "toolUseId": "1", "input": {"entries": ["remember this"]}}
+        model = MockedModelProvider(
+            [
+                {"role": "assistant", "content": [{"toolUse": tool_use}]},
+                {"role": "assistant", "content": [{"text": "done"}]},
+            ]
+        )
+        agent = Agent(model=model, memory_manager=manager)
+
+        await agent.invoke_async("save a memory")
+
+        # The drain hook on AfterInvocationEvent guarantees the write completed.
+        assert manager._pending_writes == set()
+        store.add.assert_called_once_with("remember this", None)
+
+
+# --- Group H: types & edge cases -----------------------------------------------------
+
+
+class TestTypes:
+    def test_memory_entry_defaults(self):
+        entry = MemoryEntry(content="x")
+        assert entry.store_name is None
+        assert entry.metadata is None
+
+    @pytest.mark.asyncio
+    async def test_memory_store_add_default_raises(self):
+        store = FakeStore("ro")
+
+        class BareStore(MemoryStore):
+            async def search(self, query, *, max_search_results=None):
+                return []
+
+        bare = BareStore(name="bare")
+        with pytest.raises(NotImplementedError, match="store 'bare' does not implement add"):
+            await bare.add("x")
+        # Sanity: Fake.search still works.
+        assert await store.search("q") == []
+
+    def test_memory_store_error_carries_errors(self):
+        err = MemoryStoreError("boom", errors=[ValueError("a"), RuntimeError("b")])
+        assert str(err) == "boom"
+        assert len(err.errors) == 2


### PR DESCRIPTION
## Description

Adds the `MemoryManager` primitive to the Python SDK: a `Plugin` that manages one or more memory-store backends and exposes `search_memory` / `add_memory` tools for agent-driven recall and persistence, plus programmatic `search()` / `add()` methods. Ported from the TypeScript SDK ([harness-sdk#2544](https://github.com/strands-agents/harness-sdk/pull/2544)), adapted to Python idioms.

**What's included**
- **`MemoryManager`** (extends `Plugin`): registers `search_memory` (+ optional `add_memory`) tools, plus any tools a store exposes via `MemoryStore.get_tools()`. The constructor fails fast on an empty store list, duplicate store names, a writable store that doesn't implement `add`, or `add_tool_config` enabled with no writable stores.
- **`MemoryStore`** (ABC): every store is searchable; the `writable` flag declares whether it accepts writes. `search_memory` targets all stores; `add_memory` targets only writable ones. The default `add` raises so a writable store that forgets to implement it fails loudly.
- **Tool store scoping**: the model may target a subset of stores by name; out-of-scope names are dropped (with a warning), or an actionable error is raised if *all* requested names are out of scope. Omitted/empty `stores` targets all in-scope stores.
- **Agent integration**: a dedicated `Agent(memory_manager=...)` keyword param (instance only; mirrors `session_manager`), registered through the plugin registry.

**Python adaptations vs. the TS PR**
- Configurable tool names are built from named inner closures via the `tool()` factory and pre-seeded into the plugin's tool list (TS used static methods).
- `AggregateError` → `MemoryStoreError` (carries `.errors`), since the 3.10 floor has no built-in `ExceptionGroup`.
- Option-bag types collapse to keyword args; `Promise.allSettled` → `asyncio.gather(return_exceptions=True)`.
- **Fire-and-forget writes** (`wait_for_writes=False`) are dispatched as tracked `asyncio` tasks and **drained at `AfterInvocationEvent`**, so writes survive Strands' per-call `run_async` event-loop teardown.

**Scope (intentionally minimal)**
Ships the `MemoryManager` and `MemoryStore` interface only, to unblock downstream consumers (e.g. AgentCore memory). Context injection and concrete store backends (e.g. a Bedrock Knowledge Base store) are deferred to follow-up PRs, matching the TS PR's scope.

## Related Issues

Ports https://github.com/strands-agents/harness-sdk/pull/2544

## Documentation PR

No new docs in this PR. A documentation PR will accompany the injection follow-up once the full feature surface (injection + a shipped store backend) is finalized.

## Type of Change

New feature

## Testing

Added `tests/strands/memory/test_memory_manager.py` (65 tests) covering: constructor validation, tool registration (names/descriptions/enablement), store-tool aggregation, `search()`/`add()` fan-out and partial-failure handling, tool store scoping (in-scope/out-of-scope/partial, omit-vs-empty), both write modes (`wait_for_writes` true/false), and a live drain-on-invocation path through a full agent run.


- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.