### PR TITLE
feat(site): generate smart preview links for changed doc pages

### DIFF
--- a/.github/workflows/docs-deploy-preview.yml
+++ b/.github/workflows/docs-deploy-preview.yml
@@ -128,6 +128,7 @@ jobs:
             const previewLinks = docFiles.map(f => {
               const urlPath = f.filename
                 .replace('site/src/content/docs/', '/docs/')
+                .replace(/\/index\.mdx$/, '/')
                 .replace(/\.mdx$/, '/');
               const label = urlPath.replace(/^\/docs\//, '').replace(/\/$/, '');
               return `- [${label}](${baseUrl}${urlPath})`;

--- a/.github/workflows/docs-deploy-preview.yml
+++ b/.github/workflows/docs-deploy-preview.yml
@@ -111,7 +111,29 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
-            const previewUrl = '${{ env.PREVIEW_URL }}';
+            const baseUrl = 'https://${{ env.CLOUDFRONT_DOMAIN }}/${{ env.S3_PATH }}';
+
+            // Get changed files in the PR
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            // Build preview links for changed doc pages
+            const docFiles = files
+              .filter(f => f.filename.startsWith('site/src/content/docs/') && f.filename.endsWith('.mdx'))
+              .filter(f => f.status !== 'removed');
+
+            const previewLinks = docFiles.map(f => {
+              const urlPath = f.filename
+                .replace('site/src/content/docs/', '/docs/')
+                .replace(/\.mdx$/, '/');
+              const label = urlPath.replace(/^\/docs\//, '').replace(/\/$/, '');
+              return `- [${label}](${baseUrl}${urlPath})`;
+            });
+
+            const fallbackUrl = `${baseUrl}/docs/user-guide/quickstart/overview/`;
 
             // Find existing bot comment
             const comments = await github.rest.issues.listComments({
@@ -125,15 +147,21 @@ jobs:
               comment.body.includes('Documentation Preview')
             );
 
-            const body = [
+            const lines = [
               '## Documentation Preview Ready',
               '',
               'Your documentation preview has been successfully deployed!',
               '',
-              `**Preview URL**: ${previewUrl}`,
-              '',
-              `_Updated at: ${new Date().toISOString()}_`
-            ].join('\n');
+            ];
+
+            if (previewLinks.length > 0) {
+              lines.push('**Changed pages:**', '', ...previewLinks);
+            } else {
+              lines.push(`**Preview URL**: ${fallbackUrl}`);
+            }
+
+            lines.push('', `_Updated at: ${new Date().toISOString()}_`);
+            const body = lines.join('\n');
 
             if (botComment) {
               await github.rest.issues.updateComment({


### PR DESCRIPTION
## Description

The doc preview workflow always links to `/docs/user-guide/quickstart/overview/` regardless of which pages the PR actually changed. This forces reviewers to manually navigate to the relevant page every time.

This PR makes the preview comment smarter: it uses `pulls.listFiles` to find all changed `.mdx` files and generates a direct preview link for each one. It handles `index.mdx` correctly (maps to the parent directory URL, not `/index/`), and falls back to the quickstart overview when no doc pages were changed.

**Test PR**: https://github.com/zastrowm/docs/pull/28

## Related Issues

N/A

## Documentation PR

N/A (this PR is itself a docs infrastructure change)

## Type of Change

New feature

## Testing

Tested end-to-end by pushing the workflow to a fork and opening a PR that modifies both an `index.mdx` and a regular `.mdx` file: https://github.com/zastrowm/docs/pull/28

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.