### PR TITLE
fix(openai): report Responses prompt-cache tokens (TypeScript)

### DIFF
--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -524,6 +524,55 @@ describe("OpenAIModel (api: 'responses')", () => {
       expect(metadata?.usage).toEqual({ inputTokens: 10, outputTokens: 5, totalTokens: 15 })
     })
 
+    it('plumbs prompt-cache reads (input_tokens_details.cached_tokens) into cacheReadInputTokens', async () => {
+      const client = createMockClient(async function* () {
+        yield { type: 'response.created', response: { id: 'r' } }
+        yield { type: 'response.output_text.delta', delta: 'hi' }
+        yield {
+          type: 'response.completed',
+          response: {
+            usage: {
+              input_tokens: 1553,
+              output_tokens: 42,
+              total_tokens: 1595,
+              input_tokens_details: { cached_tokens: 873 },
+            },
+          },
+        }
+      })
+      const model = new OpenAIModel({ api: 'responses', client })
+      const events = await collectIterator(model.stream([new Message({ role: 'user', content: [new TextBlock('x')] })]))
+      const metadata = events.find((e: any) => e.type === 'modelMetadataEvent') as any
+      expect(metadata?.usage).toEqual({
+        inputTokens: 1553,
+        outputTokens: 42,
+        totalTokens: 1595,
+        cacheReadInputTokens: 873,
+      })
+    })
+
+    it('omits cacheReadInputTokens when there is no cache hit (cached_tokens 0 or absent)', async () => {
+      const client = createMockClient(async function* () {
+        yield { type: 'response.created', response: { id: 'r' } }
+        yield {
+          type: 'response.completed',
+          response: {
+            usage: {
+              input_tokens: 1553,
+              output_tokens: 42,
+              total_tokens: 1595,
+              input_tokens_details: { cached_tokens: 0 },
+            },
+          },
+        }
+      })
+      const model = new OpenAIModel({ api: 'responses', client })
+      const events = await collectIterator(model.stream([new Message({ role: 'user', content: [new TextBlock('x')] })]))
+      const metadata = events.find((e: any) => e.type === 'modelMetadataEvent') as any
+      expect(metadata?.usage).toEqual({ inputTokens: 1553, outputTokens: 42, totalTokens: 1595 })
+      expect(metadata?.usage).not.toHaveProperty('cacheReadInputTokens')
+    })
+
     it('emits URL citation delta from response.output_text.annotation.added', async () => {
       const client = createMockClient(async function* () {
         yield { type: 'response.created', response: { id: 'r' } }

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -20,6 +20,7 @@ import type {
   ResponseFunctionToolCall,
   ResponseFunctionCallOutputItem,
   ResponseCreateParamsStreaming,
+  ResponseUsage,
 } from 'openai/resources/responses/responses'
 import type { Message, StopReason, ToolResultBlock } from '../../types/messages.js'
 import type { ImageBlock, DocumentBlock } from '../../types/media.js'
@@ -331,7 +332,12 @@ function formatDocumentInput(docBlock: DocumentBlock): Record<string, unknown> |
 export interface ResponsesStreamState {
   dataType: string | null
   toolCalls: Map<string, { name: string; arguments: string; callId: string; itemId: string }>
-  finalUsage: { inputTokens: number; outputTokens: number; totalTokens: number } | null
+  finalUsage: {
+    inputTokens: number
+    outputTokens: number
+    totalTokens: number
+    cacheReadInputTokens?: number
+  } | null
   stopReason: StopReason
 }
 
@@ -347,6 +353,29 @@ export function createResponsesStreamState(): ResponsesStreamState {
     finalUsage: null,
     stopReason: 'endTurn',
   }
+}
+
+/**
+ * Maps a Responses API `usage` object to the SDK's usage shape, including
+ * prompt-cache reads. The Responses API reports cache hits via
+ * `usage.input_tokens_details.cached_tokens`; surfacing it as
+ * `cacheReadInputTokens` keeps the Responses path consistent with the Bedrock,
+ * Anthropic, and Vercel model adapters (and lets `telemetry/tracer.ts` emit
+ * `gen_ai.usage.cache_read_input_tokens`).
+ *
+ * @internal
+ */
+function mapResponsesUsage(usage: ResponseUsage): NonNullable<ResponsesStreamState['finalUsage']> {
+  const mapped: NonNullable<ResponsesStreamState['finalUsage']> = {
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    totalTokens: usage.total_tokens,
+  }
+  const cached = usage.input_tokens_details?.cached_tokens
+  if (typeof cached === 'number' && cached > 0) {
+    mapped.cacheReadInputTokens = cached
+  }
+  return mapped
 }
 
 /**
@@ -464,11 +493,7 @@ export function mapResponsesEventToSDK(
     case 'response.incomplete': {
       const resp = event.response
       if (resp.usage) {
-        state.finalUsage = {
-          inputTokens: resp.usage.input_tokens,
-          outputTokens: resp.usage.output_tokens,
-          totalTokens: resp.usage.total_tokens,
-        }
+        state.finalUsage = mapResponsesUsage(resp.usage)
       }
       if (resp.incomplete_details?.reason === 'max_output_tokens') {
         state.stopReason = 'maxTokens'
@@ -479,11 +504,7 @@ export function mapResponsesEventToSDK(
     case 'response.completed': {
       const resp = event.response
       if (resp.usage) {
-        state.finalUsage = {
-          inputTokens: resp.usage.input_tokens,
-          outputTokens: resp.usage.output_tokens,
-          totalTokens: resp.usage.total_tokens,
-        }
+        state.finalUsage = mapResponsesUsage(resp.usage)
       }
       break
     }


### PR DESCRIPTION
## Description

The TypeScript `OpenAIModel` Responses adapter dropped OpenAI prompt-cache usage. `mapResponsesEventToSDK` built `finalUsage` from `input_tokens` / `output_tokens` / `total_tokens` only, so `usage.input_tokens_details.cached_tokens` was never surfaced as `cacheReadInputTokens`. Cache reads were therefore invisible in `AgentResult` usage metrics and OTel spans (`gen_ai.usage.cache_read_input_tokens`) for the Responses path, even when the API was returning `cached_tokens`.

This restores parity with the other adapters — `models/bedrock.ts`, `models/anthropic.ts`, and `models/vercel.ts` already plumb `cacheReadInputTokens`/`cacheWriteInputTokens`. The `Usage` type (`models/streaming.ts`) already declares both fields and the accumulator already sums them, so only the Responses adapter needed updating.

It is the TypeScript counterpart of the Python issue/PR (#2407 / #2663). The write side already works (a caller can pass `prompt_cache_key` / `prompt_cache_retention` via `params`, which `formatResponsesRequest` spreads into the request body); this PR makes the resulting cache reads observable.

Changes:
- Extract `mapResponsesUsage()` and call it from both the `response.completed` and `response.incomplete` branches (dedupes the existing mapping).
- Set `cacheReadInputTokens` only when `cached_tokens > 0`, matching the optional-field behavior of the other adapters.
- Add unit tests for a cache hit and the no-cache (`cached_tokens: 0`) case.

## Related Issues

Fixes #2781

## Documentation PR

No docs change needed — this aligns the Responses adapter with existing usage/telemetry behavior already documented for the other model providers.

## Type of Change

Bug fix

## Testing

`strands-ts`: `npm run build` (tsc, no errors), `npm run lint` (0 errors), `npm test` (full unit-node suite: 124 files / 3396 tests pass, no type errors). The two new tests in `src/models/openai/__tests__/responses.test.ts` cover the cache-hit and no-cache paths.

- [x] I ran the TypeScript equivalents (`npm run build`, `npm run lint`, `npm test`)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
