### PR TITLE
ci(changelog): add changelog generator and sync workflow

### DIFF
--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -1,0 +1,137 @@
+name: "Changelog: Sync"
+
+on:
+  release:
+    types: [published]
+  schedule:
+    - cron: '17 7 * * *'   # daily backstop for missed release events
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Single release tag to sync'
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    # On release: only our in-scope tag prefixes. The bare `v` prefix is for
+    # pre-monorepo python releases; the action itself rejects any tag that
+    # isn't `v<digit>`, so a stray non-version `v…` tag produces a no-op run.
+    # Cron/dispatch: always run.
+    if: >
+      github.event_name != 'release' ||
+      startsWith(github.event.release.tag_name, 'python/v') ||
+      startsWith(github.event.release.tag_name, 'typescript/v') ||
+      startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    # De-dupe overlapping runs of the SAME event type + tag (e.g. two release
+    # events for one tag, or two manual dispatches). The group includes
+    # github.event_name, so it deliberately does NOT serialize a release run
+    # against the daily cron: cron runs in backfill mode with no tag, so its key
+    # is always `...-schedule-backfill` and can't match a release's
+    # `...-release-<tag>`. A cross-event duplicate (cron regenerating a release
+    # whose single-mode PR is still open) is tolerated -- the content is
+    # identical and the stray PR is closed manually (see the notes block below).
+    # cancel-in-progress: false so an in-flight sync finishes rather than being
+    # interrupted.
+    concurrency:
+      group: changelog-sync-${{ github.event_name }}-${{ github.event.release.tag_name || inputs.tag || 'backfill' }}
+      cancel-in-progress: false
+    # The PAT (CHANGELOG_BOT_TOKEN) performs every write -- checkout, the
+    # github-script reads, and the branch push + PR creation all use it, not the
+    # default GITHUB_TOKEN. So GITHUB_TOKEN needs only read; keeping write here
+    # would be dead, misleading privilege.
+    permissions:
+      contents: read
+    steps:
+      # Notes:
+      # - Historical backfill is a deliberate one-time manual operation (run
+      #   the action against a branch and open a hand-reviewed PR) -- not wired
+      #   here.
+      # - Duplicate-PR window: skip-existing checks files on main, not open
+      #   PRs, and release vs. cron runs use different PR branch names, so a
+      #   release-triggered PR is NOT auto-closed by a later cron run. The
+      #   concurrency group only de-dupes within the same event type; a
+      #   release-vs-cron duplicate is tolerated because the content is
+      #   identical -- close the stray PR manually.
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+      - run: npm ci --prefix site
+
+      - name: Generate harness changelog files
+        working-directory: site
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN }}
+          SOURCE_REPO: strands-agents/harness-sdk
+          MODE: ${{ github.event_name == 'schedule' && 'backfill' || 'single' }}
+          SKIP_EXISTING: ${{ github.event_name == 'schedule' }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: npm run changelog:sync
+
+      - name: Compute harness branch name
+        id: harness_branch
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [ -n "$TAG" ]; then
+            SUFFIX=$(printf '%s' "$TAG" | sed 's/[^A-Za-z0-9._-][^A-Za-z0-9._-]*/-/g')
+          else
+            SUFFIX=backfill
+          fi
+          echo "name=changelog/sync-harness-sdk-$SUFFIX" >> "$GITHUB_OUTPUT"
+
+      # Dedicated agent account (outside the org): a classic PAT with the
+      # public_repo scope. Authors the PR as a real user, so the PR triggers
+      # the required CI Gate (unlike github.token, whose PRs don't).
+      # Account can't push to upstream directly, so the branch lands on its
+      # fork and the PR is opened cross-repo against target-repo. Note:
+      # `strands-agent` is SINGULAR -- the dedicated bot account, distinct
+      # from the `strands-agents` (plural) org. Not a typo.
+      - name: Open harness changelog PR
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ secrets.CHANGELOG_BOT_TOKEN }}
+          push-to-fork: strands-agent/harness-sdk
+          add-paths: site/src/content/changelog/**
+          branch: ${{ steps.harness_branch.outputs.name }}
+          title: "docs(changelog): sync strands-agents/harness-sdk ${{ github.event.release.tag_name || inputs.tag || 'backfill' }}"
+          commit-message: "docs(changelog): sync strands-agents/harness-sdk ${{ github.event.release.tag_name || inputs.tag || 'backfill' }}"
+          body: |
+            Automated changelog sync.
+            Add a curated `highlights:` block to any release file before merging if desired.
+          delete-branch: true
+
+      # Evals backstop: evals' own release workflow opens the cross-repo PR for
+      # instant sync; this catches missed events. The condition runs the evals
+      # step whether the harness step passed or failed (the two syncs are
+      # independent -- a harness failure must not delay the evals backstop a day)
+      # but NOT when the run was cancelled.
+      - name: Generate missed evals changelog files
+        if: (success() || failure()) && github.event_name == 'schedule'
+        working-directory: site
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN }}
+          SOURCE_REPO: strands-agents/evals
+          MODE: backfill
+          SKIP_EXISTING: 'true'
+        run: npm run changelog:sync
+
+      - name: Open evals changelog PR
+        if: (success() || failure()) && github.event_name == 'schedule'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ secrets.CHANGELOG_BOT_TOKEN }}
+          push-to-fork: strands-agent/harness-sdk
+          add-paths: site/src/content/changelog/**
+          branch: changelog/sync-evals-backfill
+          title: "docs(changelog): sync strands-agents/evals backfill"
+          commit-message: "docs(changelog): sync strands-agents/evals backfill"
+          body: Automated evals changelog backstop.
+          delete-branch: true

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -27,16 +27,9 @@ jobs:
       startsWith(github.event.release.tag_name, 'typescript/v') ||
       startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
-    # De-dupe overlapping runs of the SAME event type + tag (e.g. two release
-    # events for one tag, or two manual dispatches). The group includes
-    # github.event_name, so it deliberately does NOT serialize a release run
-    # against the daily cron: cron runs in backfill mode with no tag, so its key
-    # is always `...-schedule-backfill` and can't match a release's
-    # `...-release-<tag>`. A cross-event duplicate (cron regenerating a release
-    # whose single-mode PR is still open) is tolerated -- the content is
-    # identical and the stray PR is closed manually (see the notes block below).
-    # cancel-in-progress: false so an in-flight sync finishes rather than being
-    # interrupted.
+    # De-dupes runs of the same event type + tag. Deliberately does NOT
+    # serialize release vs. cron: a cross-event duplicate PR has identical
+    # content and is closed manually. In-flight syncs finish (no cancel).
     concurrency:
       group: changelog-sync-${{ github.event_name }}-${{ github.event.release.tag_name || inputs.tag || 'backfill' }}
       cancel-in-progress: false
@@ -47,16 +40,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Notes:
-      # - Historical backfill is a deliberate one-time manual operation (run
-      #   the action against a branch and open a hand-reviewed PR) -- not wired
-      #   here.
-      # - Duplicate-PR window: skip-existing checks files on main, not open
-      #   PRs, and release vs. cron runs use different PR branch names, so a
-      #   release-triggered PR is NOT auto-closed by a later cron run. The
-      #   concurrency group only de-dupes within the same event type; a
-      #   release-vs-cron duplicate is tolerated because the content is
-      #   identical -- close the stray PR manually.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -65,16 +48,8 @@ jobs:
           node-version-file: .node-version
       - run: npm ci --prefix site
 
-      - name: Generate harness changelog files
-        working-directory: site
-        env:
-          GITHUB_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN }}
-          SOURCE_REPO: strands-agents/harness-sdk
-          MODE: ${{ github.event_name == 'schedule' && 'backfill' || 'single' }}
-          SKIP_EXISTING: ${{ github.event_name == 'schedule' }}
-          TAG: ${{ github.event.release.tag_name || inputs.tag }}
-        run: npm run changelog:sync
-
+      # Cheap step first: if branch-name computation is going to fail, fail
+      # before the expensive Generate step.
       - name: Compute harness branch name
         id: harness_branch
         env:
@@ -86,6 +61,16 @@ jobs:
             SUFFIX=backfill
           fi
           echo "name=changelog/sync-harness-sdk-$SUFFIX" >> "$GITHUB_OUTPUT"
+
+      - name: Generate harness changelog files
+        working-directory: site
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN }}
+          SOURCE_REPO: strands-agents/harness-sdk
+          MODE: ${{ github.event_name == 'schedule' && 'backfill' || 'single' }}
+          SKIP_EXISTING: ${{ github.event_name == 'schedule' }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: npm run changelog:sync
 
       # Dedicated agent account (outside the org): a classic PAT with the
       # public_repo scope. Authors the PR as a real user, so the PR triggers

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -40,6 +40,7 @@
       "devDependencies": {
         "@astrojs/markdown-satteri": "^0.3.3",
         "@astrojs/starlight": "^0.41.3",
+        "@octokit/rest": "^21.1.1",
         "@types/js-yaml": "^4.0.9",
         "@types/mdast": "^4.0.4",
         "@types/node": "^24.10.1",
@@ -72,7 +73,7 @@
       },
       "devDependencies": {
         "@a2a-js/sdk": "^0.3.10",
-        "@ai-sdk/amazon-bedrock": "^4.0.124",
+        "@ai-sdk/amazon-bedrock": "^4.0.128",
         "@ai-sdk/openai": "^3.0.41",
         "@ai-sdk/provider": "^3.0.0",
         "@anthropic-ai/sdk": "^0.106.0",
@@ -96,21 +97,21 @@
         "@opentelemetry/sdk-metrics": "^2.6.1",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/sdk-trace-node": "^2.6.1",
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.15.1",
         "@types/express": "^5.0.6",
-        "@types/node": "^25.9.1",
+        "@types/node": "^25.9.4",
         "@types/uuid": "^11.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.61.1",
+        "@typescript-eslint/eslint-plugin": "^8.62.1",
         "@typescript-eslint/parser": "^8.0.0",
         "@vitest/browser": "^4.1.9",
         "@vitest/browser-playwright": "^4.1.6",
         "@vitest/coverage-v8": "^4.1.6",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "eslint-plugin-tsdoc": "^0.5.0",
         "express": "^5.2.1",
         "openai": "^6.45.0",
         "playwright": "^1.61.0",
-        "tsx": "^4.21.0",
+        "tsx": "^4.22.5",
         "typescript": "^6.0.3",
         "vitest": "^4.1.6"
       },
@@ -136,7 +137,7 @@
         "@opentelemetry/sdk-metrics": "^2.6.1",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/sdk-trace-node": "^2.6.1",
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.15.1",
         "express": "^5.1.0",
         "openai": "^6.45.0",
         "zod": "^4.1.12"
@@ -2347,6 +2348,206 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^6.1.4",
+        "@octokit/plugin-paginate-rest": "^11.4.2",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -3905,6 +4106,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -5088,6 +5296,23 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/fast-copy": {
@@ -10393,6 +10618,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@astrojs/markdown-satteri": "^0.3.3",
     "@astrojs/starlight": "^0.41.3",
+    "@octokit/rest": "^21.1.1",
     "@types/js-yaml": "^4.0.9",
     "@types/mdast": "^4.0.4",
     "@types/node": "^24.10.1",

--- a/site/scripts/changelog/build-release-file.ts
+++ b/site/scripts/changelog/build-release-file.ts
@@ -1,0 +1,129 @@
+// Orchestrate one GitHub release into a rendered changelog file. Pure given
+// injected deps (enrich + readExisting), so it's unit-testable without network.
+
+import { tagToMeta, getPackageUrl } from './tag-meta'
+import { parseNewContributors } from './parse-release-body'
+import { renderMarkdown, mergePreserving } from './render-markdown'
+import type { Release, Enrichment, ParsedEntry, RenderedEntry, ReleaseFile } from './types'
+
+export interface BuildDeps {
+  deriveEntries(repo: string, release: Release): Promise<{ entries: ParsedEntry[]; warning?: string }>
+  enrich(prRepo: string, pr: number): Promise<Enrichment>
+  readExisting(path: string): Promise<string | null>
+  skipExisting?: boolean
+}
+
+function fileNameFor(sdk: string, language: string | undefined, version: string): string {
+  if (sdk === 'evals') return `evals/v${version}.md`
+  return `harness/${language}-v${version}.md`
+}
+
+export async function buildReleaseFile(
+  repo: string,
+  release: Release,
+  deps: BuildDeps
+): Promise<{ path: string; contents: string; warning?: string } | null> {
+  const meta = tagToMeta(repo, release.tag_name)
+  if (!meta) return null
+
+  const path = `site/src/content/changelog/${fileNameFor(meta.sdk, meta.language, meta.version)}`
+  const existing = await deps.readExisting(path)
+
+  // skipExisting (used by the daily cron backstop): only generate files for
+  // releases that don't have one yet. Checked BEFORE enrichment so a skipped
+  // release costs zero PR API calls, and existing files (possibly carrying
+  // richer enrichment from when labels were fresher) are never regressed by a
+  // rate-limited re-run. A full refresh is an explicit backfill dispatch.
+  if (deps.skipExisting && existing) return null
+
+  // Entries come from the GitHub compare API (every merged PR between the prior
+  // tag and this one) -- deterministic and independent of release-note format.
+  // The release body is NOT parsed for entries; it's preserved as curated
+  // narrative via mergePreserving below.
+  const { entries: parsed, warning } = await deps.deriveEntries(repo, release)
+
+  // Two gates apply to every entry:
+  //
+  // 1. Docs-only (ALL streams): a PR confined to docs/blog/website dirs never
+  //    lines up with an SDK+language, so it's dropped everywhere -- including
+  //    pre-monorepo bare-`v` and evals, which are otherwise unfiltered. This
+  //    keeps the changelog focused on SDK+language work (a blog-only PR or a
+  //    pure docs change won't appear in any stream).
+  // 2. Language (monorepo prefixed tags only): those releases list every merged
+  //    PR regardless of language, so gate by which SDK dirs the PR touched --
+  //    python stream keeps python-touching PRs, ts keeps ts-touching, both ->
+  //    both. Unknown file info -> kept (degrade open).
+  //
+  //    CRUCIAL: only gate when the PR has a POSITIVE dir signal -- i.e. it
+  //    touches strands-py/ and/or strands-ts/. A PR with EMPTY languages
+  //    (touches neither: root config/CI, or a pre-monorepo flat-layout PR whose
+  //    code lived under src/ before the strands-py/ dir existed) must be KEPT,
+  //    not dropped. Gating on empty languages would wrongly empty pre-monorepo
+  //    releases whose tags were re-applied as python/v* in the monorepo.
+  //    Pre-monorepo bare-`v` and evals are single-language: no language gate.
+  const isMonorepoStream =
+    meta.sdk === 'harness' && (release.tag_name.startsWith('python/') || release.tag_name.startsWith('typescript/'))
+
+  // Shared keep/drop decision for both entries and new contributors: drop a
+  // docs-only PR from every stream, and on a monorepo stream drop a PR with a
+  // POSITIVE dir signal for the OTHER language (empty/unknown languages are
+  // kept -- see the language-gate note above).
+  const dropFromStream = (enr: Enrichment) =>
+    enr.docsOnly ||
+    (isMonorepoStream &&
+      Array.isArray(enr.languages) &&
+      enr.languages.length > 0 &&
+      !enr.languages.includes(meta.language!))
+
+  const entries: RenderedEntry[] = []
+  for (const p of parsed) {
+    const prRepo = p.prRepo || repo
+    const enr = p.pr
+      ? await deps.enrich(prRepo, p.pr)
+      : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false }
+    if (dropFromStream(enr)) continue
+    const breaking = p.breaking || enr.breaking
+    entries.push({
+      type: breaking && p.type === 'other' ? 'breaking' : p.type,
+      breaking,
+      scope: p.scope,
+      areas: enr.areas,
+      title: p.title,
+      pr: p.pr,
+      prUrl: p.pr ? `https://github.com/${prRepo}/pull/${p.pr}` : null,
+      commit: enr.commit,
+      commitUrl: enr.commit ? `https://github.com/${prRepo}/commit/${enr.commit}` : null,
+      author: enr.author || p.author,
+    })
+  }
+
+  // New contributors use the same keep/drop rule as entries (dropFromStream):
+  // a docs-only first PR doesn't belong in an SDK+language changelog, and a
+  // monorepo PR with a positive other-language signal is gated out -- but a
+  // first PR touching no sdk dir (e.g. ci) or with unknown files is kept in
+  // both streams: people aren't noise.
+  const rawContributors = parseNewContributors(release.body)
+  const newContributors = []
+  for (const c of rawContributors) {
+    // Use the PR's own repo (mirrors the entries path) -- first-contribution
+    // links can point at the pre-monorepo repos.
+    const enr = await deps.enrich(c.prRepo || repo, c.pr)
+    if (dropFromStream(enr)) continue
+    newContributors.push(c)
+  }
+
+  const file: ReleaseFile = {
+    sdk: meta.sdk,
+    language: meta.language,
+    version: meta.version,
+    tag: release.tag_name,
+    date: release.published_at!.slice(0, 10), // safe: run.ts filters out releases with null published_at before calling here
+    releaseUrl: release.html_url,
+    packageUrl: getPackageUrl(meta.sdk, meta.language, meta.version),
+    entries,
+    newContributors,
+  }
+
+  const contents = existing ? mergePreserving(file, existing) : renderMarkdown(file)
+  return warning ? { path, contents, warning } : { path, contents }
+}

--- a/site/scripts/changelog/build-release-file.ts
+++ b/site/scripts/changelog/build-release-file.ts
@@ -29,45 +29,22 @@ export async function buildReleaseFile(
   const path = `site/src/content/changelog/${fileNameFor(meta.sdk, meta.language, meta.version)}`
   const existing = await deps.readExisting(path)
 
-  // skipExisting (used by the daily cron backstop): only generate files for
-  // releases that don't have one yet. Checked BEFORE enrichment so a skipped
-  // release costs zero PR API calls, and existing files (possibly carrying
-  // richer enrichment from when labels were fresher) are never regressed by a
-  // rate-limited re-run. A full refresh is an explicit backfill dispatch.
+  // Checked BEFORE enrichment so a skipped release costs zero PR API calls
+  // and existing files are never regressed by a degraded re-run.
   if (deps.skipExisting && existing) return null
 
-  // Entries come from the GitHub compare API (every merged PR between the prior
-  // tag and this one) -- deterministic and independent of release-note format.
-  // The release body is NOT parsed for entries; it's preserved as curated
-  // narrative via mergePreserving below.
+  // Entries come from the compare API, not the release body (which is only
+  // preserved as curated narrative via mergePreserving below).
   const { entries: parsed, warning } = await deps.deriveEntries(repo, release)
 
-  // Two gates apply to every entry:
-  //
-  // 1. Docs-only (ALL streams): a PR confined to docs/blog/website dirs never
-  //    lines up with an SDK+language, so it's dropped everywhere -- including
-  //    pre-monorepo bare-`v` and evals, which are otherwise unfiltered. This
-  //    keeps the changelog focused on SDK+language work (a blog-only PR or a
-  //    pure docs change won't appear in any stream).
-  // 2. Language (monorepo prefixed tags only): those releases list every merged
-  //    PR regardless of language, so gate by which SDK dirs the PR touched --
-  //    python stream keeps python-touching PRs, ts keeps ts-touching, both ->
-  //    both. Unknown file info -> kept (degrade open).
-  //
-  //    CRUCIAL: only gate when the PR has a POSITIVE dir signal -- i.e. it
-  //    touches strands-py/ and/or strands-ts/. A PR with EMPTY languages
-  //    (touches neither: root config/CI, or a pre-monorepo flat-layout PR whose
-  //    code lived under src/ before the strands-py/ dir existed) must be KEPT,
-  //    not dropped. Gating on empty languages would wrongly empty pre-monorepo
-  //    releases whose tags were re-applied as python/v* in the monorepo.
-  //    Pre-monorepo bare-`v` and evals are single-language: no language gate.
+  // Entry gates: docs-only PRs drop on every stream; monorepo streams also
+  // drop a PR that touches ONLY the other language's dir. Only a POSITIVE dir
+  // signal gates -- empty/unknown languages are kept (pre-monorepo PRs have no
+  // strands-py/strands-ts dirs; gating on empty would wrongly empty those
+  // releases).
   const isMonorepoStream =
     meta.sdk === 'harness' && (release.tag_name.startsWith('python/') || release.tag_name.startsWith('typescript/'))
 
-  // Shared keep/drop decision for both entries and new contributors: drop a
-  // docs-only PR from every stream, and on a monorepo stream drop a PR with a
-  // POSITIVE dir signal for the OTHER language (empty/unknown languages are
-  // kept -- see the language-gate note above).
   const dropFromStream = (enr: Enrichment) =>
     enr.docsOnly ||
     (isMonorepoStream &&
@@ -97,16 +74,12 @@ export async function buildReleaseFile(
     })
   }
 
-  // New contributors use the same keep/drop rule as entries (dropFromStream):
-  // a docs-only first PR doesn't belong in an SDK+language changelog, and a
-  // monorepo PR with a positive other-language signal is gated out -- but a
-  // first PR touching no sdk dir (e.g. ci) or with unknown files is kept in
-  // both streams: people aren't noise.
+  // New contributors share dropFromStream; a first PR touching no sdk dir
+  // (e.g. ci) is kept in both streams.
   const rawContributors = parseNewContributors(release.body)
   const newContributors = []
   for (const c of rawContributors) {
-    // Use the PR's own repo (mirrors the entries path) -- first-contribution
-    // links can point at the pre-monorepo repos.
+    // Enrich against the PR's own repo (may be a pre-monorepo repo).
     const enr = await deps.enrich(c.prRepo || repo, c.pr)
     if (dropFromStream(enr)) continue
     newContributors.push(c)

--- a/site/scripts/changelog/derive-entries.ts
+++ b/site/scripts/changelog/derive-entries.ts
@@ -1,0 +1,88 @@
+// Derive a release's changelog entries deterministically from the GitHub
+// compare API instead of parsing the release-notes body. The compare endpoint
+// lists every merged commit between two tags regardless of how the notes are
+// written, so the breakdown is immune to release-note format drift. Each
+// commit is resolved to its PR via the commit->PR API for authoritative
+// association (handles squash and merge-commit repos), then classified with the
+// shared conventional-commit logic. Pure given an injected client.
+
+import { classifyTitle } from './parse-release-body'
+import { tagToMeta } from './tag-meta'
+import { compareVersionDesc } from '../../src/util/semver'
+import type { Client, ParsedEntry } from './types'
+
+/**
+ * The previous tag in the same stream (same sdk + language) as `tag`, or null
+ * if `tag` is the first release in its stream. Streams: python/v*, typescript/v*
+ * (harness), and bare v* (evals / pre-monorepo). Uses tagToMeta to classify and
+ * compareVersionDesc to order.
+ */
+export async function previousTagInStream(
+  repo: string,
+  tag: string,
+  client: Pick<Client, 'listTags'>
+): Promise<string | null> {
+  const meta = tagToMeta(repo, tag)
+  if (!meta) return null
+  const tags = (await client.listTags(repo)) || []
+  // Parse tagToMeta once per tag, then filter/sort/search on the precomputed value.
+  const stream = tags
+    .flatMap((t) => {
+      if (t.name === tag) return []
+      const m = tagToMeta(repo, t.name)
+      if (!m || m.sdk !== meta.sdk || m.language !== meta.language) return []
+      return [{ name: t.name, version: m.version }]
+    })
+    .sort((a, b) => compareVersionDesc(a.version, b.version)) // newest-first
+  // The immediate predecessor is the newest tag older than `tag`.
+  for (const entry of stream) {
+    if (compareVersionDesc(meta.version, entry.version) < 0) {
+      // `meta` is newer than `entry` (compareVersionDesc<0 means first is newer)
+      return entry.name
+    }
+  }
+  return null
+}
+
+/**
+ * Derive parsed-line entries (the shape parseReleaseBody returns) for the range
+ * base..head in `repo`. Resolves each commit to its PR(s); a commit with no
+ * associated PR (direct push) is skipped. Memoizes commit->PR lookups.
+ */
+export async function deriveEntries(opts: {
+  repo: string
+  base: string | null
+  head: string
+  client: Pick<Client, 'compareCommits' | 'commitPulls'>
+}): Promise<{ entries: ParsedEntry[]; truncated: boolean; warning?: string }> {
+  const { repo, base, head, client } = opts
+  if (!base) {
+    // First release in the stream -- no prior tag to diff against. Don't guess
+    // the whole history; emit nothing and let the caller note it.
+    return {
+      entries: [],
+      truncated: false,
+      warning: `${head}: no prior tag in stream -- entries not derived from compare.`,
+    }
+  }
+  const cmp = (await client.compareCommits(repo, base, head)) || { commits: [] }
+  const commits = cmp.commits || []
+  const seen = new Set<number>()
+  const entries: ParsedEntry[] = []
+  for (const c of commits) {
+    const pulls = (await client.commitPulls(repo, c.sha)) || []
+    for (const pr of pulls) {
+      if (seen.has(pr.number)) continue // a PR can map to multiple commits
+      seen.add(pr.number)
+      entries.push({ ...classifyTitle(pr.title || ''), author: pr.user || null, pr: pr.number, prRepo: repo })
+    }
+  }
+  const truncated = cmp.truncated === true
+  return {
+    entries,
+    truncated,
+    warning: truncated
+      ? `${head}: compare range exceeded GitHub's 250-commit cap -- entry list may be incomplete; review before merge.`
+      : undefined,
+  }
+}

