### PR TITLE
feat: add internal middleware system for InvokeModelStage

### DIFF
--- a/strands-py/src/strands/_middleware/README.md
+++ b/strands-py/src/strands/_middleware/README.md
@@ -1,0 +1,37 @@
+# Python Middleware
+
+This implementation follows the behavioral spec defined in `strands-ts/src/middleware/README.md` with the following intentional divergences:
+
+## Scope
+
+Only `InvokeModelStage` is implemented. `ExecuteToolStage` and `AgentStreamStage` will be added as needed.
+
+## Result encoding
+
+Python async generators cannot `return` values. The implementation uses a `MiddlewareResult` sentinel yielded as the last item in the generator. Integration sites strip it from the event stream. Pass-through is:
+
+```python
+async def passthrough(context, next_fn):
+    async for event in next_fn(context):
+        yield event
+```
+
+## No removal / cleanup
+
+Once registered, middleware cannot be removed. This matches the Python hook system which also does not support removal.
+
+## Private module
+
+The `_middleware/` package is not part of the public API. Internal consumers access it via `agent._middleware_registry.add_middleware(...)`.
+
+## System prompt as a union type
+
+`InvokeModelContext.system_prompt` is `str | list[SystemContentBlock] | None` (a single union field). The terminal decomposes this into the two-param form needed by `Model.stream()` via `split_system_prompt()`.
+
+## Defensive copies
+
+Context fields (`messages`, `system_prompt`, `tool_specs`, `tool_choice`) are deep-copied when building the middleware context. `invocation_state` is shared by reference. `model_state` is not on the context — the terminal reads it directly from the agent.
+
+## Generator cleanup
+
+Python's `compose()` uses `try/finally` with explicit `aclose()`. TypeScript relies on `yield*` delegation which calls `.return()` automatically. Both correctly clean up generators.

--- a/strands-py/src/strands/_middleware/__init__.py
+++ b/strands-py/src/strands/_middleware/__init__.py
@@ -1,0 +1,8 @@
+"""Internal middleware system for wrapping agent stages."""
+
+from .registry import MiddlewareRegistry as MiddlewareRegistry
+from .stages import InvokeModelContext as InvokeModelContext
+from .stages import InvokeModelResult as InvokeModelResult
+from .stages import InvokeModelStage as InvokeModelStage
+from .types import MiddlewareResult as MiddlewareResult
+from .types import MiddlewareStage as MiddlewareStage

--- a/strands-py/src/strands/_middleware/registry.py
+++ b/strands-py/src/strands/_middleware/registry.py
@@ -1,0 +1,143 @@
+"""Middleware registry for composing handler chains."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Any
+
+from .types import (
+    MiddlewareHandler,
+    MiddlewareInputHandler,
+    MiddlewareInputPhase,
+    MiddlewareNext,
+    MiddlewareOutputHandler,
+    MiddlewareOutputPhase,
+    MiddlewareResult,
+    MiddlewareStage,
+    MiddlewareWrapPhase,
+)
+
+_PHASE_ORDER: dict[str, int] = {"input": 0, "output": 1, "wrap": 2}
+
+
+@dataclass
+class _TaggedHandler:
+    phase: str
+    handler: MiddlewareHandler
+
+
+class MiddlewareRegistry:
+    """Registry that stores middleware handlers keyed by stage tokens and composes them into chains."""
+
+    def __init__(self) -> None:
+        self._handlers: dict[MiddlewareStage[Any, Any, Any], list[_TaggedHandler]] = {}
+
+    def add_middleware(
+        self,
+        stage_or_phase: (
+            MiddlewareStage[Any, Any, Any]
+            | MiddlewareInputPhase[Any, Any, Any]
+            | MiddlewareWrapPhase[Any, Any, Any]
+            | MiddlewareOutputPhase[Any, Any, Any]
+        ),
+        handler: Any,
+    ) -> None:
+        """Register middleware for a stage or phase sub-token."""
+        if isinstance(stage_or_phase, MiddlewareInputPhase):
+            self._add_input(stage_or_phase, handler)
+        elif isinstance(stage_or_phase, MiddlewareOutputPhase):
+            self._add_output(stage_or_phase, handler)
+        elif isinstance(stage_or_phase, MiddlewareWrapPhase):
+            self._add_wrap(stage_or_phase._stage, handler)
+        else:
+            self._add_wrap(stage_or_phase, handler)
+
+    def _add_wrap(self, stage: MiddlewareStage[Any, Any, Any], handler: MiddlewareHandler) -> None:
+        handlers = self._handlers.setdefault(stage, [])
+        handlers.append(_TaggedHandler(phase="wrap", handler=handler))
+
+    def _add_input(self, phase: MiddlewareInputPhase[Any, Any, Any], handler: MiddlewareInputHandler) -> None:
+        stage = phase._stage
+
+        async def adapted(context: Any, next_fn: MiddlewareNext) -> AsyncGenerator[Any, None]:
+            transformed = handler(context)
+            if inspect.isawaitable(transformed):
+                transformed = await transformed
+            async for event in next_fn(transformed):
+                yield event
+
+        handlers = self._handlers.setdefault(stage, [])
+        handlers.append(_TaggedHandler(phase="input", handler=adapted))
+
+    def _add_output(self, phase: MiddlewareOutputPhase[Any, Any, Any], handler: MiddlewareOutputHandler) -> None:
+        stage = phase._stage
+
+        async def adapted(context: Any, next_fn: MiddlewareNext) -> AsyncGenerator[Any, None]:
+            async for event in next_fn(context):
+                if isinstance(event, MiddlewareResult):
+                    transformed = handler(event.value)
+                    if inspect.isawaitable(transformed):
+                        transformed = await transformed
+                    yield MiddlewareResult(transformed)
+                else:
+                    yield event
+
+        handlers = self._handlers.setdefault(stage, [])
+        handlers.append(_TaggedHandler(phase="output", handler=adapted))
+
+    def compose(self, stage: MiddlewareStage[Any, Any, Any], terminal: MiddlewareNext) -> MiddlewareNext:
+        """Compose all registered handlers for a stage into a single chain.
+
+        Returns the terminal directly if no handlers are registered (zero overhead fast path).
+        """
+        tagged = self._handlers.get(stage)
+        if not tagged:
+            return terminal
+
+        sorted_handlers = sorted(tagged, key=lambda t: _PHASE_ORDER[t.phase])
+
+        current: MiddlewareNext = terminal
+        for i in range(len(sorted_handlers) - 1, -1, -1):
+            handler = sorted_handlers[i].handler
+            next_fn = current
+
+            def _make_layer(h: MiddlewareHandler, nf: MiddlewareNext) -> MiddlewareNext:
+                async def layer(ctx: Any) -> AsyncGenerator[Any, None]:
+                    inner_gens: list[AsyncGenerator[Any, None]] = []
+
+                    def tracking_next(c: Any) -> AsyncGenerator[Any, None]:
+                        gen = nf(c)
+                        inner_gens.append(gen)
+                        return gen
+
+                    handler_gen = h(ctx, tracking_next)
+                    try:
+                        async for event in handler_gen:
+                            yield event
+                    finally:
+                        await handler_gen.aclose()
+                        for gen in inner_gens:
+                            await gen.aclose()
+
+                return layer
+
+            current = _make_layer(handler, next_fn)
+
+        return current
+
+    async def invoke(
+        self,
+        stage: MiddlewareStage[Any, Any, Any],
+        context: Any,
+        terminal: MiddlewareNext,
+    ) -> AsyncGenerator[Any, None]:
+        """Compose and invoke the middleware chain for a stage."""
+        chain = self.compose(stage, terminal)
+        gen = chain(context)
+        try:
+            async for event in gen:
+                yield event
+        finally:
+            await gen.aclose()

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -9,7 +9,8 @@ from .types import MiddlewareStage
 
 if TYPE_CHECKING:
     from ..agent.agent import Agent
-    from ..types.content import Messages, SystemPrompt
+    from ..types.content import Message, Messages, SystemPrompt
+    from ..types.event_loop import Metrics, Usage
     from ..types.streaming import StopReason
     from ..types.tools import ToolSpec
 
@@ -36,9 +37,9 @@ class InvokeModelResult:
     """Result from InvokeModelStage middleware."""
 
     stop_reason: StopReason
-    message: dict[str, Any]
-    usage: dict[str, Any]
-    metrics: dict[str, Any]
+    message: Message
+    usage: Usage
+    metrics: Metrics
 
 
 InvokeModelStage: MiddlewareStage[InvokeModelContext, InvokeModelResult, Any] = MiddlewareStage(name="invokeModel")

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -1,0 +1,44 @@
+"""Built-in middleware stages and their context/result types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from .types import MiddlewareStage
+
+if TYPE_CHECKING:
+    from ..agent.agent import Agent
+    from ..types.content import Messages, SystemPrompt
+    from ..types.streaming import StopReason
+    from ..types.tools import ToolSpec
+
+
+@dataclass
+class InvokeModelContext:
+    """Context passed to InvokeModelStage middleware.
+
+    All collection fields (messages, system_prompt, tool_specs, tool_choice) are
+    defensive copies — middleware cannot accidentally mutate agent state.
+    invocation_state is shared by reference (hooks and tools write to it during streaming).
+    """
+
+    agent: Agent
+    messages: Messages
+    system_prompt: SystemPrompt
+    tool_specs: list[ToolSpec]
+    tool_choice: Any | None
+    invocation_state: dict[str, Any]
+
+
+@dataclass
+class InvokeModelResult:
+    """Result from InvokeModelStage middleware."""
+
+    stop_reason: StopReason
+    message: dict[str, Any]
+    usage: dict[str, Any]
+    metrics: dict[str, Any]
+
+
+InvokeModelStage: MiddlewareStage[InvokeModelContext, InvokeModelResult, Any] = MiddlewareStage(name="invokeModel")

