### PR TITLE
fix(site): update community contribution link to harness-sdk repo

### DIFF
--- a/site/src/components/CommunityContributionAside.astro
+++ b/site/src/components/CommunityContributionAside.astro
@@ -6,7 +6,7 @@ import { Aside } from '@astrojs/starlight/components';
   This is a community-maintained package that is not owned or supported by the Strands team. Validate and review
   the package before using it in your project.
 
-  Have your own integration? <a href="https://github.com/strands-agents/docs/issues/new?assignees=&labels=enhancement&projects=&template=content_addition.yml&title=%5BContent+Addition%5D%3A+">
+  Have your own integration? <a href="https://github.com/strands-agents/harness-sdk/issues/new?assignees=&labels=enhancement&projects=&template=content_addition.yml&title=%5BContent+Addition%5D%3A+">
     We'd love to add it here too!
   </a>
 </Aside>


### PR DESCRIPTION
## Description

After the monorepo merge, the docs site now lives in `strands-agents/harness-sdk` rather than the old standalone `strands-agents/docs` repo. The "content addition" issue link in the `CommunityContributionAside` component still pointed to the old repo, so users clicking it would file issues in the wrong place.

This updates the link to point to `harness-sdk`.

## Related Issues

N/A

## Documentation PR

N/A — this is a docs site fix itself.

## Type of Change

Bug fix

## Testing

Verified that the `content_addition.yml` issue template exists in `strands-agents/harness-sdk` via `gh api`.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
