### PR TITLE
feat(memory): add Agent memory_manager param with configurable sync auto-flush

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -506,8 +506,9 @@ class Agent(AgentBase):
 
         return resolved_conversation_manager, resolved_plugins
 
+    @staticmethod
     def _resolve_memory_manager(
-        self, memory_manager: MemoryManager | MemoryManagerConfig | None
+        memory_manager: MemoryManager | MemoryManagerConfig | None,
     ) -> MemoryManager | None:
         """Resolve the ``memory_manager`` argument into a MemoryManager instance or None.
 

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -42,6 +42,7 @@ from ..types._snapshot import (
 )
 
 if TYPE_CHECKING:
+    from ..memory import MemoryManager, MemoryManagerConfig
     from ..tools import ToolProvider
 from .._middleware import MiddlewareRegistry
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
@@ -166,6 +167,7 @@ class Agent(AgentBase):
         hooks: list[HookProvider | HookCallback] | None = None,
         interventions: list[InterventionHandler] | None = None,
         session_manager: SessionManager | None = None,
+        memory_manager: "MemoryManager | MemoryManagerConfig | None" = None,
         structured_output_prompt: str | None = None,
         tool_executor: ToolExecutor | None = None,
         retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
@@ -240,6 +242,12 @@ class Agent(AgentBase):
                 Defaults to None.
             session_manager: Manager for handling agent sessions including conversation history and state.
                 If provided, enables session-based persistence and state management.
+            memory_manager: Cross-session memory manager. Accepts a
+                :class:`~strands.memory.MemoryManager` instance or a
+                :class:`~strands.memory.MemoryManagerConfig` (auto-wrapped). When set, its
+                search/add tools are registered and the synchronous ``Agent(...)`` entry point
+                awaits pending extraction writes after each invocation unless the manager sets
+                ``flush_on_invocation_end=False``. Defaults to None.
             structured_output_prompt: Custom prompt message used when forcing structured output.
                 When using structured output, if the model doesn't automatically use the output tool,
                 the agent sends a follow-up message to request structured formatting. This parameter
@@ -431,6 +439,12 @@ class Agent(AgentBase):
             for plugin in plugins_to_register:
                 self._plugin_registry.add_and_init(plugin)
 
+        # Resolve and register the memory manager (a Plugin); keep a reference so the
+        # synchronous entry point can flush pending extraction writes.
+        self.memory_manager = self._resolve_memory_manager(memory_manager)
+        if self.memory_manager is not None:
+            self._plugin_registry.add_and_init(self.memory_manager)
+
         self.hooks.invoke_callbacks(AgentInitializedEvent(agent=self))
 
     @staticmethod
@@ -462,18 +476,14 @@ class Agent(AgentBase):
 
         supported = get_args(ContextManagerStrategy)
         if context_manager not in supported:
-            raise ValueError(
-                f"Unsupported context_manager value: {context_manager!r}. Supported values: {supported}"
-            )
+            raise ValueError(f"Unsupported context_manager value: {context_manager!r}. Supported values: {supported}")
 
         from ..vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
         from .conversation_manager import SummarizingConversationManager
 
         resolved_plugins = list(plugins) if plugins else []
 
-        has_offloader = any(
-            isinstance(p, ContextOffloader) for p in resolved_plugins
-        )
+        has_offloader = any(isinstance(p, ContextOffloader) for p in resolved_plugins)
         if not has_offloader:
             offloader = ContextOffloader(
                 storage=InMemoryStorage(),
@@ -491,6 +501,30 @@ class Agent(AgentBase):
             )
 
         return resolved_conversation_manager, resolved_plugins
+
+    def _resolve_memory_manager(
+        self, memory_manager: "MemoryManager | MemoryManagerConfig | None"
+    ) -> "MemoryManager | None":
+        """Resolve the ``memory_manager`` argument into a MemoryManager instance or None.
+
+        A :class:`~strands.memory.MemoryManagerConfig` is wrapped into a
+        :class:`~strands.memory.MemoryManager`; an instance passes through.
+        """
+        if memory_manager is None:
+            return None
+
+        from ..memory import MemoryManager, MemoryManagerConfig
+
+        if isinstance(memory_manager, MemoryManager):
+            return memory_manager
+        if isinstance(memory_manager, MemoryManagerConfig):
+            return MemoryManager(
+                stores=memory_manager.stores,
+                search_tool_config=memory_manager.search_tool_config,
+                add_tool_config=memory_manager.add_tool_config,
+                flush_on_invocation_end=memory_manager.flush_on_invocation_end,
+            )
+        raise ValueError("memory_manager must be a MemoryManager or MemoryManagerConfig")
 
     def cancel(self) -> None:
         """Cancel the currently running agent invocation.