--- a/strands-py/src/strands/_middleware/types.py
+++ b/strands-py/src/strands/_middleware/types.py
@@ -1,0 +1,75 @@
+"""Middleware type system."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+TContext = TypeVar("TContext")
+TResult = TypeVar("TResult")
+TEvent = TypeVar("TEvent")
+
+
+@dataclass
+class MiddlewareResult(Generic[TResult]):
+    """Sentinel yielded as the last item to communicate the result up the chain."""
+
+    value: TResult
+
+
+class MiddlewareInputPhase(Generic[TContext, TResult, TEvent]):
+    """Phase sub-token for Input handlers — transforms context before execution."""
+
+    __slots__ = ("_stage", "_phase")
+
+    def __init__(self, stage: MiddlewareStage[TContext, TResult, TEvent]) -> None:
+        self._stage = stage
+        self._phase = "input"
+
+
+class MiddlewareWrapPhase(Generic[TContext, TResult, TEvent]):
+    """Phase sub-token for Wrap handlers — full async generator wrap."""
+
+    __slots__ = ("_stage", "_phase")
+
+    def __init__(self, stage: MiddlewareStage[TContext, TResult, TEvent]) -> None:
+        self._stage = stage
+        self._phase = "wrap"
+
+
+class MiddlewareOutputPhase(Generic[TContext, TResult, TEvent]):
+    """Phase sub-token for Output handlers — transforms result after execution."""
+
+    __slots__ = ("_stage", "_phase")
+
+    def __init__(self, stage: MiddlewareStage[TContext, TResult, TEvent]) -> None:
+        self._stage = stage
+        self._phase = "output"
+
+
+class MiddlewareStage(Generic[TContext, TResult, TEvent]):
+    """A stage token identifying a middleware interception point."""
+
+    __slots__ = ("name", "Input", "Wrap", "Output")
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.Input: MiddlewareInputPhase[TContext, TResult, TEvent] = MiddlewareInputPhase(self)
+        self.Wrap: MiddlewareWrapPhase[TContext, TResult, TEvent] = MiddlewareWrapPhase(self)
+        self.Output: MiddlewareOutputPhase[TContext, TResult, TEvent] = MiddlewareOutputPhase(self)
+
+    def __repr__(self) -> str:
+        return f"MiddlewareStage(name={self.name!r})"
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    def __eq__(self, other: object) -> bool:
+        return self is other
+
+
+MiddlewareNext = Callable[[Any], AsyncGenerator[Any, None]]
+MiddlewareHandler = Callable[[Any, MiddlewareNext], AsyncGenerator[Any, None]]
+MiddlewareInputHandler = Callable[[Any], Any | Awaitable[Any]]
+MiddlewareOutputHandler = Callable[[Any], Any | Awaitable[Any]]

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -43,6 +43,7 @@ from ..types._snapshot import (
 
 if TYPE_CHECKING:
     from ..tools import ToolProvider
+from .._middleware import MiddlewareRegistry
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from ..hooks import (
     AfterInvocationEvent,
@@ -73,7 +74,7 @@ from ..tools.structured_output._structured_output_context import StructuredOutpu
 from ..tools.watcher import ToolWatcher
 from ..types._events import AgentResultEvent, EventLoopStopEvent, InitEventLoopEvent, ModelStreamChunkEvent, TypedEvent
 from ..types.agent import AgentInput, ConcurrentInvocationMode, Limits
-from ..types.content import ContentBlock, Message, Messages, SystemContentBlock
+from ..types.content import ContentBlock, Message, Messages, SystemContentBlock, split_system_prompt
 from ..types.exceptions import ConcurrencyException, ContextWindowOverflowException
 from ..types.tools import AgentTool
 from ..types.traces import AttributeValue
@@ -267,7 +268,7 @@ class Agent(AgentBase):
         self.model = BedrockModel() if not model else BedrockModel(model_id=model) if isinstance(model, str) else model
         self.messages = messages if messages is not None else []
         # initializing self._system_prompt for backwards compatibility
-        self._system_prompt, self._system_prompt_content = self._initialize_system_prompt(system_prompt)
+        self._system_prompt, self._system_prompt_content = split_system_prompt(system_prompt)
         self._default_structured_output_model = structured_output_model
         self._structured_output_prompt = structured_output_prompt
         self.agent_id = _identifier.validate(agent_id or _DEFAULT_AGENT_ID, _identifier.Identifier.AGENT)
@@ -351,6 +352,8 @@ class Agent(AgentBase):
         self.tool_caller = _ToolCaller(self)
 
         self.hooks = HookRegistry()
+
+        self._middleware_registry = MiddlewareRegistry()
 
         self._plugin_registry = _PluginRegistry(self)
 
@@ -547,7 +550,7 @@ class Agent(AgentBase):
                   - list[SystemContentBlock]: Content blocks with features like caching
                   - None: Clear the system prompt
         """
-        self._system_prompt, self._system_prompt_content = self._initialize_system_prompt(value)
+        self._system_prompt, self._system_prompt_content = split_system_prompt(value)
 
     @property
     def system_prompt_content(self) -> list[SystemContentBlock] | None:
@@ -1326,30 +1329,6 @@ class Agent(AgentBase):
             value = limits[key]
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 raise TypeError(f"limits[{key!r}] must be a positive int, got {value!r}")
-
-    def _initialize_system_prompt(
-        self, system_prompt: str | list[SystemContentBlock] | None
-    ) -> tuple[str | None, list[SystemContentBlock] | None]:
-        """Initialize system prompt fields from constructor input.
-
-        Maintains backwards compatibility by keeping system_prompt as str when string input
-        provided, avoiding breaking existing consumers.
-
-        Maps system_prompt input to both string and content block representations:
-        - If string: system_prompt=string, _system_prompt_content=[{text: string}]
-        - If list with text elements: system_prompt=concatenated_text, _system_prompt_content=list
-        - If list without text elements: system_prompt=None, _system_prompt_content=list
-        - If None: system_prompt=None, _system_prompt_content=None
-        """
-        if isinstance(system_prompt, str):
-            return system_prompt, [{"text": system_prompt}]
-        elif isinstance(system_prompt, list):
-            # Concatenate all text elements for backwards compatibility, None if no text found
-            text_parts = [block["text"] for block in system_prompt if "text" in block]
-            system_prompt_str = "\n".join(text_parts) if text_parts else None
-            return system_prompt_str, system_prompt
-        else:
-            return None, None
 
     async def _append_messages(self, *messages: Message) -> None:
         """Appends messages to history and invoke the callbacks for the MessageAddedEvent."""

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -8,13 +8,16 @@ The event loop allows agents to:
 4. Manage recursive execution cycles
 """
 
+import copy
 import logging
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any
 
 from opentelemetry import trace as trace_api
 
+from .._middleware.stages import InvokeModelContext, InvokeModelResult, InvokeModelStage
+from .._middleware.types import MiddlewareResult
 from ..experimental.checkpoint import Checkpoint, CheckpointPosition
 from ..hooks import AfterModelCallEvent, BeforeModelCallEvent, MessageAddedEvent
 from ..telemetry.metrics import Trace
@@ -34,7 +37,7 @@ from ..types._events import (
     TypedEvent,
 )
 from ..types.agent import Limits
-from ..types.content import Message, Messages
+from ..types.content import Message, Messages, split_system_prompt
 from ..types.event_loop import Metrics, Usage
 from ..types.exceptions import (
     ContextWindowOverflowException,
@@ -477,86 +480,31 @@ async def _handle_model_execution(
     # Retry loop - actual retry logic is handled by retry_strategy hook
     # Hooks control when to stop retrying via the event.retry flag
     while True:
-        model_id = agent.model.config.get("model_id") if hasattr(agent.model, "config") else None
-        model_invoke_span = tracer.start_model_invoke_span(
-            messages=agent.messages,
-            parent_span=cycle_span,
-            model_id=model_id,
-            custom_trace_attributes=agent.trace_attributes,
-            system_prompt=agent.system_prompt,
-            system_prompt_content=agent._system_prompt_content,
-        )
-        with trace_api.use_span(model_invoke_span, end_on_exit=False):
+        try:
+            # Estimate input tokens for the upcoming model call (non-fatal)
+            projected_input_tokens: int | None = None
             try:
-                # Estimate input tokens for the upcoming model call (non-fatal)
-                projected_input_tokens: int | None = None
-                try:
-                    projected_input_tokens = await _estimate_input_tokens(agent)
-                except Exception as e:
-                    logger.debug("error=<%s> | token estimation failed, proceeding without estimate", e)
+                projected_input_tokens = await _estimate_input_tokens(agent)
+            except Exception as e:
+                logger.debug("error=<%s> | token estimation failed, proceeding without estimate", e)
 
-                before_model_call_event = BeforeModelCallEvent(
-                    agent=agent,
-                    invocation_state=invocation_state,
-                    projected_input_tokens=projected_input_tokens,
+            before_model_call_event = BeforeModelCallEvent(
+                agent=agent,
+                invocation_state=invocation_state,
+                projected_input_tokens=projected_input_tokens,
+            )
+            await agent.hooks.invoke_callbacks_async(before_model_call_event)
+
+            if before_model_call_event.cancel:
+                cancel_text = (
+                    before_model_call_event.cancel
+                    if isinstance(before_model_call_event.cancel, str)
+                    else "model call denied by hook"
                 )
-                await agent.hooks.invoke_callbacks_async(before_model_call_event)
-
-                if before_model_call_event.cancel:
-                    cancel_text = (
-                        before_model_call_event.cancel
-                        if isinstance(before_model_call_event.cancel, str)
-                        else "model call denied by hook"
-                    )
-                    message: Message = {"role": "assistant", "content": [{"text": cancel_text}]}
-                    stop_reason: StopReason = "end_turn"
-                    usage: Usage = {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}
-                    metrics: Metrics = {"latencyMs": 0}
-
-                    after_model_call_event = AfterModelCallEvent(
-                        agent=agent,
-                        invocation_state=invocation_state,
-                        stop_response=AfterModelCallEvent.ModelStopResponse(
-                            stop_reason=stop_reason,
-                            message=message,
-                        ),
-                    )
-                    await agent.hooks.invoke_callbacks_async(after_model_call_event)
-
-                    tracer.end_model_invoke_span(model_invoke_span, message, usage, metrics, stop_reason)
-                    if after_model_call_event.retry:
-                        continue
-                    yield ModelStopReason(stop_reason=stop_reason, message=message, usage=usage, metrics=metrics)
-                    break
-
-                if structured_output_context.forced_mode:
-                    tool_spec = structured_output_context.get_tool_spec()
-                    tool_specs = [tool_spec] if tool_spec else []
-                else:
-                    tool_specs = agent.tool_registry.get_all_tool_specs()
-
-                async for event in stream_messages(
-                    agent.model,
-                    agent.system_prompt,
-                    agent.messages,
-                    tool_specs,
-                    system_prompt_content=agent._system_prompt_content,
-                    tool_choice=structured_output_context.tool_choice,
-                    invocation_state=invocation_state,
-                    model_state=agent._model_state,
-                    cancel_signal=agent._cancel_signal,
-                ):
-                    yield event
-
-                stop_reason, message, usage, metrics = event["stop"]
-                invocation_state.setdefault("request_state", {})
-
-                # Attach metadata to the assistant message immediately so it's
-                # available to all downstream consumers (hooks, events, state).
-                message["metadata"] = {
-                    "usage": usage,
-                    "metrics": metrics,
-                }
+                message: Message = {"role": "assistant", "content": [{"text": cancel_text}]}
+                stop_reason: StopReason = "end_turn"
+                usage: Usage = {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}
+                metrics: Metrics = {"latencyMs": 0}
 
                 after_model_call_event = AfterModelCallEvent(
                     agent=agent,
@@ -566,54 +514,113 @@ async def _handle_model_execution(
                         message=message,
                     ),
                 )
-
                 await agent.hooks.invoke_callbacks_async(after_model_call_event)
 
-                # Check if hooks want to retry the model call
                 if after_model_call_event.retry:
-                    logger.debug(
-                        "stop_reason=<%s>, retry_requested=<True> | hook requested model retry",
-                        stop_reason,
-                    )
-                    tracer.end_model_invoke_span(model_invoke_span, message, usage, metrics, stop_reason)
-                    continue  # Retry the model call
+                    continue
+                yield ModelStopReason(stop_reason=stop_reason, message=message, usage=usage, metrics=metrics)
+                break
 
-                if stop_reason == "max_tokens":
-                    message = recover_message_on_max_tokens_reached(message)
+            if structured_output_context.forced_mode:
+                tool_spec = structured_output_context.get_tool_spec()
+                tool_specs = [tool_spec] if tool_spec else []
+            else:
+                tool_specs = agent.tool_registry.get_all_tool_specs()
 
-                tracer.end_model_invoke_span(model_invoke_span, message, usage, metrics, stop_reason)
-                break  # Success! Break out of retry loop
+            # Build middleware context with defensive copies to prevent accidental mutation.
+            # invocation_state is intentionally shared by reference (hooks/tools write to it).
+            system_prompt_value = (
+                agent._system_prompt_content
+                if agent._system_prompt_content is not None
+                else agent.system_prompt
+            )
+            middleware_context = InvokeModelContext(
+                agent=agent,
+                messages=copy.deepcopy(agent.messages),
+                system_prompt=copy.deepcopy(system_prompt_value),
+                tool_specs=copy.deepcopy(tool_specs),
+                tool_choice=copy.deepcopy(structured_output_context.tool_choice),
+                invocation_state=invocation_state,
+            )
 
-            except Exception as e:
-                tracer.end_span_with_error(model_invoke_span, str(e), e)
-                after_model_call_event = AfterModelCallEvent(
-                    agent=agent,
-                    invocation_state=invocation_state,
-                    exception=e,
+            # Run through middleware chain (terminal includes span tracking)
+            model_result: InvokeModelResult | None = None
+            async for event in agent._middleware_registry.invoke(
+                InvokeModelStage,
+                middleware_context,
+                _make_invoke_model_terminal(agent, cycle_span, tracer),
+            ):
+                if isinstance(event, MiddlewareResult):
+                    model_result = event.value
+                else:
+                    yield event
+
+            assert model_result is not None
+            stop_reason = model_result.stop_reason
+            message = model_result.message
+            usage = model_result.usage
+            metrics = model_result.metrics
+
+            invocation_state.setdefault("request_state", {})
+
+            # Attach metadata to the assistant message immediately so it's
+            # available to all downstream consumers (hooks, events, state).
+            message["metadata"] = {
+                "usage": usage,
+                "metrics": metrics,
+            }
+
+            after_model_call_event = AfterModelCallEvent(
+                agent=agent,
+                invocation_state=invocation_state,
+                stop_response=AfterModelCallEvent.ModelStopResponse(
+                    stop_reason=stop_reason,
+                    message=message,
+                ),
+            )
+
+            await agent.hooks.invoke_callbacks_async(after_model_call_event)
+
+            # Check if hooks want to retry the model call
+            if after_model_call_event.retry:
+                logger.debug(
+                    "stop_reason=<%s>, retry_requested=<True> | hook requested model retry",
+                    stop_reason,
                 )
-                await agent.hooks.invoke_callbacks_async(after_model_call_event)
+                continue  # Retry the model call
 
-                # Emit backwards-compatible events if retry strategy supports it
-                # (prior to making the retry strategy configurable, this is what we emitted)
+            if stop_reason == "max_tokens":
+                message = recover_message_on_max_tokens_reached(message)
 
-                if (
-                    isinstance(agent._retry_strategy, ModelRetryStrategy)
-                    and agent._retry_strategy._backwards_compatible_event_to_yield
-                ):
-                    yield agent._retry_strategy._backwards_compatible_event_to_yield
+            break  # Success! Break out of retry loop
 
-                # Check if hooks want to retry the model call
-                if after_model_call_event.retry:
-                    logger.debug(
-                        "exception=<%s>, retry_requested=<True> | hook requested model retry",
-                        type(e).__name__,
-                    )
+        except Exception as e:
+            after_model_call_event = AfterModelCallEvent(
+                agent=agent,
+                invocation_state=invocation_state,
+                exception=e,
+            )
+            await agent.hooks.invoke_callbacks_async(after_model_call_event)
 
-                    continue  # Retry the model call
+            # Emit backwards-compatible events if retry strategy supports it
+            if (
+                isinstance(agent._retry_strategy, ModelRetryStrategy)
+                and agent._retry_strategy._backwards_compatible_event_to_yield
+            ):
+                yield agent._retry_strategy._backwards_compatible_event_to_yield
 
-                # No retry requested, raise the exception
-                yield ForceStopEvent(reason=e)
-                raise e
+            # Check if hooks want to retry the model call
+            if after_model_call_event.retry:
+                logger.debug(
+                    "exception=<%s>, retry_requested=<True> | hook requested model retry",
+                    type(e).__name__,
+                )
+
+                continue  # Retry the model call
+
+            # No retry requested, raise the exception
+            yield ForceStopEvent(reason=e)
+            raise e
 
     try:
         # Add message in trace and mark the end of the stream messages trace
@@ -632,6 +639,53 @@ async def _handle_model_execution(
         yield ForceStopEvent(reason=e)
         logger.exception("cycle failed")
         raise EventLoopException(e, invocation_state["request_state"]) from e
+
+
+def _make_invoke_model_terminal(
+    agent: "Agent", cycle_span: Any, tracer: Tracer
+) -> "Callable[[InvokeModelContext], AsyncGenerator[Any, None]]":
+    """Create the terminal function for InvokeModelStage middleware."""
+
+    async def terminal(ctx: InvokeModelContext) -> AsyncGenerator[Any, None]:
+        system_prompt_str, system_prompt_content = split_system_prompt(ctx.system_prompt)
+
+        model_id = agent.model.config.get("model_id") if hasattr(agent.model, "config") else None
+        model_invoke_span = tracer.start_model_invoke_span(
+            messages=ctx.messages,
+            parent_span=cycle_span,
+            model_id=model_id,
+            custom_trace_attributes=agent.trace_attributes,
+            system_prompt=system_prompt_str,
+            system_prompt_content=system_prompt_content,
+        )
+        with trace_api.use_span(model_invoke_span, end_on_exit=False):
+            try:
+                async for event in stream_messages(
+                    agent.model,
+                    system_prompt_str,
+                    ctx.messages,
+                    ctx.tool_specs,
+                    system_prompt_content=system_prompt_content,
+                    tool_choice=ctx.tool_choice,
+                    invocation_state=ctx.invocation_state,
+                    model_state=agent._model_state,
+                    cancel_signal=agent._cancel_signal,
+                ):
+                    yield event
+
+                stop_reason, message, usage, metrics = event["stop"]  # type: ignore[possibly-undefined]
+                tracer.end_model_invoke_span(model_invoke_span, message, usage, metrics, stop_reason)
+                yield MiddlewareResult(InvokeModelResult(
+                    stop_reason=stop_reason,
+                    message=message,
+                    usage=usage,
+                    metrics=metrics,
+                ))
+            except Exception as e:
+                tracer.end_span_with_error(model_invoke_span, str(e), e)
+                raise
+
+    return terminal
 
 
 async def _handle_tool_execution(

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -555,7 +555,11 @@ async def _handle_model_execution(
                 else:
                     yield event
 
-            assert model_result is not None
+            if model_result is None:
+                raise RuntimeError(
+                    "Middleware chain did not produce a MiddlewareResult. "
+                    "Ensure all middleware forwards the result from next()."
+                )
             stop_reason = model_result.stop_reason
             message = model_result.message
             usage = model_result.usage
@@ -673,7 +677,7 @@ def _make_invoke_model_terminal(
                 ):
                     yield event
 
-                stop_reason, message, usage, metrics = event["stop"]  # type: ignore[possibly-undefined]
+                stop_reason, message, usage, metrics = event["stop"]
                 tracer.end_model_invoke_span(model_invoke_span, message, usage, metrics, stop_reason)
                 yield MiddlewareResult(InvokeModelResult(
                     stop_reason=stop_reason,

--- a/strands-py/src/strands/types/content.py
+++ b/strands-py/src/strands/types/content.py
@@ -115,6 +115,30 @@ class SystemContentBlock(TypedDict, total=False):
     text: str
 
 
+SystemPrompt = str | list[SystemContentBlock] | None
+"""System prompt as either a plain string or structured content blocks (e.g., with cache points)."""
+
+
+def split_system_prompt(system_prompt: SystemPrompt) -> tuple[str | None, list[SystemContentBlock] | None]:
+    """Split a unified system prompt into the legacy two-field representation.
+
+    Maps a single system_prompt value into both string and content block representations
+    needed by Model.stream():
+    - If string: (string, [{text: string}])
+    - If list with text elements: (concatenated_text, list)
+    - If list without text elements: (None, list)
+    - If None: (None, None)
+    """
+    if isinstance(system_prompt, str):
+        return system_prompt, [{"text": system_prompt}]
+    elif isinstance(system_prompt, list):
+        text_parts = [block["text"] for block in system_prompt if "text" in block]
+        system_prompt_str = "\n".join(text_parts) if text_parts else None
+        return system_prompt_str, system_prompt
+    else:
+        return None, None
+
+
 class DeltaContent(TypedDict, total=False):
     """A block of content in a streaming response.
 