--- a/site/scripts/changelog/enrich.ts
+++ b/site/scripts/changelog/enrich.ts
@@ -1,0 +1,95 @@
+// Enrich a parsed line from its linked PR: area-* labels, breaking flag,
+// short merge-commit SHA, author, and (for monorepo PRs) which SDK languages
+// the PR actually touches -- derived from changed-file paths because language
+// labels are too sparse to rely on. Pure given an injected fetcher (no network
+// here), so it's unit-testable. Degrades to empty enrichment when the PR can't
+// be fetched (deleted PR, missing permissions, old repo) -- callers still emit
+// the entry, just without areas/commit, and with languages unknown.
+
+import type { PrData, Enrichment } from './types'
+
+// Monorepo top-level dirs that mark a PR as touching an SDK language.
+const LANGUAGE_DIRS: Record<string, string> = {
+  'strands-py': 'python',
+  'strands-ts': 'typescript',
+}
+
+// Top-level dirs holding docs/blog/website content rather than SDK code.
+// `site/` is the monorepo home for all docs+blog+website; `docs/` is the
+// pre-monorepo / evals docs tree. A PR confined to these never lines up with
+// an SDK+language, so it's dropped on every stream (see build-release-file).
+const DOCS_DIRS = new Set(['site', 'docs'])
+
+// A changed path is "docs" if it's under a docs dir OR is a top-level docs file
+// -- a repo-root Markdown file (README.md, AGENTS.md, ...) or a well-known root doc
+// regardless of extension (CONTRIBUTING, CHANGELOG, NOTICE, LICENSE, ...). These
+// carry no SDK+language surface, so a PR confined to them is docs-only.
+const ROOT_DOC_NAMES = new Set([
+  'readme',
+  'contributing',
+  'changelog',
+  'notice',
+  'license',
+  'security',
+  'code_of_conduct',
+  'maintainers',
+  'authors',
+  'codeowners',
+])
+function isDocPath(f: string): boolean {
+  const p = String(f)
+  const segs = p.split('/')
+  if (DOCS_DIRS.has(segs[0])) return true
+  if (segs.length > 1) return false // nested under a non-docs dir -> code-ish
+  // top-level file: any markdown, or a known root doc by basename
+  if (/\.mdx?$/i.test(p)) return true
+  const base = p.replace(/\.[^.]*$/, '').toLowerCase()
+  return ROOT_DOC_NAMES.has(base)
+}
+
+/**
+ * Derive SDK languages from changed-file paths. Returns:
+ * - string[] of languages (possibly empty = site/ci/docs-only PR)
+ * - null when file info is unavailable (unknown -- callers should not filter)
+ */
+function languagesFromFiles(files: unknown): string[] | null {
+  if (!Array.isArray(files)) return null
+  const langs = new Set<string>()
+  for (const f of files) {
+    const top = String(f).split('/')[0]
+    if (LANGUAGE_DIRS[top]) langs.add(LANGUAGE_DIRS[top])
+  }
+  return [...langs]
+}
+
+/**
+ * True when every changed file lives under a docs/website dir -- i.e. a
+ * docs/blog/site-only PR. Unknown (null) or empty file lists are NOT docs-only
+ * (we don't drop on missing info). A PR touching docs AND code is not docs-only.
+ */
+function docsOnlyFromFiles(files: unknown): boolean {
+  if (!Array.isArray(files) || files.length === 0) return false
+  return files.every(isDocPath)
+}
+
+export async function enrichFromPr(
+  repo: string,
+  num: number,
+  fetcher: (repo: string, num: number) => Promise<PrData | null>
+): Promise<Enrichment> {
+  const pr = await fetcher(repo, num)
+  // Unfetchable PR (deleted / rate-limited): degrade open -- keep the entry,
+  // languages unknown, not docs-only (explicit, not relying on falsy undefined).
+  if (!pr) return { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false }
+  const areas = (pr.labels || []).filter((l) => l.startsWith('area-')).map((l) => l.slice('area-'.length))
+  const breaking = (pr.labels || []).some((l) => l.toLowerCase() === 'breaking change')
+  const commit = pr.merge_commit_sha ? pr.merge_commit_sha.slice(0, 7) : null
+  return {
+    areas,
+    breaking,
+    commit,
+    author: pr.user || null,
+    languages: languagesFromFiles(pr.files),
+    docsOnly: docsOnlyFromFiles(pr.files),
+  }
+}

