### PR TITLE
docs: add context management page for context_manager=auto 

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -73,6 +73,7 @@ sidebar:
           - docs/user-guide/concepts/agents/prompts
           - docs/user-guide/concepts/agents/hooks
           - docs/user-guide/concepts/agents/conversation-management
+          - docs/user-guide/concepts/context-management
           - docs/user-guide/concepts/agents/retry-strategies
           - docs/user-guide/concepts/interrupts
           - label: Tools

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -17,6 +17,11 @@ As conversations grow, managing this context becomes increasingly important for 
 3. **Relevance**: Older messages may become less relevant to the current conversation
 4. **Coherence**: Maintaining logical flow and preserving important information
 
+:::tip[Quick setup]
+For most agents, you can skip manual configuration entirely.
+See [Context Management](../context-management).
+:::
+
 ## Built-in Conversation Managers
 
 The SDK provides a flexible system for context management through the ConversationManager interface. This allows you to implement different strategies for managing conversation history. You can either leverage one of Strands's provided managers:

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -170,3 +170,4 @@ async function proactiveSummarizing() {
   })
   // --8<-- [end:proactive_summarizing]
 }
+

--- a/site/src/content/docs/user-guide/concepts/context-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/context-management.mdx
@@ -8,21 +8,13 @@ sidebar:
     variant: tip
 ---
 
-As conversations grow, your agent's context window fills with
-messages, tool results, and system prompts. Without management,
-this leads to token limit errors, degraded performance, and
-loss of relevant information.
+As conversations grow, your agent's context window fills with messages, tool results, and system prompts. Without management, this leads to token limit errors, degraded performance, and loss of relevant information.
 
-The SDK provides several layers of context management that you
-can use independently or together.
+The SDK provides several layers of context management that you can use independently or together.
 
 ## Automatic context management
 
-For most agents with multi-turn conversations, you don't need
-to configure conversation management and context offloading
-separately. Pass `context_manager="auto"` (Python) or
-`contextManager: "auto"` (TypeScript) and the SDK wires up
-both with tuned defaults:
+For most agents with multi-turn conversations, you don't need to configure conversation management and context offloading separately. Pass `context_manager="auto"` (Python) or `contextManager: "auto"` (TypeScript) and the SDK wires up both with tuned defaults:
 
 <Tabs>
 <Tab label="Python">
@@ -45,36 +37,19 @@ agent = Agent(context_manager="auto")
 
 ### What it sets up
 
