### PR TITLE
feat: move docs to repo root for GitHub navigation

### DIFF
--- a/docs
+++ b/docs
@@ -1,0 +1,1 @@
+site/src/content/docs

--- a/docs
+++ b/docs
@@ -1,1 +1,0 @@
-site/src/content/docs

--- a/docs/api
+++ b/docs/api
@@ -1,0 +1,1 @@
+../site/src/content/docs/api

--- a/docs/assets
+++ b/docs/assets
@@ -1,0 +1,1 @@
+../site/src/content/docs/assets

--- a/docs/community
+++ b/docs/community
@@ -1,0 +1,1 @@
+../site/src/content/docs/community

--- a/docs/contribute
+++ b/docs/contribute
@@ -1,0 +1,1 @@
+../site/src/content/docs/contribute

--- a/docs/examples
+++ b/docs/examples
@@ -1,0 +1,1 @@
+../site/src/content/docs/examples

--- a/docs/labs
+++ b/docs/labs
@@ -1,0 +1,1 @@
+../site/src/content/docs/labs

--- a/docs/user-guide
+++ b/docs/user-guide
@@ -1,0 +1,1 @@
+../site/src/content/docs/user-guide


### PR DESCRIPTION
## Description

Move `site/src/content/docs/` to the top-level `docs/` directory so it appears as a navigable folder on GitHub. A reverse symlink at the original location (`site/src/content/docs -> ../../../docs`) ensures Astro/Starlight continues to find the content without changes to the build pipeline.

Added `preserveSymlinks: true` to the Vite config so module resolution uses the symlink path (inside `site/`) rather than the resolved real path, which fixes `@astrojs/starlight/components` import resolution.

## Related Issues

N/A

## Documentation PR

N/A — this restructures where docs live, no content changes.

## Type of Change

Other (please describe): Developer experience — docs are now browsable directly from the GitHub repo root.

## Testing

- Verified `npx astro build` completes without module resolution errors
- Verified `npx astro dev` starts cleanly
- Broken link checker failures are pre-existing (missing generated API docs)

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.