### PR TITLE
feat(strands-py): add cancel to BeforeInvocationEvent/BeforeModelCallEvent + intervention HookOrder presets

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -965,6 +965,36 @@ class Agent(AgentBase):
                 before_invocation_event.messages if before_invocation_event.messages is not None else current_messages
             )
 
+            # Short-circuit the invocation if a hook requested cancellation. No model
+            # inference or tool execution occurs; a single assistant message carrying the
+            # cancel text is appended, AfterInvocationEvent still fires, and the result
+            # stops with "end_turn". Mirrors strands-ts agent-loop cancel semantics.
+            if before_invocation_event.cancel:
+                cancel_text = (
+                    before_invocation_event.cancel
+                    if isinstance(before_invocation_event.cancel, str)
+                    else "invocation denied by hook"
+                )
+                cancel_message: Message = {"role": "assistant", "content": [{"text": cancel_text}]}
+                await self._append_messages(cancel_message)
+                after_invocation_event, _interrupts = await self.hooks.invoke_callbacks_async(
+                    AfterInvocationEvent(agent=self, invocation_state=invocation_state, result=None)
+                )
+                stop_event = EventLoopStopEvent(
+                    "end_turn",
+                    cancel_message,
+                    self.event_loop_metrics,
+                    invocation_state.get("request_state", {}),
+                )
+                yield stop_event
+                if after_invocation_event.resume is not None:
+                    logger.debug("resume=<True> | hook requested agent resume after cancelled invocation")
+                    self._interrupt_state.resume(after_invocation_event.resume)
+                    current_messages = await self._convert_prompt_to_messages(after_invocation_event.resume)
+                    continue
+                current_messages = None
+                continue
+
             agent_result: AgentResult | None = None
             try:
                 yield InitEventLoopEvent()

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -35,6 +35,7 @@ from ..types._events import (
 )
 from ..types.agent import Limits
 from ..types.content import Message, Messages
