### PR TITLE
fix: remove pin messaging barrel export

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -383,38 +383,6 @@ The same parameter works with `SummarizingConversationManager`.
 
 The pin metadata is written during the first context reduction and remains set permanently, protecting those messages through all subsequent reductions.
 
-### Pinning Messages at Runtime
-
-For dynamic control, use the utility functions to pin or unpin messages by index. This enables agents or application logic to mark messages as important based on their content rather than position.
-
-<Tabs>
-<Tab label="Python">
-
-```python
-from strands.agent.conversation_manager.pin_message import pin_message, unpin_message, is_pinned
-
-pin_message(agent.messages, 0)
-
-if is_pinned(agent.messages, 0):
-    print("Message is protected from eviction")
-
-unpin_message(agent.messages, 0)
-```
-
-</Tab>
-<Tab label="TypeScript">
-
-```typescript
---8<-- "user-guide/concepts/agents/conversation-management_imports.ts:pin_message_imports"
-
---8<-- "user-guide/concepts/agents/conversation-management.ts:pin_message_usage"
-```
-
-</Tab>
-</Tabs>
-
-**Tool-pair partner protection**: Pinning a `toolUse` message automatically protects its adjacent `toolResult` partner (matched by `toolUseId`), and vice versa. This prevents orphaned tool interactions in the conversation history.
-
 ## Proactive Context Compression
 
 By default, conversation managers are reactive. They only reduce context after the model rejects a request with a context window overflow error. Proactive compression avoids wasting round-trips and output token starvation by triggering context reduction before the model call when the projected input token count exceeds a configurable threshold of the model's context window.

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -391,7 +391,7 @@ For dynamic control, use the utility functions to pin or unpin messages by index
 <Tab label="Python">
 
 ```python
-from strands.agent.conversation_manager import pin_message, unpin_message, is_pinned
+from strands.agent.conversation_manager.pin_message import pin_message, unpin_message, is_pinned
 
 pin_message(agent.messages, 0)
 
@@ -405,9 +405,15 @@ unpin_message(agent.messages, 0)
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/agents/conversation-management_imports.ts:pin_message_imports"
+import { pinMessage, unpinMessage, isPinned } from '@strands-agents/sdk/conversation-manager/pin-message'
 
---8<-- "user-guide/concepts/agents/conversation-management.ts:pin_message_usage"
+pinMessage(agent.messages, 0)
+
+if (isPinned(agent.messages, 0)) {
+  console.log('Message is protected from eviction')
+}
+
+unpinMessage(agent.messages, 0)
 ```
 
 </Tab>

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -405,15 +405,9 @@ unpin_message(agent.messages, 0)
 <Tab label="TypeScript">
 
 ```typescript
-import { pinMessage, unpinMessage, isPinned } from '@strands-agents/sdk/conversation-manager/pin-message'
+--8<-- "user-guide/concepts/agents/conversation-management_imports.ts:pin_message_imports"
 
-pinMessage(agent.messages, 0)
-
-if (isPinned(agent.messages, 0)) {
-  console.log('Message is protected from eviction')
-}
-
-unpinMessage(agent.messages, 0)
+--8<-- "user-guide/concepts/agents/conversation-management.ts:pin_message_usage"
 ```
 
 </Tab>

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -7,7 +7,6 @@ import {
   SummarizingConversationManager,
   BedrockModel,
 } from '@strands-agents/sdk'
-import { pinMessage, unpinMessage, isPinned } from '@strands-agents/sdk/conversation-manager/pin-message'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 import type { LocalAgent, ConversationManagerReduceOptions } from '@strands-agents/sdk'
 
@@ -177,16 +176,4 @@ async function pinFirstExample() {
   // --8<-- [end:pin_first]
 }
 
-async function pinMessageUsage() {
-  const agent = new Agent({})
-  // --8<-- [start:pin_message_usage]
-  pinMessage(agent.messages, 0)
-
-  if (isPinned(agent.messages, 0)) {
-    console.log('Message is protected from eviction')
-  }
-
-  unpinMessage(agent.messages, 0)
-  // --8<-- [end:pin_message_usage]
-}
 

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -6,9 +6,6 @@ import {
   SlidingWindowConversationManager,
   SummarizingConversationManager,
   BedrockModel,
-  pinMessage,
-  unpinMessage,
-  isPinned,
 } from '@strands-agents/sdk'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 import type { LocalAgent, ConversationManagerReduceOptions } from '@strands-agents/sdk'
@@ -179,15 +176,3 @@ async function pinFirstExample() {
   // --8<-- [end:pin_first]
 }
 
-async function pinMessageUsage() {
-  const agent = new Agent({})
-  // --8<-- [start:pin_message_usage]
-  pinMessage(agent.messages, 0)
-
-  if (isPinned(agent.messages, 0)) {
-    console.log('Message is protected from eviction')
-  }
-
-  unpinMessage(agent.messages, 0)
-  // --8<-- [end:pin_message_usage]
-}

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -7,6 +7,7 @@ import {
   SummarizingConversationManager,
   BedrockModel,
 } from '@strands-agents/sdk'
