### PR TITLE
chore: make bedrock kb metadata mutable

### DIFF
--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.ts
@@ -660,6 +660,133 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
   })
 
+  describe('dynamic scope mutability', () => {
+    /** A search store whose `send` echoes the RetrieveCommand and resolves to empty results. */
+    function searchStore(overrides: Record<string, unknown> = {}): {
+      store: BedrockKnowledgeBaseStore
+      runtime: { send: MockedFunction<any> }
+    } {
+      const runtime = mockClient()
+      runtime.send.mockResolvedValue({ retrievalResults: [] })
+      const store = new BedrockKnowledgeBaseStore({
+        name: 'kb',
+        knowledgeBaseId: 'kb-1',
+        runtimeClient: runtime as any,
+        ...overrides,
+      })
+      return { store, runtime }
+    }
+
+    /** Reads the filter the most recent RetrieveCommand was sent with. */
+    function lastSearchFilter(runtime: { send: MockedFunction<any> }): unknown {
+      const calls = runtime.send.mock.calls
+      return calls[calls.length - 1]?.[0].input.retrievalConfiguration.vectorSearchConfiguration.filter
+    }
+
+    /** A writable CUSTOM store whose agent `send` echoes the ingestion command. */
+    function customStore(overrides: Record<string, unknown> = {}): {
+      store: BedrockKnowledgeBaseStore
+      agent: { send: MockedFunction<any> }
+    } {
+      const agent = mockClient()
+      agent.send.mockResolvedValue({})
+      const store = new BedrockKnowledgeBaseStore({
+        name: 'kb',
+        knowledgeBaseId: 'kb-1',
+        writable: true,
+        dataSourceType: 'CUSTOM',
+        dataSourceId: 'ds-1',
+        agentClient: agent as any,
+        ...overrides,
+      })
+      return { store, agent }
+    }
+
+    /** Reads the inline attributes the most recent CUSTOM ingestion document carried. */
+    function lastInlineAttributes(agent: { send: MockedFunction<any> }): any[] {
+      const calls = agent.send.mock.calls
+      return calls[calls.length - 1]?.[0].input.documents[0].metadata?.inlineAttributes ?? []
+    }
+
+    it('reflects a mutated scope in the next search filter', async () => {
+      const { store, runtime } = searchStore({ scope: 'tenant-a' })
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'tenant-a' } })
+
+      store.scope = 'tenant-b'
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'tenant-b' } })
+    })
+
+    it('reflects a mutated scopeMetadataKey in the derived filter', async () => {
+      const { store, runtime } = searchStore({ scope: 'acme' })
+      store.scopeMetadataKey = 'tenant'
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'tenant', value: 'acme' } })
+    })
+
+    it('derives a filter once a scope is set on a previously unscoped store', async () => {
+      const { store, runtime } = searchStore()
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toBeUndefined()
+
+      store.scope = 'later'
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'later' } })
+    })
+
+    it('keeps using an explicit filter even after scope is mutated', async () => {
+      const filter = { equals: { key: 'custom', value: 'v' } }
+      const { store, runtime } = searchStore({ scope: 'a', filter })
+      store.scope = 'b'
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual(filter)
+    })
+
+    it('re-enables scope-derived filtering when the explicit filter is cleared', async () => {
+      const { store, runtime } = searchStore({ scope: 'a', filter: { equals: { key: 'custom', value: 'v' } } })
+      store.filter = undefined
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'a' } })
+    })
+
+    it('snapshots the filter at call entry, ignoring a scope mutation made after the call', async () => {
+      const { store, runtime } = searchStore({ scope: 'before' })
+      const pending = store.search('q')
+      store.scope = 'after' // mutate before the in-flight search settles
+      await pending
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'before' } })
+    })
+
+    it('stamps the current scope on writes after a mutation', async () => {
+      const { store, agent } = customStore({ scope: 'tenant-a' })
+      await store.add('fact')
+      expect(lastInlineAttributes(agent)).toStrictEqual([
+        { key: 'namespace', value: { type: 'STRING', stringValue: 'tenant-a' } },
+      ])
+
+      store.scope = 'tenant-b'
+      await store.add('fact')
+      expect(lastInlineAttributes(agent)).toStrictEqual([
+        { key: 'namespace', value: { type: 'STRING', stringValue: 'tenant-b' } },
+      ])
+    })
+
+    it('still scopes writes by scope even when an explicit search filter is set (search/write asymmetry)', async () => {
+      const { store, agent } = customStore({ scope: 'tenant-a', filter: { equals: { key: 'custom', value: 'v' } } })
+      await store.add('fact')
+      expect(lastInlineAttributes(agent)).toStrictEqual([
+        { key: 'namespace', value: { type: 'STRING', stringValue: 'tenant-a' } },
+      ])
+    })
+
+    it('leaves name (the routing identity) untouched when scope is mutated', () => {
+      const { store } = searchStore({ scope: 'a' })
+      store.scope = 'b'
+      expect(store.name).toBe('kb')
+    })
+  })
+
   describe('metadata logging', () => {
     it('logs a debug line when a CUSTOM document drops an unsupported metadata value', async () => {
       const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {})

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
@@ -148,9 +148,29 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
   private readonly _knowledgeBaseId: string
   private readonly _dataSourceType: 'CUSTOM' | 'S3' | 'OTHER' | undefined
   private readonly _dataSourceId: string | undefined
-  private readonly _scope: string | undefined
-  private readonly _scopeMetadataKey: string
-  private readonly _filter: RetrievalFilter | undefined
+
+  /**
+   * Logical namespace isolating documents: applied as a metadata filter on {@link search} and stamped
+   * on writes via {@link add}.
+   *
+   * Mutable at runtime — assign a new value to re-point subsequent `search`/`add` calls at a different
+   * partition (e.g. switching the active tenant on a reused store). The effective search filter is
+   * derived from this on each call (see {@link _resolveFilter}), so a change takes effect immediately;
+   * an explicit {@link filter} overrides it for search. Unlike {@link name}, this is not a store-identity
+   * field, so changing it never affects `MemoryManager` routing.
+   *
+   * A store instance shared across agents shares one `scope`. For concurrent per-tenant isolation,
+   * give each agent its own store instance (cheap — it is just config) rather than mutating a shared one.
+   */
+  public scope: string | undefined
+  /** Metadata attribute key used for scope-based filtering. Mutable at runtime; see {@link scope}. */
+  public scopeMetadataKey: string
+  /**
+   * Explicit retrieval filter. When set, it overrides the scope-derived filter for {@link search}.
+   * Mutable at runtime — set to `undefined` to re-enable scope-derived search filtering. Note the
+   * asymmetry: an explicit filter affects search only; writes always scope by {@link scope}.
+   */
+  public filter: RetrievalFilter | undefined
 
   constructor(config: BedrockKnowledgeBaseStoreConfig) {
     this.name = config.name
@@ -173,19 +193,22 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
 
     if (this.writable) this._validateWriteConfig()
 
-    this._scope = config.scope
-    this._scopeMetadataKey = config.scopeMetadataKey ?? 'namespace'
+    // Store raw config only; the effective search filter is derived per call in `_resolveFilter` so
+    // runtime mutations of `scope` / `scopeMetadataKey` / `filter` take effect immediately.
+    this.scope = config.scope
+    this.scopeMetadataKey = config.scopeMetadataKey ?? 'namespace'
+    this.filter = config.filter
+  }
 
-    if (config.filter) {
-      this._filter = config.filter
-    } else if (config.scope) {
-      this._filter = {
-        equals: {
-          key: this._scopeMetadataKey,
-          value: config.scope,
-        },
-      }
-    }
+  /**
+   * Resolves the effective retrieval filter for a search: an explicit {@link filter} wins; otherwise
+   * one is derived from the current {@link scope} / {@link scopeMetadataKey}. Computed per call (rather
+   * than precomputed at construction) so runtime mutations of those fields are reflected.
+   */
+  private _resolveFilter(): RetrievalFilter | undefined {
+    if (this.filter) return this.filter
+    if (this.scope) return { equals: { key: this.scopeMetadataKey, value: this.scope } }
+    return undefined
   }
 
   /**
@@ -202,6 +225,9 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
       throw new Error('BedrockKnowledgeBaseStore: maxSearchResults must be at least 1.')
     }
     const limit = options?.maxSearchResults || this.maxSearchResults || DEFAULT_MAX_SEARCH_RESULTS
+    // Snapshot the filter at call entry (before the first await) so it is deterministic for this
+    // in-flight search even if `scope` / `filter` are mutated concurrently.
+    const filter = this._resolveFilter()
 
     let response
     try {
@@ -212,7 +238,7 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
           retrievalConfiguration: {
             vectorSearchConfiguration: {
               numberOfResults: limit,
-              ...(this._filter && { filter: this._filter }),
+              ...(filter && { filter }),
             },
           },
         })
@@ -402,13 +428,13 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
   ): Array<{ key: string; value: MetadataAttributeValue }> {
     const attrs: Array<{ key: string; value: MetadataAttributeValue }> = []
 
-    if (this._scope) {
-      attrs.push({ key: this._scopeMetadataKey, value: { type: 'STRING', stringValue: this._scope } })
+    if (this.scope) {
+      attrs.push({ key: this.scopeMetadataKey, value: { type: 'STRING', stringValue: this.scope } })
     }
 
     if (metadata) {
       for (const [key, value] of Object.entries(metadata)) {
-        if (this._scope && key === this._scopeMetadataKey) {
+        if (this.scope && key === this.scopeMetadataKey) {
           logger.warn(`store=<${this.name}>, key=<${key}> | dropping metadata key that collides with scopeMetadataKey`)
           continue
         }


### PR DESCRIPTION
## Description

Makes a `BedrockKnowledgeBaseStore`'s scoping metadata mutable at runtime so a developer can re-point the store at a different tenant/namespace partition without rebuilding it — e.g. switching the active user on a reused store, or re-scoping inside a hook/tool callback.

Previously `scope`, `scopeMetadataKey`, and `filter` were captured into private `readonly` fields and the retrieval filter was **precomputed in the constructor**. The write path (`_resolveAttributes`) already read `scope` lazily, but `search()` used the frozen `_filter`, so even exposing `scope` would not have changed search behavior. This PR fixes that asymmetry:

- `_scope` / `_scopeMetadataKey` / `_filter` (private `readonly`) become **`scope` / `scopeMetadataKey` / `filter`** public mutable fields.
- The precomputed constructor filter is removed; the constructor now stores raw config only.
- A new private `_resolveFilter()` derives the effective filter **per call** — an explicit `filter` wins, otherwise it is derived from the current `scope` / `scopeMetadataKey` — so mutations take effect on the next `search`/`add`.
- `search()` snapshots the filter at call entry (before the first `await`) so it is deterministic for an in-flight call even if `scope` is mutated concurrently.

Store **identity stays immutable**: `name` (and `writable`) remain `readonly` because `MemoryManager` keys all routing and dedup on `name`. The change is localized to the concrete store — the `MemoryStore` interface is unchanged.

Note the intentional asymmetry, documented on the fields: an explicit `filter` overrides scope for **search only**; writes always scope by `scope`. Set `store.filter = undefined` to re-enable scope-derived search filtering.

This also reserves a forward-compatible seam: if per-invocation namespace resolution from `appState` is needed later, it can be added as an optional trailing `context` parameter on the store methods (read inside the same lazy `_resolve*` helpers), which is non-breaking under structural typing. That is documented but not implemented here.

## Related Issues

Follows up on #2630 (the `BedrockKnowledgeBaseStore` implementation). Addresses the per-write namespacing question raised in #2671 (review thread r3388561124).

## Documentation PR

No `site/` docs change. Updated the design doc `designs/0011-memory-manager.md` with a "Dynamic store metadata" convention note (identity fields immutable; behavioral fields may be mutable if derived lazily; per-agent isolation by instance; the reserved optional-`context` seam).

## Type of Change

New feature

## Testing

Added unit tests to `bedrock-knowledge-base-store.test.ts` (in a `dynamic scope mutability` block) covering: scope mutation reflected in the next search filter, `scopeMetadataKey` mutation, deriving a filter once a scope is set on a previously unscoped store, an explicit filter overriding and surviving scope mutation, clearing the filter to re-enable scope-derived search, snapshot-at-call-entry (a post-call mutation is ignored by the in-flight search), writes following the current scope after mutation, the search/write asymmetry, and `name` staying untouched.

- 50/50 unit tests pass (`vitest run --project unit-node`), 40 existing + 10 new; no type errors.
- `tsc --noEmit --project src/tsconfig.json` clean.
- ESLint clean on the changed source files; Prettier clean on the changed source files.

- [ ] I ran `hatch run prepare` (N/A — TypeScript package; ran `vitest`, `tsc`, `eslint`, `prettier` instead)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.