-This composes two components whose defaults were optimal on
-[ContextBench](https://arxiv.org/abs/2602.05892):
+This composes two components whose defaults scored highest across [ContextBench](https://arxiv.org/abs/2602.05892) evaluations relative to other Strands Agent configurations:
 
-- **SummarizingConversationManager** (`summary_ratio=0.3`,
-  `compression_threshold=0.85`): proactively summarizes older
-  messages before the context window fills, preserving key
-  information while freeing space for new turns.
-- **ContextOffloader plugin** (`max_result_tokens=1500`,
-  `preview_tokens=750`): intercepts large tool results at
-  execution time, stores them externally, and keeps a truncated
-  preview in context. Registers a
-  `retrieve_offloaded_content` tool so the agent can fetch
-  full content on demand.
+- **SummarizingConversationManager** (summary ratio of 0.3, compression threshold of 0.85): proactively summarizes older messages before the context window fills, preserving key information while freeing space for new turns.
+- **ContextOffloader plugin** (max result tokens of 1,500, preview tokens of 750): intercepts large tool results at execution time, stores them externally, and keeps a truncated preview in context. Registers a `retrieve_offloaded_content` tool so the agent can fetch full content on demand.
 
-For full details on each component, see
-[Conversation Management](./agents/conversation-management#summarizingconversationmanager)
-and [Context Offloader](./plugins/context-offloader).
+For full details on each component, see [Conversation Management](./agents/conversation-management#summarizingconversationmanager) and [Context Offloader](./plugins/context-offloader).
 
 ### Combining with explicit configuration
 
-Your own settings take precedence when you need fine-grained
-control:
+Your own settings take precedence when you need fine-grained control:
 
-- **Custom conversation manager**: If you also pass
-  `conversation_manager` / `conversationManager`, your manager
-  replaces the auto-composed `SummarizingConversationManager`.
-  The SDK still adds the `ContextOffloader` plugin.
-- **Existing ContextOffloader**: If your `plugins` list already
-  contains a `ContextOffloader` instance, no duplicate is added.
-  Your configuration is preserved.
+- **Custom conversation manager**: If you also pass `conversation_manager` / `conversationManager`, your manager replaces the auto-composed `SummarizingConversationManager`. The SDK still adds the `ContextOffloader` plugin.
+- **Existing ContextOffloader**: If your `plugins` list already contains a `ContextOffloader` instance, no duplicate is added. Your configuration is preserved.
 
 <Tabs>
 <Tab label="Python">
@@ -98,9 +73,9 @@ agent = Agent(
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/context-management_imports.ts:custom_cm_imports"
+--8<-- "user-guide/concepts/context-management_imports.ts:custom_conversation_manager_imports"
 
---8<-- "user-guide/concepts/context-management.ts:custom_cm"
+--8<-- "user-guide/concepts/context-management.ts:custom_conversation_manager"
 ```
 </Tab>
 </Tabs>
@@ -108,14 +83,7 @@ agent = Agent(
 ### Limitations
 
 :::caution[Not compatible with stateful models]
-Stateful models manage conversation state server-side.
-Setting `context_manager="auto"` with a stateful model raises
-a `ValueError` (Python) or `Error` (TypeScript).
+Stateful models manage conversation state server-side. Setting `context_manager="auto"` with a stateful model raises a `ValueError` (Python) or `Error` (TypeScript).
 :::
 
-The auto-composed offloader uses in-memory storage that does not
-persist across process restarts. If your agent uses session
-management and needs durable offloaded content, configure an
-explicit `ContextOffloader` with `FileStorage` or `S3Storage`.
-See [Storage Backends](./plugins/context-offloader#storage-backends).
-
+The auto-composed offloader uses in-memory storage that does not persist across process restarts. If your agent uses session management and needs durable offloaded content, configure an explicit `ContextOffloader` with `FileStorage` or `S3Storage`. See [Storage Backends](./plugins/context-offloader#storage-backends).

--- a/site/src/content/docs/user-guide/concepts/context-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/context-management.mdx
@@ -1,0 +1,117 @@
+---
+title: Context Management
+description: "Manage your agent's context window as conversations grow and tool results accumulate."
+tags: [conversation-management, token-management]
+---
+
+As conversations grow, your agent's context window fills with
+messages, tool results, and system prompts. Without management,
+this leads to token limit errors, degraded performance, and
+loss of relevant information.
+
+The SDK provides several layers of context management that you
+can use independently or together.
+
+## Automatic context management
+
+For most agents with multi-turn conversations, you don't need
+to configure conversation management and context offloading
+separately. Pass `context_manager="auto"` (Python) or
+`contextManager: "auto"` (TypeScript) and the SDK wires up
+both with tuned defaults:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+
+agent = Agent(context_manager="auto")
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/context-management_imports.ts:basic_imports"
+
+--8<-- "user-guide/concepts/context-management.ts:basic"
+```
+</Tab>
+</Tabs>
+
+### What it sets up
+
+This composes two components whose defaults were optimal on
+[ContextBench](https://arxiv.org/abs/2602.05892):
+
+- **SummarizingConversationManager** (`summary_ratio=0.3`,
+  `compression_threshold=0.85`): proactively summarizes older
+  messages before the context window fills, preserving key
+  information while freeing space for new turns.
+- **ContextOffloader plugin** (`max_result_tokens=1500`,
+  `preview_tokens=750`): intercepts large tool results at
+  execution time, stores them externally, and keeps a truncated
+  preview in context. Registers a
+  `retrieve_offloaded_content` tool so the agent can fetch
+  full content on demand.
+
+For full details on each component, see
+[Conversation Management](./agents/conversation-management#summarizingconversationmanager)
+and [Context Offloader](./plugins/context-offloader).
+
+### Combining with explicit configuration
+
+Your own settings take precedence when you need fine-grained
+control:
+
+- **Custom conversation manager**: If you also pass
+  `conversation_manager` / `conversationManager`, your manager
+  replaces the auto-composed `SummarizingConversationManager`.
+  The SDK still adds the `ContextOffloader` plugin.
+- **Existing ContextOffloader**: If your `plugins` list already
+  contains a `ContextOffloader` instance, no duplicate is added.
+  Your configuration is preserved.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.agent.conversation_manager import (
+    SlidingWindowConversationManager,
+)
+
+# Your conversation manager is used;
+# ContextOffloader is still added automatically
+agent = Agent(
+    context_manager="auto",
+    conversation_manager=SlidingWindowConversationManager(
+        window_size=30,
+    ),
+)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/context-management_imports.ts:custom_cm_imports"
+
+--8<-- "user-guide/concepts/context-management.ts:custom_cm"
+```
+</Tab>
+</Tabs>
+
+### Limitations
+
+:::caution[Not compatible with stateful models]
+Stateful models manage conversation state server-side.
+Setting `context_manager="auto"` with a stateful model raises
+a `ValueError` (Python) or `Error` (TypeScript).
+:::
+
+The auto-composed offloader uses in-memory storage that does not
+persist across process restarts. If your agent uses session
+management and needs durable offloaded content, configure an
+explicit `ContextOffloader` with `FileStorage` or `S3Storage`.
+See [Storage Backends](./plugins/context-offloader#storage-backends).
+

--- a/site/src/content/docs/user-guide/concepts/context-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/context-management.mdx
@@ -2,6 +2,10 @@
 title: Context Management
 description: "Manage your agent's context window as conversations grow and tool results accumulate."
 tags: [conversation-management, token-management]
+sidebar:
+  badge:
+    text: New
+    variant: tip
 ---
 
 As conversations grow, your agent's context window fills with

--- a/site/src/content/docs/user-guide/concepts/context-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/context-management.mdx
@@ -82,8 +82,6 @@ agent = Agent(
 
 ### Limitations
 
-:::caution[Not compatible with stateful models]
-Stateful models manage conversation state server-side. Setting `context_manager="auto"` with a stateful model raises a `ValueError` (Python) or `Error` (TypeScript).
-:::
+**Stateful models**: Stateful models manage conversation state server-side. Setting `context_manager="auto"` with a stateful model raises a `ValueError` (Python) or `Error` (TypeScript).
 
 The auto-composed offloader uses in-memory storage that does not persist across process restarts. If your agent uses session management and needs durable offloaded content, configure an explicit `ContextOffloader` with `FileStorage` or `S3Storage`. See [Storage Backends](./plugins/context-offloader#storage-backends).

--- a/site/src/content/docs/user-guide/concepts/context-management.ts
+++ b/site/src/content/docs/user-guide/concepts/context-management.ts
@@ -8,8 +8,8 @@ async function basic() {
   // --8<-- [end:basic]
 }
 
-async function customCm() {
-  // --8<-- [start:custom_cm]
+async function customConversationManager() {
+  // --8<-- [start:custom_conversation_manager]
   // Your conversation manager is used;
   // ContextOffloader is still added automatically
   const agent = new Agent({
@@ -18,5 +18,5 @@ async function customCm() {
       windowSize: 30,
     }),
   })
-  // --8<-- [end:custom_cm]
+  // --8<-- [end:custom_conversation_manager]
 }

--- a/site/src/content/docs/user-guide/concepts/context-management.ts
+++ b/site/src/content/docs/user-guide/concepts/context-management.ts
@@ -1,0 +1,22 @@
+import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
+
+async function basic() {
+  // --8<-- [start:basic]
+  const agent = new Agent({
+    contextManager: 'auto',
+  })
+  // --8<-- [end:basic]
+}
+
+async function customCm() {
+  // --8<-- [start:custom_cm]
+  // Your conversation manager is used;
+  // ContextOffloader is still added automatically
+  const agent = new Agent({
+    contextManager: 'auto',
+    conversationManager: new SlidingWindowConversationManager({
+      windowSize: 30,
+    }),
+  })
+  // --8<-- [end:custom_cm]
+}

--- a/site/src/content/docs/user-guide/concepts/context-management_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/context-management_imports.ts
@@ -4,9 +4,9 @@
 import { Agent } from '@strands-agents/sdk'
 // --8<-- [end:basic_imports]
 
-// --8<-- [start:custom_cm_imports]
+// --8<-- [start:custom_conversation_manager_imports]
 import {
   Agent,
   SlidingWindowConversationManager,
 } from '@strands-agents/sdk'
-// --8<-- [end:custom_cm_imports]
+// --8<-- [end:custom_conversation_manager_imports]

--- a/site/src/content/docs/user-guide/concepts/context-management_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/context-management_imports.ts
@@ -1,0 +1,12 @@
+// @ts-nocheck
+
+// --8<-- [start:basic_imports]
+import { Agent } from '@strands-agents/sdk'
+// --8<-- [end:basic_imports]
+
+// --8<-- [start:custom_cm_imports]
+import {
+  Agent,
+  SlidingWindowConversationManager,
+} from '@strands-agents/sdk'
+// --8<-- [end:custom_cm_imports]

--- a/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -49,6 +49,12 @@ For non-text content, the plugin replaces the result with a descriptive placehol
 
 ## Getting Started
 
+:::tip[Quick setup]
+You can enable a pre-configured `ContextOffloader` alongside
+summarization-based context management with a single parameter.
+See [Context Management](../context-management).
+:::
+
 Pass a `ContextOffloader` instance to your agent's `plugins` list with your choice of storage backend:
 
 <Tabs>


### PR DESCRIPTION
## Description

Adds documentation for the `context_manager="auto"` facade introduced in #2643. The new page lives at `site/src/content/docs/user-guide/concepts/context-management.mdx` as a top-level Concepts entry, positioned directly below Conversation Management in the sidebar.

The page covers:
- Basic usage with Python and TypeScript examples
- What the "auto" strategy composes (SummarizingConversationManager + ContextOffloader) and the ContextBench-optimal defaults
- Coexistence rules when combining with explicit `conversation_manager` or existing `ContextOffloader` plugins
- Limitations (stateful models, in-memory storage)

Also adds tip callouts on the existing conversation-management and context-offloader pages pointing to the new page.

## Related Issues

strands-agents/harness-sdk#2643

## Documentation PR

This PR *is* the documentation change.

## Type of Change

Documentation update

## Testing

- Verified all `--8<--` snippet markers resolve between MDX and TypeScript files
- Verified nav entry placement in `navigation.yml`
- Verified cross-reference links are correct relative paths
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.