### PR TITLE
docs(a2a): document per-context conversation isolation

### DIFF
--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -326,11 +326,9 @@ The server serves the agent card at `/.well-known/agent-card.json` and handles J
 
 The A2A protocol identifies each conversation with a `context_id`. The server isolates conversation state per `context_id` so that callers in different contexts never read or influence each other's history. Two modes control how that isolation works.
 
-The recommended mode is `agent_factory`. You provide a callable that takes a `context_id` and returns a fresh agent.
+The recommended mode is `agent_factory` — you provide a callable that takes a `context_id` and returns a dedicated agent for each conversation, reusing it for later requests in that context. This enables different conversations to run concurrently because each owns an independent agent.
 
-The server builds a dedicated agent the first time it sees a `context_id`, gives it its own lock, and reuses it for later requests in that context. Different contexts run concurrently because each owns an independent agent.
-
-The factory is also where you wire per context concerns such as a context scoped `session_manager`.
+The factory is also where you wire per-conversation concerns such as a `session_manager` to persist that conversation's history.
 
 <Tabs>
 <Tab label="Python">
@@ -354,7 +352,7 @@ a2a_server.serve()
 <Tab label="TypeScript">
 
 ```typescript
-import { Agent } from '@strands-agents/sdk'
+import { Agent, SessionManager, FileStorage } from '@strands-agents/sdk'
 import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 
 --8<-- "user-guide/concepts/multi-agent/agent-to-agent.ts:factory_server"
@@ -369,9 +367,9 @@ The server retains at most `max_contexts` contexts at once (default 1000). When 
 Contexts are keyed on the client supplied `context_id`. A caller who knows another caller's `context_id` can attach to that conversation. Multi-tenant deployments must enforce authenticated identity at the transport or gateway layer.
 :::
 
-Passing a single `agent` instead of an `agent_factory` is deprecated. In that mode the server reuses one agent across every context, swapping each context's saved state on and off the shared instance under a lock. This serializes all requests.
-
-A single `agent` with a configured `session_manager` is rejected, because the session manager would persist every context into one interleaved session. Prefer `agent_factory` for any deployment that serves more than one conversation.
+:::caution[Passing a single `agent` is deprecated]
+In single-agent mode the server reuses one agent across every context, swapping each context's saved state on and off the shared instance under a lock, which serializes all requests. A single `agent` with a configured `session_manager` is rejected, because the session manager would persist every context into one interleaved session. Prefer `agent_factory` for any deployment that serves more than one conversation.
+:::
 
 ### Server Configuration Options
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -326,7 +326,7 @@ The server serves the agent card at `/.well-known/agent-card.json` and handles J
 
 The A2A protocol identifies each conversation with a `context_id`. The server isolates conversation state per `context_id` so that callers in different contexts never read or influence each other's history. Two modes control how that isolation works.
 
-The recommended mode is `agent_factory` — you provide a callable that takes a `context_id` and returns a dedicated agent for each conversation, reusing it for later requests in that context. This enables different conversations to run concurrently because each owns an independent agent.
+The recommended mode is `agent_factory` - you provide a callable that takes a `context_id` and returns a dedicated agent for each conversation, reusing it for later requests in that context. This enables different conversations to run concurrently because each owns an independent agent.
 
 The factory is also where you wire per-conversation concerns such as a `session_manager` to persist that conversation's history.
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -311,6 +311,7 @@ a2a_server.serve()
 <Tab label="TypeScript">
 
 ```typescript
+import { Agent } from '@strands-agents/sdk'
 import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 
 --8<-- "user-guide/concepts/multi-agent/agent-to-agent.ts:basic_server"
@@ -325,7 +326,11 @@ The server serves the agent card at `/.well-known/agent-card.json` and handles J
 
 The A2A protocol identifies each conversation with a `context_id`. The server isolates conversation state per `context_id` so that callers in different contexts never read or influence each other's history. Two modes control how that isolation works.
 
-The recommended mode is `agent_factory`. You provide a callable that takes a `context_id` and returns a fresh agent. The server builds a dedicated agent the first time it sees a `context_id`, gives it its own lock, and reuses it for later requests in that context. Different contexts run concurrently because each owns an independent agent. The factory is also where you wire per context concerns such as a context scoped `session_manager`.
+The recommended mode is `agent_factory`. You provide a callable that takes a `context_id` and returns a fresh agent.
+
+The server builds a dedicated agent the first time it sees a `context_id`, gives it its own lock, and reuses it for later requests in that context. Different contexts run concurrently because each owns an independent agent.
+
+The factory is also where you wire per context concerns such as a context scoped `session_manager`.
 
 <Tabs>
 <Tab label="Python">