+from ..types.event_loop import Metrics, Usage
 from ..types.exceptions import (
     ContextWindowOverflowException,
     EventLoopException,
@@ -494,13 +495,55 @@ async def _handle_model_execution(
                 except Exception as e:
                     logger.debug("error=<%s> | token estimation failed, proceeding without estimate", e)
 
-                await agent.hooks.invoke_callbacks_async(
-                    BeforeModelCallEvent(
+                before_model_call_event = BeforeModelCallEvent(
+                    agent=agent,
+                    invocation_state=invocation_state,
+                    projected_input_tokens=projected_input_tokens,
+                )
+                await agent.hooks.invoke_callbacks_async(before_model_call_event)
+
+                # Short-circuit the model call if a hook requested cancellation. The model
+                # is not invoked; a cancel assistant message becomes the response, the turn
+                # ends with "end_turn", and AfterModelCallEvent still fires (and may request
+                # a retry). Mirrors strands-ts agent-loop model-call cancel semantics.
+                if before_model_call_event.cancel:
+                    cancel_text = (
+                        before_model_call_event.cancel
+                        if isinstance(before_model_call_event.cancel, str)
+                        else "model call denied by hook"
+                    )
+                    stop_reason: StopReason = "end_turn"
+                    message: Message = {"role": "assistant", "content": [{"text": cancel_text}]}
+                    usage = Usage(inputTokens=0, outputTokens=0, totalTokens=0)
+                    metrics = Metrics(latencyMs=0)
+                    invocation_state.setdefault("request_state", {})
+                    message["metadata"] = {"usage": usage, "metrics": metrics}
+
+                    after_model_call_event = AfterModelCallEvent(
                         agent=agent,
                         invocation_state=invocation_state,
-                        projected_input_tokens=projected_input_tokens,
+                        stop_response=AfterModelCallEvent.ModelStopResponse(
+                            stop_reason=stop_reason,
+                            message=message,
+                        ),
                     )
-                )
+                    await agent.hooks.invoke_callbacks_async(after_model_call_event)
+
+                    if after_model_call_event.retry:
+                        logger.debug("cancel_requested=<True>, retry_requested=<True> | hook requested model retry")
+                        tracer.end_model_invoke_span(model_invoke_span, message, usage, metrics, stop_reason)
+                        continue  # Retry the model call
+
+                    tracer.end_model_invoke_span(model_invoke_span, message, usage, metrics, stop_reason)
+                    # Emit the terminal model-stop event so downstream consumers receive the
+                    # cancel message as the model's response, then end the turn.
+                    yield ModelStopReason(
+                        stop_reason=stop_reason,
+                        message=message,
+                        usage=usage,
+                        metrics=metrics,
+                    )
+                    break  # Cancelled: skip model invocation and end the turn
 
                 if structured_output_context.forced_mode:
                     tool_spec = structured_output_context.get_tool_spec()

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -54,13 +54,20 @@ class BeforeInvocationEvent(HookEvent):
             and dynamic configuration.
         messages: The input messages for this invocation. Can be modified by hooks
             to redact or transform content before processing.
+        cancel: Set by hook callbacks to cancel this invocation. When set to ``True``, a
+            default cancel message ("invocation denied by hook") is used as the assistant
+            response. When set to a string, that string is used as the assistant response
+            message. The agent loop short-circuits: no model inference or tool execution
+            occurs, ``AfterInvocationEvent`` still fires, and the resulting ``AgentResult``
+            has ``stop_reason`` ``"end_turn"``. Defaults to ``False``.
     """
 
     invocation_state: dict[str, Any] = field(default_factory=dict)
     messages: Messages | None = None
+    cancel: bool | str = False
 
     def _can_write(self, name: str) -> bool:
-        return name == "messages"
+        return name in ["messages", "cancel"]
 
 
 @dataclass
@@ -240,10 +247,19 @@ class BeforeModelCallEvent(HookEvent):
             Computed by the agent loop from message metadata and token estimation.
             Available for hooks and plugins (e.g. conversation managers) to make
             proactive decisions about context management. None if estimation failed.
+        cancel: Set by hook callbacks to cancel this model call. When set to ``True``, a
+            default cancel message ("model call denied by hook") is used as the assistant
+            response. When set to a string, that string is used as the assistant response
+            message. The model is not invoked; ``AfterModelCallEvent`` still fires (and may
+            request a retry via its ``retry`` flag). Defaults to ``False``.
     """
 
     invocation_state: dict[str, Any] = field(default_factory=dict)
     projected_input_tokens: int | None = None
+    cancel: bool | str = False
+
+    def _can_write(self, name: str) -> bool:
+        return name == "cancel"
 
 
 @dataclass

--- a/strands-py/src/strands/hooks/registry.py
+++ b/strands-py/src/strands/hooks/registry.py
@@ -28,10 +28,19 @@ class HookOrder:
     """Named constants for hook execution priority.
 
     Lower values execute first. Hooks with the same order preserve registration order.
+
+    ``SDK_FIRST``/``SDK_LAST`` mark where the SDK's own hooks run. The
+    ``INTERVENTION_*`` presets are reference points for intervention-style hooks:
+    ``INTERVENTION_INPUT`` runs late on input (``Before*``) events so input
+    interventions see the fully-prepared input, while ``INTERVENTION_OUTPUT`` runs
+    early on output (``After*``) events so output interventions act before other
+    consumers.
     """
 
     SDK_FIRST: int = -100
+    INTERVENTION_OUTPUT: int = -90
     DEFAULT: int = 0
+    INTERVENTION_INPUT: int = 90
     SDK_LAST: int = 100
 
 

--- a/strands-py/tests/strands/agent/test_agent_hooks.py
+++ b/strands-py/tests/strands/agent/test_agent_hooks.py
@@ -1239,3 +1239,43 @@ def test_allows_retry_after_cancel_on_model_call():
     assert result.stop_reason == "end_turn"
     assert before_count == 2
     assert result.message["content"][0]["text"] == "Hello"
+
+
+def test_resume_after_cancelled_invocation():
+    """Python-only divergence from strands-ts: the BeforeInvocation cancel path honors
+    ``AfterInvocationEvent.resume`` so a hook can deny the first invocation and then
+    resume with new input, mirroring the resume contract of the normal (non-cancelled)
+    agent loop. The TS oracle simply returns after a cancelled invocation and has no
+    resume concept on this path.
+
+    First invocation is cancelled with a custom message; AfterInvocationEvent sets
+    ``resume``; the second (resumed) invocation runs the real model response.
+    """
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+
+    cancelled_once = False
+
+    def before(event: BeforeInvocationEvent):
+        if not cancelled_once:
+            event.cancel = "first denied"
+
+    def after(event: AfterInvocationEvent):
+        nonlocal cancelled_once
+        if not cancelled_once:
+            cancelled_once = True
+            event.resume = "second try"
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeInvocationEvent, before)
+    agent.hooks.add_callback(AfterInvocationEvent, after)
+
+    result = agent("Test")
+
+    # The resumed invocation produces the real model response and ends the turn.
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Hello"
+    # The cancel message, the resumed user input, and the final model response are all present.
+    assert [m["role"] for m in agent.messages] == ["assistant", "user", "assistant"]
+    assert agent.messages[0]["content"][0]["text"] == "first denied"
+    assert agent.messages[1]["content"][0]["text"] == "second try"
+    assert agent.messages[2]["content"][0]["text"] == "Hello"

--- a/strands-py/tests/strands/agent/test_agent_hooks.py
+++ b/strands-py/tests/strands/agent/test_agent_hooks.py
@@ -1075,3 +1075,167 @@ def test_hooks_param_callable_invoked_during_lifecycle():
 
     assert len(before_events) == 1
     assert isinstance(before_events[0], BeforeInvocationEvent)
+
+
+# ========== Tests for cancel via hooks ==========
+# Mirrors strands-ts agent.hook.test.ts "cancel invocation via hooks" and
+# "cancel model call via hooks". The agent-loop short-circuit on
+# BeforeInvocationEvent.cancel / BeforeModelCallEvent.cancel is the behavioral oracle.
+
+
+def test_cancel_invocation_with_default_message():
+    """cancels invocation with default message when cancel is True."""
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+    hook_provider = MockHookProvider([BeforeInvocationEvent, AfterInvocationEvent, BeforeModelCallEvent])
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_hook(hook_provider)
+
+    def cancel(event: BeforeInvocationEvent):
+        event.cancel = True
+
+    agent.hooks.add_callback(BeforeInvocationEvent, cancel)
+
+    result = agent("Test")
+
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "invocation denied by hook"
+    # Model is never called when the invocation is cancelled.
+    assert BeforeModelCallEvent not in hook_provider.event_types_received
+
+
+def test_cancel_invocation_with_custom_message():
+    """cancels invocation with custom message when cancel is a string."""
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeInvocationEvent, lambda event: setattr(event, "cancel", "Unauthorized user"))
+
+    result = agent("Test")
+
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Unauthorized user"
+
+
+def test_cancel_invocation_does_not_append_user_message():
+    """does not append user message when invocation is cancelled."""
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeInvocationEvent, lambda event: setattr(event, "cancel", True))
+
+    agent("Test")
+
+    assert len(agent.messages) == 1
+    assert agent.messages[0]["role"] == "assistant"
+
+
+def test_cancel_invocation_emits_after_invocation_event():
+    """emits AfterInvocationEvent when invocation is cancelled (Before once, After once)."""
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+    hook_provider = MockHookProvider([BeforeInvocationEvent, AfterInvocationEvent])
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_hook(hook_provider)
+    agent.hooks.add_callback(BeforeInvocationEvent, lambda event: setattr(event, "cancel", True))
+
+    agent("Test")
+
+    received = hook_provider.event_types_received
+    assert received.count(BeforeInvocationEvent) == 1
+    assert received.count(AfterInvocationEvent) == 1
+
+
+def test_cancel_model_call_with_default_message():
+    """cancels model call with default message when cancel is True."""
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeModelCallEvent, lambda event: setattr(event, "cancel", True))
+
+    result = agent("Test")
+
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "model call denied by hook"
+
+
+def test_cancel_model_call_with_custom_message():
+    """cancels model call with custom message when cancel is a string."""
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeModelCallEvent, lambda event: setattr(event, "cancel", "Rate limited"))
+
+    result = agent("Test")
+
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Rate limited"
+
+
+def test_cancel_model_call_emits_after_model_call_event():
+    """emits AfterModelCallEvent when model call is cancelled (Before once, After once)."""
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+    hook_provider = MockHookProvider([BeforeModelCallEvent, AfterModelCallEvent])
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_hook(hook_provider)
+    agent.hooks.add_callback(BeforeModelCallEvent, lambda event: setattr(event, "cancel", True))
+
+    agent("Test")
+
+    received = hook_provider.event_types_received
+    assert received.count(BeforeModelCallEvent) == 1
+    assert received.count(AfterModelCallEvent) == 1
+
+
+def test_cancel_model_call_does_not_invoke_model():
+    """the model is not invoked when the model call is cancelled.
+
+    Divergence from strands-ts: the TS oracle asserts the (hookable) ModelMessageEvent is
+    NOT emitted. In strands-py ModelMessageEvent is a stream TypedEvent, not a hook event,
+    so we assert the equivalent behavioral guarantee directly: the model's ``stream`` is
+    never consumed (the queued response remains unused).
+    """
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeModelCallEvent, lambda event: setattr(event, "cancel", True))
+
+    agent("Test")
+
+    # The mock provider hands out responses by advancing ``index``; a cancelled model call
+    # must not consume the queued response.
+    assert mock_provider.index == 0
+    # The cancel message (not the model's "Hello") is the final assistant message.
+    assert agent.messages[-1]["content"][0]["text"] == "model call denied by hook"
+
+
+def test_allows_retry_after_cancel_on_model_call():
+    """allows retry after cancel on model call.
+
+    First BeforeModelCallEvent cancels; the AfterModelCallEvent requests a retry; the
+    second BeforeModelCallEvent lets the real model response through.
+    """
+    mock_provider = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello"}]}])
+
+    before_count = 0
+
+    def before(event: BeforeModelCallEvent):
+        nonlocal before_count
+        before_count += 1
+        if before_count == 1:
+            event.cancel = "Not yet"
+
+    def after(event: AfterModelCallEvent):
+        if before_count == 1:
+            event.retry = True
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeModelCallEvent, before)
+    agent.hooks.add_callback(AfterModelCallEvent, after)
+
+    result = agent("Test")
+
+    assert result.stop_reason == "end_turn"
+    assert before_count == 2
+    assert result.message["content"][0]["text"] == "Hello"