--- a/site/scripts/changelog/enrich.ts
+++ b/site/scripts/changelog/enrich.ts
@@ -1,10 +1,9 @@
 // Enrich a parsed line from its linked PR: area-* labels, breaking flag,
 // short merge-commit SHA, author, and (for monorepo PRs) which SDK languages
-// the PR actually touches -- derived from changed-file paths because language
-// labels are too sparse to rely on. Pure given an injected fetcher (no network
-// here), so it's unit-testable. Degrades to empty enrichment when the PR can't
-// be fetched (deleted PR, missing permissions, old repo) -- callers still emit
-// the entry, just without areas/commit, and with languages unknown.
+// the PR touches -- derived from changed-file paths because language labels
+// are too sparse to rely on. Pure given an injected fetcher, so unit-testable.
+// A null fetch (404: permission/cross-repo edge cases) degrades to an
+// unenriched entry; rate limits fail the run in github-client instead.
 
 import type { PrData, Enrichment } from './types'
 
@@ -78,8 +77,8 @@ export async function enrichFromPr(
   fetcher: (repo: string, num: number) => Promise<PrData | null>
 ): Promise<Enrichment> {
   const pr = await fetcher(repo, num)
-  // Unfetchable PR (deleted / rate-limited): degrade open -- keep the entry,
-  // languages unknown, not docs-only (explicit, not relying on falsy undefined).
+  // Unfetchable PR (404): degrade open -- keep the entry, languages unknown,
+  // not docs-only. Rate limits throw in the fetcher and never reach here.
   if (!pr) return { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false }
   const areas = (pr.labels || []).filter((l) => l.startsWith('area-')).map((l) => l.slice('area-'.length))
   const breaking = (pr.labels || []).some((l) => l.toLowerCase() === 'breaking change')

--- a/site/scripts/changelog/github-client.ts
+++ b/site/scripts/changelog/github-client.ts
@@ -47,10 +47,18 @@ export function makeClient(token: string, warn: (msg: string) => void = () => {}
           })
           out.files = files.map((f: any) => f.filename)
         } catch (e: any) {
+          // Rate limiting must fail the run rather than silently produce
+          // release notes with degraded gating/enrichment.
+          if (e.status === 403 || e.status === 429) throw e
           warn(`PR ${repoFull}#${num} files: ${e.status || e.message} -- gating skipped`)
         }
         return out
       } catch (e: any) {
+        if (e.status === 403 || e.status === 429) {
+          throw new Error(`rate limited fetching PR ${repoFull}#${num} -- re-run once the limit resets`)
+        }
+        // 404: cross-repo or permission edge cases -- degrade to an
+        // unenriched entry rather than failing the whole sync.
         if (e.status !== 404) warn(`PR ${repoFull}#${num}: ${e.status || e.message} -- skipping enrichment`)
         return null
       }

--- a/site/scripts/changelog/github-client.ts
+++ b/site/scripts/changelog/github-client.ts
@@ -1,0 +1,101 @@
+import { Octokit } from '@octokit/rest'
+import type { Client, Release } from './types'
+
+function splitRepo(full: string): { owner: string; repo: string } {
+  const [owner, repo] = full.split('/')
+  if (!owner || !repo) throw new Error(`invalid repo (expected owner/repo): ${full}`)
+  return { owner, repo }
+}
+
+/** Build the injected Client from a token. `warn` receives best-effort,
+ *  non-fatal degradation messages (missing PR, rate-limit on file list, etc.). */
+export function makeClient(token: string, warn: (msg: string) => void = () => {}): Client {
+  const octokit = new Octokit({ auth: token })
+  // Octokit response types are cast at this boundary; only the domain shapes in ./types cross into the pure logic.
+  return {
+    listReleases: async (repoFull) => {
+      const { owner, repo } = splitRepo(repoFull)
+      const data = await octokit.paginate(octokit.rest.repos.listReleases, { owner, repo, per_page: 100 })
+      return data as Release[]
+    },
+    getRelease: async (repoFull, t) => {
+      const { owner, repo } = splitRepo(repoFull)
+      try {
+        const res = await octokit.rest.repos.getReleaseByTag({ owner, repo, tag: t })
+        return res.data as any
+      } catch (e: any) {
+        if (e.status === 404) return null
+        throw e
+      }
+    },
+    getPr: async (repoFull, num) => {
+      const { owner, repo } = splitRepo(repoFull)
+      try {
+        const res = await octokit.rest.pulls.get({ owner, repo, pull_number: num })
+        const pr = res.data
+        const out: { labels: string[]; merge_commit_sha: string | null; user: string | null; files?: string[] } = {
+          labels: (pr.labels || []).map((l: any) => l.name),
+          merge_commit_sha: pr.merge_commit_sha ?? null,
+          user: pr.user ? pr.user.login : null,
+        }
+        try {
+          const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
+            owner,
+            repo,
+            pull_number: num,
+            per_page: 100,
+          })
+          out.files = files.map((f: any) => f.filename)
+        } catch (e: any) {
+          warn(`PR ${repoFull}#${num} files: ${e.status || e.message} -- gating skipped`)
+        }
+        return out
+      } catch (e: any) {
+        if (e.status !== 404) warn(`PR ${repoFull}#${num}: ${e.status || e.message} -- skipping enrichment`)
+        return null
+      }
+    },
+    listTags: async (repoFull) => {
+      const { owner, repo } = splitRepo(repoFull)
+      const tags = await octokit.paginate(octokit.rest.repos.listTags, { owner, repo, per_page: 100 })
+      return tags.map((t: any) => ({ name: t.name, commitSha: t.commit && t.commit.sha }))
+    },
+    compareCommits: async (repoFull, base, head) => {
+      const { owner, repo } = splitRepo(repoFull)
+      try {
+        const commits: Array<{ sha: string }> = []
+        let total: number | null = null
+        for await (const page of octokit.paginate.iterator(octokit.rest.repos.compareCommitsWithBasehead, {
+          owner,
+          repo,
+          basehead: `${base}...${head}`,
+          per_page: 100,
+        })) {
+          if (total === null && typeof page.data.total_commits === 'number') total = page.data.total_commits
+          for (const c of page.data.commits || []) commits.push({ sha: c.sha })
+        }
+        return { commits, truncated: typeof total === 'number' && total > commits.length }
+      } catch (e: any) {
+        warn(`compare ${repoFull} ${base}...${head}: ${e.status || e.message} -- no entries derived`)
+        return { commits: [], truncated: false }
+      }
+    },
+    commitPulls: async (repoFull, sha) => {
+      const { owner, repo } = splitRepo(repoFull)
+      try {
+        const res = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+          owner,
+          repo,
+          commit_sha: sha,
+          per_page: 100,
+        })
+        return (res.data || [])
+          .filter((pr: any) => pr.merged_at)
+          .map((pr: any) => ({ number: pr.number, title: pr.title, user: pr.user ? pr.user.login : null }))
+      } catch (e: any) {
+        if (e.status !== 404) warn(`commit ${repoFull}@${sha} pulls: ${e.status || e.message} -- skipped`)
+        return []
+      }
+    },
+  }
+}

--- a/site/scripts/changelog/parse-release-body.ts
+++ b/site/scripts/changelog/parse-release-body.ts
@@ -1,0 +1,63 @@
+// Parse the "New Contributors" section of a GitHub release body, and classify
+// PR titles into changelog fields. Pure, dependency-free.
+//
+// Entries themselves are derived from the compare API (see derive-entries.ts),
+// not parsed from the body -- so the body is read only for the "New Contributors"
+// section, which the compare API doesn't expose.
+
+import type { NewContributor } from './types'
+
+const LINE = /^\s*[-*]\s+(.*)$/
+// Cross-SDK marker in newer harness notes, e.g. "title _(shared with TS)_".
+// Language gating (from PR changed files) already decides stream membership,
+// so strip this annotation from the rendered title.
+const SHARED_ANNOTATION = /\s*_\(shared with [^)]+\)_\s*$/i
+const CONVENTIONAL = /^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(?:\(([^)]+)\))?(!)?:\s*(.+)$/i
+const KNOWN_TYPES = new Set(['feat', 'fix', 'docs', 'perf', 'refactor', 'test', 'chore'])
+// GitHub's "## New Contributors" lines: "@login made their first contribution in <pr-url>".
+// Login may carry a bracket suffix for apps/bots, e.g. dependabot[bot].
+const FIRST_CONTRIBUTION =
+  /^@([\w-]+(?:\[[\w-]+\])?) made their first contribution\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/i
+
+/**
+ * Classify a PR title / commit message into changelog fields. Strips the
+ * cross-SDK "_(shared with ...)_" annotation, then applies the conventional-commit
+ * grammar (type/scope/!), falling back to type "other" for non-conventional
+ * titles. Used by the compare-driven derive-entries path.
+ */
+export function classifyTitle(message: string): {
+  type: string
+  scope: string | null
+  breaking: boolean
+  title: string
+} {
+  const msg = String(message).trim().replace(SHARED_ANNOTATION, '')
+  const cc = msg.match(CONVENTIONAL)
+  if (cc) {
+    const type = cc[1].toLowerCase()
+    return {
+      type: KNOWN_TYPES.has(type) ? type : 'other',
+      scope: cc[2] || null,
+      breaking: cc[3] === '!',
+      title: cc[4].trim(),
+    }
+  }
+  return { type: 'other', scope: null, breaking: false, title: msg }
+}
+
+/**
+ * Extract GitHub's "## New Contributors" section into structured data.
+ * prRepo is the repo from the PR url (may differ from the release's repo for
+ * pre-monorepo releases) -- gate/enrich against THAT repo, mirroring entries.
+ */
+export function parseNewContributors(body: string | null | undefined): NewContributor[] {
+  if (!body) return []
+  const out: NewContributor[] = []
+  for (const raw of body.replace(/\r\n?/g, '\n').split('\n')) {
+    const li = raw.match(LINE)
+    if (!li) continue
+    const m = li[1].trim().match(FIRST_CONTRIBUTION)
+    if (m) out.push({ login: m[1], pr: Number(m[3]), prRepo: m[2] })
+  }
+  return out
+}

--- a/site/scripts/changelog/render-markdown.ts
+++ b/site/scripts/changelog/render-markdown.ts
@@ -1,0 +1,94 @@
+// Render a release into the changelog markdown file format consumed by the
+// harness-sdk content collection (Plan 1 Zod schema). Hand-rolled minimal YAML
+// emitter -- entries are flat objects emitted as inline flow maps, mirroring the
+// committed fixtures. mergePreserving keeps any human-written highlights/body
+// on re-sync while refreshing the parsed entries/urls.
+
+import type { ReleaseFile } from './types'
+
+function q(s: unknown): string {
+  return `"${String(s)
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\t/g, '\\t')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')}"`
+}
+
+// YAML 1.1 words that, left bare, parse as booleans/null instead of strings.
+const YAML_RESERVED = new Set(['true', 'false', 'yes', 'no', 'on', 'off', 'null', 'none', '~'])
+
+// Bareword if safe for YAML, else quoted. Quote anything that starts with a
+// digit, contains YAML-significant chars, or is a reserved bool/null word.
+function scalar(v: unknown): string {
+  if (v === null || v === undefined) return 'null'
+  if (typeof v === 'number') return String(v)
+  if (v === '') return '""'
+  if (/^[\w.@/-]+$/.test(String(v)) && !/^\d/.test(String(v)) && !YAML_RESERVED.has(String(v).toLowerCase()))
+    return String(v)
+  return q(v)
+}
+
+function flowEntry(e: ReleaseFile['entries'][number]): string {
+  const parts = [
+    `type: ${e.type}`,
+    `breaking: ${e.breaking === true}`,
+    `scope: ${e.scope ? scalar(e.scope) : 'null'}`,
+    `areas: [${e.areas.map(scalar).join(', ')}]`,
+    `title: ${q(e.title)}`,
+    `pr: ${e.pr == null ? 'null' : e.pr}`,
+    `prUrl: ${e.prUrl ? q(e.prUrl) : 'null'}`,
+    `commit: ${e.commit ? q(e.commit) : 'null'}`,
+    `commitUrl: ${e.commitUrl ? q(e.commitUrl) : 'null'}`,
+    `author: ${e.author ? scalar(e.author) : 'null'}`,
+  ]
+  return `  - { ${parts.join(', ')} }`
+}
+
+/**
+ * @param f  release file shape (see build-release-file.ts)
+ * @param body  optional curated markdown body to append
+ */
+export function renderMarkdown(f: ReleaseFile, body = ''): string {
+  const lines = ['---']
+  lines.push(`sdk: ${f.sdk}`)
+  if (f.language) lines.push(`language: ${f.language}`)
+  lines.push(`version: ${q(f.version)}`)
+  lines.push(`tag: ${scalar(f.tag)}`)
+  lines.push(`date: ${f.date}`)
+  lines.push(`releaseUrl: ${f.releaseUrl}`)
+  lines.push(`packageUrl: ${f.packageUrl}`)
+  if (f.highlights && f.highlights.trim()) {
+    lines.push('highlights: |')
+    for (const l of f.highlights.replace(/\s+$/, '').split('\n')) lines.push(`  ${l}`)
+  }
+  if (f.entries && f.entries.length) {
+    lines.push('entries:')
+    for (const e of f.entries) lines.push(flowEntry(e))
+  } else {
+    lines.push('entries: []')
+  }
+  if (f.newContributors && f.newContributors.length) {
+    lines.push('newContributors:')
+    for (const c of f.newContributors) {
+      lines.push(`  - { login: ${scalar(c.login)}, pr: ${c.pr} }`)
+    }
+  }
+  lines.push('---')
+  return lines.join('\n') + '\n' + (body ? '\n' + body.replace(/\s+$/, '') + '\n' : '')
+}
+
+// Pull the human-authored highlights block + markdown body out of an existing
+// file so a re-sync doesn't clobber curation. Entries/urls always regenerate.
+export function mergePreserving(fresh: ReleaseFile, existing: string | null): string {
+  if (!existing) return renderMarkdown(fresh)
+  const fm = existing.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+  const body = fm ? fm[2].trim() : ''
+  let highlights = fresh.highlights
+  if (fm) {
+    // Capture a block scalar `highlights: |` up to the next top-level key or EOF.
+    const hl = fm[1].match(/highlights:\s*\|\s*\n([\s\S]*?)(?=\n[A-Za-z][\w-]*:|$)/)
+    if (hl) highlights = hl[1].replace(/^ {1,2}/gm, '').replace(/\s+$/, '')
+  }
+  return renderMarkdown({ ...fresh, highlights }, body)
+}

