### PR TITLE
fix: add missing /openai path segment to Bedrock Mantle base URL

### DIFF
--- a/strands-py/src/strands/models/_openai_bedrock.py
+++ b/strands-py/src/strands/models/_openai_bedrock.py
@@ -20,7 +20,7 @@ from typing import Any, TypedDict
 import boto3
 from botocore.credentials import CredentialProvider
 
-_MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
+_MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/openai/v1"
 _MANTLE_DOCS_URL = "https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html"
 
 

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1790,7 +1790,7 @@ class TestOpenAIModelBedrockMantleConfig:
 
         # Token is minted lazily per request, so inspect the resolved kwargs.
         resolved = model._resolve_client_args()
-        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
         assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
         # Optional kwargs aren't forwarded so provide_token's own defaults apply.
         mock_provide_token.assert_called_once_with(region="us-east-1")
@@ -1850,7 +1850,7 @@ class TestOpenAIModelBedrockMantleConfig:
             bedrock_mantle_config={"region": "us-east-1"},
         )
         resolved = model._resolve_client_args()
-        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
         assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
         assert resolved["timeout"] == 42
         assert resolved["http_client"] is sentinel_http_client
@@ -1886,7 +1886,7 @@ class TestOpenAIModelBedrockMantleConfig:
             model = OpenAIModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={})
             resolved = model._resolve_client_args()
 
-        assert resolved["base_url"] == "https://bedrock-mantle.eu-west-1.api.aws/v1"
+        assert resolved["base_url"] == "https://bedrock-mantle.eu-west-1.api.aws/openai/v1"
         mock_provide_token.assert_called_once_with(region="eu-west-1")
 
     def test_bedrock_mantle_config_region_resolved_from_boto_session(self, openai_client, mock_provide_token):
@@ -1901,7 +1901,7 @@ class TestOpenAIModelBedrockMantleConfig:
 
         resolved = model._resolve_client_args()
 
-        assert resolved["base_url"] == "https://bedrock-mantle.ap-southeast-2.api.aws/v1"
+        assert resolved["base_url"] == "https://bedrock-mantle.ap-southeast-2.api.aws/openai/v1"
         mock_provide_token.assert_called_once_with(region="ap-southeast-2")
 
     def test_bedrock_mantle_config_explicit_region_wins_over_boto_session(self, openai_client, mock_provide_token):

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1357,7 +1357,7 @@ class TestOpenAIResponsesModelBedrockMantleConfig:
         _ = openai_client
         model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={"region": "us-east-1"})
         resolved = model._resolve_client_args()
-        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
         assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
         mock_provide_token.assert_called_once_with(region="us-east-1")
 
@@ -1401,7 +1401,7 @@ class TestOpenAIResponsesModelBedrockMantleConfig:
             bedrock_mantle_config={"region": "us-east-1"},
         )
         resolved = model._resolve_client_args()
-        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/v1"
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
         assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
         assert resolved["timeout"] == 42
         assert resolved["http_client"] is sentinel_http_client
@@ -1436,7 +1436,7 @@ class TestOpenAIResponsesModelBedrockMantleConfig:
             model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={})
             resolved = model._resolve_client_args()
 
-        assert resolved["base_url"] == "https://bedrock-mantle.eu-west-1.api.aws/v1"
+        assert resolved["base_url"] == "https://bedrock-mantle.eu-west-1.api.aws/openai/v1"
         mock_provide_token.assert_called_once_with(region="eu-west-1")
 
     def test_bedrock_mantle_config_region_resolved_from_boto_session(self, openai_client, mock_provide_token):
@@ -1451,7 +1451,7 @@ class TestOpenAIResponsesModelBedrockMantleConfig:
 
         resolved = model._resolve_client_args()
 
-        assert resolved["base_url"] == "https://bedrock-mantle.ap-southeast-2.api.aws/v1"
+        assert resolved["base_url"] == "https://bedrock-mantle.ap-southeast-2.api.aws/openai/v1"
         mock_provide_token.assert_called_once_with(region="ap-southeast-2")
 
     def test_bedrock_mantle_config_wraps_token_failures_with_context(self, openai_client, mock_provide_token):

--- a/strands-py/tests_integ/models/test_model_mantle.py
+++ b/strands-py/tests_integ/models/test_model_mantle.py
@@ -2,7 +2,7 @@
 
 Exercises the ``bedrock_mantle_config`` pathway on ``OpenAIModel`` (Chat Completions) and
 ``OpenAIResponsesModel`` (Responses API) against the live
-``bedrock-mantle.<region>.api.aws/v1`` endpoint. Credentials come from the
+``bedrock-mantle.<region>.api.aws/openai/v1`` endpoint. Credentials come from the
 ambient AWS credential chain; no explicit API key is passed by the user.
 """
 


### PR DESCRIPTION
## Summary

Fixes the `_MANTLE_BASE_URL_TEMPLATE` in `_openai_bedrock.py` which was missing the `/openai` path segment, causing `400 validation_error` for OpenAI Responses API models (e.g. `openai.gpt-5.4`) routed through Bedrock Mantle.

**Before:** `https://bedrock-mantle.{region}.api.aws/v1`
**After:** `https://bedrock-mantle.{region}.api.aws/openai/v1`

## Changes

- `strands-py/src/strands/models/_openai_bedrock.py`: Updated URL template
- `strands-py/tests/strands/models/test_openai.py`: Updated 4 test assertions
- `strands-py/tests/strands/models/test_openai_responses.py`: Updated 4 test assertions
- `strands-py/tests_integ/models/test_model_mantle.py`: Updated docstring URL

## Testing

All 20 Bedrock Mantle config tests pass (10 for OpenAIModel + 10 for OpenAIResponsesModel).

Fixes #2629