### PR TITLE
fix(template): remove stale consuming-repos reference from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ Other (please describe):
 
 ## Testing
 
-How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
+How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.
 
 - [ ] I ran `hatch run prepare`
 


### PR DESCRIPTION
## Summary

The PR template's testing section listed `consuming repositories: agents-docs, agents-tools, agents-cli`. Those repos were copied from another project's template and don't apply to harness-sdk, so the instruction is misleading to contributors.

## Fix

Replace the specific (incorrect) repo list with a generic instruction:

```diff
- How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
+ How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.
```

## Testing

- [ ] N/A — template-only change.