--- a/site/scripts/changelog/render-markdown.ts
+++ b/site/scripts/changelog/render-markdown.ts
@@ -6,13 +6,10 @@
 
 import type { ReleaseFile } from './types'
 
+// JSON string encoding is a strict subset of YAML double-quoted scalar syntax,
+// so this always yields a valid YAML string.
 function q(s: unknown): string {
-  return `"${String(s)
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\t/g, '\\t')
-    .replace(/\r/g, '\\r')
-    .replace(/\n/g, '\\n')}"`
+  return JSON.stringify(String(s))
 }
 
 // YAML 1.1 words that, left bare, parse as booleans/null instead of strings.

--- a/site/scripts/changelog/run.ts
+++ b/site/scripts/changelog/run.ts
@@ -1,0 +1,105 @@
+// Entry-point logic: pick releases (single tag or full backfill), build each
+// into a file, write it, and collect any format-drift warnings. Pure given an
+// injected client + fs ops, so it's unit-testable without network. The real
+// client is supplied by sync.ts via github-client.ts.
+
+import { buildReleaseFile, type BuildDeps } from './build-release-file'
+import { enrichFromPr } from './enrich'
+import { deriveEntries, previousTagInStream } from './derive-entries'
+import { tagToMeta } from './tag-meta'
+import { compareVersionDesc } from '../../src/util/semver'
+import type { Client, Release, PrData } from './types'
+
+export interface RunOpts {
+  repo: string
+  mode: 'single' | 'backfill'
+  tag?: string
+  skipExisting?: boolean
+  client: Client
+  readExisting(path: string): Promise<string | null>
+  writeFile(path: string, contents: string): Promise<void>
+}
+
+export async function run(opts: RunOpts): Promise<{ written: string[]; warnings: string[] }> {
+  const warnings: string[] = []
+  let releases: Release[]
+  if (opts.mode === 'backfill') {
+    releases = await opts.client.listReleases(opts.repo)
+  } else {
+    const r = await opts.client.getRelease(opts.repo, opts.tag!)
+    releases = r ? [r] : []
+    if (!r) warnings.push(`${opts.repo}: no release found for tag "${opts.tag || ''}" -- nothing to sync.`)
+  }
+
+  // Skip drafts (no published_at). Keep prereleases whose tag maps to a
+  // recognized stream version (e.g. typescript/v1.0.0-rc.0) -- rc releases are
+  // a first-class part of the changelog (the semver util orders them, and they
+  // are backfilled), and whether they appear must NOT hinge on whether the
+  // publisher ticked GitHub's "pre-release" box. A flagged prerelease whose tag
+  // is NOT a recognized version (an oddball/non-stream tag) is still dropped.
+  releases = releases.filter((r) => r && r.published_at && (!r.prerelease || tagToMeta(opts.repo, r.tag_name) != null))
+
+  // Memoize PR fetches: a first-time contributor's PR usually also appears in
+  // "What's Changed", and on the monorepo each fetch includes a paginated file
+  // list -- caching roughly halves API spend on a backfill.
+  const prCache = new Map<string, Promise<PrData | null>>()
+  const getPr = (repo: string, num: number) => {
+    const key = `${repo}#${num}`
+    if (!prCache.has(key)) prCache.set(key, opts.client.getPr(repo, num))
+    return prCache.get(key)!
+  }
+
+  // Resolve the prior tag (same stream) to diff each release against.
+  // Backfill: derive it from the already-fetched release list (no extra tag
+  // listing). Single: query tags via previousTagInStream. Cached per tag.
+  const priorCache = new Map<string, string | null>()
+  const streamKey = (m: ReturnType<typeof tagToMeta>) => (m ? `${m.sdk}:${m.language ?? ''}` : null)
+  let backfillPrior: Map<string, string | null> | null = null
+  if (opts.mode === 'backfill') {
+    // Group in-scope release tags by stream, newest-first, so each release's
+    // predecessor is the next one down in its own stream.
+    backfillPrior = new Map()
+    const byStream = new Map<string, Array<{ tag: string; version: string }>>()
+    for (const r of releases) {
+      const m = tagToMeta(opts.repo, r.tag_name)
+      const k = streamKey(m)
+      if (!k) continue
+      if (!byStream.has(k)) byStream.set(k, [])
+      byStream.get(k)!.push({ tag: r.tag_name, version: m!.version })
+    }
+    for (const list of byStream.values()) {
+      list.sort((a, b) => compareVersionDesc(a.version, b.version)) // newest-first
+      for (let i = 0; i < list.length; i++) {
+        backfillPrior.set(list[i].tag, list[i + 1] ? list[i + 1].tag : null)
+      }
+    }
+  }
+  const priorTagFor = async (tag: string): Promise<string | null> => {
+    if (priorCache.has(tag)) return priorCache.get(tag)!
+    const prior = backfillPrior
+      ? (backfillPrior.get(tag) ?? null)
+      : await previousTagInStream(opts.repo, tag, opts.client)
+    priorCache.set(tag, prior)
+    return prior
+  }
+
+  const deps: BuildDeps = {
+    deriveEntries: async (repo: string, release: Release) => {
+      const base = await priorTagFor(release.tag_name)
+      return deriveEntries({ repo, base, head: release.tag_name, client: opts.client })
+    },
+    enrich: (prRepo: string, pr: number) => enrichFromPr(prRepo, pr, getPr),
+    readExisting: opts.readExisting,
+    skipExisting: opts.skipExisting === true,
+  }
+
+  const written: string[] = []
+  for (const release of releases) {
+    const built = await buildReleaseFile(opts.repo, release, deps)
+    if (!built) continue
+    await opts.writeFile(built.path, built.contents)
+    written.push(built.path)
+    if (built.warning) warnings.push(built.warning)
+  }
+  return { written, warnings }
+}

--- a/site/scripts/changelog/sync.ts
+++ b/site/scripts/changelog/sync.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env tsx
+// CLI entry for the changelog generator. Generates/updates the changelog .md
+// files in the working tree. Does NOT open a PR -- the workflow (or a developer
+// running this locally) commits the resulting diff. Runnable locally:
+//   tsx scripts/changelog/sync.ts --mode backfill
+//   tsx scripts/changelog/sync.ts --tag python/v1.42.0
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join, dirname, resolve } from 'node:path'
+import { execSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { run } from './run'
+import { makeClient } from './github-client'
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 ? process.argv[i + 1] : undefined
+}
+function flag(name: string): boolean {
+  return process.argv.includes(`--${name}`)
+}
+
+function resolveToken(): string {
+  // Prefer GITHUB_TOKEN env over --token: the --token CLI arg is visible via
+  // `ps` and /proc on shared systems. Use GITHUB_TOKEN or `gh auth login`
+  // instead; --token is supported but discouraged outside local dev.
+  const explicit = arg('token') || process.env.GITHUB_TOKEN
+  if (explicit) return explicit
+  try {
+    return execSync('gh auth token', { encoding: 'utf8' }).trim()
+  } catch (e: any) {
+    const detail = e.stderr ? String(e.stderr).trim() : e.message
+    throw new Error(`No token: pass --token, set GITHUB_TOKEN, or run \`gh auth login\`. (gh error: ${detail})`)
+  }
+}
+
+async function main() {
+  const sourceRepo = arg('source-repo') || process.env.SOURCE_REPO || 'strands-agents/harness-sdk'
+  const mode = (arg('mode') || process.env.MODE) === 'backfill' ? 'backfill' : 'single'
+  const tag = arg('tag') || process.env.TAG || undefined
+  const skipExisting = flag('skip-existing') || process.env.SKIP_EXISTING === 'true'
+
+  if (mode === 'single' && !tag) {
+    console.error('changelog: single mode requires --tag <release-tag> (or use --mode backfill).')
+    process.exit(1)
+  }
+
+  // The site dir is the repo-relative root for content paths (build-release-file
+  // returns paths like "site/src/content/changelog/...").
+  const here = dirname(fileURLToPath(import.meta.url))
+  const repoRoot = resolve(here, '../../..') // scripts/changelog -> site -> repo root
+
+  const warnings: string[] = []
+  const client = makeClient(resolveToken(), (m) => warnings.push(m))
+
+  const result = await run({
+    repo: sourceRepo,
+    mode,
+    tag,
+    skipExisting,
+    client,
+    readExisting: async (p) => {
+      try {
+        return readFileSync(join(repoRoot, p), 'utf8')
+      } catch {
+        return null
+      }
+    },
+    writeFile: async (p, contents) => {
+      const full = join(repoRoot, p)
+      mkdirSync(dirname(full), { recursive: true })
+      writeFileSync(full, contents)
+    },
+  })
+
+  console.log(`changelog: wrote ${result.written.length} file(s)`)
+  for (const w of [...warnings, ...result.warnings]) console.warn(`warning: ${w}`)
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : e)
+  process.exit(1)
+})

--- a/site/scripts/changelog/tag-meta.ts
+++ b/site/scripts/changelog/tag-meta.ts
@@ -1,0 +1,50 @@
+// Map a repo + release tag to changelog metadata, and build package-registry URLs.
+// Pure, dependency-free. Mirrors site/src/config/changelog.ts (Plan 1 contract).
+
+import type { TagMeta, Sdk, Language } from './types'
+
+function cleanVersion(raw: string): string {
+  // Strip a leading 'v' and any stray dot after it (handles 'v.1.2.0').
+  return raw.replace(/^v\.?/, '')
+}
+
+/**
+ * @param repo  e.g. 'strands-agents/harness-sdk' | 'strands-agents/evals'
+ * @param tag   the release tag
+ */
+export function tagToMeta(repo: string, tag: string): TagMeta | null {
+  const isEvals = repo.endsWith('/evals')
+  if (isEvals) {
+    // Evals is python-only; accept bare vX or python/vX.
+    const m = tag.match(/(?:^|\/)v\.?(\d.*)$/)
+    if (!m) return null
+    return { sdk: 'evals', language: undefined, version: cleanVersion('v' + m[1]) }
+  }
+  // The archived pre-monorepo TypeScript repo: all its releases are
+  // harness/typescript history (used only by the one-time backfill).
+  if (repo.endsWith('/sdk-typescript')) {
+    if (!/^v\.?\d/.test(tag)) return null
+    return { sdk: 'harness', language: 'typescript', version: cleanVersion(tag) }
+  }
+  // harness-sdk
+  if (tag.startsWith('python-wasm/')) return null
+  if (tag.startsWith('python/')) {
+    return { sdk: 'harness', language: 'python', version: cleanVersion(tag.slice('python/'.length)) }
+  }
+  if (tag.startsWith('typescript/')) {
+    return { sdk: 'harness', language: 'typescript', version: cleanVersion(tag.slice('typescript/'.length)) }
+  }
+  if (/^v\.?\d/.test(tag)) {
+    return { sdk: 'harness', language: 'python', version: cleanVersion(tag) }
+  }
+  return null
+}
+
+const pypi = (name: string, v: string) => `https://pypi.org/project/${name}/${v}/`
+const npm = (name: string, v: string) => `https://www.npmjs.com/package/${name}/v/${v}`
+
+export function getPackageUrl(sdk: Sdk, language: Language | undefined, version: string): string {
+  if (sdk === 'evals') return pypi('strands-agents-evals', version)
+  if (language === 'typescript') return npm('@strands-agents/sdk', version)
+  return pypi('strands-agents', version)
+}

--- a/site/scripts/changelog/types.ts
+++ b/site/scripts/changelog/types.ts
@@ -1,0 +1,113 @@
+// Shared interfaces for the changelog generator. Mirrors the injected-dependency
+// shapes the pure modules consumed as JSDoc typedefs in the devtools .cjs source.
+
+export type Sdk = 'harness' | 'evals'
+export type Language = 'python' | 'typescript'
+
+export interface TagMeta {
+  sdk: Sdk
+  language?: Language
+  version: string
+}
+
+/** A GitHub release, as much of it as the generator reads. */
+export interface Release {
+  tag_name: string
+  published_at: string | null
+  html_url: string
+  body: string | null
+  prerelease?: boolean
+}
+
+/** PR data the enricher needs (built by github-client from the GitHub API). */
+export interface PrData {
+  labels: string[]
+  merge_commit_sha: string | null
+  user: string | null
+  files?: string[]
+}
+
+/** One classified line before enrichment. */
+export interface ParsedEntry {
+  type: string
+  scope: string | null
+  breaking: boolean
+  title: string
+  author: string | null
+  pr: number | null
+  prRepo: string | null
+}
+
+/** A first-time contributor parsed from the release body. */
+export interface NewContributor {
+  login: string
+  pr: number
+  prRepo: string
+}
+
+/** Enrichment derived from a PR. */
+export interface Enrichment {
+  areas: string[]
+  breaking: boolean
+  commit: string | null
+  author: string | null
+  languages: string[] | null
+  docsOnly: boolean
+}
+
+// RenderedEntry and ReleaseFile are hand-written rather than reused via
+// z.infer from src/content.config.ts because that schema module imports from
+// 'astro:content', which cannot be evaluated in the plain tsx/Node build-time
+// context this generator runs in. Additionally, ReleaseFile.date is a string
+// here -- the Zod schema coerces it to Date at content-collection read time.
+
+/** A fully built, render-ready entry. */
+export interface RenderedEntry {
+  type: string
+  breaking: boolean
+  scope: string | null
+  areas: string[]
+  title: string
+  pr: number | null
+  prUrl: string | null
+  commit: string | null
+  commitUrl: string | null
+  author: string | null
+}
+
+/** The release-file shape render-markdown consumes. */
+export interface ReleaseFile {
+  sdk: Sdk
+  language?: Language
+  version: string
+  tag: string
+  date: string
+  releaseUrl: string
+  packageUrl: string
+  highlights?: string
+  entries: RenderedEntry[]
+  newContributors: NewContributor[]
+}
+
+/** A single derived commit from the compare API. */
+export interface CompareCommit {
+  sha: string
+}
+
+/** A PR associated with a commit. */
+export interface CommitPull {
+  number: number
+  title: string
+  user: string | null
+}
+
+/** The injected GitHub client. github-client.ts provides the real one;
+ *  tests provide fakes. */
+export interface Client {
+  listReleases(repo: string): Promise<Release[]>
+  getRelease(repo: string, tag: string): Promise<Release | null>
+  getPr(repo: string, num: number): Promise<PrData | null>
+  listTags(repo: string): Promise<Array<{ name: string; commitSha?: string }>>
+  compareCommits(repo: string, base: string, head: string): Promise<{ commits: CompareCommit[]; truncated?: boolean }>
+  commitPulls(repo: string, sha: string): Promise<CommitPull[]>
+}