--- a/strands-py/src/strands/types/content.py
+++ b/strands-py/src/strands/types/content.py
@@ -120,14 +120,18 @@ SystemPrompt = str | list[SystemContentBlock] | None
 
 
 def split_system_prompt(system_prompt: SystemPrompt) -> tuple[str | None, list[SystemContentBlock] | None]:
-    """Split a unified system prompt into the legacy two-field representation.
+    """Split a unified system prompt into the two-field form needed by Model.stream().
 
-    Maps a single system_prompt value into both string and content block representations
-    needed by Model.stream():
-    - If string: (string, [{text: string}])
-    - If list with text elements: (concatenated_text, list)
-    - If list without text elements: (None, list)
-    - If None: (None, None)
+    The string representation is maintained for backwards compatibility with model providers
+    that expect `system_prompt: str`. The content block representation supports advanced
+    features like cache points.
+
+    Returns:
+        (system_prompt_str, system_prompt_content) where:
+        - If string input: (string, [{text: string}])
+        - If list with text elements: (concatenated_text, list)
+        - If list without text elements: (None, list)
+        - If None: (None, None)
     """
     if isinstance(system_prompt, str):
         return system_prompt, [{"text": system_prompt}]

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -10,6 +10,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 import strands
+import strands._middleware
 import strands.telemetry
 from strands import Agent
 from strands.event_loop._retry import ModelRetryStrategy
@@ -158,6 +159,8 @@ def agent(model, system_prompt, messages, tool_registry, thread_pool, hook_regis
     mock._interrupt_state = _InterruptState()
     mock._cancel_signal = threading.Event()
     mock._model_state = {}
+    mock._system_prompt_content = None
+    mock._middleware_registry = strands._middleware.MiddlewareRegistry()
     mock._checkpointing = False
     mock._checkpoint = None
     mock._checkpoint_cycle_index = 0
@@ -560,7 +563,7 @@ async def test_event_loop_cycle_creates_spans(
     mock_tracer.start_model_invoke_span.assert_called_once()
     call_kwargs = mock_tracer.start_model_invoke_span.call_args[1]
     assert call_kwargs["system_prompt"] == agent.system_prompt
-    assert call_kwargs["system_prompt_content"] == agent._system_prompt_content
+    assert call_kwargs["system_prompt_content"] == [{"text": agent.system_prompt}]
     mock_tracer.end_model_invoke_span.assert_called_once()
     mock_tracer.end_event_loop_cycle_span.assert_called_once()
 
@@ -829,6 +832,11 @@ async def test_request_state_initialization(alist):
     # not setting this to False results in endless recursion
     mock_agent._interrupt_state.activated = False
     mock_agent._cancel_signal = threading.Event()
+    mock_agent._system_prompt_content = None
+    mock_agent.system_prompt = None
+    mock_agent._middleware_registry = strands._middleware.MiddlewareRegistry()
+    mock_agent.messages = []
+    mock_agent.tool_registry.get_all_tool_specs.return_value = []
     mock_agent.event_loop_metrics.start_cycle.return_value = (0, MagicMock())
     mock_agent.hooks.invoke_callbacks_async = AsyncMock()
 

--- a/strands-py/tests/strands/event_loop/test_event_loop_metadata.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop_metadata.py
@@ -6,6 +6,7 @@ import unittest.mock
 import pytest
 
 import strands
+import strands._middleware
 import strands.event_loop.event_loop
 from strands import Agent
 from strands.event_loop._retry import ModelRetryStrategy
@@ -55,6 +56,9 @@ def agent(model, messages, tool_registry, hook_registry):
     mock.tool_executor = SequentialToolExecutor()
     mock._interrupt_state = _InterruptState()
     mock._cancel_signal = threading.Event()
+    mock._model_state = {}
+    mock._system_prompt_content = None
+    mock._middleware_registry = strands._middleware.MiddlewareRegistry()
     mock.trace_attributes = {}
     mock.retry_strategy = ModelRetryStrategy()
     return mock

--- a/strands-py/tests/strands/event_loop/test_event_loop_structured_output.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop_structured_output.py
@@ -10,6 +10,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import StatusCode
 from pydantic import BaseModel
 
+from strands._middleware import MiddlewareRegistry
 from strands.event_loop.event_loop import event_loop_cycle, recurse_event_loop
 from strands.telemetry.metrics import EventLoopMetrics
 from strands.telemetry.tracer import Tracer
@@ -61,6 +62,8 @@ def mock_agent():
     agent._interrupt_state.context = {}
     agent._cancel_signal = threading.Event()
     agent._model_state = {}
+    agent._system_prompt_content = None
+    agent._middleware_registry = MiddlewareRegistry()
     agent._checkpointing = False
     agent._checkpoint = None
     agent._checkpoint_cycle_index = 0

--- a/strands-py/tests/strands/middleware/test_agent_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_middleware.py
@@ -60,7 +60,9 @@ def test_wrap_handler_receives_invoke_model_context(agent):
     ctx = received_context[0]
     assert ctx.agent is agent
     assert isinstance(ctx.messages, list)
+    assert ctx.system_prompt is not None or ctx.system_prompt is None  # field exists
     assert isinstance(ctx.tool_specs, list)
+    assert hasattr(ctx, "tool_choice")
     assert isinstance(ctx.invocation_state, dict)
 
 
@@ -108,6 +110,25 @@ def test_wrap_context_transformation_tool_specs(agent):
     agent("test")
 
     assert received_tool_specs == []
+
+
+def test_context_modification_does_not_mutate_agent_state():
+    """Context fields are defensive copies — middleware mutations don't affect agent state."""
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "ok"}]}])
+    agent = Agent(model=model, callback_handler=None, system_prompt="original")
+
+    async def mutating_middleware(context, next_fn):
+        context.messages.append({"role": "user", "content": [{"text": "injected"}]})
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, mutating_middleware)
+    agent("test")
+
+    # Agent's messages should not contain the injected message from middleware mutation
+    # (it will have the user "test" message and the model response, but not "injected" before "test")
+    user_texts = [m["content"][0].get("text") for m in agent.messages if m.get("role") == "user"]
+    assert "injected" not in user_texts
 
 
 def test_wrap_short_circuit_skips_model_call(agent):
@@ -391,7 +412,7 @@ def test_short_circuit_model_not_called(model):
 
 
 def test_hooks_fire_when_middleware_short_circuits(model):
-    """AfterModelCallEvent fires even when middleware short-circuits (never calls next)."""
+    """Both BeforeModelCallEvent and AfterModelCallEvent fire even when middleware short-circuits."""
 
     hook_provider = MockHookProvider(event_types="all")
     agent = Agent(model=model, callback_handler=None, hooks=[hook_provider])
@@ -409,6 +430,7 @@ def test_hooks_fire_when_middleware_short_circuits(model):
 
     _, events = hook_provider.get_events()
     event_types = [type(e) for e in events]
+    assert BeforeModelCallEvent in event_types
     assert AfterModelCallEvent in event_types
 
 

--- a/strands-py/tests/strands/middleware/test_agent_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_middleware.py
@@ -60,7 +60,7 @@ def test_wrap_handler_receives_invoke_model_context(agent):
     ctx = received_context[0]
     assert ctx.agent is agent
     assert isinstance(ctx.messages, list)
-    assert ctx.system_prompt is not None or ctx.system_prompt is None  # field exists
+    assert hasattr(ctx, "system_prompt")
     assert isinstance(ctx.tool_specs, list)
     assert hasattr(ctx, "tool_choice")
     assert isinstance(ctx.invocation_state, dict)