--- a/strands-py/tests/strands/hooks/test_events.py
+++ b/strands-py/tests/strands/hooks/test_events.py
@@ -105,3 +105,65 @@ def test_after_events_should_reverse_callbacks(orchestrator):
 
     assert after_node_event.should_reverse_callbacks is True
     assert after_invocation_event.should_reverse_callbacks is True
+
+
+# ========== Tests for cancel field on BeforeInvocationEvent / BeforeModelCallEvent ==========
+# Mirrors strands-ts hooks/__tests__/events.test.ts cancel-writability tests.
+
+
+def test_before_invocation_event_cancel_defaults_to_false(orchestrator):
+    """BeforeInvocationEvent.cancel defaults to False."""
+    from strands.hooks import BeforeInvocationEvent
+
+    event = BeforeInvocationEvent(agent=orchestrator)
+    assert event.cancel is False
+
+
+def test_before_invocation_event_allows_cancel_to_be_set(orchestrator):
+    """BeforeInvocationEvent.cancel can be set to True or a string message."""
+    from strands.hooks import BeforeInvocationEvent
+
+    event = BeforeInvocationEvent(agent=orchestrator)
+    event.cancel = True
+    assert event.cancel is True
+
+    event.cancel = "unauthorized"
+    assert event.cancel == "unauthorized"
+
+
+def test_before_invocation_event_agent_not_writable(orchestrator):
+    """BeforeInvocationEvent.agent remains read-only."""
+    from strands.hooks import BeforeInvocationEvent
+
+    event = BeforeInvocationEvent(agent=orchestrator)
+    with pytest.raises(AttributeError, match="Property agent is not writable"):
+        event.agent = Mock()
+
+
+def test_before_model_call_event_cancel_defaults_to_false(orchestrator):
+    """BeforeModelCallEvent.cancel defaults to False."""
+    from strands.hooks import BeforeModelCallEvent
+
+    event = BeforeModelCallEvent(agent=orchestrator)
+    assert event.cancel is False
+
+
+def test_before_model_call_event_allows_cancel_to_be_set(orchestrator):
+    """BeforeModelCallEvent.cancel can be set to True or a string message."""
+    from strands.hooks import BeforeModelCallEvent
+
+    event = BeforeModelCallEvent(agent=orchestrator)
+    event.cancel = True
+    assert event.cancel is True
+
+    event.cancel = "rate limited"
+    assert event.cancel == "rate limited"
+
+
+def test_before_model_call_event_agent_not_writable(orchestrator):
+    """BeforeModelCallEvent.agent remains read-only."""
+    from strands.hooks import BeforeModelCallEvent
+
+    event = BeforeModelCallEvent(agent=orchestrator)
+    with pytest.raises(AttributeError, match="Property agent is not writable"):
+        event.agent = Mock()

