### PR TITLE
fix(a2a): isolate conversation state per context in TypeScript

### DIFF
--- a/strands-py/src/strands/multiagent/a2a/executor.py
+++ b/strands-py/src/strands/multiagent/a2a/executor.py
@@ -49,11 +49,7 @@ AgentFactory = Callable[[str], SAAgent]
 
 @dataclass
 class _StreamState:
-    """Per-invocation A2A-compliant streaming state.
-
-    Held locally per request rather than on the executor: in factory mode different contexts run
-    concurrently, so shared instance attributes would corrupt each other's artifact tracking.
-    """
+    """Per-invocation A2A-compliant streaming state."""
 
     artifact_id: str
     is_first_chunk: bool = True
@@ -61,11 +57,7 @@ class _StreamState:
 
 @dataclass
 class _ContextEntry:
-    """Per-context bookkeeping for factory mode: a dedicated agent and its serializing lock.
-
-    Keeping the agent and lock in one entry means the LRU map has a single source of truth; there
-    is no second map to keep in sync on insert, reorder, or eviction.
-    """
+    """Per-context bookkeeping for factory mode: a dedicated agent and its serializing lock."""
 
     agent: SAAgent
     lock: asyncio.Lock
@@ -150,8 +142,7 @@ class StrandsA2AExecutor(AgentExecutor):
         self._contexts_lock = asyncio.Lock()
 
         if agent_factory is not None:
-            # Factory mode: a dedicated agent and lock per context. The per-context lock serializes
-            # only same-context requests, so different contexts run concurrently.
+            # Factory mode: a dedicated agent and lock per context.
             self.agent: SAAgent | None = None
             self._contexts: OrderedDict[str, _ContextEntry] = OrderedDict()
         else:
@@ -169,7 +160,6 @@ class StrandsA2AExecutor(AgentExecutor):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            # The template snapshot is the agent's clean state, captured before any request mutates it.
             self.agent = agent
             self._template_snapshot = self._capture_state(agent)  # type: ignore[arg-type]
             self._snapshots: OrderedDict[str, Snapshot] = OrderedDict()
@@ -179,12 +169,7 @@ class StrandsA2AExecutor(AgentExecutor):
         return agent.take_snapshot(preset="session")
 
     def _restore_state(self, agent: SAAgent, snapshot: Snapshot) -> None:
-        """Load a snapshot into an agent, restoring its session state.
-
-        No defensive copy is needed: ``load_snapshot`` deep-copies every field it restores (and
-        ``take_snapshot`` deep-copies on capture), so a run never mutates a stored or template
-        snapshot in place.
-        """
+        """Load a snapshot into an agent, restoring its session state."""
         agent.load_snapshot(snapshot)
 
     def _evict_excess_contexts(self) -> None:
@@ -227,18 +212,13 @@ class StrandsA2AExecutor(AgentExecutor):
         updater: TaskUpdater,
         stream_state: _StreamState | None,
     ) -> None:
-        """Single-agent mode: swap this context's snapshot on/off the shared agent under a lock.
-
-        The lock serializes all requests (a single ``Agent`` cannot be invoked concurrently). The
-        agent is reset to the template afterward so no context's data lingers on it.
-        """
+        """Single-agent mode: swap this context's snapshot on/off the shared agent under a lock."""
         async with self._contexts_lock:
             self._restore_state(self.agent, self._snapshots.get(context_id, self._template_snapshot))  # type: ignore[arg-type]
             try:
                 await self._stream_agent(self.agent, content_blocks, invocation_state, updater, stream_state)  # type: ignore[arg-type]
             finally:
-                # Persist this context's updated history (even on error/cancel, to retain partial
-                # turns), evict beyond the cap, then reset the shared agent for the next caller.
+                # Persist updated history (even on error), evict, then reset the agent for the next caller.
                 self._snapshots[context_id] = self._capture_state(self.agent)  # type: ignore[arg-type]
                 self._snapshots.move_to_end(context_id)
                 self._evict_excess_contexts()
@@ -364,17 +344,13 @@ class StrandsA2AExecutor(AgentExecutor):
                 stacklevel=3,
             )
 
-        # Per-invocation streaming state (None in legacy mode). Local to this request so concurrent
-        # requests in factory mode cannot corrupt each other's artifact tracking.
+        # Per-invocation streaming state (None in legacy mode).
         stream_state = _StreamState(artifact_id=str(uuid.uuid4())) if self.enable_a2a_compliant_streaming else None
 
-        # Pass the A2A RequestContext through invocation state so downstream
-        # tools and hooks can access request metadata, task info, configuration, etc.
+        # Forward the A2A RequestContext so downstream tools and hooks can read request metadata.
         invocation_state: dict[str, Any] = {"a2a_request_context": context}
 
-        # The A2A framework populates context_id for every request before execute() runs
-        # (client-supplied, generated when absent, or inferred from the referenced task) and
-        # surfaces a generated id in the response. We rely on that and key isolation on it.
+        # The framework always populates context_id before execute() runs; isolation is keyed on it.
         context_id = context.context_id
         if not context_id:
             raise ServerError(error=InternalError(message="Request is missing a context_id")) from None

--- a/strands-py/src/strands/multiagent/a2a/executor.py
+++ b/strands-py/src/strands/multiagent/a2a/executor.py
@@ -10,7 +10,6 @@ streamed requests to the A2AServer.
 
 import asyncio
 import base64
-import copy
 import json
 import logging
 import mimetypes
@@ -182,10 +181,11 @@ class StrandsA2AExecutor(AgentExecutor):
     def _restore_state(self, agent: SAAgent, snapshot: Snapshot) -> None:
         """Load a snapshot into an agent, restoring its session state.
 
-        Deep-copies once at the boundary so a run never mutates a stored or template snapshot in
-        place (snapshots, including the template, are restored repeatedly).
+        No defensive copy is needed: ``load_snapshot`` deep-copies every field it restores (and
+        ``take_snapshot`` deep-copies on capture), so a run never mutates a stored or template
+        snapshot in place.
         """
-        agent.load_snapshot(copy.deepcopy(snapshot))
+        agent.load_snapshot(snapshot)
 
     def _evict_excess_contexts(self) -> None:
         """Evict least-recently-used contexts beyond ``max_contexts``. Caller holds the lock."""

--- a/strands-ts/src/a2a/__tests__/async-lock.test.ts
+++ b/strands-ts/src/a2a/__tests__/async-lock.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { AsyncLock } from '../async-lock.js'
+
+describe('AsyncLock', () => {
+  it('serializes critical sections in FIFO order', async () => {
+    const lock = new AsyncLock()
+    const order: number[] = []
+
+    async function task(id: number, delayMs: number): Promise<void> {
+      const release = await lock.acquire()
+      try {
+        order.push(id)
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+      } finally {
+        release()
+      }
+    }
+
+    // Start three tasks "concurrently". Despite descending delays, the lock
+    // forces them to run one at a time in acquisition order.
+    await Promise.all([task(1, 15), task(2, 10), task(3, 5)])
+
+    expect(order).toStrictEqual([1, 2, 3])
+  })
+
+  it('prevents overlap of holders', async () => {
+    const lock = new AsyncLock()
+    let active = 0
+    let maxActive = 0
+
+    async function task(): Promise<void> {
+      const release = await lock.acquire()
+      try {
+        active++
+        maxActive = Math.max(maxActive, active)
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        active--
+      } finally {
+        release()
+      }
+    }
+
+    await Promise.all([task(), task(), task(), task()])
+
+    expect(maxActive).toBe(1)
+  })
+
+  it('releases the lock even if the holder throws', async () => {
+    const lock = new AsyncLock()
+
+    const release = await lock.acquire()
+    try {
+      throw new Error('boom')
+    } catch {
+      // swallow
+    } finally {
+      release()
+    }
+
+    // A subsequent acquire must resolve (would hang if the lock leaked).
+    const release2 = await lock.acquire()
+    release2()
+    expect(true).toBe(true)
+  })
+})

