### PR TITLE
fix: reduce workflow noise from deployment history and label churn

### DIFF
--- a/.github/workflows/auto-strands-review.yml
+++ b/.github/workflows/auto-strands-review.yml
@@ -28,7 +28,9 @@ jobs:
   trigger-review:
     name: Trigger Strands Review
     needs: authorization-check
-    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    environment:
+      name: ${{ needs.authorization-check.outputs.approval-env }}
+      deployment: false
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/docs-strands-command.yml
+++ b/.github/workflows/docs-strands-command.yml
@@ -39,7 +39,9 @@ jobs:
 
   setup-and-process:
     needs: [authorization-check]
-    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    environment:
+      name: ${{ needs.authorization-check.outputs.approval-env }}
+      deployment: false
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -17,41 +17,40 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const totalChanges = pr.additions + pr.deletions;
-            
-            // Remove existing size labels
-            const labels = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number
-            });
-            
-            for (const label of labels.data) {
-              if (label.name.startsWith('size/')) {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.payload.pull_request.number,
-                  name: label.name
-                });
-              }
-            }
-            
-            // Determine and apply new size label
+
             let sizeLabel;
             if (totalChanges <= 20) sizeLabel = 'size/xs';
             else if (totalChanges <= 100) sizeLabel = 'size/s';
             else if (totalChanges <= 500) sizeLabel = 'size/m';
             else if (totalChanges <= 1000) sizeLabel = 'size/l';
-            else {
-              sizeLabel = 'size/xl';
-            }
-            
-            await github.rest.issues.addLabels({
+            else sizeLabel = 'size/xl';
+
+            const labels = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: [sizeLabel]
+              issue_number: pr.number
             });
+
+            const existingSize = labels.data.filter(l => l.name.startsWith('size/'));
+            const alreadyCorrect = existingSize.length === 1 && existingSize[0].name === sizeLabel;
+
+            if (!alreadyCorrect) {
+              for (const label of existingSize) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label.name
+                });
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [sizeLabel]
+              });
+            }
 
             if (sizeLabel === 'size/xl') {
               core.setFailed(`PR is too large (${totalChanges} lines). Please split into smaller PRs.`);

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -29,7 +29,9 @@ jobs:
   check-access-and-checkout:
     runs-on: ubuntu-latest
     needs: authorization-check
-    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    environment:
+      name: ${{ needs.authorization-check.outputs.approval-env }}
+      deployment: false
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -40,7 +40,9 @@ jobs:
   
   setup-and-process:
     needs: [authorization-check]
-    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    environment:
+      name: ${{ needs.authorization-check.outputs.approval-env }}
+      deployment: false
     permissions:
       # Needed to create a branch for the Implementer Agent
       contents: write

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -35,7 +35,9 @@ jobs:
     name: Run integration tests
     runs-on: ubuntu-latest
     needs: authorization-check
-    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    environment:
+      name: ${{ needs.authorization-check.outputs.approval-env }}
+      deployment: false
     permissions:
       id-token: write
       pull-requests: read


### PR DESCRIPTION
## Description

Two sources of unnecessary noise in our GitHub UI:

1. **Spurious deployment entries** — Workflows that only use environments for approval gating (integ tests, strands commands, auto-review) were creating deployment objects on every run. These clutter the repo's deployment history with entries that aren't actual deployments. Adding [`deployment: false`](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments) to these environment references preserves the approval gate while opting out of deployment tracking.

2. **Label remove/re-add churn** — The PR size labeler unconditionally removed all `size/` labels then re-added the computed one, even when the correct label was already present. Every push generated a pointless "removed size/m" + "added size/m" pair in the PR timeline. Now it checks first and no-ops if the label hasn't changed.

## Related Issues

N/A

## Documentation PR

N/A — no documentation changes needed.

## Type of Change

Other: CI workflow noise reduction

## Testing

These are workflow-only changes with no application code impact.

- [x] Verified YAML syntax is valid
- [x] Confirmed per [GitHub docs](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments) that `deployment: false` still enforces required reviewers and wait timers

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.