@@ -349,6 +354,9 @@ a2a_server.serve()
 <Tab label="TypeScript">
 
 ```typescript
+import { Agent } from '@strands-agents/sdk'
+import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
+
 --8<-- "user-guide/concepts/multi-agent/agent-to-agent.ts:factory_server"
 ```
 
@@ -361,7 +369,9 @@ The server retains at most `max_contexts` contexts at once (default 1000). When 
 Contexts are keyed on the client supplied `context_id`. A caller who knows another caller's `context_id` can attach to that conversation. Multi-tenant deployments must enforce authenticated identity at the transport or gateway layer.
 :::
 
-Passing a single `agent` instead of an `agent_factory` is deprecated. In that mode the server reuses one agent across every context, swapping each context's saved state on and off the shared instance under a lock, which serializes all requests. A single `agent` with a configured `session_manager` is rejected, because the session manager would persist every context into one interleaved session. Prefer `agent_factory` for any deployment that serves more than one conversation.
+Passing a single `agent` instead of an `agent_factory` is deprecated. In that mode the server reuses one agent across every context, swapping each context's saved state on and off the shared instance under a lock. This serializes all requests.
+
+A single `agent` with a configured `session_manager` is rejected, because the session manager would persist every context into one interleaved session. Prefer `agent_factory` for any deployment that serves more than one conversation.
 
 ### Server Configuration Options
 
@@ -384,7 +394,7 @@ The `A2AServer` constructor accepts several configuration options:
 - `push_config_store`: Custom push notification configuration storage (optional)
 - `push_sender`: Custom push notification sender implementation (optional)
 
-Provide exactly one of `agent_factory` or `agent`.
+Provide exactly one of `agent_factory` or `agent`, recommend `agent_factory`.
 
 </Tab>
 <Tab label="TypeScript">
@@ -409,7 +419,7 @@ The `A2AExpressServer` constructor accepts a config object:
 - `taskStore`: Task store for persisting task state (defaults to InMemoryTaskStore)
 - `userBuilder`: User builder for authentication (default: no authentication)
 
-Provide exactly one of `agentFactory` or `agent`.
+Provide exactly one of `agentFactory` or `agent`, recommend `agent_factory`.
 
 ```typescript
 --8<-- "user-guide/concepts/multi-agent/agent-to-agent.ts:server_config"

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -419,7 +419,7 @@ The `A2AExpressServer` constructor accepts a config object:
 - `taskStore`: Task store for persisting task state (defaults to InMemoryTaskStore)
 - `userBuilder`: User builder for authentication (default: no authentication)
 
-Provide exactly one of `agentFactory` or `agent`, recommend `agent_factory`.
+Provide exactly one of `agentFactory` or `agent`, recommend `agentFactory`.
 
 ```typescript
 --8<-- "user-guide/concepts/multi-agent/agent-to-agent.ts:server_config"

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -291,16 +291,17 @@ from strands.multiagent.a2a import A2AServer
 
 logging.basicConfig(level=logging.INFO)
 
-# Create a Strands agent
-strands_agent = Agent(
-    name="Calculator Agent",
-    description="A calculator agent that can perform basic arithmetic operations.",
-    tools=[calculator],
-    callback_handler=None
-)
+# Build a fresh agent for each A2A context so callers stay isolated
+def create_agent(context_id: str) -> Agent:
+    return Agent(
+        name="Calculator Agent",
+        description="A calculator agent that can perform basic arithmetic operations.",
+        tools=[calculator],
+        callback_handler=None
+    )
 
-# Create A2A server (streaming enabled by default)
-a2a_server = A2AServer(agent=strands_agent)
+# Create A2A server with a per context agent factory (streaming enabled by default)
+a2a_server = A2AServer(agent_factory=create_agent)
 
 # Start the server
 a2a_server.serve()
@@ -320,6 +321,48 @@ import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 
 The server serves the agent card at `/.well-known/agent-card.json` and handles JSON-RPC requests at the root path. Streaming is supported by default.
 
