### PR TITLE
ci: allow `blog` type in PR title validation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,6 +20,7 @@ jobs:
             feat
             fix
             docs
+            blog
             style
             refactor
             perf


### PR DESCRIPTION
## Description

Add `blog` as a valid conventional commit type prefix in the PR title validation workflow. PRs prefixed with `blog:` were being rejected by the linter even though they represent a legitimate change category for blog content.

## Related Issues

None

## Documentation PR

N/A — CI-only change.

## Type of Change

Other (please describe): CI workflow update

## Testing

Verified the YAML is valid and the new type is correctly placed in the allowlist.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.