+import { pinMessage, unpinMessage, isPinned } from '@strands-agents/sdk/conversation-manager/pin-message'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 import type { LocalAgent, ConversationManagerReduceOptions } from '@strands-agents/sdk'
 
@@ -174,5 +175,18 @@ async function pinFirstExample() {
     }),
   })
   // --8<-- [end:pin_first]
+}
+
+async function pinMessageUsage() {
+  const agent = new Agent({})
+  // --8<-- [start:pin_message_usage]
+  pinMessage(agent.messages, 0)
+
+  if (isPinned(agent.messages, 0)) {
+    console.log('Message is protected from eviction')
+  }
+
+  unpinMessage(agent.messages, 0)
+  // --8<-- [end:pin_message_usage]
 }
 

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
@@ -55,3 +55,7 @@ import { Agent, SummarizingConversationManager } from '@strands-agents/sdk'
 import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
 // --8<-- [end:pin_first_imports]
 
+// --8<-- [start:pin_message_imports]
+import { pinMessage, unpinMessage, isPinned } from '@strands-agents/sdk/conversation-manager/pin-message'
+// --8<-- [end:pin_message_imports]
+

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
@@ -55,7 +55,4 @@ import { Agent, SummarizingConversationManager } from '@strands-agents/sdk'
 import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
 // --8<-- [end:pin_first_imports]
 
-// --8<-- [start:pin_message_imports]
-import { pinMessage, unpinMessage, isPinned } from '@strands-agents/sdk/conversation-manager/pin-message'
-// --8<-- [end:pin_message_imports]
 

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
@@ -55,6 +55,3 @@ import { Agent, SummarizingConversationManager } from '@strands-agents/sdk'
 import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
 // --8<-- [end:pin_first_imports]
 
-// --8<-- [start:pin_message_imports]
-import { pinMessage, unpinMessage, isPinned } from '@strands-agents/sdk'
-// --8<-- [end:pin_message_imports]

--- a/strands-py/src/strands/agent/conversation_manager/__init__.py
+++ b/strands-py/src/strands/agent/conversation_manager/__init__.py
@@ -16,7 +16,6 @@ is critical for effective agent interactions.
 
 from .conversation_manager import ConversationManager, ProactiveCompressionConfig
 from .null_conversation_manager import NullConversationManager
-from .pin_message import is_pinned, pin_message, unpin_message
 from .sliding_window_conversation_manager import SlidingWindowConversationManager
 from .summarizing_conversation_manager import SummarizingConversationManager
 
@@ -26,7 +25,4 @@ __all__ = [
     "ProactiveCompressionConfig",
     "SlidingWindowConversationManager",
     "SummarizingConversationManager",
-    "is_pinned",
-    "pin_message",
-    "unpin_message",
 ]

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -124,6 +124,10 @@
     "./sandbox/ssh": {
       "types": "./dist/src/sandbox/ssh.d.ts",
       "default": "./dist/src/sandbox/ssh.js"
+    },
+    "./conversation-manager/pin-message": {
+      "types": "./dist/src/conversation-manager/pin-message.d.ts",
+      "default": "./dist/src/conversation-manager/pin-message.js"
     }
   },
   "scripts": {

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -124,10 +124,6 @@
     "./sandbox/ssh": {
       "types": "./dist/src/sandbox/ssh.d.ts",
       "default": "./dist/src/sandbox/ssh.js"
-    },
-    "./conversation-manager/pin-message": {
-      "types": "./dist/src/conversation-manager/pin-message.d.ts",
-      "default": "./dist/src/conversation-manager/pin-message.js"
     }
   },
   "scripts": {

--- a/strands-ts/src/conversation-manager/index.ts
+++ b/strands-ts/src/conversation-manager/index.ts
@@ -19,4 +19,3 @@ export {
   SummarizingConversationManager,
   type SummarizingConversationManagerConfig,
 } from './summarizing-conversation-manager.js'
-export { isPinned, pinMessage, unpinMessage } from './pin-message.js'

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -268,7 +268,6 @@ export {
   SummarizingConversationManager,
   type SummarizingConversationManagerConfig,
 } from './conversation-manager/summarizing-conversation-manager.js'
-export { isPinned, pinMessage, unpinMessage } from './conversation-manager/pin-message.js'
 
 // Logging
 export { configureLogging } from './logging/logger.js'


### PR DESCRIPTION
## Description

PR #2749 added barrel exports for the pin_message utility functions (`is_pinned`, `pin_message`, `unpin_message` in Python and `isPinned`, `pinMessage`, `unpinMessage` in TypeScript) to the package-level indexes. This PR removes those re-exports from:

- `strands-py/src/strands/agent/conversation_manager/__init__.py`
- `strands-ts/src/conversation-manager/index.ts`
- `strands-ts/src/index.ts`

The underlying `pin_message` module and its functionality are unchanged — only the top-level re-exports are removed.

## Related Issues

#2749

## Documentation PR

N/A — docs code snippets already import from the submodule path directly.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