+### Conversation Isolation
+
+The A2A protocol identifies each conversation with a `context_id`. The server isolates conversation state per `context_id` so that callers in different contexts never read or influence each other's history. Two modes control how that isolation works.
+
+The recommended mode is `agent_factory`. You provide a callable that takes a `context_id` and returns a fresh agent. The server builds a dedicated agent the first time it sees a `context_id`, gives it its own lock, and reuses it for later requests in that context. Different contexts run concurrently because each owns an independent agent. The factory is also where you wire per context concerns such as a context scoped `session_manager`.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.multiagent.a2a import A2AServer
+
+def create_agent(context_id: str) -> Agent:
+    return Agent(
+        name="Calculator Agent",
+        description="A calculator agent.",
+        callback_handler=None
+    )
+
+a2a_server = A2AServer(agent_factory=create_agent)
+a2a_server.serve()
+```
+
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/multi-agent/agent-to-agent.ts:factory_server"
+```
+
+</Tab>
+</Tabs>
+
+The server retains at most `max_contexts` contexts at once (default 1000). When that cap is exceeded, the server evicts the least recently used context, and a later request that reuses the evicted `context_id` starts a fresh conversation. Tune this cap to bound memory in long running servers.
+
+:::caution[`context_id` is not an authentication boundary]
+Contexts are keyed on the client supplied `context_id`. A caller who knows another caller's `context_id` can attach to that conversation. Multi-tenant deployments must enforce authenticated identity at the transport or gateway layer.
+:::
+
+Passing a single `agent` instead of an `agent_factory` is deprecated. In that mode the server reuses one agent across every context, swapping each context's saved state on and off the shared instance under a lock, which serializes all requests. A single `agent` with a configured `session_manager` is rejected, because the session manager would persist every context into one interleaved session. Prefer `agent_factory` for any deployment that serves more than one conversation.
+
 ### Server Configuration Options
 
 <Tabs>
@@ -327,7 +370,9 @@ The server serves the agent card at `/.well-known/agent-card.json` and handles J
 
 The `A2AServer` constructor accepts several configuration options:
 
-- `agent`: The Strands agent to wrap with A2A compatibility
+- `agent_factory`: Callable that takes a `context_id` and returns a fresh agent per context (recommended)
+- `agent`: A single Strands agent reused across contexts (deprecated; prefer `agent_factory`)
+- `max_contexts`: Maximum number of per context agents to retain concurrently (default: 1000, must be at least 1)
 - `host`: Hostname or IP address to bind to (default: "127.0.0.1")
 - `port`: Port to bind to (default: 9000)
 - `version`: Version of the agent (default: "0.0.1")
@@ -339,17 +384,21 @@ The `A2AServer` constructor accepts several configuration options:
 - `push_config_store`: Custom push notification configuration storage (optional)
 - `push_sender`: Custom push notification sender implementation (optional)
 
+Provide exactly one of `agent_factory` or `agent`.
+
 </Tab>
 <Tab label="TypeScript">
 
 The TypeScript SDK provides two server classes:
 
-- **`A2AServer`** — Base class that manages the agent card and request handler. Use this when integrating with your own HTTP framework.
-- **`A2AExpressServer`** — Express-based server with `serve()` and `createMiddleware()` methods.
+- **`A2AServer`**: Base class that manages the agent card and request handler. Use this when integrating with your own HTTP framework.
+- **`A2AExpressServer`**: Express based server with `serve()` and `createMiddleware()` methods.
 
 The `A2AExpressServer` constructor accepts a config object:
 
-- `agent`: The Strands Agent to serve via A2A protocol
+- `agentFactory`: Callable that takes a `contextId` and returns a fresh agent per context (recommended)
+- `agent`: A single Strands Agent reused across contexts (deprecated; prefer `agentFactory`)
+- `maxContexts`: Maximum number of per context agents to retain concurrently (default: 1000, must be at least 1)
 - `name` (required): Human-readable name for the agent
 - `description`: Description of the agent's purpose
 - `host`: Host to bind the server to (default: `'127.0.0.1'`)
@@ -359,6 +408,8 @@ The `A2AExpressServer` constructor accepts a config object:
 - `skills`: Skills to advertise in the agent card
 - `taskStore`: Task store for persisting task state (defaults to InMemoryTaskStore)
 - `userBuilder`: User builder for authentication (default: no authentication)
