### PR TITLE
docs: add Syntax component for inline language-specific identifiers

### DIFF
--- a/.agents/references/mdx-authoring.md
+++ b/.agents/references/mdx-authoring.md
@@ -22,6 +22,21 @@ Practical reference for writing documentation in this repo. This site uses Astro
 </Tabs>
 ```
 
+`<Syntax>` is also globally available. Use it when shared prose needs to reference a language-specific identifier — any method name, parameter, class name, or short expression that differs between Python and TypeScript:
+
+```mdx
+Use <Syntax py=".as_tool()" ts=".asTool()" /> to customize the tool name.
+The <Syntax py="Agent.retry_strategy" ts="Agent.retryStrategy" /> parameter controls retry behavior.
+```
+
+Renders as inline `<code>` by default. Pass `code={false}` for plain text. Reacts live to the global language toggle — no page reload.
+
+**When to use `<Syntax>` vs `<Tabs>`:**
+- `<Syntax>`: single identifier or short expression that differs by language, embedded in a prose sentence.
+- `<Tabs>`: code blocks, multi-line examples, or content that's structurally different between languages.
+
+Never spell out both language variants manually in prose. Use `<Syntax>` instead.
+
 For other Starlight components (`Aside`, `Card`, `CardGrid`, `LinkCard`, `Icon`, `Badge`), use explicit imports:
 
 ```mdx