--- a/strands-ts/src/a2a/__tests__/async-lock.test.ts
+++ b/strands-ts/src/a2a/__tests__/async-lock.test.ts
@@ -7,13 +7,9 @@ describe('AsyncLock', () => {
     const order: number[] = []
 
     async function task(id: number, delayMs: number): Promise<void> {
-      const release = await lock.acquire()
-      try {
-        order.push(id)
-        await new Promise((resolve) => setTimeout(resolve, delayMs))
-      } finally {
-        release()
-      }
+      using _release = await lock.acquire()
+      order.push(id)
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
     }
 
     // Start three tasks "concurrently". Despite descending delays, the lock
@@ -29,15 +25,11 @@ describe('AsyncLock', () => {
     let maxActive = 0
 
     async function task(): Promise<void> {
-      const release = await lock.acquire()
-      try {
-        active++
-        maxActive = Math.max(maxActive, active)
-        await new Promise((resolve) => setTimeout(resolve, 5))
-        active--
-      } finally {
-        release()
-      }
+      using _release = await lock.acquire()
+      active++
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      active--
     }
 
     await Promise.all([task(), task(), task(), task()])
@@ -48,18 +40,15 @@ describe('AsyncLock', () => {
   it('releases the lock even if the holder throws', async () => {
     const lock = new AsyncLock()
 
-    const release = await lock.acquire()
     try {
+      using _release = await lock.acquire()
       throw new Error('boom')
     } catch {
-      // swallow
-    } finally {
-      release()
+      // swallow; the `using` handle is disposed as the block unwinds
     }
 
     // A subsequent acquire must resolve (would hang if the lock leaked).
-    const release2 = await lock.acquire()
-    release2()
+    using _release2 = await lock.acquire()
     expect(true).toBe(true)
   })
 })

--- a/strands-ts/src/a2a/__tests__/executor.test.ts
+++ b/strands-ts/src/a2a/__tests__/executor.test.ts
@@ -46,7 +46,7 @@ describe('A2AExecutor', () => {
     it('streams text deltas as artifact chunks and publishes completed status', async () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Agent response' })
       const agent = new Agent({ model, printer: false })
-      const executor = new A2AExecutor(agent)
+      const executor = new A2AExecutor({ agent })
       const eventBus = createMockEventBus()
 
       await executor.execute(createRequestContext('Hello agent'), eventBus)
@@ -97,7 +97,7 @@ describe('A2AExecutor', () => {
         { type: 'textBlock', text: 'Second' },
       ])
       const agent = new Agent({ model, printer: false })
-      const executor = new A2AExecutor(agent)
+      const executor = new A2AExecutor({ agent })
       const eventBus = createMockEventBus()
 
       await executor.execute(createRequestContext('Hello'), eventBus)
@@ -114,7 +114,7 @@ describe('A2AExecutor', () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Response' })
       const agent = new Agent({ model, printer: false })
       vi.spyOn(agent, 'stream')
-      const executor = new A2AExecutor(agent)
+      const executor = new A2AExecutor({ agent })
       const eventBus = createMockEventBus()
 
       const context: RequestContext = {
@@ -144,7 +144,7 @@ describe('A2AExecutor', () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Response' })
       const agent = new Agent({ model, printer: false })
       const streamSpy = vi.spyOn(agent, 'stream')
-      const executor = new A2AExecutor(agent)
+      const executor = new A2AExecutor({ agent })
       const eventBus = createMockEventBus()
       const context = createRequestContext('hello', 'task-42')
 
@@ -158,7 +158,7 @@ describe('A2AExecutor', () => {
     it('re-throws when agent throws, publishing only the initial task event', async () => {
       const model = new MockMessageModel().addTurn(new Error('Agent failed'))
       const agent = new Agent({ model, printer: false })
-      const executor = new A2AExecutor(agent)
+      const executor = new A2AExecutor({ agent })
       const eventBus = createMockEventBus()
 
       await expect(executor.execute(createRequestContext('Hello'), eventBus)).rejects.toThrow('Agent failed')
@@ -197,7 +197,7 @@ describe('A2AExecutor', () => {
         },
       }
 
-      const executor = new A2AExecutor(undefined, { agentFactory: () => mockAgent })
+      const executor = new A2AExecutor({ agentFactory: () => mockAgent })
       const eventBus = createMockEventBus()
 
       await executor.execute(createRequestContext('Generate an image'), eventBus)
@@ -225,7 +225,7 @@ describe('A2AExecutor', () => {
     it('throws A2AError.invalidRequest when parts produce no content blocks', async () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Response' })
       const agent = new Agent({ model, printer: false })
-      const executor = new A2AExecutor(agent)
+      const executor = new A2AExecutor({ agent })
       const eventBus = createMockEventBus()
 
       const context: RequestContext = {
@@ -243,7 +243,7 @@ describe('A2AExecutor', () => {
     it('throws A2AError.unsupportedOperation', async () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: '' })
       const agent = new Agent({ model, printer: false })
-      const executor = new A2AExecutor(agent)
+      const executor = new A2AExecutor({ agent })
       const eventBus = createMockEventBus()
 
       await expect(executor.cancelTask('task-1', eventBus)).rejects.toThrow('Task cancellation is not supported')
@@ -311,14 +311,14 @@ describe('A2AExecutor context isolation', () => {
 
     it('throws when both agent and agentFactory are provided', () => {
       const agent = new Agent({ model: new MockMessageModel(), printer: false })
-      expect(() => new A2AExecutor(agent, { agentFactory: () => agent })).toThrow(
+      expect(() => new A2AExecutor({ agent, agentFactory: () => agent })).toThrow(
         "Provide exactly one of 'agent' or 'agentFactory'."
       )
     })
 
     it('throws when maxContexts is less than 1', () => {
-      expect(() => new A2AExecutor(undefined, { agentFactory: makeEchoAgent, maxContexts: 0 })).toThrow(
-        'maxContexts must be >= 1'
+      expect(() => new A2AExecutor({ agentFactory: makeEchoAgent, maxContexts: 0 })).toThrow(
+        'maxContexts must be at least 1'
       )
     })
   })
@@ -327,7 +327,7 @@ describe('A2AExecutor context isolation', () => {
     it('builds one agent per context and reuses it within a context', async () => {
       const built: string[] = []
       const agentsByContext = new Map<string, Agent>()
-      const executor = new A2AExecutor(undefined, {
+      const executor = new A2AExecutor({
         agentFactory: (contextId) => {
           built.push(contextId)
           const agent = makeEchoAgent()
@@ -347,7 +347,7 @@ describe('A2AExecutor context isolation', () => {
     })
 
     it('isolates history across contexts and continues it within one', async () => {
-      const executor = new A2AExecutor(undefined, { agentFactory: makeEchoAgent })
+      const executor = new A2AExecutor({ agentFactory: makeEchoAgent })
 
       // ctx-A turn 1: just the user message in history -> ECHO[1].
       let bus = createMockEventBus()
@@ -369,7 +369,7 @@ describe('A2AExecutor context isolation', () => {
 
     it('evicts the least-recently-used context beyond maxContexts', async () => {
       const built: string[] = []
-      const executor = new A2AExecutor(undefined, {
+      const executor = new A2AExecutor({
         agentFactory: (contextId) => {
           built.push(contextId)
           return makeEchoAgent()
@@ -390,7 +390,7 @@ describe('A2AExecutor context isolation', () => {
 
   describe('single-agent mode (deprecated)', () => {
     it('isolates history across contexts via snapshot swapping', async () => {
-      const executor = new A2AExecutor(makeEchoAgent())
+      const executor = new A2AExecutor({ agent: makeEchoAgent() })
 
       let bus = createMockEventBus()
       await executor.execute(ctxRequest('ctx-A', 'a-1', 'SECRET-AAAA'), bus)
@@ -412,7 +412,7 @@ describe('A2AExecutor context isolation', () => {
     it('throws when a single agent has a sessionManager', () => {
       const agent = makeEchoAgent()
       ;(agent as unknown as { sessionManager: unknown }).sessionManager = {}
-      expect(() => new A2AExecutor(agent)).toThrow('sessionManager is not supported')
+      expect(() => new A2AExecutor({ agent })).toThrow('sessionManager is not supported')
     })
   })
 })

--- a/strands-ts/src/a2a/__tests__/executor.test.ts
+++ b/strands-ts/src/a2a/__tests__/executor.test.ts
@@ -11,6 +11,7 @@ import { ImageBlock, encodeBase64 } from '../../types/media.js'
 import { ContentBlockEvent, ModelStreamUpdateEvent } from '../../hooks/events.js'
 import { AgentResult } from '../../types/agent.js'
 import { Message } from '../../types/messages.js'
+import type { ModelStreamEvent } from '../../models/streaming.js'
 
 function createMockEventBus(): ExecutionEventBus & { events: AgentExecutionEvent[] } {
   const events: AgentExecutionEvent[] = []
@@ -196,7 +197,7 @@ describe('A2AExecutor', () => {
         },
       }
 
-      const executor = new A2AExecutor(mockAgent)
+      const executor = new A2AExecutor(undefined, { agentFactory: () => mockAgent })
       const eventBus = createMockEventBus()
 
       await executor.execute(createRequestContext('Generate an image'), eventBus)
@@ -247,6 +248,171 @@ describe('A2AExecutor', () => {
 
       await expect(executor.cancelTask('task-1', eventBus)).rejects.toThrow('Task cancellation is not supported')
       expect(eventBus.events).toStrictEqual([])
+    })
+  })
+})
+
+// ============================================================================
+// Per-context conversation isolation
+//
+// These tests drive a real Agent (with a deterministic echo model) through a
+// single executor across two distinct A2A contextIds, asserting that no
+// conversation state leaks between contexts, while a single context still
+// accumulates its own history across turns.
+// ============================================================================
+
+/**
+ * Deterministic, network-free model that echoes the latest user text prefixed
+ * with `ECHO[<history-length>]`, so tests can observe per-context history growth.
+ */
+class EchoModel extends MockMessageModel {
+  override async *stream(messages: Message[]): AsyncGenerator<ModelStreamEvent> {
+    const lastUser = [...messages].reverse().find((m) => m.role === 'user')
+    const lastText = lastUser?.content.find((b): b is TextBlock => b.type === 'textBlock')?.text ?? ''
+    const reply = `ECHO[${messages.length}]: ${lastText}`
+    yield { type: 'modelMessageStartEvent', role: 'assistant' }
+    yield { type: 'modelContentBlockStartEvent' }
+    yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: reply } }
+    yield { type: 'modelContentBlockStopEvent' }
+    yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
+  }
+}
+
+function makeEchoAgent(): Agent {
+  return new Agent({ model: new EchoModel(), printer: false })
+}
+
+function ctxRequest(contextId: string, taskId: string, text: string): RequestContext {
+  return {
+    taskId,
+    contextId,
+    userMessage: {
+      kind: 'message',
+      messageId: `msg-${taskId}`,
+      role: 'user',
+      parts: [{ kind: 'text', text }],
+    },
+  }
+}
+
+function artifactTexts(eventBus: ReturnType<typeof createMockEventBus>): string[] {
+  return eventBus.events
+    .filter((e): e is TaskArtifactUpdateEvent => e.kind === 'artifact-update')
+    .flatMap((e) => e.artifact.parts)
+    .filter((p): p is { kind: 'text'; text: string } => p.kind === 'text')
+    .map((p) => p.text)
+}
+
+describe('A2AExecutor context isolation', () => {
+  describe('constructor validation', () => {
+    it('throws when neither agent nor agentFactory is provided', () => {
+      expect(() => new A2AExecutor()).toThrow("Provide exactly one of 'agent' or 'agentFactory'.")
+    })
+
+    it('throws when both agent and agentFactory are provided', () => {
+      const agent = new Agent({ model: new MockMessageModel(), printer: false })
+      expect(() => new A2AExecutor(agent, { agentFactory: () => agent })).toThrow(
+        "Provide exactly one of 'agent' or 'agentFactory'."
+      )
+    })
+
+    it('throws when maxContexts is less than 1', () => {
+      expect(() => new A2AExecutor(undefined, { agentFactory: makeEchoAgent, maxContexts: 0 })).toThrow(
+        'maxContexts must be >= 1'
+      )
+    })
+  })
+
+  describe('factory mode', () => {
+    it('builds one agent per context and reuses it within a context', async () => {
+      const built: string[] = []
+      const agentsByContext = new Map<string, Agent>()
+      const executor = new A2AExecutor(undefined, {
+        agentFactory: (contextId) => {
+          built.push(contextId)
+          const agent = makeEchoAgent()
+          agentsByContext.set(contextId, agent)
+          return agent
+        },
+      })
+
+      await executor.execute(ctxRequest('ctx-A', 'a-1', 'first'), createMockEventBus())
+      await executor.execute(ctxRequest('ctx-A', 'a-2', 'second'), createMockEventBus())
+      await executor.execute(ctxRequest('ctx-B', 'b-1', 'first'), createMockEventBus())
+
+      // Factory invoked once per distinct context, not per request.
+      expect(built).toStrictEqual(['ctx-A', 'ctx-B'])
+      // Distinct Agent instances per context.
+      expect(agentsByContext.get('ctx-A')).not.toBe(agentsByContext.get('ctx-B'))
+    })
+
+    it('isolates history across contexts and continues it within one', async () => {
+      const executor = new A2AExecutor(undefined, { agentFactory: makeEchoAgent })
+
+      // ctx-A turn 1: just the user message in history -> ECHO[1].
+      let bus = createMockEventBus()
+      await executor.execute(ctxRequest('ctx-A', 'a-1', 'SECRET-AAAA'), bus)
+      expect(artifactTexts(bus).some((t) => t.includes('ECHO[1]:') && t.includes('SECRET-AAAA'))).toBe(true)
+
+      // ctx-A turn 2: history now has user1, assistant1, user2 -> ECHO[3].
+      bus = createMockEventBus()
+      await executor.execute(ctxRequest('ctx-A', 'a-2', 'again'), bus)
+      expect(artifactTexts(bus).some((t) => t.includes('ECHO[3]:'))).toBe(true)
+
+      // ctx-B is independent -> starts fresh, never sees ctx-A's secret.
+      bus = createMockEventBus()
+      await executor.execute(ctxRequest('ctx-B', 'b-1', 'hello'), bus)
+      const textsB = artifactTexts(bus)
+      expect(textsB.some((t) => t.includes('ECHO[1]:'))).toBe(true)
+      expect(textsB.some((t) => t.includes('SECRET-AAAA'))).toBe(false)
+    })
+
+    it('evicts the least-recently-used context beyond maxContexts', async () => {
+      const built: string[] = []
+      const executor = new A2AExecutor(undefined, {
+        agentFactory: (contextId) => {
+          built.push(contextId)
+          return makeEchoAgent()
+        },
+        maxContexts: 2,
+      })
+
+      await executor.execute(ctxRequest('ctx-A', 'a-1', 'hi'), createMockEventBus())
+      await executor.execute(ctxRequest('ctx-B', 'b-1', 'hi'), createMockEventBus())
+      await executor.execute(ctxRequest('ctx-A', 'a-2', 'again'), createMockEventBus()) // touch A
+      await executor.execute(ctxRequest('ctx-C', 'c-1', 'hi'), createMockEventBus()) // evicts B
+
+      // B was evicted, so reusing it rebuilds a fresh agent (factory called again for B).
+      await executor.execute(ctxRequest('ctx-B', 'b-2', 'hi'), createMockEventBus())
+      expect(built).toStrictEqual(['ctx-A', 'ctx-B', 'ctx-C', 'ctx-B'])
+    })
+  })
+
+  describe('single-agent mode (deprecated)', () => {
+    it('isolates history across contexts via snapshot swapping', async () => {
+      const executor = new A2AExecutor(makeEchoAgent())
+
+      let bus = createMockEventBus()
+      await executor.execute(ctxRequest('ctx-A', 'a-1', 'SECRET-AAAA'), bus)
+      expect(artifactTexts(bus).some((t) => t.includes('ECHO[1]:') && t.includes('SECRET-AAAA'))).toBe(true)
+
+      // ctx-A continues -> ECHO[3].
+      bus = createMockEventBus()
+      await executor.execute(ctxRequest('ctx-A', 'a-2', 'again'), bus)
+      expect(artifactTexts(bus).some((t) => t.includes('ECHO[3]:'))).toBe(true)
+
+      // ctx-B starts fresh and never sees ctx-A's secret.
+      bus = createMockEventBus()
+      await executor.execute(ctxRequest('ctx-B', 'b-1', 'hello'), bus)
+      const textsB = artifactTexts(bus)
+      expect(textsB.some((t) => t.includes('ECHO[1]:'))).toBe(true)
+      expect(textsB.some((t) => t.includes('SECRET-AAAA'))).toBe(false)
+    })
+
+    it('throws when a single agent has a sessionManager', () => {
+      const agent = makeEchoAgent()
+      ;(agent as unknown as { sessionManager: unknown }).sessionManager = {}
+      expect(() => new A2AExecutor(agent)).toThrow('sessionManager is not supported')
     })
   })
 })

--- a/strands-ts/src/a2a/__tests__/server.test.ts
+++ b/strands-ts/src/a2a/__tests__/server.test.ts
@@ -51,5 +51,31 @@ describe('A2AServer', () => {
       })
       expect(server.agentCard).toBeDefined()
     })
+
+    it('builds an agent card from a factory-built representative agent', () => {
+      const built: string[] = []
+      const server = new A2AServer({
+        agentFactory: (contextId) => {
+          built.push(contextId)
+          return new Agent({ model: new MockMessageModel(), printer: false })
+        },
+        name: 'Factory Agent',
+      })
+
+      // Factory invoked once at construction (placeholder context) for card metadata.
+      expect(built).toHaveLength(1)
+      expect(server.agentCard.name).toBe('Factory Agent')
+    })
+
+    it('throws when neither agent nor agentFactory is provided', () => {
+      expect(() => new A2AServer({ name: 'No Agent' })).toThrow("Provide exactly one of 'agent' or 'agentFactory'.")
+    })
+
+    it('throws when both agent and agentFactory are provided', () => {
+      const agent = new Agent({ model: new MockMessageModel(), printer: false })
+      expect(() => new A2AServer({ agent, agentFactory: () => agent, name: 'Both' })).toThrow(
+        "Provide exactly one of 'agent' or 'agentFactory'."
+      )
+    })
   })
 })

--- a/strands-ts/src/a2a/async-lock.ts
+++ b/strands-ts/src/a2a/async-lock.ts
@@ -1,4 +1,11 @@
 /**
+ * A held lock. Dispose it (e.g. via `using`) to release the lock for the next waiter.
+ */
+export interface LockHandle {
+  [Symbol.dispose](): void
+}
+
+/**
  * Minimal async mutex for serializing access to a resource.
  *
  * JavaScript has no built-in equivalent of Python's `asyncio.Lock`. This
@@ -14,10 +21,20 @@ export class AsyncLock {
   /**
    * Acquires the lock, waiting until all previously-acquired holders release.
    *
-   * @returns A release function. Call it exactly once (e.g. in a `finally`) to
-   *   let the next waiter proceed.
+   * The returned handle releases the lock on disposal: declare it with `using`
+   * so the lock is freed when the block exits (including on throw), with no
+   * explicit `finally`.
+   *
+   * @returns A handle whose disposal releases the lock for the next waiter.
+   *   Disposal is idempotent.
+   *
+   * @example
+   * ```typescript
+   * using _lock = await lock.acquire()
+   * // ... critical section; lock released at scope exit
+   * ```
    */
-  async acquire(): Promise<() => void> {
+  async acquire(): Promise<LockHandle> {
     let release!: () => void
     const next = new Promise<void>((resolve) => {
       release = resolve
@@ -28,6 +45,13 @@ export class AsyncLock {
     this._tail = previous.then(() => next)
     await previous
 
-    return release
+    let released = false
+    return {
+      [Symbol.dispose](): void {
+        if (released) return
+        released = true
+        release()
+      },
+    }
   }
 }

--- a/strands-ts/src/a2a/async-lock.ts
+++ b/strands-ts/src/a2a/async-lock.ts
@@ -1,18 +1,8 @@
 /**
- * A held lock. Dispose it (e.g. via `using`) to release the lock for the next waiter.
- */
-export interface LockHandle {
-  [Symbol.dispose](): void
-}
-
-/**
  * Minimal async mutex for serializing access to a resource.
  *
- * JavaScript has no built-in equivalent of Python's `asyncio.Lock`. This
- * implements the same contract: `acquire()` resolves only once all previously
- * acquired holders have released, so awaiting callers run one at a time in FIFO
- * order. Used by {@link A2AExecutor} to serialize same-context requests (one
- * lock per context in factory mode) and all requests in single-agent mode.
+ * `acquire()` resolves only once all previously acquired holders have released,
+ * so awaiting callers run one at a time in FIFO order.
  */
 export class AsyncLock {
   /** Resolves when the currently-held lock (if any) is released. */
@@ -21,20 +11,12 @@ export class AsyncLock {
   /**
    * Acquires the lock, waiting until all previously-acquired holders release.
    *
-   * The returned handle releases the lock on disposal: declare it with `using`
-   * so the lock is freed when the block exits (including on throw), with no
-   * explicit `finally`.
+   * Declare the result with `using` to release the lock at scope exit:
+   * `using _lock = await lock.acquire()`.
    *
-   * @returns A handle whose disposal releases the lock for the next waiter.
-   *   Disposal is idempotent.
-   *
-   * @example
-   * ```typescript
-   * using _lock = await lock.acquire()
-   * // ... critical section; lock released at scope exit
-   * ```
+   * @returns A handle whose disposal releases the lock. Disposal is idempotent.
    */
-  async acquire(): Promise<LockHandle> {
+  async acquire(): Promise<{ [Symbol.dispose](): void }> {
     let release!: () => void
     const next = new Promise<void>((resolve) => {
       release = resolve

--- a/strands-ts/src/a2a/async-lock.ts
+++ b/strands-ts/src/a2a/async-lock.ts
@@ -1,0 +1,33 @@
+/**
+ * Minimal async mutex for serializing access to a resource.
+ *
+ * JavaScript has no built-in equivalent of Python's `asyncio.Lock`. This
+ * implements the same contract: `acquire()` resolves only once all previously
+ * acquired holders have released, so awaiting callers run one at a time in FIFO
+ * order. Used by {@link A2AExecutor} to serialize same-context requests (one
+ * lock per context in factory mode) and all requests in single-agent mode.
+ */
+export class AsyncLock {
+  /** Resolves when the currently-held lock (if any) is released. */
+  private _tail: Promise<void> = Promise.resolve()
+
+  /**
+   * Acquires the lock, waiting until all previously-acquired holders release.
+   *
+   * @returns A release function. Call it exactly once (e.g. in a `finally`) to
+   *   let the next waiter proceed.
+   */
+  async acquire(): Promise<() => void> {
+    let release!: () => void
+    const next = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    // Wait on the current tail, then install ours so the next acquirer waits on us.
+    const previous = this._tail
+    this._tail = previous.then(() => next)
+    await previous
+
+    return release
+  }
+}

--- a/strands-ts/src/a2a/executor.ts
+++ b/strands-ts/src/a2a/executor.ts
@@ -17,11 +17,6 @@ import { normalizeError } from '../errors.js'
 import { logger } from '../logging/logger.js'
 import { AsyncLock } from './async-lock.js'
 
-/** Deep-copies a snapshot. Snapshots are JSON-serializable, so a round-trip is sufficient. */
-function cloneSnapshot(snapshot: Snapshot): Snapshot {
-  return JSON.parse(JSON.stringify(snapshot)) as Snapshot
-}
-
 /**
  * A factory that builds a fresh {@link Agent} for a given A2A `contextId`.
  *
@@ -150,8 +145,8 @@ export class A2AExecutor implements AgentExecutor {
   private readonly _agentFactory?: AgentFactory
   private readonly _maxContexts: number
 
-  /** Guards the per-context bookkeeping maps below. */
-  private readonly _contextsLock = new AsyncLock()
+  /** Serializes single-agent mode: only one request may use the shared agent at a time. */
+  private readonly _sharedAgentLock = new AsyncLock()
 
   // Factory mode: a dedicated agent and lock per context.
   private readonly _contexts = new Map<string, ContextEntry>()
@@ -211,14 +206,16 @@ export class A2AExecutor implements AgentExecutor {
   /**
    * Load a snapshot into an agent, restoring its session state.
    *
-   * Deep-copies once at the boundary so a run never mutates a stored or template
-   * snapshot in place (snapshots, including the template, are restored repeatedly).
+   * No defensive copy is needed: `loadSnapshot` reconstructs the agent's state
+   * from the snapshot rather than referencing it — messages are rebuilt as new
+   * instances and `StateStore` deep-copies the state on load — so a subsequent
+   * run cannot mutate a stored or template snapshot in place.
    */
   private _restoreState(agent: LocalAgent, snapshot: Snapshot): void {
-    agent.loadSnapshot(cloneSnapshot(snapshot))
+    agent.loadSnapshot(snapshot)
   }
 
-  /** Evict least-recently-used contexts beyond `maxContexts`. Caller holds the contexts lock. */
+  /** Evict least-recently-used contexts beyond `maxContexts`. Must be called without yielding. */
   private _evictExcessContexts(): void {
     const contexts: Map<string, unknown> = this._agentFactory !== undefined ? this._contexts : this._snapshots
     // Map preserves insertion order; the first key is the least-recently-used because
@@ -230,24 +227,27 @@ export class A2AExecutor implements AgentExecutor {
     }
   }
 
-  /** Return the dedicated agent and lock for a context, building it on first use (factory mode). */
-  private async _acquireContextAgent(contextId: string): Promise<ContextEntry> {
-    const release = await this._contextsLock.acquire()
-    try {
-      let entry = this._contexts.get(contextId)
-      if (entry === undefined) {
-        entry = { agent: this._agentFactory!(contextId), lock: new AsyncLock() }
-        this._contexts.set(contextId, entry)
-        this._evictExcessContexts()
-      } else {
-        // Mark most-recently-used: delete-then-set moves the entry to the Map's end.
-        this._contexts.delete(contextId)
-        this._contexts.set(contextId, entry)
-      }
-      return entry
-    } finally {
-      release()
+  /**
+   * Return the dedicated agent and lock for a context, building it on first use (factory mode).
+   *
+   * No lock guards the map here: the factory is synchronous, so this method never yields between
+   * reading and writing `_contexts`, and JavaScript's run-to-completion semantics make the
+   * check-then-create-or-reorder sequence atomic with respect to other contexts.
+   */
+  private _acquireContextAgent(contextId: string): ContextEntry {
+    let entry = this._contexts.get(contextId)
+    if (entry === undefined) {
+      entry = { agent: this._agentFactory!(contextId), lock: new AsyncLock() }
+      this._contexts.set(contextId, entry)
+      this._evictExcessContexts()
+    } else {
+      // Mark most-recently-used: delete-then-set moves the entry to the Map's end.
+      // ECMAScript guarantees Map iteration in insertion order, and `set` on an existing
+      // key keeps its position, so delete-then-set is the spec-guaranteed way to reorder.
+      this._contexts.delete(contextId)
+      this._contexts.set(contextId, entry)
     }
+    return entry
   }
 
   /**
@@ -285,13 +285,9 @@ export class A2AExecutor implements AgentExecutor {
     contentBlocks: ContentBlock[],
     eventBus: ExecutionEventBus
   ): Promise<void> {
-    const { agent, lock } = await this._acquireContextAgent(context.contextId)
-    const release = await lock.acquire()
-    try {
-      await this._streamAgent(agent, context, contentBlocks, eventBus)
-    } finally {
-      release()
-    }
+    const { agent, lock } = this._acquireContextAgent(context.contextId)
+    using _release = await lock.acquire()
+    await this._streamAgent(agent, context, contentBlocks, eventBus)
   }
 
   /**
@@ -306,22 +302,18 @@ export class A2AExecutor implements AgentExecutor {
     eventBus: ExecutionEventBus
   ): Promise<void> {
     const agent = this._agent!
-    const release = await this._contextsLock.acquire()
+    using _release = await this._sharedAgentLock.acquire()
+    this._restoreState(agent, this._snapshots.get(context.contextId) ?? this._templateSnapshot!)
     try {
-      this._restoreState(agent, this._snapshots.get(context.contextId) ?? this._templateSnapshot!)
-      try {
-        await this._streamAgent(agent, context, contentBlocks, eventBus)
-      } finally {
-        // Persist this context's updated history (even on error, to retain partial turns),
-        // evict beyond the cap, then reset the shared agent for the next caller. Delete-then-set
-        // places the entry at the most-recently-used end whether or not it already existed.
-        this._snapshots.delete(context.contextId)
-        this._snapshots.set(context.contextId, this._captureState(agent))
-        this._evictExcessContexts()
-        this._restoreState(agent, this._templateSnapshot!)
-      }
+      await this._streamAgent(agent, context, contentBlocks, eventBus)
     } finally {
-      release()
+      // Persist this context's updated history (even on error, to retain partial turns),
+      // evict beyond the cap, then reset the shared agent for the next caller. Delete-then-set
+      // places the entry at the most-recently-used end whether or not it already existed.
+      this._snapshots.delete(context.contextId)
+      this._snapshots.set(context.contextId, this._captureState(agent))
+      this._evictExcessContexts()
+      this._restoreState(agent, this._templateSnapshot!)
     }
   }
 

--- a/strands-ts/src/a2a/executor.ts
+++ b/strands-ts/src/a2a/executor.ts
@@ -10,12 +10,16 @@ import type { AgentExecutor } from '@a2a-js/sdk/server'
 import { A2AError } from '@a2a-js/sdk/server'
 import type { InvokableAgent, LocalAgent } from '../types/agent.js'
 import type { Snapshot } from '../types/snapshot.js'
-import { deepCopy } from '../types/json.js'
 import { ModelStreamUpdateEvent, ContentBlockEvent } from '../hooks/events.js'
 import { contentBlocksToParts, partsToContentBlocks } from './adapters.js'
 import { normalizeError } from '../errors.js'
 import { logger } from '../logging/logger.js'
 import { AsyncLock } from './async-lock.js'
+
+/** Deep-copies a snapshot. Snapshots are JSON-serializable, so a round-trip is sufficient. */
+function cloneSnapshot(snapshot: Snapshot): Snapshot {
+  return JSON.parse(JSON.stringify(snapshot)) as Snapshot
+}
 
 /**
  * A factory that builds a fresh {@link Agent} for a given A2A `contextId`.
@@ -46,11 +50,14 @@ interface ContextEntry {
 
 /**
  * Options for constructing an {@link A2AExecutor}.
+ *
+ * Provide exactly one of `agent` (deprecated) or `agentFactory`.
  */
 export interface A2AExecutorOptions {
+  /** A single agent reused across contexts. Deprecated; prefer `agentFactory`. */
+  agent?: InvokableAgent
   /**
    * Callable that takes a `contextId` and returns a fresh agent per context. Recommended.
-   * Provide exactly one of `agent` or `agentFactory`.
    */
   agentFactory?: AgentFactory
   /**
@@ -80,6 +87,16 @@ function asSnapshotAgent(agent: InvokableAgent): SnapshotAgent {
     )
   }
   return agent as unknown as SnapshotAgent
+}
+
+/**
+ * Whether an agent has a configured `sessionManager`. Single-agent mode rejects this:
+ * snapshot-swapping one shared instance would interleave every context into one session.
+ * `sessionManager` is an `Agent` field not declared on {@link InvokableAgent}, so it is
+ * read defensively here.
+ */
+function hasSessionManager(agent: InvokableAgent): boolean {
+  return (agent as { sessionManager?: unknown }).sessionManager !== undefined
 }
 
 /**
@@ -146,16 +163,15 @@ export class A2AExecutor implements AgentExecutor {
   /**
    * Creates a new A2AExecutor.
    *
-   * Provide exactly one of a single `agent` (deprecated) or `options.agentFactory`.
+   * Provide exactly one of `agent` (deprecated) or `agentFactory`.
    *
-   * @param agent - A single agent reused across contexts. Deprecated; prefer `agentFactory`.
-   * @param options - Executor options including `agentFactory` and `maxContexts`.
+   * @param options - Executor options: `agent` or `agentFactory`, plus optional `maxContexts`.
    */
-  constructor(agent?: InvokableAgent, options: A2AExecutorOptions = {}) {
-    const { agentFactory, maxContexts = DEFAULT_MAX_CONTEXTS } = options
+  constructor(options: A2AExecutorOptions = {}) {
+    const { agent, agentFactory, maxContexts = DEFAULT_MAX_CONTEXTS } = options
 
     if (maxContexts < 1) {
-      throw new Error(`maxContexts must be >= 1, got ${maxContexts}`)
+      throw new Error(`maxContexts must be at least 1, got ${maxContexts}`)
     }
     if ((agent === undefined) === (agentFactory === undefined)) {
       throw new Error("Provide exactly one of 'agent' or 'agentFactory'.")
@@ -168,7 +184,7 @@ export class A2AExecutor implements AgentExecutor {
     } else {
       // Single-agent mode: reuse one agent, swapping each context's snapshot on/off it.
       const sharedAgent = asSnapshotAgent(agent!)
-      if ((sharedAgent as { sessionManager?: unknown }).sessionManager !== undefined) {
+      if (hasSessionManager(sharedAgent)) {
         throw new Error(
           "A single 'agent' with a sessionManager is not supported: the session manager " +
             "persists every context's messages into one interleaved session. Use " +
@@ -198,14 +214,14 @@ export class A2AExecutor implements AgentExecutor {
    * snapshot in place (snapshots, including the template, are restored repeatedly).
    */
   private _restoreState(agent: LocalAgent, snapshot: Snapshot): void {
-    agent.loadSnapshot(deepCopy(snapshot) as unknown as Snapshot)
+    agent.loadSnapshot(cloneSnapshot(snapshot))
   }
 
   /** Evict least-recently-used contexts beyond `maxContexts`. Caller holds the contexts lock. */
   private _evictExcessContexts(): void {
     const contexts: Map<string, unknown> = this._agentFactory !== undefined ? this._contexts : this._snapshots
     // Map preserves insertion order; the first key is the least-recently-used because
-    // touched contexts are re-inserted at the end (see `_touch`).
+    // touched contexts are re-inserted at the end (delete-then-set on access).
     while (contexts.size > this._maxContexts) {
       const evictedId = contexts.keys().next().value as string
       contexts.delete(evictedId)
@@ -213,16 +229,7 @@ export class A2AExecutor implements AgentExecutor {
     }
   }
 
-  /** Move a key to the most-recently-used position (end) of a Map. */
-  private _touch<V>(map: Map<string, V>, key: string): void {
-    const value = map.get(key)!
-    map.delete(key)
-    map.set(key, value)
-  }
-
-  /**
-   * Return the dedicated agent and lock for a context, building it on first use (factory mode).
-   */
+  /** Return the dedicated agent and lock for a context, building it on first use (factory mode). */
   private async _acquireContextAgent(contextId: string): Promise<ContextEntry> {
     const release = await this._contextsLock.acquire()
     try {
@@ -232,7 +239,9 @@ export class A2AExecutor implements AgentExecutor {
         this._contexts.set(contextId, entry)
         this._evictExcessContexts()
       } else {
-        this._touch(this._contexts, contextId)
+        // Mark most-recently-used: delete-then-set moves the entry to the Map's end.
+        this._contexts.delete(contextId)
+        this._contexts.set(contextId, entry)
       }
       return entry
     } finally {
@@ -303,9 +312,10 @@ export class A2AExecutor implements AgentExecutor {
         await this._streamAgent(agent, context, contentBlocks, eventBus)
       } finally {
         // Persist this context's updated history (even on error, to retain partial turns),
-        // evict beyond the cap, then reset the shared agent for the next caller.
+        // evict beyond the cap, then reset the shared agent for the next caller. Delete-then-set
+        // places the entry at the most-recently-used end whether or not it already existed.
+        this._snapshots.delete(context.contextId)
         this._snapshots.set(context.contextId, this._captureState(agent))
-        this._touch(this._snapshots, context.contextId)
         this._evictExcessContexts()
         this._restoreState(agent, this._templateSnapshot!)
       }

--- a/strands-ts/src/a2a/executor.ts
+++ b/strands-ts/src/a2a/executor.ts
@@ -10,6 +10,7 @@ import type { AgentExecutor } from '@a2a-js/sdk/server'
 import { A2AError } from '@a2a-js/sdk/server'
 import type { InvokableAgent, LocalAgent } from '../types/agent.js'
 import type { Snapshot } from '../types/snapshot.js'
+import type { ContentBlock } from '../types/messages.js'
 import { ModelStreamUpdateEvent, ContentBlockEvent } from '../hooks/events.js'
 import { contentBlocksToParts, partsToContentBlocks } from './adapters.js'
 import { normalizeError } from '../errors.js'
@@ -54,7 +55,7 @@ interface ContextEntry {
  * Provide exactly one of `agent` (deprecated) or `agentFactory`.
  */
 export interface A2AExecutorOptions {
-  /** A single agent reused across contexts. Deprecated; prefer `agentFactory`. */
+  /** @deprecated A single agent reused across contexts. Prefer `agentFactory`. */
   agent?: InvokableAgent
   /**
    * Callable that takes a `contextId` and returns a fresh agent per context. Recommended.
@@ -281,7 +282,7 @@ export class A2AExecutor implements AgentExecutor {
    */
   private async _runWithContextAgent(
     context: RequestContext,
-    contentBlocks: ReturnType<typeof partsToContentBlocks>,
+    contentBlocks: ContentBlock[],
     eventBus: ExecutionEventBus
   ): Promise<void> {
     const { agent, lock } = await this._acquireContextAgent(context.contextId)
@@ -301,7 +302,7 @@ export class A2AExecutor implements AgentExecutor {
    */
   private async _runWithSharedAgent(
     context: RequestContext,
-    contentBlocks: ReturnType<typeof partsToContentBlocks>,
+    contentBlocks: ContentBlock[],
     eventBus: ExecutionEventBus
   ): Promise<void> {
     const agent = this._agent!
@@ -330,7 +331,7 @@ export class A2AExecutor implements AgentExecutor {
   private async _streamAgent(
     agent: InvokableAgent,
     context: RequestContext,
-    contentBlocks: ReturnType<typeof partsToContentBlocks>,
+    contentBlocks: ContentBlock[],
     eventBus: ExecutionEventBus
   ): Promise<void> {
     const { taskId, contextId } = context

--- a/strands-ts/src/a2a/executor.ts
+++ b/strands-ts/src/a2a/executor.ts
@@ -17,28 +17,13 @@ import { normalizeError } from '../errors.js'
 import { logger } from '../logging/logger.js'
 import { AsyncLock } from './async-lock.js'
 
-/**
- * A factory that builds a fresh {@link Agent} for a given A2A `contextId`.
- *
- * Invoked once per context. Each returned agent owns an independent conversation
- * and runs under its own lock, so different contexts execute concurrently and
- * never share state. The factory is also where per-context concerns such as a
- * `sessionManager` are wired.
- */
+/** Builds a fresh agent for a given A2A `contextId`, invoked once per context. */
 export type AgentFactory = (contextId: string) => InvokableAgent
 
-/**
- * Cap on concurrently tracked A2A contexts. Beyond this, the least-recently-used
- * context is evicted to bound memory in long-running servers.
- */
+/** Default cap on concurrently tracked A2A contexts. */
 export const DEFAULT_MAX_CONTEXTS = 1000
 
-/**
- * Per-context bookkeeping for factory mode: a dedicated agent and its serializing lock.
- *
- * Keeping the agent and lock in one entry means the LRU map has a single source of
- * truth; there is no second map to keep in sync on insert, reorder, or eviction.
- */
+/** Factory mode: a context's dedicated agent and the lock serializing its requests. */
 interface ContextEntry {
   agent: InvokableAgent
   lock: AsyncLock
@@ -52,28 +37,16 @@ interface ContextEntry {
 export interface A2AExecutorOptions {
   /** @deprecated A single agent reused across contexts. Prefer `agentFactory`. */
   agent?: InvokableAgent
-  /**
-   * Callable that takes a `contextId` and returns a fresh agent per context. Recommended.
-   */
+  /** Callable that returns a fresh agent per `contextId`. Recommended. */
   agentFactory?: AgentFactory
-  /**
-   * Maximum number of contexts to retain concurrently; the least-recently-used is
-   * evicted beyond this. Must be at least 1. Defaults to {@link DEFAULT_MAX_CONTEXTS}.
-   */
+  /** Maximum contexts to retain; the least-recently-used is evicted beyond it. Must be at least 1. */
   maxContexts?: number
 }
 
-/**
- * An agent that can both be invoked and snapshotted — i.e. a full Strands `Agent`.
- * Single-agent mode requires both: `stream` to run, and `takeSnapshot`/`loadSnapshot`
- * to swap per-context state on and off the shared instance.
- */
+/** A full Strands `Agent` that can be both invoked and snapshotted. */
 type SnapshotAgent = InvokableAgent & LocalAgent
 
-/**
- * Narrows an {@link InvokableAgent} to a {@link SnapshotAgent}, which exposes the
- * snapshot APIs needed for single-agent-mode state swapping.
- */
+/** Narrows to a {@link SnapshotAgent}, throwing if the agent lacks snapshot support. */
 function asSnapshotAgent(agent: InvokableAgent): SnapshotAgent {
   const candidate = agent as Partial<LocalAgent>
   if (typeof candidate.takeSnapshot !== 'function' || typeof candidate.loadSnapshot !== 'function') {
@@ -85,12 +58,7 @@ function asSnapshotAgent(agent: InvokableAgent): SnapshotAgent {
   return agent as unknown as SnapshotAgent
 }
 
-/**
- * Whether an agent has a configured `sessionManager`. Single-agent mode rejects this:
- * snapshot-swapping one shared instance would interleave every context into one session.
- * `sessionManager` is an `Agent` field not declared on {@link InvokableAgent}, so it is
- * read defensively here.
- */
+/** Whether the agent has a configured `sessionManager` (a field not declared on {@link InvokableAgent}). */
 function hasSessionManager(agent: InvokableAgent): boolean {
   return (agent as { sessionManager?: unknown }).sessionManager !== undefined
 }
@@ -100,44 +68,30 @@ function hasSessionManager(agent: InvokableAgent): boolean {
  *
  * Converts A2A message parts to Strands content blocks, streams the agent
  * execution, and publishes text deltas as artifact updates through the A2A
- * event bus. Text chunks are appended to a single artifact as they arrive,
- * implementing A2A-compliant streaming behavior.
+ * event bus.
  *
- * ## Conversation isolation
+ * Conversation state is isolated per A2A `contextId`. There are two modes:
  *
- * Conversation state is isolated per A2A `contextId` so callers in different
- * contexts cannot read or influence each other's history. There are two modes:
+ * - **`agentFactory`** (recommended): returns a dedicated agent per context. Each
+ *   context owns an independent agent under its own lock, so different contexts run
+ *   concurrently and never share state. The factory is also where per-context
+ *   concerns such as a `sessionManager` are wired.
+ * - **`agent`** (deprecated): a single agent reused across contexts, with each
+ *   context's state swapped on/off it under a lock. Not multi-tenant safe; prefer
+ *   `agentFactory`.
  *
- * - **`agentFactory`** (recommended): a callable that takes a `contextId` and returns
- *   a dedicated agent, invoked once per context. Each context owns an independent
- *   agent and runs under its own lock, so different contexts execute concurrently
- *   and never share state. The factory is also where per-context concerns such as
- *   a `sessionManager` are wired.
- * - **`agent`** (deprecated): a single agent reused across contexts. Each context's
- *   conversation state is swapped on/off this instance under a lock, so requests are
- *   serialized. Not multi-tenant safe for concurrency; prefer `agentFactory`.
+ * `contextId` is client-supplied and is **not** an authentication boundary: a caller
+ * that knows another's `contextId` can attach to that conversation. Multi-tenant
+ * deployments must enforce authenticated identity at the transport/gateway layer.
  *
- * Contexts are keyed on the client-supplied `contextId`, which is **not** an
- * authentication boundary. A caller that knows another caller's `contextId` can
- * attach to that conversation. Multi-tenant deployments must enforce authenticated
- * identity at the transport/gateway layer.
- *
- * At most `maxContexts` contexts are retained; beyond that the least-recently-used
- * is evicted and a later request reusing that `contextId` starts fresh.
- *
- * ## Invocation state
- *
- * The executor populates the agent's `invocationState` with the incoming A2A
- * {@link RequestContext} under the reserved key `a2aRequestContext`. Hooks and
- * tools running inside the agent can read `event.invocationState.a2aRequestContext`
- * to correlate with the A2A request (taskId, contextId, user message metadata).
+ * The incoming {@link RequestContext} is forwarded to the agent's `invocationState`
+ * under the reserved key `a2aRequestContext` for hooks and tools to read.
  *
  * @example
  * ```typescript
  * import { Agent } from '@strands-agents/sdk'
  * import { A2AExecutor } from '@strands-agents/sdk/a2a'
  *
- * // Recommended: a dedicated agent per context
  * const executor = new A2AExecutor({ agentFactory: (contextId) => new Agent({ model: 'my-model' }) })
  * ```
  */
@@ -178,7 +132,6 @@ export class A2AExecutor implements AgentExecutor {
     if (agentFactory !== undefined) {
       this._agentFactory = agentFactory
     } else {
-      // Single-agent mode: reuse one agent, swapping each context's snapshot on/off it.
       const sharedAgent = asSnapshotAgent(agent!)
       if (hasSessionManager(sharedAgent)) {
         throw new Error(
@@ -193,7 +146,6 @@ export class A2AExecutor implements AgentExecutor {
           'the contextId) instead to isolate conversations per context.'
       )
       this._agent = sharedAgent
-      // The template snapshot is the agent's clean state, captured before any request mutates it.
       this._templateSnapshot = this._captureState(sharedAgent)
     }
   }
@@ -203,23 +155,14 @@ export class A2AExecutor implements AgentExecutor {
     return agent.takeSnapshot({ preset: 'session' })
   }
 
-  /**
-   * Load a snapshot into an agent, restoring its session state.
-   *
-   * No defensive copy is needed: `loadSnapshot` reconstructs the agent's state
-   * from the snapshot rather than referencing it — messages are rebuilt as new
-   * instances and `StateStore` deep-copies the state on load — so a subsequent
-   * run cannot mutate a stored or template snapshot in place.
-   */
+  /** Load a snapshot into an agent, restoring its session state. */
   private _restoreState(agent: LocalAgent, snapshot: Snapshot): void {
     agent.loadSnapshot(snapshot)
   }
 
-  /** Evict least-recently-used contexts beyond `maxContexts`. Must be called without yielding. */
+  /** Evict least-recently-used contexts beyond `maxContexts`. */
   private _evictExcessContexts(): void {
     const contexts: Map<string, unknown> = this._agentFactory !== undefined ? this._contexts : this._snapshots
-    // Map preserves insertion order; the first key is the least-recently-used because
-    // touched contexts are re-inserted at the end (delete-then-set on access).
     while (contexts.size > this._maxContexts) {
       const evictedId = contexts.keys().next().value as string
       contexts.delete(evictedId)
@@ -227,13 +170,7 @@ export class A2AExecutor implements AgentExecutor {
     }
   }
 
-  /**
-   * Return the dedicated agent and lock for a context, building it on first use (factory mode).
-   *
-   * No lock guards the map here: the factory is synchronous, so this method never yields between
-   * reading and writing `_contexts`, and JavaScript's run-to-completion semantics make the
-   * check-then-create-or-reorder sequence atomic with respect to other contexts.
-   */
+  /** Return the dedicated agent and lock for a context, creating it on first use (factory mode). */
   private _acquireContextAgent(contextId: string): ContextEntry {
     let entry = this._contexts.get(contextId)
     if (entry === undefined) {
@@ -241,9 +178,7 @@ export class A2AExecutor implements AgentExecutor {
       this._contexts.set(contextId, entry)
       this._evictExcessContexts()
     } else {
-      // Mark most-recently-used: delete-then-set moves the entry to the Map's end.
-      // ECMAScript guarantees Map iteration in insertion order, and `set` on an existing
-      // key keeps its position, so delete-then-set is the spec-guaranteed way to reorder.
+      // Move to most-recently-used end.
       this._contexts.delete(contextId)
       this._contexts.set(contextId, entry)
     }
@@ -252,9 +187,6 @@ export class A2AExecutor implements AgentExecutor {
 
   /**
    * Executes the agent in response to an A2A message.
-   *
-   * Routes to the per-context agent (factory mode) or the shared agent
-   * (single-agent mode), isolating conversation state by `contextId`.
    *
    * @param context - The A2A request context containing the user message
    * @param eventBus - The event bus for publishing A2A artifact and status events
@@ -266,8 +198,7 @@ export class A2AExecutor implements AgentExecutor {
       throw A2AError.invalidRequest('No content blocks available')
     }
 
-    // Publish initial task event to register the task with the ResultManager.
-    // Without this, artifact and status events are ignored as "unknown task".
+    // Register the task with the ResultManager; without this, later events are ignored as "unknown task".
     eventBus.publish({ kind: 'task', id: taskId, contextId, status: { state: 'working' } })
 
     if (this._agentFactory !== undefined) {
@@ -277,9 +208,7 @@ export class A2AExecutor implements AgentExecutor {
     }
   }
 
-  /**
-   * Factory mode: run against this context's dedicated agent, serialized only per context.
-   */
+  /** Factory mode: run against this context's dedicated agent, serialized only per context. */
   private async _runWithContextAgent(
     context: RequestContext,
     contentBlocks: ContentBlock[],
@@ -290,12 +219,7 @@ export class A2AExecutor implements AgentExecutor {
     await this._streamAgent(agent, context, contentBlocks, eventBus)
   }
 
-  /**
-   * Single-agent mode: swap this context's snapshot on/off the shared agent under a lock.
-   *
-   * The lock serializes all requests (a single agent cannot be invoked concurrently). The
-   * agent is reset to the template afterward so no context's data lingers on it.
-   */
+  /** Single-agent mode: swap this context's snapshot on/off the shared agent under a lock. */
   private async _runWithSharedAgent(
     context: RequestContext,
     contentBlocks: ContentBlock[],
@@ -307,9 +231,7 @@ export class A2AExecutor implements AgentExecutor {
     try {
       await this._streamAgent(agent, context, contentBlocks, eventBus)
     } finally {
-      // Persist this context's updated history (even on error, to retain partial turns),
-      // evict beyond the cap, then reset the shared agent for the next caller. Delete-then-set
-      // places the entry at the most-recently-used end whether or not it already existed.
+      // Persist updated history (even on error), evict, then reset the agent for the next caller.
       this._snapshots.delete(context.contextId)
       this._snapshots.set(context.contextId, this._captureState(agent))
       this._evictExcessContexts()
@@ -317,9 +239,7 @@ export class A2AExecutor implements AgentExecutor {
     }
   }
 
-  /**
-   * Streams one agent invocation and translates its events to A2A artifact updates.
-   */
+  /** Streams one agent invocation and translates its events to A2A artifact updates. */
   private async _streamAgent(
     agent: InvokableAgent,
     context: RequestContext,
@@ -331,9 +251,6 @@ export class A2AExecutor implements AgentExecutor {
     let isFirstChunk = true
 
     try {
-      // Forward the A2A RequestContext to the agent under a reserved key so
-      // hooks and tools can correlate with the A2A request (taskId, contextId,
-      // user message metadata).
       const stream = agent.stream(contentBlocks, {
         invocationState: { a2aRequestContext: context },
       })
@@ -389,8 +306,8 @@ export class A2AExecutor implements AgentExecutor {
           // If no deltas were streamed, publish the full result; otherwise empty to close the artifact
           parts: [{ kind: 'text', text: isFirstChunk && next.value ? next.value.toString() : '' }],
         },
-        append: !isFirstChunk, // false for new artifact, true to append to streamed chunks
-        lastChunk: true, // Always true — this runs after the stream loop ends
+        append: !isFirstChunk,
+        lastChunk: true,
       })
 
       eventBus.publish({ kind: 'status-update', taskId, contextId, status: { state: 'completed' }, final: true })

--- a/strands-ts/src/a2a/executor.ts
+++ b/strands-ts/src/a2a/executor.ts
@@ -8,11 +8,79 @@
 import type { ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server'
 import type { AgentExecutor } from '@a2a-js/sdk/server'
 import { A2AError } from '@a2a-js/sdk/server'
-import type { InvokableAgent } from '../types/agent.js'
+import type { InvokableAgent, LocalAgent } from '../types/agent.js'
+import type { Snapshot } from '../types/snapshot.js'
+import { deepCopy } from '../types/json.js'
 import { ModelStreamUpdateEvent, ContentBlockEvent } from '../hooks/events.js'
 import { contentBlocksToParts, partsToContentBlocks } from './adapters.js'
 import { normalizeError } from '../errors.js'
 import { logger } from '../logging/logger.js'
+import { AsyncLock } from './async-lock.js'
+
+/**
+ * A factory that builds a fresh {@link Agent} for a given A2A `contextId`.
+ *
+ * Invoked once per context. Each returned agent owns an independent conversation
+ * and runs under its own lock, so different contexts execute concurrently and
+ * never share state. The factory is also where per-context concerns such as a
+ * `sessionManager` are wired.
+ */
+export type AgentFactory = (contextId: string) => InvokableAgent
+
+/**
+ * Cap on concurrently tracked A2A contexts. Beyond this, the least-recently-used
+ * context is evicted to bound memory in long-running servers.
+ */
+export const DEFAULT_MAX_CONTEXTS = 1000
+
+/**
+ * Per-context bookkeeping for factory mode: a dedicated agent and its serializing lock.
+ *
+ * Keeping the agent and lock in one entry means the LRU map has a single source of
+ * truth; there is no second map to keep in sync on insert, reorder, or eviction.
+ */
+interface ContextEntry {
+  agent: InvokableAgent
+  lock: AsyncLock
+}
+
+/**
+ * Options for constructing an {@link A2AExecutor}.
+ */
+export interface A2AExecutorOptions {
+  /**
+   * Callable that takes a `contextId` and returns a fresh agent per context. Recommended.
+   * Provide exactly one of `agent` or `agentFactory`.
+   */
+  agentFactory?: AgentFactory
+  /**
+   * Maximum number of contexts to retain concurrently; the least-recently-used is
+   * evicted beyond this. Must be at least 1. Defaults to {@link DEFAULT_MAX_CONTEXTS}.
+   */
+  maxContexts?: number
+}
+
+/**
+ * An agent that can both be invoked and snapshotted — i.e. a full Strands `Agent`.
+ * Single-agent mode requires both: `stream` to run, and `takeSnapshot`/`loadSnapshot`
+ * to swap per-context state on and off the shared instance.
+ */
+type SnapshotAgent = InvokableAgent & LocalAgent
+
+/**
+ * Narrows an {@link InvokableAgent} to a {@link SnapshotAgent}, which exposes the
+ * snapshot APIs needed for single-agent-mode state swapping.
+ */
+function asSnapshotAgent(agent: InvokableAgent): SnapshotAgent {
+  const candidate = agent as Partial<LocalAgent>
+  if (typeof candidate.takeSnapshot !== 'function' || typeof candidate.loadSnapshot !== 'function') {
+    throw new Error(
+      'A2AExecutor requires an Agent that supports snapshots (takeSnapshot/loadSnapshot). ' +
+        'Pass a Strands Agent instance.'
+    )
+  }
+  return agent as unknown as SnapshotAgent
+}
 
 /**
  * Bridges a Strands Agent into the A2A protocol as an AgentExecutor.
@@ -22,49 +90,161 @@ import { logger } from '../logging/logger.js'
  * event bus. Text chunks are appended to a single artifact as they arrive,
  * implementing A2A-compliant streaming behavior.
  *
+ * ## Conversation isolation
+ *
+ * Conversation state is isolated per A2A `contextId` so callers in different
+ * contexts cannot read or influence each other's history. There are two modes:
+ *
+ * - **`agentFactory`** (recommended): a callable that takes a `contextId` and returns
+ *   a dedicated agent, invoked once per context. Each context owns an independent
+ *   agent and runs under its own lock, so different contexts execute concurrently
+ *   and never share state. The factory is also where per-context concerns such as
+ *   a `sessionManager` are wired.
+ * - **`agent`** (deprecated): a single agent reused across contexts. Each context's
+ *   conversation state is swapped on/off this instance under a lock, so requests are
+ *   serialized. Not multi-tenant safe for concurrency; prefer `agentFactory`.
+ *
+ * Contexts are keyed on the client-supplied `contextId`, which is **not** an
+ * authentication boundary. A caller that knows another caller's `contextId` can
+ * attach to that conversation. Multi-tenant deployments must enforce authenticated
+ * identity at the transport/gateway layer.
+ *
+ * At most `maxContexts` contexts are retained; beyond that the least-recently-used
+ * is evicted and a later request reusing that `contextId` starts fresh.
+ *
  * ## Invocation state
  *
  * The executor populates the agent's `invocationState` with the incoming A2A
  * {@link RequestContext} under the reserved key `a2aRequestContext`. Hooks and
  * tools running inside the agent can read `event.invocationState.a2aRequestContext`
- * to correlate with the A2A request (taskId, contextId, user message metadata)
- * for logging, metrics, or audit.
- *
- * Because the A2A framework (not user code) drives `execute()`, there is no
- * per-request path for the user to supply their own `invocationState`. If a
- * user hook writes to the `a2aRequestContext` key, it will be overwritten on
- * the next request.
+ * to correlate with the A2A request (taskId, contextId, user message metadata).
  *
  * @example
  * ```typescript
  * import { Agent } from '@strands-agents/sdk'
  * import { A2AExecutor } from '@strands-agents/sdk/a2a'
  *
- * const agent = new Agent({ model: 'my-model' })
- * const executor = new A2AExecutor(agent)
+ * // Recommended: a dedicated agent per context
+ * const executor = new A2AExecutor({ agentFactory: (contextId) => new Agent({ model: 'my-model' }) })
  * ```
  */
 export class A2AExecutor implements AgentExecutor {
-  private _agent: InvokableAgent
+  private readonly _agentFactory?: AgentFactory
+  private readonly _maxContexts: number
+
+  /** Guards the per-context bookkeeping maps below. */
+  private readonly _contextsLock = new AsyncLock()
+
+  // Factory mode: a dedicated agent and lock per context.
+  private readonly _contexts = new Map<string, ContextEntry>()
+
+  // Single-agent mode: one shared agent, swapping each context's snapshot on/off it.
+  private readonly _agent?: SnapshotAgent
+  private readonly _templateSnapshot?: Snapshot
+  private readonly _snapshots = new Map<string, Snapshot>()
 
   /**
    * Creates a new A2AExecutor.
    *
-   * @param agent - The agent to execute for incoming A2A requests
+   * Provide exactly one of a single `agent` (deprecated) or `options.agentFactory`.
+   *
+   * @param agent - A single agent reused across contexts. Deprecated; prefer `agentFactory`.
+   * @param options - Executor options including `agentFactory` and `maxContexts`.
    */
-  constructor(agent: InvokableAgent) {
-    this._agent = agent
+  constructor(agent?: InvokableAgent, options: A2AExecutorOptions = {}) {
+    const { agentFactory, maxContexts = DEFAULT_MAX_CONTEXTS } = options
+
+    if (maxContexts < 1) {
+      throw new Error(`maxContexts must be >= 1, got ${maxContexts}`)
+    }
+    if ((agent === undefined) === (agentFactory === undefined)) {
+      throw new Error("Provide exactly one of 'agent' or 'agentFactory'.")
+    }
+
+    this._maxContexts = maxContexts
+
+    if (agentFactory !== undefined) {
+      this._agentFactory = agentFactory
+    } else {
+      // Single-agent mode: reuse one agent, swapping each context's snapshot on/off it.
+      const sharedAgent = asSnapshotAgent(agent!)
+      if ((sharedAgent as { sessionManager?: unknown }).sessionManager !== undefined) {
+        throw new Error(
+          "A single 'agent' with a sessionManager is not supported: the session manager " +
+            "persists every context's messages into one interleaved session. Use " +
+            "'agentFactory' to build a per-context agent with its own sessionManager."
+        )
+      }
+      logger.warn(
+        "Passing a single 'agent' to A2AExecutor is deprecated and will be removed in a future " +
+          'version. A single agent serializes all requests; pass an agentFactory (a callable taking ' +
+          'the contextId) instead to isolate conversations per context.'
+      )
+      this._agent = sharedAgent
+      // The template snapshot is the agent's clean state, captured before any request mutates it.
+      this._templateSnapshot = this._captureState(sharedAgent)
+    }
+  }
+
+  /** Snapshot an agent's session state. */
+  private _captureState(agent: LocalAgent): Snapshot {
+    return agent.takeSnapshot({ preset: 'session' })
+  }
+
+  /**
+   * Load a snapshot into an agent, restoring its session state.
+   *
+   * Deep-copies once at the boundary so a run never mutates a stored or template
+   * snapshot in place (snapshots, including the template, are restored repeatedly).
+   */
+  private _restoreState(agent: LocalAgent, snapshot: Snapshot): void {
+    agent.loadSnapshot(deepCopy(snapshot) as unknown as Snapshot)
+  }
+
+  /** Evict least-recently-used contexts beyond `maxContexts`. Caller holds the contexts lock. */
+  private _evictExcessContexts(): void {
+    const contexts: Map<string, unknown> = this._agentFactory !== undefined ? this._contexts : this._snapshots
+    // Map preserves insertion order; the first key is the least-recently-used because
+    // touched contexts are re-inserted at the end (see `_touch`).
+    while (contexts.size > this._maxContexts) {
+      const evictedId = contexts.keys().next().value as string
+      contexts.delete(evictedId)
+      logger.debug(`context_id=<${evictedId}> | evicted least-recently-used A2A context`)
+    }
+  }
+
+  /** Move a key to the most-recently-used position (end) of a Map. */
+  private _touch<V>(map: Map<string, V>, key: string): void {
+    const value = map.get(key)!
+    map.delete(key)
+    map.set(key, value)
+  }
+
+  /**
+   * Return the dedicated agent and lock for a context, building it on first use (factory mode).
+   */
+  private async _acquireContextAgent(contextId: string): Promise<ContextEntry> {
+    const release = await this._contextsLock.acquire()
+    try {
+      let entry = this._contexts.get(contextId)
+      if (entry === undefined) {
+        entry = { agent: this._agentFactory!(contextId), lock: new AsyncLock() }
+        this._contexts.set(contextId, entry)
+        this._evictExcessContexts()
+      } else {
+        this._touch(this._contexts, contextId)
+      }
+      return entry
+    } finally {
+      release()
+    }
   }
 
   /**
    * Executes the agent in response to an A2A message.
    *
-   * Converts A2A message parts to Strands content blocks, then streams the
-   * agent execution. Text deltas are streamed incrementally into a single
-   * artifact; non-text content blocks (images, videos, documents) are each
-   * published as separate complete artifacts. A final artifact with
-   * `lastChunk: true` signals the end of the text artifact, followed by a
-   * completed status update.
+   * Routes to the per-context agent (factory mode) or the shared agent
+   * (single-agent mode), isolating conversation state by `contextId`.
    *
    * @param context - The A2A request context containing the user message
    * @param eventBus - The event bus for publishing A2A artifact and status events
@@ -80,6 +260,70 @@ export class A2AExecutor implements AgentExecutor {
     // Without this, artifact and status events are ignored as "unknown task".
     eventBus.publish({ kind: 'task', id: taskId, contextId, status: { state: 'working' } })
 
+    if (this._agentFactory !== undefined) {
+      await this._runWithContextAgent(context, contentBlocks, eventBus)
+    } else {
+      await this._runWithSharedAgent(context, contentBlocks, eventBus)
+    }
+  }
+
+  /**
+   * Factory mode: run against this context's dedicated agent, serialized only per context.
+   */
+  private async _runWithContextAgent(
+    context: RequestContext,
+    contentBlocks: ReturnType<typeof partsToContentBlocks>,
+    eventBus: ExecutionEventBus
+  ): Promise<void> {
+    const { agent, lock } = await this._acquireContextAgent(context.contextId)
+    const release = await lock.acquire()
+    try {
+      await this._streamAgent(agent, context, contentBlocks, eventBus)
+    } finally {
+      release()
+    }
+  }
+
+  /**
+   * Single-agent mode: swap this context's snapshot on/off the shared agent under a lock.
+   *
+   * The lock serializes all requests (a single agent cannot be invoked concurrently). The
+   * agent is reset to the template afterward so no context's data lingers on it.
+   */
+  private async _runWithSharedAgent(
+    context: RequestContext,
+    contentBlocks: ReturnType<typeof partsToContentBlocks>,
+    eventBus: ExecutionEventBus
+  ): Promise<void> {
+    const agent = this._agent!
+    const release = await this._contextsLock.acquire()
+    try {
+      this._restoreState(agent, this._snapshots.get(context.contextId) ?? this._templateSnapshot!)
+      try {
+        await this._streamAgent(agent, context, contentBlocks, eventBus)
+      } finally {
+        // Persist this context's updated history (even on error, to retain partial turns),
+        // evict beyond the cap, then reset the shared agent for the next caller.
+        this._snapshots.set(context.contextId, this._captureState(agent))
+        this._touch(this._snapshots, context.contextId)
+        this._evictExcessContexts()
+        this._restoreState(agent, this._templateSnapshot!)
+      }
+    } finally {
+      release()
+    }
+  }
+
+  /**
+   * Streams one agent invocation and translates its events to A2A artifact updates.
+   */
+  private async _streamAgent(
+    agent: InvokableAgent,
+    context: RequestContext,
+    contentBlocks: ReturnType<typeof partsToContentBlocks>,
+    eventBus: ExecutionEventBus
+  ): Promise<void> {
+    const { taskId, contextId } = context
     const artifactId = globalThis.crypto.randomUUID()
     let isFirstChunk = true
 
@@ -87,7 +331,7 @@ export class A2AExecutor implements AgentExecutor {
       // Forward the A2A RequestContext to the agent under a reserved key so
       // hooks and tools can correlate with the A2A request (taskId, contextId,
       // user message metadata).
-      const stream = this._agent.stream(contentBlocks, {
+      const stream = agent.stream(contentBlocks, {
         invocationState: { a2aRequestContext: context },
       })
       let next = await stream.next()

--- a/strands-ts/src/a2a/index.ts
+++ b/strands-ts/src/a2a/index.ts
@@ -12,4 +12,4 @@
 export { A2AServer, type A2AServerConfig } from './server.js'
 export { A2AAgent, type A2AAgentConfig } from './a2a-agent.js'
 export { A2AStreamUpdateEvent, A2AResultEvent, type A2AEventData, type A2AStreamEvent } from './events.js'
-export { A2AExecutor } from './executor.js'
+export { A2AExecutor, type AgentFactory, type A2AExecutorOptions, DEFAULT_MAX_CONTEXTS } from './executor.js'

--- a/strands-ts/src/a2a/server.ts
+++ b/strands-ts/src/a2a/server.ts
@@ -23,7 +23,7 @@ const AGENT_CARD_CONTEXT_ID = '__agent_card__'
  * Provide exactly one of `agent` (deprecated) or `agentFactory`.
  */
 export interface A2AServerConfig {
-  /** The Strands Agent to serve via A2A protocol. Deprecated; prefer `agentFactory`. */
+  /** @deprecated The Strands Agent to serve via A2A protocol. Prefer `agentFactory`. */
   agent?: InvokableAgent
   /**
    * Callable that takes a `contextId` and returns a dedicated agent per A2A context.

--- a/strands-ts/src/a2a/server.ts
+++ b/strands-ts/src/a2a/server.ts
@@ -12,14 +12,32 @@ import type { AgentCard, AgentSkill } from '@a2a-js/sdk'
 import type { TaskStore, A2ARequestHandler } from '@a2a-js/sdk/server'
 import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server'
 import type { InvokableAgent } from '../types/agent.js'
-import { A2AExecutor } from './executor.js'
+import { A2AExecutor, type AgentFactory } from './executor.js'
+
+/** Placeholder context id used to build a representative agent for card metadata in factory mode. */
+const AGENT_CARD_CONTEXT_ID = '__agent_card__'
 
 /**
  * Configuration options for creating an A2AServer.
+ *
+ * Provide exactly one of `agent` (deprecated) or `agentFactory`.
  */
 export interface A2AServerConfig {
-  /** The Strands Agent to serve via A2A protocol */
-  agent: InvokableAgent
+  /** The Strands Agent to serve via A2A protocol. Deprecated; prefer `agentFactory`. */
+  agent?: InvokableAgent
+  /**
+   * Callable that takes a `contextId` and returns a dedicated agent per A2A context.
+   * Contexts run concurrently and the factory is the place to wire per-context
+   * concerns such as a context-scoped `sessionManager`. The factory is invoked once
+   * at construction (with a placeholder context id) solely to derive the agent card
+   * metadata; that agent is not used for request handling.
+   */
+  agentFactory?: AgentFactory
+  /**
+   * Maximum number of per-context agents to retain concurrently (factory mode);
+   * the least-recently-used is evicted beyond this. Must be at least 1.
+   */
+  maxContexts?: number
   /** Human-readable name for the agent */
   name: string
   /** Optional description of the agent's purpose */
@@ -65,11 +83,19 @@ export class A2AServer {
    * @param config - Configuration for the server
    */
   constructor(config: A2AServerConfig) {
+    if ((config.agent === undefined) === (config.agentFactory === undefined)) {
+      throw new Error("Provide exactly one of 'agent' or 'agentFactory'.")
+    }
+
     const httpUrl = config.httpUrl ?? ''
+
+    // The agent used to derive card metadata (name/description/skills). With a factory,
+    // build a representative agent once; per-request agents are created lazily by the executor.
+    const cardAgent = config.agent ?? config.agentFactory!(AGENT_CARD_CONTEXT_ID)
 
     this._agentCard = {
       name: config.name,
-      description: config.description ?? '',
+      description: config.description ?? cardAgent.description ?? '',
       version: config.version ?? '0.0.1',
       protocolVersion: '0.2.0',
       url: httpUrl,
@@ -82,7 +108,10 @@ export class A2AServer {
     }
 
     const taskStore = config.taskStore ?? new InMemoryTaskStore()
-    const executor = new A2AExecutor(config.agent)
+    const executor = new A2AExecutor(config.agent, {
+      ...(config.agentFactory !== undefined && { agentFactory: config.agentFactory }),
+      ...(config.maxContexts !== undefined && { maxContexts: config.maxContexts }),
+    })
     this._requestHandler = new DefaultRequestHandler(this._agentCard, taskStore, executor)
   }
 

--- a/strands-ts/src/a2a/server.ts
+++ b/strands-ts/src/a2a/server.ts
@@ -27,10 +27,10 @@ export interface A2AServerConfig {
   agent?: InvokableAgent
   /**
    * Callable that takes a `contextId` and returns a dedicated agent per A2A context.
-   * Contexts run concurrently and the factory is the place to wire per-context
-   * concerns such as a context-scoped `sessionManager`. The factory is invoked once
-   * at construction (with a placeholder context id) solely to derive the agent card
-   * metadata; that agent is not used for request handling.
+   * Contexts run concurrently and the factory is where per-context concerns such as a
+   * context-scoped `sessionManager` are wired. At construction it is invoked once with a
+   * placeholder context id to derive the agent card metadata, so it should not
+   * unconditionally allocate expensive resources.
    */
   agentFactory?: AgentFactory
   /**
@@ -83,16 +83,13 @@ export class A2AServer {
    * @param config - Configuration for the server
    */
   constructor(config: A2AServerConfig) {
-    // Require exactly one agent source: `=== ` catches both "neither" and "both".
     if ((config.agent === undefined) === (config.agentFactory === undefined)) {
       throw new Error("Provide exactly one of 'agent' or 'agentFactory'.")
     }
 
     const httpUrl = config.httpUrl ?? ''
 
-    // Derive card metadata (name/description) from a representative agent. In factory mode this
-    // builds a throwaway agent with a placeholder contextId — it is never used for requests, so
-    // factories should not unconditionally allocate expensive resources.
+    // Build a representative agent for card metadata (via the factory in factory mode).
     const cardAgent = config.agent ?? config.agentFactory!(AGENT_CARD_CONTEXT_ID)
 
     this._agentCard = {

--- a/strands-ts/src/a2a/server.ts
+++ b/strands-ts/src/a2a/server.ts
@@ -83,14 +83,16 @@ export class A2AServer {
    * @param config - Configuration for the server
    */
   constructor(config: A2AServerConfig) {
+    // Require exactly one agent source: `=== ` catches both "neither" and "both".
     if ((config.agent === undefined) === (config.agentFactory === undefined)) {
       throw new Error("Provide exactly one of 'agent' or 'agentFactory'.")
     }
 
     const httpUrl = config.httpUrl ?? ''
 
-    // The agent used to derive card metadata (name/description/skills). With a factory,
-    // build a representative agent once; per-request agents are created lazily by the executor.
+    // Derive card metadata (name/description) from a representative agent. In factory mode this
+    // builds a throwaway agent with a placeholder contextId — it is never used for requests, so
+    // factories should not unconditionally allocate expensive resources.
     const cardAgent = config.agent ?? config.agentFactory!(AGENT_CARD_CONTEXT_ID)
 
     this._agentCard = {
@@ -108,7 +110,8 @@ export class A2AServer {
     }
 
     const taskStore = config.taskStore ?? new InMemoryTaskStore()
-    const executor = new A2AExecutor(config.agent, {
+    const executor = new A2AExecutor({
+      ...(config.agent !== undefined && { agent: config.agent }),
       ...(config.agentFactory !== undefined && { agentFactory: config.agentFactory }),
       ...(config.maxContexts !== undefined && { maxContexts: config.maxContexts }),
     })


### PR DESCRIPTION
## Description

Ports the Python A2A context-isolation fix (#2628) to the TypeScript SDK. The TS `A2AExecutor` previously held a single `Agent` and reused it for every request, so conversation history leaked between callers sharing the server. This brings TS to parity with Python's per-`contextId` isolation.

Two modes, mirroring Python:

- **`agentFactory`** (recommended): a dedicated `Agent` per `contextId`, each serialized by its own lock so distinct contexts run concurrently and never share state. The factory is where per-context concerns like a `sessionManager` are wired.
- **single `agent`** (deprecated): conversation state is snapshot-swapped on/off one shared instance under a global lock. Emits a `DeprecationWarning` and rejects a configured `sessionManager` (it would interleave every context into one session).

Both modes bound memory with an LRU cap (`maxContexts`, default 1000). Per-context state round-trips through the `session` snapshot preset, which already includes `modelState` — so no snapshot-schema change was needed on the TS side (unlike Python, which added it in #2680).

## Public API Changes

`A2AExecutor` and `A2AServer` now accept `agentFactory` and `maxContexts`; the single `agent` becomes optional (provide exactly one). Existing `A2AServer({ agent, ... })` keeps working, now isolated, with a deprecation warning.

```typescript
// Recommended
const server = new A2AServer({
  agentFactory: (contextId) => new Agent({ model, sessionManager: sessionFor(contextId) }),
  name: 'My Agent',
})
```

A small `AsyncLock` primitive is added (JS has no `asyncio.Lock`) to serialize same-context requests in factory mode and all requests in single-agent mode.

## Breaking Changes

None. The single-`agent` path is preserved (now isolated) and only warns.

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
