### PR TITLE
feat: pass sequenceNumber to memory store addMessages method

### DIFF
--- a/strands-ts/src/memory/extraction/__tests__/extraction.test.ts
+++ b/strands-ts/src/memory/extraction/__tests__/extraction.test.ts
@@ -4,7 +4,7 @@ import { InvocationTrigger, IntervalTrigger } from '../triggers.js'
 import { ExtractionCoordinator, SAVE_FAILURES_BEFORE_BACKOFF, BACKOFF_PROBE_INTERVAL } from '../coordinator.js'
 import type { Model } from '../../../models/model.js'
 import type { ExtractionConfig, Extractor } from '../types.js'
-import type { MemoryStore, MemoryEntry } from '../../types.js'
+import type { MemoryStore, MemoryEntry, AddMessagesContext } from '../../types.js'
 import type { MessageData } from '../../../types/messages.js'
 import { Message, TextBlock, ToolUseBlock } from '../../../types/messages.js'
 import { AfterInvocationEvent, MessageAddedEvent } from '../../../hooks/events.js'
@@ -130,6 +130,119 @@ describe('MemoryManager extraction', () => {
       expect(batch).toHaveLength(2)
       expect(batch[0]!.role).toBe('user')
       expect(batch[1]!.role).toBe('assistant')
+    })
+  })
+
+  describe('addMessages context (per-message seqs)', () => {
+    it('passes sequenceNumbers index-aligned with the filtered batch', async () => {
+      const store = createExtractionStore('s', { trigger: [new InvocationTrigger()] }, 'addMessages')
+      const mm = new MemoryManager({ stores: [store] })
+      const agent = createMockAgent()
+      mm.initAgent(agent)
+
+      await addMessages(agent, userMsg('first'), userMsg('second'))
+      await fireInvocation(agent, mm)
+
+      const batch = store.addMessages.mock.calls[0]![0] as MessageData[]
+      const ctx = store.addMessages.mock.calls[0]![1] as AddMessagesContext
+      // Assert the whole context so an unexpected field added to the envelope later is caught.
+      expect(ctx).toEqual({ sequenceNumbers: [0, 1] })
+      expect(ctx.sequenceNumbers).toHaveLength(batch.length)
+    })
+
+    it('keeps a message seq when a message before it is filtered to empty (gap)', async () => {
+      const store = createExtractionStore('s', { trigger: [new InvocationTrigger()] }, 'addMessages')
+      const mm = new MemoryManager({ stores: [store] })
+      const agent = createMockAgent()
+      mm.initAgent(agent)
+
+      // seq 0 (kept), seq 1 (tool-only, filtered to empty and dropped), seq 2 (kept).
+      const toolOnly = new Message({
+        role: 'assistant',
+        content: [new ToolUseBlock({ name: 't', toolUseId: '1', input: {} })],
+      })
+      await addMessages(agent, userMsg('a'), toolOnly, userMsg('b'))
+      await fireInvocation(agent, mm)
+
+      const batch = store.addMessages.mock.calls[0]![0] as MessageData[]
+      const ctx = store.addMessages.mock.calls[0]![1] as AddMessagesContext
+      expect(batch).toHaveLength(2)
+      // The dropped message leaves a gap: 1 is missing, the surviving messages keep their own seqs.
+      expect(ctx).toEqual({ sequenceNumbers: [0, 2] })
+    })
+
+    it('re-fires the same seqs for a multi-message batch whose save failed (stable across retries)', async () => {
+      const store = createExtractionStore('s', { trigger: [new InvocationTrigger()] }, 'addMessages')
+      store.addMessages.mockRejectedValueOnce(new Error('backend down'))
+      const mm = new MemoryManager({ stores: [store] })
+      const agent = createMockAgent()
+      mm.initAgent(agent)
+
+      await addMessages(agent, userMsg('first'), userMsg('second'))
+      await fireInvocation(agent, mm) // fails, mark rolled back
+      await fireInvocation(agent, mm) // retries the same batch
+
+      expect(store.addMessages).toHaveBeenCalledTimes(2)
+      const first = store.addMessages.mock.calls[0]![1] as AddMessagesContext
+      const second = store.addMessages.mock.calls[1]![1] as AddMessagesContext
+      expect(first).toEqual({ sequenceNumbers: [0, 1] })
+      // The retry carries the identical context in order, not a fresh renumbering.
+      expect(second).toEqual(first)
+    })
+
+    it('anchors the seq to the message, not the batch position', async () => {
+      const store = createExtractionStore('s', { trigger: [new InvocationTrigger()] }, 'addMessages')
+      const mm = new MemoryManager({ stores: [store] })
+      const agent = createMockAgent()
+      mm.initAgent(agent)
+
+      // First turn (seq 0) saves cleanly; second turn (seq 1) fails then retries.
+      await addMessages(agent, userMsg('turn one'))
+      await fireInvocation(agent, mm)
+      store.addMessages.mockRejectedValueOnce(new Error('backend down'))
+      await addMessages(agent, userMsg('turn two'))
+      await fireInvocation(agent, mm) // fails, rolled back
+      await fireInvocation(agent, mm) // retries turn two
+
+      expect(store.addMessages).toHaveBeenCalledTimes(3)
+      const retried = store.addMessages.mock.calls[2]![1] as AddMessagesContext
+      // Retried batch carries the message's original seq (1), not a renumbered 0.
+      expect(retried).toEqual({ sequenceNumbers: [1] })
+    })
+
+    it('gives each store index-aligned seqs from the shared buffer', async () => {
+      const a = createExtractionStore('a', { trigger: [new InvocationTrigger()] }, 'addMessages')
+      const b = createExtractionStore('b', { trigger: [new InvocationTrigger()] }, 'addMessages')
+      const mm = new MemoryManager({ stores: [a, b] })
+      const agent = createMockAgent()
+      mm.initAgent(agent)
+
+      await addMessages(agent, userMsg('first'), userMsg('second'))
+      await fireInvocation(agent, mm)
+
+      const ctxA = a.addMessages.mock.calls[0]![1] as AddMessagesContext
+      const ctxB = b.addMessages.mock.calls[0]![1] as AddMessagesContext
+      expect(ctxA).toEqual({ sequenceNumbers: [0, 1] })
+      expect(ctxB).toEqual({ sequenceNumbers: [0, 1] })
+    })
+
+    it('does not pass sequenceNumbers on the extractor route', async () => {
+      const extractor: Extractor = { extract: vi.fn().mockResolvedValue([{ content: 'fact' }]) }
+      const store = createExtractionStore('s', { trigger: [new InvocationTrigger()], extractor }, 'both')
+      const mm = new MemoryManager({ stores: [store] })
+      const agent = createMockAgent()
+      mm.initAgent(agent)
+
+      await addMessages(agent, userMsg('something happened'))
+      await fireInvocation(agent, mm)
+
+      expect(store.addMessages).not.toHaveBeenCalled()
+      // The extractor receives (messages, context); the context is the extractor envelope only, with
+      // no sequenceNumbers. Assert the whole object so a future stray field is caught positively.
+      expect(extractor.extract).toHaveBeenCalledTimes(1)
+      const extractArgs = (extractor.extract as ReturnType<typeof vi.fn>).mock.calls[0]!
+      expect(extractArgs).toHaveLength(2)
+      expect(extractArgs[1]).toEqual({ defaultModel: undefined })
     })
   })
 

