### PR TITLE
docs: add strands-apify community tool page

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -295,6 +295,7 @@ sidebar:
           - docs/community/tools/utcp
       - label: Tools
         items:
+          - docs/community/tools/strands-apify
           - docs/community/tools/strands-deepgram
           - docs/community/tools/strands-hubspot
           - docs/community/tools/strands-spraay

--- a/site/src/content/docs/community/tools/strands-apify.mdx
+++ b/site/src/content/docs/community/tools/strands-apify.mdx
@@ -1,0 +1,73 @@
+---
+project:
+  pypi: https://pypi.org/project/strands-apify/
+  github: https://github.com/apify/strands-apify
+  maintainer: apify
+service:
+  name: apify
+  link: https://apify.com/
+title: strands-apify
+community: true
+description: "Web scraping for social media, search engines, e-commerce, and more via Apify Actors"
+integrationType: tool
+languages: Python
+sidebar:
+  label: "Apify"
+---
+
+
+[strands-apify](https://github.com/apify/strands-apify) gives your Strands agent web scraping, search, crawling, e-commerce, and social media capabilities through the [Apify platform](https://apify.com/) and its library of thousands of pre-built Actors.
+
+## Prerequisites
+
+- An [Apify account](https://apify.com/) (free tier available)
+- [Apify API token](https://console.apify.com/account/integrations) from Apify Console > Integrations
+
+## Installation
+
+```bash
+pip install strands-apify
+```
+
+## Usage
+
+```python
+from strands import Agent
+from strands_apify import APIFY_CORE_TOOLS
+
+agent = Agent(tools=APIFY_CORE_TOOLS)
+agent("Scrape https://docs.apify.com and summarize the page")
+```
+
+Pick individual tools for a more focused agent:
+
+```python
+from strands import Agent
+from strands_apify import apify_google_search_scraper
+
+agent = Agent(tools=[apify_google_search_scraper])
+agent("Find the top-rated Italian restaurants in Prague")
+```
+
+## Key Features
+
+- **18 pre-built tools** for scraping, search, social media, and e-commerce
+- **Focused tool sets** (`APIFY_CORE_TOOLS`, `APIFY_SEARCH_TOOLS`, `APIFY_SOCIAL_TOOLS`) sized for reliable LLM tool selection; `APIFY_ALL_TOOLS` bundles everything but can overwhelm tool choice
+- **Apify Store access** to run any of thousands of Actors with a single generic tool
+- **Dataset integration** to fetch and process Actor results directly
+- **URL to markdown** conversion for any webpage
+
+## Configuration
+
+```bash
+APIFY_TOKEN=your_apify_api_token          # Required
+STRANDS_APIFY_QUIET=1                     # Optional: suppress rich panels in interactive shells
+```
+
+## Resources
+
+- [PyPI package](https://pypi.org/project/strands-apify/)
+- [GitHub repository](https://github.com/apify/strands-apify)
+- [Full tool reference and examples](https://docs.apify.com/platform/integrations/strands-agents)
+- [Apify Store](https://apify.com/store)
+- [Apify API reference](https://docs.apify.com/api/v2)

--- a/site/src/content/docs/community/tools/strands-apify.mdx
+++ b/site/src/content/docs/community/tools/strands-apify.mdx
@@ -16,7 +16,7 @@ sidebar:
 ---
 
 
-[strands-apify](https://github.com/apify/strands-apify) gives your Strands agent web scraping, search, crawling, e-commerce, and social media capabilities through the [Apify platform](https://apify.com/) and its library of thousands of pre-built Actors.
+[strands-apify](https://github.com/apify/strands-apify) gives your Strands agent web scraping, search, crawling, e-commerce, and social media capabilities through the [Apify platform](https://apify.com/) and its library of thousands of pre-built Actors. For the full tool reference and model provider setup, see the [Strands Agents on Apify docs](https://docs.apify.com/platform/integrations/strands-agents).
 
 ## Prerequisites
 

--- a/site/src/content/docs/community/tools/strands-apify.mdx
+++ b/site/src/content/docs/community/tools/strands-apify.mdx
@@ -12,7 +12,7 @@ description: "Web scraping for social media, search engines, e-commerce, and mor
 integrationType: tool
 languages: Python
 sidebar:
-  label: "Apify"
+  label: "apify"
 ---
 
 


### PR DESCRIPTION
## Description

Adds a documentation page for [strands-apify](https://github.com/apify/strands-apify),
a community integration that gives Strands agents web scraping, search, crawling,
e-commerce, and social media capabilities through the Apify platform.

The page covers:
- Prerequisites (Apify account + API token)
- Installation via pip
- Usage examples for both a pre-built tool set (`APIFY_CORE_TOOLS`) and individual tool selection
- Key features including all four tool set constants (`APIFY_CORE_TOOLS`, `APIFY_SEARCH_TOOLS`,
  `APIFY_SOCIAL_TOOLS`, `APIFY_ALL_TOOLS`) with a note on when to use each
- Environment variable configuration (`APIFY_TOKEN`, `STRANDS_APIFY_QUIET`)
- Links to the full Apify-side reference docs, PyPI, GitHub, and Apify Store

Also adds the page to `navigation.yml` under Community > Tools.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

All changes are under `site/src/content/docs/community/tools/strands-apify.mdx` and
`site/src/config/navigation.yml`.

## Type of Change

Documentation update

## Testing

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.