### PR TITLE
fix(bedrock): preserve signature-only reasoning blocks across turns

### DIFF
--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -11,6 +11,7 @@ import {
   GuardContentBlock,
   ToolResultBlock,
   JsonBlock,
+  ReasoningBlock,
 } from '../../types/messages.js'
 import { ImageBlock, DocumentBlock, VideoBlock } from '../../types/media.js'
 import { warnOnce } from '../../logging/warn-once.js'
@@ -485,6 +486,24 @@ describe('AnthropicModel', () => {
         input_schema: { type: 'object', properties: {} },
       })
       expect(captured.request.tool_choice).toEqual({ type: 'auto' })
+    })
+
+    it('formats a signature-only reasoning block', async () => {
+      const { captured, mockClient } = setupCapture()
+      const provider = new AnthropicModel({ client: mockClient })
+      const messages = [
+        new Message({
+          role: 'assistant',
+          content: [new ReasoningBlock({ signature: 'sig-abc' }), new TextBlock('answer')],
+        }),
+      ]
+
+      await collectIterator(provider.stream(messages))
+
+      expect(captured.request.messages[0].content).toEqual([
+        { type: 'thinking', thinking: '', signature: 'sig-abc' },
+        { type: 'text', text: 'answer' },
+      ])
     })
 
     describe('Prompt Caching (Lookahead logic)', () => {

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -714,6 +714,38 @@ describe('BedrockModel', () => {
       })
     })
 
+    it('formats a signature-only reasoning block', async () => {
+      const provider = new BedrockModel()
+      const messages = [
+        new Message({
+          role: 'assistant',
+          content: [new ReasoningBlock({ signature: 'sig-abc' }), new TextBlock('the answer')],
+        }),
+      ]
+
+      collectIterator(provider.stream(messages))
+
+      expect(mockConverseStreamCommand).toHaveBeenLastCalledWith({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                reasoningContent: {
+                  reasoningText: {
+                    text: '',
+                    signature: 'sig-abc',
+                  },
+                },
+              },
+              { text: 'the answer' },
+            ],
+          },
+        ],
+        modelId: expect.any(String),
+      })
+    })
+
     it('formats cache point blocks in messages', async () => {
       const provider = new BedrockModel()
       const messages = [
@@ -1126,6 +1158,20 @@ describe('BedrockModel', () => {
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
         await expect(collectIterator(provider.stream(messages))).rejects.toThrow(expected)
+      })
+
+      it('throws for a reasoning block with no text, signature, or redacted content', async () => {
+        const provider = new BedrockModel()
+        const messages = [
+          new Message({
+            role: 'assistant',
+            content: [new ReasoningBlock({})],
+          }),
+        ]
+
+        await expect(collectIterator(provider.stream(messages))).rejects.toThrow(
+          "reasoning content requires one of 'text', 'signature', or 'redactedContent' to be set"
+        )
       })
     })
   })

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -536,10 +536,10 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
       }
 
       case 'reasoningBlock':
-        if (block.text && block.signature) {
+        if (block.signature) {
           return {
             type: 'thinking',
-            thinking: block.text,
+            thinking: block.text ?? '',
             signature: block.signature,
           } as unknown as Anthropic.ContentBlockParam
         } else if (block.redactedContent) {

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -1062,12 +1062,12 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       }
 
       case 'reasoningBlock': {
-        if (block.text) {
+        if (block.text !== undefined || block.signature !== undefined) {
           return {
             reasoningContent: {
               reasoningText: {
-                text: block.text,
-                signature: block.signature,
+                text: block.text ?? '',
+                ...(block.signature !== undefined && { signature: block.signature }),
               },
             },
           }
@@ -1078,7 +1078,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
             },
           }
         } else {
-          throw Error("reasoning content format incorrect. Either 'text' or 'redactedContent' must be set.")
+          throw Error("reasoning content requires one of 'text', 'signature', or 'redactedContent' to be set")
         }
       }
 


### PR DESCRIPTION
## Description

Multi-turn tool loops with extended/adaptive thinking on Claude crash on the second turn with:

```
ModelError: reasoning content format incorrect. Either 'text' or 'redactedContent' must be set.
```

Under adaptive thinking with `display: "omitted"` (the default on Claude 4.7+), the model returns a reasoning block carrying a **signature with an empty thinking text**. The streaming API never emits reasoning text in this mode — only the signature, which is encrypted thinking the API decrypts to restore the model's reasoning on the next turn.

The two providers mishandled this signature-only block when re-serializing it for the next turn:

- **`bedrock.ts`** gated on `if (block.text)` and **threw** on the signature-only shape, crashing every multi-turn tool loop with thinking enabled.
- **`anthropic.ts`** gated on `if (block.text && block.signature)` and **dropped** the block, silently breaking the multi-turn protocol the docs require during tool use.

This PR makes both providers preserve the block so it round-trips:

- `bedrock.ts` accepts a block with text and/or signature, sending `reasoningText.text` defaulted to `''` (Bedrock requires the field non-null) alongside the signature.
- `anthropic.ts` emits the signed `thinking` block whenever a signature is present, with `thinking` defaulted to `''`.

The guards differ intentionally: Bedrock Converse also serves open-reasoning models (e.g. DeepSeek) that emit reasoning text with no signature, so it accepts text-or-signature; the first-party Anthropic API requires a signature on every `thinking` block, so a signature-less block there is unsendable and correctly falls through.

The Bedrock format error message is also updated to reflect that a signature alone is now valid.

Refs: https://platform.claude.com/docs/en/build-with-claude/extended-thinking#controlling-thinking-display

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

No documentation changes needed.

## Type of Change

Bug fix

## Testing

Added regression tests in both providers:
- `bedrock.test.ts`: `formats a signature-only reasoning block`, and `throws for a reasoning block with no text, signature, or redacted content` (covers the updated error path).
- `anthropic.test.ts`: `formats a signature-only reasoning block`.

Verified the full TS suite, lint, format, and type-check pass via the repo pre-commit hook (`npm run build` / `test:coverage` / `lint` / `format:check` / `type-check`). Also verified end-to-end against the live Bedrock and first-party Anthropic services: multi-turn tool loops with adaptive thinking now complete where they previously crashed.

This is a TypeScript-only change, so `hatch run prepare` (Python) does not apply.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

