### PR TITLE
fix: improve devx for instantiating multiple bedrock KBs

### DIFF
--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.ts
@@ -660,6 +660,133 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
   })
 
+  describe('dynamic scope mutability', () => {
+    /** A search store whose `send` echoes the RetrieveCommand and resolves to empty results. */
+    function searchStore(overrides: Record<string, unknown> = {}): {
+      store: BedrockKnowledgeBaseStore
+      runtime: { send: MockedFunction<any> }
+    } {
+      const runtime = mockClient()
+      runtime.send.mockResolvedValue({ retrievalResults: [] })
+      const store = new BedrockKnowledgeBaseStore({
+        name: 'kb',
+        knowledgeBaseId: 'kb-1',
+        runtimeClient: runtime as any,
+        ...overrides,
+      })
+      return { store, runtime }
+    }
+
+    /** Reads the filter the most recent RetrieveCommand was sent with. */
+    function lastSearchFilter(runtime: { send: MockedFunction<any> }): unknown {
+      const calls = runtime.send.mock.calls
+      return calls[calls.length - 1]?.[0].input.retrievalConfiguration.vectorSearchConfiguration.filter
+    }
+
+    /** A writable CUSTOM store whose agent `send` echoes the ingestion command. */
+    function customStore(overrides: Record<string, unknown> = {}): {
+      store: BedrockKnowledgeBaseStore
+      agent: { send: MockedFunction<any> }
+    } {
+      const agent = mockClient()
+      agent.send.mockResolvedValue({})
+      const store = new BedrockKnowledgeBaseStore({
+        name: 'kb',
+        knowledgeBaseId: 'kb-1',
+        writable: true,
+        dataSourceType: 'CUSTOM',
+        dataSourceId: 'ds-1',
+        agentClient: agent as any,
+        ...overrides,
+      })
+      return { store, agent }
+    }
+
+    /** Reads the inline attributes the most recent CUSTOM ingestion document carried. */
+    function lastInlineAttributes(agent: { send: MockedFunction<any> }): any[] {
+      const calls = agent.send.mock.calls
+      return calls[calls.length - 1]?.[0].input.documents[0].metadata?.inlineAttributes ?? []
+    }
+
+    it('reflects a mutated scope in the next search filter', async () => {
+      const { store, runtime } = searchStore({ scope: 'tenant-a' })
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'tenant-a' } })
+
+      store.scope = 'tenant-b'
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'tenant-b' } })
+    })
+
+    it('reflects a mutated scopeMetadataKey in the derived filter', async () => {
+      const { store, runtime } = searchStore({ scope: 'acme' })
+      store.scopeMetadataKey = 'tenant'
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'tenant', value: 'acme' } })
+    })
+
+    it('derives a filter once a scope is set on a previously unscoped store', async () => {
+      const { store, runtime } = searchStore()
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toBeUndefined()
+
+      store.scope = 'later'
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'later' } })
+    })
+
+    it('keeps using an explicit filter even after scope is mutated', async () => {
+      const filter = { equals: { key: 'custom', value: 'v' } }
+      const { store, runtime } = searchStore({ scope: 'a', filter })
+      store.scope = 'b'
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual(filter)
+    })
+
+    it('re-enables scope-derived filtering when the explicit filter is cleared', async () => {
+      const { store, runtime } = searchStore({ scope: 'a', filter: { equals: { key: 'custom', value: 'v' } } })
+      store.filter = undefined
+      await store.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'a' } })
+    })
+
+    it('snapshots the filter at call entry, ignoring a scope mutation made after the call', async () => {
+      const { store, runtime } = searchStore({ scope: 'before' })
+      const pending = store.search('q')
+      store.scope = 'after' // mutate before the in-flight search settles
+      await pending
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'before' } })
+    })
+
+    it('stamps the current scope on writes after a mutation', async () => {
+      const { store, agent } = customStore({ scope: 'tenant-a' })
+      await store.add('fact')
+      expect(lastInlineAttributes(agent)).toStrictEqual([
+        { key: 'namespace', value: { type: 'STRING', stringValue: 'tenant-a' } },
+      ])
+
+      store.scope = 'tenant-b'
+      await store.add('fact')
+      expect(lastInlineAttributes(agent)).toStrictEqual([
+        { key: 'namespace', value: { type: 'STRING', stringValue: 'tenant-b' } },
+      ])
+    })
+
+    it('still scopes writes by scope even when an explicit search filter is set (search/write asymmetry)', async () => {
+      const { store, agent } = customStore({ scope: 'tenant-a', filter: { equals: { key: 'custom', value: 'v' } } })
+      await store.add('fact')
+      expect(lastInlineAttributes(agent)).toStrictEqual([
+        { key: 'namespace', value: { type: 'STRING', stringValue: 'tenant-a' } },
+      ])
+    })
+
+    it('leaves name (the routing identity) untouched when scope is mutated', () => {
+      const { store } = searchStore({ scope: 'a' })
+      store.scope = 'b'
+      expect(store.name).toBe('kb')
+    })
+  })
+
   describe('metadata logging', () => {
     it('logs a debug line when a CUSTOM document drops an unsupported metadata value', async () => {
       const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {})

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.ts
@@ -2,12 +2,13 @@ import { describe, it, expect, beforeEach, vi, type MockedFunction } from 'vites
 import { BedrockAgentRuntimeClient } from '@aws-sdk/client-bedrock-agent-runtime'
 import { BedrockAgentClient } from '@aws-sdk/client-bedrock-agent'
 import { BedrockKnowledgeBaseStore } from '../store.js'
+import { MemoryManager } from '../../../memory/index.js'
 import { logger } from '../../../logging/logger.js'
 
 // Mock the AWS SDK clients. Command classes are stubbed to echo their input as `{ input }`, so a
 // test can assert on `send`'s argument — mirroring src/session/__tests__/s3-storage.test.ts. Client
 // constructors return a stub with a `send` spy; tests that exercise behavior inject their own client
-// instead (the store accepts `runtimeClient` / `agentClient` / `s3.client`).
+// instead (the store accepts `config.runtimeClient` / `config.agentClient` / `config.s3.client`).
 vi.mock('@aws-sdk/client-bedrock-agent-runtime', () => ({
   BedrockAgentRuntimeClient: vi.fn().mockImplementation(function () {
     return { send: vi.fn() }
@@ -45,6 +46,75 @@ function mockClient(): { send: MockedFunction<any> } {
   return { send: vi.fn() }
 }
 
+/**
+ * Builds a store from a base connection config plus per-store fields. `config` overrides merge onto
+ * the shared connection (`knowledgeBaseId: 'kb-1'` + injected runtime/agent clients); `overrides`
+ * carry the per-store fields that sit outside `config` (`name`, `scope`, `writable`, ...). The
+ * returned `runtime` / `agent` spies are the injected clients, ready to program and inspect.
+ */
+function makeStore(
+  overrides: Record<string, unknown> = {},
+  configOverrides: Record<string, unknown> = {}
+): {
+  store: BedrockKnowledgeBaseStore
+  runtime: { send: MockedFunction<any> }
+  agent: { send: MockedFunction<any> }
+} {
+  const runtime = mockClient()
+  runtime.send.mockResolvedValue({ retrievalResults: [] })
+  const agent = mockClient()
+  agent.send.mockResolvedValue({})
+  const store = new BedrockKnowledgeBaseStore({
+    config: { knowledgeBaseId: 'kb-1', runtimeClient: runtime as any, agentClient: agent as any, ...configOverrides },
+    name: 'kb',
+    ...overrides,
+  })
+  return { store, runtime, agent }
+}
+
+/** A writable CUSTOM store built via {@link makeStore}, with the data source wired into `config`. */
+function makeCustomStore(
+  overrides: Record<string, unknown> = {},
+  configOverrides: Record<string, unknown> = {}
+): { store: BedrockKnowledgeBaseStore; agent: { send: MockedFunction<any> } } {
+  const { store, agent } = makeStore(
+    { writable: true, ...overrides },
+    { dataSourceType: 'CUSTOM', dataSourceId: 'ds-1', ...configOverrides }
+  )
+  return { store, agent }
+}
+
+/** A writable S3 store built via {@link makeStore}, with the data source + bucket wired into `config`. */
+function makeS3Store(
+  overrides: Record<string, unknown> = {},
+  configOverrides: Record<string, unknown> = {}
+): { store: BedrockKnowledgeBaseStore; agent: { send: MockedFunction<any> }; s3: { send: MockedFunction<any> } } {
+  const s3 = mockClient()
+  s3.send.mockResolvedValue({})
+  const { store, agent } = makeStore(
+    { writable: true, ...overrides },
+    {
+      dataSourceType: 'S3',
+      dataSourceId: 'ds-1',
+      s3: { bucket: 'my-bucket', client: s3 as any, prefix: 'memories' },
+      ...configOverrides,
+    }
+  )
+  return { store, agent, s3 }
+}
+
+/** Reads the filter the most recent RetrieveCommand was sent with. */
+function lastSearchFilter(runtime: { send: MockedFunction<any> }): unknown {
+  const calls = runtime.send.mock.calls
+  return calls[calls.length - 1]?.[0].input.retrievalConfiguration.vectorSearchConfiguration.filter
+}
+
+/** Reads the inline attributes the most recent CUSTOM ingestion document carried. */
+function lastInlineAttributes(agent: { send: MockedFunction<any> }): any[] {
+  const calls = agent.send.mock.calls
+  return calls[calls.length - 1]?.[0].input.documents[0].metadata?.inlineAttributes ?? []
+}
+
 describe('BedrockKnowledgeBaseStore', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -52,107 +122,69 @@ describe('BedrockKnowledgeBaseStore', () => {
 
   describe('constructor', () => {
     it('exposes name and defaults writable to false', () => {
-      const store = new BedrockKnowledgeBaseStore({ name: 'kb', knowledgeBaseId: 'kb-1' })
+      const { store } = makeStore()
       expect(store.name).toBe('kb')
       expect(store.writable).toBe(false)
       expect(store.description).toBeUndefined()
       expect(store.maxSearchResults).toBeUndefined()
     })
 
+    it('keeps name and scope as independent fields', () => {
+      const { store } = makeStore({ name: 'explicit', scope: 'user-abc' })
+      expect(store.name).toBe('explicit')
+      expect(store.scope).toBe('user-abc')
+    })
+
+    it('requires name at the type level', () => {
+      // @ts-expect-error name is required
+      new BedrockKnowledgeBaseStore({ config: { knowledgeBaseId: 'kb-1' }, scope: 'user-abc' })
+    })
+
     it('carries through description and maxSearchResults', () => {
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        description: 'product docs',
-        maxSearchResults: 7,
-      })
+      const { store } = makeStore({ description: 'product docs', maxSearchResults: 7 })
       expect(store.description).toBe('product docs')
       expect(store.maxSearchResults).toBe(7)
     })
 
     it('throws when writable is true but dataSourceType is omitted', () => {
-      expect(() => new BedrockKnowledgeBaseStore({ name: 'kb', knowledgeBaseId: 'kb-1', writable: true })).toThrow(
+      expect(() => makeStore({ writable: true })).toThrow("add requires dataSourceType 'CUSTOM' or 'S3'")
+    })
+
+    it("throws when writable is true but dataSourceType is 'OTHER'", () => {
+      expect(() => makeStore({ writable: true }, { dataSourceType: 'OTHER' })).toThrow(
         "add requires dataSourceType 'CUSTOM' or 'S3'"
       )
     })
 
-    it("throws when writable is true but dataSourceType is 'OTHER'", () => {
-      expect(
-        () =>
-          new BedrockKnowledgeBaseStore({
-            name: 'kb',
-            knowledgeBaseId: 'kb-1',
-            writable: true,
-            dataSourceType: 'OTHER',
-          })
-      ).toThrow("add requires dataSourceType 'CUSTOM' or 'S3'")
-    })
-
     it('throws when maxSearchResults is less than 1', () => {
-      expect(() => new BedrockKnowledgeBaseStore({ name: 'kb', knowledgeBaseId: 'kb-1', maxSearchResults: 0 })).toThrow(
-        'maxSearchResults must be at least 1'
-      )
-      expect(
-        () => new BedrockKnowledgeBaseStore({ name: 'kb', knowledgeBaseId: 'kb-1', maxSearchResults: -5 })
-      ).toThrow('maxSearchResults must be at least 1')
+      expect(() => makeStore({ maxSearchResults: 0 })).toThrow('maxSearchResults must be at least 1')
+      expect(() => makeStore({ maxSearchResults: -5 })).toThrow('maxSearchResults must be at least 1')
     })
 
     it("allows writable with a 'CUSTOM' data source", () => {
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: 'ds-1',
-      })
+      const { store } = makeCustomStore()
       expect(store.writable).toBe(true)
     })
 
     it("allows writable with an 'S3' data source", () => {
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        writable: true,
-        dataSourceType: 'S3',
-        dataSourceId: 'ds-1',
-        s3: { bucket: 'b', client: {} as any, prefix: 'p' },
-      })
+      const { store } = makeS3Store()
       expect(store.writable).toBe(true)
     })
 
     it('constructs a default runtime client when none is injected', () => {
-      new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-      })
+      new BedrockKnowledgeBaseStore({ config: { knowledgeBaseId: 'kb-1' }, name: 'kb' })
       expect(vi.mocked(BedrockAgentRuntimeClient)).toHaveBeenCalledWith({})
     })
 
     it('uses the injected runtime client without constructing one', () => {
-      const runtime = mockClient()
-      new BedrockKnowledgeBaseStore({ name: 'kb', knowledgeBaseId: 'kb-1', runtimeClient: runtime as any })
+      makeStore()
       expect(vi.mocked(BedrockAgentRuntimeClient)).not.toHaveBeenCalled()
     })
   })
 
   describe('search', () => {
-    function searchStore(overrides: Record<string, unknown> = {}): {
-      store: BedrockKnowledgeBaseStore
-      runtime: { send: MockedFunction<any> }
-    } {
-      const runtime = mockClient()
-      runtime.send.mockResolvedValue({ retrievalResults: [] })
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        runtimeClient: runtime as any,
-        ...overrides,
-      })
-      return { store, runtime }
-    }
-
     it('issues a RetrieveCommand with the query and a default result limit of 10', async () => {
-      const { store, runtime } = searchStore()
+      const { store, runtime } = makeStore()
       await store.search('how do refunds work')
       expect(runtime.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -166,7 +198,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it("uses the store's maxSearchResults when the caller omits one", async () => {
-      const { store, runtime } = searchStore({ maxSearchResults: 5 })
+      const { store, runtime } = makeStore({ maxSearchResults: 5 })
       await store.search('q')
       expect(runtime.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -178,7 +210,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('lets a per-call maxSearchResults override the store default', async () => {
-      const { store, runtime } = searchStore({ maxSearchResults: 5 })
+      const { store, runtime } = makeStore({ maxSearchResults: 5 })
       await store.search('q', { maxSearchResults: 2 })
       expect(runtime.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -190,7 +222,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('derives a scope filter (default key "namespace") and applies it to retrieval', async () => {
-      const { store, runtime } = searchStore({ scope: 'user-123' })
+      const { store, runtime } = makeStore({ scope: 'user-123' })
       await store.search('q')
       expect(runtime.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -207,7 +239,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('honors a custom scopeMetadataKey when building the scope filter', async () => {
-      const { store, runtime } = searchStore({ scope: 'acme', scopeMetadataKey: 'tenant' })
+      const { store, runtime } = makeStore({ scope: 'acme' }, { scopeMetadataKey: 'tenant' })
       await store.search('q')
       expect(runtime.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -224,7 +256,7 @@ describe('BedrockKnowledgeBaseStore', () => {
 
     it('prefers an explicit filter over a scope-derived one', async () => {
       const filter = { equals: { key: 'custom', value: 'v' } }
-      const { store, runtime } = searchStore({ scope: 'ignored', filter })
+      const { store, runtime } = makeStore({ scope: 'ignored', filter })
       await store.search('q')
       expect(runtime.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -238,7 +270,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('maps content, metadata, location, and score onto each entry', async () => {
-      const runtime = mockClient()
+      const { store, runtime } = makeStore()
       runtime.send.mockResolvedValue({
         retrievalResults: [
           {
@@ -248,11 +280,6 @@ describe('BedrockKnowledgeBaseStore', () => {
             score: 0.92,
           },
         ],
-      })
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        runtimeClient: runtime as any,
       })
 
       const results = await store.search('q')
@@ -269,43 +296,28 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('defaults missing content to an empty string and omits absent metadata', async () => {
-      const runtime = mockClient()
+      const { store, runtime } = makeStore()
       runtime.send.mockResolvedValue({ retrievalResults: [{}] })
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        runtimeClient: runtime as any,
-      })
 
       const results = await store.search('q')
       expect(results).toStrictEqual([{ content: '', metadata: {} }])
     })
 
     it('returns an empty array when the knowledge base yields no results', async () => {
-      const { store } = searchStore()
+      const { store } = makeStore()
       await expect(store.search('q')).resolves.toStrictEqual([])
     })
 
     it('returns an empty array when the response omits retrievalResults entirely', async () => {
-      const runtime = mockClient()
+      const { store, runtime } = makeStore()
       runtime.send.mockResolvedValue({})
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        runtimeClient: runtime as any,
-      })
       await expect(store.search('q')).resolves.toStrictEqual([])
     })
 
     it('logs and rethrows when the retrieve call fails', async () => {
       const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {})
-      const runtime = mockClient()
+      const { store, runtime } = makeStore()
       runtime.send.mockRejectedValue(new Error('retrieve boom'))
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        runtimeClient: runtime as any,
-      })
 
       await expect(store.search('q')).rejects.toThrow('retrieve boom')
       expect(errorSpy).toHaveBeenCalled()
@@ -314,56 +326,30 @@ describe('BedrockKnowledgeBaseStore', () => {
   })
 
   describe('add — CUSTOM data source', () => {
-    function customStore(overrides: Record<string, unknown> = {}): {
-      store: BedrockKnowledgeBaseStore
-      agent: { send: MockedFunction<any> }
-    } {
-      const agent = mockClient()
-      agent.send.mockResolvedValue({})
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: 'ds-1',
-        agentClient: agent as any,
-        ...overrides,
-      })
-      return { store, agent }
-    }
-
     it('throws when dataSourceId is missing', () => {
-      expect(
-        () =>
-          new BedrockKnowledgeBaseStore({
-            name: 'kb',
-            knowledgeBaseId: 'kb-1',
-            writable: true,
-            dataSourceType: 'CUSTOM',
-          })
-      ).toThrow('dataSourceId is required')
+      expect(() => makeStore({ writable: true }, { dataSourceType: 'CUSTOM' })).toThrow('dataSourceId is required')
     })
 
     it('throws when content is empty or whitespace-only', async () => {
-      const { store } = customStore()
+      const { store } = makeCustomStore()
       await expect(store.add('')).rejects.toThrow('content must not be empty')
       await expect(store.add('   ')).rejects.toThrow('content must not be empty')
     })
 
     it('returns the generated custom document id', async () => {
-      const { store } = customStore()
+      const { store } = makeCustomStore()
       await expect(store.add('fact')).resolves.toStrictEqual({ documentId: 'test-uuid-v7' })
     })
 
     it('uses the same id for the document identifier and the returned documentId', async () => {
-      const { store, agent } = customStore()
+      const { store, agent } = makeCustomStore()
       const result = await store.add('fact')
       const document = agent.send.mock.calls[0]?.[0].input.documents[0]
       expect(document.content.custom.customDocumentIdentifier.id).toBe(result.documentId)
     })
 
     it('ingests an inline CUSTOM document with no metadata field when no scope or metadata', async () => {
-      const { store, agent } = customStore()
+      const { store, agent } = makeCustomStore()
       await store.add('remember this')
       expect(agent.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -388,7 +374,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('attaches the scope as a leading inline attribute', async () => {
-      const { store, agent } = customStore({ scope: 'user-123' })
+      const { store, agent } = makeCustomStore({ scope: 'user-123' })
       await store.add('fact')
       const document = agent.send.mock.calls[0]?.[0].input.documents[0]
       expect(document.metadata.inlineAttributes).toStrictEqual([
@@ -397,7 +383,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('drops metadata keys that collide with scopeMetadataKey and preserves scope', async () => {
-      const { store, agent } = customStore({ scope: 'tenant-A' })
+      const { store, agent } = makeCustomStore({ scope: 'tenant-A' })
       const warnSpy = vi.spyOn(logger, 'warn')
       await store.add('fact', { namespace: 'tenant-EVIL', other: 'ok' })
       const document = agent.send.mock.calls[0]?.[0].input.documents[0]
@@ -410,7 +396,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('maps supported metadata value types and skips unsupported ones', async () => {
-      const { store, agent } = customStore()
+      const { store, agent } = makeCustomStore()
       await store.add('fact', {
         str: 'a',
         num: 1,
@@ -431,16 +417,8 @@ describe('BedrockKnowledgeBaseStore', () => {
 
     it('logs and rethrows when ingestion fails', async () => {
       const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {})
-      const agent = mockClient()
+      const { store, agent } = makeCustomStore()
       agent.send.mockRejectedValue(new Error('ingest boom'))
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: 'ds-1',
-        agentClient: agent as any,
-      })
 
       await expect(store.add('fact')).rejects.toThrow('ingest boom')
       expect(errorSpy).toHaveBeenCalled()
@@ -448,12 +426,11 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('lazily constructs a default agent client when none is injected', async () => {
+      // No injected agentClient, so construct directly rather than via the helper.
       const store = new BedrockKnowledgeBaseStore({
+        config: { knowledgeBaseId: 'kb-1', dataSourceType: 'CUSTOM', dataSourceId: 'ds-1' },
         name: 'kb',
-        knowledgeBaseId: 'kb-1',
         writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: 'ds-1',
       })
       await store.add('fact')
       expect(vi.mocked(BedrockAgentClient)).toHaveBeenCalledWith({})
@@ -461,50 +438,21 @@ describe('BedrockKnowledgeBaseStore', () => {
   })
 
   describe('add — S3 data source', () => {
-    function s3Store(overrides: Record<string, unknown> = {}): {
-      store: BedrockKnowledgeBaseStore
-      agent: { send: MockedFunction<any> }
-      s3: { send: MockedFunction<any> }
-    } {
-      const agent = mockClient()
-      agent.send.mockResolvedValue({})
-      const s3 = mockClient()
-      s3.send.mockResolvedValue({})
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        writable: true,
-        dataSourceType: 'S3',
-        dataSourceId: 'ds-1',
-        agentClient: agent as any,
-        s3: { bucket: 'my-bucket', client: s3 as any, prefix: 'memories' },
-        ...overrides,
-      })
-      return { store, agent, s3 }
-    }
-
     it('throws when the s3 config is missing', () => {
-      expect(
-        () =>
-          new BedrockKnowledgeBaseStore({
-            name: 'kb',
-            knowledgeBaseId: 'kb-1',
-            writable: true,
-            dataSourceType: 'S3',
-            dataSourceId: 'ds-1',
-          })
-      ).toThrow('s3 config is required')
+      expect(() => makeStore({ writable: true }, { dataSourceType: 'S3', dataSourceId: 'ds-1' })).toThrow(
+        's3 config is required'
+      )
     })
 
     it("returns the uploaded content object's s3:// URI as the document id", async () => {
-      const { store } = s3Store()
+      const { store } = makeS3Store()
       await expect(store.add('content')).resolves.toStrictEqual({
         documentId: 's3://my-bucket/memories/test-uuid-v7.txt',
       })
     })
 
     it('uploads the content object and ingests an S3 document referencing it (no sidecar)', async () => {
-      const { store, agent, s3 } = s3Store()
+      const { store, agent, s3 } = makeS3Store()
       await store.add('s3 content')
 
       expect(s3.send).toHaveBeenCalledTimes(1)
@@ -539,15 +487,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     it('does not double up the slash when the prefix already ends in one', async () => {
       const client = mockClient()
       client.send.mockResolvedValue({})
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        writable: true,
-        dataSourceType: 'S3',
-        dataSourceId: 'ds-1',
-        agentClient: mockClient() as any,
-        s3: { bucket: 'my-bucket', client: client as any, prefix: 'memories/' },
-      })
+      const { store } = makeS3Store({}, { s3: { bucket: 'my-bucket', client: client as any, prefix: 'memories/' } })
       await store.add('content')
       expect(client.send).toHaveBeenCalledWith(
         expect.objectContaining({ input: expect.objectContaining({ Key: 'memories/test-uuid-v7.txt' }) })
@@ -555,7 +495,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('writes a sidecar carrying the scope and points the document metadata at it', async () => {
-      const { store, agent, s3 } = s3Store({ scope: 'team-a' })
+      const { store, agent, s3 } = makeS3Store({ scope: 'team-a' })
       await store.add('content')
 
       expect(s3.send).toHaveBeenCalledTimes(2)
@@ -582,7 +522,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('writes a sidecar built from caller metadata', async () => {
-      const { store, s3 } = s3Store()
+      const { store, s3 } = makeS3Store()
       await store.add('content', { priority: 'high' })
 
       expect(s3.send).toHaveBeenCalledTimes(2)
@@ -601,7 +541,7 @@ describe('BedrockKnowledgeBaseStore', () => {
     })
 
     it('omits unsupported metadata values from the sidecar', async () => {
-      const { store, s3 } = s3Store()
+      const { store, s3 } = makeS3Store()
       await store.add('content', { keep: 'yes', drop: { nested: true } })
 
       expect(s3.send).toHaveBeenNthCalledWith(
@@ -622,12 +562,14 @@ describe('BedrockKnowledgeBaseStore', () => {
       const s3 = mockClient()
       s3.send.mockResolvedValue({})
       const store = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId: 'kb-1',
+          dataSourceType: 'S3',
+          dataSourceId: 'ds-1',
+          s3: { bucket: 'my-bucket', client: s3 as any, prefix: 'memories' },
+        },
         name: 'kb',
-        knowledgeBaseId: 'kb-1',
         writable: true,
-        dataSourceType: 'S3',
-        dataSourceId: 'ds-1',
-        s3: { bucket: 'my-bucket', client: s3 as any, prefix: 'memories' },
       })
       await store.add('content')
       expect(vi.mocked(BedrockAgentClient)).toHaveBeenCalledWith({})
@@ -635,7 +577,7 @@ describe('BedrockKnowledgeBaseStore', () => {
 
     it('logs and rethrows when the S3 upload fails, before any ingestion', async () => {
       const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {})
-      const { store, agent, s3 } = s3Store()
+      const { store, agent, s3 } = makeS3Store()
       s3.send.mockRejectedValue(new Error('upload boom'))
 
       await expect(store.add('content')).rejects.toThrow('upload boom')
@@ -649,157 +591,90 @@ describe('BedrockKnowledgeBaseStore', () => {
     it('throws when add is called on a non-writable store', async () => {
       const agent = mockClient()
       const store = new BedrockKnowledgeBaseStore({
+        config: { knowledgeBaseId: 'kb-1', dataSourceType: 'OTHER', dataSourceId: 'ds-1', agentClient: agent as any },
         name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        dataSourceType: 'OTHER',
-        dataSourceId: 'ds-1',
-        agentClient: agent as any,
       })
       await expect(store.add('fact')).rejects.toThrow('store is not writable')
       expect(agent.send).not.toHaveBeenCalled()
     })
   })
 
-  describe('dynamic scope mutability', () => {
-    /** A search store whose `send` echoes the RetrieveCommand and resolves to empty results. */
-    function searchStore(overrides: Record<string, unknown> = {}): {
-      store: BedrockKnowledgeBaseStore
-      runtime: { send: MockedFunction<any> }
-    } {
+  describe('config reuse across namespaces', () => {
+    it('reuses an injected runtime client across stores built from the same config', async () => {
       const runtime = mockClient()
       runtime.send.mockResolvedValue({ retrievalResults: [] })
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        runtimeClient: runtime as any,
-        ...overrides,
-      })
-      return { store, runtime }
-    }
+      const config = { knowledgeBaseId: 'kb-1', runtimeClient: runtime as any }
 
-    /** Reads the filter the most recent RetrieveCommand was sent with. */
-    function lastSearchFilter(runtime: { send: MockedFunction<any> }): unknown {
-      const calls = runtime.send.mock.calls
-      return calls[calls.length - 1]?.[0].input.retrievalConfiguration.vectorSearchConfiguration.filter
-    }
+      const personal = new BedrockKnowledgeBaseStore({ config, name: 'personal', scope: 'user-abc' })
+      const team = new BedrockKnowledgeBaseStore({ config, name: 'team', scope: 'other' })
 
-    /** A writable CUSTOM store whose agent `send` echoes the ingestion command. */
-    function customStore(overrides: Record<string, unknown> = {}): {
-      store: BedrockKnowledgeBaseStore
-      agent: { send: MockedFunction<any> }
-    } {
+      expect(vi.mocked(BedrockAgentRuntimeClient)).not.toHaveBeenCalled()
+      await personal.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'user-abc' } })
+      await team.search('q')
+      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'other' } })
+    })
+
+    it('constructs a separate default runtime client per store when the config injects none', () => {
+      const config = { knowledgeBaseId: 'kb-1' }
+      new BedrockKnowledgeBaseStore({ config, name: 'a' })
+      new BedrockKnowledgeBaseStore({ config, name: 'b' })
+      expect(vi.mocked(BedrockAgentRuntimeClient)).toHaveBeenCalledTimes(2)
+    })
+
+    it('inherits the data source from the shared config when writing', async () => {
       const agent = mockClient()
       agent.send.mockResolvedValue({})
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: 'ds-1',
+      const config = {
+        knowledgeBaseId: 'kb-shared',
+        dataSourceType: 'CUSTOM' as const,
+        dataSourceId: 'ds-shared',
         agentClient: agent as any,
-        ...overrides,
-      })
-      return { store, agent }
-    }
-
-    /** Reads the inline attributes the most recent CUSTOM ingestion document carried. */
-    function lastInlineAttributes(agent: { send: MockedFunction<any> }): any[] {
-      const calls = agent.send.mock.calls
-      return calls[calls.length - 1]?.[0].input.documents[0].metadata?.inlineAttributes ?? []
-    }
-
-    it('reflects a mutated scope in the next search filter', async () => {
-      const { store, runtime } = searchStore({ scope: 'tenant-a' })
-      await store.search('q')
-      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'tenant-a' } })
-
-      store.scope = 'tenant-b'
-      await store.search('q')
-      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'tenant-b' } })
+      }
+      const store = new BedrockKnowledgeBaseStore({ config, name: 'personal', scope: 'user-abc', writable: true })
+      await store.add('fact')
+      expect(agent.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ knowledgeBaseId: 'kb-shared', dataSourceId: 'ds-shared' }),
+        })
+      )
     })
 
-    it('reflects a mutated scopeMetadataKey in the derived filter', async () => {
-      const { store, runtime } = searchStore({ scope: 'acme' })
-      store.scopeMetadataKey = 'tenant'
-      await store.search('q')
-      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'tenant', value: 'acme' } })
+    it('registers distinct-name stores together in a MemoryManager', () => {
+      const config = { knowledgeBaseId: 'kb-1', runtimeClient: mockClient() as any }
+      const personal = new BedrockKnowledgeBaseStore({ config, name: 'personal', scope: 'user-abc' })
+      const team = new BedrockKnowledgeBaseStore({ config, name: 'team', scope: 'other' })
+      expect(() => new MemoryManager({ stores: [personal, team] })).not.toThrow()
     })
 
-    it('derives a filter once a scope is set on a previously unscoped store', async () => {
-      const { store, runtime } = searchStore()
+    it('rejects two stores with the same name in a MemoryManager', () => {
+      const config = { knowledgeBaseId: 'kb-1', runtimeClient: mockClient() as any }
+      const a = new BedrockKnowledgeBaseStore({ config, name: 'dupe', scope: 'user-abc' })
+      const b = new BedrockKnowledgeBaseStore({ config, name: 'dupe', scope: 'other' })
+      expect(() => new MemoryManager({ stores: [a, b] })).toThrow("duplicate store name 'dupe'")
+    })
+  })
+
+  describe('scope and filter resolution', () => {
+    it('applies no filter when the store has no scope', async () => {
+      const { store, runtime } = makeStore()
       await store.search('q')
       expect(lastSearchFilter(runtime)).toBeUndefined()
-
-      store.scope = 'later'
-      await store.search('q')
-      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'later' } })
     })
 
-    it('keeps using an explicit filter even after scope is mutated', async () => {
-      const filter = { equals: { key: 'custom', value: 'v' } }
-      const { store, runtime } = searchStore({ scope: 'a', filter })
-      store.scope = 'b'
-      await store.search('q')
-      expect(lastSearchFilter(runtime)).toStrictEqual(filter)
-    })
-
-    it('re-enables scope-derived filtering when the explicit filter is cleared', async () => {
-      const { store, runtime } = searchStore({ scope: 'a', filter: { equals: { key: 'custom', value: 'v' } } })
-      store.filter = undefined
-      await store.search('q')
-      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'a' } })
-    })
-
-    it('snapshots the filter at call entry, ignoring a scope mutation made after the call', async () => {
-      const { store, runtime } = searchStore({ scope: 'before' })
-      const pending = store.search('q')
-      store.scope = 'after' // mutate before the in-flight search settles
-      await pending
-      expect(lastSearchFilter(runtime)).toStrictEqual({ equals: { key: 'namespace', value: 'before' } })
-    })
-
-    it('stamps the current scope on writes after a mutation', async () => {
-      const { store, agent } = customStore({ scope: 'tenant-a' })
+    it('scopes writes by scope even when an explicit search filter is set (search/write asymmetry)', async () => {
+      const { store, agent } = makeCustomStore({ scope: 'tenant-a', filter: { equals: { key: 'custom', value: 'v' } } })
       await store.add('fact')
       expect(lastInlineAttributes(agent)).toStrictEqual([
         { key: 'namespace', value: { type: 'STRING', stringValue: 'tenant-a' } },
       ])
-
-      store.scope = 'tenant-b'
-      await store.add('fact')
-      expect(lastInlineAttributes(agent)).toStrictEqual([
-        { key: 'namespace', value: { type: 'STRING', stringValue: 'tenant-b' } },
-      ])
-    })
-
-    it('still scopes writes by scope even when an explicit search filter is set (search/write asymmetry)', async () => {
-      const { store, agent } = customStore({ scope: 'tenant-a', filter: { equals: { key: 'custom', value: 'v' } } })
-      await store.add('fact')
-      expect(lastInlineAttributes(agent)).toStrictEqual([
-        { key: 'namespace', value: { type: 'STRING', stringValue: 'tenant-a' } },
-      ])
-    })
-
-    it('leaves name (the routing identity) untouched when scope is mutated', () => {
-      const { store } = searchStore({ scope: 'a' })
-      store.scope = 'b'
-      expect(store.name).toBe('kb')
     })
   })
 
   describe('metadata logging', () => {
     it('logs a debug line when a CUSTOM document drops an unsupported metadata value', async () => {
       const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {})
-      const agent = mockClient()
-      agent.send.mockResolvedValue({})
-      const store = new BedrockKnowledgeBaseStore({
-        name: 'kb',
-        knowledgeBaseId: 'kb-1',
-        writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: 'ds-1',
-        agentClient: agent as any,
-      })
+      const { store } = makeCustomStore()
 
       await store.add('fact', { good: 'v', bad: { nested: true } })
       expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('key=<bad>'))

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/index.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/index.ts
@@ -1,5 +1,6 @@
 export {
   BedrockKnowledgeBaseStore,
+  type BedrockKnowledgeBaseConfig,
   type BedrockKnowledgeBaseS3Config,
   type BedrockKnowledgeBaseStoreConfig,
   type BedrockKnowledgeBaseAddResult,

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
@@ -148,9 +148,29 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
   private readonly _knowledgeBaseId: string
   private readonly _dataSourceType: 'CUSTOM' | 'S3' | 'OTHER' | undefined
   private readonly _dataSourceId: string | undefined
-  private readonly _scope: string | undefined
-  private readonly _scopeMetadataKey: string
-  private readonly _filter: RetrievalFilter | undefined
+
+  /**
+   * Logical namespace isolating documents: applied as a metadata filter on {@link search} and stamped
+   * on writes via {@link add}.
+   *
+   * Mutable at runtime — assign a new value to re-point subsequent `search`/`add` calls at a different
+   * partition (e.g. switching the active tenant on a reused store). The effective search filter is
+   * derived from this on each call (see {@link _resolveFilter}), so a change takes effect immediately;
+   * an explicit {@link filter} overrides it for search. Unlike {@link name}, this is not a store-identity
+   * field, so changing it never affects `MemoryManager` routing.
+   *
+   * A store instance shared across agents shares one `scope`. For concurrent per-tenant isolation,
+   * give each agent its own store instance (cheap — it is just config) rather than mutating a shared one.
+   */
+  public scope: string | undefined
+  /** Metadata attribute key used for scope-based filtering. Mutable at runtime; see {@link scope}. */
+  public scopeMetadataKey: string
+  /**
+   * Explicit retrieval filter. When set, it overrides the scope-derived filter for {@link search}.
+   * Mutable at runtime — set to `undefined` to re-enable scope-derived search filtering. Note the
+   * asymmetry: an explicit filter affects search only; writes always scope by {@link scope}.
+   */
+  public filter: RetrievalFilter | undefined
 
   constructor(config: BedrockKnowledgeBaseStoreConfig) {
     this.name = config.name
@@ -173,19 +193,22 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
 
     if (this.writable) this._validateWriteConfig()
 
-    this._scope = config.scope
-    this._scopeMetadataKey = config.scopeMetadataKey ?? 'namespace'
+    // Store raw config only; the effective search filter is derived per call in `_resolveFilter` so
+    // runtime mutations of `scope` / `scopeMetadataKey` / `filter` take effect immediately.
+    this.scope = config.scope
+    this.scopeMetadataKey = config.scopeMetadataKey ?? 'namespace'
+    this.filter = config.filter
+  }
 
-    if (config.filter) {
-      this._filter = config.filter
-    } else if (config.scope) {
-      this._filter = {
-        equals: {
-          key: this._scopeMetadataKey,
-          value: config.scope,
-        },
-      }
-    }
+  /**
+   * Resolves the effective retrieval filter for a search: an explicit {@link filter} wins; otherwise
+   * one is derived from the current {@link scope} / {@link scopeMetadataKey}. Computed per call (rather
+   * than precomputed at construction) so runtime mutations of those fields are reflected.
+   */
+  private _resolveFilter(): RetrievalFilter | undefined {
+    if (this.filter) return this.filter
+    if (this.scope) return { equals: { key: this.scopeMetadataKey, value: this.scope } }
+    return undefined
   }
 
   /**
@@ -202,6 +225,9 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
       throw new Error('BedrockKnowledgeBaseStore: maxSearchResults must be at least 1.')
     }
     const limit = options?.maxSearchResults || this.maxSearchResults || DEFAULT_MAX_SEARCH_RESULTS
+    // Snapshot the filter at call entry (before the first await) so it is deterministic for this
+    // in-flight search even if `scope` / `filter` are mutated concurrently.
+    const filter = this._resolveFilter()
 
     let response
     try {
@@ -212,7 +238,7 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
           retrievalConfiguration: {
             vectorSearchConfiguration: {
               numberOfResults: limit,
-              ...(this._filter && { filter: this._filter }),
+              ...(filter && { filter }),
             },
           },
         })
@@ -402,13 +428,13 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
   ): Array<{ key: string; value: MetadataAttributeValue }> {
     const attrs: Array<{ key: string; value: MetadataAttributeValue }> = []
 
-    if (this._scope) {
-      attrs.push({ key: this._scopeMetadataKey, value: { type: 'STRING', stringValue: this._scope } })
+    if (this.scope) {
+      attrs.push({ key: this.scopeMetadataKey, value: { type: 'STRING', stringValue: this.scope } })
     }
 
     if (metadata) {
       for (const [key, value] of Object.entries(metadata)) {
-        if (this._scope && key === this._scopeMetadataKey) {
+        if (this.scope && key === this.scopeMetadataKey) {
           logger.warn(`store=<${this.name}>, key=<${key}> | dropping metadata key that collides with scopeMetadataKey`)
           continue
         }

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
@@ -66,8 +66,12 @@ export interface BedrockKnowledgeBaseS3Config {
   prefix: string
 }
 
-/** Configuration for {@link BedrockKnowledgeBaseStore}. */
-export interface BedrockKnowledgeBaseStoreConfig extends MemoryStoreConfig {
+/**
+ * Connection to a Bedrock Knowledge Base: which knowledge base, which data source, and the clients
+ * used to reach them. This is the reusable half of a store's config — build one and pass it to many
+ * {@link BedrockKnowledgeBaseStoreConfig}s that differ only by namespace.
+ */
+export interface BedrockKnowledgeBaseConfig {
   /** The Bedrock Knowledge Base identifier to query and ingest into. */
   knowledgeBaseId: string
   /**
@@ -96,16 +100,28 @@ export interface BedrockKnowledgeBaseStoreConfig extends MemoryStoreConfig {
   dataSourceId?: string
   /** S3 ingestion settings. Required when `dataSourceType` is `'S3'`; ignored otherwise. */
   s3?: BedrockKnowledgeBaseS3Config
-  /** Logical namespace used to isolate documents; applied as a metadata filter on search. */
-  scope?: string
   /** Metadata attribute key used for scope-based filtering. Defaults to `'namespace'`. */
   scopeMetadataKey?: string
-  /** Explicit retrieval filter; overrides the auto-generated scope filter when provided. */
-  filter?: RetrievalFilter
   /** Pre-constructed runtime client for Retrieve calls. When omitted, a default client is constructed. */
   runtimeClient?: BedrockAgentRuntimeClient
   /** Pre-constructed agent client for IngestKnowledgeBaseDocuments calls. When omitted, a default client is constructed lazily on first write. */
   agentClient?: BedrockAgentClient
+}
+
+/**
+ * Configuration for {@link BedrockKnowledgeBaseStore}.
+ *
+ * The reusable connection lives in {@link config}; the per-store identity and behavior fields
+ * (`name`, `scope`, ...) sit beside it. To run one knowledge base across many namespaces, build a
+ * {@link config} once and reuse it, varying only `name` and `scope` per store.
+ */
+export interface BedrockKnowledgeBaseStoreConfig extends MemoryStoreConfig {
+  /** Connection to the knowledge base. Reuse one `config` across stores that differ only by `scope`. */
+  config: BedrockKnowledgeBaseConfig
+  /** Logical namespace used to isolate documents; applied as a metadata filter on search and stamped on writes. */
+  scope?: string
+  /** Explicit retrieval filter; overrides the auto-generated scope filter when provided. */
+  filter?: RetrievalFilter
 }
 
 /** Result returned by {@link BedrockKnowledgeBaseStore.add}. */
@@ -123,12 +139,13 @@ export interface BedrockKnowledgeBaseAddResult {
  * import { BedrockKnowledgeBaseStore } from '@strands-agents/sdk/vended-memory-stores/bedrock-knowledge-base'
  *
  * const store = new BedrockKnowledgeBaseStore({
- *   name: 'personal',
- *   knowledgeBaseId: 'KB123',
- *   writable: true,
- *   dataSourceType: 'CUSTOM',
- *   dataSourceId: 'DS456',
+ *   config: {
+ *     knowledgeBaseId: 'KB123',
+ *     dataSourceType: 'CUSTOM',
+ *     dataSourceId: 'DS456',
+ *   },
  *   scope: 'user-abc',
+ *   writable: true,
  * })
  *
  * const results = await store.search('what are my preferences?')
@@ -151,37 +168,31 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
 
   /**
    * Logical namespace isolating documents: applied as a metadata filter on {@link search} and stamped
-   * on writes via {@link add}.
-   *
-   * Mutable at runtime — assign a new value to re-point subsequent `search`/`add` calls at a different
-   * partition (e.g. switching the active tenant on a reused store). The effective search filter is
-   * derived from this on each call (see {@link _resolveFilter}), so a change takes effect immediately;
-   * an explicit {@link filter} overrides it for search. Unlike {@link name}, this is not a store-identity
-   * field, so changing it never affects `MemoryManager` routing.
-   *
-   * A store instance shared across agents shares one `scope`. For concurrent per-tenant isolation,
-   * give each agent its own store instance (cheap — it is just config) rather than mutating a shared one.
+   * on writes via {@link add}. Unlike {@link name}, it is not a store-identity field, so it never
+   * affects `MemoryManager` routing. For per-tenant isolation, construct one store per scope — cheap,
+   * since they can share a single {@link BedrockKnowledgeBaseConfig}.
    */
-  public scope: string | undefined
-  /** Metadata attribute key used for scope-based filtering. Mutable at runtime; see {@link scope}. */
-  public scopeMetadataKey: string
+  public readonly scope: string | undefined
+  /** Metadata attribute key used for scope-based filtering. */
+  public readonly scopeMetadataKey: string
   /**
    * Explicit retrieval filter. When set, it overrides the scope-derived filter for {@link search}.
-   * Mutable at runtime — set to `undefined` to re-enable scope-derived search filtering. Note the
-   * asymmetry: an explicit filter affects search only; writes always scope by {@link scope}.
+   * Note the asymmetry: an explicit filter affects search only; writes always scope by {@link scope}.
    */
-  public filter: RetrievalFilter | undefined
+  public readonly filter: RetrievalFilter | undefined
 
-  constructor(config: BedrockKnowledgeBaseStoreConfig) {
-    this.name = config.name
-    if (config.description !== undefined) this.description = config.description
-    if (config.maxSearchResults !== undefined) {
-      if (config.maxSearchResults < 1) {
+  constructor(options: BedrockKnowledgeBaseStoreConfig) {
+    const { config, scope, name, description, writable, maxSearchResults, filter } = options
+
+    this.name = name
+    if (description !== undefined) this.description = description
+    if (maxSearchResults !== undefined) {
+      if (maxSearchResults < 1) {
         throw new Error('BedrockKnowledgeBaseStore: maxSearchResults must be at least 1.')
       }
-      this.maxSearchResults = config.maxSearchResults
+      this.maxSearchResults = maxSearchResults
     }
-    this.writable = config.writable ?? false
+    this.writable = writable ?? false
 
     this._runtimeClient = config.runtimeClient ?? new BedrockAgentRuntimeClient({})
     this._agentClient = config.agentClient
@@ -193,17 +204,14 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
 
     if (this.writable) this._validateWriteConfig()
 
-    // Store raw config only; the effective search filter is derived per call in `_resolveFilter` so
-    // runtime mutations of `scope` / `scopeMetadataKey` / `filter` take effect immediately.
-    this.scope = config.scope
+    this.scope = scope
     this.scopeMetadataKey = config.scopeMetadataKey ?? 'namespace'
-    this.filter = config.filter
+    this.filter = filter
   }
 
   /**
    * Resolves the effective retrieval filter for a search: an explicit {@link filter} wins; otherwise
-   * one is derived from the current {@link scope} / {@link scopeMetadataKey}. Computed per call (rather
-   * than precomputed at construction) so runtime mutations of those fields are reflected.
+   * one is derived from {@link scope} / {@link scopeMetadataKey}.
    */
   private _resolveFilter(): RetrievalFilter | undefined {
     if (this.filter) return this.filter
@@ -225,8 +233,6 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
       throw new Error('BedrockKnowledgeBaseStore: maxSearchResults must be at least 1.')
     }
     const limit = options?.maxSearchResults || this.maxSearchResults || DEFAULT_MAX_SEARCH_RESULTS
-    // Snapshot the filter at call entry (before the first await) so it is deterministic for this
-    // in-flight search even if `scope` / `filter` are mutated concurrently.
     const filter = this._resolveFilter()
 
     let response

--- a/strands-ts/test/integ/memory/bedrock-knowledge-base-store.test.node.ts
+++ b/strands-ts/test/integ/memory/bedrock-knowledge-base-store.test.node.ts
@@ -61,13 +61,15 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       const { knowledgeBaseId, customDataSourceId } = config()
 
       const store = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'CUSTOM',
+          dataSourceId: customDataSourceId,
+          runtimeClient,
+          agentClient,
+        },
         name: 'integ-custom',
-        knowledgeBaseId,
         writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: customDataSourceId,
-        runtimeClient,
-        agentClient,
       })
 
       const marker = uniqueMarker('custom-add')
@@ -93,13 +95,15 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
 
       const scope = uniqueMarker('scope')
       const store = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'CUSTOM',
+          dataSourceId: customDataSourceId,
+          runtimeClient,
+          agentClient,
+        },
         name: 'integ-custom-scoped',
-        knowledgeBaseId,
         writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: customDataSourceId,
-        runtimeClient,
-        agentClient,
         scope,
       })
 
@@ -124,23 +128,27 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       const marker = uniqueMarker('isolation')
 
       const storeA = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'CUSTOM',
+          dataSourceId: customDataSourceId,
+          runtimeClient,
+          agentClient,
+        },
         name: 'integ-scope-a',
-        knowledgeBaseId,
         writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: customDataSourceId,
-        runtimeClient,
-        agentClient,
         scope: scopeA,
       })
 
       const storeB = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'CUSTOM',
+          dataSourceId: customDataSourceId,
+          runtimeClient,
+          agentClient,
+        },
         name: 'integ-scope-b',
-        knowledgeBaseId,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: customDataSourceId,
-        runtimeClient,
-        agentClient,
         scope: scopeB,
       })
 
@@ -163,13 +171,15 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       const { knowledgeBaseId, customDataSourceId } = config()
 
       const store = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'CUSTOM',
+          dataSourceId: customDataSourceId,
+          runtimeClient,
+          agentClient,
+        },
         name: 'integ-custom-meta',
-        knowledgeBaseId,
         writable: true,
-        dataSourceType: 'CUSTOM',
-        dataSourceId: customDataSourceId,
-        runtimeClient,
-        agentClient,
       })
 
       const marker = uniqueMarker('custom-meta')
@@ -200,14 +210,16 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       const { knowledgeBaseId, s3DataSourceId, s3Bucket } = config()
 
       const store = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'S3',
+          dataSourceId: s3DataSourceId,
+          runtimeClient,
+          agentClient,
+          s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
+        },
         name: 'integ-s3',
-        knowledgeBaseId,
         writable: true,
-        dataSourceType: 'S3',
-        dataSourceId: s3DataSourceId,
-        runtimeClient,
-        agentClient,
-        s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
       })
 
       const marker = uniqueMarker('s3-add')
@@ -235,15 +247,17 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
 
       const scope = uniqueMarker('s3scope')
       const store = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'S3',
+          dataSourceId: s3DataSourceId,
+          runtimeClient,
+          agentClient,
+          s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
+        },
         name: 'integ-s3-scoped',
-        knowledgeBaseId,
         writable: true,
-        dataSourceType: 'S3',
-        dataSourceId: s3DataSourceId,
-        runtimeClient,
-        agentClient,
         scope,
-        s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
       })
 
       const marker = uniqueMarker('s3-scoped')
@@ -268,26 +282,30 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       const marker = uniqueMarker('s3-isolation')
 
       const storeA = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'S3',
+          dataSourceId: s3DataSourceId,
+          runtimeClient,
+          agentClient,
+          s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
+        },
         name: 'integ-s3-iso-a',
-        knowledgeBaseId,
         writable: true,
-        dataSourceType: 'S3',
-        dataSourceId: s3DataSourceId,
-        runtimeClient,
-        agentClient,
         scope: scopeA,
-        s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
       })
 
       const storeB = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'S3',
+          dataSourceId: s3DataSourceId,
+          runtimeClient,
+          agentClient,
+          s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
+        },
         name: 'integ-s3-iso-b',
-        knowledgeBaseId,
-        dataSourceType: 'S3',
-        dataSourceId: s3DataSourceId,
-        runtimeClient,
-        agentClient,
         scope: scopeB,
-        s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
       })
 
       const result = await storeA.add(`S3 isolated: ${marker}`)
@@ -310,14 +328,16 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       const { knowledgeBaseId, s3DataSourceId, s3Bucket } = config()
 
       const store = new BedrockKnowledgeBaseStore({
+        config: {
+          knowledgeBaseId,
+          dataSourceType: 'S3',
+          dataSourceId: s3DataSourceId,
+          runtimeClient,
+          agentClient,
+          s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
+        },
         name: 'integ-s3-meta',
-        knowledgeBaseId,
         writable: true,
-        dataSourceType: 'S3',
-        dataSourceId: s3DataSourceId,
-        runtimeClient,
-        agentClient,
-        s3: { bucket: s3Bucket, client: s3Client, prefix: `integ-test/${uniqueMarker('pfx')}/` },
       })
 
       const marker = uniqueMarker('s3-meta')
@@ -344,9 +364,8 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       const { knowledgeBaseId } = config()
 
       const store = new BedrockKnowledgeBaseStore({
+        config: { knowledgeBaseId, runtimeClient },
         name: 'integ-readonly',
-        knowledgeBaseId,
-        runtimeClient,
       })
 
       await expect(store.add('should fail')).rejects.toThrow()
@@ -356,9 +375,8 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       const { knowledgeBaseId } = config()
 
       const store = new BedrockKnowledgeBaseStore({
+        config: { knowledgeBaseId, runtimeClient },
         name: 'integ-readonly-search',
-        knowledgeBaseId,
-        runtimeClient,
       })
 
       const entries = await store.search('hello')
@@ -369,10 +387,9 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       expect(
         () =>
           new BedrockKnowledgeBaseStore({
+            config: { knowledgeBaseId: 'fake-id', dataSourceType: 'OTHER' },
             name: 'integ-other',
-            knowledgeBaseId: 'fake-id',
             writable: true,
-            dataSourceType: 'OTHER',
           })
       ).toThrow("add requires dataSourceType 'CUSTOM' or 'S3'")
     })
@@ -383,10 +400,9 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       expect(
         () =>
           new BedrockKnowledgeBaseStore({
+            config: { knowledgeBaseId, dataSourceType: 'CUSTOM' },
             name: 'integ-no-ds',
-            knowledgeBaseId,
             writable: true,
-            dataSourceType: 'CUSTOM',
           })
       ).toThrow('dataSourceId is required')
     })
@@ -397,11 +413,9 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       expect(
         () =>
           new BedrockKnowledgeBaseStore({
+            config: { knowledgeBaseId, dataSourceType: 'S3', dataSourceId: s3DataSourceId },
             name: 'integ-no-s3',
-            knowledgeBaseId,
             writable: true,
-            dataSourceType: 'S3',
-            dataSourceId: s3DataSourceId,
           })
       ).toThrow('s3 config is required')
     })


### PR DESCRIPTION
## Description

Running one Bedrock Knowledge Base across multiple namespaces is a first-class use case (per-user, per-team, per-org memory partitions backed by the same KB). With the constructor shipped in #2630, doing so meant retyping the entire connection config for every namespace, with only `scope` differing:

```typescript
const personal = new BedrockKnowledgeBaseStore({ name: 'personal', knowledgeBaseId: 'KB123', dataSourceType: 'CUSTOM', dataSourceId: 'DS456', writable: true, scope: 'user-abc' })
const team     = new BedrockKnowledgeBaseStore({ name: 'team',     knowledgeBaseId: 'KB123', dataSourceType: 'CUSTOM', dataSourceId: 'DS456', writable: true, scope: 'team-xyz' })
```

This PR restructures the constructor into a single nested shape that cleanly separates the **reusable connection** from the **per-store identity**. Build the connection once, then spin up one store per namespace:

```typescript
const config = { knowledgeBaseId: 'KB123', dataSourceType: 'CUSTOM', dataSourceId: 'DS456' }

const personal = new BedrockKnowledgeBaseStore({ config, name: 'personal', scope: 'user-abc', writable: true })
const team     = new BedrockKnowledgeBaseStore({ config, name: 'team',     scope: 'team-xyz', writable: true })
new MemoryManager({ stores: [personal, team] })
```

This is a DX-only change — search/ingest/validation behavior is unchanged. It only restructures the constructor input.

**Key design decisions** (reviewer-relevant):

- **One shape, always nested — no flat form, no factory, no builder.** A factory method/class and a `shared`-config merge were both considered and rejected: the store should have no notion of "sharing," and a configured store is not the place to encode a caller-side reuse pattern. Reusing `config` across stores is just the caller passing the same object.
- **Clean split, every field in exactly one place.** Connection settings (`knowledgeBaseId`, `dataSourceType`, `dataSourceId`, `s3`, `scopeMetadataKey`, `runtimeClient`, `agentClient`) live inside the new `BedrockKnowledgeBaseConfig`; per-store identity/behavior (`name`, `scope`, `description`, `writable`, `maxSearchResults`, `filter`) sit beside it. No field is settable in two places, so there is no override-precedence rule or excess-property edge case to reason about.
- **`name` is required and independent of `scope`.** An earlier iteration defaulted `name` to `scope`; this was dropped in favor of keeping them distinct — `name` is the routing identity surfaced to the model, `scope` is the data partition. Requiring `name` lets the store config simply `extends MemoryStoreConfig` (which already provides `name`, `description`, `maxSearchResults`, `writable`) instead of carrying an `Omit<>` workaround, and removes a runtime guard.
- **Per-namespace state is immutable.** `scope`, `scopeMetadataKey`, and `filter` are `readonly` — to target a different namespace, construct another store from the same `config` rather than mutating one in place.
- **Client reuse falls out for free.** Inject `runtimeClient` / `agentClient` into `config` and every store built from it reuses them; omit them and each store lazily builds its own default, exactly as before.

## Related Issues

Builds on #2630 (adds `BedrockKnowledgeBaseStore`) and should land after it. Follow-up to #2544.

## Documentation PR

No docs change in this PR. Note: the pre-existing examples in `designs/0011-memory-manager.md` use the original flat constructor form (and reference an `extraction` field that does not exist on the store); they predate this change and #2630, and are left for a separate docs reconciliation.

## Type of Change

Breaking change

This restructures the public constructor of `BedrockKnowledgeBaseStore`. Because the store is introduced by #2630 and is not yet on `main`, this is a pre-release API change with no released consumers to migrate.

### Public API Changes

The constructor now takes a nested `config` plus per-store fields, and a new `BedrockKnowledgeBaseConfig` type is exported:

```typescript
// Before (#2630): flat
new BedrockKnowledgeBaseStore({
  name: 'personal',
  knowledgeBaseId: 'KB123',
  dataSourceType: 'CUSTOM',
  dataSourceId: 'DS456',
  writable: true,
  scope: 'user-abc',
})

// After: connection nested under `config`, identity beside it
new BedrockKnowledgeBaseStore({
  config: { knowledgeBaseId: 'KB123', dataSourceType: 'CUSTOM', dataSourceId: 'DS456' },
  name: 'personal',
  scope: 'user-abc',
  writable: true,
})
```

`name` is now required. `scope`, `scopeMetadataKey`, and `filter` are exposed as `readonly` instance fields — to target a different namespace, construct another store from the same `config` rather than mutating one in place.

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

TypeScript-only change, verified with the strands-ts gates: `npm run build`, `npm run test` (unit, including a `@ts-expect-error` assertion that `name` is required and a `config`-reuse suite covering client reuse, per-store defaults, and `MemoryManager` registration/dedup), `npm run type-check` (src + integ), `npm run lint`, `npm run format:check` — all green. All existing unit tests and the 15 integ-test constructions were migrated to the nested shape with no behavior assertions lost.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.