### PR TITLE
fix(site): update stale GitHub links from old repos to harness-sdk

### DIFF
--- a/.agents/references/code-verification.md
+++ b/.agents/references/code-verification.md
@@ -69,10 +69,10 @@ If the local clones aren't available, fetch source through the GitHub API:
 
 ```bash
 # Python SDK (now local at strands-py/src/strands/)
-gh api repos/strands-agents/sdk-python/contents/strands-py/src/strands/[path]
+gh api repos/strands-agents/harness-sdk/contents/strands-py/src/strands/[path]
 
 # TypeScript SDK (now local at strands-ts/src/)
-gh api repos/strands-agents/sdk-python/contents/strands-ts/src/[path]
+gh api repos/strands-agents/harness-sdk/contents/strands-ts/src/[path]
 ```
 
 ## Tier 3: Installed Package Introspection

--- a/.agents/skills/docs-planner/SKILL.md
+++ b/.agents/skills/docs-planner/SKILL.md
@@ -25,7 +25,7 @@ Compare the inventory against:
 
 - **SDK surface area**: Are all major features documented? Features without docs pages are gaps.
 - **Diataxis completeness**: For each feature area, does documentation exist across all four types? A feature with reference but no tutorial has a gap.
-- **Community signals**: If GitHub CLI is available, pull open issues labeled "documentation" from strands-agents/docs, strands-agents/sdk-python, and strands-agents/sdk-typescript. Map questions to existing docs (unclear/hard to find) or missing docs (content gap).
+- **Community signals**: If GitHub CLI is available, pull open issues labeled "documentation" from strands-agents/harness-sdk. Map questions to existing docs (unclear/hard to find) or missing docs (content gap).
 - **Competitive comparison** (if provided): What do LangChain, CrewAI, Anthropic, and OpenAI document about equivalent features that we don't?
 
 ### Step 3: Prioritize

--- a/designs/0001-plugins.md
+++ b/designs/0001-plugins.md
@@ -136,7 +136,7 @@ agent = Agent()
 agent.add_hook(BeforeInvocationEvent, log_start)
 ```
 
-While both of these examples attach a hook to the agent, there is room for improvement to meet our [We are accessible to humans and agents](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md?plain=1#L46) tenet where we say, "We don’t take shortcuts on curated DX for humans".
+While both of these examples attach a hook to the agent, there is room for improvement to meet our [We are accessible to humans and agents](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md?plain=1#L46) tenet where we say, "We don’t take shortcuts on curated DX for humans".
 
 To help improve this devex, a new `@hook` decorator can be introduced to make it easy to wrap a function as a plugin, and then pass it into agent initialization. This aligns more closely with our "curated DX for humans" that the Strands team attempts to excel in.
 
@@ -169,7 +169,7 @@ These features have related responsibilities, but their differences are nuanced,
 - **Plugin**: A high-level abstraction of the Strands SDK. A plugin represents some change to the standard behavior of an Agent, modifying the agents core attributes in order to elicit a desired behavior.
 - **Hooks**: A low-level primitive of the Strands SDK. A hook is a mechanism to execute code at a specific lifecycle event in the SDK, and gives relevant context at that specific lifecycle event in order to change the standard agents behavior.
 
-`Plugins` basically represent the usage/modification of **low-level primitives** like: system prompt, messages, tools, model, and **hooks**. The problem with this definition of `Plugins` is that it overlaps with the `HookProvider` abstraction currently present in the SDK. Well defined abstractions with clear separation of concerns align with the tenet [**The obvious path is the happy path**](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md?plain=1#L45), but including both of these goes against this tenet and can lead to customer confusion on which abstraction to choose. The code example below helps highlight this issue:
+`Plugins` basically represent the usage/modification of **low-level primitives** like: system prompt, messages, tools, model, and **hooks**. The problem with this definition of `Plugins` is that it overlaps with the `HookProvider` abstraction currently present in the SDK. Well defined abstractions with clear separation of concerns align with the tenet [**The obvious path is the happy path**](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md?plain=1#L45), but including both of these goes against this tenet and can lead to customer confusion on which abstraction to choose. The code example below helps highlight this issue:
 
 ```python
 # HookProvider example

