### PR TITLE
docs: improve monorepo clarity for releases and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,17 @@ body:
     attributes:
       value: |
         Thanks for suggesting a new feature for Strands Agents SDK!
+  - type: dropdown
+    id: sdk-language
+    attributes:
+      label: SDK Language
+      description: Which Strands SDK is this feature for?
+      options:
+        - Python
+        - TypeScript
+        - Both / Not language-specific
+    validations:
+      required: true
   - type: textarea
     id: problem-statement
     attributes:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+  categories:
+    - title: Python SDK
+      labels:
+        - python
+    - title: TypeScript SDK
+      labels:
+        - typescript
+    - title: Other Changes
+      labels:
+        - "*"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@
     <a href="https://github.com/strands-agents/harness-sdk/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/harness-sdk"/></a>
     <a href="https://github.com/strands-agents/harness-sdk/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/harness-sdk"/></a>
     <a href="https://github.com/strands-agents/harness-sdk/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/releases?q=python%2F&expanded=false"><img alt="Latest Python release" src="https://img.shields.io/github/v/release/strands-agents/harness-sdk?filter=python%2F*&label=python"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/releases?q=typescript%2F&expanded=false"><img alt="Latest TypeScript release" src="https://img.shields.io/github/v/release/strands-agents/harness-sdk?filter=typescript%2F*&label=typescript"/></a>
     <a href="https://pypi.org/project/strands-agents/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/strands-agents"/></a>
+    <a href="https://www.npmjs.com/package/@strands-agents/sdk"><img alt="npm version" src="https://img.shields.io/npm/v/%40strands-agents%2Fsdk"/></a>
     <a href="https://python.org"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/strands-agents"/></a>
     <a href="https://discord.gg/strands"><img alt="Strands Discord" src="https://img.shields.io/badge/Discord-Strands-5865F2?logo=discord&logoColor=white"/></a>
   </div>
@@ -38,8 +41,8 @@ This monorepo contains the Python SDK, TypeScript SDK, documentation site, and s
 
 | Directory | Description |
 |-----------|-------------|
-| `strands-py/` | Python SDK — agent loop, model providers, tools ([PyPI](https://pypi.org/project/strands-agents/)) |
-| `strands-ts/` | TypeScript SDK — agent loop, model providers, tools ([npm](https://www.npmjs.com/package/@strands/agent)) |
+| `strands-py/` | Python SDK — agent loop, model providers, tools ([PyPI](https://pypi.org/project/strands-agents/) · [releases](https://github.com/strands-agents/harness-sdk/releases?q=python%2F&expanded=false)) |
+| `strands-ts/` | TypeScript SDK — agent loop, model providers, tools ([npm](https://www.npmjs.com/package/@strands-agents/sdk) · [releases](https://github.com/strands-agents/harness-sdk/releases?q=typescript%2F&expanded=false)) |
 | `strands-wasm/` | WebAssembly bindings for running Python tools from TypeScript agents |
 | `strands-py-wasm/` | Python host for WASM components (bridges WIT interfaces to Python) |
 | `strandly/` | Developer CLI for local builds, codegen, and workspace tooling |

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@
     <a href="https://github.com/strands-agents/harness-sdk/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/harness-sdk"/></a>
     <a href="https://github.com/strands-agents/harness-sdk/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/harness-sdk"/></a>
     <a href="https://github.com/strands-agents/harness-sdk/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/harness-sdk"/></a>
-    <a href="https://github.com/strands-agents/harness-sdk/releases?q=python%2F&expanded=false"><img alt="Latest Python release" src="https://img.shields.io/github/v/release/strands-agents/harness-sdk?filter=python%2F*&label=python"/></a>
-    <a href="https://github.com/strands-agents/harness-sdk/releases?q=typescript%2F&expanded=false"><img alt="Latest TypeScript release" src="https://img.shields.io/github/v/release/strands-agents/harness-sdk?filter=typescript%2F*&label=typescript"/></a>
     <a href="https://pypi.org/project/strands-agents/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/strands-agents"/></a>
     <a href="https://www.npmjs.com/package/@strands-agents/sdk"><img alt="npm version" src="https://img.shields.io/npm/v/%40strands-agents%2Fsdk"/></a>
     <a href="https://python.org"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/strands-agents"/></a>


### PR DESCRIPTION
## Summary
- Add `.github/release.yml` so auto-generated release notes are grouped into Python SDK / TypeScript SDK / Other sections using the existing `python`/`typescript` labels (today both SDK releases share one undifferentiated PR list)
- Add filtered per-SDK release links to the README package table — GitHub's sidebar only shows one "Latest" release, which hides the other SDK's latest
- Fix the npm package link: the published package is `@strands-agents/sdk`, not `@strands/agent`; add an npm version badge alongside the existing PyPI one
- Add an SDK Language dropdown to the feature request form, matching the bug report form

The root README restructure that was previously part of this PR has been split out to #2763 per review feedback.

## Test plan
- [ ] npm badge renders and links to the correct package (verified shields.io endpoint resolves)
- [ ] Filtered release links show only the matching SDK's releases
- [ ] YAML validated locally for release.yml and feature_request.yml
- [ ] Next release's auto-generated notes show grouped sections