### PR TITLE
fix(issue-labeler): stop over-applying area-community and chore

### DIFF
--- a/.github/labelers/area.yml
+++ b/.github/labelers/area.yml
@@ -14,6 +14,8 @@ instructions: |
   General agent class behavior (invocation, streaming, result handling) belongs to area-agent. Do not assign area-agent merely because an issue mentions "agent"; require evidence it concerns the core agent class itself.
   area-community is NOT a catch-all. Use it only for repo health, governance, contributor process, release process, and CI dependency bumps. If no area clearly applies, assign no area label rather than defaulting to area-community.
   area-devx covers how it feels to use the SDK: papercuts, confusing or awkward public APIs, error-message quality, ergonomics, surprising behavior that does not match what a developer would reasonably expect, and usability of the developer-facing interface. It is appropriate even for a specific subsystem when the issue is about that subsystem's public API being confusing, awkward, or surprising to use (as opposed to a clear functional bug in its internal behavior). It is NOT a catch-all for any generic "make it better" request that lacks a concrete usability concern.
+  Order matters: list the most important label first, because at most 2 labels are kept. Rank by specificity — concrete feature areas (area-mcp, area-model, area-agent, area-persistence, etc.) come before softer cross-cutting labels (area-devx, area-community) that are not tied to one feature area. When an issue reports a bug in a concrete area, that area takes priority.
+  Example: "the MCPClient constructor arguments are confusing and the error when a server is unreachable is unhelpful" -> area-mcp, then area-devx (concrete area first, usability second). But "MCPClient drops messages under concurrent calls" -> area-mcp only (functional bug in internals; no devx concern).
 
 labels:
   area-a2a:

--- a/.github/labelers/area.yml
+++ b/.github/labelers/area.yml
@@ -11,7 +11,9 @@ instructions: |
   Documentation content issues belong to documentation, not area-devx.
   Storage backend implementation issues (S3, DynamoDB, file) belong to area-persistence. Session lifecycle and interface issues belong to area-sessions.
   Context window/token management belongs to area-context.
-  General agent class behavior (invocation, streaming, result handling) belongs to area-agent.
+  General agent class behavior (invocation, streaming, result handling) belongs to area-agent. Do not assign area-agent merely because an issue mentions "agent"; require evidence it concerns the core agent class itself.
+  area-community is NOT a catch-all. Use it only for repo health, governance, contributor process, release process, and CI dependency bumps. If no area clearly applies, assign no area label rather than defaulting to area-community.
+  area-devx covers how it feels to use the SDK: papercuts, confusing or awkward public APIs, error-message quality, ergonomics, surprising behavior that does not match what a developer would reasonably expect, and usability of the developer-facing interface. It is appropriate even for a specific subsystem when the issue is about that subsystem's public API being confusing, awkward, or surprising to use (as opposed to a clear functional bug in its internal behavior). It is NOT a catch-all for any generic "make it better" request that lacks a concrete usability concern.
 
 labels:
   area-a2a:
@@ -23,13 +25,13 @@ labels:
   area-bidirectional-streaming:
     description: "Bidirectional streaming, BidiAgent, real-time audio/video, WebRTC, WebSocket, Nova Sonic, voice agents"
   area-community:
-    description: "Community health, monorepo consolidation, contributor guides, governance, CI dependency bumps, release process"
+    description: "Repo health, governance, contributor guides, release process, and CI dependency bumps. Not a fallback for issues that fit no other area."
   area-config:
     description: "Config-based agents, agent config files, mcp-config, declarative agent/graph/swarm definitions from YAML"
   area-context:
     description: "Conversation management, context windows, context reduction, sliding window, token management, compression strategies"
   area-devx:
-    description: "Developer experience improvements, better APIs, ergonomics, helper methods, error messages, SDK usability"
+    description: "Developer experience: papercuts, confusing or awkward public APIs, error messages, ergonomics, surprising behavior that doesn't match expectations, helper methods, and usability of the SDK's developer-facing interface"
   area-hil:
     description: "Human-in-the-loop, interrupt/resume, suspend/resume, approval workflows, callback-based tool execution"
   area-hooks:

--- a/.github/labelers/type.yml
+++ b/.github/labelers/type.yml
@@ -3,15 +3,13 @@
 # Use max_labels: 1 in the workflow since these are mutually exclusive.
 
 instructions: |