--- a/site/test/changelog/build-release-file.test.ts
+++ b/site/test/changelog/build-release-file.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect } from 'vitest'
+import { buildReleaseFile } from '../../scripts/changelog/build-release-file'
+import { classifyTitle } from '../../scripts/changelog/parse-release-body'
+import type { BuildDeps } from '../../scripts/changelog/build-release-file'
+
+// buildReleaseFile sources entries from deps.deriveEntries (compare-driven), not
+// from the release body. These tests describe the desired entry set as a bullet
+// body for readability; this local helper turns that bullet body into the
+// parsed-line shape deriveEntries returns, so the tests exercise the same
+// downstream enrichment + gating the real derive feeds. (It is NOT the
+// production path -- that reads the compare API.)
+const BULLET =
+  /^\s*[-*]\s+(.*?)(?:\s+by\s+@([\w-]+(?:\[[\w-]+\])?))?\s+in\s+https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\s*$/
+const parseBulletBody = (body: string | null | undefined) =>
+  String(body || '')
+    .split('\n')
+    .map((line) => line.match(BULLET))
+    .filter((m): m is RegExpMatchArray => m !== null && !/made their first contribution/.test(m[0]))
+    .map((m) => ({ ...classifyTitle(m[1]), author: m[2] || null, pr: Number(m[4]), prRepo: m[3] }))
+const bodyDerive = async (_repo: string, release: { body: string | null }) => ({
+  entries: parseBulletBody(release.body),
+  warning: undefined,
+})
+
+const release = {
+  tag_name: 'python/v1.42.0',
+  published_at: '2026-06-01T18:18:57Z',
+  html_url: 'https://github.com/strands-agents/harness-sdk/releases/tag/python%2Fv1.42.0',
+  body: "## What's Changed\n* feat(model): plumb cache tokens by @yatszhash in https://github.com/strands-agents/sdk-python/pull/2287\n",
+}
+
+describe('build-release-file', () => {
+  it('produces correct path + parsed/enriched contents', async () => {
+    const result = await buildReleaseFile('strands-agents/harness-sdk', release, {
+      enrich: async () => ({
+        areas: ['model'],
+        breaking: false,
+        commit: '155239d',
+        author: 'yatszhash',
+        languages: null,
+        docsOnly: false,
+      }),
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    } as any)
+    expect(result!.path).toBe('site/src/content/changelog/harness/python-v1.42.0.md')
+    expect(result!.contents).toMatch(/sdk: harness/)
+    expect(result!.contents).toMatch(/title: "plumb cache tokens"/)
+    expect(result!.contents).toMatch(/areas: \[model\]/)
+    // prUrl/commitUrl use the PR's own repo (sdk-python), not harness-sdk
+    expect(result!.contents).toMatch(/sdk-python\/pull\/2287/)
+    expect(result!.contents).toMatch(/sdk-python\/commit\/155239d/)
+    expect(result!.warning).toBe(undefined)
+  })
+
+  it('evals file path + no language', async () => {
+    const evalsRelease = {
+      tag_name: 'v0.2.1',
+      published_at: '2026-05-29T00:00:00Z',
+      html_url: 'https://github.com/strands-agents/evals/releases/tag/v0.2.1',
+      body: '* feat: add chaos testing by @x in https://github.com/strands-agents/evals/pull/224\n',
+    }
+    const r = await buildReleaseFile('strands-agents/evals', evalsRelease, {
+      enrich: async () => ({
+        areas: [],
+        breaking: false,
+        commit: 'aaa1111',
+        author: 'x',
+        languages: null,
+        docsOnly: false,
+      }),
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    } as any)
+    expect(r!.path).toBe('site/src/content/changelog/evals/v0.2.1.md')
+    expect(r!.contents).not.toMatch(/\nlanguage:/)
+  })
+
+  it('skips out-of-scope tags', async () => {
+    const r = await buildReleaseFile('strands-agents/harness-sdk', { ...release, tag_name: 'python-wasm/v0.0.1' }, {
+      enrich: async () => ({
+        areas: [],
+        breaking: false,
+        commit: null,
+        author: null,
+        languages: null,
+        docsOnly: false,
+      }),
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    } as any)
+    expect(r).toBe(null)
+  })
+
+  it('passes through a derive warning (e.g. truncated compare range)', async () => {
+    const r = await buildReleaseFile('strands-agents/harness-sdk', release, {
+      deriveEntries: async () => ({ entries: [], warning: 'python/v1.42.0: compare range exceeded 250 commits' }),
+      enrich: async () => ({
+        areas: [],
+        breaking: false,
+        commit: null,
+        author: null,
+        languages: null,
+        docsOnly: false,
+      }),
+      readExisting: async () => null,
+    } as any)
+    expect(r).toBeTruthy()
+    expect(r!.warning).toMatch(/exceeded 250 commits/)
+  })
+
+  it('monorepo release filters entries by stream language from PR files', async () => {
+    const body = [
+      '* feat: py thing by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+      '* feat: ts thing by @b in https://github.com/strands-agents/harness-sdk/pull/2',
+      '* feat: both thing by @c in https://github.com/strands-agents/harness-sdk/pull/3',
+      '* chore: neither-dir thing by @d in https://github.com/strands-agents/harness-sdk/pull/4',
+      '* fix: unknown thing by @e in https://github.com/strands-agents/harness-sdk/pull/5',
+    ].join('\n')
+    // 4 = empty languages (touches neither SDK dir -- e.g. root/ci, or a flat-layout
+    // pre-monorepo PR). 5 = unknown (files unavailable).
+    const langByPr: Record<number, string[] | null> = {
+      1: ['python'],
+      2: ['typescript'],
+      3: ['python', 'typescript'],
+      4: [],
+      5: null,
+    }
+    const deps = {
+      enrich: async (_repo: string, pr: number) => ({
+        areas: [],
+        breaking: false,
+        commit: null,
+        author: null,
+        languages: langByPr[pr],
+        docsOnly: false,
+      }),
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    }
+    const py = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body },
+      deps as any
+    )
+    // python stream keeps py(1), both(3); drops ts(2). Empty-languages(4) and
+    // unknown(5) are KEPT -- only a POSITIVE other-language signal drops a PR.
+    expect(py!.contents).toMatch(/py thing/)
+    expect(py!.contents).toMatch(/both thing/)
+    expect(py!.contents).toMatch(/neither-dir thing/)
+    expect(py!.contents).toMatch(/unknown thing/)
+    expect(py!.contents).not.toMatch(/ts thing/)
+
+    const ts = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'typescript/v1.5.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body },
+      deps as any
+    )
+    // typescript stream: keeps ts(2), both(3), neither-dir(4), unknown(5); drops py(1)
+    expect(ts!.contents).toMatch(/ts thing/)
+    expect(ts!.contents).toMatch(/both thing/)
+    expect(ts!.contents).toMatch(/neither-dir thing/)
+    expect(ts!.contents).toMatch(/unknown thing/)
+    expect(ts!.contents).not.toMatch(/py thing/)
+    expect(ts!.contents).not.toMatch(/site thing/)
+  })
+
+  it('monorepo-tagged release with PRs in the OLD flat repo is not language-gated', async () => {
+    // Early python releases were re-tagged `python/v*` but their PRs live in the
+    // old `sdk-python` repo (code under `src/`, no strands-py/ dir). The file
+    // signal there is empty languages -- gating on it would empty the release.
+    const body = [
+      '* feat: real py feature by @a in https://github.com/strands-agents/sdk-python/pull/423',
+      '* fix: another py fix by @b in https://github.com/strands-agents/sdk-python/pull/429',
+    ].join('\n')
+    const deps = {
+      // old-repo PRs touch src/ etc -> languagesFromFiles yields [] (empty)
+      enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: false }),
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    }
+    const r = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'python/v1.0.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body },
+      deps as any
+    )
+    // Both entries must survive -- the cross-repo PRs are python by provenance,
+    // not gated by the (nonexistent) monorepo dir signal.
+    expect(r!.contents).toMatch(/real py feature/)
+    expect(r!.contents).toMatch(/another py fix/)
+  })
+
+  it('pre-monorepo and evals releases are not language-filtered', async () => {
+    const deps = {
+      // even if files say typescript, a single-language-repo release keeps everything
+      enrich: async () => ({
+        areas: [],
+        breaking: false,
+        commit: null,
+        author: null,
+        languages: ['typescript'],
+        docsOnly: false,
+      }),
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    }
+    const old = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      {
+        tag_name: 'v1.9.1',
+        published_at: '2026-01-01T00:00:00Z',
+        html_url: 'h',
+        body: '* feat: old thing by @a in https://github.com/strands-agents/sdk-python/pull/9',
+      },
+      deps as any
+    )
+    expect(old!.contents).toMatch(/old thing/)
+    const ev = await buildReleaseFile(
+      'strands-agents/evals',
+      {
+        tag_name: 'v0.2.1',
+        published_at: '2026-01-01T00:00:00Z',
+        html_url: 'h',
+        body: '* feat: eval thing by @a in https://github.com/strands-agents/evals/pull/9',
+      },
+      deps as any
+    )
+    expect(ev!.contents).toMatch(/eval thing/)
+  })
+
+  it('new contributors are language-gated, but docs/ci-only ones appear in both streams', async () => {
+    const body = [
+      '* feat: x by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+      '',
+      '## New Contributors',
+      '* @pydev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/10',
+      '* @tsdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/11',
+      '* @docsdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/12',
+      '* @mystery made their first contribution in https://github.com/strands-agents/harness-sdk/pull/13',
+    ].join('\n')
+    const langByPr: Record<number, string[] | null> = {
+      1: ['python'],
+      10: ['python'],
+      11: ['typescript'],
+      12: [],
+      13: null,
+    }
+    const deps = {
+      enrich: async (_r: string, pr: number) => ({
+        areas: [],
+        breaking: false,
+        commit: null,
+        author: null,
+        languages: langByPr[pr],
+        docsOnly: false,
+      }),
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    }
+    const py = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body },
+      deps as any
+    )
+    // python stream: pydev (python), docsdev (neither -> both), mystery (unknown -> both); NOT tsdev
+    expect(py!.contents).toMatch(/login: pydev/)
+    expect(py!.contents).toMatch(/login: docsdev/)
+    expect(py!.contents).toMatch(/login: mystery/)
+    expect(py!.contents).not.toMatch(/login: tsdev/)
+
+    const ts = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'typescript/v1.5.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body },
+      deps as any
+    )
+    expect(ts!.contents).toMatch(/login: tsdev/)
+    expect(ts!.contents).toMatch(/login: docsdev/)
+    expect(ts!.contents).toMatch(/login: mystery/)
+    expect(ts!.contents).not.toMatch(/login: pydev/)
+  })
+
+  it('docs-only PRs are dropped on every stream (incl. pre-monorepo and evals)', async () => {
+    const body = [
+      '* feat: real code by @a in https://github.com/strands-agents/sdk-python/pull/1',
+      '* docs: blog post by @b in https://github.com/strands-agents/sdk-python/pull/2',
+    ].join('\n')
+    const deps = {
+      enrich: async (_r: string, pr: number) =>
+        pr === 2
+          ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }
+          : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false },
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    }
+    // pre-monorepo bare-v (no language gate, but docs-only still drops)
+    const old = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'v1.9.1', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body },
+      deps as any
+    )
+    expect(old!.contents).toMatch(/real code/)
+    expect(old!.contents).not.toMatch(/blog post/)
+    // evals (no language gate either)
+    const ev = await buildReleaseFile(
+      'strands-agents/evals',
+      {
+        tag_name: 'v0.2.1',
+        published_at: '2026-01-01T00:00:00Z',
+        html_url: 'h',
+        body: '* docs: site only by @b in https://github.com/strands-agents/evals/pull/2',
+      },
+      {
+        enrich: async () => ({ areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }),
+        deriveEntries: bodyDerive,
+        readExisting: async () => null,
+      } as any
+    )
+    expect(ev!.contents).not.toMatch(/site only/)
+  })
+
+  it('docs-only first-time contributors are dropped on every stream', async () => {
+    const body = [
+      '* feat: x by @a in https://github.com/strands-agents/sdk-python/pull/1',
+      '',
+      '## New Contributors',
+      '* @blogger made their first contribution in https://github.com/strands-agents/sdk-python/pull/2',
+    ].join('\n')
+    const deps = {
+      enrich: async (_r: string, pr: number) =>
+        pr === 2
+          ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }
+          : { areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false },
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    }
+    // pre-monorepo stream: a blog-only first contribution does NOT appear
+    const old = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'v1.9.1', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body },
+      deps as any
+    )
+    expect(old!.contents).not.toMatch(/login: blogger/)
+  })
+
+  it('monorepo new contributor whose PR is in the OLD flat repo is not language-gated', async () => {
+    // Mirror of the entries-loop guard for the contributors loop: a python/v*
+    // release's first-contributor PR can live in sdk-python (no strands-py/ dir ->
+    // languages []). It must NOT be dropped by the language gate.
+    const body = [
+      '* feat: x by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+      '',
+      '## New Contributors',
+      '* @earlybird made their first contribution in https://github.com/strands-agents/sdk-python/pull/900',
+    ].join('\n')
+    const deps = {
+      enrich: async (_r: string, pr: number) =>
+        pr === 900
+          ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: false } // cross-repo, code-touching
+          : { areas: [], breaking: false, commit: null, author: null, languages: ['python'], docsOnly: false },
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    }
+    const py = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body },
+      deps as any
+    )
+    expect(py!.contents).toMatch(/login: earlybird/) // survives -- cross-repo, not dir-gated
+  })
+
+  it('docs-only contributor is dropped even on a monorepo stream', async () => {
+    // Pins the gate ordering: docs-only check runs before the language gate.
+    const body = [
+      '* feat: x by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+      '',
+      '## New Contributors',
+      '* @docsdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/5',
+    ].join('\n')
+    const deps = {
+      enrich: async (_r: string, pr: number) =>
+        pr === 5
+          ? { areas: [], breaking: false, commit: null, author: null, languages: [], docsOnly: true }
+          : { areas: [], breaking: false, commit: null, author: null, languages: ['python'], docsOnly: false },
+      deriveEntries: bodyDerive,
+      readExisting: async () => null,
+    }
+    const py = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body },
+      deps as any
+    )
+    expect(py!.contents).not.toMatch(/login: docsdev/)
+  })
+
+  it('new contributors flow into frontmatter, not entries', async () => {
+    const body = [
+      '* feat: real thing by @a in https://github.com/strands-agents/harness-sdk/pull/1',
+      '',
+      '## New Contributors',
+      '* @newdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/2700',
+    ].join('\n')
+    const r = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { tag_name: 'python/v1.43.0', published_at: '2026-06-12T00:00:00Z', html_url: 'h', body },
+      {
+        enrich: async () => ({
+          areas: [],
+          breaking: false,
+          commit: null,
+          author: null,
+          languages: ['python'],
+          docsOnly: false,
+        }),
+        deriveEntries: bodyDerive,
+        readExisting: async () => null,
+      } as any
+    )
+    expect(r!.contents).toMatch(/newContributors:\n  - \{ login: newdev, pr: 2700 \}/)
+    expect(r!.contents).not.toMatch(/first contribution/) // not an entry
+  })
+
+  it('breaking marker promotes type when no conventional type', async () => {
+    // a non-conventional line that the PR labels mark breaking -> type becomes 'breaking'
+    const r = await buildReleaseFile(
+      'strands-agents/harness-sdk',
+      { ...release, body: '* drop the old api by @x in https://github.com/strands-agents/harness-sdk/pull/1\n' },
+      {
+        enrich: async () => ({
+          areas: [],
+          breaking: true,
+          commit: 'bbb2222',
+          author: 'x',
+          languages: null,
+          docsOnly: false,
+        }),
+        deriveEntries: bodyDerive,
+        readExisting: async () => null,
+      } as any
+    )
+    expect(r!.contents).toMatch(/type: breaking/)
+    expect(r!.contents).toMatch(/breaking: true/)
+  })
+})

