### PR TITLE
docs(strands-ts): update Bedrock examples to default model id

### DIFF
--- a/strands-ts/README.md
+++ b/strands-ts/README.md
@@ -75,7 +75,7 @@ const result = await agent.invoke('What is the square root of 1764?')
 console.log(result)
 ```
 
-> **Note**: For the default Amazon Bedrock model provider, you'll need AWS credentials configured and model access enabled for Claude Sonnet 4 in your region.
+> **Note**: For the default Amazon Bedrock model provider, you'll need AWS credentials configured and model access enabled for Claude Sonnet 4.6 in your region.
 
 ---
 
@@ -103,7 +103,7 @@ import { Agent, BedrockModel } from '@strands-agents/sdk'
 
 const model = new BedrockModel({
   region: 'us-east-1',
-  modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+  modelId: 'global.anthropic.claude-sonnet-4-6',
   maxTokens: 4096,
   temperature: 0.7
 })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -130,13 +130,13 @@ export type AgentConfig = {
    * ```typescript
    * // Using a string model ID (creates BedrockModel)
    * const agent = new Agent({
-   *   model: 'anthropic.claude-3-5-sonnet-20240620-v1:0'
+   *   model: 'global.anthropic.claude-sonnet-4-6'
    * })
    *
    * // Using an explicit BedrockModel instance with configuration
    * const agent = new Agent({
    *   model: new BedrockModel({
-   *     modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+   *     modelId: 'global.anthropic.claude-sonnet-4-6',
    *     temperature: 0.7,
    *     maxTokens: 2048
    *   })


### PR DESCRIPTION
## Description

The `strands-ts` README and the `Agent` config JSDoc still demonstrated the legacy Bedrock model id `anthropic.claude-3-5-sonnet-20240620-v1:0`. This updates those examples to the current default, `global.anthropic.claude-sonnet-4-6` (`MODEL_DEFAULTS.bedrock.modelId`), so copy-pasted snippets match what `BedrockModel` actually uses by default. Docs/comments only — no behavior change.

## Related Issues

N/A

## Type of Change

Documentation update

## Testing

`hatch run prepare` is Python-specific and not applicable to these TS doc changes. The repo pre-commit hook ran the strands-ts suite (2982 tests), lint, format, and type checks — all green.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
