### PR TITLE
fix: preserve non-ASCII text in provider request formatting

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -162,7 +162,7 @@ class AnthropicModel(Model):
             return {
                 "content": [
                     self._format_request_message_content(
-                        {"text": json.dumps(tool_result_content["json"])}
+                        {"text": json.dumps(tool_result_content["json"], ensure_ascii=False)}
                         if "json" in tool_result_content
                         else cast(ContentBlock, tool_result_content)
                     )

--- a/strands-py/src/strands/models/llamaapi.py
+++ b/strands-py/src/strands/models/llamaapi.py
@@ -131,7 +131,7 @@ class LlamaAPIModel(Model):
         """
         return {
             "function": {
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
                 "name": tool_use["name"],
             },
             "id": tool_use["toolUseId"],
@@ -149,7 +149,7 @@ class LlamaAPIModel(Model):
         contents = cast(
             list[ContentBlock],
             [
-                {"text": json.dumps(content["json"])} if "json" in content else content
+                {"text": json.dumps(content["json"], ensure_ascii=False)} if "json" in content else content
                 for content in tool_result["content"]
             ],
         )

--- a/strands-py/src/strands/models/llamacpp.py
+++ b/strands-py/src/strands/models/llamacpp.py
@@ -256,7 +256,7 @@ class LlamaCppModel(Model):
         """
         return {
             "function": {
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
                 "name": tool_use["name"],
             },
             "id": tool_use["toolUseId"],
@@ -273,7 +273,7 @@ class LlamaCppModel(Model):
             llama.cpp compatible tool message.
         """
         contents = [
-            {"text": json.dumps(content["json"])} if "json" in content else content
+            {"text": json.dumps(content["json"], ensure_ascii=False)} if "json" in content else content
             for content in tool_result["content"]
         ]
 

--- a/strands-py/src/strands/models/mistral.py
+++ b/strands-py/src/strands/models/mistral.py
@@ -158,7 +158,7 @@ class MistralModel(Model):
         return {
             "function": {
                 "name": tool_use["name"],
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
             },
             "id": tool_use["toolUseId"],
             "type": "function",
@@ -176,7 +176,7 @@ class MistralModel(Model):
         content_parts: list[str] = []
         for content in tool_result["content"]:
             if "json" in content:
-                content_parts.append(json.dumps(content["json"]))
+                content_parts.append(json.dumps(content["json"], ensure_ascii=False))
             elif "text" in content:
                 content_parts.append(content["text"])
 

--- a/strands-py/src/strands/models/ollama.py
+++ b/strands-py/src/strands/models/ollama.py
@@ -140,7 +140,7 @@ class OllamaModel(Model):
                 for formatted_tool_result_content in self._format_request_message_contents(
                     "tool",
                     (
-                        {"text": json.dumps(tool_result_content["json"])}
+                        {"text": json.dumps(tool_result_content["json"], ensure_ascii=False)}
                         if "json" in tool_result_content
                         else cast(ContentBlock, tool_result_content)
                     ),

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -211,7 +211,7 @@ class OpenAIModel(Model):
         """
         return {
             "function": {
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
                 "name": tool_use["name"],
             },
             "id": tool_use["toolUseId"],
@@ -232,7 +232,7 @@ class OpenAIModel(Model):
         contents = cast(
             list[ContentBlock],
             [
-                {"text": json.dumps(content["json"])} if "json" in content else content
+                {"text": json.dumps(content["json"], ensure_ascii=False)} if "json" in content else content
                 for content in tool_result["content"]
             ],
         )

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -694,7 +694,7 @@ class OpenAIResponsesModel(Model):
             "type": "function_call",
             "call_id": tool_use["toolUseId"],
             "name": tool_use["name"],
-            "arguments": json.dumps(tool_use["input"]),
+            "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
         }
 
     @classmethod
@@ -720,7 +720,7 @@ class OpenAIResponsesModel(Model):
 
         for content in tool_result["content"]:
             if "json" in content:
-                output_parts.append({"type": "input_text", "text": json.dumps(content["json"])})
+                output_parts.append({"type": "input_text", "text": json.dumps(content["json"], ensure_ascii=False)})
             elif "text" in content:
                 output_parts.append({"type": "input_text", "text": content["text"]})
             elif "image" in content:

--- a/strands-py/src/strands/models/writer.py
+++ b/strands-py/src/strands/models/writer.py
@@ -167,7 +167,7 @@ class WriterModel(Model):
         """
         return {
             "function": {
-                "arguments": json.dumps(tool_use["input"]),
+                "arguments": json.dumps(tool_use["input"], ensure_ascii=False),
                 "name": tool_use["name"],
             },
             "id": tool_use["toolUseId"],
@@ -186,7 +186,7 @@ class WriterModel(Model):
         contents = cast(
             list[ContentBlock],
             [
-                {"text": json.dumps(content["json"])} if "json" in content else content
+                {"text": json.dumps(content["json"], ensure_ascii=False)} if "json" in content else content
                 for content in tool_result["content"]
             ],
         )

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -397,6 +397,30 @@ def test_format_request_with_tool_results(model, model_id, max_tokens):
     assert tru_request == exp_request
 
 
+def test_format_request_with_tool_results_preserves_non_ascii(model):
+    """Test that non-ASCII tool-result json content is not escaped in the request sent to the model."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "c1",
+                        "status": "success",
+                        "content": [{"json": {"city": "東京"}}],
+                    }
+                }
+            ],
+        }
+    ]
+
+    tru_request = model.format_request(messages)
+    text = tru_request["messages"][0]["content"][0]["content"][0]["text"]
+
+    assert "\\u" not in text
+    assert '"city": "東京"' in text
+
+
 def test_format_request_with_unsupported_type(model):
     messages = [
         {

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -214,6 +214,36 @@ def test_format_request_tool_message():
     assert tru_result == exp_result
 
 
+def test_format_request_message_tool_call_preserves_non_ascii():
+    """Test that non-ASCII tool-call arguments are not escaped in the request sent to the model."""
+    tool_use = {
+        "input": {"city": "東京"},
+        "name": "search",
+        "toolUseId": "c1",
+    }
+
+    tru_result = OpenAIModel.format_request_message_tool_call(tool_use)
+    arguments = tru_result["function"]["arguments"]
+
+    assert "\\u" not in arguments
+    assert '"city": "東京"' in arguments
+
+
+def test_format_request_tool_message_preserves_non_ascii():
+    """Test that non-ASCII tool-result json content is not escaped in the request sent to the model."""
+    tool_result = {
+        "content": [{"json": {"city": "東京"}}],
+        "status": "success",
+        "toolUseId": "c1",
+    }
+
+    tru_result = OpenAIModel.format_request_tool_message(tool_result)
+    content = tru_result["content"]
+
+    assert "\\u" not in content
+    assert '"city": "東京"' in content
+
+
 def test_format_request_tool_message_single_text_returns_string():
     """Test that single text content is returned as string for model compatibility."""
     tool_result = {


### PR DESCRIPTION
Thank you to the Strands maintainers for the excellent SDK — and for the recent #2653 which fixed the `@tool` decorator path. This PR addresses the provider-side counterpart of the same issue.

Fixes #2660

## Problem

Provider request-formatting paths serialize tool-call arguments and tool-result `{"json": ...}` content blocks with `json.dumps()`, which defaults to `ensure_ascii=True`. Non-ASCII text (CJK, emoji) is therefore escaped to `\uXXXX` **in the request sent to the model**. For non-Latin scripts this inflates token usage (and cost) and hurts readability/debuggability.

This is the provider-side counterpart to the `@tool` decorator path fixed in #2653, and it matches what the SDK already does in `telemetry/tracer.py` and the session managers (`ensure_ascii=False`).

## Reproduction (no network / API key needed)

```python
from strands.models.openai import OpenAIModel

tool_result = {"toolUseId": "c1", "status": "success", "content": [{"json": {"city": "東京"}}]}
print(OpenAIModel.format_request_tool_message(tool_result)["content"])
```

| | Before | After |
|---|--------|-------|
| OpenAI tool-result `{"json": {"city": "東京"}}` | `{"city": "東京"}` ❌ | `{"city": "東京"}` ✅ |
| OpenAI tool-call args `{"query": "東京"}` | `{"query": "東京"}` ❌ | `{"query": "東京"}` ✅ |
| Anthropic tool-result json | `\uXXXX`-escaped ❌ | preserved ✅ |
| Response-parsing paths (`bedrock.py`, `ollama.py`, `gemini.py` stream→internal) | unchanged | ✅ unchanged (not request-facing) |
| Public API / signatures / output ordering | — | ✅ unchanged |

## Change

`json.dumps(x)` → `json.dumps(x, ensure_ascii=False)` in the model-visible `format_request_*` paths only, across the affected providers (openai, anthropic, mistral, llamaapi, writer, llamacpp, ollama, openai_responses). Response→internal conversion paths are intentionally left untouched.

## Tests

Added regression tests on the issue's primary paths (`test_openai.py`, `test_anthropic.py`). Verified they catch the bug:

- Source reverted (bug present) → **3 failed** (e.g. `assert '\u' not in '{"city": "東京"}'`)
- Source restored (fix) → **3 passed**
- Full changed-provider suite → **398 passed**, no regressions.
- `ruff check` / `ruff format --check` / `mypy` (changed files) all clean.

---

_This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, rationale, and test results before submission._



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.