--- a/site/test/changelog/derive-entries.test.ts
+++ b/site/test/changelog/derive-entries.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import { deriveEntries, previousTagInStream } from '../../scripts/changelog/derive-entries'
+
+describe('derive-entries', () => {
+  // --- deriveEntries -----------------------------------------------------------
+
+  it('derives parsed-line entries from compare commits via commit->PR', async () => {
+    const client = {
+      compareCommits: async () => ({
+        commits: [{ sha: 'a1' }, { sha: 'b2' }],
+        truncated: false,
+      }),
+      commitPulls: async (_repo: any, sha: string) =>
+        sha === 'a1'
+          ? [{ number: 1799, title: 'feat(model): add service_tier', user: 'pgrayy' }]
+          : [{ number: 2087, title: 'fix: enforce user-first message', user: 'lizradway' }],
+    }
+    const { entries, truncated } = await deriveEntries({
+      repo: 'strands-agents/harness-sdk',
+      base: 'python/v1.34.1',
+      head: 'python/v1.35.0',
+      client: client as any,
+    })
+    expect(truncated).toBe(false)
+    expect(entries).toEqual([
+      {
+        type: 'feat',
+        scope: 'model',
+        breaking: false,
+        title: 'add service_tier',
+        author: 'pgrayy',
+        pr: 1799,
+        prRepo: 'strands-agents/harness-sdk',
+      },
+      {
+        type: 'fix',
+        scope: null,
+        breaking: false,
+        title: 'enforce user-first message',
+        author: 'lizradway',
+        pr: 2087,
+        prRepo: 'strands-agents/harness-sdk',
+      },
+    ])
+  })
+
+  it('dedups a PR that spans multiple commits', async () => {
+    const client = {
+      compareCommits: async () => ({ commits: [{ sha: 'a1' }, { sha: 'a2' }], truncated: false }),
+      commitPulls: async () => [{ number: 500, title: 'feat: x', user: 'a' }], // same PR on both commits
+    }
+    const { entries } = await deriveEntries({ repo: 'r', base: 'v1', head: 'v2', client: client as any })
+    expect(entries.length).toBe(1)
+    expect(entries[0].pr).toBe(500)
+  })
+
+  it('skips commits with no associated PR (direct push)', async () => {
+    const client = {
+      compareCommits: async () => ({ commits: [{ sha: 'a1' }, { sha: 'a2' }], truncated: false }),
+      commitPulls: async (_r: any, sha: string) => (sha === 'a1' ? [{ number: 7, title: 'fix: y', user: 'b' }] : []),
+    }
+    const { entries } = await deriveEntries({ repo: 'r', base: 'v1', head: 'v2', client: client as any })
+    expect(entries.map((e) => e.pr)).toEqual([7])
+  })
+
+  it('no prior tag -> no entries, with a warning', async () => {
+    const { entries, warning } = await deriveEntries({ repo: 'r', base: null, head: 'v0.1.0', client: {} as any })
+    expect(entries).toEqual([])
+    expect(warning).toMatch(/no prior tag/)
+  })
+
+  it('truncated compare range yields a warning', async () => {
+    const client = {
+      compareCommits: async () => ({ commits: [{ sha: 'a1' }], truncated: true }),
+      commitPulls: async () => [{ number: 1, title: 'feat: z', user: 'c' }],
+    }
+    const { truncated, warning } = await deriveEntries({ repo: 'r', base: 'v1', head: 'v2', client: client as any })
+    expect(truncated).toBe(true)
+    expect(warning).toMatch(/250-commit cap/)
+  })
+
+  it('processes every commit in a large (paginated) range -- no downstream cap', async () => {
+    // The client paginates compare; deriveEntries must emit an entry for each of
+    // the >100 commits it returns (guards against a regression to first-page-only).
+    const N = 230
+    const commits = Array.from({ length: N }, (_, i) => ({ sha: `s${i}` }))
+    const client = {
+      compareCommits: async () => ({ commits, truncated: false }),
+      commitPulls: async (_r: any, sha: string) => [
+        { number: Number(sha.slice(1)) + 1, title: `feat: c${sha}`, user: 'a' },
+      ],
+    }
+    const { entries } = await deriveEntries({ repo: 'r', base: 'v1', head: 'v2', client: client as any })
+    expect(entries.length).toBe(N)
+  })
+
+  // --- previousTagInStream -----------------------------------------------------
+
+  const harnessTags = (names: string[]) => ({ listTags: async () => names.map((name) => ({ name })) })
+
+  it('finds the immediate predecessor in the python stream', async () => {
+    const client = harnessTags([
+      'python/v1.36.0',
+      'python/v1.35.0',
+      'python/v1.34.1',
+      'typescript/v1.5.0',
+      'python/v1.34.0',
+    ])
+    const prior = await previousTagInStream('strands-agents/harness-sdk', 'python/v1.35.0', client)
+    expect(prior).toBe('python/v1.34.1')
+  })
+
+  it('ignores tags from other streams', async () => {
+    // typescript tags must not be chosen as the prior for a python release
+    const client = harnessTags(['typescript/v1.9.0', 'python/v1.20.0', 'typescript/v1.8.0'])
+    const prior = await previousTagInStream('strands-agents/harness-sdk', 'python/v1.21.0', client)
+    expect(prior).toBe('python/v1.20.0')
+  })
+
+  it('orders numerically, not lexically (v1.9.0 precedes v1.10.0)', async () => {
+    const client = harnessTags(['python/v1.10.0', 'python/v1.9.0', 'python/v1.8.0'])
+    const prior = await previousTagInStream('strands-agents/harness-sdk', 'python/v1.10.0', client)
+    expect(prior).toBe('python/v1.9.0')
+  })
+
+  it('returns null for the first release in a stream', async () => {
+    const client = harnessTags(['python/v1.0.0', 'typescript/v0.5.0'])
+    const prior = await previousTagInStream('strands-agents/harness-sdk', 'python/v1.0.0', client)
+    expect(prior).toBe(null)
+  })
+
+  it('evals bare-v stream resolves its own predecessor', async () => {
+    const client = { listTags: async () => ['v0.2.0', 'v0.1.17', 'v0.1.16'].map((name) => ({ name })) }
+    const prior = await previousTagInStream('strands-agents/evals', 'v0.2.0', client)
+    expect(prior).toBe('v0.1.17')
+  })
+})

--- a/site/test/changelog/enrich.test.ts
+++ b/site/test/changelog/enrich.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import { enrichFromPr } from '../../scripts/changelog/enrich'
+
+describe('enrich', () => {
+  it('extracts areas, commit, author', async () => {
+    const fetcher = async (repo: string, num: number) => {
+      expect(repo).toBe('strands-agents/harness-sdk')
+      expect(num).toBe(2287)
+      return {
+        labels: ['enhancement', 'python', 'area-model', 'area-otel', 'size/xs'],
+        merge_commit_sha: '155239dca769c8eea7652b2496822ea47283a1a9',
+        user: 'yatszhash',
+      }
+    }
+    const e = await enrichFromPr('strands-agents/harness-sdk', 2287, fetcher)
+    expect(e.areas).toEqual(['model', 'otel'])
+    expect(e.breaking).toBe(false)
+    expect(e.commit).toBe('155239d')
+    expect(e.author).toBe('yatszhash')
+  })
+
+  it('detects breaking label', async () => {
+    const f = async () => ({ labels: ['breaking change'], merge_commit_sha: 'abcdef0123', user: 'x' })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.breaking).toBe(true)
+  })
+
+  it('missing pr degrades gracefully (fetcher returns null)', async () => {
+    const f = async () => null
+    const e = await enrichFromPr('r', 1, f)
+    expect(e).toEqual({ areas: [], breaking: false, commit: null, author: null, languages: null, docsOnly: false })
+  })
+
+  it('docsOnly true when every file is under site/ or docs/', async () => {
+    const f = async () => ({
+      labels: [],
+      merge_commit_sha: 'abc1234',
+      user: 'x',
+      files: ['site/src/content/blog/post.md', 'docs/guide.md'],
+    })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.docsOnly).toBe(true)
+  })
+
+  it('docsOnly false when a PR also touches code', async () => {
+    const f = async () => ({
+      labels: [],
+      merge_commit_sha: 'abc1234',
+      user: 'x',
+      files: ['site/blog/post.md', 'strands-py/src/agent.py'],
+    })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.docsOnly).toBe(false)
+  })
+
+  it('docsOnly false on unknown or empty file info (do not drop)', async () => {
+    const unknown = await enrichFromPr('r', 1, async () => ({ labels: [], merge_commit_sha: 'a', user: 'x' }))
+    expect(unknown.docsOnly).toBe(false)
+    const empty = await enrichFromPr('r', 1, async () => ({ labels: [], merge_commit_sha: 'a', user: 'x', files: [] }))
+    expect(empty.docsOnly).toBe(false)
+  })
+
+  it('docsOnly true for top-level doc files (README, AGENTS.md, CONTRIBUTING)', async () => {
+    const f = async () => ({
+      labels: [],
+      merge_commit_sha: 'a',
+      user: 'x',
+      files: ['README.md', 'AGENTS.md', 'CONTRIBUTING'],
+    })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.docsOnly).toBe(true)
+  })
+
+  it('docsOnly false when a root doc PR also touches code', async () => {
+    const f = async () => ({
+      labels: [],
+      merge_commit_sha: 'a',
+      user: 'x',
+      files: ['README.md', 'strands-py/src/agent.py'],
+    })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.docsOnly).toBe(false)
+  })
+
+  it('docsOnly false for a top-level non-doc file (e.g. pyproject.toml)', async () => {
+    // A root config/build file is not docs -- don't drop a release-affecting change.
+    const f = async () => ({ labels: [], merge_commit_sha: 'a', user: 'x', files: ['pyproject.toml'] })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.docsOnly).toBe(false)
+  })
+
+  it('no merge sha yields null commit', async () => {
+    const f = async () => ({ labels: [], merge_commit_sha: null, user: null })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.commit).toBe(null)
+    expect(e.author).toBe(null)
+  })
+
+  it('derives languages from monorepo top-level dirs', async () => {
+    const f = async () => ({
+      labels: [],
+      merge_commit_sha: 'abc1234',
+      user: 'x',
+      files: ['strands-py/src/agent.py', 'strands-py/tests/t.py'],
+    })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.languages).toEqual(['python'])
+  })
+
+  it('PR touching both sdk dirs yields both languages', async () => {
+    const f = async () => ({
+      labels: [],
+      merge_commit_sha: 'abc1234',
+      user: 'x',
+      files: ['strands-py/a.py', 'strands-ts/b.ts'],
+    })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.languages!.sort()).toEqual(['python', 'typescript'])
+  })
+
+  it('site/ci/docs-only PR yields empty languages', async () => {
+    const f = async () => ({
+      labels: [],
+      merge_commit_sha: 'abc1234',
+      user: 'x',
+      files: ['site/src/page.astro', '.github/workflows/x.yml', 'designs/d.md'],
+    })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.languages).toEqual([])
+  })
+
+  it('missing files info yields null languages (unknown -- keep everywhere)', async () => {
+    const f = async () => ({ labels: [], merge_commit_sha: 'abc1234', user: 'x' })
+    const e = await enrichFromPr('r', 1, f)
+    expect(e.languages).toBe(null)
+  })
+})

