### PR TITLE
feat: migrate TS integration test role to shared test-infra CDK stack

### DIFF
--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Configure Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+         role-to-assume: ${{ secrets.STRANDS_INTEG_TEST_ROLE }}
          aws-region: us-east-1
          mask-aws-account-id: true
 

--- a/strands-ts/test/integ/__fixtures__/model-providers.ts
+++ b/strands-ts/test/integ/__fixtures__/model-providers.ts
@@ -43,7 +43,7 @@ export const bedrock = {
   models: {
     default: {},
     reasoning: {
-      modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+      modelId: 'global.anthropic.claude-sonnet-4-6',
       additionalRequestFields: { thinking: { type: 'enabled', budget_tokens: 1024 } },
     },
     video: { modelId: 'us.amazon.nova-pro-v1:0' },
@@ -245,7 +245,7 @@ export const vercelBedrock = {
       providerOptions?: Record<string, unknown>
     }
     return new VercelModel({
-      provider: provider('us.anthropic.claude-sonnet-4-20250514-v1:0'),
+      provider: provider('global.anthropic.claude-sonnet-4-6'),
       ...rest,
       ...(providerOptions && { providerOptions }),
     })

--- a/test-infra/lib/constructs/bedrock-knowledge-base-test-resources.ts
+++ b/test-infra/lib/constructs/bedrock-knowledge-base-test-resources.ts
@@ -5,7 +5,7 @@ import * as s3vectors from 'aws-cdk-lib/aws-s3vectors';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as bedrock from 'aws-cdk-lib/aws-bedrock';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
-import { TestFeatureConstruct } from './test-feature-construct';
+import { TestFeatureConstruct, TestFeatureConstructProps } from './test-feature-construct';
 
 /**
  * Titan Text Embeddings v2 produces 1024-dimensional vectors and Bedrock
@@ -22,13 +22,7 @@ const EMBEDDING_DIMENSION = 1024;
  */
 const NON_FILTERABLE_METADATA_KEYS = ['AMAZON_BEDROCK_TEXT', 'AMAZON_BEDROCK_METADATA'];
 
-export interface BedrockKnowledgeBaseTestResourcesProps {
-  /**
-   * Shared integration-test role granted permission to query the knowledge
-   * base and ingest documents into it. When omitted the usage grant is skipped.
-   */
-  readonly role?: iam.IRole;
-}
+export interface BedrockKnowledgeBaseTestResourcesProps extends TestFeatureConstructProps {}
 
 /**
  * A Bedrock knowledge base backed by an S3 Vectors index, its source bucket,

--- a/test-infra/lib/constructs/integ-test-role.ts
+++ b/test-infra/lib/constructs/integ-test-role.ts
@@ -65,6 +65,13 @@ export class IntegTestRole extends Construct {
       maxSessionDuration: cdk.Duration.hours(1),
     });
 
+    this.role.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['sts:GetCallerIdentity'],
+        resources: ['*'],
+      }),
+    );
+
     if (props.internal) {
       this.addLegacyBasePolicy();
     }
@@ -96,6 +103,7 @@ export class IntegTestRole extends Construct {
           'arn:aws:bedrock:*:*:foundation-model/anthropic.claude-3-haiku-20240307-v1:0',
           'arn:aws:bedrock:*:*:foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
           'arn:aws:bedrock:*:*:foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0',
+          'arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0',
           'arn:aws:bedrock:*:*:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0',
           'arn:aws:bedrock:*:*:foundation-model/meta.llama3-2-90b-instruct-v1:0',
           'arn:aws:bedrock:*:*:inference-profile/us.meta.llama3-2-90b-instruct-v1:0',

--- a/test-infra/lib/constructs/ssh-ec2-test-resources.ts
+++ b/test-infra/lib/constructs/ssh-ec2-test-resources.ts
@@ -3,16 +3,9 @@ import { Construct } from 'constructs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
-import { TestFeatureConstruct } from './test-feature-construct';
+import { TestFeatureConstruct, TestFeatureConstructProps } from './test-feature-construct';
 
-export interface SshEc2TestResourcesProps {
-  /**
-   * Shared integration-test role granted permission to open an SSM session to
-   * the instance and read its SSH private key. When omitted the usage grant is
-   * skipped.
-   */
-  readonly role?: iam.IRole;
-}
+export interface SshEc2TestResourcesProps extends TestFeatureConstructProps {}
 
 /**
  * The smallest reachable Linux instance the SSH sandbox integration test can

--- a/test-infra/lib/constructs/test-feature-construct.ts
+++ b/test-infra/lib/constructs/test-feature-construct.ts
@@ -3,6 +3,14 @@ import { Construct } from 'constructs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { TestFeature, ssmParameterPath } from '../constants';
 
+export interface TestFeatureConstructProps {
+  /**
+   * Shared integration-test role granted scoped permissions by the feature.
+   * When omitted the usage grant is skipped.
+   */
+  readonly role?: iam.IRole;
+}
+
 export abstract class TestFeatureConstruct extends Construct {
   abstract readonly featureName: TestFeature;
 

--- a/test-infra/package-lock.json
+++ b/test-infra/package-lock.json
@@ -19,6 +19,9 @@
         "ts-jest": "^29",
         "ts-node": "^10.9.2",
         "typescript": "~5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -2217,6 +2220,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2236,6 +2240,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
       "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3902,6 +3907,7 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -4313,6 +4319,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"


### PR DESCRIPTION
## Description

Migrate the TypeScript SDK integration test role into the shared `test-infra/` CDK stack. This aligns the TS role with the pattern already used by the Python SDK, where feature-scoped constructs (Bedrock KB, SSH EC2) layer scoped grants onto a shared identity.

Changes:
- Add `sts:GetCallerIdentity` to the base role (used by session tests to derive account ID for bucket naming, applies to all deploys including community)
- Add missing `us.*` inference profile for Claude Sonnet 4.5 to the IAM role (required by caching tests)
- Bump deprecated model references in test fixtures to current models
- Wire the TS integration test workflow to use the role from the shared stack
- Add CDK constructs for Bedrock Knowledge Base and SSH EC2 test resources with scoped IAM grants
- Add `TestFeatureConstruct` base class with SSM parameter helpers

## Related Issues

N/A

## Type of Change

New feature

## Testing

- Verified all model IDs used in integration tests have corresponding ARNs in the role
- CI will validate end-to-end once the stack is deployed

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
