### PR TITLE
feat: add model_state as a snapshot field

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -26,10 +26,10 @@ snapshot = agent.take_snapshot(preset="session")
 
 print(snapshot.schema_version)  # "1.0"
 print(snapshot.created_at)      # ISO 8601 timestamp
-print(snapshot.data.keys())     # messages, state, conversation_manager_state, interrupt_state
+print(snapshot.data.keys())     # messages, state, conversation_manager_state, interrupt_state, model_state
 ```
 
-The `"session"` preset captures `messages`, `state`, `conversation_manager_state`, and `interrupt_state`. The `system_prompt` and `model_state` fields are not included by default — see [Field Selection](#field-selection) to customize which fields are captured.
+The `"session"` preset captures `messages`, `state`, `conversation_manager_state`, `interrupt_state`, and `model_state`. The `system_prompt` field is not included by default — see [Field Selection](#field-selection) to customize which fields are captured.
 </Tab>
 <Tab label="TypeScript">
 

--- a/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -29,7 +29,7 @@ print(snapshot.created_at)      # ISO 8601 timestamp
 print(snapshot.data.keys())     # messages, state, conversation_manager_state, interrupt_state
 ```
 
-The `"session"` preset captures `messages`, `state`, `conversation_manager_state`, and `interrupt_state`. The `system_prompt` field is not included by default — see [Field Selection](#field-selection) to customize which fields are captured.
+The `"session"` preset captures `messages`, `state`, `conversation_manager_state`, and `interrupt_state`. The `system_prompt` and `model_state` fields are not included by default — see [Field Selection](#field-selection) to customize which fields are captured.
 </Tab>
 <Tab label="TypeScript">
 
@@ -96,6 +96,7 @@ Snapshots support flexible field selection through presets, includes, and exclud
 | `conversation_manager_state` | Conversation manager internal state |
 | `interrupt_state` | Human-in-the-loop interrupt state |
 | `system_prompt` | System prompt content |
+| `model_state` | Model provider state (e.g. response IDs for stateful models) |
 
 </Tab>
 <Tab label="TypeScript">

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1366,6 +1366,8 @@ class Agent(AgentBase):
             # Store the content-block representation so round-trips preserve caching hints and
             # other block-level metadata.
             data["system_prompt"] = copy.deepcopy(self._system_prompt_content)
+        if "model_state" in fields:
+            data["model_state"] = copy.deepcopy(self._model_state)
 
         return Snapshot(
             scope="agent",
@@ -1399,6 +1401,8 @@ class Agent(AgentBase):
             self._interrupt_state = _InterruptState.from_dict(data["interrupt_state"])
         if "system_prompt" in data:
             self.system_prompt = copy.deepcopy(data["system_prompt"])
+        if "model_state" in data:
+            self._model_state = data["model_state"]
 
     def _redact_user_content(self, content: list[ContentBlock], redact_message: str) -> list[ContentBlock]:
         """Redact user content preserving toolResult blocks.

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1402,7 +1402,7 @@ class Agent(AgentBase):
         if "system_prompt" in data:
             self.system_prompt = copy.deepcopy(data["system_prompt"])
         if "model_state" in data:
-            self._model_state = data["model_state"]
+            self._model_state = copy.deepcopy(data["model_state"])
 
     def _redact_user_content(self, content: list[ContentBlock], redact_message: str) -> list[ContentBlock]:
         """Redact user content preserving toolResult blocks.

--- a/strands-py/src/strands/types/_snapshot.py
+++ b/strands-py/src/strands/types/_snapshot.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, TypedDict
 
 from .exceptions import SnapshotException
 
-SnapshotField = Literal["messages", "state", "conversation_manager_state", "interrupt_state", "system_prompt"]
+SnapshotField = Literal["messages", "state", "conversation_manager_state", "interrupt_state", "system_prompt", "model_state"]
 SnapshotPreset = Literal["session"]
 Scope = Literal["agent"]
 
@@ -18,6 +18,7 @@ ALL_SNAPSHOT_FIELDS: tuple[SnapshotField, ...] = (
     "conversation_manager_state",
     "interrupt_state",
     "system_prompt",
+    "model_state",
 )
 
 VALID_SCOPES: tuple[Scope, ...] = ("agent",)

--- a/strands-py/src/strands/types/_snapshot.py
+++ b/strands-py/src/strands/types/_snapshot.py
@@ -33,7 +33,7 @@ VALID_SCOPES: tuple[Scope, ...] = ("agent",)
 SNAPSHOT_SCHEMA_VERSION = "1.0"
 
 SNAPSHOT_PRESETS: dict[str, tuple[SnapshotField, ...]] = {
-    "session": ("messages", "state", "conversation_manager_state", "interrupt_state"),
+    "session": ("messages", "state", "conversation_manager_state", "interrupt_state", "model_state"),
 }
 
 

--- a/strands-py/src/strands/types/_snapshot.py
+++ b/strands-py/src/strands/types/_snapshot.py
@@ -8,7 +8,14 @@ from typing import Any, Literal, TypedDict
 
 from .exceptions import SnapshotException
 
-SnapshotField = Literal["messages", "state", "conversation_manager_state", "interrupt_state", "system_prompt", "model_state"]
+SnapshotField = Literal[
+    "messages",
+    "state",
+    "conversation_manager_state",
+    "interrupt_state",
+    "system_prompt",
+    "model_state",
+]
 SnapshotPreset = Literal["session"]
 Scope = Literal["agent"]
 

--- a/strands-py/tests/strands/agent/test_snapshot.py
+++ b/strands-py/tests/strands/agent/test_snapshot.py
@@ -202,6 +202,8 @@ def test_missing_fields_leave_agent_unchanged(omitted_field):
         before = fresh_agent.conversation_manager.get_state()
     elif omitted_field == "interrupt_state":
         before = fresh_agent._interrupt_state.to_dict()
+    elif omitted_field == "model_state":
+        before = dict(fresh_agent._model_state)
     else:
         pytest.fail(f"Unhandled field in test: {omitted_field!r}. Update this test when adding new snapshot fields.")
 
@@ -217,6 +219,8 @@ def test_missing_fields_leave_agent_unchanged(omitted_field):
         assert fresh_agent.conversation_manager.get_state() == before
     elif omitted_field == "interrupt_state":
         assert fresh_agent._interrupt_state.to_dict() == before
+    elif omitted_field == "model_state":
+        assert fresh_agent._model_state == before
     else:
         pytest.fail(f"Unhandled field in test: {omitted_field!r}. Update this test when adding new snapshot fields.")
 
@@ -451,3 +455,80 @@ def test_take_snapshot_system_prompt_is_independent_copy():
     agent.system_prompt = "mutated prompt"
     assert snapshot.data["system_prompt"] == original_content
     assert snapshot.data["system_prompt"] != agent._system_prompt_content
+
+
+# model_state snapshot field
+
+
+def test_model_state_is_valid_snapshot_field():
+    """model_state is recognized as a valid SnapshotField."""
+    assert "model_state" in ALL_SNAPSHOT_FIELDS
+
+
+def test_model_state_not_in_session_preset():
+    """model_state is not included in the session preset."""
+    assert "model_state" not in SNAPSHOT_PRESETS["session"]
+
+
+def test_take_snapshot_captures_model_state():
+    """take_snapshot with include=['model_state'] captures the agent's _model_state."""
+    agent = _make_agent()
+    agent._model_state = {"response_id": "resp_abc123"}
+    snapshot = agent.take_snapshot(include=["model_state"])
+
+    assert snapshot.data["model_state"] == {"response_id": "resp_abc123"}
+
+
+def test_take_snapshot_model_state_is_independent_copy():
+    """Mutating agent._model_state after take_snapshot doesn't corrupt the snapshot."""
+    agent = _make_agent()
+    agent._model_state = {"response_id": "resp_abc123"}
+    snapshot = agent.take_snapshot(include=["model_state"])
+
+    agent._model_state["response_id"] = "resp_mutated"
+    assert snapshot.data["model_state"]["response_id"] == "resp_abc123"
+
+
+def test_load_snapshot_restores_model_state():
+    """load_snapshot restores model_state onto the agent."""
+    agent = _make_agent()
+    agent._model_state = {"old": "state"}
+
+    snap = _make_snapshot(data={"model_state": {"response_id": "resp_restored"}})
+    agent.load_snapshot(snap)
+
+    assert agent._model_state == {"response_id": "resp_restored"}
+
+
+def test_load_snapshot_without_model_state_leaves_it_unchanged():
+    """A snapshot without model_state in data does not alter agent._model_state."""
+    agent = _make_agent()
+    agent._model_state = {"response_id": "resp_keep"}
+
+    snap = _make_snapshot(data={"messages": [{"role": "user", "content": [{"text": "hi"}]}]})
+    agent.load_snapshot(snap)
+
+    assert agent._model_state == {"response_id": "resp_keep"}
+
+
+def test_load_snapshot_with_empty_model_state_clears_it():
+    """A snapshot with model_state={} overwrites a non-empty _model_state."""
+    agent = _make_agent()
+    agent._model_state = {"response_id": "resp_existing"}
+
+    snap = _make_snapshot(data={"model_state": {}})
+    agent.load_snapshot(snap)
+
+    assert agent._model_state == {}
+
+
+def test_model_state_round_trip():
+    """model_state survives take_snapshot -> load_snapshot round-trip."""
+    agent = _make_agent()
+    agent._model_state = {"response_id": "resp_xyz", "extra": 42}
+    snapshot = agent.take_snapshot(include=["model_state"])
+
+    fresh_agent = _make_agent()
+    fresh_agent.load_snapshot(snapshot)
+
+    assert fresh_agent._model_state == {"response_id": "resp_xyz", "extra": 42}

--- a/strands-py/tests/strands/agent/test_snapshot.py
+++ b/strands-py/tests/strands/agent/test_snapshot.py
@@ -128,7 +128,7 @@ def test_snapshot_structural_invariants(messages, state_dict, system_prompt):
     assert ISO_8601_UTC_RE.match(snapshot.created_at), f"created_at={snapshot.created_at!r} not ISO 8601 UTC"
     assert isinstance(snapshot.data, dict)
     assert isinstance(snapshot.app_data, dict)
-    for field in ("messages", "state", "conversation_manager_state", "interrupt_state"):
+    for field in ("messages", "state", "conversation_manager_state", "interrupt_state", "model_state"):
         assert field in snapshot.data
     assert "system_prompt" not in snapshot.data
 
@@ -465,9 +465,9 @@ def test_model_state_is_valid_snapshot_field():
     assert "model_state" in ALL_SNAPSHOT_FIELDS
 
 
-def test_model_state_not_in_session_preset():
-    """model_state is not included in the session preset."""
-    assert "model_state" not in SNAPSHOT_PRESETS["session"]
+def test_model_state_in_session_preset():
+    """model_state is included in the session preset."""
+    assert "model_state" in SNAPSHOT_PRESETS["session"]
 
 
 def test_take_snapshot_captures_model_state():
@@ -520,6 +520,16 @@ def test_load_snapshot_with_empty_model_state_clears_it():
     agent.load_snapshot(snap)
 
     assert agent._model_state == {}
+
+
+def test_load_snapshot_model_state_is_independent_copy():
+    """Mutating agent._model_state after load_snapshot doesn't corrupt the snapshot."""
+    agent = _make_agent()
+    snap = _make_snapshot(data={"model_state": {"response_id": "resp_original"}})
+    agent.load_snapshot(snap)
+
+    agent._model_state["response_id"] = "resp_mutated"
+    assert snap.data["model_state"]["response_id"] == "resp_original"
 
 
 def test_model_state_round_trip():


### PR DESCRIPTION
## Description

The snapshot system currently has no way to capture `_model_state` (provider-specific runtime state like `response_id` for the OpenAI Responses API). Callers that need to persist this across context switches — such as the A2A executor — are forced to work around the gap by manually stashing it in `app_data`.

This adds `model_state` as a first-class `SnapshotField` and includes it in the `session` preset, matching the TypeScript SDK which already has `modelState` in its session preset.

```python
# model_state is now captured automatically with the session preset
snapshot = agent.take_snapshot(preset="session")

# Restore it later — model_state comes back too
agent.load_snapshot(snapshot)
```

Absent field in a snapshot = no-op on load (existing `_model_state` preserved). Present but empty `{}` = clears the agent's `_model_state`.

## Related Issues

Discussion in #2628

## Documentation PR

Documentation updated in this PR — added `model_state` to the snapshot fields table and updated the session preset description.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.