### PR TITLE
feat: add pr-feedback agent skill for triaging PR review comments

### DIFF
--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -38,15 +38,12 @@ Ensure the final PR body is written to `.local/pr-body.md` (create `.local/` if 
 gh pr create \
   --title "<title>" \
   --body-file .local/pr-body.md \
-  --draft \
-  --web
+  --draft
 ```
 
 - Default to `--draft`. Only omit it if the user explicitly asks for a non-draft PR.
 - Do NOT pass `--repo` — let `gh` infer the upstream from the git remotes so the PR targets the correct upstream repository.
-- Always pass `--web` to open the PR in the browser for final review before submission.
 
 ## Rules
 
-- Never create the PR without `--web` — the user must confirm in the browser.
 - If `gh` is not authenticated or the command fails, show the error and stop.

--- a/.agents/skills/pr-feedback/SKILL.md
+++ b/.agents/skills/pr-feedback/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: pr-feedback
+description: Fetches PR review feedback and inline comments, categorizes them, and presents options to the user. Use when the user asks to get, read, address, or fix review comments on a pull request.
+---
+
+# PR Review Feedback
+
+Fetch PR review feedback and inline comments, categorize them, and present options to fix.
+
+## Process
+
+### 1. Determine the PR Number
+
+Auto-detect from the current branch:
+
+```bash
+gh pr view --json number -q .number
+```
+
+If that fails (detached HEAD, no tracking branch), ask the user for the PR number or URL.
+
+### 2. Fetch All Feedback
+
+Use the bundled script to fetch reviews, inline comments, and issue-level comments in one shot:
+
+```bash
+bash .agents/skills/pr-feedback/fetch-pr-feedback.sh <number> [--repo owner/repo]
+```
+
+- Omit `<number>` to auto-detect from the current branch.
+- Use `--repo` when the PR is in a different repo than the current directory.
+
+The script returns JSON with three arrays:
+- `reviews` — top-level review summaries (non-empty bodies only)
+- `inline_comments` — unresolved thread comments with `upvotes`/`downvotes` arrays (usernames who reacted), `outdated` flag, and `diffHunk` on the first comment in each thread
+- `comments` — issue-level comments
+
+### 3. Summarize and Present to the User
+
+Read all the feedback, use your judgment to group related items, and present a numbered list of things to address. Keep each item to one line. Put the most impactful items first.
+
+Use upvotes, downvotes, and the PR author's own replies to determine priority:
+
+- **Upvoted by the PR author**: This signals agreement — recommend fixing it.
+- **Author replied agreeing** (e.g. "good point", "I'll fix", "makes sense"): Same as an upvote — recommend fixing it.
+- **Upvoted by other reviewers** (not the author): Signals community agreement the issue matters — lean toward recommending.
+- **No signal from the author**: Present as a suggestion but don't assume it should be fixed.
+- **Author replied disagreeing or explaining**: Present for context but mark as "discussed — likely skip".
+- **Outdated comments**: Group separately at the end — these may have been addressed by subsequent pushes.
+
+When presenting the list, annotate items you recommend fixing (based on the signals above) so the user can quickly confirm "all recommended" or cherry-pick.
+
+### 4. Fix What the User Selects
+
+Address only the confirmed items. After fixing, briefly note what changed — one line per item.
+
+## Rules
+
+- Always auto-detect the PR number before asking the user.
+- Never fix anything before presenting the list and getting user confirmation.
+- If the output is too large to parse in one shot, focus on non-outdated comments first.

--- a/.agents/skills/pr-feedback/fetch-pr-feedback.sh
+++ b/.agents/skills/pr-feedback/fetch-pr-feedback.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Usage: fetch-pr-feedback [PR_NUMBER] [--repo OWNER/REPO]
+# If PR_NUMBER is omitted, auto-detects from current branch.
+# Outputs all unresolved feedback as JSON to stdout.
+
+REPO_FLAG=()
+PR_NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    *) PR_NUMBER="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$PR_NUMBER" ]]; then
+  PR_NUMBER=$(gh pr view "${REPO_FLAG[@]}" --json number -q .number 2>/dev/null) || {
+    echo "ERROR: Could not detect PR number. Pass it as an argument." >&2
+    exit 1
+  }
+fi
+
+OWNER_REPO=$(gh pr view "$PR_NUMBER" "${REPO_FLAG[@]}" --json url -q '.url' \
+  | sed -E 's|https://github.com/([^/]+/[^/]+)/pull/.*|\1|')
+
+OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
+REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
+
+echo "{"
+
+# Reviews (top-level review summaries, excluding empty-body reviews)
+echo "\"reviews\":"
+gh pr view "$PR_NUMBER" "${REPO_FLAG[@]}" --json reviews \
+  --jq '[.reviews[] | select(.body != "") | {id: .id, author: .author.login, state: .state, body: .body, createdAt: .submittedAt}]'
+echo ","
+
+# Inline comments — only unresolved threads via GraphQL, with outdated flag and reactions
+echo "\"inline_comments\":"
+gh api graphql -f query="
+{
+  repository(owner: \"${OWNER}\", name: \"${REPO}\") {
+    pullRequest(number: ${PR_NUMBER}) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          isOutdated
+          comments(first: 100) {
+            nodes {
+              id
+              path
+              line
+              originalLine
+              body
+              diffHunk
+              createdAt
+              author { login }
+              reactions(first: 10) {
+                nodes {
+                  content
+                  user { login }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not) | . as $thread | .comments.nodes[0] as $first | .comments.nodes[] | {id: .id, path: .path, line: (.line // .originalLine), body: .body, user: .author.login, outdated: $thread.isOutdated, createdAt: .createdAt, upvotes: [.reactions.nodes[] | select(.content == "THUMBS_UP") | .user.login], downvotes: [.reactions.nodes[] | select(.content == "THUMBS_DOWN") | .user.login]} + (if .id == $first.id then {diffHunk: $first.diffHunk} else {} end)]'
+echo ","
+
+# Issue-level comments
+echo "\"comments\":"
+gh pr view "$PR_NUMBER" "${REPO_FLAG[@]}" --json comments \
+  --jq '[.comments[] | {author: .author.login, body: .body, createdAt: .createdAt}]'
+
+echo "}"


### PR DESCRIPTION
## Description

Adds the `pr-feedback` agent skill — a companion to `pr-create` and `pr-writer` that closes the PR feedback loop. When invoked, it fetches all unresolved review comments (reviews, inline threads, and issue-level comments) via a bundled shell script that uses GitHub's GraphQL API. It then categorizes items by priority signals — upvotes from the author indicate agreement, reviewer upvotes signal community consensus, author replies determine whether to recommend or skip — and presents a numbered list the user can selectively address.

The script also surfaces reaction data (thumbs up/down with usernames) on each comment, enabling the skill to distinguish "author agreed to fix" from "open discussion" without requiring the user to manually triage.

## Related Issues

Follow-up to #2646 which added the `pr-create` and `pr-writer` skills.

## Documentation PR

N/A — internal agent skill, not user-facing documentation.

## Type of Change

New feature

## Testing

Tested by invoking the skill against PRs #2646 and #2681 in live Claude Code sessions. The script correctly returns structured JSON with reviews, inline comments (with reactions), and issue-level comments.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