@@ -634,7 +668,7 @@ class Agent(AgentBase):
                 - structured_output: Parsed structured output when structured_output_model was specified
         """
         return run_async(
-            lambda: self.invoke_async(
+            lambda: self._invoke_async_and_flush(
                 prompt,
                 invocation_state=invocation_state,
                 structured_output_model=structured_output_model,
@@ -643,6 +677,19 @@ class Agent(AgentBase):
                 **kwargs,
             )
         )
+
+    async def _invoke_async_and_flush(self, prompt: AgentInput = None, **kwargs: Any) -> AgentResult:
+        """Run ``invoke_async`` then flush the memory manager within this loop.
+
+        The synchronous entry point runs each invocation in its own event loop, which would
+        cancel background extraction saves on close. Flushing here persists them. The async
+        path does not flush, leaving extraction on its trigger cadence.
+        """
+        try:
+            return await self.invoke_async(prompt, **kwargs)
+        finally:
+            if self.memory_manager is not None and self.memory_manager.flush_on_invocation_end:
+                await self.memory_manager.flush()
 
     async def invoke_async(
         self,

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -242,12 +242,11 @@ class Agent(AgentBase):
                 Defaults to None.
             session_manager: Manager for handling agent sessions including conversation history and state.
                 If provided, enables session-based persistence and state management.
-            memory_manager: Cross-session memory manager. Accepts a
-                :class:`~strands.memory.MemoryManager` instance or a
-                :class:`~strands.memory.MemoryManagerConfig` (auto-wrapped). When set, its
-                search/add tools are registered and the synchronous ``Agent(...)`` entry point
-                awaits pending extraction writes after each invocation unless the manager sets
-                ``flush_on_invocation_end=False``. Defaults to None.
+            memory_manager: Cross-session memory manager, as a
+                :class:`~strands.memory.MemoryManager` or a
+                :class:`~strands.memory.MemoryManagerConfig` (auto-wrapped). Registers its
+                memory tools; the synchronous ``Agent(...)`` entry point flushes pending
+                extraction after each invocation. Defaults to None.
             structured_output_prompt: Custom prompt message used when forcing structured output.
                 When using structured output, if the model doesn't automatically use the output tool,
                 the agent sends a follow-up message to request structured formatting. This parameter

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -442,7 +442,7 @@ class Agent(AgentBase):
         # synchronous entry point can flush pending extraction writes.
         self.memory_manager = self._resolve_memory_manager(memory_manager)
         if self.memory_manager is not None:
-            if self.memory_manager.name in self._plugin_registry:
+            if self.memory_manager.name in self._plugin_registry._plugins:
                 raise ValueError(
                     "MemoryManager is already registered; pass it through either the memory_manager "
                     "parameter or plugins, not both"

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -42,7 +42,6 @@ from ..types._snapshot import (
 )
 
 if TYPE_CHECKING:
-    from ..memory import MemoryManager, MemoryManagerConfig
     from ..tools import ToolProvider
 from .._middleware import MiddlewareRegistry
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
@@ -60,6 +59,7 @@ from ..hooks.registry import TEvent
 from ..interrupt import _InterruptState
 from ..interventions.handler import InterventionHandler
 from ..interventions.registry import InterventionRegistry
+from ..memory import MemoryManager, MemoryManagerConfig
 from ..models.bedrock import BedrockModel
 from ..models.model import Model, _ModelPlugin
 from ..plugins import Plugin
@@ -167,7 +167,7 @@ class Agent(AgentBase):
         hooks: list[HookProvider | HookCallback] | None = None,
         interventions: list[InterventionHandler] | None = None,
         session_manager: SessionManager | None = None,
-        memory_manager: "MemoryManager | MemoryManagerConfig | None" = None,
+        memory_manager: MemoryManager | MemoryManagerConfig | None = None,
         structured_output_prompt: str | None = None,
         tool_executor: ToolExecutor | None = None,
         retry_strategy: ModelRetryStrategy | _DefaultRetryStrategySentinel | None = _DEFAULT_RETRY_STRATEGY,
@@ -444,8 +444,8 @@ class Agent(AgentBase):
         if self.memory_manager is not None:
             if self.memory_manager.name in self._plugin_registry._plugins:
                 raise ValueError(
-                    "MemoryManager is already registered; pass it through either the memory_manager "
-                    "parameter or plugins, not both"
+                    "A MemoryManager is already registered via plugins; pass it through the "
+                    "memory_manager parameter instead"
                 )
             self._plugin_registry.add_and_init(self.memory_manager)
 
@@ -507,8 +507,8 @@ class Agent(AgentBase):
         return resolved_conversation_manager, resolved_plugins
 
     def _resolve_memory_manager(
-        self, memory_manager: "MemoryManager | MemoryManagerConfig | None"
-    ) -> "MemoryManager | None":
+        self, memory_manager: MemoryManager | MemoryManagerConfig | None
+    ) -> MemoryManager | None:
         """Resolve the ``memory_manager`` argument into a MemoryManager instance or None.
 
         A :class:`~strands.memory.MemoryManagerConfig` is wrapped into a
