### PR TITLE
docs: add message pinning section to conversation management page

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -107,6 +107,7 @@ Key features of the `SlidingWindowConversationManager`:
 
     When disabled, full results are preserved but more historical messages may be removed. For a proactive alternative that preserves full content externally, see the [Context Offloader](../plugins/context-offloader) plugin.
 - **Per-Turn Management**: Optionally apply context management proactively during the agent loop execution, not just at the end.
+- **Message Pinning**: Protect specific messages from trimming during context reduction. See [Message Pinning](#message-pinning).
 - **Proactive Compression**: Pass `proactiveCompression: true` or `proactiveCompression: { compressionThreshold: 0.7 }` to trigger context reduction before the model call when projected input tokens exceed a configurable threshold. See [Proactive Context Compression](#proactive-context-compression).
 
 **Per-Turn Management**:
@@ -325,8 +326,94 @@ Pass a custom `model` to `SummarizingConversationManager` to override the model 
 - **Context Window Management**: Automatically reduces context when token limits are exceeded
 - **Intelligent Summarization**: Uses structured bullet-point summaries to capture key information
 - **Tool Pair Preservation**: Ensures tool use and result message pairs aren't broken during summarization
+- **Message Pinning**: Protect specific messages from summarization during context reduction. See [Message Pinning](#message-pinning).
 - **Flexible Configuration**: Customize summarization behavior through various parameters
 - **Fallback Safety**: Handles summarization failures gracefully
+
+## Message Pinning
+
+Message pinning protects specific messages from eviction during context reduction. Pinned messages survive both sliding-window trimming and summarization, which makes pinning useful for preserving system prompts, critical instructions, or key decisions that must remain in the conversation regardless of length.
+
+Messages are pinned by setting `metadata.custom.pinned = true` on the message object. The SDK provides both a declarative configuration (`pin_first` / `pinFirst`) and runtime utility functions for programmatic control.
+
+### Protecting Initial Messages with `pin_first`
+
+Both `SlidingWindowConversationManager` and `SummarizingConversationManager` accept a `pin_first` (Python) / `pinFirst` (TypeScript) parameter that permanently protects the first N messages from eviction. This is the simplest way to preserve system prompts or initial instructions across all context reductions.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.agent.conversation_manager import SlidingWindowConversationManager
+
+agent = Agent(
+    conversation_manager=SlidingWindowConversationManager(
+        window_size=40,
+        pin_first=1,
+    )
+)
+```
+
+The same parameter works with `SummarizingConversationManager`:
+
+```python
+from strands.agent.conversation_manager import SummarizingConversationManager
+
+agent = Agent(
+    conversation_manager=SummarizingConversationManager(
+        pin_first=2,
+    )
+)
+```
+
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/conversation-management_imports.ts:pin_first_imports"
+
+--8<-- "user-guide/concepts/agents/conversation-management.ts:pin_first"
+```
+
+The same parameter works with `SummarizingConversationManager`.
+
+</Tab>
+</Tabs>
+
+The pin metadata is written during the first context reduction and remains set permanently, protecting those messages through all subsequent reductions.
+
+### Pinning Messages at Runtime
+
+For dynamic control, use the utility functions to pin or unpin messages by index. This enables agents or application logic to mark messages as important based on their content rather than position.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.agent.conversation_manager import pin_message, unpin_message, is_pinned
+
+pin_message(agent.messages, 0)
+
+if is_pinned(agent.messages, 0):
+    print("Message is protected from eviction")
+
+unpin_message(agent.messages, 0)
+```
+
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/conversation-management_imports.ts:pin_message_imports"
+
+--8<-- "user-guide/concepts/agents/conversation-management.ts:pin_message_usage"
+```
+
+</Tab>
+</Tabs>
+
+**Tool-pair partner protection**: Pinning a `toolUse` message automatically protects its adjacent `toolResult` partner (matched by `toolUseId`), and vice versa. This prevents orphaned tool interactions in the conversation history.
 
 ## Proactive Context Compression
 

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -6,6 +6,9 @@ import {
   SlidingWindowConversationManager,
   SummarizingConversationManager,
   BedrockModel,
+  pinMessage,
+  unpinMessage,
+  isPinned,
 } from '@strands-agents/sdk'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 import type { LocalAgent, ConversationManagerReduceOptions } from '@strands-agents/sdk'
@@ -165,3 +168,26 @@ async function proactiveSummarizing() {
   // --8<-- [end:proactive_summarizing]
 }
 
+async function pinFirstExample() {
+  // --8<-- [start:pin_first]
+  const agent = new Agent({
+    conversationManager: new SlidingWindowConversationManager({
+      windowSize: 40,
+      pinFirst: 1,
+    }),
+  })
+  // --8<-- [end:pin_first]
+}
+
+async function pinMessageUsage() {
+  const agent = new Agent({})
+  // --8<-- [start:pin_message_usage]
+  pinMessage(agent.messages, 0)
+
+  if (isPinned(agent.messages, 0)) {
+    console.log('Message is protected from eviction')
+  }
+
+  unpinMessage(agent.messages, 0)
+  // --8<-- [end:pin_message_usage]
+}

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
@@ -50,3 +50,11 @@ import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
 // --8<-- [start:proactive_summarizing_imports]
 import { Agent, SummarizingConversationManager } from '@strands-agents/sdk'
 // --8<-- [end:proactive_summarizing_imports]
+
+// --8<-- [start:pin_first_imports]
+import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
+// --8<-- [end:pin_first_imports]
+
+// --8<-- [start:pin_message_imports]
+import { pinMessage, unpinMessage, isPinned } from '@strands-agents/sdk'
+// --8<-- [end:pin_message_imports]

--- a/strands-py/src/strands/agent/conversation_manager/__init__.py
+++ b/strands-py/src/strands/agent/conversation_manager/__init__.py
@@ -16,6 +16,7 @@ is critical for effective agent interactions.
 
 from .conversation_manager import ConversationManager, ProactiveCompressionConfig
 from .null_conversation_manager import NullConversationManager
+from .pin_message import is_pinned, pin_message, unpin_message
 from .sliding_window_conversation_manager import SlidingWindowConversationManager
 from .summarizing_conversation_manager import SummarizingConversationManager
 
@@ -25,4 +26,7 @@ __all__ = [
     "ProactiveCompressionConfig",
     "SlidingWindowConversationManager",
     "SummarizingConversationManager",
+    "is_pinned",
+    "pin_message",
+    "unpin_message",
 ]

--- a/strands-ts/src/conversation-manager/index.ts
+++ b/strands-ts/src/conversation-manager/index.ts
@@ -19,3 +19,4 @@ export {
   SummarizingConversationManager,
   type SummarizingConversationManagerConfig,
 } from './summarizing-conversation-manager.js'
+export { isPinned, pinMessage, unpinMessage } from './pin-message.js'

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -268,6 +268,7 @@ export {
   SummarizingConversationManager,
   type SummarizingConversationManagerConfig,
 } from './conversation-manager/summarizing-conversation-manager.js'
+export { isPinned, pinMessage, unpinMessage } from './conversation-manager/pin-message.js'
 
 // Logging
 export { configureLogging } from './logging/logger.js'


### PR DESCRIPTION

## Description

Add a "Message Pinning" section to the conversation management documentation page. Covers the new `pin_first`/`pinFirst` configuration parameter and runtime utility functions (`pin_message`/`pinMessage`, `unpin_message`/`unpinMessage`, `is_pinned`/`isPinned`) with examples for both Python and TypeScript. Adds cross-reference bullets in the SlidingWindow and Summarizing manager feature lists.

## Related Issues

Documents the feature added in #2644

## Documentation PR

Changes are under `site/` in this PR.

## Type of Change

Documentation update

## Testing

- [x] Verified snippet inclusion tags match between `.mdx` and `.ts` files
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
```