--- a/.agents/references/mdx-authoring.md
+++ b/.agents/references/mdx-authoring.md
@@ -29,7 +29,7 @@ Use <Syntax py=".as_tool()" ts=".asTool()" /> to customize the tool name.
 The <Syntax py="Agent.retry_strategy" ts="Agent.retryStrategy" /> parameter controls retry behavior.
 ```
 
-Renders as inline `<code>` by default. Pass `code={false}` for plain text. Reacts live to the global language toggle — no page reload.
+Renders as inline `<code>` by default. Pass `plain` for plain text. Reacts live to the global language toggle — no page reload.
 
 **When to use `<Syntax>` vs `<Tabs>`:**
 - `<Syntax>`: single identifier or short expression that differs by language, embedded in a prose sentence.

--- a/.agents/references/voice-guide.md
+++ b/.agents/references/voice-guide.md
@@ -322,7 +322,7 @@ Strands ships both a Python and TypeScript SDK. Most doc pages show code in both
 - Python has `from strands import Agent`, TypeScript has `import { Agent } from '@strands-agents/sdk'` (verify current package name)
 - Error handling differs: Python raises exceptions, TypeScript may use different patterns
 
-**Prose between tabs should be language-neutral.** Don't write "Pass the `retry_strategy` parameter..." when the tabs show both Python and TypeScript. Write "Configure a retry strategy:" and let the code speak for itself. Language-specific parameter names belong in the code blocks, not in the prose.
+**Prose between tabs should be language-neutral — or use `<Syntax>`.** When shared prose needs to reference a language-specific identifier, use the `<Syntax>` component rather than spelling out both variants manually. This adapts to the reader's language selection and keeps prose clean. For introductory sentences before tabs, you can also write language-neutral prose ("Configure a retry strategy:") and let the code speak for itself.
 
 **Never name the language inside its own tab.** The reader selected the tab; they know which language they're reading. State facts directly without prefixing the language name. The tab itself provides that context.
 

--- a/.agents/skills/docs-audit/SKILL.md
+++ b/.agents/skills/docs-audit/SKILL.md
@@ -59,6 +59,7 @@ Specific checks:
 - Is essential context at the top?
 - Is inline code properly formatted with backticks?
 - Is terminology consistent with the terminology lock?
+- Are language-specific identifiers in shared prose using the `<Syntax>` component rather than being spelled out manually with language labels?
 
 ### Step 5: Competitive comparison (optional)
 

--- a/.agents/skills/docs-reviewer/SKILL.md
+++ b/.agents/skills/docs-reviewer/SKILL.md
@@ -27,7 +27,7 @@ Reference `../../references/voice-guide.md` for the full layer definitions. Chec
 - **Narrative flow:** Start with why the topic matters and what use-case problems it solves. Throughout, show how to implement using Strands SDK in a self-contained, concise way.
 - **Framing:** Does the first sentence of every section describe the developer's goal? Flag sections leading with API descriptions.
 - **Register:** Is the tone appropriate for the content type?
-- **Constraints:** Scan for banned phrases, em-dashes, passive voice, hedging. Apply type-aware overrides (passive in reference is fine; longer sentences in explanation are fine). Flag any prose inside a `<Tab>` that names the language of that tab (e.g., "Python requires..." inside the Python tab, "In TypeScript..." inside the TypeScript tab). The reader chose the tab; they know what language they're reading.
+- **Constraints:** Scan for banned phrases, em-dashes, passive voice, hedging. Apply type-aware overrides (passive in reference is fine; longer sentences in explanation are fine). Flag any prose inside a `<Tab>` that names the language of that tab (e.g., "Python requires..." inside the Python tab, "In TypeScript..." inside the TypeScript tab). The reader chose the tab; they know what language they're reading. Flag language-specific identifiers spelled out manually in shared prose — these should use the `<Syntax>` component to adapt to the reader's language selection.
 - **Authenticity:** Structural variety, visible editorial choices, concision.
 
 ### 2. Terminology Consistency

--- a/.agents/skills/docs-writer/SKILL.md
+++ b/.agents/skills/docs-writer/SKILL.md
@@ -52,7 +52,9 @@ Write each section following the outline.
 
 ### Step 3b: Apply MDX formatting
 
-Apply MDX formatting patterns from `../../references/mdx-authoring.md` — especially Tabs/Tab syntax, snippet includes, and callout syntax.
+Apply MDX formatting patterns from `../../references/mdx-authoring.md` — especially Tabs/Tab syntax, the `<Syntax>` component for inline language-specific identifiers, snippet includes, and callout syntax.
+
+When shared prose needs to reference a language-specific identifier (method name, parameter, class, etc.), use `<Syntax py="..." ts="..." />`. This keeps prose clean and adapts to the reader's language selection. Never spell out both variants manually in prose.
 
 Code examples longer than a few lines live in runnable `.ts`/`.py` source files alongside the MDX page, not inline. Pull them in via the `--8<--` include syntax. See "Snippet Inclusion" and "TypeScript Snippet Scoping" in `mdx-authoring.md` for the imports/body file pattern and naming conventions.
 

--- a/site/CONTRIBUTING.md
+++ b/site/CONTRIBUTING.md
@@ -28,6 +28,7 @@ npm run build      # generates static site
 - Content lives in `docs/` as standard Markdown files
 - Navigation structure is defined in `src/config/navigation.yml`
 - Use `<Tabs>` / `<Tab label="...">` for Python/TypeScript code tabs (auto-imported)
+- Use `<Syntax py="python_name" ts="tsName" />` for inline language-specific identifiers in prose (auto-imported). Renders as `<code>` by default; pass `code={false}` for plain text. Reacts live to the global language toggle.
 - Use `--8<-- "path/to/file.ts:snippet_name"` to pull in code snippets from external files
 - Relative file links (e.g. `../tools/index.md`) resolve automatically — no need to use slugs
 - Link to API reference pages with the `@api` shorthand: `[@api/python/strands.agent.agent](#Class)`

--- a/site/CONTRIBUTING.md
+++ b/site/CONTRIBUTING.md
@@ -28,7 +28,7 @@ npm run build      # generates static site
 - Content lives in `docs/` as standard Markdown files
 - Navigation structure is defined in `src/config/navigation.yml`
 - Use `<Tabs>` / `<Tab label="...">` for Python/TypeScript code tabs (auto-imported)
-- Use `<Syntax py="python_name" ts="tsName" />` for inline language-specific identifiers in prose (auto-imported). Renders as `<code>` by default; pass `code={false}` for plain text. Reacts live to the global language toggle.
+- Use `<Syntax py="python_name" ts="tsName" />` for inline language-specific identifiers in prose (auto-imported). Renders as `<code>` by default; pass `plain` for plain text. Reacts live to the global language toggle.
 - Use `--8<-- "path/to/file.ts:snippet_name"` to pull in code snippets from external files
 - Relative file links (e.g. `../tools/index.md`) resolve automatically — no need to use slugs
 - Link to API reference pages with the `@api` shorthand: `[@api/python/strands.agent.agent](#Class)`

--- a/site/SITE-ARCHITECTURE.md
+++ b/site/SITE-ARCHITECTURE.md
@@ -246,7 +246,7 @@ Available: `Tabs`/`TabItem`, `Aside`, `Card`/`CardGrid`, `LinkCard`, `Icon`, `Ba
 
 ### Auto-Imported Components
 
-We use [astro-auto-import](https://github.com/delucis/astro-auto-import) to make `Tabs` and `Tab` available globally without explicit imports. Since language tabs appear on nearly every page, this reduces boilerplate.
+We use [astro-auto-import](https://github.com/delucis/astro-auto-import) to make `Tabs`, `Tab`, and `Syntax` available globally without explicit imports. Since language tabs and inline language-specific identifiers appear on nearly every page, this reduces boilerplate.
 
 ```mdx
 <!-- No import needed — just use directly -->
@@ -265,6 +265,25 @@ For other components, use [explicit imports](https://starlight.astro.build/compo
 ### `AutoSyncTabs`
 
 A wrapper around Starlight's `Tabs` that auto-generates a `syncKey` from tab labels. Tabs with identical label sets automatically sync together across the page. Auto-imported as `Tabs` (see above).
+
+### `Syntax`
+
+Inline component for language-specific identifiers in prose. Renders the Python or TypeScript variant based on the global language toggle, avoiding the `"python_name (Python) or tsName (TypeScript)"` pattern. Auto-imported.
+
+```mdx
+Pass <Syntax py="context_manager" ts="contextManager" /> to configure...
+```
+
+Props:
+- `py` (required): Python syntax variant
+- `ts` (required): TypeScript syntax variant
+- `code` (default: `true`): Wraps output in `<code>`. Set `code={false}` for plain text.
+
+The component reads the same `localStorage` key as the language toggle and swaps live without page reload.
+
+**When to use:** Any time a single identifier, method name, or parameter differs between Python and TypeScript and you're writing shared prose (not inside a `<Tab>` section).
+
+**When NOT to use:** For code blocks (use `<Tabs>`), for conceptual differences between SDKs that aren't simple name swaps, or for content that only applies to one language.
 
 ### `PageLink`
 

--- a/site/SITE-ARCHITECTURE.md
+++ b/site/SITE-ARCHITECTURE.md
@@ -277,7 +277,7 @@ Pass <Syntax py="context_manager" ts="contextManager" /> to configure...
 Props:
 - `py` (required): Python syntax variant
 - `ts` (required): TypeScript syntax variant
-- `code` (default: `true`): Wraps output in `<code>`. Set `code={false}` for plain text.
+- `plain` (default: `false`): Renders as plain text instead of `<code>`.
 
 The component reads the same `localStorage` key as the language toggle and swaps live without page reload.
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -101,6 +101,9 @@ export default defineConfig({
           ],
           './src/components/AutoSyncTabs.astro': [
             ['default', "Tabs"]
+          ],
+          './src/components/Syntax.astro': [
+            ['default', 'Syntax']
           ]
         },
       ],

--- a/site/src/components/Syntax.astro
+++ b/site/src/components/Syntax.astro
@@ -2,22 +2,22 @@
 interface Props {
   py: string;
   ts: string;
-  code?: boolean;
+  plain?: boolean;
 }
 
-const { py, ts, code = true } = Astro.props;
+const { py, ts, plain = false } = Astro.props;
 ---
 
 <syntax-switch>
-  {code ? (
-    <>
-      <code data-lang="Python">{py}</code>
-      <code data-lang="TypeScript">{ts}</code>
-    </>
-  ) : (
+  {plain ? (
     <>
       <span data-lang="Python">{py}</span>
       <span data-lang="TypeScript">{ts}</span>
+    </>
+  ) : (
+    <>
+      <code data-lang="Python">{py}</code>
+      <code data-lang="TypeScript">{ts}</code>
     </>
   )}
 </syntax-switch>

--- a/site/src/components/Syntax.astro
+++ b/site/src/components/Syntax.astro
@@ -1,19 +1,33 @@
 ---
 interface Props {
-  /** Python syntax variant */
   py: string;
-  /** TypeScript syntax variant */
   ts: string;
-  /** Render as inline code (default: true) */
   code?: boolean;
 }
 
 const { py, ts, code = true } = Astro.props;
 ---
 
-<syntax-switch data-py={py} data-ts={ts} data-code={code.toString()}>
-  {code ? <code></code> : <span></span>}
+<syntax-switch>
+  {code ? (
+    <>
+      <code data-lang="Python">{py}</code>
+      <code data-lang="TypeScript">{ts}</code>
+    </>
+  ) : (
+    <>
+      <span data-lang="Python">{py}</span>
+      <span data-lang="TypeScript">{ts}</span>
+    </>
+  )}
 </syntax-switch>
+
+<style>
+  /* Default: show TypeScript, hide Python (matches site-wide default) */
+  syntax-switch [data-lang="Python"] {
+    display: none;
+  }
+</style>
 
 <script is:inline>
   (function () {
@@ -30,10 +44,8 @@ const { py, ts, code = true } = Astro.props;
 
     function updateAll() {
       var lang = getLang();
-      document.querySelectorAll('syntax-switch').forEach(function (el) {
-        var text = lang === 'Python' ? el.getAttribute('data-py') : el.getAttribute('data-ts');
-        var target = el.querySelector('code') || el.querySelector('span');
-        if (target) target.textContent = text;
+      document.querySelectorAll('syntax-switch [data-lang]').forEach(function (el) {
+        el.style.display = el.getAttribute('data-lang') === lang ? 'inline' : 'none';
       });
     }
 
@@ -47,13 +59,9 @@ const { py, ts, code = true } = Astro.props;
       if (e.key === STORAGE_KEY) updateAll();
     });
 
-    // Listen for same-tab language changes from LanguageToggle click handler.
-    // The toggle sets localStorage but 'storage' only fires cross-tab, so we
-    // observe the key via a click listener on the toggle buttons.
     document.addEventListener('click', function (e) {
       var btn = e.target && e.target.closest && e.target.closest('.lang-option');
       if (btn) {
-        // Defer to next microtask so localStorage is already written by LanguageToggle
         Promise.resolve().then(updateAll);
       }
     });

--- a/site/src/components/Syntax.astro
+++ b/site/src/components/Syntax.astro
@@ -1,0 +1,61 @@
+---
+interface Props {
+  /** Python syntax variant */
+  py: string;
+  /** TypeScript syntax variant */
+  ts: string;
+  /** Render as inline code (default: true) */
+  code?: boolean;
+}
+
+const { py, ts, code = true } = Astro.props;
+---
+
+<syntax-switch data-py={py} data-ts={ts} data-code={code.toString()}>
+  {code ? <code></code> : <span></span>}
+</syntax-switch>
+
+<script is:inline>
+  (function () {
+    if (window.__strandsSyntaxSwitchInit) return;
+    window.__strandsSyntaxSwitchInit = true;
+
+    var STORAGE_KEY = 'starlight-synced-tabs__jarkqt';
+    var DEFAULT_LANG = 'TypeScript';
+
+    function getLang() {
+      try { return localStorage.getItem(STORAGE_KEY) || DEFAULT_LANG; }
+      catch (e) { return DEFAULT_LANG; }
+    }
+
+    function updateAll() {
+      var lang = getLang();
+      document.querySelectorAll('syntax-switch').forEach(function (el) {
+        var text = lang === 'Python' ? el.getAttribute('data-py') : el.getAttribute('data-ts');
+        var target = el.querySelector('code') || el.querySelector('span');
+        if (target) target.textContent = text;
+      });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', updateAll);
+    } else {
+      updateAll();
+    }
+
+    window.addEventListener('storage', function (e) {
+      if (e.key === STORAGE_KEY) updateAll();
+    });
+
+    // Listen for same-tab language changes from LanguageToggle click handler.
+    // The toggle sets localStorage but 'storage' only fires cross-tab, so we
+    // observe the key via a click listener on the toggle buttons.
+    document.addEventListener('click', function (e) {
+      var btn = e.target && e.target.closest && e.target.closest('.lang-option');
+      if (btn) {
+        // Defer to next microtask so localStorage is already written by LanguageToggle
+        Promise.resolve().then(updateAll);
+      }
+    });
+  })();
+</script>

--- a/site/src/content/docs/contribute/contributing/documentation.mdx
+++ b/site/src/content/docs/contribute/contributing/documentation.mdx
@@ -89,6 +89,22 @@ Code examples are critical—they show developers exactly what to do. Always tes
 - Add comments — explain non-obvious parts
 - Use realistic names — avoid foo/bar, use descriptive names
 
+### Inline language-specific names
+
+When prose references a method, parameter, or class name that differs between Python and TypeScript, use the `<Syntax>` component instead of writing both variants manually:
+
+```mdx
+<!-- Good: adapts to the reader's language selection -->
+Use <Syntax py=".as_tool()" ts=".asTool()" /> to customize the tool name.
+
+<!-- Bad: clutters prose with both variants -->
+Use `.as_tool()` (Python) or `.asTool()` (TypeScript) to customize the tool name.
+```
+
+`<Syntax>` is auto-imported (no `import` statement needed). It renders as inline `<code>` by default and reacts live to the global language toggle. Pass `code={false}` for plain text output.
+
+Use `<Syntax>` for simple name swaps. For code blocks or conceptual differences between SDKs, use `<Tabs>` instead.
+
 <Tabs>
 <Tab label="Python">
 

--- a/site/src/content/docs/contribute/contributing/documentation.mdx
+++ b/site/src/content/docs/contribute/contributing/documentation.mdx
@@ -6,6 +6,27 @@ sidebar:
 
 Good documentation helps developers succeed with Strands. We welcome contributions that make our docs clearer, more complete, or more helpful. Our documentation lives in the `site/` directory of the [Strands SDK repository](https://github.com/strands-agents/harness-sdk).
 
+## Agent skills
+
+The repository ships agent skills in `.agents/skills/` that encode our documentation conventions, site components, and quality standards. If you're using an AI coding assistant, activate these skills before making documentation changes — they'll produce output that matches our style without you needing to internalize everything on this page.
+
+| Skill | What it does |
+|-------|--------------|
+| `docs-writer` | Drafts or rewrites documentation pages following site conventions |
+| `docs-reviewer` | Reviews drafts for voice, structure, and terminology before PR |
+| `docs-audit` | Assesses a page for quality, accuracy, and voice compliance |
+| `docs-planner` | Identifies documentation gaps and prioritizes the backlog |
+
+Use them by giving your agent a goal that references the skill:
+
+```
+Write a new doc page for the retry strategies feature. Use the docs-writer skill.
+```
+
+```
+Audit the context management page for accuracy and voice issues. Use the docs-audit skill.
+```
+
 ## What we accept
 
 We're looking for contributions that improve the developer experience. Documentation changes can range from small typo fixes to complete new guides.
@@ -89,22 +110,6 @@ Code examples are critical—they show developers exactly what to do. Always tes
 - Add comments — explain non-obvious parts
 - Use realistic names — avoid foo/bar, use descriptive names
 
-### Inline language-specific names
-
-When prose references a method, parameter, or class name that differs between Python and TypeScript, use the `<Syntax>` component instead of writing both variants manually:
-
-```mdx
-<!-- Good: adapts to the reader's language selection -->
-Use <Syntax py=".as_tool()" ts=".asTool()" /> to customize the tool name.
-
-<!-- Bad: clutters prose with both variants -->
-Use `.as_tool()` (Python) or `.asTool()` (TypeScript) to customize the tool name.
-```
-
-`<Syntax>` is auto-imported (no `import` statement needed). It renders as inline `<code>` by default and reacts live to the global language toggle. Pass `code={false}` for plain text output.
-
-Use `<Syntax>` for simple name swaps. For code blocks or conceptual differences between SDKs, use `<Tabs>` instead.
-
 <Tabs>
 <Tab label="Python">
 
@@ -130,4 +135,5 @@ agent("What's the weather like?")
 ```
 </Tab>
 </Tabs>
+
 

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -87,9 +87,9 @@ Each model invocation ends with a stop reason that determines what happens next:
 - **End turn**: The model has finished its response and has no further actions to take. This is the normal successful termination. The loop exits and returns the model's final message.
 - **Tool use**: The model wants to execute one or more tools before continuing. The loop executes the requested tools, appends the results to the conversation history, and invokes the model again.
 - **Cancelled**: The agent was stopped externally via `agent.cancel()`. See [Cancellation](#cancellation) below.
-- **Limit turns** (`limit_turns` / `limitTurns`): The per-invocation turn budget was exhausted. See [Invocation Limits](#invocation-limits).
-- **Limit total tokens** (`limit_total_tokens` / `limitTotalTokens`): The cumulative token budget was exhausted. See [Invocation Limits](#invocation-limits).
-- **Limit output tokens** (`limit_output_tokens` / `limitOutputTokens`): The output token budget was exhausted. See [Invocation Limits](#invocation-limits).
+- **Limit turns** (<Syntax py="limit_turns" ts="limitTurns" />): The per-invocation turn budget was exhausted. See [Invocation Limits](#invocation-limits).
+- **Limit total tokens** (<Syntax py="limit_total_tokens" ts="limitTotalTokens" />): The cumulative token budget was exhausted. See [Invocation Limits](#invocation-limits).
+- **Limit output tokens** (<Syntax py="limit_output_tokens" ts="limitOutputTokens" />): The output token budget was exhausted. See [Invocation Limits](#invocation-limits).
 - **Max tokens**: The model's response was truncated because it hit the token limit. This is unrecoverable within the current loop. The model cannot continue from a partial response, and the loop terminates with an error.
 - **Stop sequence**: The model encountered a configured stop sequence. Like end turn, this terminates the loop normally.
 - **Content filtered**: The response was blocked by safety mechanisms.

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -100,7 +100,7 @@ Key features of the `SlidingWindowConversationManager`:
 - **Maintains Window Size**: Automatically removes messages from the window if the number of messages exceeds the limit.
 - **Dangling Message Cleanup**: Removes incomplete message sequences to maintain valid conversation state.
 - **Overflow Trimming**: In the case of a context window overflow, it will trim the oldest messages from history until the request fits in the models context window.
-- **Configurable Tool Result Truncation**: Enable or disable truncation of tool results when the message exceeds context window limits. When enabled (the default; `should_truncate_results=True` in Python, `shouldTruncateResults: true` in TypeScript), the oldest message with tool results is truncated first so recent context is preserved as long as possible. Truncation depends on content type:
+- **Configurable Tool Result Truncation**: Enable or disable truncation of tool results when the message exceeds context window limits. When enabled (the default; <Syntax py="should_truncate_results=True" ts="shouldTruncateResults: true" />), the oldest message with tool results is truncated first so recent context is preserved as long as possible. Truncation depends on content type:
     - Text payloads keep their head and tail, separated by a `<truncated chars="N"/>` marker.
     - Images, videos, binary documents, and oversized JSON are replaced by a typed placeholder, for example `[image: png, source: bytes, 12345 bytes]`.
     - The tool result's original `status` and `error` fields are preserved.

--- a/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -28,7 +28,7 @@ Hook callbacks are registered against specific event types and receive strongly-
 
 ### Registering Individual Hook Callbacks
 
-The simplest way to register a hook callback is using the `agent.add_hook()` method:
+The simplest way to register a hook callback is using the <Syntax py="agent.add_hook()" ts="agent.addHook()" /> method:
 
 <Tabs>
 <Tab label="Python">

--- a/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
@@ -110,7 +110,7 @@ result = agent.tool.current_time(timezone="US/Pacific")
 </Tab>
 </Tabs>
 
-Direct tool calls bypass the natural language interface and execute the tool using specified parameters. These calls are added to the conversation history by default. However, you can opt out of this behavior by setting `record_direct_tool_call=False` in Python.
+Direct tool calls bypass the natural language interface and execute the tool using specified parameters. These calls are added to the conversation history by default. However, you can opt out of this behavior by setting <Syntax py="record_direct_tool_call=False" ts="recordDirectToolCall: false" />.
 
 ## Prompt Engineering
 

--- a/site/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
@@ -3,7 +3,7 @@ title: Retry Strategies
 tags: [event-loop, error-handling]
 ---
 
-Model providers occasionally encounter errors such as rate limits, service unavailability, or network timeouts. By default, the agent retries throttled responses automatically with exponential backoff. The `Agent.retry_strategy` (Python) or `Agent.retryStrategy` (TypeScript) parameter lets you customize this behavior.
+Model providers occasionally encounter errors such as rate limits, service unavailability, or network timeouts. By default, the agent retries throttled responses automatically with exponential backoff. The <Syntax py="Agent.retry_strategy" ts="Agent.retryStrategy" /> parameter lets you customize this behavior.
 
 ## Default Behavior
 
@@ -129,7 +129,7 @@ agent = Agent(
 
 ## When Retries Occur
 
-Default retry strategies handle throttling errors (`ModelThrottledException` in Python, `ModelThrottledError` in TypeScript) raised by model providers for rate-limiting. Other exceptions propagate immediately without retry.
+Default retry strategies handle throttling errors (<Syntax py="ModelThrottledException" ts="ModelThrottledError" />) raised by model providers for rate-limiting. Other exceptions propagate immediately without retry.
 
 To extend or narrow the retryable set, see [Custom Retry Logic](#custom-retry-logic).
 

--- a/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -144,7 +144,7 @@ snapshot = agent.take_snapshot(preset="session", exclude=["interrupt_state"])
 
 ## Application Data
 
-Snapshots support an `app_data` (Python) / `appData` (TypeScript) field for storing application-owned data alongside the agent state. Strands does not read or modify this data — it's passed through verbatim.
+Snapshots support an <Syntax py="app_data" ts="appData" /> field for storing application-owned data alongside the agent state. Strands does not read or modify this data — it's passed through verbatim.
 
 This is useful for attaching metadata like a display name for the snapshot, the current step in a workflow, user preferences, or any other context your application needs to associate with a particular point in time.
 

--- a/site/src/content/docs/user-guide/concepts/agents/state.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/state.mdx
@@ -318,7 +318,7 @@ print(result.state)
 </Tab>
 </Tabs>
 
-Invocation state (`invocationState` in TypeScript, `invocation_state` / `request_state` in Python):
+Invocation state (<Syntax py="invocation_state" ts="invocationState" />):
 
 - Is initialized at the beginning of each agent invocation (defaults to `{}` when omitted)
 - Persists through recursive event loop cycles within a single invocation

--- a/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
@@ -28,7 +28,7 @@ Key benefits:
 
 ## Basic Usage
 
-Define an output structure using a schema. In Python, use a Pydantic model and pass it to `structured_output_model`. In TypeScript, use a Zod schema and pass it to `structuredOutputSchema`. Then, access the validated output from the `AgentResult`.
+Define an output structure using a schema and pass it to <Syntax py="structured_output_model" ts="structuredOutputSchema" />. Then, access the validated output from the `AgentResult`.
 
 <Tabs>
 <Tab label="Python">
@@ -97,7 +97,7 @@ result = asyncio.run(
 
 The structured output system converts your schema definitions into tool specifications that guide the language model to produce correctly formatted responses. All of the model providers supported in Strands can work with Structured Output.
 
-In Python, Strands accepts the `structured_output_model` parameter in agent invocations, which manages the conversion, validation, and response processing automatically. In TypeScript, the `structuredOutputSchema` parameter (either at agent initialization or per-invocation) handles this process. The validated result is available in the `AgentResult.structured_output` (Python) or `AgentResult.structuredOutput` (TypeScript) field.
+Strands accepts the <Syntax py="structured_output_model" ts="structuredOutputSchema" /> parameter in agent invocations, which manages the conversion, validation, and response processing automatically. The validated result is available in the <Syntax py="AgentResult.structured_output" ts="AgentResult.structuredOutput" /> field.
 
 
 ### Error Handling

--- a/site/src/content/docs/user-guide/concepts/context-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/context-management.mdx
@@ -14,7 +14,7 @@ The SDK provides several layers of context management that you can use independe
 
 ## Automatic context management
 
-For most agents with multi-turn conversations, you don't need to configure conversation management and context offloading separately. Pass `context_manager="auto"` (Python) or `contextManager: "auto"` (TypeScript) and the SDK wires up both with tuned defaults:
+For most agents with multi-turn conversations, you don't need to configure conversation management and context offloading separately. Pass <Syntax py='context_manager="auto"' ts='contextManager: "auto"' /> and the SDK wires up both with tuned defaults:
 
 <Tabs>
 <Tab label="Python">
@@ -48,7 +48,7 @@ For full details on each component, see [Conversation Management](./agents/conve
 
 Your own settings take precedence when you need fine-grained control:
 
-- **Custom conversation manager**: If you also pass `conversation_manager` / `conversationManager`, your manager replaces the auto-composed `SummarizingConversationManager`. The SDK still adds the `ContextOffloader` plugin.
+- **Custom conversation manager**: If you also pass <Syntax py="conversation_manager" ts="conversationManager" />, your manager replaces the auto-composed `SummarizingConversationManager`. The SDK still adds the `ContextOffloader` plugin.
 - **Existing ContextOffloader**: If your `plugins` list already contains a `ContextOffloader` instance, no duplicate is added. Your configuration is preserved.
 
 <Tabs>
@@ -82,6 +82,6 @@ agent = Agent(
 
 ### Limitations
 
-**Stateful models**: Stateful models manage conversation state server-side. Setting `context_manager="auto"` with a stateful model raises a `ValueError` (Python) or `Error` (TypeScript).
+**Stateful models**: Stateful models manage conversation state server-side. Setting <Syntax py='context_manager="auto"' ts='contextManager: "auto"' /> with a stateful model raises a <Syntax py="ValueError" ts="Error" />.
 
 The auto-composed offloader uses in-memory storage that does not persist across process restarts. If your agent uses session management and needs durable offloaded content, configure an explicit `ContextOffloader` with `FileStorage` or `S3Storage`. See [Storage Backends](./plugins/context-offloader#storage-backends).

--- a/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -221,7 +221,7 @@ If you encounter import errors for `@google/genai`, ensure the package is instal
 
 ### API Key Issues
 
-Make sure your Google AI API key is properly set via `client_args` (Python) or `apiKey` (TypeScript), or as the `GOOGLE_API_KEY` / `GEMINI_API_KEY` environment variable. You can obtain an API key from the [Google AI Studio](https://aistudio.google.com/app/apikey).
+Make sure your Google AI API key is properly set via <Syntax py="client_args" ts="apiKey" />, or as the `GOOGLE_API_KEY` / `GEMINI_API_KEY` environment variable. You can obtain an API key from the [Google AI Studio](https://aistudio.google.com/app/apikey).
 
 ### Rate Limiting and Safety Issues
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -34,7 +34,7 @@ When implementing the "Agents as Tools" pattern with Strands Agents SDK:
 
 ## Implementing Agents as Tools with Strands Agents SDK
 
-Strands Agents SDK provides three ways to implement the "Agents as Tools" pattern: passing agents directly in the `tools` array for the simplest setup, `.as_tool()`/`.asTool()` when you need to customize tool name, description, or context behavior, and the `@tool` decorator or `tool()` function for full control over how the agent is invoked.
+Strands Agents SDK provides three ways to implement the "Agents as Tools" pattern: passing agents directly in the `tools` array for the simplest setup, <Syntax py=".as_tool()" ts=".asTool()" /> when you need to customize tool name, description, or context behavior, and the `@tool` decorator or `tool()` function for full control over how the agent is invoked.
 
 ```mermaid
 flowchart TD
@@ -102,7 +102,7 @@ orchestrator = Agent(
 
 ### Customizing Agent Tools
 
-When you need to customize the tool name, description, or context behavior, use `.as_tool()` (Python) or `.asTool()` (TypeScript) explicitly:
+When you need to customize the tool name, description, or context behavior, use <Syntax py=".as_tool()" ts=".asTool()" /> explicitly:
 
 <Tabs>
 <Tab label="Python">
@@ -129,7 +129,7 @@ orchestrator = Agent(
 
 #### Context Management
 
-By default, both direct passing and `.as_tool()`/`.asTool()` reset the agent's conversation context between invocations, ensuring every call starts from a clean baseline. To preserve the agent's conversation history across invocations:
+By default, both direct passing and <Syntax py=".as_tool()" ts=".asTool()" /> reset the agent's conversation context between invocations, ensuring every call starts from a clean baseline. To preserve the agent's conversation history across invocations:
 
 <Tabs>
 <Tab label="Python">

--- a/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -19,10 +19,10 @@ The default [`SlidingWindowConversationManager`](../agents/conversation-manageme
 
 ## How It Works
 
-After each tool call, the plugin estimates the result's token count and compares it against the `max_result_tokens` threshold (default: 2,500 tokens). If the result exceeds it, the plugin:
+After each tool call, the plugin estimates the result's token count and compares it against the <Syntax py="max_result_tokens" ts="maxResultTokens" /> threshold (default: 2,500 tokens). If the result exceeds it, the plugin:
 
 1. Stores each content block individually in the configured storage backend, preserving its content type
-2. Replaces the in-context result with the first `preview_tokens` tokens (default: 1,000) plus per-block storage references
+2. Replaces the in-context result with the first <Syntax py="preview_tokens" ts="previewTokens" /> tokens (default: 1,000) plus per-block storage references
 
 Token estimation uses `model.count_tokens()`, which delegates to the model provider's native counting API if available, otherwise falling back to a character-based heuristic (chars/4 for text, chars/2 for JSON).
 
@@ -43,7 +43,7 @@ For non-text content, the plugin replaces the result with a descriptive placehol
 
 | Content Type | What the agent sees |
 |-------------|----------|
-| Text / JSON | First `preview_tokens` tokens + storage reference |
+| Text / JSON | First <Syntax py="preview_tokens" ts="previewTokens" /> tokens + storage reference |
 | Image | `[image: format, N bytes]` placeholder + storage reference |
 | Document | `[document: format, name, N bytes]` placeholder + storage reference |
 

--- a/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -24,7 +24,7 @@ After each tool call, the plugin estimates the result's token count and compares
 1. Stores each content block individually in the configured storage backend, preserving its content type
 2. Replaces the in-context result with the first <Syntax py="preview_tokens" ts="previewTokens" /> tokens (default: 1,000) plus per-block storage references
 
-Token estimation uses `model.count_tokens()`, which delegates to the model provider's native counting API if available, otherwise falling back to a character-based heuristic (chars/4 for text, chars/2 for JSON).
+Token estimation uses <Syntax py="model.count_tokens()" ts="model.countTokens()" />, which delegates to the model provider's native counting API if available, otherwise falling back to a character-based heuristic (chars/4 for text, chars/2 for JSON).
 
 Results under the threshold pass through unchanged.
 

--- a/site/src/content/docs/user-guide/concepts/plugins/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/index.mdx
@@ -4,7 +4,7 @@ tags: [hooks, event-loop]
 description: "Extend agent behavior with plugins. Add steering, guardrails, and custom capabilities that hook into the agent lifecycle."
 ---
 
-Plugins allow you to change the typical behavior of an agent. They enable you to introduce concepts like [Skills](https://agentskills.io/specification), [steering](./steering), or other behavioral modifications into the agentic loop. Plugins work by taking advantage of the low-level primitives exposed by the Agent class—`model`, `system_prompt`, `messages`, `tools`, and `hooks`—and executing logic to improve an agent's behavior.
+Plugins allow you to change the typical behavior of an agent. They enable you to introduce concepts like [Skills](https://agentskills.io/specification), [steering](./steering), or other behavioral modifications into the agentic loop. Plugins work by taking advantage of the low-level primitives exposed by the Agent class—`model`, <Syntax py="system_prompt" ts="systemPrompt" />, `messages`, `tools`, and `hooks`—and executing logic to improve an agent's behavior.
 
 The Strands SDK provides built-in plugins that you can use out of the box:
 
@@ -176,7 +176,7 @@ TypeScript plugins register hooks manually in the `initAgent` method using `agen
 
 ### Manual Hook and Tool Registration
 
-For more control, you can manually register hooks and tools in the `init_agent` method:
+For more control, you can manually register hooks and tools in the <Syntax py="init_agent" ts="initAgent" /> method:
 
 <Tabs>
 <Tab label="Python">

--- a/site/src/content/docs/user-guide/concepts/plugins/skills.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/skills.mdx
@@ -62,7 +62,7 @@ The injected system prompt metadata looks like this:
 </available_skills>
 ```
 
-This XML block is refreshed before each invocation, so changes to available skills (through `set_available_skills` / `setAvailableSkills`) take effect immediately. Activated skills are tracked in [agent state](../agents/state.mdx) for session persistence.
+This XML block is refreshed before each invocation, so changes to available skills (through <Syntax py="set_available_skills" ts="setAvailableSkills" />) take effect immediately. Activated skills are tracked in [agent state](../agents/state.mdx) for session persistence.
 
 ## Usage
 
@@ -263,7 +263,7 @@ The `allowed-tools` field is currently informational. When a skill is activated,
 :::
 
 :::note[Name validation]
-Skill names must match the parent directory name. By default, validation issues produce warnings rather than errors. Pass `strict=True` (Python) or `strict: true` (TypeScript) to raise exceptions instead.
+Skill names must match the parent directory name. By default, validation issues produce warnings rather than errors. Pass <Syntax py="strict=True" ts="strict: true" /> to raise exceptions instead.
 :::
 
 ### Resource directories

--- a/site/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -478,7 +478,7 @@ For more information on using MCP tools, see [MCP Tools](mcp-tools.md).
 
 ### 4. Agents as Tools
 
-Agents can be passed directly in another agent's `tools` array — the SDK automatically converts them into tools. Use `.as_tool()` (Python) or `.asTool()` (TypeScript) when you need to customize the tool name, description, or context behavior. For full details, see [Agents as Tools](../multi-agent/agents-as-tools.md).
+Agents can be passed directly in another agent's `tools` array — the SDK automatically converts them into tools. Use <Syntax py=".as_tool()" ts=".asTool()" /> when you need to customize the tool name, description, or context behavior. For full details, see [Agents as Tools](../multi-agent/agents-as-tools.md).
 
 <Tabs>
 <Tab label="Python">

--- a/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -414,7 +414,7 @@ with tracer.start_as_current_span("my-custom-operation") as span:
 </Tabs>
 
 :::tip
-`getTracer()` (TypeScript) and `trace.get_tracer()` (Python) use the global tracer provider. When you use `setupTracer()` or `StrandsTelemetry()` without a custom provider, it's automatically registered as global — so your custom spans will use the same provider as the agent's auto-instrumented spans.
+<Syntax py="trace.get_tracer()" ts="getTracer()" /> uses the global tracer provider. When you use <Syntax py="StrandsTelemetry()" ts="setupTracer()" /> without a custom provider, it's automatically registered as global — so your custom spans will use the same provider as the agent's auto-instrumented spans.
 :::
 
 ### Configuring the exporters from source code


### PR DESCRIPTION
## Description

Adds a new `<Syntax>` MDX component that renders language-appropriate identifiers (Python snake_case vs TypeScript camelCase) inline based on the global language selector. This eliminates the manual pattern of spelling out both variants in shared prose (e.g., `` `snake_name` / `camelName` ``).

## Motivation

Documentation pages frequently reference SDK identifiers in prose that sits outside language-specific tabs. Previously this meant writing both names inline, which was verbose, inconsistent across pages, and didn't react to the reader's language preference. The new component provides a single source of truth per identifier that switches live with the language toggle.

## Public API Changes

No public API changes — this is a documentation infrastructure addition.

### Component API

```mdx
<Syntax py="conversation_manager" ts="conversationManager" />
<Syntax py=".as_tool()" ts=".asTool()" />
<Syntax py="strict=True" ts="strict: true" code={false} />
```

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `py` | string | required | Python identifier |
| `ts` | string | required | TypeScript identifier |
| `code` | boolean | `true` | Wrap in `<code>` (false for plain text) |

## Implementation

- `site/src/components/Syntax.astro` — custom element `<syntax-switch>` with an idempotent inline script that reads the same localStorage key as the existing language tabs
- Auto-imported via `astro-auto-import` so no explicit imports needed in MDX
- Reacts to tab clicks (`.lang-option` delegated listener) and cross-tab `storage` events

## Scope

- Converted ~26 instances across 16 documentation pages
- Updated agent skills (writer, reviewer, audit) to teach future authors about the component
- Updated references (mdx-authoring.md, voice-guide.md) and contributor docs

## Type of Change

Documentation update

## Testing

- [x] Full `npx astro build` passes (655 pages, 0 broken links)
- [x] Verified every TypeScript identifier against SDK source at `sdk-typescript/strands-ts/src/`
- [x] Manual browser testing confirms live language switching

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