--- a/strands-ts/src/memory/extraction/coordinator.ts
+++ b/strands-ts/src/memory/extraction/coordinator.ts
@@ -24,17 +24,23 @@ function _blockKind(block: ContentBlockData): string {
   return Object.keys(block)[0] ?? ''
 }
 
-/** Removes excluded content blocks, and drops any message left empty. Does not mutate the input. */
-function _filterMessages(messages: MessageData[], filter: MemoryMessageFilter): MessageData[] {
+/**
+ * Removes excluded content blocks, and drops any message left empty. Does not mutate the input.
+ * Carries each message's sequence number through so it stays aligned with the filtered batch.
+ */
+function _filterMessages(buffered: BufferedMessage[], filter: MemoryMessageFilter): BufferedMessage[] {
   const exclude = new Set<string>(filter.exclude)
-  const result: MessageData[] = []
-  for (const message of messages) {
+  const result: BufferedMessage[] = []
+  for (const { seq, message } of buffered) {
     const content = message.content.filter((block) => !exclude.has(_blockKind(block)))
     if (content.length > 0) {
       result.push({
-        role: message.role,
-        content,
-        ...(message.metadata !== undefined && { metadata: message.metadata }),
+        seq,
+        message: {
+          role: message.role,
+          content,
+          ...(message.metadata !== undefined && { metadata: message.metadata }),
+        },
       })
     }
   }
@@ -173,10 +179,7 @@ export class ExtractionCoordinator {
 
     const extraction = store.extraction!
     const filter = extraction.filter ?? DEFAULT_MEMORY_MESSAGE_FILTER
-    const filtered = _filterMessages(
-      fresh.map((buffered) => buffered.message),
-      filter
-    )
+    const filtered = _filterMessages(fresh, filter)
 
     try {
       if (filtered.length > 0) {
@@ -223,8 +226,9 @@ export class ExtractionCoordinator {
    * Fact writes run in parallel. If any fails we throw, which makes the caller retry the whole batch
    * next time - so a fact that already saved may be written again (stores should expect duplicates).
    */
-  private async _write(store: MemoryStore, messages: MessageData[]): Promise<void> {
+  private async _write(store: MemoryStore, buffered: BufferedMessage[]): Promise<void> {
     const extractor = store.extraction!.extractor
+    const messages = buffered.map((buffer) => buffer.message)
 
     if (extractor) {
       const entries = await extractor.extract(messages, { defaultModel: this._defaultModel })
@@ -232,14 +236,15 @@ export class ExtractionCoordinator {
       const failures = settled.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
       if (failures.length > 0) {
         throw new AggregateError(
-          failures.map((f) => f.reason),
+          failures.map((failure) => failure.reason),
           `failed to write ${failures.length} of ${entries.length} extracted entries`
         )
       }
       return
     }
 
-    await store.addMessages!(messages)
+    // Pass each message's sequence number so a store can build an idempotency key surviving retries.
+    await store.addMessages!(messages, { sequenceNumbers: buffered.map((buffer) => buffer.seq) })
   }
 
   /**

--- a/strands-ts/src/memory/types.ts
+++ b/strands-ts/src/memory/types.ts
@@ -35,10 +35,20 @@ export interface SearchOptions {
 
 /**
  * Context the {@link MemoryManager} supplies to {@link MemoryStore.addMessages} alongside a batch.
+ *
+ * An extension point: fields are added here without changing the {@link MemoryStore.addMessages}
+ * signature.
  */
-// Extension point: empty interface so fields can be added without a breaking signature change.
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface AddMessagesContext {}
+export interface AddMessagesContext {
+  /**
+   * Per-message identities aligned one-to-one with `messages` (`sequenceNumbers[i]` identifies
+   * `messages[i]`). A retried batch reuses the same numbers, so a store can build an idempotency key
+   * that survives retries - unlike a content hash, which collides when two messages share text (e.g.
+   * "ok"). Numbers increase with order but may have gaps, and reset to 0 each agent run, so a durable
+   * dedup token must combine one with a run-unique id.
+   */
+  readonly sequenceNumbers?: readonly number[]
+}
 
 /**
  * Declarative properties shared by every memory store and its config.


### PR DESCRIPTION
## Description

Additive backward-compatible extension point for the memory subsystem, requested by the AgentCore Memory team while building a store on top of `MemoryManager`. Per-message `sequenceNumbers` on `AddMessagesContext` to enable deduping.

Extraction delivery is at-least-once: when an `addMessages` write fails, the coordinator rolls its mark back and re-fires the same batch (the documented "stores should expect duplicates" path). A backend that dedups on a client-supplied token (e.g. AgentCore's `createEvent` `clientToken`) needs each logical message to produce the *same* token on the original send and every re-send. Content hashing breaks this when two distinct messages share text ("ok", "yes"); positional batch index breaks it because filtering and retries shift positions.

The coordinator already assigns each buffered message a stable `seq` at record time that survives re-fire. We now thread those numbers through to the store:

```typescript
addMessages?(messages: MessageData[], context?: AddMessagesContext): Promise<unknown>

interface AddMessagesContext {
  // sequenceNumbers[i] identifies messages[i]; a retried batch reuses the same numbers.
  readonly sequenceNumbers?: readonly number[]
}
```

`sequenceNumbers` is index-aligned with the filtered batch the store actually receives, so content filtering that drops a message leaves a gap (a batch may carry `[0, 2]`) rather than renumbering. Numbers are stable only within one agent run and reset to 0 across runs, so a durable dedup token must combine one with a run-unique id (e.g. `${sessionId}:${seq}`). Populated only on the no-extractor passthrough; the extractor route is unchanged.

## Related Issues

N/A

## Documentation PR

No new docs required — both are additive extension points documented inline; no public surface a user follows a guide to reach.

## Type of Change

New feature

## Testing

Unit tests

This is the TypeScript SDK (`strands-ts/`); `hatch run prepare` is the Python workflow and does not apply. Validated with the TS build, the memory + Bedrock KB unit suites, and lint.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.