### PR TITLE
ci: add PR labeling to issue-labeler workflow

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -3,9 +3,12 @@ name: Issue Labeler
 on:
   issues:
     types: [opened]
+  pull_request_target:
+    types: [opened]
 
 permissions:
   issues: write
+  pull-requests: write
   id-token: write
   contents: read
 


### PR DESCRIPTION
## Summary

- Add `pull_request_target: [opened]` trigger to issue-labeler workflow
- Add `pull-requests: write` permission so labels can be applied to PRs
- Depends on https://github.com/strands-agents/devtools/pull/60 (action needs fallback expressions for PR event data)

## Test plan

- [ ] Merge devtools PR first
- [ ] Verify new PRs get area/type/language labels applied automatically