### PR TITLE
feat: allow same-account IAM roles to assume the integ test role

### DIFF
--- a/test-infra/lib/constructs/integ-test-role.ts
+++ b/test-infra/lib/constructs/integ-test-role.ts
@@ -43,22 +43,30 @@ export class IntegTestRole extends Construct {
       ? requiredInternalEnv('STRANDS_TEST_INFRA_PRIVATE_REPOS').split(',')
       : [];
 
+    const account = cdk.Stack.of(this).account;
+    const runnerRoleNames = process.env.STRANDS_TEST_INFRA_RUNNER_ROLES?.split(',') ?? [];
+
     const assumedBy = props.internal
-      ? new iam.FederatedPrincipal(
-          `arn:aws:iam::${cdk.Stack.of(this).account}:oidc-provider/token.actions.githubusercontent.com`,
-          {
-            StringEquals: {
-              'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+      ? new iam.CompositePrincipal(
+          new iam.FederatedPrincipal(
+            `arn:aws:iam::${account}:oidc-provider/token.actions.githubusercontent.com`,
+            {
+              StringEquals: {
+                'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+              },
+              StringLike: {
+                'token.actions.githubusercontent.com:sub': [...publicRepos, ...privateRepos].map(
+                  (repo) => `repo:strands-agents/${repo}:*`,
+                ),
+              },
             },
-            StringLike: {
-              'token.actions.githubusercontent.com:sub': [...publicRepos, ...privateRepos].map(
-                (repo) => `repo:strands-agents/${repo}:*`,
-              ),
-            },
-          },
-          'sts:AssumeRoleWithWebIdentity',
+            'sts:AssumeRoleWithWebIdentity',
+          ),
+          ...runnerRoleNames.map(
+            (name) => new iam.ArnPrincipal(`arn:aws:iam::${account}:role/${name}`),
+          ),
         )
-      : new iam.AccountPrincipal(cdk.Stack.of(this).account);
+      : new iam.AccountPrincipal(account);
 
     this.role = new iam.Role(this, 'IntegRole', {
       assumedBy,

--- a/test-infra/test/test-infra.test.ts
+++ b/test-infra/test/test-infra.test.ts
@@ -178,6 +178,28 @@ test('community mode uses AccountPrincipal trust', () => {
   });
 });
 
+test('internal mode with RUNNER_ROLES adds AssumeRole trust for those roles', () => {
+  process.env.STRANDS_TEST_INFRA_RUNNER_ROLES = 'MyTestRunner';
+  try {
+    const template = synth({ internal: true, testFeatures: ['bedrock-knowledge-base'] });
+
+    template.hasResourceProperties('AWS::IAM::Role', {
+      AssumeRolePolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 'sts:AssumeRole',
+            Principal: {
+              AWS: Match.stringLikeRegexp(':role/MyTestRunner$'),
+            },
+          }),
+        ]),
+      },
+    });
+  } finally {
+    delete process.env.STRANDS_TEST_INFRA_RUNNER_ROLES;
+  }
+});
+
 test('community mode does not attach the legacy broad policy', () => {
   const template = synth({ internal: false });
 


### PR DESCRIPTION
## Description

Allow same-account IAM roles to assume the integration test role via a new `STRANDS_TEST_INFRA_RUNNER_ROLES` environment variable (comma-separated role names). This enables runners like CI pipeline roles to assume the integ test role directly.

Changes:
- Add `STRANDS_TEST_INFRA_RUNNER_ROLES` env var support to `IntegTestRole` trust policy
- Use `CompositePrincipal` to combine OIDC federation with IAM role principals
- Add unit test covering the new trust policy entry

## Related Issues

N/A

## Type of Change

New feature

## Testing

- Unit tests pass (19/19)
- Verified synthesized CloudFormation includes `sts:AssumeRole` statement for configured runner roles

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