+
+Provide exactly one of `agentFactory` or `agent`.
 
 ```typescript
 --8<-- "user-guide/concepts/multi-agent/agent-to-agent.ts:server_config"
@@ -380,9 +431,11 @@ from strands import Agent
 from strands.multiagent.a2a import A2AServer
 import uvicorn
 
-# Create your agent and A2A server
-agent = Agent(name="My Agent", description="A customizable agent", callback_handler=None)
-a2a_server = A2AServer(agent=agent)
+# Create your agent factory and A2A server
+def create_agent(context_id: str) -> Agent:
+    return Agent(name="My Agent", description="A customizable agent", callback_handler=None)
+
+a2a_server = A2AServer(agent_factory=create_agent)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -447,11 +500,12 @@ class CustomQueueManager(QueueManager):
     # Implementation details...
     pass
 
-# Create agent with custom components
-agent = Agent(name="My Agent", description="A customizable agent", callback_handler=None)
+# Create an agent factory with custom components
+def create_agent(context_id: str) -> Agent:
+    return Agent(name="My Agent", description="A customizable agent", callback_handler=None)
 
 a2a_server = A2AServer(
-    agent=agent,
+    agent_factory=create_agent,
     task_store=CustomTaskStore(),
     queue_manager=CustomQueueManager(),
     push_config_store=MyPushConfigStore(),
@@ -477,10 +531,8 @@ The TypeScript `A2AExpressServer` supports a custom `taskStore` for persisting t
 import { Agent } from '@strands-agents/sdk'
 import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 
-const agent = new Agent({ systemPrompt: 'You are a helpful agent.' })
-
 const server = new A2AExpressServer({
-  agent,
+  agentFactory: (contextId) => new Agent({ systemPrompt: 'You are a helpful agent.' }),
   name: 'My Agent',
   taskStore: myCustomTaskStore, // Must implement TaskStore from @a2a-js/sdk/server
 })
@@ -500,23 +552,24 @@ The `A2AServer` supports automatic path-based mounting for deployment scenarios 
 from strands import Agent
 from strands.multiagent.a2a import A2AServer
 
-# Create an agent
-agent = Agent(
-    name="Calculator Agent",
-    description="A calculator agent",
-    callback_handler=None
-)
+# Create an agent factory
+def create_agent(context_id: str) -> Agent:
+    return Agent(
+        name="Calculator Agent",
+        description="A calculator agent",
+        callback_handler=None
+    )
 
 # Deploy with path-based mounting
 # The agent will be accessible at http://my-alb.amazonaws.com/calculator/
 a2a_server = A2AServer(
-    agent=agent,
+    agent_factory=create_agent,
     http_url="http://my-alb.amazonaws.com/calculator"
 )
 
 # For load balancers that strip path prefixes, use serve_at_root=True
 a2a_server_with_root = A2AServer(
-    agent=agent,
+    agent_factory=create_agent,
     http_url="http://my-alb.amazonaws.com/calculator",
     serve_at_root=True  # Serves at root even though URL has /calculator path
 )
@@ -531,10 +584,8 @@ Use the `httpUrl` option to set the public URL for the agent card. For custom pa
 import { Agent } from '@strands-agents/sdk'
 import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 
-const agent = new Agent({ systemPrompt: 'A calculator agent.' })
-
 const server = new A2AExpressServer({
-  agent,
+  agentFactory: (contextId) => new Agent({ systemPrompt: 'A calculator agent.' }),
   name: 'Calculator Agent',
   httpUrl: 'http://my-alb.amazonaws.com/calculator',
 })

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.ts
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.ts
@@ -102,7 +102,8 @@ async function serverConfigExample() {
       }),
     name: 'My Agent',
     description: 'A helpful agent',
-    maxContexts: 1000, // Retain at most 1000 per context agents; evict least recently used
+    // Retain at most 1000 per context agents; evict least recently used
+    maxContexts: 1000,
     host: '0.0.0.0',
     port: 8080,
     version: '1.0.0',

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.ts
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 // NOTE: Type-checking is disabled because the examples reference remote services not available at build time.
 
-import { Agent, tool } from '@strands-agents/sdk'
+import { Agent, tool, SessionManager, FileStorage } from '@strands-agents/sdk'
 import { A2AAgent } from '@strands-agents/sdk/a2a'
 import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 import { z } from 'zod'
@@ -77,13 +77,20 @@ async function basicServerExample() {
 
 async function factoryServerExample() {
   // --8<-- [start:factory_server]
-  // The factory runs once per contextId. Wire per context concerns such as a
-  // session manager here so each conversation stays isolated.
+  // The factory runs once per contextId and returns a dedicated agent, so each conversation
+  // is isolated. Wire an optional sessionManager here to persist that conversation's history,
+  // scoped to the contextId.
+  const storage = new FileStorage('./sessions')
+
   const server = new A2AExpressServer({
     agentFactory: (contextId) =>
       new Agent({
         name: 'Calculator Agent',
         description: 'A calculator agent.',
+        sessionManager: new SessionManager({
+          sessionId: contextId,
+          storage: { snapshot: storage },
+        }),
       }),
     name: 'Calculator Agent',
     maxContexts: 1000,

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.ts
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.ts
@@ -61,13 +61,12 @@ async function asToolExample() {
 
 async function basicServerExample() {
   // --8<-- [start:basic_server]
-  const agent = new Agent({
-    systemPrompt: 'You are a calculator agent that can perform basic arithmetic.',
-  })
-
-  // Create and start the A2A server
+  // Build a fresh agent for each A2A context so callers stay isolated
   const server = new A2AExpressServer({
-    agent,
+    agentFactory: (contextId) =>
+      new Agent({
+        systemPrompt: 'You are a calculator agent that can perform basic arithmetic.',
+      }),
     name: 'Calculator Agent',
     description: 'A calculator agent that can perform basic arithmetic operations.',
   })
@@ -76,16 +75,34 @@ async function basicServerExample() {
   // --8<-- [end:basic_server]
 }
 
-async function serverConfigExample() {
-  const agent = new Agent({
-    systemPrompt: 'You are a helpful agent.',
+async function factoryServerExample() {
+  // --8<-- [start:factory_server]
+  // The factory runs once per contextId. Wire per context concerns such as a
+  // session manager here so each conversation stays isolated.
+  const server = new A2AExpressServer({
+    agentFactory: (contextId) =>
+      new Agent({
+        name: 'Calculator Agent',
+        description: 'A calculator agent.',
+      }),
+    name: 'Calculator Agent',
+    maxContexts: 1000,
   })
 
+  await server.serve()
+  // --8<-- [end:factory_server]
+}
+
+async function serverConfigExample() {
   // --8<-- [start:server_config]
   const server = new A2AExpressServer({
-    agent,
+    agentFactory: (contextId) =>
+      new Agent({
+        systemPrompt: 'You are a helpful agent.',
+      }),
     name: 'My Agent',
     description: 'A helpful agent',
+    maxContexts: 1000, // Retain at most 1000 per context agents; evict least recently used
     host: '0.0.0.0',
     port: 8080,
     version: '1.0.0',
@@ -100,15 +117,12 @@ async function serverConfigExample() {
 }
 
 async function expressMiddlewareExample() {
-  const agent = new Agent({
-    systemPrompt: 'You are a helpful agent.',
-  })
-
   // --8<-- [start:express_middleware]
   const express = (await import('express')).default
 
   const server = new A2AExpressServer({
-    agent,
+    agentFactory: (contextId) =>
+      new Agent({ systemPrompt: 'You are a customizable agent.' }),
     name: 'My Agent',
     description: 'A customizable agent',
   })
@@ -130,12 +144,11 @@ async function expressMiddlewareExample() {
 }
 
 async function abortExample() {
-  const agent = new Agent({
-    systemPrompt: 'You are a helpful agent.',
-  })
-
   // --8<-- [start:abort_signal]
-  const server = new A2AExpressServer({ agent, name: 'My Agent' })
+  const server = new A2AExpressServer({
+    agentFactory: (contextId) => new Agent({ systemPrompt: 'You are a helpful agent.' }),
+    name: 'My Agent',
+  })
 
   const controller = new AbortController()
   await server.serve({ signal: controller.signal })
@@ -149,6 +162,7 @@ void basicUsageExample()
 void streamingExample()
 void asToolExample()
 void basicServerExample()
+void factoryServerExample()
 void serverConfigExample()
 void expressMiddlewareExample()
 void abortExample()


### PR DESCRIPTION
## Description

Updates the Agent-to-Agent guide to match the per-context conversation isolation work merged in both SDKs (#2696 for TypeScript, plus the Python executor). The guide previously showed only the single `agent` server pattern, which is now deprecated.

Changes:

- Server examples now use the recommended `agent_factory` / `agentFactory` pattern.
- New "Conversation Isolation" section covering the two modes (`agent_factory` vs deprecated single `agent`), the `max_contexts` LRU cap, and a caution that `context_id` is not an authentication boundary.
- Server configuration option tables list `agent_factory`/`agentFactory` and `max_contexts`/`maxContexts`, and note that exactly one agent source is required.
- A new `factory_server` TypeScript snippet backs the isolation example.

## Related Issues

Documents the A2A context isolation work (TypeScript: #2696).

## Type of Change

Documentation update

## Testing

- [x] `npm run format:check` (the new snippet passes; pre-existing unrelated warnings remain)
- [x] `npm run typecheck:snippets` (no errors from the A2A snippet)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