--- a/site/test/changelog/parse-release-body.test.ts
+++ b/site/test/changelog/parse-release-body.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { classifyTitle, parseNewContributors } from '../../scripts/changelog/parse-release-body'
+
+describe('parse-release-body', () => {
+  // --- classifyTitle -----------------------------------------------------------
+
+  it('classifies conventional-commit titles (type/scope/breaking)', () => {
+    expect(classifyTitle('fix(tests): fix flaky tests')).toEqual({
+      type: 'fix',
+      scope: 'tests',
+      breaking: false,
+      title: 'fix flaky tests',
+    })
+    expect(classifyTitle('feat(gemini): plumb through cache tokens')).toEqual({
+      type: 'feat',
+      scope: 'gemini',
+      breaking: false,
+      title: 'plumb through cache tokens',
+    })
+    expect(classifyTitle('feat!: drop legacy run()')).toEqual({
+      type: 'feat',
+      scope: null,
+      breaking: true,
+      title: 'drop legacy run()',
+    })
+  })
+
+  it('maps non-changelog conventional types (build/ci/style/revert) to other', () => {
+    // KNOWN_TYPES is the changelog-visible subset; everything else collapses to 'other'.
+    expect(classifyTitle('ci: bump runner').type).toBe('other')
+    expect(classifyTitle('build(deps): bump uuid').type).toBe('other')
+  })
+
+  it('non-conventional title falls back to type other', () => {
+    expect(classifyTitle('just did a thing')).toEqual({
+      type: 'other',
+      scope: null,
+      breaking: false,
+      title: 'just did a thing',
+    })
+  })
+
+  it('strips the "_(shared with TS/Python)_" cross-SDK annotation from the title', () => {
+    expect(classifyTitle('feat: add memory injection _(shared with TS)_').title).toBe('add memory injection')
+  })
+
+  // --- parseNewContributors ----------------------------------------------------
+
+  const nc = `## What's Changed
+* feat: real change by @dev in https://github.com/o/r/pull/1
+
+## New Contributors
+* @senthilkumarmohan made their first contribution in https://github.com/strands-agents/harness-sdk/pull/2623
+* @ianholtz made their first contribution in https://github.com/strands-agents/harness-sdk/pull/2651
+
+**Full Changelog**: https://github.com/o/r/compare/a...b`
+
+  it('extracts structured logins + prs + prRepo', () => {
+    expect(parseNewContributors(nc)).toEqual([
+      { login: 'senthilkumarmohan', pr: 2623, prRepo: 'strands-agents/harness-sdk' },
+      { login: 'ianholtz', pr: 2651, prRepo: 'strands-agents/harness-sdk' },
+    ])
+  })
+
+  it('empty/undefined body yields no contributors', () => {
+    expect(parseNewContributors('')).toEqual([])
+    expect(parseNewContributors(null)).toEqual([])
+  })
+
+  it('captures bracket-suffixed bot logins (e.g. dependabot[bot])', () => {
+    const body = '* @dependabot[bot] made their first contribution in https://github.com/o/r/pull/625'
+    expect(parseNewContributors(body)).toEqual([{ login: 'dependabot[bot]', pr: 625, prRepo: 'o/r' }])
+  })
+
+  it('handles CRLF line endings (real GitHub bodies)', () => {
+    const crlf = '## New Contributors\r\n* @dev made their first contribution in https://github.com/o/r/pull/7\r\n'
+    expect(parseNewContributors(crlf)).toEqual([{ login: 'dev', pr: 7, prRepo: 'o/r' }])
+  })
+
+  it('ignores non-contributor bullets (regular "What\'s Changed" entries)', () => {
+    // Only first-contribution lines are captured; entry bullets are derived from
+    // the compare API, not this parser.
+    expect(parseNewContributors('* feat: real change by @dev in https://github.com/o/r/pull/1')).toEqual([])
+  })
+})

--- a/site/test/changelog/render-fixture.test.ts
+++ b/site/test/changelog/render-fixture.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { renderMarkdown } from '../../scripts/changelog/render-markdown'
+import type { ReleaseFile } from '../../scripts/changelog/types'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const contentDir = resolve(here, '../../src/content/changelog')
+
+describe('render-markdown byte-identical to committed fixtures', () => {
+  it('reproduces harness/python-v1.41.0.md exactly', () => {
+    const committed = readFileSync(resolve(contentDir, 'harness/python-v1.41.0.md'), 'utf8')
+    // The file shape that produced it (read the committed file to fill these in
+    // verbatim during implementation -- sdk/language/version/tag/date/urls and
+    // the entries array, each entry with type/breaking/scope/areas/title/pr/
+    // prUrl/commit/commitUrl/author).
+    // Values transcribed verbatim from the committed file on this branch.
+    // NOTE: releaseUrl is NOT percent-encoded (the API's html_url form), and
+    // commit SHAs are quoted strings in the committed file.
+    const file: ReleaseFile = {
+      sdk: 'harness',
+      language: 'python',
+      version: '1.41.0',
+      tag: 'python/v1.41.0',
+      date: '2026-05-21',
+      releaseUrl: 'https://github.com/strands-agents/harness-sdk/releases/tag/python/v1.41.0',
+      packageUrl: 'https://pypi.org/project/strands-agents/1.41.0/',
+      entries: [
+        {
+          type: 'feat',
+          breaking: false,
+          scope: 'plugins',
+          areas: ['multiagent'],
+          title: 'add MultiAgentPlugin for Swarm and Graph orchestrators',
+          pr: 2280,
+          prUrl: 'https://github.com/strands-agents/sdk-python/pull/2280',
+          commit: 'afb0dd9',
+          commitUrl: 'https://github.com/strands-agents/sdk-python/commit/afb0dd9',
+          author: 'zastrowm',
+        },
+        {
+          type: 'feat',
+          breaking: false,
+          scope: null,
+          areas: [],
+          title: 'bump starlette dependency to 1.x',
+          pr: 2297,
+          prUrl: 'https://github.com/strands-agents/sdk-python/pull/2297',
+          commit: '1232230',
+          commitUrl: 'https://github.com/strands-agents/sdk-python/commit/1232230',
+          author: 'pgrayy',
+        },
+        {
+          type: 'feat',
+          breaking: false,
+          scope: 'bedrock',
+          areas: ['model'],
+          title: 'add TTL support to auto-injected tool and system/user cache points',
+          pr: 2232,
+          prUrl: 'https://github.com/strands-agents/sdk-python/pull/2232',
+          commit: '46ce50b',
+          commitUrl: 'https://github.com/strands-agents/sdk-python/commit/46ce50b',
+          author: 'kpx-dev',
+        },
+        {
+          type: 'fix',
+          breaking: false,
+          scope: 'tests',
+          areas: [],
+          title: 'add use_native_token_count=True when expected',
+          pr: 2311,
+          prUrl: 'https://github.com/strands-agents/sdk-python/pull/2311',
+          commit: '64a6862',
+          commitUrl: 'https://github.com/strands-agents/sdk-python/commit/64a6862',
+          author: 'lizradway',
+        },
+      ],
+      newContributors: [],
+    }
+    expect(renderMarkdown(file)).toBe(committed)
+  })
+})

--- a/site/test/changelog/render-markdown.test.ts
+++ b/site/test/changelog/render-markdown.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import { renderMarkdown, mergePreserving } from '../../scripts/changelog/render-markdown'
+
+describe('render-markdown', () => {
+  const file = {
+    sdk: 'harness' as const,
+    language: 'python' as const,
+    version: '1.42.0',
+    tag: 'python/v1.42.0',
+    date: '2026-06-01',
+    releaseUrl: 'https://github.com/strands-agents/harness-sdk/releases/tag/python%2Fv1.42.0',
+    packageUrl: 'https://pypi.org/project/strands-agents/1.42.0/',
+    entries: [
+      {
+        type: 'feat',
+        breaking: false,
+        scope: 'model',
+        areas: ['model'],
+        title: 'plumb cache tokens',
+        pr: 2287,
+        prUrl: 'https://github.com/strands-agents/sdk-python/pull/2287',
+        commit: '155239d',
+        commitUrl: 'https://github.com/strands-agents/sdk-python/commit/155239d',
+        author: 'yatszhash',
+      },
+    ],
+    newContributors: [],
+  }
+
+  it('renders valid frontmatter markdown', () => {
+    const md = renderMarkdown(file)
+    expect(md).toMatch(/^---\n/)
+    expect(md).toMatch(/\nsdk: harness\n/)
+    expect(md).toMatch(/\nlanguage: python\n/)
+    expect(md).toMatch(/\nversion: "1\.42\.0"\n/)
+    expect(md).toMatch(/\ntag: python\/v1\.42\.0\n/)
+    expect(md).toMatch(/type: feat/)
+    expect(md).toMatch(/areas: \[model\]/)
+    expect(md).toMatch(/title: "plumb cache tokens"/)
+    expect(md).not.toMatch(/highlights:/) // none provided
+  })
+
+  it('evals omits language key', () => {
+    const md = renderMarkdown({
+      ...file,
+      sdk: 'evals' as const,
+      language: undefined,
+      tag: 'v0.2.1',
+      version: '0.2.1',
+      releaseUrl: 'https://github.com/strands-agents/evals/releases/tag/v0.2.1',
+      packageUrl: 'https://pypi.org/project/strands-agents-evals/0.2.1/',
+    })
+    expect(md).not.toMatch(/\nlanguage:/)
+  })
+
+  it('empty entries renders entries: []', () => {
+    expect(renderMarkdown({ ...file, entries: [] })).toMatch(/\nentries: \[\]\n/)
+  })
+
+  it('quotes all-digit commit so YAML keeps it a string', () => {
+    const md = renderMarkdown({
+      ...file,
+      entries: [{ ...file.entries[0], commit: '1122334', commitUrl: 'https://github.com/o/r/commit/1122334' }],
+    })
+    expect(md).toMatch(/commit: "1122334"/)
+  })
+
+  it('null pr/commit/author render as null', () => {
+    const md = renderMarkdown({
+      ...file,
+      entries: [
+        {
+          type: 'feat',
+          breaking: false,
+          scope: null,
+          areas: [],
+          title: 'x',
+          pr: null,
+          prUrl: null,
+          commit: null,
+          commitUrl: null,
+          author: null,
+        },
+      ],
+    })
+    expect(md).toMatch(/pr: null/)
+    expect(md).toMatch(/commit: null/)
+    expect(md).toMatch(/author: null/)
+    expect(md).toMatch(/scope: null/)
+  })
+
+  it('quotes areas that contain YAML-significant chars', () => {
+    const md = renderMarkdown({
+      ...file,
+      entries: [{ ...file.entries[0], areas: ['model', 'a,b', 'weird]bracket', 'has space'] }],
+    })
+    // commas/brackets/spaces inside a label must be quoted so the flow seq stays valid
+    expect(md).toMatch(/areas: \[model, "a,b", "weird\]bracket", "has space"\]/)
+  })
+
+  it('quotes YAML reserved bool/null words in scope and areas', () => {
+    const md = renderMarkdown({
+      ...file,
+      entries: [{ ...file.entries[0], scope: 'on', areas: ['yes', 'null', 'model'] }],
+    })
+    expect(md).toMatch(/scope: "on"/)
+    expect(md).toMatch(/areas: \["yes", "null", model\]/)
+  })
+
+  it('escapes quotes and newlines in titles', () => {
+    const md = renderMarkdown({
+      ...file,
+      entries: [{ ...file.entries[0], title: 'add "quoted" thing' }],
+    })
+    expect(md).toMatch(/title: "add \\"quoted\\" thing"/)
+  })
+
+  it('renders newContributors when present, omits when empty', () => {
+    const md = renderMarkdown({
+      ...file,
+      newContributors: [
+        { login: 'newdev', pr: 2700, prRepo: 'o/r' },
+        { login: 'other-dev', pr: 2701, prRepo: 'o/r' },
+      ],
+    })
+    expect(md).toMatch(/newContributors:\n  - \{ login: newdev, pr: 2700 \}\n  - \{ login: other-dev, pr: 2701 \}/)
+    expect(renderMarkdown(file)).not.toMatch(/newContributors/)
+  })
+
+  it('mergePreserving keeps existing highlights + body, refreshes entries', () => {
+    const existing = `---
+sdk: harness
+language: python
+version: "1.42.0"
+tag: python/v1.42.0
+date: 2026-06-01
+releaseUrl: https://example/r
+packageUrl: https://example/p
+highlights: |
+  Hand written summary.
+entries: []
+---
+
+Some curated prose body.`
+    const merged = mergePreserving(file, existing)
+    expect(merged).toMatch(/highlights: \|/)
+    expect(merged).toMatch(/Hand written summary\./)
+    expect(merged).toMatch(/Some curated prose body\./)
+    expect(merged).toMatch(/plumb cache tokens/) // entries refreshed from fresh file
+  })
+
+  it('mergePreserving with no existing file just renders fresh', () => {
+    const merged = mergePreserving(file, null)
+    expect(merged).toBe(renderMarkdown(file))
+  })
+})