--- a/designs/0007-intervention-primitive.md
+++ b/designs/0007-intervention-primitive.md
@@ -288,7 +288,7 @@ Strength:    Formally verifiable, identity-aware, argument-level scoping per rol
 Hook points: BeforeToolCall
 ```
 
-Answers "is this principal authorized?" — identity-aware, argument-level scoping per role, formally verifiable. Returns `Interrupt` instead of `Deny` when a residual policy exists that would approve with human consent. See the [Cedar Authorization design doc](https://github.com/strands-agents/docs/designs/0006-cedar-authorization.md) for the full proposal.
+Answers "is this principal authorized?" — identity-aware, argument-level scoping per role, formally verifiable. Returns `Interrupt` instead of `Deny` when a residual policy exists that would approve with human consent. See the [Cedar Authorization design doc](https://github.com/strands-agents/harness-sdk/blob/main/designs/0006-cedar-authorization.md) for the full proposal.
 
 ```python
 cedar = CedarAuthHandler.builder()

--- a/site/SITE-ARCHITECTURE.md
+++ b/site/SITE-ARCHITECTURE.md
@@ -319,7 +319,7 @@ const rawNavLinks: NavLink[] = [
   },
   {
     label: 'Contribute ❤️',
-    href: 'https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md',
+    href: 'https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md',
     external: true,  // Opens in new tab with arrow icon
   },
 ]

