### PR TITLE
docs: make root README language-neutral with homepage value prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,15 @@ This monorepo contains the Python SDK, TypeScript SDK, documentation site, and s
 | `site/` | Documentation site built with Astro/Starlight ([strandsagents.com](https://strandsagents.com)) |
 | `designs/` | Design proposals for significant features (RFC-style) |
 
-## Feature Overview
+## Why Strands
 
-- **Lightweight & Flexible**: Simple agent loop that just works and is fully customizable
-- **Model Agnostic**: Support for Amazon Bedrock, Anthropic, Gemini, LiteLLM, Llama, Ollama, OpenAI, Writer, and custom providers
-- **Advanced Capabilities**: Multi-agent systems, autonomous agents, and streaming support
-- **Built-in MCP**: Native support for Model Context Protocol (MCP) servers, enabling access to thousands of pre-built tools
+Build an agent harness. Control it end-to-end.
+
+- **Build your way** — Any model, any cloud. Context management, execution limits, and observability built in before you write a line of config. Swap backends when you scale; your code stays the same.
+- **Model agnostic** — First-class support for Amazon Bedrock, Anthropic, OpenAI, and Gemini, plus [many more providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/) and custom ones.
+- **Stay in control** — The agent loop traces every decision by default. Hooks let you intercept any step to log it, validate it, or redirect it.
+- **Deliver outcomes that work** — Guardrails catch mistakes before they run. Steering handlers let agents correct themselves instead of failing silently.
+- **Built-in MCP** — Native Model Context Protocol support connects agents to thousands of pre-built tools.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Build an agent harness. Control it end-to-end.
 - **Model agnostic** — First-class support for Amazon Bedrock, Anthropic, OpenAI, and Gemini, plus [many more providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/) and custom ones.
 - **Stay in control** — The agent loop traces every decision by default. Hooks let you intercept any step to log it, validate it, or redirect it.
 - **Deliver outcomes that work** — Guardrails catch mistakes before they run. Steering handlers let agents correct themselves instead of failing silently.
-- **Built-in MCP** — Native Model Context Protocol support connects agents to thousands of pre-built tools.
+
+Plus everything you'd expect: native MCP support, streaming, multi-agent patterns, and structured output.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -56,258 +56,43 @@ This monorepo contains the Python SDK, TypeScript SDK, documentation site, and s
 
 ## Quick Start
 
+Both SDKs default to the Amazon Bedrock model provider — you'll need AWS credentials configured and model access enabled for Claude Sonnet. The [Quickstart Guide](https://strandsagents.com/docs/user-guide/quickstart/) covers configuring other providers (Anthropic, OpenAI, Gemini, Ollama, and more).
+
+### Python
+
+Requires Python 3.10+:
+
 ```bash
-# Install Strands Agents
 pip install strands-agents strands-agents-tools
 ```
 
 ```python
 from strands import Agent
 from strands_tools import calculator
+
 agent = Agent(tools=[calculator])
 agent("What is the square root of 1764")
 ```
 
-> **Note**: For the default Amazon Bedrock model provider, you'll need AWS credentials configured and model access enabled for Claude 4 Sonnet in the us-west-2 region. See the [Quickstart Guide](https://strandsagents.com/) for details on configuring other model providers.
+Continue in the [Python SDK README](strands-py/) — tools, model providers, MCP, bidirectional streaming.
 
-## Installation
+### TypeScript
 
-Ensure you have Python 3.10+ installed, then:
-
-```bash
-# Create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
-
-# Install Strands and tools
-pip install strands-agents strands-agents-tools
-```
-
-## Features at a Glance
-
-### Python-Based Tools
-
-Easily build tools using Python decorators:
-
-```python
-from strands import Agent, tool
-
-@tool
-def word_count(text: str) -> int:
-    """Count words in text.
-
-    This docstring is used by the LLM to understand the tool's purpose.
-    """
-    return len(text.split())
-
-agent = Agent(tools=[word_count])
-response = agent("How many words are in this sentence?")
-```
-
-**Hot Reloading from Directory:**
-Enable automatic tool loading and reloading from the `./tools/` directory:
-
-```python
-from strands import Agent
-
-# Agent will watch ./tools/ directory for changes
-agent = Agent(load_tools_from_directory=True)
-response = agent("Use any tools you find in the tools directory")
-```
-
-### MCP Support
-
-Seamlessly integrate Model Context Protocol (MCP) servers:
-
-```python
-from strands import Agent
-from strands.tools.mcp import MCPClient
-from mcp import stdio_client, StdioServerParameters
-
-aws_docs_client = MCPClient(
-    lambda: stdio_client(StdioServerParameters(command="uvx", args=["awslabs.aws-documentation-mcp-server@latest"]))
-)
-
-with aws_docs_client:
-   agent = Agent(tools=aws_docs_client.list_tools_sync())
-   response = agent("Tell me about Amazon Bedrock and how to use it with Python")
-```
-
-### Multiple Model Providers
-
-Support for various model providers:
-
-```python
-from strands import Agent
-from strands.models import BedrockModel
-from strands.models.ollama import OllamaModel
-from strands.models.llamaapi import LlamaAPIModel
-from strands.models.gemini import GeminiModel
-from strands.models.llamacpp import LlamaCppModel
-
-# Bedrock
-bedrock_model = BedrockModel(
-  model_id="us.amazon.nova-pro-v1:0",
-  temperature=0.3,
-  streaming=True, # Enable/disable streaming
-)
-agent = Agent(model=bedrock_model)
-agent("Tell me about Agentic AI")
-
-# Google Gemini
-gemini_model = GeminiModel(
-  client_args={
-    "api_key": "your_gemini_api_key",
-  },
-  model_id="gemini-2.5-flash",
-  params={"temperature": 0.7}
-)
-agent = Agent(model=gemini_model)
-agent("Tell me about Agentic AI")
-
-# Ollama
-ollama_model = OllamaModel(
-  host="http://localhost:11434",
-  model_id="llama3"
-)
-agent = Agent(model=ollama_model)
-agent("Tell me about Agentic AI")
-
-# Llama API
-llama_model = LlamaAPIModel(
-    model_id="Llama-4-Maverick-17B-128E-Instruct-FP8",
-)
-agent = Agent(model=llama_model)
-response = agent("Tell me about Agentic AI")
-```
-
-Built-in providers:
- - [Amazon Bedrock](https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/)
- - [Anthropic](https://strandsagents.com/docs/user-guide/concepts/model-providers/anthropic/)
- - [Gemini](https://strandsagents.com/docs/user-guide/concepts/model-providers/gemini/)
- - [Cohere](https://strandsagents.com/docs/user-guide/concepts/model-providers/cohere/)
- - [LiteLLM](https://strandsagents.com/docs/user-guide/concepts/model-providers/litellm/)
- - [llama.cpp](https://strandsagents.com/docs/user-guide/concepts/model-providers/llamacpp/)
- - [LlamaAPI](https://strandsagents.com/docs/user-guide/concepts/model-providers/llamaapi/)
- - [MistralAI](https://strandsagents.com/docs/user-guide/concepts/model-providers/mistral/)
- - [Ollama](https://strandsagents.com/docs/user-guide/concepts/model-providers/ollama/)
- - [OpenAI](https://strandsagents.com/docs/user-guide/concepts/model-providers/openai/)
- - [OpenAI Responses API](https://strandsagents.com/docs/user-guide/concepts/model-providers/openai/)
- - [SageMaker](https://strandsagents.com/docs/user-guide/concepts/model-providers/sagemaker/)
- - [Writer](https://strandsagents.com/docs/user-guide/concepts/model-providers/writer/)
-
-Custom providers can be implemented using [Custom Providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/custom_model_provider/)
-
-### Example tools
-
-Strands offers an optional strands-agents-tools package with pre-built tools for quick experimentation:
-
-```python
-from strands import Agent
-from strands_tools import calculator
-agent = Agent(tools=[calculator])
-agent("What is the square root of 1764")
-```
-
-It's also available on GitHub via [strands-agents/tools](https://github.com/strands-agents/tools).
-
-### Bidirectional Streaming
-
-> **⚠️ Experimental Feature**: Bidirectional streaming is currently in experimental status. APIs may change in future releases as we refine the feature based on user feedback and evolving model capabilities.
-
-Build real-time voice and audio conversations with persistent streaming connections. Unlike traditional request-response patterns, bidirectional streaming maintains long-running conversations where users can interrupt, provide continuous input, and receive real-time audio responses. Get started with your first BidiAgent by following the [Quickstart](https://strandsagents.com/docs/user-guide/concepts/bidirectional-streaming/quickstart/) guide. 
-
-**Supported Model Providers:**
-- Amazon Nova Sonic (v1, v2)
-- Google Gemini Live
-- OpenAI Realtime API
-
-**Installation:**
+Requires Node.js 20+:
 
 ```bash
-# Server-side only (no audio I/O dependencies)
-pip install strands-agents[bidi]
-
-# With audio I/O support (includes PyAudio dependency)
-pip install strands-agents[bidi,bidi-io]
+npm install @strands-agents/sdk
 ```
 
-**Quick Example:**
+```typescript
+import { Agent } from '@strands-agents/sdk'
 
-```python
-import asyncio
-from strands.experimental.bidi import BidiAgent
-from strands.experimental.bidi.models import BidiNovaSonicModel
-from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
-from strands.experimental.bidi.tools import stop_conversation
-from strands_tools import calculator
-
-async def main():
-    # Create bidirectional agent with Nova Sonic v2
-    model = BidiNovaSonicModel()
-    agent = BidiAgent(model=model, tools=[calculator, stop_conversation])
-
-    # Setup audio and text I/O (requires bidi-io extra)
-    audio_io = BidiAudioIO()
-    text_io = BidiTextIO()
-
-    # Run with real-time audio streaming
-    # Say "stop conversation" to gracefully end the conversation
-    await agent.run(
-        inputs=[audio_io.input()],
-        outputs=[audio_io.output(), text_io.output()]
-    )
-
-if __name__ == "__main__":
-    asyncio.run(main())
+const agent = new Agent()
+const result = await agent.invoke('What is the square root of 1764?')
+console.log(result)
 ```
 
-> **Note**: `BidiAudioIO` and `BidiTextIO` require the `bidi-io` extra. For server-side deployments where audio I/O is handled by clients (browsers, mobile apps), install only `strands-agents[bidi]` and implement custom input/output handlers using the `BidiInput` and `BidiOutput` protocols.
-
-**Configuration Options:**
-
-```python
-from strands.experimental.bidi.models import BidiNovaSonicModel
-
-# Configure audio settings and turn detection (v2 only)
-model = BidiNovaSonicModel(
-    provider_config={
-        "audio": {
-            "input_rate": 16000,
-            "output_rate": 16000,
-            "voice": "matthew"
-        },
-        "turn_detection": {
-            "endpointingSensitivity": "MEDIUM"  # HIGH, MEDIUM, or LOW
-        },
-        "inference": {
-            "max_tokens": 2048,
-            "temperature": 0.7
-        }
-    }
-)
-
-# Configure I/O devices
-audio_io = BidiAudioIO(
-    input_device_index=0,  # Specific microphone
-    output_device_index=1,  # Specific speaker
-    input_buffer_size=10,
-    output_buffer_size=10
-)
-
-# Text input mode (type messages instead of speaking)
-text_io = BidiTextIO()
-await agent.run(
-    inputs=[text_io.input()],  # Use text input
-    outputs=[audio_io.output(), text_io.output()]
-)
-
-# Multi-modal: Both audio and text input
-await agent.run(
-    inputs=[audio_io.input(), text_io.input()],  # Speak OR type
-    outputs=[audio_io.output(), text_io.output()]
-)
-```
+Continue in the [TypeScript SDK README](strands-ts/) — Zod-typed tools, structured output, MCP, multi-agent patterns.
 
 ## Documentation
 
@@ -317,7 +102,7 @@ For detailed guidance & examples, explore our documentation:
 - [Quick Start Guide](https://strandsagents.com/docs/user-guide/quickstart/)
 - [Agent Loop](https://strandsagents.com/docs/user-guide/concepts/agents/agent-loop/)
 - [Examples](https://strandsagents.com/docs/examples/)
-- [API Reference](https://strandsagents.com/docs/api/python/strands.agent.agent/)
+- [API Reference — Python](https://strandsagents.com/docs/api/python/strands.agent.agent/) · [TypeScript](https://strandsagents.com/docs/api/typescript/)
 - [Production & Deployment Guide](https://strandsagents.com/docs/user-guide/deploy/operating-agents-in-production/)
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ This monorepo contains the Python SDK, TypeScript SDK, documentation site, and s
 
 | Directory | Description |
 |-----------|-------------|
-| `strands-py/` | Python SDK — agent loop, model providers, tools ([PyPI](https://pypi.org/project/strands-agents/) · [releases](https://github.com/strands-agents/harness-sdk/releases?q=python%2F&expanded=false)) |
-| `strands-ts/` | TypeScript SDK — agent loop, model providers, tools ([npm](https://www.npmjs.com/package/@strands-agents/sdk) · [releases](https://github.com/strands-agents/harness-sdk/releases?q=typescript%2F&expanded=false)) |
+| `strands-py/` | Python SDK: agent loop, model providers, tools ([PyPI](https://pypi.org/project/strands-agents/) · [releases](https://github.com/strands-agents/harness-sdk/releases?q=python%2F&expanded=false)) |
+| `strands-ts/` | TypeScript SDK: agent loop, model providers, tools ([npm](https://www.npmjs.com/package/@strands-agents/sdk) · [releases](https://github.com/strands-agents/harness-sdk/releases?q=typescript%2F&expanded=false)) |
 | `strands-wasm/` | WebAssembly bindings for running Python tools from TypeScript agents |
 | `strands-py-wasm/` | Python host for WASM components (bridges WIT interfaces to Python) |
 | `strandly/` | Developer CLI for local builds, codegen, and workspace tooling |
@@ -51,16 +51,16 @@ This monorepo contains the Python SDK, TypeScript SDK, documentation site, and s
 
 Build an agent harness. Control it end-to-end.
 
-- **Build your way** — Any model, any cloud. Context management, execution limits, and observability built in before you write a line of config. Swap backends when you scale; your code stays the same.
-- **Model agnostic** — First-class support for Amazon Bedrock, Anthropic, OpenAI, and Gemini, plus [many more providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/) and custom ones.
-- **Stay in control** — The agent loop traces every decision by default. Hooks let you intercept any step to log it, validate it, or redirect it.
-- **Deliver outcomes that work** — Guardrails catch mistakes before they run. Steering handlers let agents correct themselves instead of failing silently.
+- **Build your way.** Any model, any cloud. Context management, execution limits, and observability built in before you write a line of config. Swap backends when you scale; your code stays the same.
+- **Model agnostic.** First-class support for Amazon Bedrock, Anthropic, OpenAI, and Gemini, plus [many more providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/) and custom ones.
+- **Stay in control.** The agent loop traces every decision by default. Hooks let you intercept any step to log it, validate it, or redirect it.
+- **Deliver outcomes that work.** Guardrails catch mistakes before they run. Steering handlers let agents correct themselves instead of failing silently.
 
 Plus everything you'd expect: native MCP support, streaming, multi-agent patterns, and structured output.
 
 ## Quick Start
 
-Both SDKs default to the Amazon Bedrock model provider — you'll need AWS credentials configured and model access enabled for Claude Sonnet. The [Quickstart Guide](https://strandsagents.com/docs/user-guide/quickstart/overview/) covers configuring other providers (Anthropic, OpenAI, Gemini, Ollama, and more).
+Both SDKs default to the Amazon Bedrock model provider, so you'll need AWS credentials configured and model access enabled for Claude Sonnet. The [Quickstart Guide](https://strandsagents.com/docs/user-guide/quickstart/overview/) covers configuring other providers (Anthropic, OpenAI, Gemini, Ollama, and more).
 
 ### Python
 
@@ -78,7 +78,7 @@ agent = Agent(tools=[calculator])
 agent("What is the square root of 1764")
 ```
 
-Continue in the [Python SDK README](strands-py/) — tools, model providers, MCP, bidirectional streaming.
+Continue in the [Python SDK README](strands-py/) for tools, model providers, MCP, and bidirectional streaming.
 
 ### TypeScript
 
@@ -96,7 +96,7 @@ const result = await agent.invoke('What is the square root of 1764?')
 console.log(result)
 ```
 
-Continue in the [TypeScript SDK README](strands-ts/) — Zod-typed tools, structured output, MCP, multi-agent patterns.
+Continue in the [TypeScript SDK README](strands-ts/) for Zod-typed tools, structured output, MCP, and multi-agent patterns.
 
 ## Documentation
 
@@ -106,10 +106,10 @@ For detailed guidance & examples, explore our documentation:
 - [Quick Start Guide](https://strandsagents.com/docs/user-guide/quickstart/overview/)
 - [Agent Loop](https://strandsagents.com/docs/user-guide/concepts/agents/agent-loop/)
 - [Examples](https://strandsagents.com/docs/examples/)
-- [API Reference — Python](https://strandsagents.com/docs/api/python/strands.agent.agent/) · [TypeScript](https://strandsagents.com/docs/api/typescript/)
+- API Reference: [Python](https://strandsagents.com/docs/api/python/strands.agent.agent/) · [TypeScript](https://strandsagents.com/docs/api/typescript/)
 - [Production & Deployment Guide](https://strandsagents.com/docs/user-guide/deploy/operating-agents-in-production/)
 
-The docs are part of this monorepo — every page on strandsagents.com is built from [`site/`](site/). Spot a problem? Edit the page and open a PR.
+The docs are part of this monorepo: every page on strandsagents.com is built from [`site/`](site/). Spot a problem? Edit the page and open a PR.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Plus everything you'd expect: native MCP support, streaming, multi-agent pattern
 
 ## Quick Start
 
-Both SDKs default to the Amazon Bedrock model provider — you'll need AWS credentials configured and model access enabled for Claude Sonnet. The [Quickstart Guide](https://strandsagents.com/docs/user-guide/quickstart/) covers configuring other providers (Anthropic, OpenAI, Gemini, Ollama, and more).
+Both SDKs default to the Amazon Bedrock model provider — you'll need AWS credentials configured and model access enabled for Claude Sonnet. The [Quickstart Guide](https://strandsagents.com/docs/user-guide/quickstart/overview/) covers configuring other providers (Anthropic, OpenAI, Gemini, Ollama, and more).
 
 ### Python
 
@@ -103,7 +103,7 @@ Continue in the [TypeScript SDK README](strands-ts/) — Zod-typed tools, struct
 For detailed guidance & examples, explore our documentation:
 
 - [User Guide](https://strandsagents.com/)
-- [Quick Start Guide](https://strandsagents.com/docs/user-guide/quickstart/)
+- [Quick Start Guide](https://strandsagents.com/docs/user-guide/quickstart/overview/)
 - [Agent Loop](https://strandsagents.com/docs/user-guide/concepts/agents/agent-loop/)
 - [Examples](https://strandsagents.com/docs/examples/)
 - [API Reference — Python](https://strandsagents.com/docs/api/python/strands.agent.agent/) · [TypeScript](https://strandsagents.com/docs/api/typescript/)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Build an agent harness. Control it end-to-end.
 - **Stay in control.** The agent loop traces every decision by default. Hooks let you intercept any step to log it, validate it, or redirect it.
 - **Deliver outcomes that work.** Guardrails catch mistakes before they run. Steering handlers let agents correct themselves instead of failing silently.
 
-Plus everything you'd expect: native MCP support, streaming, multi-agent patterns, and structured output.
+MCP, streaming, multi-agent patterns, and structured output are all built in.
 
 ## Quick Start
 
@@ -78,7 +78,7 @@ agent = Agent(tools=[calculator])
 agent("What is the square root of 1764")
 ```
 
-Continue in the [Python SDK README](strands-py/) for tools, model providers, MCP, and bidirectional streaming.
+The [Python SDK README](strands-py/) covers tools, model providers, MCP, and bidirectional streaming.
 
 ### TypeScript
 
@@ -96,7 +96,7 @@ const result = await agent.invoke('What is the square root of 1764?')
 console.log(result)
 ```
 
-Continue in the [TypeScript SDK README](strands-ts/) for Zod-typed tools, structured output, MCP, and multi-agent patterns.
+More in the [TypeScript SDK README](strands-ts/), including Zod-typed tools, structured output, and multi-agent patterns.
 
 ## Documentation
 
@@ -109,7 +109,7 @@ For detailed guidance & examples, explore our documentation:
 - API Reference: [Python](https://strandsagents.com/docs/api/python/strands.agent.agent/) · [TypeScript](https://strandsagents.com/docs/api/typescript/)
 - [Production & Deployment Guide](https://strandsagents.com/docs/user-guide/deploy/operating-agents-in-production/)
 
-The docs are part of this monorepo: every page on strandsagents.com is built from [`site/`](site/). Spot a problem? Edit the page and open a PR.
+The docs themselves live in this monorepo under [`site/`](site/), and doc PRs are welcome alongside code changes.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     <a href="https://github.com/strands-agents/harness-sdk/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/strands-agents/harness-sdk"/></a>
     <a href="https://github.com/strands-agents/harness-sdk/issues"><img alt="GitHub open issues" src="https://img.shields.io/github/issues/strands-agents/harness-sdk"/></a>
     <a href="https://github.com/strands-agents/harness-sdk/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/harness-sdk"/></a>
-    <a href="https://github.com/strands-agents/harness-sdk/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/harness-sdk"/></a>
+    <a href="https://github.com/strands-agents/harness-sdk/blob/main/LICENSE.APACHE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/harness-sdk"/></a>
     <a href="https://pypi.org/project/strands-agents/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/strands-agents"/></a>
     <a href="https://www.npmjs.com/package/@strands-agents/sdk"><img alt="npm version" src="https://img.shields.io/npm/v/%40strands-agents%2Fsdk"/></a>
     <a href="https://python.org"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/strands-agents"/></a>
@@ -151,7 +151,7 @@ Come meet the Strands team and other users on [**Discord**](https://discord.com/
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE.APACHE](LICENSE.APACHE) file for details.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This monorepo contains the Python SDK, TypeScript SDK, documentation site, and s
 | `strands-wasm/` | WebAssembly bindings for running Python tools from TypeScript agents |
 | `strands-py-wasm/` | Python host for WASM components (bridges WIT interfaces to Python) |
 | `strandly/` | Developer CLI for local builds, codegen, and workspace tooling |
-| `site/` | Documentation site built with Astro/Starlight ([strandsagents.com](https://strandsagents.com)) |
+| `site/` | Source for the [strandsagents.com](https://strandsagents.com) documentation site (Astro/Starlight) |
 | `designs/` | Design proposals for significant features (RFC-style) |
 
 ## Why Strands
@@ -108,6 +108,8 @@ For detailed guidance & examples, explore our documentation:
 - [Examples](https://strandsagents.com/docs/examples/)
 - [API Reference — Python](https://strandsagents.com/docs/api/python/strands.agent.agent/) · [TypeScript](https://strandsagents.com/docs/api/typescript/)
 - [Production & Deployment Guide](https://strandsagents.com/docs/user-guide/deploy/operating-agents-in-production/)
+
+The docs are part of this monorepo — every page on strandsagents.com is built from [`site/`](site/). Spot a problem? Edit the page and open a PR.
 
 ## Development
 


### PR DESCRIPTION
## Summary
Split out from #2759 per review feedback (one logical change per PR).

- Restructure the root README as a language-neutral monorepo front door: Quick Start now shows complete install + first-agent steps for both Python and TypeScript, each linking to its SDK README for feature depth
- Remove ~230 lines of Python-only feature content (tools, model providers, MCP, bidirectional streaming) — all of it already exists verbatim in `strands-py/README.md`, verified heading-by-heading and code-block-by-code-block
- Replace the generic Feature Overview with a "Why Strands" section mirroring the homepage value prop (build your way / stay in control / outcomes), with MCP as a light callout rather than a headline bullet
- Link both Python and TypeScript API references
- Link the quickstart overview page directly, avoiding a 404 + client-side redirect

## Test plan
- [ ] All doc links return 200 (quickstart overview, model-providers index, TS API reference verified)
- [ ] Python/TypeScript snippets match the sub-package READMEs
- [ ] Removed content confirmed present in strands-py/README.md