-  Choose exactly one type.
-  The conventional-commit prefix in the title is authoritative when present:
-  "feat:"/"feat(...)" is an enhancement; "fix:"/"fix(...)" is a bug;
-  "chore:", "ci:", "build:", "refactor:", "perf:", "style:", "test:" are chores;
-  "docs:" follows the documentation rules below.
-  Only treat a PR as a chore when its own changes are maintenance with no
-  user-facing impact (dependency bumps, CI config, internal refactors). A PR
-  that adds or changes user-facing functionality is an enhancement even if it
-  also touches build or CI files.
+  Choose exactly one type. You are given only the title and body — there is no diff or file list, so judge from those.
+  The conventional-commit prefix in the title is authoritative when present, including its optional scope (e.g. "feat(core):" counts as "feat:"). Match the prefix regardless of scope:
+  - "feat" -> enhancement
+  - "fix" -> bug
+  - "chore", "ci", "build", "refactor", "perf", "style", "test" -> chore
+  - "docs" -> follow the documentation rules below
+  The prefix wins even when the description sounds user-facing: a "perf:" or "refactor:" title is a chore. When no conventional-commit prefix is present, fall back to the body: maintenance with no user-facing impact (dependency bumps, CI config, internal refactors) is a chore, while anything that adds or changes user-facing functionality is an enhancement.
   If the title starts with [BUG] it is a bug. If the title starts with [FEATURE] it is an enhancement.
   Documentation improvements or corrections are bugs. Requests for new docs or content additions are enhancements. Documentation questions are questions.
 

--- a/.github/labelers/type.yml
+++ b/.github/labelers/type.yml
@@ -3,9 +3,16 @@
 # Use max_labels: 1 in the workflow since these are mutually exclusive.
 
 instructions: |
-  Choose exactly one type. If the title starts with [BUG] it is a bug.
-  If the title starts with [FEATURE] it is an enhancement.
-  CI/dependency PRs that open as issues are chores.
+  Choose exactly one type.
+  The conventional-commit prefix in the title is authoritative when present:
+  "feat:"/"feat(...)" is an enhancement; "fix:"/"fix(...)" is a bug;
+  "chore:", "ci:", "build:", "refactor:", "perf:", "style:", "test:" are chores;
+  "docs:" follows the documentation rules below.
+  Only treat a PR as a chore when its own changes are maintenance with no
+  user-facing impact (dependency bumps, CI config, internal refactors). A PR
+  that adds or changes user-facing functionality is an enhancement even if it
+  also touches build or CI files.
+  If the title starts with [BUG] it is a bug. If the title starts with [FEATURE] it is an enhancement.
   Documentation improvements or corrections are bugs. Requests for new docs or content additions are enhancements. Documentation questions are questions.
 
 labels:

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           sparse-checkout: .github/labelers
           sparse-checkout-cone-mode: false
-      # max_labels omitted: issues may span multiple areas
       - uses: strands-agents/devtools/issue-labeler@main
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           config_path: '.github/labelers/area.yml'
+          max_labels: '2'
 
   label-type:
     name: "Label: Type"


### PR DESCRIPTION
## Summary

Tuning fixes after observing mislabels on recent PRs (e.g. a `feat:` PR labeled `chore`, and `area-community` landing on nearly everything).

## Problems

- **`area-community` over-applied.** Its description read as a catch-all, so PRs that fit no specific area defaulted to it.
- **`chore` on feature PRs.** `type.yml` ignored the conventional-commit prefix; a PR titled `feat: ...` was labeled `chore`.
- **Too many area labels.** The area job used the default cap of 3; most issues span at most 2 areas.
- **Same catch-all risk elsewhere.** Reviewing the rest of `area.yml`, `area-devx` ("ergonomics, usability") and `area-agent` ("core agent class") had the same magnet phrasing.

## Fix

- Narrow `area-community` and instruct the classifier to assign no area label when none clearly applies.
- Add a guard so `area-agent` requires the core agent class rather than any mention of "agent".
- Clarify `area-devx` as the developer-experience axis: papercuts, confusing or awkward public APIs, error messages, and surprising behavior that doesn't match expectations. It is appropriate even for a specific subsystem when the issue is about that subsystem's public API being confusing or surprising to use (as opposed to a clear functional bug in its internals), but it is not a catch-all for generic "make it better" requests.
- Make the conventional-commit prefix authoritative in `type.yml`: match prefixes regardless of scope, treat the prefix as decisive over the user-facing heuristic, and judge from title + body (the labeler has no diff visibility).
- Set `max_labels: '2'` on the area job.

## Testing

- [ ] After merge, confirm a `feat:` PR receives `enhancement` (not `chore`) and that unrelated PRs no longer get `area-community` by default.