### PR TITLE
chore: fixup test-infra constructs

### DIFF
--- a/test-infra/bin/test-infra.ts
+++ b/test-infra/bin/test-infra.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import { StrandsTestInfraStack } from '../lib/stacks/test-infra-stack';
 import { TestFeature, VALID_TEST_FEATURES } from '../lib/constants';
 

--- a/test-infra/lib/constructs/bedrock-knowledge-base-test-resources.ts
+++ b/test-infra/lib/constructs/bedrock-knowledge-base-test-resources.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3vectors from 'aws-cdk-lib/aws-s3vectors';
@@ -68,7 +68,7 @@ export class BedrockKnowledgeBaseTestResources extends TestFeatureConstruct {
     super(scope, id);
 
     const model = bedrock.FoundationModel.fromFoundationModelId(this, 'EmbeddingModel', EMBEDDING_MODEL);
-    this.sourceBucket = new s3.Bucket(this, 'Source', {
+    this.sourceBucket = new s3.Bucket(this, 'SourceBucket', {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
     });
@@ -163,16 +163,14 @@ export class BedrockKnowledgeBaseTestResources extends TestFeatureConstruct {
   /**
    * Grant a consumer (the integration-test role) permission to query the
    * knowledge base and ingest documents directly into it via
-   * IngestKnowledgeBaseDocuments — not the asynchronous StartIngestionJob path.
+   * IngestKnowledgeBaseDocuments. Intentionally excludes bedrock:StartIngestionJob;
+   * these tests validate only the synchronous direct-ingestion APIs.
    */
   private grantUsage(role: iam.IRole): void {
     role.addToPrincipalPolicy(
       new iam.PolicyStatement({
         actions: [
-          // Query.
           'bedrock:Retrieve',
-          // Direct document ingestion (IngestKnowledgeBaseDocumentsCommand),
-          // for both the S3 and CUSTOM data sources on this knowledge base.
           'bedrock:IngestKnowledgeBaseDocuments',
           'bedrock:GetKnowledgeBaseDocuments',
           'bedrock:ListKnowledgeBaseDocuments',
@@ -240,14 +238,14 @@ export class BedrockKnowledgeBaseTestResources extends TestFeatureConstruct {
 
     role.addToPolicy(
       new iam.PolicyStatement({
-        actions: ['bedrock:InvokeModel'],
-        resources: [model.modelArn],
+        actions: ['bedrock:ListFoundationModels', 'bedrock:ListCustomModels'],
+        resources: ['*'],
       }),
     );
     role.addToPolicy(
       new iam.PolicyStatement({
-        actions: ['bedrock:ListFoundationModels', 'bedrock:ListCustomModels'],
-        resources: ['*'],
+        actions: ['bedrock:InvokeModel'],
+        resources: [model.modelArn],
       }),
     );
     role.addToPolicy(

--- a/test-infra/lib/constructs/integ-test-role.ts
+++ b/test-infra/lib/constructs/integ-test-role.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 
@@ -60,7 +60,7 @@ export class IntegTestRole extends Construct {
         )
       : new iam.AccountPrincipal(cdk.Stack.of(this).account);
 
-    this.role = new iam.Role(this, 'Role', {
+    this.role = new iam.Role(this, 'IntegRole', {
       assumedBy,
       maxSessionDuration: cdk.Duration.hours(1),
     });
@@ -222,10 +222,7 @@ export class IntegTestRole extends Construct {
           's3:ListBucket',
           's3:DeleteObject',
         ],
-        resources: persistentBucketNames.flatMap((name) => [
-          `arn:aws:s3:::${name}`,
-          `arn:aws:s3:::${name}/*`,
-        ]),
+        resources: persistentBucketNames.map((name) => `arn:aws:s3:::${name}`),
       }),
     );
 

--- a/test-infra/lib/constructs/ssh-ec2-test-resources.ts
+++ b/test-infra/lib/constructs/ssh-ec2-test-resources.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -63,7 +63,7 @@ export class SshEc2TestResources extends TestFeatureConstruct {
     // ED25519 key pair; CDK stores the private key in SSM automatically.
     this.keyPair = new ec2.KeyPair(this, 'KeyPair', { type: ec2.KeyPairType.ED25519 });
 
-    this.instance = new ec2.Instance(this, 'Instance', {
+    this.instance = new ec2.Instance(this, 'SshTargetInstance', {
       vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
       // Cheapest current-gen burstable; AL2023 ships and runs sshd by default.
@@ -128,17 +128,23 @@ export class SshEc2TestResources extends TestFeatureConstruct {
         ],
       }),
     );
-    // The SSH-over-SSM data channel. Scoped to sessions owned by the caller.
+    // The SSH-over-SSM data channel and session cleanup. Scoped to sessions
+    // owned by the caller.
+    const sessionArn = cdk.Stack.of(this).formatArn({
+      service: 'ssm',
+      resource: 'session',
+      resourceName: '${aws:userid}-*',
+    });
     role.addToPrincipalPolicy(
       new iam.PolicyStatement({
         actions: ['ssmmessages:OpenDataChannel'],
-        resources: [
-          cdk.Stack.of(this).formatArn({
-            service: 'ssm',
-            resource: 'session',
-            resourceName: '${aws:userid}-*',
-          }),
-        ],
+        resources: [sessionArn],
+      }),
+    );
+    role.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        actions: ['ssm:TerminateSession'],
+        resources: [sessionArn],
       }),
     );
     // Read the SSH private key.

--- a/test-infra/lib/constructs/test-feature-construct.ts
+++ b/test-infra/lib/constructs/test-feature-construct.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { TestFeature, ssmParameterPath } from '../constants';

--- a/test-infra/lib/stacks/test-infra-stack.ts
+++ b/test-infra/lib/stacks/test-infra-stack.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { TestFeature } from '../constants';
 import { IntegTestRole } from '../constructs/integ-test-role';

--- a/test-infra/test/test-infra.test.ts
+++ b/test-infra/test/test-infra.test.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import { Template, Match } from 'aws-cdk-lib/assertions';
 import { StrandsTestInfraStack } from '../lib/stacks/test-infra-stack';
 
@@ -8,7 +8,7 @@ beforeAll(() => {
   originalEnv = { ...process.env };
   process.env.STRANDS_TEST_INFRA_PRIVATE_REPOS = 'repo-a,repo-b';
   process.env.STRANDS_TEST_INFRA_BUCKET_NAMES = 'test-bucket-*';
-  process.env.STRANDS_TEST_INFRA_PERSISTENT_BUCKET_NAMES = 'test-persistent-bucket-*';
+  process.env.STRANDS_TEST_INFRA_PERSISTENT_BUCKET_NAMES = 'test-persistent-bucket-*,test-session-bucket-*';
   process.env.STRANDS_TEST_INFRA_SECRET_NAMES = 'test-secret';
 });
 
@@ -116,6 +116,24 @@ test('SSH VPC has three SSM interface endpoints and no NAT gateway', () => {
   template.resourceCountIs('AWS::EC2::NatGateway', 0);
 });
 
+test('SSH grants StartSession, TerminateSession, OpenDataChannel, and private key read', () => {
+  const template = synth({ internal: true, testFeatures: ['ssh-ec2'] });
+
+  const policies = template.findResources('AWS::IAM::Policy');
+  const statements = Object.values(policies).flatMap(
+    (p: any) => p.Properties?.PolicyDocument?.Statement ?? [],
+  );
+  const actions = statements.flatMap((s: any) =>
+    Array.isArray(s.Action) ? s.Action : [s.Action],
+  );
+  expect(actions).toEqual(expect.arrayContaining([
+    'ssm:StartSession',
+    'ssm:TerminateSession',
+    'ssmmessages:OpenDataChannel',
+    'ssm:GetParameter',
+  ]));
+});
+
 test('SSH instance has no inbound security group rules', () => {
   const template = synth({ testFeatures: ['ssh-ec2'] });
 
@@ -170,6 +188,27 @@ test('community mode does not attach the legacy broad policy', () => {
       expect(stmt.Action).not.toEqual(expect.arrayContaining(['aoss:CreateSecurityPolicy']));
     }
   }
+});
+
+test('persistent bucket policy grants access without DeleteBucket', () => {
+  const template = synth({ internal: true });
+
+  const policies = template.findResources('AWS::IAM::Policy');
+  const statements = Object.values(policies).flatMap(
+    (p: any) => p.Properties?.PolicyDocument?.Statement ?? [],
+  );
+  const persistentStmt = statements.find(
+    (s: any) =>
+      Array.isArray(s.Action) &&
+      s.Action.includes('s3:PutObject') &&
+      !s.Action.includes('s3:DeleteBucket') &&
+      JSON.stringify(s.Resource).includes('test-persistent-bucket-*'),
+  );
+  expect(persistentStmt).toBeDefined();
+  expect(persistentStmt.Action).toEqual(
+    expect.arrayContaining(['s3:PutObject', 's3:GetObject', 's3:CreateBucket', 's3:ListBucket', 's3:DeleteObject']),
+  );
+  expect(persistentStmt.Action).not.toContain('s3:DeleteBucket');
 });
 
 // --- Feature Toggling ---


### PR DESCRIPTION
## Description

Follow-up fixes to test-infra constructs based on review feedback:

- Canonical CDK v2 imports (`aws-cdk-lib` instead of `aws-cdk-lib/core`) across all files
- Add `ssm:TerminateSession` to SSH construct for robust session cleanup
- Rename role logical ID to `IntegRole`
- Simplify persistent bucket resource ARNs to use same `.map()` pattern as ephemeral buckets
- Reorder KB service role statements to put `ListFoundationModels`/`ListCustomModels` first (per AWS docs)
- Clarify `grantUsage` comment on intentional `StartIngestionJob` exclusion
- Add test coverage for SSH IAM grants and persistent bucket policy

## Related Issues

Follow-up to #2670

## Type of Change

Bug fix

## Testing

- [x] Unit tests pass (18/18)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published