--- a/strands-py/tests/strands/hooks/test_registry.py
+++ b/strands-py/tests/strands/hooks/test_registry.py
@@ -367,3 +367,47 @@ def test_after_events_lower_order_still_runs_first(registry, agent):
     registry.invoke_callbacks(AfterModelCallEvent(agent=agent))
     # Lower order first, but within same group registration order is reversed
     assert order == ["first", "default_b", "default_a", "last"]
+
+
+# ========== Tests for intervention HookOrder presets ==========
+
+
+def test_hook_order_intervention_preset_values():
+    """Test that the intervention HookOrder presets match the cross-language contract.
+
+    Mirrors the values in strands-ts ``HookOrder`` (src/hooks/types.ts):
+    SDK_FIRST=-100, INTERVENTION_OUTPUT=-90, DEFAULT=0, INTERVENTION_INPUT=90, SDK_LAST=100.
+    """
+    assert HookOrder.SDK_FIRST == -100
+    assert HookOrder.INTERVENTION_OUTPUT == -90
+    assert HookOrder.DEFAULT == 0
+    assert HookOrder.INTERVENTION_INPUT == 90
+    assert HookOrder.SDK_LAST == 100
+
+
+def test_intervention_input_runs_after_default_before_sdk_last(registry, agent):
+    """INTERVENTION_INPUT runs after DEFAULT hooks but before SDK_LAST on Before events."""
+    order = []
+
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("default"), order=HookOrder.DEFAULT)
+    registry.add_callback(
+        BeforeModelCallEvent, lambda e: order.append("intervention_input"), order=HookOrder.INTERVENTION_INPUT
+    )
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("sdk_last"), order=HookOrder.SDK_LAST)
+
+    registry.invoke_callbacks(BeforeModelCallEvent(agent=agent))
+    assert order == ["default", "intervention_input", "sdk_last"]
+
+
+def test_intervention_output_runs_before_default_after_sdk_first(registry, agent):
+    """INTERVENTION_OUTPUT runs after SDK_FIRST but before DEFAULT hooks."""
+    order = []
+
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("default"), order=HookOrder.DEFAULT)
+    registry.add_callback(
+        BeforeModelCallEvent, lambda e: order.append("intervention_output"), order=HookOrder.INTERVENTION_OUTPUT
+    )
+    registry.add_callback(BeforeModelCallEvent, lambda e: order.append("sdk_first"), order=HookOrder.SDK_FIRST)
+
+    registry.invoke_callbacks(BeforeModelCallEvent(agent=agent))
+    assert order == ["sdk_first", "intervention_output", "default"]


