### PR TITLE
fix(strands-py): default to us-east-1 for integration tests

### DIFF
--- a/strands-py/tests_integ/conftest.py
+++ b/strands-py/tests_integ/conftest.py
@@ -125,6 +125,8 @@ def retry_on_flaky(
 
 
 def pytest_sessionstart(session):
+    os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+    os.environ.setdefault("AWS_REGION", "us-east-1")
     _load_api_keys_from_secrets_manager()
 
 


### PR DESCRIPTION
## Description

Default `AWS_DEFAULT_REGION` and `AWS_REGION` to `us-east-1` in the python integration test This matches the CI workflow configuration and allows local integration test runs to work without manually exporting region env vars (which drives me nuts normally)

## Related Issues

N/A

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
