### PR TITLE
fix(strands-ts): update package.json repository URLs to harness-sdk

### DIFF
--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -192,12 +192,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/strands-agents/sdk-python.git"
+    "url": "git+https://github.com/strands-agents/harness-sdk.git"
   },
   "bugs": {
-    "url": "https://github.com/strands-agents/sdk-python/issues"
+    "url": "https://github.com/strands-agents/harness-sdk/issues"
   },
-  "homepage": "https://github.com/strands-agents/sdk-python#readme",
+  "homepage": "https://github.com/strands-agents/harness-sdk#readme",
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1037.0",
     "@types/json-schema": "^7.0.15",


### PR DESCRIPTION
## Summary
- Updates `repository`, `bugs`, and `homepage` URLs in `strands-ts/package.json` from the old `strands-agents/sdk-python` to `strands-agents/harness-sdk`