### PR DESCRIPTION
## DescriptionCross-language **port of the merged strands-ts cancellation support** (commit `ad8006f`, _"feat: add cancellation support to BeforeInvocationEvent and BeforeModelCallEvent"_) into `strands-py/`. This is the **foundation** that unblocks the Interventions primitive port (the interventions registry expresses `deny`/`guide` by writing `event.cancel` on `Before*` events); the interventions primitive itself is **out of scope** here.Before this change, only `BeforeToolCallEvent` had a cancel mechanism (`cancel_tool`); `BeforeInvocationEvent` and `BeforeModelCallEvent` had no cancel field and the attribute was immutable, so 2 of the 5 intervention lifecycle hooks could not express `deny`/`guide`.### What changed1. **Writable `cancel: bool | str`** on `BeforeInvocationEvent` and `BeforeModelCallEvent`, mirroring the existing `BeforeToolCallEvent.cancel_tool` `_can_write` pattern (`strands-py/src/strands/hooks/events.py`).2. **Agent-loop short-circuit** honoring those cancels, matching TS semantics:   - `BeforeInvocationEvent.cancel` (`agent.py` `_run_loop`): append a single assistant cancel message (default `"invocation denied by hook"`, or the provided string), fire `AfterInvocationEvent`, stop with `stop_reason="end_turn"`; **no model inference or tool execution**, and the user message is **not** appended.   - `BeforeModelCallEvent.cancel` (`event_loop.py` `_handle_model_execution`): skip model invocation, use the cancel message (default `"model call denied by hook"`, or the string) as the response, fire `AfterModelCallEvent` (**retry honored** via its `retry` flag), end the turn with `"end_turn"`. `MessageAddedEvent` still fires.3. **`HookOrder` intervention presets** `INTERVENTION_OUTPUT = -90` and `INTERVENTION_INPUT = 90` (`registry.py`), verified value-for-value against `strands-ts/src/hooks/types.ts`.4. **Mirrored Python tests** for all of the above.## Related IssuesImplements the cancellation foundation tracked in agent-of-mkmeral/strands-coder-private#248.Reference: strands-ts commit `ad8006f`.cc @mkmeral @lizradway## Python ↔ TypeScript divergences (deliberate)| # | Area | TS behavior | Python behavior | Rationale ||---|------|-------------|-----------------|-----------|| 1 | `BeforeModelCall` cancel telemetry | TS asserts the hookable `ModelMessageEvent` is **not** emitted | `ModelMessageEvent` does not exist as a hook event in Python; `ModelMessageEvent` is a **stream `TypedEvent`**. The cancel path yields the terminal `ModelStopReason` wrapping the cancel message. | Behavioral guarantee preserved (model not invoked, `MessageAddedEvent` fires, `stop_reason="end_turn"`). The Python test asserts **model-not-invoked** directly (the mock provider's queued response is never consumed). || 2 | `HookOrder` shape | `const` object literal | Plain class with `int` attributes (the existing Python `HookOrder` pattern) | Values match exactly: `SDK_FIRST=-100, INTERVENTION_OUTPUT=-90, DEFAULT=0, INTERVENTION_INPUT=90, SDK_LAST=100`. || 3 | Resume after cancelled invocation | TS simply returns an `AgentResult` after a cancelled invocation (no resume concept on this path) | Python's `BeforeInvocation` cancel path additionally honors `AfterInvocationEvent.resume`, mirroring the resume contract of the **normal** (non-cancelled) agent loop | Keeps the cancel path internally consistent with the peer Python `AfterInvocationEvent.resume` API rather than transliterating the TS early-return. Covered by `test_resume_after_cancelled_invocation`. |## Type of ChangeNew feature## Testing- `hatch fmt --formatter` / `hatch fmt --linter` (ruff) and `mypy` are clean on all changed files.- **18 new mirrored tests** + 1 added during review (resume-after-cancel coverage):  - `tests/strands/agent/test_agent_hooks.py`: cancel invocation (default/custom message, no user-message append, `AfterInvocationEvent` fires), cancel model call (default/custom message, `AfterModelCallEvent` fires, model not invoked, retry-after-cancel), resume-after-cancel.  - `tests/strands/hooks/test_events.py`: `cancel` writability + defaults on both events; `agent` stays read-only.  - `tests/strands/hooks/test_registry.py`: `HookOrder` preset values + intervention ordering relative to `DEFAULT`/`SDK_FIRST`/`SDK_LAST`.- Full `tests/strands/agent/` + `tests/strands/hooks/` suites: **551+ passing**, no regressions.- The 34–35 pre-existing failures under `tests/strands/event_loop/` (`'Mock' object is not iterable`) were verified to reproduce **identically on the untouched parent commit** (same failing test set, byte-for-byte) — they are unrelated to this change (bare `AsyncMock` on `hooks.invoke_callbacks_async` in those tests).- [ ] I ran `hatch run prepare`## Review Loop SummaryThis PR went through a pre-PR review chain before opening:| Iteration | Actor | Findings Addressed ||-----------|-------|--------------------|| 0 | porter (run 27143753228) | Initial port: writable `cancel` on both events, agent-loop short-circuit, `INTERVENTION_*` presets, 18 mirrored tests. || 1 | reviewer | Verified behavioral parity against the live `strands-ts/` oracle + tests; ran readiness (ruff/mypy clean, suites green); proved the `event_loop/` failures are pre-existing on baseline (zero new). One 🟡: the Python-only resume-after-cancelled-invocation branch was untested and the divergence unrecorded → **added `test_resume_after_cancelled_invocation` and recorded divergence #3**. No 🔴 findings. Converged. |## Checklist- [x] I have read the CONTRIBUTING document- [x] I have added any necessary tests that prove my fix is effective or my feature works- [ ] I have updated the documentation accordingly- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed- [x] My changes generate no new warnings- [x] Any dependent changes have been merged and published----By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.