@@ -516,8 +516,6 @@ class Agent(AgentBase):
         """
         if memory_manager is None:
             return None
-
-        from ..memory import MemoryManager, MemoryManagerConfig
 
         if isinstance(memory_manager, MemoryManager):
             return memory_manager

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -524,7 +524,6 @@ class Agent(AgentBase):
                 stores=memory_manager.stores,
                 search_tool_config=memory_manager.search_tool_config,
                 add_tool_config=memory_manager.add_tool_config,
-                flush_on_invocation_end=memory_manager.flush_on_invocation_end,
             )
         raise ValueError("memory_manager must be a MemoryManager or MemoryManagerConfig")
 
@@ -690,7 +689,7 @@ class Agent(AgentBase):
         try:
             return await self.invoke_async(prompt, **kwargs)
         finally:
-            if self.memory_manager is not None and self.memory_manager.flush_on_invocation_end:
+            if self.memory_manager is not None:
                 await self.memory_manager.flush()
 
     async def invoke_async(

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -442,6 +442,11 @@ class Agent(AgentBase):
         # synchronous entry point can flush pending extraction writes.
         self.memory_manager = self._resolve_memory_manager(memory_manager)
         if self.memory_manager is not None:
+            if self.memory_manager.name in self._plugin_registry:
+                raise ValueError(
+                    "MemoryManager is already registered; pass it through either the memory_manager "
+                    "parameter or plugins, not both"
+                )
             self._plugin_registry.add_and_init(self.memory_manager)
 
         self.hooks.invoke_callbacks(AgentInitializedEvent(agent=self))

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -69,7 +69,7 @@ class MemoryManager(Plugin):
         from strands.memory import MemoryManager
 
         memory_manager = MemoryManager(stores=[my_store])
-        agent = Agent(model=model, plugins=[memory_manager])
+        agent = Agent(model=model, memory_manager=memory_manager)
         agent("Remember I prefer dark mode")
 
         results = await memory_manager.search("user preferences")

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -175,7 +175,8 @@ class MemoryManager(Plugin):
         # Extraction coordinator, created in ``init_agent`` when configured.
         self._coordinator: ExtractionCoordinator | None = None
 
-        self._flush_on_invocation_end = flush_on_invocation_end
+        # Gates the synchronous Agent(...) auto-flush; see Agent.memory_manager.
+        self.flush_on_invocation_end = flush_on_invocation_end
 
         # Build tools now; surfaced via the ``tools`` property.
         self._memory_tools: list[AgentTool] = self._build_tools()
@@ -231,11 +232,6 @@ class MemoryManager(Plugin):
                 tools.extend(store.get_tools())
 
         return tools
-
-    @property
-    def flush_on_invocation_end(self) -> bool:
-        """Whether the synchronous ``Agent(...)`` entry point flushes after each invocation."""
-        return self._flush_on_invocation_end
 
     @property
     def tools(self) -> list[AgentTool]:  # type: ignore[override]

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -7,8 +7,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from ..hooks.events import AfterInvocationEvent, MessageAddedEvent
-from ..hooks.registry import HookOrder
+from ..hooks.events import MessageAddedEvent
 from ..plugins.plugin import Plugin
 from ..tools.decorator import tool
 from ..types.exceptions import AggregateMemoryError
@@ -64,16 +63,12 @@ def _flatten_reasons(reasons: list[BaseException]) -> list[BaseException]:
 class MemoryManager(Plugin):
     """Provides cross-session memory retrieval and storage for agents.
 
