### PR TITLE
feat(site): add For humans / For agents toggle to homepage hero

### DIFF
--- a/site/src/components/landing/AgentSetupCard.astro
+++ b/site/src/components/landing/AgentSetupCard.astro
@@ -90,11 +90,11 @@ const tools = [
     <div class="agent-prompt-row">
       <span class="agent-prompt-text">{PROMPT}</span>
       <button class="agent-prompt-copy" aria-label="Copy prompt">
-        <svg class="copy-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+        <svg class="copy-icon" aria-hidden="true" width="14" height="14" viewBox="0 0 16 16" fill="none">
           <rect x="5" y="5" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
           <path d="M3 10.5V3a1.5 1.5 0 0 1 1.5-1.5H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
         </svg>
-        <svg class="check-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+        <svg class="check-icon" aria-hidden="true" width="14" height="14" viewBox="0 0 16 16" fill="none">
           <path d="M3.5 8.5L6.5 11.5L12.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </button>

--- a/site/src/components/landing/AgentSetupCard.astro
+++ b/site/src/components/landing/AgentSetupCard.astro
@@ -62,19 +62,23 @@ const tools = [
 <div class="agent-setup-card">
   <p class="agent-setup-heading">Set up with your coding agent</p>
 
-  <div class="agent-tool-tabs" role="tablist" aria-label="Coding tool">
-    {tools.map((tool, i) => (
-      <button
-        class="agent-tool-tab"
-        role="tab"
-        aria-selected={i === 0 ? 'true' : 'false'}
-        data-tool={tool.id}
-        id={'agent-tab-' + tool.id}
-        aria-controls={'agent-panel-' + tool.id}
-      >
-        {tool.label}
-      </button>
-    ))}
+  <div class="agent-tool-tabrow">
+    <div class="agent-tool-tabs" role="tablist" aria-label="Coding tool">
+      {tools.map((tool, i) => (
+        <button
+          class="agent-tool-tab"
+          type="button"
+          role="tab"
+          aria-selected={i === 0 ? 'true' : 'false'}
+          tabindex={i === 0 ? '0' : '-1'}
+          data-tool={tool.id}
+          id={'agent-tab-' + tool.id}
+          aria-controls={'agent-panel-' + tool.id}
+        >
+          {tool.label}
+        </button>
+      ))}
+    </div>
     <a class="agent-tool-other" href={withBase('/docs/user-guide/build-with-ai/')}>Other</a>
   </div>
 
@@ -132,10 +136,15 @@ const tools = [
   }
 
   /* Tabs mirror the LanguageToggle underline pattern */
-  .agent-tool-tabs {
+  .agent-tool-tabrow {
     display: flex;
     align-items: stretch;
     border-bottom: 2px solid var(--sl-color-gray-5);
+  }
+
+  .agent-tool-tabs {
+    display: flex;
+    align-items: stretch;
   }
 
   .agent-tool-tab {
@@ -246,15 +255,35 @@ const tools = [
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll<HTMLElement>('.agent-setup-card').forEach((card) => {
-      // Tool tab switching
-      const tabs = card.querySelectorAll<HTMLButtonElement>('.agent-tool-tab')
+      // Tool tab switching with the ARIA tablist keyboard pattern:
+      // roving tabindex plus arrow/Home/End navigation that moves focus
+      // and selects in one step (automatic activation).
+      const tabs = Array.from(card.querySelectorAll<HTMLButtonElement>('.agent-tool-tab'))
       const panels = card.querySelectorAll<HTMLElement>('.agent-tool-panel')
-      tabs.forEach((tab) => {
-        tab.addEventListener('click', () => {
-          tabs.forEach((t) => t.setAttribute('aria-selected', t === tab ? 'true' : 'false'))
-          panels.forEach((p) => {
-            p.hidden = p.dataset.tool !== tab.dataset.tool
-          })
+
+      const selectTab = (tab: HTMLButtonElement, focus = false) => {
+        tabs.forEach((t) => {
+          const selected = t === tab
+          t.setAttribute('aria-selected', selected ? 'true' : 'false')
+          t.tabIndex = selected ? 0 : -1
+        })
+        panels.forEach((p) => {
+          p.hidden = p.dataset.tool !== tab.dataset.tool
+        })
+        if (focus) tab.focus()
+      }
+
+      tabs.forEach((tab, i) => {
+        tab.addEventListener('click', () => selectTab(tab))
+        tab.addEventListener('keydown', (e) => {
+          let next = -1
+          if (e.key === 'ArrowRight') next = (i + 1) % tabs.length
+          else if (e.key === 'ArrowLeft') next = (i - 1 + tabs.length) % tabs.length
+          else if (e.key === 'Home') next = 0
+          else if (e.key === 'End') next = tabs.length - 1
+          else return
+          e.preventDefault()
+          selectTab(tabs[next], true)
         })
       })
 

--- a/site/src/components/landing/AgentSetupCard.astro
+++ b/site/src/components/landing/AgentSetupCard.astro
@@ -7,16 +7,7 @@
  * kept in sync with it.
  */
 import CodeBlock from './CodeBlock.astro'
-
-interface Props {
-  baseUrl: string
-}
-
-const { baseUrl } = Astro.props
-const withBase = (path: string) => {
-  const b = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
-  return b + path
-}
+import { pathWithBase } from '../../util/links'
 
 const PROMPT = 'Add the Strands Agents SDK to my project. Docs: https://strandsagents.com/llms.txt'
 
@@ -79,7 +70,7 @@ const tools = [
         </button>
       ))}
     </div>
-    <a class="agent-tool-other" href={withBase('/docs/user-guide/build-with-ai/')}>Other</a>
+    <a class="agent-tool-other" href={pathWithBase('/docs/user-guide/build-with-ai/')}>Other</a>
   </div>
 
   {tools.map((tool, i) => (
@@ -106,9 +97,9 @@ const tools = [
   </div>
 
   <p class="agent-setup-links">
-    <a href={withBase('/llms.txt')}>llms.txt</a>
-    <a href={withBase('/llms-full.txt')}>llms-full.txt</a>
-    <a href={withBase('/docs/user-guide/build-with-ai/')}>Build with AI guide</a>
+    <a href={pathWithBase('/llms.txt')}>llms.txt</a>
+    <a href={pathWithBase('/llms-full.txt')}>llms-full.txt</a>
+    <a href={pathWithBase('/docs/user-guide/build-with-ai/')}>Build with AI guide</a>
   </p>
 </div>
 
@@ -292,7 +283,11 @@ const tools = [
       const copyBtn = card.querySelector<HTMLButtonElement>('.agent-prompt-copy')
       if (prompt && copyBtn) {
         copyBtn.addEventListener('click', async () => {
-          await navigator.clipboard.writeText(prompt.dataset.copy || '')
+          try {
+            await navigator.clipboard.writeText(prompt.dataset.copy || '')
+          } catch {
+            return
+          }
           copyBtn.classList.add('copied')
           setTimeout(() => copyBtn.classList.remove('copied'), 2000)
         })

--- a/site/src/components/landing/AgentSetupCard.astro
+++ b/site/src/components/landing/AgentSetupCard.astro
@@ -1,0 +1,271 @@
+---
+/**
+ * Agent setup card shown in the hero's "For agents" state.
+ *
+ * Surfaces the Strands MCP server setup per coding tool plus llms.txt
+ * links. Content mirrors /docs/user-guide/build-with-ai/ and should be
+ * kept in sync with it.
+ */
+import CodeBlock from './CodeBlock.astro'
+
+interface Props {
+  baseUrl: string
+}
+
+const { baseUrl } = Astro.props
+const withBase = (path: string) => {
+  const b = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+  return b + path
+}
+
+const PROMPT = 'Add the Strands Agents SDK to my project. Docs: https://strandsagents.com/llms.txt'
+
+const claudeCodeCmd = 'claude mcp add strands uvx strands-agents-mcp-server'
+
+const cursorJson = `{
+  "mcpServers": {
+    "strands-agents": {
+      "command": "uvx",
+      "args": ["strands-agents-mcp-server"]
+    }
+  }
+}`
+
+const kiroJson = `{
+  "mcpServers": {
+    "strands-agents": {
+      "command": "uvx",
+      "args": ["strands-agents-mcp-server"],
+      "disabled": false,
+      "autoApprove": ["search_docs", "fetch_doc"]
+    }
+  }
+}`
+
+const vscodeJson = `{
+  "servers": {
+    "strands-agents": {
+      "command": "uvx",
+      "args": ["strands-agents-mcp-server"]
+    }
+  }
+}`
+
+const tools = [
+  { id: 'claude-code', label: 'Claude Code', note: 'Run in your terminal:', code: claudeCodeCmd, lang: 'bash' },
+  { id: 'cursor', label: 'Cursor', note: 'Add to ~/.cursor/mcp.json:', code: cursorJson, lang: 'json' },
+  { id: 'kiro', label: 'Kiro', note: 'Add to ~/.kiro/settings/mcp.json:', code: kiroJson, lang: 'json' },
+  { id: 'vscode', label: 'VS Code', note: 'Add to your mcp.json:', code: vscodeJson, lang: 'json' },
+]
+---
+
+<div class="agent-setup-card">
+  <p class="agent-setup-heading">Set up with your coding agent</p>
+
+  <div class="agent-tool-tabs" role="tablist" aria-label="Coding tool">
+    {tools.map((tool, i) => (
+      <button
+        class="agent-tool-tab"
+        role="tab"
+        aria-selected={i === 0 ? 'true' : 'false'}
+        data-tool={tool.id}
+      >
+        {tool.label}
+      </button>
+    ))}
+    <a class="agent-tool-other" href={withBase('/docs/user-guide/build-with-ai/')}>Other</a>
+  </div>
+
+  {tools.map((tool, i) => (
+    <div class="agent-tool-panel" role="tabpanel" data-tool={tool.id} hidden={i !== 0}>
+      <p class="agent-tool-note">{tool.note}</p>
+      <CodeBlock code={tool.code} lang={tool.lang} />
+    </div>
+  ))}
+
+  <div class="agent-prompt" data-copy={PROMPT}>
+    <p class="agent-prompt-label">Or paste this prompt:</p>
+    <div class="agent-prompt-row">
+      <span class="agent-prompt-text">{PROMPT}</span>
+      <button class="agent-prompt-copy" aria-label="Copy prompt">
+        <svg class="copy-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <rect x="5" y="5" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
+          <path d="M3 10.5V3a1.5 1.5 0 0 1 1.5-1.5H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+        </svg>
+        <svg class="check-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <path d="M3.5 8.5L6.5 11.5L12.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <p class="agent-setup-links">
+    <a href={withBase('/llms.txt')}>llms.txt</a>
+    <a href={withBase('/llms-full.txt')}>llms-full.txt</a>
+    <a href={withBase('/docs/user-guide/build-with-ai/')}>Build with AI guide</a>
+  </p>
+</div>
+
+<style>
+  .agent-setup-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    border: 1px solid rgba(0, 204, 95, 0.35);
+    border-radius: 12px;
+    padding: 1.25rem;
+    background: rgba(0, 0, 0, 0.4);
+  }
+
+  :global([data-theme='light']) .agent-setup-card {
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  .agent-setup-heading {
+    font-family: 'Figtree', sans-serif;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--strands-green);
+    margin: 0;
+  }
+
+  /* Tabs mirror the LanguageToggle underline pattern */
+  .agent-tool-tabs {
+    display: flex;
+    align-items: stretch;
+    border-bottom: 2px solid var(--sl-color-gray-5);
+  }
+
+  .agent-tool-tab {
+    padding: 0.25rem 0.625rem;
+    border: none;
+    background: transparent;
+    color: var(--sl-color-gray-3);
+    font-size: 0.8125rem;
+    font-weight: 400;
+    font-family: var(--sl-font);
+    cursor: pointer;
+    transition: color 0.15s ease, box-shadow 0.15s ease;
+    white-space: nowrap;
+    box-shadow: 0 2px 0 0 var(--sl-color-gray-5);
+    margin-bottom: -2px;
+  }
+
+  .agent-tool-tab:hover {
+    color: var(--sl-color-white);
+  }
+
+  .agent-tool-tab[aria-selected='true'] {
+    font-weight: 600;
+    color: var(--sl-color-text-accent);
+    box-shadow: 0 2px 0 0 var(--sl-color-text-accent);
+  }
+
+  .agent-tool-other {
+    margin-left: auto;
+    align-self: center;
+    font-size: 0.8125rem;
+    color: var(--sl-color-gray-3);
+  }
+
+  .agent-tool-note {
+    font-family: 'Figtree', sans-serif;
+    font-size: 0.8rem;
+    color: var(--sl-color-gray-3);
+    margin: 0 0 0.4rem;
+  }
+
+  .agent-prompt-label {
+    font-family: 'Figtree', sans-serif;
+    font-size: 0.8rem;
+    color: var(--sl-color-gray-3);
+    margin: 0 0 0.3rem;
+  }
+
+  .agent-prompt-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+  }
+
+  :global([data-theme='light']) .agent-prompt-row {
+    background: rgba(0, 0, 0, 0.04);
+    border-color: rgba(0, 0, 0, 0.1);
+  }
+
+  .agent-prompt-text {
+    font-family: ui-monospace, 'SF Mono', 'Cascadia Code', monospace;
+    font-size: 0.75rem;
+    color: var(--sl-color-gray-3);
+  }
+
+  .agent-prompt-copy {
+    background: none;
+    border: none;
+    color: var(--sl-color-gray-4);
+    cursor: pointer;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    margin-left: auto;
+    transition: color 0.2s ease;
+  }
+
+  .agent-prompt-copy:hover {
+    color: var(--sl-color-white);
+  }
+
+  .agent-prompt-copy .check-icon { display: none; }
+  .agent-prompt-copy.copied .copy-icon { display: none; }
+  .agent-prompt-copy.copied .check-icon { display: block; }
+  .agent-prompt-copy.copied { color: var(--strands-green, #00cc5f); }
+
+  .agent-setup-links {
+    display: flex;
+    gap: 1rem;
+    font-family: 'Figtree', sans-serif;
+    font-size: 0.8rem;
+    margin: 0;
+  }
+
+  .agent-setup-links a {
+    color: var(--sl-color-gray-3);
+  }
+
+  .agent-setup-links a:hover {
+    color: var(--strands-green);
+  }
+</style>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll<HTMLElement>('.agent-setup-card').forEach((card) => {
+      // Tool tab switching
+      const tabs = card.querySelectorAll<HTMLButtonElement>('.agent-tool-tab')
+      const panels = card.querySelectorAll<HTMLElement>('.agent-tool-panel')
+      tabs.forEach((tab) => {
+        tab.addEventListener('click', () => {
+          tabs.forEach((t) => t.setAttribute('aria-selected', t === tab ? 'true' : 'false'))
+          panels.forEach((p) => {
+            p.hidden = p.dataset.tool !== tab.dataset.tool
+          })
+        })
+      })
+
+      // Prompt copy (same pattern as CodeBlock's copy button)
+      const prompt = card.querySelector<HTMLElement>('.agent-prompt')
+      const copyBtn = card.querySelector<HTMLButtonElement>('.agent-prompt-copy')
+      if (prompt && copyBtn) {
+        copyBtn.addEventListener('click', async () => {
+          await navigator.clipboard.writeText(prompt.dataset.copy || '')
+          copyBtn.classList.add('copied')
+          setTimeout(() => copyBtn.classList.remove('copied'), 2000)
+        })
+      }
+    })
+  })
+</script>

--- a/site/src/components/landing/AgentSetupCard.astro
+++ b/site/src/components/landing/AgentSetupCard.astro
@@ -69,6 +69,8 @@ const tools = [
         role="tab"
         aria-selected={i === 0 ? 'true' : 'false'}
         data-tool={tool.id}
+        id={'agent-tab-' + tool.id}
+        aria-controls={'agent-panel-' + tool.id}
       >
         {tool.label}
       </button>
@@ -77,7 +79,7 @@ const tools = [
   </div>
 
   {tools.map((tool, i) => (
-    <div class="agent-tool-panel" role="tabpanel" data-tool={tool.id} hidden={i !== 0}>
+    <div class="agent-tool-panel" role="tabpanel" data-tool={tool.id} hidden={i !== 0} id={'agent-panel-' + tool.id} aria-labelledby={'agent-tab-' + tool.id}>
       <p class="agent-tool-note">{tool.note}</p>
       <CodeBlock code={tool.code} lang={tool.lang} />
     </div>

--- a/site/src/components/landing/CodeBlock.astro
+++ b/site/src/components/landing/CodeBlock.astro
@@ -22,11 +22,11 @@ const { code, lang = 'python', filename, badge } = Astro.props
       <span class="code-filename">{filename}</span>
       {badge && <span class="code-badge">{badge}</span>}
       <button class="copy-button" aria-label="Copy code">
-        <svg class="copy-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <svg class="copy-icon" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none">
           <rect x="5" y="5" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
           <path d="M3 10.5V3a1.5 1.5 0 0 1 1.5-1.5H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
         </svg>
-        <svg class="check-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <svg class="check-icon" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none">
           <path d="M3.5 8.5L6.5 11.5L12.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </button>
@@ -34,11 +34,11 @@ const { code, lang = 'python', filename, badge } = Astro.props
   )}
   {!filename && (
     <button class="copy-button copy-button-floating" aria-label="Copy code">
-      <svg class="copy-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <svg class="copy-icon" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none">
         <rect x="5" y="5" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
         <path d="M3 10.5V3a1.5 1.5 0 0 1 1.5-1.5H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
       </svg>
-      <svg class="check-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <svg class="check-icon" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none">
         <path d="M3.5 8.5L6.5 11.5L12.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </button>

--- a/site/src/components/landing/HeroSection.astro
+++ b/site/src/components/landing/HeroSection.astro
@@ -334,38 +334,55 @@ await agent.invoke('Research AI agent frameworks')`
 
   .hero-code {
     min-width: 0;
+    display: flex;
+    flex-direction: column;
   }
 
   .audience-toggle {
     display: inline-flex;
-    align-items: stretch;
-    border-bottom: 2px solid var(--sl-color-gray-5);
+    align-self: flex-start;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 999px;
+    padding: 2px;
     margin-bottom: 0.75rem;
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  :global([data-theme='light']) .audience-toggle {
+    border-color: rgba(0, 0, 0, 0.12);
+    background: rgba(0, 0, 0, 0.03);
   }
 
   .audience-option {
-    padding: 0.25rem 0.625rem;
+    padding: 0.25rem 0.875rem;
     border: none;
+    border-radius: 999px;
     background: transparent;
     color: var(--sl-color-gray-3);
     font-size: 0.8125rem;
-    font-weight: 400;
-    font-family: var(--sl-font);
+    font-weight: 500;
+    font-family: 'Figtree', sans-serif;
     cursor: pointer;
-    transition: color 0.15s ease, box-shadow 0.15s ease;
+    transition: background 0.2s ease, color 0.2s ease;
     white-space: nowrap;
-    box-shadow: 0 2px 0 0 var(--sl-color-gray-5);
-    margin-bottom: -2px;
   }
 
   .audience-option:hover {
     color: var(--sl-color-white);
   }
 
+  :global([data-theme='light']) .audience-option:hover {
+    color: var(--sl-color-gray-1);
+  }
+
   .audience-option[aria-checked='true'] {
+    background: var(--strands-green);
+    color: #0e0e0e;
     font-weight: 600;
-    color: var(--sl-color-text-accent);
-    box-shadow: 0 2px 0 0 var(--sl-color-text-accent);
+  }
+
+  .audience-option[aria-checked='true']:hover {
+    color: #0e0e0e;
   }
 
   /* Stack the two panels in one grid cell and cross-fade on swap */
@@ -379,10 +396,14 @@ await agent.invoke('Research AI agent frameworks')`
     transition: opacity 0.3s ease, visibility 0.3s;
   }
 
+  /* pointer-events guards against descendants that reset visibility
+     (LangCodeBlock keeps its active variant visibility: visible), which would
+     otherwise capture clicks through the hidden panel */
   .hero-section[data-audience='humans'] .hero-panel[data-panel='agents'],
   .hero-section[data-audience='agents'] .hero-panel[data-panel='humans'] {
     opacity: 0;
     visibility: hidden;
+    pointer-events: none;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/site/src/components/landing/HeroSection.astro
+++ b/site/src/components/landing/HeroSection.astro
@@ -135,7 +135,7 @@ await agent.invoke('Research AI agent frameworks')`
           />
         </div>
         <div class="hero-panel" data-panel="agents">
-          <AgentSetupCard baseUrl={baseUrl} />
+          <AgentSetupCard />
         </div>
       </div>
     </div>

--- a/site/src/components/landing/HeroSection.astro
+++ b/site/src/components/landing/HeroSection.astro
@@ -3,6 +3,7 @@
  * Hero section: headline + subtext on left, code snippet on right.
  */
 import LangCodeBlock from './LangCodeBlock.astro'
+import AgentSetupCard from './AgentSetupCard.astro'
 import { getStarCount } from '../../util/github'
 
 interface Props {
@@ -73,7 +74,7 @@ agent.addHook(BeforeToolCallEvent, (event) => {
 await agent.invoke('Research AI agent frameworks')`
 ---
 
-<section class="hero-section">
+<section class="hero-section" data-audience="humans">
   <div class="hero-background"></div>
   <div class="hero-inner">
     <div class="hero-text">
@@ -120,12 +121,23 @@ await agent.invoke('Research AI agent frameworks')`
       </p>
     </div>
     <div class="hero-code">
-      <LangCodeBlock
-        pythonCode={heroPython}
-        pythonFilename="research_agent.py"
-        tsCode={heroTs}
-        tsFilename="research_agent.ts"
-      />
+      <div class="audience-toggle" role="radiogroup" aria-label="Audience">
+        <button class="audience-option" role="radio" aria-checked="true" data-audience="humans">For humans</button>
+        <button class="audience-option" role="radio" aria-checked="false" data-audience="agents">For agents</button>
+      </div>
+      <div class="hero-panels">
+        <div class="hero-panel" data-panel="humans">
+          <LangCodeBlock
+            pythonCode={heroPython}
+            pythonFilename="research_agent.py"
+            tsCode={heroTs}
+            tsFilename="research_agent.ts"
+          />
+        </div>
+        <div class="hero-panel" data-panel="agents">
+          <AgentSetupCard baseUrl={baseUrl} />
+        </div>
+      </div>
     </div>
   </div>
 </section>
@@ -257,14 +269,14 @@ await agent.invoke('Research AI agent frameworks')`
      cycling code example (data-active-lang lives on <html>, set by
      LangCodeBlock's shared script). Without JS the attribute is absent and
      both commands render normally. */
-  :global(html[data-active-lang='Python']) .hero-install[data-lang='Python'],
-  :global(html[data-active-lang='TypeScript']) .hero-install[data-lang='TypeScript'] {
+  :global(html[data-active-lang='Python']) .hero-section[data-audience='humans'] .hero-install[data-lang='Python'],
+  :global(html[data-active-lang='TypeScript']) .hero-section[data-audience='humans'] .hero-install[data-lang='TypeScript'] {
     border-color: var(--strands-green);
     box-shadow: 0 0 12px rgba(0, 204, 95, 0.25);
   }
 
-  :global(html[data-active-lang='Python']) .hero-install[data-lang='TypeScript'],
-  :global(html[data-active-lang='TypeScript']) .hero-install[data-lang='Python'] {
+  :global(html[data-active-lang='Python']) .hero-section[data-audience='humans'] .hero-install[data-lang='TypeScript'],
+  :global(html[data-active-lang='TypeScript']) .hero-section[data-audience='humans'] .hero-install[data-lang='Python'] {
     opacity: 0.6;
   }
 
@@ -322,6 +334,61 @@ await agent.invoke('Research AI agent frameworks')`
 
   .hero-code {
     min-width: 0;
+  }
+
+  .audience-toggle {
+    display: inline-flex;
+    align-items: stretch;
+    border-bottom: 2px solid var(--sl-color-gray-5);
+    margin-bottom: 0.75rem;
+  }
+
+  .audience-option {
+    padding: 0.25rem 0.625rem;
+    border: none;
+    background: transparent;
+    color: var(--sl-color-gray-3);
+    font-size: 0.8125rem;
+    font-weight: 400;
+    font-family: var(--sl-font);
+    cursor: pointer;
+    transition: color 0.15s ease, box-shadow 0.15s ease;
+    white-space: nowrap;
+    box-shadow: 0 2px 0 0 var(--sl-color-gray-5);
+    margin-bottom: -2px;
+  }
+
+  .audience-option:hover {
+    color: var(--sl-color-white);
+  }
+
+  .audience-option[aria-checked='true'] {
+    font-weight: 600;
+    color: var(--sl-color-text-accent);
+    box-shadow: 0 2px 0 0 var(--sl-color-text-accent);
+  }
+
+  /* Stack the two panels in one grid cell and cross-fade on swap */
+  .hero-panels {
+    display: grid;
+  }
+
+  .hero-panel {
+    grid-area: 1 / 1;
+    min-width: 0;
+    transition: opacity 0.3s ease, visibility 0.3s;
+  }
+
+  .hero-section[data-audience='humans'] .hero-panel[data-panel='agents'],
+  .hero-section[data-audience='agents'] .hero-panel[data-panel='humans'] {
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero-panel {
+      transition: none;
+    }
   }
 
   @media (max-width: 768px) {
@@ -394,5 +461,20 @@ await agent.invoke('Research AI agent frameworks')`
         if (e.target !== btn && !btn.contains(e.target as Node)) copy()
       })
     })
+
+    const section = document.querySelector<HTMLElement>('.hero-section')
+    if (section) {
+      const options = section.querySelectorAll<HTMLButtonElement>('.audience-option')
+      options.forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const audience = btn.dataset.audience
+          if (!audience) return
+          section.dataset.audience = audience
+          options.forEach((opt) => {
+            opt.setAttribute('aria-checked', opt === btn ? 'true' : 'false')
+          })
+        })
+      })
+    }
   })
 </script>

--- a/site/src/components/landing/HeroSection.astro
+++ b/site/src/components/landing/HeroSection.astro
@@ -93,11 +93,11 @@ await agent.invoke('Research AI agent frameworks')`
         <div class="hero-install" data-copy="pip install strands-agents" data-lang="Python">
           <code>pip install strands-agents</code>
           <button class="install-copy" aria-label="Copy install command">
-            <svg class="copy-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <svg class="copy-icon" aria-hidden="true" width="14" height="14" viewBox="0 0 16 16" fill="none">
               <rect x="5" y="5" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
               <path d="M3 10.5V3a1.5 1.5 0 0 1 1.5-1.5H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
             </svg>
-            <svg class="check-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <svg class="check-icon" aria-hidden="true" width="14" height="14" viewBox="0 0 16 16" fill="none">
               <path d="M3.5 8.5L6.5 11.5L12.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </button>
@@ -105,11 +105,11 @@ await agent.invoke('Research AI agent frameworks')`
         <div class="hero-install" data-copy="npm install @strands-agents/sdk" data-lang="TypeScript">
           <code>npm install @strands-agents/sdk</code>
           <button class="install-copy" aria-label="Copy install command">
-            <svg class="copy-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <svg class="copy-icon" aria-hidden="true" width="14" height="14" viewBox="0 0 16 16" fill="none">
               <rect x="5" y="5" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
               <path d="M3 10.5V3a1.5 1.5 0 0 1 1.5-1.5H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
             </svg>
-            <svg class="check-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <svg class="check-icon" aria-hidden="true" width="14" height="14" viewBox="0 0 16 16" fill="none">
               <path d="M3.5 8.5L6.5 11.5L12.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </button>

--- a/site/src/components/landing/HeroSection.astro
+++ b/site/src/components/landing/HeroSection.astro
@@ -121,9 +121,9 @@ await agent.invoke('Research AI agent frameworks')`
       </p>
     </div>
     <div class="hero-code">
-      <div class="audience-toggle" role="radiogroup" aria-label="Audience">
-        <button class="audience-option" role="radio" aria-checked="true" data-audience="humans">For humans</button>
-        <button class="audience-option" role="radio" aria-checked="false" data-audience="agents">For agents</button>
+      <div class="audience-toggle" role="group" aria-label="Audience">
+        <button class="audience-option" type="button" aria-pressed="true" data-audience="humans">For humans</button>
+        <button class="audience-option" type="button" aria-pressed="false" data-audience="agents">For agents</button>
       </div>
       <div class="hero-panels">
         <div class="hero-panel" data-panel="humans">
@@ -375,13 +375,13 @@ await agent.invoke('Research AI agent frameworks')`
     color: var(--sl-color-gray-1);
   }
 
-  .audience-option[aria-checked='true'] {
+  .audience-option[aria-pressed='true'] {
     background: var(--strands-green);
     color: #0e0e0e;
     font-weight: 600;
   }
 
-  .audience-option[aria-checked='true']:hover {
+  .audience-option[aria-pressed='true']:hover {
     color: #0e0e0e;
   }
 
@@ -492,7 +492,7 @@ await agent.invoke('Research AI agent frameworks')`
           if (!audience) return
           section.dataset.audience = audience
           options.forEach((opt) => {
-            opt.setAttribute('aria-checked', opt === btn ? 'true' : 'false')
+            opt.setAttribute('aria-pressed', opt === btn ? 'true' : 'false')
           })
         })
       })

--- a/site/src/components/landing/HeroSection.astro
+++ b/site/src/components/landing/HeroSection.astro
@@ -184,6 +184,7 @@ await agent.invoke('Research AI agent frameworks')`
     color: var(--sl-color-white);
     letter-spacing: -0.03em;
     margin: 0;
+    text-wrap: balance;
   }
 
   .hero-highlight {

--- a/site/src/components/landing/HeroSection.astro
+++ b/site/src/components/landing/HeroSection.astro
@@ -79,12 +79,9 @@ await agent.invoke('Research AI agent frameworks')`
   <div class="hero-inner">
     <div class="hero-text">
       <h1 class="hero-title">
-        The open source<br />
-        <span class="hero-highlight">agent harness SDK.</span>
+        The open source toolkit for building
+        <span class="hero-highlight">production agents.</span>
       </h1>
-      <p class="hero-subtitle">
-        The open source toolkit for building production agents.
-      </p>
       <div class="hero-cta">
         <a href={withBase('/docs/user-guide/quickstart/overview/')} class="cta-button primary">Get Started</a>
         <a href="https://github.com/strands-agents/harness-sdk" class="cta-button secondary">GitHub</a>

--- a/site/src/layouts/LandingLayout.astro
+++ b/site/src/layouts/LandingLayout.astro
@@ -112,6 +112,9 @@ Astro.locals.t = mockT
     
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href={pathWithBase('/favicon.svg')} />
+
+    <!-- Canonical -->
+    <link rel="canonical" href={Astro.url.href} />
     
     <!-- Open Graph -->
     <meta property="og:title" content={title} />

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -50,6 +50,34 @@ const base = import.meta.env.BASE_URL || '/'
       <Copyright />
     </div>
   </footer>
+
+  <script>
+    // Scroll-responsive strands background animation
+    // Adjusts background-position offset along the flow axis so scrolling
+    // feels like controlling the tempo of the strand movement
+    const primary = document.querySelector<HTMLElement>('.strands-curve-primary')
+    const secondary = document.querySelector<HTMLElement>('.strands-curve-secondary')
+
+    if (primary && secondary && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      let ticking = false
+
+      window.addEventListener('scroll', () => {
+        if (!ticking) {
+          requestAnimationFrame(() => {
+            const scrollY = window.scrollY
+
+            // Offset background-position along the flow axis via CSS variable
+            // Primary responds more (0.3x scroll), secondary less (0.15x) for depth
+            primary.style.setProperty('--scroll-offset', `${-(scrollY * 0.3) % 344}px`)
+            secondary.style.setProperty('--scroll-offset', `${-(scrollY * 0.15) % 344}px`)
+
+            ticking = false
+          })
+          ticking = true
+        }
+      }, { passive: true })
+    }
+  </script>
 </LandingLayout>
 
 <style>
@@ -149,31 +177,3 @@ const base = import.meta.env.BASE_URL || '/'
   @media (max-width: 768px) {
   }
 </style>
-
-<script>
-  // Scroll-responsive strands background animation
-  // Adjusts background-position offset along the flow axis so scrolling
-  // feels like controlling the tempo of the strand movement
-  const primary = document.querySelector<HTMLElement>('.strands-curve-primary')
-  const secondary = document.querySelector<HTMLElement>('.strands-curve-secondary')
-
-  if (primary && secondary && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-    let ticking = false
-
-    window.addEventListener('scroll', () => {
-      if (!ticking) {
-        requestAnimationFrame(() => {
-          const scrollY = window.scrollY
-
-          // Offset background-position along the flow axis via CSS variable
-          // Primary responds more (0.3x scroll), secondary less (0.15x) for depth
-          primary.style.setProperty('--scroll-offset', `${-(scrollY * 0.3) % 344}px`)
-          secondary.style.setProperty('--scroll-offset', `${-(scrollY * 0.15) % 344}px`)
-
-          ticking = false
-        })
-        ticking = true
-      }
-    }, { passive: true })
-  }
-</script>


### PR DESCRIPTION
## Description

Adds a "For humans | For agents" toggle to the homepage hero, inspired by ai-sdk.dev. The hero's right panel now switches between the code example ("For humans") and an agent setup card ("For agents") that surfaces the existing MCP server and llms.txt resources, which were previously invisible from the homepage.

The agent setup card includes:
- Per-tool MCP install tabs (Claude Code, Cursor, Kiro, VS Code) with copyable snippets sourced from the Build with AI guide, plus an "Other" link to that guide
- A copyable prompt for AI coding agents
- Links to llms.txt, llms-full.txt, and the Build with AI guide

The left hero column (headline, CTAs, install commands) is identical in both states. Toggle state is per-visit and not persisted. While "For agents" is shown, the install-command glow turns off and the panel cross-fades to the agent card.

The hero headline is also updated to "The open source toolkit for building production agents." (with "production agents." in brand green), promoting the previous tagline into the H1 and removing the separate subtitle line.

This PR also folds in homepage HTML/CSS quality fixes found while auditing the page for W3C validity, accessibility, and SEO:
- Decorative copy icons are hidden from assistive tech (aria-hidden)
- The hero audience toggle uses aria-pressed buttons; the tool tabs implement the full ARIA tablist keyboard pattern (roving tabindex, arrow/Home/End)
- Added a canonical link to the landing page head
- Moved the curve animation script inside the layout so no content renders after </html> (fixes a W3C validity error)

> Note: this builds on #2775 (homepage language switching). Until that merges, the diff here includes its commits.

## Related Issues

None

## Documentation PR

No documentation changes needed. The agent setup card surfaces existing docs (Build with AI guide, llms.txt); its snippets mirror site/src/content/docs/user-guide/build-with-ai.mdx.

## Type of Change

New feature

## Testing

- `npm run typecheck`, `npm run test` (316 passed, 2 skipped), and `npm run build` pass in `site/`
- Verified the homepage in a headless browser:
  - Toggle cross-fades between the code example and the agent card with no layout shift; install glow turns off in the agents state
  - All four tool tabs show and copy the correct snippet; prompt copy works; llms.txt and guide links resolve (200)
  - Toggle state resets on reload
  - Keyboard: audience toggle operable via Enter/Space; tool tabs support arrow keys, Home/End, and roving tabindex
  - Reduced motion: instant panel swap; mobile (390px) and light theme render cleanly
- Accessibility: re-ran axe-core; the new controls introduce no violations (decorative icons hidden, ARIA tablist valid)
- W3C: build output validates with 0 errors (2 pre-existing info-level "section lacks heading" warnings remain, unrelated to this change)

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

<img width="2880" height="1608" alt="pr2-dark-desktop-agents" src="https://github.com/user-attachments/assets/f058cf64-5682-4576-8c13-fc3808c3be9a" />
<img width="2880" height="1608" alt="pr2-dark-desktop-humans" src="https://github.com/user-attachments/assets/afc74719-e548-45fc-9ee4-9523887d9a42" />
<img width="780" height="1576" alt="pr2-dark-mobile-agents" src="https://github.com/user-attachments/assets/e26ceed0-fc51-4978-af7a-68bf7cc4dd30" />
<img width="780" height="1576" alt="pr2-dark-mobile-humans" src="https://github.com/user-attachments/assets/63275b3e-3905-44a0-83e7-3bfb6439e79a" />
<img width="2880" height="1608" alt="pr2-light-desktop-agents" src="https://github.com/user-attachments/assets/8d2afa36-8ade-44e7-b12d-c9b9c82cde78" />
<img width="2880" height="1608" alt="pr2-light-desktop-humans" src="https://github.com/user-attachments/assets/ddfbb37a-cf02-4820-ad7d-5dfd94c10565" />
<img width="780" height="1576" alt="pr2-light-mobile-agents" src="https://github.com/user-attachments/assets/42185625-3a9a-4483-918a-901d88bcd861" />
<img width="780" height="1576" alt="pr2-light-mobile-humans" src="https://github.com/user-attachments/assets/550b5533-2d10-465e-ae47-601aa4666e6b" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
