### PR TITLE
fix(dependabot): label npm updates typescript instead of javascript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 100
+    labels:
+      - "dependencies"
+      - "python"
     commit-message:
       prefix: "ci(python)"
     groups:
@@ -50,6 +53,9 @@ updates:
     directory: "/strands-py-wasm"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "python"
     commit-message:
       prefix: "ci(python)"
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 100
+    labels:
+      - "dependencies"
+      - "typescript"
     commit-message:
       prefix: "ci(typescript)"
     cooldown:
@@ -38,6 +41,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 100
+    labels:
+      - "dependencies"
+      - "typescript"
     commit-message:
       prefix: "ci(docs)"
   - package-ecosystem: "pip"


### PR DESCRIPTION
## Summary

Dependabot applied its default `javascript` ecosystem label to npm dependency PRs. Since the repo's npm packages (the TypeScript SDK at `/` and the docs site at `/site`) are TypeScript, this drew a complaint.

## Fix

Set explicit `labels:` on both npm entries so updates get `dependencies` + `typescript` instead of the default `javascript`:

```yaml
labels:
  - "dependencies"
  - "typescript"
```

`dependencies` is included so that label is preserved (explicit labels replace dependabot's defaults).

## Follow-up (not in this PR)

Existing open `javascript`-labeled PRs will be migrated to `typescript` and the `javascript` repo label removed separately.

## Testing

- [ ] Confirm the next dependabot npm PR opens with `dependencies` + `typescript` and no `javascript`.