-    When using the synchronous ``Agent(...)`` entry point, set
-    ``flush_on_invocation_end=True`` so extraction writes persist across its
-    per-invocation event loop.
-
     Example:
         ```python
         from strands import Agent
         from strands.memory import MemoryManager
 
-        memory_manager = MemoryManager(stores=[my_store], flush_on_invocation_end=True)
+        memory_manager = MemoryManager(stores=[my_store])
         agent = Agent(model=model, plugins=[memory_manager])
         agent("Remember I prefer dark mode")
 
@@ -88,7 +83,7 @@ class MemoryManager(Plugin):
         stores: list[MemoryStore],
         search_tool_config: MemoryToolConfig | bool = True,
         add_tool_config: MemoryAddToolConfig | bool = False,
-        flush_on_invocation_end: bool = False,
+        flush_on_invocation_end: bool = True,
     ) -> None:
         """Initialize the memory manager.
 
@@ -100,11 +95,10 @@ class MemoryManager(Plugin):
             add_tool_config: Add tool configuration. ``False`` (default) disables
                 the add tool; ``True`` lets it write to all writable stores; a
                 :class:`MemoryAddToolConfig` restricts/customizes it.
-            flush_on_invocation_end: When True, await pending extraction writes at
-                the end of each agent invocation. Enable when driving the agent
-                through the synchronous ``Agent(...)`` entry point, whose
-                per-invocation event loop would otherwise cancel in-flight saves.
-                Defaults to False (fire-and-forget).
+            flush_on_invocation_end: When True (default), the synchronous
+                ``Agent(...)`` entry point awaits pending extraction writes after
+                each invocation so they persist across its per-invocation event
+                loop. Set False to opt out and flush manually.
 
         Raises:
             ValueError: If ``stores`` is empty, a store name is duplicated, a
@@ -237,6 +231,11 @@ class MemoryManager(Plugin):
                 tools.extend(store.get_tools())
 
         return tools
+
+    @property
+    def flush_on_invocation_end(self) -> bool:
+        """Whether the synchronous ``Agent(...)`` entry point flushes after each invocation."""
+        return self._flush_on_invocation_end
 
     @property
     def tools(self) -> list[AgentTool]:  # type: ignore[override]
@@ -523,6 +522,11 @@ class MemoryManager(Plugin):
 
         Wires up automatic extraction for any store configured with an
         ``ExtractionConfig``. A no-op when no store uses extraction.
+
+        Extraction runs in the background. The synchronous ``Agent(...)`` entry
+        point awaits :meth:`flush` after each invocation so writes persist;
+        callers driving the agent through their own event loop should await
+        :meth:`flush` at a shutdown boundary.
         """
         if len(self._extraction_stores) == 0:
             return
@@ -537,19 +541,6 @@ class MemoryManager(Plugin):
             assert store.extraction is not None  # noqa: S101 - extraction stores always configure this.
             for trigger in _normalize_triggers(store.extraction.trigger):
                 trigger.attach(ExtractionTriggerContext(agent=agent, fire=self._make_fire(coordinator, store)))
-
-        if self._flush_on_invocation_end:
-            agent.add_hook(self._flush_after_invocation, AfterInvocationEvent, order=HookOrder.SDK_LAST)
-        else:
-            logger.warning(
-                "flush_on_invocation_end=<False> | background extraction is lost if the event loop closes "
-                "before it finishes (e.g. the synchronous Agent(...) entry point); safe to ignore if you "
-                "await MemoryManager.flush() at a shutdown boundary or enable flush_on_invocation_end."
-            )
-
-    async def _flush_after_invocation(self, event: AfterInvocationEvent) -> None:
-        """Await pending extraction writes at the end of an agent invocation."""
-        await self.flush()
 
     @staticmethod
     def _make_fire(coordinator: ExtractionCoordinator, store: MemoryStore) -> Callable[[], None]:

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -83,7 +83,6 @@ class MemoryManager(Plugin):
         stores: list[MemoryStore],
         search_tool_config: MemoryToolConfig | bool = True,
         add_tool_config: MemoryAddToolConfig | bool = False,
-        flush_on_invocation_end: bool = True,
     ) -> None:
         """Initialize the memory manager.
 
@@ -95,10 +94,6 @@ class MemoryManager(Plugin):
             add_tool_config: Add tool configuration. ``False`` (default) disables
                 the add tool; ``True`` lets it write to all writable stores; a
                 :class:`MemoryAddToolConfig` restricts/customizes it.
-            flush_on_invocation_end: When True (default), the synchronous
-                ``Agent(...)`` entry point awaits pending extraction writes after
-                each invocation so they persist across its per-invocation event
-                loop. Set False to opt out and flush manually.
 
         Raises:
             ValueError: If ``stores`` is empty, a store name is duplicated, a
@@ -174,9 +169,6 @@ class MemoryManager(Plugin):
 
         # Extraction coordinator, created in ``init_agent`` when configured.
         self._coordinator: ExtractionCoordinator | None = None
-
-        # Gates the synchronous Agent(...) auto-flush; see Agent.memory_manager.
-        self.flush_on_invocation_end = flush_on_invocation_end
 
         # Build tools now; surfaced via the ``tools`` property.
         self._memory_tools: list[AgentTool] = self._build_tools()

--- a/strands-py/src/strands/memory/types.py
+++ b/strands-py/src/strands/memory/types.py
@@ -115,14 +115,15 @@ class MemoryManagerConfig:
         add_tool_config: Add tool configuration. Defaults to ``False`` (opt-in);
             ``True`` allows all writable stores, or pass a
             :class:`MemoryAddToolConfig` to restrict it.
-        flush_on_invocation_end: When ``True``, await pending extraction writes at
-            the end of each agent invocation. Defaults to ``False``.
+        flush_on_invocation_end: When ``True`` (default), the synchronous
+            ``Agent(...)`` entry point flushes pending extraction writes after
+            each invocation. Set ``False`` to opt out.
     """
 
     stores: list[MemoryStore]
     search_tool_config: MemoryToolConfig | bool = True
     add_tool_config: MemoryAddToolConfig | bool = False
-    flush_on_invocation_end: bool = False
+    flush_on_invocation_end: bool = True
 
 
 class MemoryStoreConfig(Protocol):

--- a/strands-py/src/strands/memory/types.py
+++ b/strands-py/src/strands/memory/types.py
@@ -115,15 +115,11 @@ class MemoryManagerConfig:
         add_tool_config: Add tool configuration. Defaults to ``False`` (opt-in);
             ``True`` allows all writable stores, or pass a
             :class:`MemoryAddToolConfig` to restrict it.
-        flush_on_invocation_end: When ``True`` (default), the synchronous
-            ``Agent(...)`` entry point flushes pending extraction writes after
-            each invocation. Set ``False`` to opt out.
     """
 
     stores: list[MemoryStore]
     search_tool_config: MemoryToolConfig | bool = True
     add_tool_config: MemoryAddToolConfig | bool = False
-    flush_on_invocation_end: bool = True
 
 
 class MemoryStoreConfig(Protocol):

--- a/strands-py/src/strands/plugins/registry.py
+++ b/strands-py/src/strands/plugins/registry.py
@@ -65,6 +65,10 @@ class _PluginRegistry:
             raise ReferenceError("Agent has been garbage collected")
         return agent
 
+    def __contains__(self, name: str) -> bool:
+        """Return whether a plugin with the given name is registered."""
+        return name in self._plugins
+
     def add_and_init(self, plugin: Plugin) -> None:
         """Add and initialize a plugin with the agent.
 

--- a/strands-py/src/strands/plugins/registry.py
+++ b/strands-py/src/strands/plugins/registry.py
@@ -65,10 +65,6 @@ class _PluginRegistry:
             raise ReferenceError("Agent has been garbage collected")
         return agent
 
-    def __contains__(self, name: str) -> bool:
-        """Return whether a plugin with the given name is registered."""
-        return name in self._plugins
-
     def add_and_init(self, plugin: Plugin) -> None:
         """Add and initialize a plugin with the agent.
 

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -2823,19 +2823,6 @@ def test_agent_sync_call_flushes_memory_manager():
     memory_manager.flush.assert_awaited_once()
 
 
-def test_agent_sync_call_does_not_flush_when_opted_out():
-    memory_manager = MemoryManager(stores=[_SearchOnlyStore()], flush_on_invocation_end=False)
-    memory_manager.flush = unittest.mock.AsyncMock()
-    agent = Agent(
-        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
-        memory_manager=memory_manager,
-    )
-
-    agent("test")
-
-    memory_manager.flush.assert_not_awaited()
-
-
 @pytest.mark.asyncio
 async def test_agent_async_invoke_does_not_flush_memory_manager():
     memory_manager = MemoryManager(stores=[_SearchOnlyStore()])

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -2802,7 +2802,7 @@ def test_agent_memory_manager_defaults_to_none():
 
 def test_agent_memory_manager_passed_via_both_paths_raises():
     memory_manager = MemoryManager(stores=[_SearchOnlyStore()])
-    with pytest.raises(ValueError, match="either the memory_manager parameter or plugins, not both"):
+    with pytest.raises(ValueError, match="pass it through the memory_manager parameter instead"):
         Agent(
             model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
             plugins=[memory_manager],

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -2800,6 +2800,16 @@ def test_agent_memory_manager_defaults_to_none():
     assert agent.memory_manager is None
 
 
+def test_agent_memory_manager_passed_via_both_paths_raises():
+    memory_manager = MemoryManager(stores=[_SearchOnlyStore()])
+    with pytest.raises(ValueError, match="either the memory_manager parameter or plugins, not both"):
+        Agent(
+            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
+            plugins=[memory_manager],
+            memory_manager=memory_manager,
+        )
+
+
 def test_agent_sync_call_flushes_memory_manager():
     memory_manager = MemoryManager(stores=[_SearchOnlyStore()])
     memory_manager.flush = unittest.mock.AsyncMock()

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -23,6 +23,7 @@ from strands.agent.state import AgentState
 from strands.handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from strands.hooks import BeforeInvocationEvent, BeforeModelCallEvent, BeforeToolCallEvent
 from strands.interrupt import Interrupt
+from strands.memory import MemoryManager, MemoryManagerConfig
 from strands.models.bedrock import DEFAULT_BEDROCK_MODEL_ID, BedrockModel
 from strands.session.repository_session_manager import RepositorySessionManager
 from strands.telemetry.tracer import serialize
@@ -2755,7 +2756,88 @@ def test_agent_plugins_can_register_hooks():
     )
 
     agent("test")
+
     assert len(hook_called) == 1
+
+
+class _SearchOnlyStore:
+    """Minimal read-only memory store for exercising Agent's memory_manager wiring."""
+
+    name = "notes"
+    description = None
+    max_search_results = None
+    writable = False
+    extraction = None
+
+    async def search(self, query, options=None):
+        return []
+
+
+def test_agent_memory_manager_instance_registers_tools_and_is_exposed():
+    memory_manager = MemoryManager(stores=[_SearchOnlyStore()])
+    agent = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
+        memory_manager=memory_manager,
+    )
+
+    assert agent.memory_manager is memory_manager
+    assert "search_memory" in agent.tool_names
+
+
+def test_agent_memory_manager_config_is_wrapped():
+    agent = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
+        memory_manager=MemoryManagerConfig(stores=[_SearchOnlyStore()]),
+    )
+
+    assert isinstance(agent.memory_manager, MemoryManager)
+    assert "search_memory" in agent.tool_names
+
+
+def test_agent_memory_manager_defaults_to_none():
+    agent = Agent(model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]))
+
+    assert agent.memory_manager is None
+
+
+def test_agent_sync_call_flushes_memory_manager():
+    memory_manager = MemoryManager(stores=[_SearchOnlyStore()])
+    memory_manager.flush = unittest.mock.AsyncMock()
+    agent = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
+        memory_manager=memory_manager,
+    )
+
+    agent("test")
+
+    memory_manager.flush.assert_awaited_once()
+
+
+def test_agent_sync_call_does_not_flush_when_opted_out():
+    memory_manager = MemoryManager(stores=[_SearchOnlyStore()], flush_on_invocation_end=False)
+    memory_manager.flush = unittest.mock.AsyncMock()
+    agent = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
+        memory_manager=memory_manager,
+    )
+
+    agent("test")
+
+    memory_manager.flush.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_async_invoke_does_not_flush_memory_manager():
+    memory_manager = MemoryManager(stores=[_SearchOnlyStore()])
+    memory_manager.flush = unittest.mock.AsyncMock()
+    agent = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "response"}]}]),
+        memory_manager=memory_manager,
+    )
+
+    await agent.invoke_async("test")
+
+    memory_manager.flush.assert_not_awaited()
 
 
 def test_as_tool_returns_agent_tool():

--- a/strands-py/tests/strands/memory/test_memory_manager.py
+++ b/strands-py/tests/strands/memory/test_memory_manager.py
@@ -1049,12 +1049,6 @@ async def test_flush_does_not_re_extract_messages_already_processed():
     store.add_messages.assert_called_once()
 
 
-def test_flush_on_invocation_end_defaults_true_and_is_configurable():
-    store = _store("s", writable=True, sinks={"add_messages"}, extraction=ExtractionConfig(trigger=InvocationTrigger()))
-    assert MemoryManager(stores=[store]).flush_on_invocation_end is True
-    assert MemoryManager(stores=[store], flush_on_invocation_end=False).flush_on_invocation_end is False
-
-
 @pytest.mark.asyncio
 async def test_init_agent_background_save_does_not_block_hook_and_flush_awaits_it():
     release = asyncio.Event()

--- a/strands-py/tests/strands/memory/test_memory_manager.py
+++ b/strands-py/tests/strands/memory/test_memory_manager.py
@@ -1049,6 +1049,12 @@ async def test_flush_does_not_re_extract_messages_already_processed():
     store.add_messages.assert_called_once()
 
 
+def test_flush_on_invocation_end_defaults_true_and_is_configurable():
+    store = _store("s", writable=True, sinks={"add_messages"}, extraction=ExtractionConfig(trigger=InvocationTrigger()))
+    assert MemoryManager(stores=[store]).flush_on_invocation_end is True
+    assert MemoryManager(stores=[store], flush_on_invocation_end=False).flush_on_invocation_end is False
+
+
 @pytest.mark.asyncio
 async def test_init_agent_background_save_does_not_block_hook_and_flush_awaits_it():
     release = asyncio.Event()
@@ -1075,73 +1081,3 @@ async def test_init_agent_background_save_does_not_block_hook_and_flush_awaits_i
     release.set()
     await flushed
     assert completed["v"] is True
-
-
-@pytest.mark.asyncio
-async def test_flush_on_invocation_end_registers_hook_that_awaits_flush():
-    extraction_store = _store(
-        "s", writable=True, sinks={"add_messages"}, extraction=ExtractionConfig(trigger=InvocationTrigger())
-    )
-    memory_manager = MemoryManager(stores=[extraction_store], flush_on_invocation_end=True)
-    agent = _FakeAgent()
-    memory_manager.init_agent(agent)
-
-    flush_hooks = [
-        callback
-        for callback, event_type, _order in agent.hooks
-        if event_type is AfterInvocationEvent and callback == memory_manager._flush_after_invocation
-    ]
-    assert len(flush_hooks) == 1
-
-    await _add_messages(agent, _user_msg("I prefer dark mode"), _assistant_msg("Noted"))
-    # Fire the invocation event only; the registered flush hook awaits flush, so
-    # the store write persists WITHOUT an explicit ``memory_manager.flush()`` call.
-    await _invoke_all(agent, AfterInvocationEvent(agent=agent))
-
-    extraction_store.add_messages.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_flush_on_invocation_end_disabled_by_default_registers_no_flush_hook():
-    extraction_store = _store(
-        "s", writable=True, sinks={"add_messages"}, extraction=ExtractionConfig(trigger=InvocationTrigger())
-    )
-    memory_manager = MemoryManager(stores=[extraction_store])
-    agent = _FakeAgent()
-    memory_manager.init_agent(agent)
-
-    # Only the recorder (MessageAddedEvent) + trigger (AfterInvocationEvent) hooks
-    # are registered; the flush method is not among them.
-    registered_callbacks = [callback for callback, _event_type, _order in agent.hooks]
-    assert memory_manager._flush_after_invocation not in registered_callbacks
-
-    await _add_messages(agent, _user_msg("I prefer dark mode"), _assistant_msg("Noted"))
-    # The event alone schedules a background save but does not await it (no flush
-    # hook), so the store has not been written synchronously by the event.
-    await _invoke_all(agent, AfterInvocationEvent(agent=agent))
-
-    extraction_store.add_messages.assert_not_called()
-
-
-def test_init_agent_warns_when_extraction_configured_without_flush_on_invocation_end(caplog):
-    extraction_store = _store(
-        "s", writable=True, sinks={"add_messages"}, extraction=ExtractionConfig(trigger=InvocationTrigger())
-    )
-    memory_manager = MemoryManager(stores=[extraction_store])
-
-    with caplog.at_level(logging.WARNING):
-        memory_manager.init_agent(_FakeAgent())
-
-    assert "flush_on_invocation_end" in caplog.text
-
-
-def test_init_agent_does_not_warn_when_flush_on_invocation_end_enabled(caplog):
-    extraction_store = _store(
-        "s", writable=True, sinks={"add_messages"}, extraction=ExtractionConfig(trigger=InvocationTrigger())
-    )
-    memory_manager = MemoryManager(stores=[extraction_store], flush_on_invocation_end=True)
-
-    with caplog.at_level(logging.WARNING):
-        memory_manager.init_agent(_FakeAgent())
-
-    assert "flush_on_invocation_end" not in caplog.text


### PR DESCRIPTION
## Description

Adds a dedicated `memory_manager` parameter to `Agent`, mirroring the TypeScript SDK's `Agent` constructor, and makes cross-session memory persistence work out of the box for the synchronous entry point.

Previously a `MemoryManager` could only be attached via `plugins=[...]`, and persisting background extraction across the synchronous `Agent(...)` entry point required the caller to opt in (the original `flush_on_invocation_end` defaulted to `False`) or to call `flush()` manually. That left a quiet footgun: each synchronous invocation runs in its own event loop (`run_async` → `asyncio.run`), which cancels in-flight background saves on close, so the last turn's extraction was typically lost unless the user knew to enable the flag.

This change gives `Agent` a first-class `memory_manager` param (matching `conversation_manager` / `session_manager`) and flushes pending extraction automatically — but only on the synchronous path, so it never forces a save every turn on the async path or interferes with `IntervalTrigger` cadence.

## Public API Changes

`Agent` accepts a `memory_manager` (a `MemoryManager` instance or a `MemoryManagerConfig`, auto-wrapped) and exposes it as `agent.memory_manager`:

```python
from strands import Agent
from strands.memory import MemoryManager

agent = Agent(model=model, memory_manager=MemoryManager(stores=[my_store]))
agent("Remember I prefer dark mode")  # extraction is flushed before the loop closes
```

`flush_on_invocation_end` (on `MemoryManager` / `MemoryManagerConfig`) has been removed. The synchronous `Agent(...)` entry point now always awaits pending extraction after each invocation; the async `invoke_async` path never auto-flushes, so callers driving their own loop continue to `await memory_manager.flush()` at a shutdown boundary.

Auto-flush covers the `Agent(...)` entry point only. The deprecated `structured_output()` sync path is not wired (it doesn't append messages, so extraction records nothing to flush there).

## Breaking Changes

The `flush_on_invocation_end` parameter that shipped in the initial memory port has been removed (same unreleased development cycle). Persistence across the synchronous entry point is now automatic and unconditional, so there is no flag to migrate. Callers needing extraction-cadence control should use `invoke_async` and `flush()` directly.

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

Ported the three TS test files (`memory-manager`, `extraction`, `model-extractor`) as example-based `pytest` suites so coverage mirrors the TS suite case-for-case; runs green under `tests/strands/memory`. Adjacent `plugins`/`tools` suites were run to confirm no regressions in plugin/tool discovery.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