--- a/strands-py/tests/strands/middleware/test_agent_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_middleware.py
@@ -1,0 +1,472 @@
+"""Integration tests for middleware with Agent (InvokeModelStage)."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from strands import Agent, Plugin
+from strands._middleware.stages import InvokeModelContext, InvokeModelResult, InvokeModelStage
+from strands._middleware.types import MiddlewareResult
+from strands.hooks import AfterModelCallEvent, BeforeModelCallEvent
+from strands.types._events import ModelStopReason
+from strands.types.streaming import Metrics, Usage
+from tests.fixtures.mock_hook_provider import MockHookProvider
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+@pytest.fixture
+def model():
+    return MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "Hello!"}]},
+        ]
+    )
+
+
+@pytest.fixture
+def agent(model):
+    return Agent(model=model, callback_handler=None)
+
+
+# --- add_middleware API ---
+
+
+# --- wrap phase ---
+
+
+def test_wrap_passthrough_does_not_alter_behavior(agent):
+    async def passthrough(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, passthrough)
+    result = agent("test")
+    assert result.message["content"][0]["text"] == "Hello!"
+
+
+def test_wrap_handler_receives_invoke_model_context(agent):
+    received_context: list[InvokeModelContext] = []
+
+    async def capture(context, next_fn):
+        received_context.append(context)
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, capture)
+    agent("test")
+
+    assert len(received_context) == 1
+    ctx = received_context[0]
+    assert ctx.agent is agent
+    assert isinstance(ctx.messages, list)
+    assert isinstance(ctx.tool_specs, list)
+    assert isinstance(ctx.invocation_state, dict)
+
+
+def test_wrap_context_transformation(agent):
+    """Middleware can modify the context before it reaches the model."""
+    transformed_system_prompt = None
+
+    async def inject_prompt(context, next_fn):
+
+        modified = replace(context, system_prompt="Injected prompt")
+        async for event in next_fn(modified):
+            yield event
+
+    async def capture_terminal(context, next_fn):
+        nonlocal transformed_system_prompt
+        transformed_system_prompt = context.system_prompt
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, inject_prompt)
+    agent._middleware_registry.add_middleware(InvokeModelStage, capture_terminal)
+    agent("test")
+
+    assert transformed_system_prompt == "Injected prompt"
+
+
+def test_wrap_context_transformation_tool_specs(agent):
+    """Middleware can modify tool_specs and the model receives the modified list."""
+    received_tool_specs = None
+
+    async def modify_specs(context, next_fn):
+
+        modified = replace(context, tool_specs=[])
+        async for event in next_fn(modified):
+            yield event
+
+    async def capture(context, next_fn):
+        nonlocal received_tool_specs
+        received_tool_specs = context.tool_specs
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, modify_specs)
+    agent._middleware_registry.add_middleware(InvokeModelStage, capture)
+    agent("test")
+
+    assert received_tool_specs == []
+
+
+def test_wrap_short_circuit_skips_model_call(agent):
+    """Middleware can short-circuit by not calling next and yielding its own result."""
+
+    async def cached_response(context, next_fn):
+        cached_message = {"role": "assistant", "content": [{"text": "Cached!"}]}
+        yield ModelStopReason(
+            stop_reason="end_turn",
+            message=cached_message,
+            usage=Usage(inputTokens=0, outputTokens=0, totalTokens=0),
+            metrics=Metrics(latencyMs=0),
+        )
+        yield MiddlewareResult(
+            InvokeModelResult(
+                stop_reason="end_turn",
+                message=cached_message,
+                usage={"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+                metrics={"latencyMs": 0},
+            )
+        )
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, cached_response)
+    result = agent("test")
+    assert result.message["content"][0]["text"] == "Cached!"
+
+
+def test_wrap_multiple_middleware_compose_correctly(agent):
+    order: list[str] = []
+
+    async def outer(context, next_fn):
+        order.append("outer_before")
+        async for event in next_fn(context):
+            yield event
+        order.append("outer_after")
+
+    async def inner(context, next_fn):
+        order.append("inner_before")
+        async for event in next_fn(context):
+            yield event
+        order.append("inner_after")
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, outer)
+    agent._middleware_registry.add_middleware(InvokeModelStage, inner)
+    agent("test")
+
+    assert order == ["outer_before", "inner_before", "inner_after", "outer_after"]
+
+
+def test_wrap_error_from_model_propagates_through_middleware():
+    """Errors from the model propagate through middleware layers."""
+
+    class FailingModel(MockedModelProvider):
+        async def stream(self, *args, **kwargs):
+            raise RuntimeError("model error")
+            yield  # noqa: B901
+
+    agent = Agent(model=FailingModel([]), callback_handler=None, retry_strategy=None)
+
+    caught_error = None
+
+    async def error_catcher(context, next_fn):
+        nonlocal caught_error
+        try:
+            async for event in next_fn(context):
+                yield event
+        except RuntimeError as e:
+            caught_error = e
+            raise
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, error_catcher)
+
+    with pytest.raises(RuntimeError, match="model error"):
+        agent("test")
+
+    assert caught_error is not None
+
+
+# --- input phase ---
+
+
+def test_input_transforms_context(agent):
+    received_system_prompt = None
+
+    async def capture(context, next_fn):
+        nonlocal received_system_prompt
+        received_system_prompt = context.system_prompt
+        async for event in next_fn(context):
+            yield event
+
+    def inject_prompt(context):
+
+        return replace(context, system_prompt="From input handler")
+
+    agent._middleware_registry.add_middleware(InvokeModelStage.Input, inject_prompt)
+    agent._middleware_registry.add_middleware(InvokeModelStage, capture)
+    agent("test")
+
+    assert received_system_prompt == "From input handler"
+
+
+def test_input_async_handler(agent):
+    received_system_prompt = None
+
+    async def capture(context, next_fn):
+        nonlocal received_system_prompt
+        received_system_prompt = context.system_prompt
+        async for event in next_fn(context):
+            yield event
+
+    async def async_inject(context):
+
+        return replace(context, system_prompt="Async input")
+
+    agent._middleware_registry.add_middleware(InvokeModelStage.Input, async_inject)
+    agent._middleware_registry.add_middleware(InvokeModelStage, capture)
+    agent("test")
+
+    assert received_system_prompt == "Async input"
+
+
+# --- output phase ---
+
+
+def test_output_transforms_result(agent):
+    transformed_results: list[InvokeModelResult] = []
+
+    def output_handler(result):
+
+        new_result = replace(result, stop_reason="custom_stop")
+        transformed_results.append(new_result)
+        return new_result
+
+    agent._middleware_registry.add_middleware(InvokeModelStage.Output, output_handler)
+    agent("test")
+
+    assert len(transformed_results) == 1
+    assert transformed_results[0].stop_reason == "custom_stop"
+
+
+# --- hooks fire outside middleware ---
+
+
+def test_before_model_call_fires_before_middleware(model):
+    hook_provider = MockHookProvider(event_types="all")
+    agent = Agent(model=model, callback_handler=None, hooks=[hook_provider])
+
+    middleware_saw_hook_fired = False
+
+    async def check_middleware(context, next_fn):
+        nonlocal middleware_saw_hook_fired
+        _, events = hook_provider.get_events()
+
+        event_types = [type(e) for e in events]
+        middleware_saw_hook_fired = BeforeModelCallEvent in event_types
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, check_middleware)
+    agent("test")
+    assert middleware_saw_hook_fired
+
+
+def test_after_model_call_fires_after_middleware(model):
+    hook_provider = MockHookProvider(event_types="all")
+    agent = Agent(model=model, callback_handler=None, hooks=[hook_provider])
+
+    middleware_completed = False
+
+    async def tracking_middleware(context, next_fn):
+        nonlocal middleware_completed
+        async for event in next_fn(context):
+            yield event
+        middleware_completed = True
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, tracking_middleware)
+    agent("test")
+
+    assert middleware_completed
+
+    _, events = hook_provider.get_events()
+    event_types = [type(e) for e in events]
+    assert AfterModelCallEvent in event_types
+
+
+# --- plugin middleware ---
+
+
+def test_plugin_can_register_middleware(model):
+
+    class TimingPlugin(Plugin):
+        name = "timing"
+
+        def __init__(self):
+            super().__init__()
+            self.call_count = 0
+
+        def init_agent(self, agent):
+            agent._middleware_registry.add_middleware(InvokeModelStage, self._middleware)
+
+        async def _middleware(self, context, next_fn):
+            self.call_count += 1
+            async for event in next_fn(context):
+                yield event
+
+    plugin = TimingPlugin()
+    agent = Agent(model=model, callback_handler=None, plugins=[plugin])
+    agent("test")
+
+    assert plugin.call_count == 1
+
+
+# --- no-middleware baselines ---
+
+
+def test_no_middleware_agent_works_correctly():
+    """Agent with no middleware produces correct results."""
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "Response"}]}])
+    agent = Agent(model=model, callback_handler=None)
+    result = agent("hello")
+    assert result.message["content"][0]["text"] == "Response"
+    assert result.stop_reason == "end_turn"
+
+
+def test_no_middleware_agent_with_tools_works_correctly():
+    """Agent with tools but no middleware executes tools correctly."""
+    import strands
+
+    @strands.tool(name="greet")
+    def greet(name: str) -> str:
+        """Greet someone."""
+        return f"Hello, {name}!"
+
+    tool_msg = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "t1", "name": "greet", "input": {"name": "World"}}}],
+    }
+    final_msg = {"role": "assistant", "content": [{"text": "Greeted!"}]}
+    model = MockedModelProvider([tool_msg, final_msg])
+    agent = Agent(model=model, tools=[greet], callback_handler=None)
+    result = agent("greet someone")
+    assert result.message["content"][0]["text"] == "Greeted!"
+
+
+def test_passthrough_middleware_preserves_result():
+    """Passthrough middleware returns the correct stop_reason and message."""
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "Correct"}]}])
+    agent = Agent(model=model, callback_handler=None)
+
+    async def passthrough(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, passthrough)
+    result = agent("test")
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Correct"
+
+
+# --- additional coverage ---
+
+
+def test_short_circuit_model_not_called(model):
+    """When middleware short-circuits, model.stream is never invoked."""
+
+
+    agent = Agent(model=model, callback_handler=None)
+    agent.model.stream = AsyncMock(wraps=agent.model.stream)
+
+    usage = {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}
+    metrics = {"latencyMs": 0}
+
+    async def cached(context, next_fn):
+        msg = {"role": "assistant", "content": [{"text": "Cached"}]}
+        yield ModelStopReason("end_turn", msg, Usage(**usage), Metrics(**metrics))
+        yield MiddlewareResult(InvokeModelResult("end_turn", msg, usage, metrics))
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, cached)
+    agent("test")
+    agent.model.stream.assert_not_called()
+
+
+def test_hooks_fire_when_middleware_short_circuits(model):
+    """AfterModelCallEvent fires even when middleware short-circuits (never calls next)."""
+
+    hook_provider = MockHookProvider(event_types="all")
+    agent = Agent(model=model, callback_handler=None, hooks=[hook_provider])
+
+    usage = {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}
+    metrics = {"latencyMs": 0}
+
+    async def cached(context, next_fn):
+        msg = {"role": "assistant", "content": [{"text": "Cached"}]}
+        yield ModelStopReason("end_turn", msg, Usage(**usage), Metrics(**metrics))
+        yield MiddlewareResult(InvokeModelResult("end_turn", msg, usage, metrics))
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, cached)
+    agent("test")
+
+    _, events = hook_provider.get_events()
+    event_types = [type(e) for e in events]
+    assert AfterModelCallEvent in event_types
+
+
+def test_phase_ordering_at_agent_level(model):
+    """Input/Output/Wrap ordering works at agent level regardless of registration order."""
+    order: list[str] = []
+
+    def output_handler(result):
+        order.append("output")
+        return result
+
+    async def wrap_handler(context, next_fn):
+        order.append("wrap")
+        async for event in next_fn(context):
+            yield event
+
+    def input_handler(context):
+        order.append("input")
+        return context
+
+    agent = Agent(model=model, callback_handler=None)
+    # Register in non-canonical order: output, wrap, input
+    agent._middleware_registry.add_middleware(InvokeModelStage.Output, output_handler)
+    agent._middleware_registry.add_middleware(InvokeModelStage, wrap_handler)
+    agent._middleware_registry.add_middleware(InvokeModelStage.Input, input_handler)
+
+    agent("test")
+    assert order == ["input", "wrap", "output"]
+
+
+
+def test_retry_on_error_use_case():
+    """Middleware can retry model calls on transient errors."""
+    call_count = 0
+
+    class FlakyModel(MockedModelProvider):
+        async def stream(self, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise RuntimeError("ThrottlingException")
+            async for event in super().stream(*args, **kwargs):
+                yield event
+
+    model = FlakyModel([{"role": "assistant", "content": [{"text": "Success!"}]}])
+    agent = Agent(model=model, callback_handler=None, retry_strategy=None)
+
+    async def retry_middleware(context, next_fn):
+        for attempt in range(3):
+            try:
+                async for event in next_fn(context):
+                    yield event
+                return
+            except RuntimeError as e:
+                if "ThrottlingException" not in str(e) or attempt == 2:
+                    raise
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, retry_middleware)
+    result = agent("test")
+    assert result.message["content"][0]["text"] == "Success!"
+    assert call_count == 3

--- a/strands-py/tests/strands/middleware/test_registry.py
+++ b/strands-py/tests/strands/middleware/test_registry.py
@@ -1,0 +1,579 @@
+"""Unit tests for MiddlewareRegistry compose and invoke mechanics."""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+
+from strands._middleware.registry import MiddlewareRegistry
+from strands._middleware.types import MiddlewareResult, MiddlewareStage
+from strands.interrupt import Interrupt, InterruptException
+
+
+@pytest.fixture
+def registry():
+    return MiddlewareRegistry()
+
+
+@pytest.fixture
+def stage():
+    return MiddlewareStage[dict, str, str](name="test")
+
+
+async def _collect(gen: AsyncGenerator[Any, None]) -> tuple[list[Any], Any]:
+    """Iterate a middleware chain, separating events from the MiddlewareResult."""
+    events: list[Any] = []
+    result = None
+    async for item in gen:
+        if isinstance(item, MiddlewareResult):
+            result = item.value
+        else:
+            events.append(item)
+    return events, result
+
+
+def _make_terminal(*events: Any, result: Any = "terminal_result"):
+    """Create a terminal function that yields events then a MiddlewareResult."""
+
+    async def terminal(context: Any) -> AsyncGenerator[Any, None]:
+        for event in events:
+            yield event
+        yield MiddlewareResult(result)
+
+    return terminal
+
+
+# --- compose: no handlers ---
+
+
+@pytest.mark.asyncio
+async def test_compose_no_handlers_returns_terminal_directly(registry, stage):
+    terminal = _make_terminal("e1", "e2", result="done")
+    chain = registry.compose(stage, terminal)
+    assert chain is terminal
+
+
+@pytest.mark.asyncio
+async def test_compose_no_handlers_events_and_result_pass_through(registry, stage):
+    terminal = _make_terminal("e1", "e2", result="done")
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert events == ["e1", "e2"]
+    assert result == "done"
+
+
+# --- wrap handler ---
+
+
+@pytest.mark.asyncio
+async def test_wrap_passthrough_forwards_events_and_result(registry, stage):
+    async def passthrough(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+
+    registry.add_middleware(stage, passthrough)
+    terminal = _make_terminal("e1", result="done")
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert events == ["e1"]
+    assert result == "done"
+
+
+@pytest.mark.asyncio
+async def test_wrap_context_modification_reaches_terminal(registry, stage):
+    received_context = {}
+
+    async def terminal(context):
+        received_context.update(context)
+        yield MiddlewareResult("done")
+
+    async def modifier(context, next_fn):
+        async for event in next_fn({**context, "added": True}):
+            yield event
+
+    registry.add_middleware(stage, modifier)
+    await _collect(registry.invoke(stage, {"original": True}, terminal))
+    assert received_context == {"original": True, "added": True}
+
+
+@pytest.mark.asyncio
+async def test_wrap_short_circuit_skips_terminal(registry, stage):
+    terminal_called = False
+
+    async def terminal(context):
+        nonlocal terminal_called
+        terminal_called = True
+        yield MiddlewareResult("should not reach")
+
+    async def short_circuit(context, next_fn):
+        yield "cached_event"
+        yield MiddlewareResult("cached_result")
+
+    registry.add_middleware(stage, short_circuit)
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert not terminal_called
+    assert events == ["cached_event"]
+    assert result == "cached_result"
+
+
+@pytest.mark.asyncio
+async def test_wrap_result_transformation(registry, stage):
+    async def transformer(context, next_fn):
+        async for event in next_fn(context):
+            if isinstance(event, MiddlewareResult):
+                yield MiddlewareResult(event.value.upper())
+            else:
+                yield event
+
+    registry.add_middleware(stage, transformer)
+    terminal = _make_terminal(result="hello")
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert result == "HELLO"
+
+
+@pytest.mark.asyncio
+async def test_wrap_event_filtering(registry, stage):
+    async def filter_middleware(context, next_fn):
+        async for event in next_fn(context):
+            if isinstance(event, MiddlewareResult) or event != "skip_me":
+                yield event
+
+    registry.add_middleware(stage, filter_middleware)
+    terminal = _make_terminal("keep", "skip_me", "also_keep", result="done")
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert events == ["keep", "also_keep"]
+    assert result == "done"
+
+
+@pytest.mark.asyncio
+async def test_wrap_event_injection(registry, stage):
+    async def before_after_injector(context, next_fn):
+        yield "before"
+        result_value = None
+        async for event in next_fn(context):
+            if isinstance(event, MiddlewareResult):
+                result_value = event.value
+            else:
+                yield event
+        yield "after"
+        yield MiddlewareResult(result_value)
+
+    registry.add_middleware(stage, before_after_injector)
+    terminal = _make_terminal("inner", result="done")
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert events == ["before", "inner", "after"]
+    assert result == "done"
+
+
+@pytest.mark.asyncio
+async def test_wrap_retry_calls_next_multiple_times(registry, stage):
+    call_count = 0
+
+    async def terminal(context):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise ValueError("not yet")
+        yield "success"
+        yield MiddlewareResult("done")
+
+    async def retry_middleware(context, next_fn):
+        for attempt in range(3):
+            try:
+                async for event in next_fn(context):
+                    yield event
+                return
+            except ValueError:
+                if attempt == 2:
+                    raise
+
+    registry.add_middleware(stage, retry_middleware)
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert call_count == 3
+    assert events == ["success"]
+    assert result == "done"
+
+
+# --- composition order ---
+
+
+@pytest.mark.asyncio
+async def test_first_registered_is_outermost(registry, stage):
+    order: list[str] = []
+
+    async def outer(context, next_fn):
+        order.append("outer_before")
+        async for event in next_fn(context):
+            yield event
+        order.append("outer_after")
+
+    async def inner(context, next_fn):
+        order.append("inner_before")
+        async for event in next_fn(context):
+            yield event
+        order.append("inner_after")
+
+    registry.add_middleware(stage, outer)
+    registry.add_middleware(stage, inner)
+    terminal = _make_terminal(result="done")
+    await _collect(registry.invoke(stage, {}, terminal))
+    assert order == ["outer_before", "inner_before", "inner_after", "outer_after"]
+
+
+@pytest.mark.asyncio
+async def test_multiple_handlers_all_see_events(registry, stage):
+    seen_by: dict[str, list] = {"a": [], "b": []}
+
+    async def handler_a(context, next_fn):
+        async for event in next_fn(context):
+            if not isinstance(event, MiddlewareResult):
+                seen_by["a"].append(event)
+            yield event
+
+    async def handler_b(context, next_fn):
+        async for event in next_fn(context):
+            if not isinstance(event, MiddlewareResult):
+                seen_by["b"].append(event)
+            yield event
+
+    registry.add_middleware(stage, handler_a)
+    registry.add_middleware(stage, handler_b)
+    terminal = _make_terminal("e1", "e2", result="done")
+    await _collect(registry.invoke(stage, {}, terminal))
+    assert seen_by["b"] == ["e1", "e2"]
+    assert seen_by["a"] == ["e1", "e2"]
+
+
+# --- input phase ---
+
+
+@pytest.mark.asyncio
+async def test_input_transforms_context(registry, stage):
+    received_context = {}
+
+    async def terminal(context):
+        received_context.update(context)
+        yield MiddlewareResult("done")
+
+    def input_handler(context):
+        return {**context, "injected": True}
+
+    registry.add_middleware(stage.Input, input_handler)
+    await _collect(registry.invoke(stage, {"original": True}, terminal))
+    assert received_context == {"original": True, "injected": True}
+
+
+@pytest.mark.asyncio
+async def test_input_async_handler(registry, stage):
+    received_context = {}
+
+    async def terminal(context):
+        received_context.update(context)
+        yield MiddlewareResult("done")
+
+    async def async_input(context):
+        return {**context, "async": True}
+
+    registry.add_middleware(stage.Input, async_input)
+    await _collect(registry.invoke(stage, {}, terminal))
+    assert received_context == {"async": True}
+
+
+@pytest.mark.asyncio
+async def test_input_runs_before_wrap(registry, stage):
+    order: list[str] = []
+
+    async def terminal(context):
+        order.append(f"terminal(injected={context.get('injected')})")
+        yield MiddlewareResult("done")
+
+    def input_handler(context):
+        order.append("input")
+        return {**context, "injected": True}
+
+    async def wrap_handler(context, next_fn):
+        order.append(f"wrap(injected={context.get('injected')})")
+        async for event in next_fn(context):
+            yield event
+
+    # Register wrap FIRST, then input — input still runs first due to phase ordering
+    registry.add_middleware(stage, wrap_handler)
+    registry.add_middleware(stage.Input, input_handler)
+    await _collect(registry.invoke(stage, {}, terminal))
+    assert order == ["input", "wrap(injected=True)", "terminal(injected=True)"]
+
+
+@pytest.mark.asyncio
+async def test_input_multiple_compose_in_order(registry, stage):
+    received_context = {}
+
+    async def terminal(context):
+        received_context.update(context)
+        yield MiddlewareResult("done")
+
+    def first_input(context):
+        return {**context, "first": True}
+
+    def second_input(context):
+        return {**context, "second": True, "saw_first": context.get("first")}
+
+    registry.add_middleware(stage.Input, first_input)
+    registry.add_middleware(stage.Input, second_input)
+    await _collect(registry.invoke(stage, {}, terminal))
+    assert received_context["first"] is True
+    assert received_context["second"] is True
+    assert received_context["saw_first"] is True
+
+
+# --- output phase ---
+
+
+@pytest.mark.asyncio
+async def test_output_transforms_result(registry, stage):
+    def output_handler(result):
+        return result + "_transformed"
+
+    registry.add_middleware(stage.Output, output_handler)
+    terminal = _make_terminal(result="original")
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert result == "original_transformed"
+
+
+@pytest.mark.asyncio
+async def test_output_async_handler(registry, stage):
+    async def async_output(result):
+        return result + "_async"
+
+    registry.add_middleware(stage.Output, async_output)
+    terminal = _make_terminal(result="base")
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert result == "base_async"
+
+
+@pytest.mark.asyncio
+async def test_output_does_not_affect_events(registry, stage):
+    def output_handler(result):
+        return "transformed"
+
+    registry.add_middleware(stage.Output, output_handler)
+    terminal = _make_terminal("e1", "e2", result="original")
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert events == ["e1", "e2"]
+    assert result == "transformed"
+
+
+@pytest.mark.asyncio
+async def test_output_runs_after_wrap(registry, stage):
+    order: list[str] = []
+
+    async def wrap_handler(context, next_fn):
+        order.append("wrap_before")
+        async for event in next_fn(context):
+            yield event
+        order.append("wrap_after")
+
+    def output_handler(result):
+        order.append("output")
+        return result + "_out"
+
+    registry.add_middleware(stage.Output, output_handler)
+    registry.add_middleware(stage, wrap_handler)
+    terminal = _make_terminal(result="base")
+    events, result = await _collect(registry.invoke(stage, {}, terminal))
+    assert "output" in order
+    assert result == "base_out"
+
+
+
+# --- error propagation ---
+
+
+@pytest.mark.asyncio
+async def test_terminal_error_propagates_through_middleware(registry, stage):
+    async def terminal(context):
+        raise ValueError("terminal_error")
+        yield  # noqa: B901 — makes it a generator
+
+    async def passthrough(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+
+    registry.add_middleware(stage, passthrough)
+    with pytest.raises(ValueError, match="terminal_error"):
+        await _collect(registry.invoke(stage, {}, terminal))
+
+
+@pytest.mark.asyncio
+async def test_middleware_error_propagates_to_caller(registry, stage):
+    async def broken_middleware(context, next_fn):
+        raise RuntimeError("middleware_error")
+        yield  # noqa: B901
+
+    registry.add_middleware(stage, broken_middleware)
+    terminal = _make_terminal(result="done")
+    with pytest.raises(RuntimeError, match="middleware_error"):
+        await _collect(registry.invoke(stage, {}, terminal))
+
+
+@pytest.mark.asyncio
+async def test_try_finally_in_middleware_runs_on_error(registry, stage):
+    finally_ran = False
+
+    async def terminal(context):
+        raise ValueError("boom")
+        yield  # noqa: B901
+
+    async def guarded(context, next_fn):
+        nonlocal finally_ran
+        try:
+            async for event in next_fn(context):
+                yield event
+        finally:
+            finally_ran = True
+
+    registry.add_middleware(stage, guarded)
+    with pytest.raises(ValueError, match="boom"):
+        await _collect(registry.invoke(stage, {}, terminal))
+    assert finally_ran
+
+
+@pytest.mark.asyncio
+async def test_try_finally_runs_on_generator_close(registry, stage):
+    finally_ran = False
+
+    async def guarded(context, next_fn):
+        nonlocal finally_ran
+        try:
+            async for event in next_fn(context):
+                yield event
+        finally:
+            finally_ran = True
+
+    registry.add_middleware(stage, guarded)
+    terminal = _make_terminal("e1", "e2", "e3", result="done")
+    gen = registry.invoke(stage, {}, terminal)
+    await gen.__anext__()
+    await gen.aclose()
+    assert finally_ran
+
+
+# --- additional coverage ---
+
+
+@pytest.mark.asyncio
+async def test_chained_context_modification_across_wrap_handlers(registry, stage):
+    """Multiple Wrap handlers each modify context; terminal sees accumulated changes."""
+    received_context = {}
+
+    async def terminal(context):
+        received_context.update(context)
+        yield MiddlewareResult("done")
+
+    async def add_a(context, next_fn):
+        async for event in next_fn({**context, "a": True}):
+            yield event
+
+    async def add_b(context, next_fn):
+        async for event in next_fn({**context, "b": True}):
+            yield event
+
+    registry.add_middleware(stage, add_a)
+    registry.add_middleware(stage, add_b)
+    await _collect(registry.invoke(stage, {"original": True}, terminal))
+    assert received_context == {"original": True, "a": True, "b": True}
+
+
+@pytest.mark.asyncio
+async def test_error_transformation_by_middleware(registry, stage):
+    """Middleware can catch and re-throw a different error."""
+
+    async def terminal(context):
+        raise ValueError("original")
+        yield  # noqa: B901
+
+    async def transformer(context, next_fn):
+        try:
+            async for event in next_fn(context):
+                yield event
+        except ValueError as e:
+            raise RuntimeError(f"Wrapped: {e}") from e
+
+    registry.add_middleware(stage, transformer)
+    with pytest.raises(RuntimeError, match="Wrapped: original"):
+        await _collect(registry.invoke(stage, {}, terminal))
+
+
+@pytest.mark.asyncio
+async def test_interrupt_exception_propagates_through_passthrough(registry, stage):
+    """InterruptException propagates through passthrough middleware without being swallowed."""
+
+    async def terminal(context):
+        raise InterruptException(Interrupt(id="int-1", name="test"))
+        yield  # noqa: B901
+
+    async def passthrough(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+
+    registry.add_middleware(stage, passthrough)
+    with pytest.raises(InterruptException):
+        await _collect(registry.invoke(stage, {}, terminal))
+
+
+@pytest.mark.asyncio
+async def test_multi_layer_finally_ordering_on_error(registry, stage):
+    """All finally blocks run in reverse order (inner first) when terminal throws."""
+    order: list[str] = []
+
+    async def terminal(context):
+        raise ValueError("boom")
+        yield  # noqa: B901
+
+    async def outer(context, next_fn):
+        try:
+            async for event in next_fn(context):
+                yield event
+        finally:
+            order.append("outer_finally")
+
+    async def inner(context, next_fn):
+        try:
+            async for event in next_fn(context):
+                yield event
+        finally:
+            order.append("inner_finally")
+
+    registry.add_middleware(stage, outer)
+    registry.add_middleware(stage, inner)
+    with pytest.raises(ValueError, match="boom"):
+        await _collect(registry.invoke(stage, {}, terminal))
+    assert order == ["inner_finally", "outer_finally"]
+
+
+@pytest.mark.asyncio
+async def test_two_layer_finally_on_generator_close(registry, stage):
+    """Both middleware finally blocks run when consumer calls aclose."""
+    order: list[str] = []
+
+    async def outer(context, next_fn):
+        try:
+            async for event in next_fn(context):
+                yield event
+        finally:
+            order.append("outer_finally")
+
+    async def inner(context, next_fn):
+        try:
+            async for event in next_fn(context):
+                yield event
+        finally:
+            order.append("inner_finally")
+
+    registry.add_middleware(stage, outer)
+    registry.add_middleware(stage, inner)
+    terminal = _make_terminal("e1", "e2", "e3", result="done")
+    gen = registry.invoke(stage, {}, terminal)
+    await gen.__anext__()
+    await gen.aclose()
+    assert "inner_finally" in order
+    assert "outer_finally" in order
+
+

--- a/strands-ts/src/middleware/README.md
+++ b/strands-ts/src/middleware/README.md
@@ -61,3 +61,150 @@ Middleware is intended to supersede hooks. The Input/Output phases already cover
 `AgentStreamStage` middleware cannot currently resume tool-level interrupts. Interrupt resolution (`_interruptState.resume()`) runs in `stream()`'s outer loop, outside the middleware chain. When a tool-level interrupt fires, `_stream` catches the `InterruptError` internally and returns a normal `AgentResult` with `stopReason: 'interrupt'` — the middleware sees the result but cannot re-enter the stream with interrupt responses.
 
 To programmatically resume interrupts within a single invocation, use `AfterInvocationEvent.resume` in a hook. A future enhancement could add a resume mechanism to `AgentStreamResult` or `AgentStreamContext` so middleware can signal re-entry with interrupt responses.
+
+---
+
+# Behavioral Requirements
+
+Each requirement below is verified by tests and should hold across language implementations.
+
+## Registry Composition
+
+### No handlers (fast path)
+- When no handlers are registered for a stage, the terminal runs directly
+- Events and result from the terminal pass through unchanged
+
+### Wrap handlers
+- A passthrough handler forwards all events and the result unchanged
+- Handlers can modify the context before calling `next`; the terminal receives the modified context
+- Multiple handlers each modifying context accumulate changes (chained modification)
+- Handlers can short-circuit by producing a result without calling `next`; the terminal is never invoked
+- Handlers can transform the result
+- Handlers can filter events (yield only events matching a predicate)
+- Handlers can inject events before or after the inner chain's events
+- Handlers can retry by calling `next` multiple times (e.g., on transient errors)
+
+### Composition order
+- First registered = outermost (executes first on the way in, last on the way out)
+- Multiple handlers all observe events flowing through the chain
+
+### Input phase
+- Input handlers transform the context before the Wrap chain runs
+- Input handlers can be sync or async
+- Input runs before Wrap regardless of registration order
+- Multiple Input handlers compose in registration order (each sees the previous output)
+
+### Output phase
+- Output handlers transform the result after the Wrap chain completes
+- Output handlers can be sync or async
+- Output handlers do not affect streaming events (only the result)
+- Output runs after Wrap regardless of registration order
+
+### Phase ordering
+- Execution order is always: Input → Wrap → Output, regardless of registration order
+
+### Removal
+- `remove()` stops a handler from firing on subsequent invocations
+- `remove()` only removes the first occurrence when a handler is registered multiple times
+- `remove()` is a no-op for a handler that was never registered
+- Removing an adapted Input/Output handler works via the reference returned at registration
+
+### Error propagation
+- Errors from the terminal propagate through middleware to the caller
+- Errors from middleware propagate to the caller
+- Middleware can catch and re-throw a different error (error transformation)
+- `InterruptError`/`InterruptException` propagates through passthrough middleware without being swallowed
+
+### Generator cleanup (finally guarantees)
+- When the terminal throws, middleware `finally` blocks run
+- When multiple middleware are stacked, all `finally` blocks run in reverse order (inner first)
+- When the consumer abandons iteration (close/aclose), middleware `finally` blocks run
+- Multi-layer `finally` blocks all run on close (not just the outermost)
+
+---
+
+## InvokeModelStage
+
+### Basic behavior
+- Middleware handler is invoked on every model call
+- Handler receives context with correct fields (agent, messages, systemPrompt, toolSpecs, toolChoice, invocationState)
+- A passthrough handler does not alter agent behavior
+- Multiple middleware compose in registration order
+
+### Context transformation
+- Middleware can modify `systemPrompt` and inner layers see the modification
+- Middleware can modify `toolSpecs` and inner layers see the modification
+- Context modification does not mutate the original context object
+
+### Short-circuit
+- Middleware can return a synthetic result without calling `next`
+- When middleware short-circuits, the model is NOT called
+- The short-circuited result is used as the model call result
+
+### Hooks boundary
+- `BeforeModelCallEvent` fires before middleware executes
+- `AfterModelCallEvent` fires after middleware completes
+- Both hooks fire even when middleware short-circuits
+
+### Phase ordering at agent level
+- Input → Wrap → Output execution order holds regardless of registration order at the agent level
+
+### Use cases
+- Retry on transient error (middleware catches error, calls `next` again)
+- Plugin can register middleware via `initAgent`/`init_agent`
+
+---
+
+## ExecuteToolStage
+
+### Basic behavior
+- Middleware handler is invoked on every tool execution
+- Handler receives context with correct fields (agent, tool, toolUse, invocationState)
+- A passthrough handler does not alter agent behavior
+- Multiple middleware compose in registration order
+
+### Context transformation
+- Middleware can modify tool input and the tool receives modified arguments
+- Context modification does not mutate the original context object
+
+### Short-circuit
+- Middleware can return a mock result without calling `next`
+- When middleware short-circuits, the real tool function is NOT called
+- The short-circuited result is used in the conversation
+
+### Hooks boundary
+- `BeforeToolCallEvent` fires before middleware executes
+- `AfterToolCallEvent` fires after middleware completes
+- Both hooks fire even when middleware short-circuits
+- `AfterToolCallEvent.result` contains the middleware-provided result on short-circuit
+
+### Input/Output phases
+- Input phase transforms the tool context before execution
+- Output phase transforms the tool result after execution
+
+### Error handling
+- Errors from the tool propagate through middleware
+
+### Use cases
+- Caching plugin: first call executes, second call with same input returns cached result
+
+---
+
+## Middleware-Initiated Interrupts
+
+### ExecuteToolStage interrupts
+- Calling `context.interrupt(name)` with no prior response throws/raises and halts the agent
+- On resume (user provides response), `context.interrupt(name)` returns the response (wrapped for forward-compat)
+- Providing a preemptive response parameter skips the interrupt entirely
+- When middleware interrupts, the tool does NOT execute
+- Interrupt ID includes the tool use ID (deterministic and scoped)
+- The interrupt source is `'middleware'` (distinguishes from hook/tool interrupts)
+- The interrupt is registered in the agent's interrupt state
+- Copying/spreading the context preserves the `interrupt()` function
+
+### AgentStreamStage interrupts
+- Calling `context.interrupt(name)` with no prior response throws/raises and halts the agent
+- On resume, `context.interrupt(name)` returns the response
+- Interrupt ID uses the `agentStream` namespace
+- The interrupt source is `'middleware'`
+- InterruptEvent is yielded on the stream

--- a/strands-ts/src/middleware/README.md
+++ b/strands-ts/src/middleware/README.md
@@ -85,10 +85,12 @@ Each requirement below is verified by tests and should hold across language impl
 ## Registry Composition
 
 ### No handlers (fast path)
+
 - When no handlers are registered for a stage, the terminal runs directly
 - Events and result from the terminal pass through unchanged
 
 ### Wrap handlers
+
 - A passthrough handler forwards all events and the result unchanged
 - Handlers can modify the context before calling `next`; the terminal receives the modified context
 - Multiple handlers each modifying context accumulate changes (chained modification)
@@ -99,37 +101,44 @@ Each requirement below is verified by tests and should hold across language impl
 - Handlers can retry by calling `next` multiple times (e.g., on transient errors)
 
 ### Composition order
+
 - First registered = outermost (executes first on the way in, last on the way out)
 - Multiple handlers all observe events flowing through the chain
 
 ### Input phase
+
 - Input handlers transform the context before the Wrap chain runs
 - Input handlers can be sync or async
 - Input runs before Wrap regardless of registration order
 - Multiple Input handlers compose in registration order (each sees the previous output)
 
 ### Output phase
+
 - Output handlers transform the result after the Wrap chain completes
 - Output handlers can be sync or async
 - Output handlers do not affect streaming events (only the result)
 - Output runs after Wrap regardless of registration order
 
 ### Phase ordering
+
 - Execution order is always: Input → Wrap → Output, regardless of registration order
 
 ### Removal
+
 - `remove()` stops a handler from firing on subsequent invocations
 - `remove()` only removes the first occurrence when a handler is registered multiple times
 - `remove()` is a no-op for a handler that was never registered
 - Removing an adapted Input/Output handler works via the reference returned at registration
 
 ### Error propagation
+
 - Errors from the terminal propagate through middleware to the caller
 - Errors from middleware propagate to the caller
 - Middleware can catch and re-throw a different error (error transformation)
 - `InterruptError`/`InterruptException` propagates through passthrough middleware without being swallowed
 
 ### Generator cleanup (finally guarantees)
+
 - When the terminal throws, middleware `finally` blocks run
 - When multiple middleware are stacked, all `finally` blocks run in reverse order (inner first)
 - When the consumer abandons iteration (close/aclose), middleware `finally` blocks run
@@ -140,30 +149,36 @@ Each requirement below is verified by tests and should hold across language impl
 ## InvokeModelStage
 
 ### Basic behavior
+
 - Middleware handler is invoked on every model call
 - Handler receives context with correct fields (agent, messages, systemPrompt, toolSpecs, toolChoice, invocationState)
 - A passthrough handler does not alter agent behavior
 - Multiple middleware compose in registration order
 
 ### Context transformation
+
 - Middleware can modify `systemPrompt` and inner layers see the modification
 - Middleware can modify `toolSpecs` and inner layers see the modification
 - Context modification does not mutate the original context object
 
 ### Short-circuit
+
 - Middleware can return a synthetic result without calling `next`
 - When middleware short-circuits, the model is NOT called
 - The short-circuited result is used as the model call result
 
 ### Hooks boundary
+
 - `BeforeModelCallEvent` fires before middleware executes
 - `AfterModelCallEvent` fires after middleware completes
 - Both hooks fire even when middleware short-circuits
 
 ### Phase ordering at agent level
+
 - Input → Wrap → Output execution order holds regardless of registration order at the agent level
 
 ### Use cases
+
 - Retry on transient error (middleware catches error, calls `next` again)
 - Plugin can register middleware via `initAgent`/`init_agent`
 
@@ -172,34 +187,41 @@ Each requirement below is verified by tests and should hold across language impl
 ## ExecuteToolStage
 
 ### Basic behavior
+
 - Middleware handler is invoked on every tool execution
 - Handler receives context with correct fields (agent, tool, toolUse, invocationState)
 - A passthrough handler does not alter agent behavior
 - Multiple middleware compose in registration order
 
 ### Context transformation
+
 - Middleware can modify tool input and the tool receives modified arguments
 - Context modification does not mutate the original context object
 
 ### Short-circuit
+
 - Middleware can return a mock result without calling `next`
 - When middleware short-circuits, the real tool function is NOT called
 - The short-circuited result is used in the conversation
 
 ### Hooks boundary
+
 - `BeforeToolCallEvent` fires before middleware executes
 - `AfterToolCallEvent` fires after middleware completes
 - Both hooks fire even when middleware short-circuits
 - `AfterToolCallEvent.result` contains the middleware-provided result on short-circuit
 
 ### Input/Output phases
+
 - Input phase transforms the tool context before execution
 - Output phase transforms the tool result after execution
 
 ### Error handling
+
 - Errors from the tool propagate through middleware
 
 ### Use cases
+
 - Caching plugin: first call executes, second call with same input returns cached result
 
 ---
@@ -207,6 +229,7 @@ Each requirement below is verified by tests and should hold across language impl
 ## Middleware-Initiated Interrupts
 
 ### ExecuteToolStage interrupts
+
 - Calling `context.interrupt(name)` with no prior response throws/raises and halts the agent
 - On resume (user provides response), `context.interrupt(name)` returns the response (wrapped for forward-compat)
 - Providing a preemptive response parameter skips the interrupt entirely
@@ -217,6 +240,7 @@ Each requirement below is verified by tests and should hold across language impl
 - Copying/spreading the context preserves the `interrupt()` function
 
 ### AgentStreamStage interrupts
+
 - Calling `context.interrupt(name)` with no prior response throws/raises and halts the agent
 - On resume, `context.interrupt(name)` returns the response
 - Interrupt ID uses the `agentStream` namespace


### PR DESCRIPTION
## Description

Begins the port of the TypeScript middleware system (#2681) to Python, scoped to a private `InvokeModelStage` so that we can unblock internal work that needs to modify input calls.

The behavioral spec is defined in `strands-ts/src/middleware/README.md` and the Python implementation documents its intentional divergences in `strands-py/src/strands/_middleware/README.md`.

Resolves: #2735

## Behavioral change: model span timing

The model invoke OTEL span now starts inside the middleware terminal (after hooks and middleware transforms) rather than before `BeforeModelCallEvent`. The span measures actual model latency more accurately — hook execution time is no longer included. Span lifecycle is preserved for success, retry, and error paths. On the cancel path (BeforeModelCallEvent.cancel), no span is emitted because the model is never invoked — this is intentionally more correct than the previous behavior which created and immediately closed a span for a call that never happened.

## `system_prompt` unification and `split_system_prompt`

The Python SDK previously passed `system_prompt` (str) and `system_prompt_content` (list of blocks) as two separate fields everywhere — the Agent stored both, `stream_messages()` accepted both, and each model provider duplicated the same normalization logic.

For middleware, exposing two fields for the same concept didn't make sense. `InvokeModelContext` uses a single union field `system_prompt: str | list[SystemContentBlock] | None` (matching TypeScript's `SystemPrompt` type). At the terminal boundary where the model is actually invoked, we call `split_system_prompt()` to decompose it back into the two-param form that `Model.stream()` expects.

`split_system_prompt()` is extracted from `Agent._initialize_system_prompt` into `types/content.py` as a shared utility. The Agent now delegates to it directly.

## Related Issues

- #2735 (Middleware — Python)
- https://github.com/strands-agents/harness-sdk/pull/2681

## Documentation PR

None

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.