--- a/site/src/content/blog/multimodal-evaluators-mllm-as-a-judge-image-to-text-strands-evals.mdx
+++ b/site/src/content/blog/multimodal-evaluators-mllm-as-a-judge-image-to-text-strands-evals.mdx
@@ -238,5 +238,5 @@ Then explore the resources below:
 
 - Read the [Strands Evals documentation](https://strandsagents.com/) for an end-to-end overview of the `Case` → `Experiment` → `Report` workflow.
 - See the [multimodal evaluator reference](https://strandsagents.com/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator/) for the full API, including `MultimodalInput`, `ImageData`, the built-in rubrics, and the four convenience subclasses.
-- Try the [multimodal evaluator example](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/multimodal_output_evaluator.py) in the Strands Agents docs repository.
+- Try the [multimodal evaluator example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/multimodal_output_evaluator.py) in the Strands Agents docs repository.
 - Share your feedback and feature requests in [GitHub Issues](https://github.com/strands-agents/evals/issues).

--- a/site/src/content/docs/community/get-featured.mdx
+++ b/site/src/content/docs/community/get-featured.mdx
@@ -25,7 +25,7 @@ The [extension template](https://github.com/strands-agents/extension-template-py
 
 ## Quick Steps
 
-1. **Create a PR** to [strands-agents/docs](https://github.com/strands-agents/docs)
+1. **Create a PR** to [strands-agents/harness-sdk](https://github.com/strands-agents/harness-sdk)
 2. **Add your doc file** in the appropriate `community/` subdirectory
 3. **Include the required frontmatter** so your page appears in the [community catalog](./community-packages.md)
 4. **Update `src/config/navigation.yml`** to include your new page in the nav
@@ -130,11 +130,11 @@ Add your page to `src/config/navigation.yml` under the Community section:
 
 Look at existing community pages for reference:
 
-- **Tool**: [strands-deepgram.mdx](https://github.com/strands-agents/docs/blob/main/src/content/docs/community/tools/strands-deepgram.mdx)
-- **Model Provider**: [nvidia-nim.mdx](https://github.com/strands-agents/docs/blob/main/src/content/docs/community/model-providers/nvidia-nim.mdx)
-- **Session Manager**: [agentcore-memory.mdx](https://github.com/strands-agents/docs/blob/main/src/content/docs/community/session-managers/agentcore-memory.mdx)
-- **Integration**: [ag-ui.mdx](https://github.com/strands-agents/docs/blob/main/src/content/docs/community/integrations/ag-ui.mdx)
+- **Tool**: [strands-deepgram.mdx](https://github.com/strands-agents/harness-sdk/blob/main/site/src/content/docs/community/tools/strands-deepgram.mdx)
+- **Model Provider**: [nvidia-nim.mdx](https://github.com/strands-agents/harness-sdk/blob/main/site/src/content/docs/community/model-providers/nvidia-nim.mdx)
+- **Session Manager**: [agentcore-memory.mdx](https://github.com/strands-agents/harness-sdk/blob/main/site/src/content/docs/community/session-managers/agentcore-memory.mdx)
+- **Integration**: [ag-ui.mdx](https://github.com/strands-agents/harness-sdk/blob/main/site/src/content/docs/community/integrations/ag-ui.mdx)
 
 ## Questions?
 
-Open an issue at [strands-agents/docs](https://github.com/strands-agents/docs/issues) — we're happy to help!
+Open an issue at [strands-agents/harness-sdk](https://github.com/strands-agents/harness-sdk/issues) — we're happy to help!

--- a/site/src/content/docs/contribute/index.mdx
+++ b/site/src/content/docs/contribute/index.mdx
@@ -29,7 +29,7 @@ You can share your tools, model providers, hooks, and session managers with the 
 - [Community Catalog](../community/community-packages.md) — Discover community-built extensions
 - [GitHub Discussions](https://github.com/strands-agents/harness-sdk/discussions) — Ask questions, share ideas
 - [Roadmap](https://github.com/orgs/strands-agents/projects/8/views/1) — See what we're working on
-- [Development Tenets](https://github.com/strands-agents/docs/blob/main/team/TENETS.md) — Principles that guide SDK design
-- [Decision Records](https://github.com/strands-agents/docs/blob/main/team/DECISIONS.md) — Past design decisions with rationale
+- [Development Tenets](https://github.com/strands-agents/harness-sdk/blob/main/team/TENETS.md) — Principles that guide SDK design
+- [Decision Records](https://github.com/strands-agents/harness-sdk/blob/main/team/DECISIONS.md) — Past design decisions with rationale
 - [Code of Conduct](https://aws.github.io/code-of-conduct) — Community guidelines
 - [Report a Security Issue](https://aws.amazon.com/security/vulnerability-reporting/) — For vulnerabilities, not public issues

--- a/site/src/content/docs/examples/README.mdx
+++ b/site/src/content/docs/examples/README.mdx
@@ -14,8 +14,8 @@ A collection of sample implementations to help you get started with Strands Agen
 2. Configure AWS credentials for Amazon Bedrock (covered in both quickstart guides above), or set up an [alternative model provider](../user-guide/concepts/model-providers/index.md)
 3. Clone the examples:
     ```bash
-    git clone https://github.com/strands-agents/docs.git
-    cd docs/docs/examples
+    git clone https://github.com/strands-agents/harness-sdk.git
+    cd harness-sdk/site/docs/examples
     ```
 4. Browse the examples below and follow the instructions in each one
 

--- a/site/src/content/docs/examples/python/agents_workflows.mdx
+++ b/site/src/content/docs/examples/python/agents_workflows.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "Agents Workflows"
 ---
 
-This [example](https://github.com/strands-agents/docs/blob/main/docs/examples/python/agents_workflow.py) shows how to create a multi-agent workflow using Strands agents to perform web research, fact-checking, and report generation. It demonstrates specialized agent roles working together in sequence to process information.
+This [example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/agents_workflow.py) shows how to create a multi-agent workflow using Strands agents to perform web research, fact-checking, and report generation. It demonstrates specialized agent roles working together in sequence to process information.
 
 ## Overview
 

--- a/site/src/content/docs/examples/python/file_operations.mdx
+++ b/site/src/content/docs/examples/python/file_operations.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "File Operations"
 ---
 
-This [example](https://github.com/strands-agents/docs/blob/main/docs/examples/python/file_operations.py) demonstrates how to create a Strands agent specialized in file operations, allowing users to read, write, search, and modify files through natural language commands. It showcases how Strands agents can be configured to work with the filesystem in a safe and intuitive manner.
+This [example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/file_operations.py) demonstrates how to create a Strands agent specialized in file operations, allowing users to read, write, search, and modify files through natural language commands. It showcases how Strands agents can be configured to work with the filesystem in a safe and intuitive manner.
 
 ## Overview
 

--- a/site/src/content/docs/examples/python/graph_loops_example.mdx
+++ b/site/src/content/docs/examples/python/graph_loops_example.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "Cyclic Graph"
 ---
 
-This [example](https://github.com/strands-agents/docs/blob/main/docs/examples/python/graph_loops_example.py) demonstrates how to create multi-agent graphs with feedback loops using the Strands Agents SDK. It showcases a write-review-improve cycle where content iterates through multiple agents until quality standards are met.
+This [example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/graph_loops_example.py) demonstrates how to create multi-agent graphs with feedback loops using the Strands Agents SDK. It showcases a write-review-improve cycle where content iterates through multiple agents until quality standards are met.
 
 ## Overview
 

--- a/site/src/content/docs/examples/python/knowledge_base_agent.mdx
+++ b/site/src/content/docs/examples/python/knowledge_base_agent.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "Knowledge-Base Workflow"
 ---
 
-This [example](https://github.com/strands-agents/docs/blob/main/docs/examples/python/knowledge_base_agent.py) demonstrates how to create a Strands agent that determines whether to store information to a knowledge base or retrieve information from it based on the user's query. It showcases a code-defined decision-making workflow that routes user inputs to the appropriate action.
+This [example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/knowledge_base_agent.py) demonstrates how to create a Strands agent that determines whether to store information to a knowledge base or retrieve information from it based on the user's query. It showcases a code-defined decision-making workflow that routes user inputs to the appropriate action.
 
 ## Setup Requirements
 

--- a/site/src/content/docs/examples/python/mcp_calculator.mdx
+++ b/site/src/content/docs/examples/python/mcp_calculator.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "MCP"
 ---
 
-This [example](https://github.com/strands-agents/docs/blob/main/docs/examples/python/mcp_calculator.py) demonstrates how to integrate Strands agents with external tools using the Model Context Protocol (MCP). It shows how to create a simple MCP server that provides calculator functionality and connect a Strands agent to use these tools.
+This [example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/mcp_calculator.py) demonstrates how to integrate Strands agents with external tools using the Model Context Protocol (MCP). It shows how to create a simple MCP server that provides calculator functionality and connect a Strands agent to use these tools.
 
 ## Overview
 

--- a/site/src/content/docs/examples/python/memory_agent.mdx
+++ b/site/src/content/docs/examples/python/memory_agent.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "Memory Agent"
 ---
 
-This [example](https://github.com/strands-agents/docs/blob/main/docs/examples/python/memory_agent.py) demonstrates how to create a Strands agent that leverages [mem0.ai](https://mem0.ai) to maintain context across conversations and provide personalized responses. It showcases how to store, retrieve, and utilize memories to create more intelligent and contextual AI interactions.
+This [example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/memory_agent.py) demonstrates how to create a Strands agent that leverages [mem0.ai](https://mem0.ai) to maintain context across conversations and provide personalized responses. It showcases how to store, retrieve, and utilize memories to create more intelligent and contextual AI interactions.
 
 ## Overview
 

--- a/site/src/content/docs/examples/python/meta_tooling.mdx
+++ b/site/src/content/docs/examples/python/meta_tooling.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "Meta Tooling"
 ---
 
-Meta-tooling refers to the ability of an AI system to create new tools at runtime, rather than being limited to a predefined set of capabilities. The following [example](https://github.com/strands-agents/docs/blob/main/docs/examples/python/meta_tooling.py) demonstrates Strands Agents' meta-tooling capabilities - allowing agents to create, load, and use custom tools at runtime.
+Meta-tooling refers to the ability of an AI system to create new tools at runtime, rather than being limited to a predefined set of capabilities. The following [example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/meta_tooling.py) demonstrates Strands Agents' meta-tooling capabilities - allowing agents to create, load, and use custom tools at runtime.
 ## Overview
 
 | Feature            | Description                                  |
@@ -47,7 +47,7 @@ agent = Agent(
 
 #### 2. Agent System Prompt outlines a strict guideline for naming, structure, and creation of the new tools.
 
-The system prompt guides the agent in proper tool creation. The [TOOL_BUILDER_SYSTEM_PROMPT](https://github.com/strands-agents/docs/blob/main/docs/examples/python/meta_tooling.py#L17) outlines important elements to enable the agent achieve meta-tooling capabilities:
+The system prompt guides the agent in proper tool creation. The [TOOL_BUILDER_SYSTEM_PROMPT](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/meta_tooling.py#L17) outlines important elements to enable the agent achieve meta-tooling capabilities:
 
   -  **Tool Naming Convention**: Provides the naming convention to use when building new custom tools.
 

--- a/site/src/content/docs/examples/python/multi_agent_example/multi_agent_example.mdx
+++ b/site/src/content/docs/examples/python/multi_agent_example/multi_agent_example.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "Multi Agents"
 ---
 
-This [example](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/teachers_assistant.py) demonstrates how to implement a multi-agent architecture using Strands Agents, where specialized agents work together under the coordination of a central orchestrator. The system uses natural language routing to direct queries to the most appropriate specialized agent based on subject matter expertise.
+This [example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/multi_agent_example/teachers_assistant.py) demonstrates how to implement a multi-agent architecture using Strands Agents, where specialized agents work together under the coordination of a central orchestrator. The system uses natural language routing to direct queries to the most appropriate specialized agent based on subject matter expertise.
 
 ## Overview
 
@@ -63,7 +63,7 @@ This example implements a multi-agent architecture where specialized agents work
 
 ### 1. Teacher's Assistant (Orchestrator)
 
-The `teacher_assistant` acts as the central coordinator that analyzes incoming natural language queries, determines the most appropriate specialized agent, and routes queries to that agent. All of this is accomplished through instructions outlined in the [TEACHER_SYSTEM_PROMPT](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/teachers_assistant.py#L51) for the agent. Furthermore, each specialized agent is part of the tools array for the orchestrator agent. 
+The `teacher_assistant` acts as the central coordinator that analyzes incoming natural language queries, determines the most appropriate specialized agent, and routes queries to that agent. All of this is accomplished through instructions outlined in the [TEACHER_SYSTEM_PROMPT](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/multi_agent_example/teachers_assistant.py#L51) for the agent. Furthermore, each specialized agent is part of the tools array for the orchestrator agent. 
 
 **Implementation:**
 
@@ -115,10 +115,10 @@ def math_assistant(query: str) -> str:
 ```
 Each specialized agent has a distinct system prompt, and tools in its inventory, and follows this general pattern.
 
-  - [Language Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/language_assistant.py) specializes in queries related to translation into different languages.
-  - [Computer Science Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/computer_science_assistant.py) specializes in queries related to writing, editing, running, code and explaining computer science concepts.
-  - [English Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/english_assistant.py) specializes in queries related to grammar, and english comprehension.
-  - [General Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/no_expertise.py) is a no specialty agent that aims to answer queries outside of the specific domains the agents are specialized in.
+  - [Language Assistant](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/multi_agent_example/language_assistant.py) specializes in queries related to translation into different languages.
+  - [Computer Science Assistant](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/multi_agent_example/computer_science_assistant.py) specializes in queries related to writing, editing, running, code and explaining computer science concepts.
+  - [English Assistant](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/multi_agent_example/english_assistant.py) specializes in queries related to grammar, and english comprehension.
+  - [General Assistant](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/multi_agent_example/no_expertise.py) is a no specialty agent that aims to answer queries outside of the specific domains the agents are specialized in.
 
 ### 3. Agent as Tool Pattern
 

--- a/site/src/content/docs/examples/python/multimodal.mdx
+++ b/site/src/content/docs/examples/python/multimodal.mdx
@@ -158,4 +158,4 @@ Here are some ways you could extend this example:
 3. **User Feedback Loop**: Allow users to provide feedback on the selection to improve future generations
 4. **Integration with Other Media**: Extend the system to work with other media types, such as video with Amazon Nova models.
 
-[example_code]: https://github.com/strands-agents/docs/tree/main/docs/examples/python/multimodal.py
+[example_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/python/multimodal.py

--- a/site/src/content/docs/examples/python/weather_forecaster.mdx
+++ b/site/src/content/docs/examples/python/weather_forecaster.mdx
@@ -4,7 +4,7 @@ sidebar:
   label: "Weather Forecaster"
 ---
 
-This [example](https://github.com/strands-agents/docs/blob/main/docs/examples/python/weather_forecaster.py) demonstrates how to integrate the Strands Agents SDK with tool use, specifically using the `http_request` tool to build a weather forecasting agent that connects with the National Weather Service API. It shows how to combine natural language understanding with API capabilities to retrieve and present weather information.
+This [example](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/weather_forecaster.py) demonstrates how to integrate the Strands Agents SDK with tool use, specifically using the `http_request` tool to build a weather forecasting agent that connects with the National Weather Service API. It shows how to combine natural language understanding with API capabilities to retrieve and present weather information.
 
 ## Overview
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/workflow.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/workflow.mdx
@@ -85,7 +85,7 @@ def process_workflow(topic):
 ```
 
 This sequential workflow creates a pipeline where each agent's output becomes the input for the next agent, allowing for specialized processing at each stage.
-For a functional example of sequential workflow implementation, see the [agents_workflows.md](https://github.com/strands-agents/docs/blob/main/docs/examples/python/agents_workflows.md) example in the Strands Agents SDK documentation.
+For a functional example of sequential workflow implementation, see the [agents_workflow.py](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/python/agents_workflow.py) example in the Strands Agents SDK documentation.
 
 
 ## Quick Start with the Workflow Tool

--- a/site/src/content/docs/user-guide/deploy/deploy_to_amazon_ec2.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_amazon_ec2.mdx
@@ -283,6 +283,6 @@ For the complete example code, including all files and configurations, see the [
 - [AWS CDK Documentation](https://docs.aws.amazon.com/cdk/v2/guide/home.html)
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 
-[project_code]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_ec2
-[app_py]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_ec2/app/app.py
-[agent_ec2_stack]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_ec2/lib/agent-ec2-stack.ts
+[project_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_ec2
+[app_py]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_ec2/app/app.py
+[agent_ec2_stack]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_ec2/lib/agent-ec2-stack.ts

--- a/site/src/content/docs/user-guide/deploy/deploy_to_amazon_eks.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_amazon_eks.mdx
@@ -225,7 +225,7 @@ For the complete example code, including all files and configurations, see the  
 - [eksctl Documentation](https://eksctl.io/usage/creating-and-managing-clusters/)
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 
-[project_code]: https://github.com/strands-agents/docs/tree/main/docs/examples/deploy_to_eks
-[app_py]: https://github.com/strands-agents/docs/tree/main/docs/examples/deploy_to_eks/docker/app/app.py
-[dockerfile]: https://github.com/strands-agents/docs/tree/main/docs/examples/deploy_to_eks/docker/Dockerfile
-[values_yaml]: https://github.com/strands-agents/docs/tree/main/docs/examples/deploy_to_eks/chart/values.yaml
+[project_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks
+[app_py]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks/docker/app/app.py
+[dockerfile]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks/docker/Dockerfile
+[values_yaml]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks/chart/values.yaml

--- a/site/src/content/docs/user-guide/deploy/deploy_to_aws_apprunner.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_aws_apprunner.mdx
@@ -306,8 +306,8 @@ For the complete example code, including all files and configurations, see the [
 - [Podman Documentation](https://docs.podman.io/en/latest/)
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 
-[project_code]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_apprunner
-[app_py]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_apprunner/docker/app/app.py
-[dockerfile]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_apprunner/docker/Dockerfile
-[agent_apprunner_stack]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_apprunner/lib/agent-apprunner-stack.ts
+[project_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner
+[app_py]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner/docker/app/app.py
+[dockerfile]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner/docker/Dockerfile
+[agent_apprunner_stack]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner/lib/agent-apprunner-stack.ts
 

--- a/site/src/content/docs/user-guide/deploy/deploy_to_aws_fargate.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_aws_fargate.mdx
@@ -304,8 +304,8 @@ For the complete example code, including all files and configurations, see the [
 - [Podman Documentation](https://docs.podman.io/en/latest/)
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 
-[project_code]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_fargate
-[app_py]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_fargate/docker/app/app.py
-[dockerfile]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_fargate/docker/Dockerfile
-[agent_fargate_stack]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_fargate/lib/agent-fargate-stack.ts
+[project_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate
+[app_py]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate/docker/app/app.py
+[dockerfile]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate/docker/Dockerfile
+[agent_fargate_stack]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate/lib/agent-fargate-stack.ts
 

--- a/site/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
@@ -302,7 +302,7 @@ For the complete example code, including all files and configurations, see the [
 - [AWS CDK Documentation](https://docs.aws.amazon.com/cdk/latest/guide/home.html)
 - [Amazon Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
 
-[project_code]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_lambda
-[agent_handler]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_lambda/lambda/agent_handler.py
-[AgentLambdaStack]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_lambda/lib/agent-lambda-stack.ts
-[package_for_lambda]: https://github.com/strands-agents/docs/tree/main/docs/examples/cdk/deploy_to_lambda/bin/package_for_lambda.py
+[project_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_lambda
+[agent_handler]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_lambda/lambda/agent_handler.py
+[AgentLambdaStack]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_lambda/lib/agent-lambda-stack.ts
+[package_for_lambda]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_lambda/bin/package_for_lambda.py

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/custom_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/custom_evaluator.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ## Overview
 
-The Strands Evals SDK allows you to create custom evaluators by extending the base `Evaluator` class. This enables you to implement domain-specific evaluation logic tailored to your unique requirements. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/custom_evaluator.py).
+The Strands Evals SDK allows you to create custom evaluators by extending the base `Evaluator` class. This enables you to implement domain-specific evaluation logic tailored to your unique requirements. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/custom_evaluator.py).
 
 ## When to Create a Custom Evaluator
 

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/faithfulness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/faithfulness_evaluator.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ## Overview
 
-The `FaithfulnessEvaluator` evaluates whether agent responses are grounded in the conversation history. It assesses if the agent's statements are faithful to the information available in the preceding context, helping detect hallucinations and unsupported claims. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/faithfulness_evaluator.py).
+The `FaithfulnessEvaluator` evaluates whether agent responses are grounded in the conversation history. It assesses if the agent's statements are faithful to the information available in the preceding context, helping detect hallucinations and unsupported claims. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/faithfulness_evaluator.py).
 
 ## Key Features
 

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/goal_success_rate_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/goal_success_rate_evaluator.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## Overview
 
-The `GoalSuccessRateEvaluator` evaluates whether all user goals were successfully achieved in a conversation. It provides a holistic assessment of whether the agent accomplished what the user set out to do, considering the entire conversation session. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/goal_success_rate_evaluator.py).
+The `GoalSuccessRateEvaluator` evaluates whether all user goals were successfully achieved in a conversation. It provides a holistic assessment of whether the agent accomplished what the user set out to do, considering the entire conversation session. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/goal_success_rate_evaluator.py).
 
 ## Key Features
 

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/helpfulness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/helpfulness_evaluator.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## Overview
 
-The `HelpfulnessEvaluator` evaluates the helpfulness of agent responses from the user's perspective. It assesses whether responses effectively address user needs, provide useful information, and contribute positively to achieving the user's goals. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/helpfulness_evaluator.py).
+The `HelpfulnessEvaluator` evaluates the helpfulness of agent responses from the user's perspective. It assesses whether responses effectively address user needs, provide useful information, and contribute positively to achieving the user's goals. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/helpfulness_evaluator.py).
 
 ## Key Features
 

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## Overview
 
-The `MultimodalOutputEvaluator` assesses the quality of agent outputs for tasks that involve images or documents alongside text. It uses an MLLM as the judge and evaluates responses against a user-defined rubric, extending [`OutputEvaluator`](output_evaluator.md) with multimodal input support. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/multimodal_output_evaluator.py).
+The `MultimodalOutputEvaluator` assesses the quality of agent outputs for tasks that involve images or documents alongside text. It uses an MLLM as the judge and evaluates responses against a user-defined rubric, extending [`OutputEvaluator`](output_evaluator.md) with multimodal input support. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/multimodal_output_evaluator.py).
 
 ## Key Features
 

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/output_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/output_evaluator.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## Overview
 
-The `OutputEvaluator` is an LLM-based evaluator that assesses the quality of agent outputs against custom criteria. It uses a judge LLM to evaluate responses based on a user-defined rubric, making it ideal for evaluating subjective qualities like safety, relevance, accuracy, and completeness. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/output_evaluator.py).
+The `OutputEvaluator` is an LLM-based evaluator that assesses the quality of agent outputs against custom criteria. It uses a judge LLM to evaluate responses based on a user-defined rubric, making it ideal for evaluating subjective qualities like safety, relevance, accuracy, and completeness. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/output_evaluator.py).
 
 ## Key Features
 

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## Overview
 
-The `ToolParameterAccuracyEvaluator` is a specialized evaluator that assesses whether tool call parameters faithfully use information from the preceding conversation context. It evaluates each tool call individually to ensure parameters are grounded in available information rather than hallucinated or incorrectly inferred. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/tool_parameter_accuracy_evaluator.py).
+The `ToolParameterAccuracyEvaluator` is a specialized evaluator that assesses whether tool call parameters faithfully use information from the preceding conversation context. It evaluates each tool call individually to ensure parameters are grounded in available information rather than hallucinated or incorrectly inferred. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/tool_parameter_accuracy_evaluator.py).
 
 ## Key Features
 

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_selection_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_selection_evaluator.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## Overview
 
-The `ToolSelectionAccuracyEvaluator` evaluates whether tool calls are justified at specific points in the conversation. It assesses if the agent selected the right tool at the right time based on the conversation context and available tools. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/tool_selection_accuracy_evaluator.py).
+The `ToolSelectionAccuracyEvaluator` evaluates whether tool calls are justified at specific points in the conversation. It assesses if the agent selected the right tool at the right time based on the conversation context and available tools. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/tool_selection_accuracy_evaluator.py).
 
 ## Key Features
 

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/trajectory_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/trajectory_evaluator.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## Overview
 
-The `TrajectoryEvaluator` is an LLM-based evaluator that assesses the sequence of actions or tool calls made by an agent during task execution. It evaluates whether the agent followed an appropriate path to reach its goal, making it ideal for evaluating multi-step reasoning and tool usage patterns. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/trajectory_evaluator.py).
+The `TrajectoryEvaluator` is an LLM-based evaluator that assesses the sequence of actions or tool calls made by an agent during task execution. It evaluates whether the agent followed an appropriate path to reach its goal, making it ideal for evaluating multi-step reasoning and tool usage patterns. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/trajectory_evaluator.py).
 
 ## Key Features
 

--- a/site/src/util/redirect.ts
+++ b/site/src/util/redirect.ts
@@ -50,27 +50,27 @@ const SLUG_RULES: SlugRule[] = [
   // CDK and deployment examples now live on GitHub
   {
     match: exactly('docs/examples/cdk/deploy_to_apprunner'),
-    to: 'https://github.com/strands-agents/docs/blob/main/docs/examples/cdk/deploy_to_apprunner/README.md',
+    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_apprunner/README.md',
   },
   {
     match: exactly('docs/examples/cdk/deploy_to_ec2'),
-    to: 'https://github.com/strands-agents/docs/blob/main/docs/examples/cdk/deploy_to_ec2/README.md',
+    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_ec2/README.md',
   },
   {
     match: exactly('docs/examples/cdk/deploy_to_fargate'),
-    to: 'https://github.com/strands-agents/docs/blob/main/docs/examples/cdk/deploy_to_fargate/README.md',
+    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_fargate/README.md',
   },
   {
     match: exactly('docs/examples/cdk/deploy_to_lambda'),
-    to: 'https://github.com/strands-agents/docs/blob/main/docs/examples/cdk/deploy_to_lambda/README.md',
+    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_lambda/README.md',
   },
   {
     match: exactly('docs/examples/deploy_to_eks'),
-    to: 'https://github.com/strands-agents/docs/blob/main/docs/examples/deploy_to_eks/README.md',
+    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/deploy_to_eks/README.md',
   },
   {
     match: exactly('docs/examples/typescript/deploy_to_bedrock_agentcore'),
-    to: 'https://github.com/strands-agents/docs/blob/main/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md',
+    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md',
   },
 ]
 


### PR DESCRIPTION
## Description

After the monorepo merge, many GitHub links across the site, design docs, and agent skills still point to the old `strands-agents/docs`, `strands-agents/sdk-python`, or `strands-agents/sdk-typescript` repositories. These repos are now deprecated in favor of `strands-agents/harness-sdk`.

This PR updates all actionable stale links:
- Example code links: `docs/blob/main/docs/examples/` → `harness-sdk/blob/main/site/docs/examples/`
- Community/contribute pages: repo references and file paths updated to `harness-sdk`
- Design docs: file-path cross-references updated (historical PR links left intact)
- Agent skills/references: removed deprecated repo names from issue search config, updated GitHub API paths

Blog posts and design doc PR/issue number references are intentionally left unchanged since those are historical and the old repos still resolve.

Follows up on feedback from #2695 (comment).

## Related Issues

https://github.com/strands-agents/harness-sdk/pull/2695#discussion_r3381589191

## Documentation PR

N/A — this IS the docs fix.

## Type of Change

Bug fix

## Testing

- Verified target paths exist in `harness-sdk` via `gh api`
- All changes are link text replacements with no functional code changes

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