--- a/site/test/changelog/run.test.ts
+++ b/site/test/changelog/run.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest'
+import { run } from '../../scripts/changelog/run'
+import type { Client } from '../../scripts/changelog/types'
+
+// Entries are now sourced from the compare API (commits between the prior tag
+// and this one, each resolved to a PR), not parsed from the release body. The
+// fake client below provides listReleases/getRelease plus the compare surface:
+// listTags (prior-tag detection), compareCommits, and commitPulls.
+
+const releases = [
+  { tag_name: 'python/v1.42.0', published_at: '2026-06-01T00:00:00Z', html_url: 'h1', body: '' },
+  { tag_name: 'python/v1.41.0', published_at: '2026-05-21T00:00:00Z', html_url: 'h0', body: '' },
+  { tag_name: 'python-wasm/v0.0.1', published_at: '2026-06-02T00:00:00Z', html_url: 'h2', body: '' },
+]
+
+function fakeClient(overrides = {}): Client {
+  return {
+    listReleases: async () => releases,
+    getRelease: async (_r: string, tag: string) => releases.find((x) => x.tag_name === tag) || null,
+    listTags: async () => releases.map((r) => ({ name: r.tag_name })),
+    // One PR (#1) merged between v1.41.0 and v1.42.0.
+    compareCommits: async (_r: string, base: string, head: string) =>
+      base === 'python/v1.41.0' && head === 'python/v1.42.0'
+        ? { commits: [{ sha: 's1' }], truncated: false }
+        : { commits: [], truncated: false },
+    commitPulls: async (_r: string, sha: string) => (sha === 's1' ? [{ number: 1, title: 'feat: a', user: 'x' }] : []),
+    getPr: async () => ({ labels: ['area-model'], merge_commit_sha: 'abc1234', user: 'x', files: ['strands-py/a.py'] }),
+    ...overrides,
+  } as Client
+}
+
+describe('run', () => {
+  it('backfill writes one file per in-scope release with compare-derived entries', async () => {
+    const written: Record<string, string> = {}
+    const res = await run({
+      repo: 'strands-agents/harness-sdk',
+      mode: 'backfill',
+      client: fakeClient(),
+      readExisting: async () => null,
+      writeFile: async (p, c) => {
+        written[p] = c
+      },
+    })
+    // python-wasm is out of scope; v1.41.0 is the first in-scope release (no prior
+    // tag -- no entries) but still gets a file; v1.42.0 gets the derived entry.
+    expect(written['site/src/content/changelog/harness/python-v1.42.0.md']).toBeTruthy()
+    expect(written['site/src/content/changelog/harness/python-v1.42.0.md']).toMatch(/title: "a"/)
+    // enrichment landed: area-model label -> areas: [model]
+    expect(written['site/src/content/changelog/harness/python-v1.42.0.md']).toMatch(/areas: \[model\]/)
+    expect(Object.keys(written).some((p) => p.includes('wasm'))).toBe(false)
+  })
+
+  it('skipExisting skips releases with files and never calls enrichment for them', async () => {
+    let prCalls = 0
+    const client = fakeClient({
+      getPr: async () => {
+        prCalls++
+        return { labels: [], merge_commit_sha: 'abc1234', user: 'x' }
+      },
+    })
+    const res = await run({
+      repo: 'strands-agents/harness-sdk',
+      mode: 'backfill',
+      skipExisting: true,
+      client,
+      readExisting: async () => '---\nsdk: harness\n---\n', // every file already exists
+      writeFile: async () => {},
+    })
+    expect(res.written).toEqual([])
+    expect(prCalls).toBe(0) // existence checked BEFORE enrichment
+  })
+
+  it('single mode writes only the given tag', async () => {
+    const written: Record<string, string> = {}
+    await run({
+      repo: 'strands-agents/harness-sdk',
+      mode: 'single',
+      tag: 'python/v1.42.0',
+      client: fakeClient(),
+      readExisting: async () => null,
+      writeFile: async (p, c) => {
+        written[p] = c
+      },
+    })
+    expect(Object.keys(written)).toEqual(['site/src/content/changelog/harness/python-v1.42.0.md'])
+  })
+
+  it('single mode with unknown tag writes nothing and warns', async () => {
+    const written: Record<string, string> = {}
+    const res = await run({
+      repo: 'strands-agents/harness-sdk',
+      mode: 'single',
+      tag: 'python/v9.9.9',
+      client: fakeClient(),
+      readExisting: async () => null,
+      writeFile: async (p, c) => {
+        written[p] = c
+      },
+    })
+    expect(Object.keys(written)).toEqual([])
+    expect(res.written).toEqual([])
+    expect(res.warnings[0]).toMatch(/no release found for tag "python\/v9\.9\.9"/)
+  })
+
+  it('keeps a prerelease whose tag maps to a recognized version (rc releases are first-class)', async () => {
+    // A GitHub release flagged prerelease=true but tagged as a real stream
+    // version (typescript rc) must still produce a changelog file -- inclusion
+    // must not hinge on the publisher's "pre-release" checkbox.
+    const pre = [
+      {
+        tag_name: 'typescript/v1.7.0-rc.0',
+        published_at: '2026-06-01T00:00:00Z',
+        html_url: 'h',
+        prerelease: true,
+        body: '',
+      },
+      {
+        tag_name: 'typescript/v1.6.0',
+        published_at: '2026-05-01T00:00:00Z',
+        html_url: 'h0',
+        prerelease: false,
+        body: '',
+      },
+    ]
+    const client = fakeClient({
+      listReleases: async () => pre,
+      getRelease: async () => null,
+      listTags: async () => pre.map((r) => ({ name: r.tag_name })),
+      compareCommits: async (_r: string, _base: string, head: string) =>
+        head === 'typescript/v1.7.0-rc.0'
+          ? { commits: [{ sha: 'sx' }], truncated: false }
+          : { commits: [], truncated: false },
+      commitPulls: async (_r: string, sha: string) =>
+        sha === 'sx' ? [{ number: 9, title: 'feat: rc thing', user: 'x' }] : [],
+    })
+    const written: Record<string, string> = {}
+    await run({
+      repo: 'strands-agents/harness-sdk',
+      mode: 'backfill',
+      client,
+      readExisting: async () => null,
+      writeFile: async (p, c) => {
+        written[p] = c
+      },
+    })
+    expect(written['site/src/content/changelog/harness/typescript-v1.7.0-rc.0.md']).toBeTruthy()
+  })
+
+  it('drops a flagged prerelease whose tag is not a recognized version', async () => {
+    // The prerelease flag still excludes oddball/non-stream tags.
+    const pre = [
+      { tag_name: 'nightly-20260601', published_at: '2026-06-01T00:00:00Z', html_url: 'h', prerelease: true, body: '' },
+    ]
+    const client = fakeClient({ listReleases: async () => pre, getRelease: async () => null })
+    const res = await run({
+      repo: 'strands-agents/harness-sdk',
+      mode: 'backfill',
+      client,
+      readExisting: async () => null,
+      writeFile: async () => {
+        throw new Error('must not write')
+      },
+    })
+    expect(res.written).toEqual([])
+  })
+
+  it('memoizes PR fetches across entries and newContributors', async () => {
+    let prCalls = 0
+    const rel = [
+      {
+        tag_name: 'python/v9.0.0',
+        published_at: '2026-06-01T00:00:00Z',
+        html_url: 'h',
+        body: '## New Contributors\n* @newdev made their first contribution in https://github.com/strands-agents/harness-sdk/pull/7',
+      },
+      { tag_name: 'python/v8.9.0', published_at: '2026-05-01T00:00:00Z', html_url: 'h0', body: '' },
+    ]
+    const client = fakeClient({
+      listReleases: async () => rel,
+      getRelease: async () => null,
+      listTags: async () => rel.map((r: { tag_name: string }) => ({ name: r.tag_name })),
+      compareCommits: async (_r: string, base: string, head: string) =>
+        head === 'python/v9.0.0' ? { commits: [{ sha: 's7' }], truncated: false } : { commits: [], truncated: false },
+      commitPulls: async (_r: string, sha: string) =>
+        sha === 's7' ? [{ number: 7, title: 'feat: thing', user: 'newdev' }] : [],
+      getPr: async () => {
+        prCalls++
+        return { labels: [], merge_commit_sha: 'abc1234', user: 'newdev', files: ['strands-py/x.py'] }
+      },
+    })
+    await run({
+      repo: 'strands-agents/harness-sdk',
+      mode: 'backfill',
+      client,
+      readExisting: async () => null,
+      writeFile: async () => {},
+    })
+    expect(prCalls).toBe(1) // entry (#7) + contributor (#7) gating share one fetch
+  })
+
+  it('skips draft releases (null published_at) without crashing', async () => {
+    const withDraft = [
+      { tag_name: 'v1.0.0', published_at: null, html_url: 'h', body: '' },
+      { tag_name: 'v0.9.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h', body: '' },
+    ]
+    const client = fakeClient({
+      listReleases: async () => withDraft,
+      getRelease: async () => null,
+      listTags: async () => withDraft.map((r: { tag_name: string }) => ({ name: r.tag_name })),
+    })
+    const written: Record<string, string> = {}
+    const res = await run({
+      repo: 'strands-agents/evals',
+      mode: 'backfill',
+      client,
+      readExisting: async () => null,
+      writeFile: async (p, c) => {
+        written[p] = c
+      },
+    })
+    // only the published one is written
+    expect(res.written).toEqual(['site/src/content/changelog/evals/v0.9.0.md'])
+  })
+
+  it('surfaces a truncated-compare warning', async () => {
+    const rel = [
+      { tag_name: 'python/v2.0.0', published_at: '2026-01-02T00:00:00Z', html_url: 'h', body: '' },
+      { tag_name: 'python/v1.0.0', published_at: '2026-01-01T00:00:00Z', html_url: 'h0', body: '' },
+    ]
+    const client = fakeClient({
+      listReleases: async () => rel,
+      getRelease: async () => null,
+      listTags: async () => rel.map((r: { tag_name: string }) => ({ name: r.tag_name })),
+      compareCommits: async () => ({ commits: [{ sha: 's1' }], truncated: true }),
+      commitPulls: async () => [{ number: 1, title: 'feat: x', user: 'a' }],
+    })
+    const res = await run({
+      repo: 'strands-agents/harness-sdk',
+      mode: 'backfill',
+      client,
+      readExisting: async () => null,
+      writeFile: async () => {},
+    })
+    expect(res.warnings.some((w) => /250-commit cap/.test(w))).toBe(true)
+  })
+})

--- a/site/test/changelog/tag-meta.test.ts
+++ b/site/test/changelog/tag-meta.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { tagToMeta, getPackageUrl } from '../../scripts/changelog/tag-meta'
+
+describe('tag-meta', () => {
+  it('harness python prefixed tag', () => {
+    expect(tagToMeta('strands-agents/harness-sdk', 'python/v1.42.0')).toEqual({
+      sdk: 'harness',
+      language: 'python',
+      version: '1.42.0',
+    })
+  })
+
+  it('harness typescript prefixed tag', () => {
+    expect(tagToMeta('strands-agents/harness-sdk', 'typescript/v1.4.0')).toEqual({
+      sdk: 'harness',
+      language: 'typescript',
+      version: '1.4.0',
+    })
+  })
+
+  it('harness bare v tag is pre-monorepo python', () => {
+    expect(tagToMeta('strands-agents/harness-sdk', 'v1.9.1')).toEqual({
+      sdk: 'harness',
+      language: 'python',
+      version: '1.9.1',
+    })
+  })
+
+  it('evals bare v tag is python-only (no language)', () => {
+    expect(tagToMeta('strands-agents/evals', 'v0.2.1')).toEqual({
+      sdk: 'evals',
+      language: undefined,
+      version: '0.2.1',
+    })
+  })
+
+  it('evals python-prefixed tag also maps to evals python', () => {
+    expect(tagToMeta('strands-agents/evals', 'python/v0.1.3')).toEqual({
+      sdk: 'evals',
+      language: undefined,
+      version: '0.1.3',
+    })
+  })
+
+  it('malformed typescript tag still parses', () => {
+    expect(tagToMeta('strands-agents/harness-sdk', 'typescript/v.1.2.0')).toEqual({
+      sdk: 'harness',
+      language: 'typescript',
+      version: '1.2.0',
+    })
+  })
+
+  it('python-wasm is skipped (null)', () => {
+    expect(tagToMeta('strands-agents/harness-sdk', 'python-wasm/v0.0.1')).toBe(null)
+  })
+
+  it('archived sdk-typescript repo bare v tags map to harness/typescript', () => {
+    expect(tagToMeta('strands-agents/sdk-typescript', 'v1.3.0')).toEqual({
+      sdk: 'harness',
+      language: 'typescript',
+      version: '1.3.0',
+    })
+    // rc tags parse too
+    expect(tagToMeta('strands-agents/sdk-typescript', 'v1.0.0-rc.5')).toEqual({
+      sdk: 'harness',
+      language: 'typescript',
+      version: '1.0.0-rc.5',
+    })
+  })
+
+  it('package urls', () => {
+    expect(getPackageUrl('harness', 'python', '1.42.0')).toBe('https://pypi.org/project/strands-agents/1.42.0/')
+    expect(getPackageUrl('harness', 'typescript', '1.4.0')).toBe(
+      'https://www.npmjs.com/package/@strands-agents/sdk/v/1.4.0'
+    )
+    expect(getPackageUrl('evals', undefined, '0.2.1')).toBe('https://pypi.org/project/strands-agents-evals/0.2.1/')
+  })
+})


### PR DESCRIPTION
## Description

Adds the `changelog-sync` workflow plus the changelog generator it runs. This is the automation half of the Strands changelog feature: it turns GitHub Releases into the structured changelog data (#2761) that the docs site (#2717) renders, and keeps that data current after the initial backfill.

**The generation logic lives in the docs project itself** (`site/scripts/changelog/`), written in TypeScript and run via `tsx` — not in a separate GitHub Action. A developer can run it locally to backfill or sync on demand; the workflow is a thin trigger that runs the script and opens a PR. (This supersedes the earlier devtools composite-action approach in the now-closed devtools#66 and evals#259.)

### What's included

**Generator** (`site/scripts/changelog/`, dependency-free pure modules + a thin I/O boundary):
- `sync.ts` — CLI entry. Resolves a token (`--token` -> `GITHUB_TOKEN` -> `gh auth token`), picks releases (single tag or full backfill), writes `site/src/content/changelog/**`, prints a summary + any warnings. Does NOT open a PR (the workflow / a developer commits the diff).
- `github-client.ts` — the only network module: an `@octokit/rest` adapter building the injected client.
- Pure logic (unit-tested without network via injected deps): `run.ts` (orchestration + PR-fetch/prior-tag memoization), `derive-entries.ts` (entries from the compare API — every merged commit between the prior tag and this one, resolved commit->PR, so it is immune to release-note format drift), `enrich.ts` (`area-*` labels, breaking flag, merge SHA, language/docs gating from changed files), `build-release-file.ts`, `render-markdown.ts`, `tag-meta.ts`, `parse-release-body.ts`.
- `compareVersionDesc` is imported from the shared `site/src/util/semver.ts` (added in #2717), so there is a single definition shared by the runtime page code and the generator.

**Workflow** (`.github/workflows/changelog-sync.yml`): checkout -> `npm ci --prefix site` -> run the generator (inputs passed via `env:`) -> `peter-evans/create-pull-request`.
- **On release** (in-scope tag prefixes): single-mode sync of the released tag.
- **Daily cron backstop**: backfill mode with `skip-existing` (only generates missing files; zero re-enrichment cost; never regresses existing files), covering missed release events for both harness and evals (evals is public, read with the same token).
- **Concurrency guard**: de-dupes runs of the same event type + tag; cross-event (release vs. cron) duplicates are tolerated because content is identical.

### Security / token / fork flow
- **No untrusted input reaches the shell.** All workflow inputs (`SOURCE_REPO`, `MODE`, `SKIP_EXISTING`, `TAG`) are passed via `env:` and read by the script from `process.env` — nothing is interpolated into a `run:` command line, closing the GitHub Actions script-injection vector. The PR branch name is sanitized in a dedicated step (via an env var, not shell-interpolated).
- PRs created with the default `GITHUB_TOKEN` don't trigger `pull_request` workflows, so the required **CI Gate** never ran on auto-created PRs. This uses a dedicated agent account's PAT (`CHANGELOG_BOT_TOKEN`, scope `public_repo`), pushing to that account's fork and opening a cross-repo PR — a real-user fork PR triggers CI. First fork PR needs a one-time maintainer "Approve and run workflows".
- Job permissions are `contents: read` (every write is the PAT's).
- `peter-evans/create-pull-request` is pinned to a full commit SHA (`22a9089…`, v7.0.11). First-party `actions/checkout` and `actions/setup-node` use `@v6` tags, matching the rest of the repo's workflows.

### Frozen historical data
The generator owns NEW releases going forward. The 83 pre-monorepo files in #2761 were generated from the now-redirected `sdk-python` / `sdk-typescript` repos and are intentionally NOT reproducible by the harness-sdk-based generator — they are a frozen one-time artifact. A `render-markdown` byte-identical fixture test and a going-forward parity check (regenerating a harness-sdk-owned release) guard the renderer contract.

## Type of Change
New feature (CI automation + build-time generator)

## Testing
- `npm test --prefix site` — full site suite green, including the ported changelog generator suites under `site/test/changelog/` (99 tests: tag mapping, semver ordering, compare-API derivation, enrichment/gating, rendering, build orchestration, run wiring) and a **byte-identical render-fixture guard** asserting the renderer reproduces a committed file exactly.
- `npm run typecheck --prefix site` — clean.
- `npx prettier --check` over the new files — clean.
- Generator smoke-tested against the live GitHub API (single tag + going-forward parity on a harness-sdk-owned release).
- Workflow YAML validated; no `${{ }}` interpolation remains in any `run:` block.
- Note: GitHub CI has not yet run on the PR, and the workflow itself can only be fully exercised post-merge (it triggers on release/cron).

## Merge order
Stack: **#2717 (page + schema + semver) -> #2761 (data) -> #2765 (this).** This branch's tests import `semver.ts` from #2717, so the order is required.
