### PR TITLE
feat: add memory injection

### DIFF
--- a/strands-py/src/strands/injection/__init__.py
+++ b/strands-py/src/strands/injection/__init__.py
@@ -1,0 +1,15 @@
+"""Context injection for Strands Agents.
+
+This package provides the configuration types for context injection — folding just-in-time text
+into the model input before a call without touching durable history. The delivery primitives
+(in ``message_injection``) are internal; reach injection through the ``ContextInjector`` plugin
+or the ``MemoryManager`` rather than using them directly.
+"""
+
+from .types import InjectionConfig, InjectionContext, InjectionTrigger
+
+__all__ = [
+    "InjectionConfig",
+    "InjectionContext",
+    "InjectionTrigger",
+]

--- a/strands-py/src/strands/injection/message_injection.py
+++ b/strands-py/src/strands/injection/message_injection.py
@@ -42,7 +42,7 @@ class RenderContentCallback(Protocol):
 RenderContent = Callable[[InjectionContext], "str | None | Awaitable[str | None]"] | RenderContentCallback
 
 
-def create_injection_middleware(
+def _create_injection_middleware(
     render_content: RenderContent,
     *,
     trigger: InjectionTriggerPredicate | None = None,
@@ -67,7 +67,7 @@ def create_injection_middleware(
     Returns:
         An ``InvokeModelStage.Input`` handler that returns a (possibly) folded context.
     """
-    resolved_trigger = resolve_trigger(trigger)
+    resolved_trigger = _resolve_trigger(trigger)
 
     async def handler(context: InvokeModelContext) -> InvokeModelContext:
         agent = context.agent
@@ -90,15 +90,15 @@ def create_injection_middleware(
         if text is None or not text.strip():
             return context
 
-        return replace(context, messages=fold_into_last_user_message(context.messages, text))
+        return replace(context, messages=_fold_into_last_user_message(context.messages, text))
 
     return handler
 
 
-def resolve_trigger(trigger: InjectionTriggerPredicate | None) -> Callable[[InjectionContext], bool]:
+def _resolve_trigger(trigger: InjectionTriggerPredicate | None) -> Callable[[InjectionContext], bool]:
     """Resolve an ``InjectionTrigger`` name or predicate into a single gate predicate.
 
-    ``"userTurn"`` maps to ``is_user_turn`` (over ``context.messages``); ``"everyTurn"`` to an
+    ``"userTurn"`` maps to ``_is_user_turn`` (over ``context.messages``); ``"everyTurn"`` to an
     always-true gate; a user-supplied predicate is wrapped so that a raise fails open (logs and
     skips injection rather than aborting the model call).
 
@@ -109,7 +109,7 @@ def resolve_trigger(trigger: InjectionTriggerPredicate | None) -> Callable[[Inje
         A predicate that, given the ``InjectionContext``, returns whether to inject this call.
     """
     if trigger is None or trigger == "userTurn":
-        return lambda context: is_user_turn(context.messages)
+        return lambda context: _is_user_turn(context.messages)
     if trigger == "everyTurn":
         return lambda context: True
 
@@ -125,7 +125,7 @@ def resolve_trigger(trigger: InjectionTriggerPredicate | None) -> Callable[[Inje
     return guarded
 
 
-def is_user_turn(messages: Messages) -> bool:
+def _is_user_turn(messages: Messages) -> bool:
     """Whether the latest message is a fresh user ask: a ``user`` message carrying no tool result.
 
     This is the ``"userTurn"`` policy — it distinguishes a new chat ask from an autonomous
@@ -143,7 +143,7 @@ def is_user_turn(messages: Messages) -> bool:
     return last["role"] == "user" and not any("toolResult" in block for block in last["content"])
 
 
-def fold_into_last_user_message(messages: Messages, text: str) -> Messages:
+def _fold_into_last_user_message(messages: Messages, text: str) -> Messages:
     """Fold ``text`` into the most recent ``user`` message as a text block, returning a NEW list.
 
     Folding into the existing user message (rather than inserting a standalone message) keeps

--- a/strands-py/src/strands/injection/message_injection.py
+++ b/strands-py/src/strands/injection/message_injection.py
@@ -1,0 +1,190 @@
+"""Delivery primitives for context injection.
+
+These fold just-in-time text into the latest user message *ephemerally* — the model sees the
+augmented input for one call while the agent's durable history is never touched. Reach injection
+through the ``ContextInjector`` plugin or the ``MemoryManager`` rather than these primitives
+directly.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any, Protocol
+
+from .types import InjectionContext, InjectionTriggerPredicate
+
+if TYPE_CHECKING:
+    from .._middleware.stages import InvokeModelContext
+    from ..types.content import ContentBlock, Message, Messages
+
+logger = logging.getLogger(__name__)
+
+
+class RenderContentCallback(Protocol):
+    """Renders the text to fold into the latest user message for a model call.
+
+    Implemented by a plain function as well — the ``**kwargs`` tail lets the calling convention
+    grow new keyword arguments without breaking existing callbacks.
+    """
+
+    def __call__(self, context: InjectionContext, **kwargs: Any) -> str | None | Awaitable[str | None]:
+        """Return the text to inject, ``None``/``""`` to skip, or an awaitable of either."""
+        ...
+
+
+# The text-rendering callback. The bare ``Callable`` arm keeps the happy path
+# (``lambda context: ...``) ergonomic; the ``RenderContentCallback`` arm is the forward-compatible
+# Protocol for callers that opt into future keyword arguments. A callback that raises fails open
+# (injection is skipped, the model call proceeds).
+RenderContent = Callable[[InjectionContext], "str | None | Awaitable[str | None]"] | RenderContentCallback
+
+
+def create_injection_middleware(
+    render_content: RenderContent,
+    *,
+    trigger: InjectionTriggerPredicate | None = None,
+) -> Callable[[InvokeModelContext], Awaitable[InvokeModelContext]]:
+    """Build an ``InvokeModelStage.Input`` handler that folds injected text into the conversation.
+
+    The handler folds ``render_content``'s text into the latest user message, ephemerally: the
+    model sees the augmented input for this one call while the agent's durable history is
+    never touched. The handler gates on the resolved trigger, asks ``render_content`` for the
+    text, and returns a context with the folded messages. Anything that skips — the trigger
+    not firing, ``render_content`` returning empty, or any callback raising — returns the
+    context unchanged so the model call proceeds (fail open). The injected text never enters
+    durable history because the input phase only rewrites the per-call context, not the
+    agent's stored messages.
+
+    Args:
+        render_content: Renders the text to inject for this call. Sync or async.
+        trigger: When to inject. An ``InjectionTrigger`` name selects a built-in policy
+            (``"userTurn"`` — default — or ``"everyTurn"``); a predicate over the
+            ``InjectionContext`` is the escape hatch. Defaults to ``"userTurn"``.
+
+    Returns:
+        An ``InvokeModelStage.Input`` handler that returns a (possibly) folded context.
+    """
+    resolved_trigger = resolve_trigger(trigger)
+
+    async def handler(context: InvokeModelContext) -> InvokeModelContext:
+        agent = context.agent
+        # Hand the callback its own list, so a callback that reorders/appends cannot perturb the
+        # per-call context. The message dicts are shared, but the upstream InvokeModelContext is
+        # already a defensive copy of agent state, so durable history is safe regardless.
+        injection_context = InjectionContext(messages=list(context.messages), state=agent.state, agent=agent)
+
+        if not resolved_trigger(injection_context):
+            return context
+
+        try:
+            text = render_content(injection_context)
+            if inspect.isawaitable(text):
+                text = await text
+        except Exception as error:  # noqa: BLE001 - fail open: a bad callback must not abort the model call.
+            logger.warning("reason=<%s> | injection render_content raised | skipping injection", error)
+            return context
+
+        if text is None or not text.strip():
+            return context
+
+        return replace(context, messages=fold_into_last_user_message(context.messages, text))
+
+    return handler
+
+
+def resolve_trigger(trigger: InjectionTriggerPredicate | None) -> Callable[[InjectionContext], bool]:
+    """Resolve an ``InjectionTrigger`` name or predicate into a single gate predicate.
+
+    ``"userTurn"`` maps to ``is_user_turn`` (over ``context.messages``); ``"everyTurn"`` to an
+    always-true gate; a user-supplied predicate is wrapped so that a raise fails open (logs and
+    skips injection rather than aborting the model call).
+
+    Args:
+        trigger: An ``InjectionTrigger`` name, a predicate, or ``None`` (defaults to ``"userTurn"``).
+
+    Returns:
+        A predicate that, given the ``InjectionContext``, returns whether to inject this call.
+    """
+    if trigger is None or trigger == "userTurn":
+        return lambda context: is_user_turn(context.messages)
+    if trigger == "everyTurn":
+        return lambda context: True
+
+    predicate = trigger
+
+    def guarded(context: InjectionContext) -> bool:
+        try:
+            return predicate(context)
+        except Exception as error:  # noqa: BLE001 - fail open: a bad predicate must not abort the model call.
+            logger.warning("reason=<%s> | injection trigger raised | skipping injection", error)
+            return False
+
+    return guarded
+
+
+def is_user_turn(messages: Messages) -> bool:
+    """Whether the latest message is a fresh user ask: a ``user`` message carrying no tool result.
+
+    This is the ``"userTurn"`` policy — it distinguishes a new chat ask from an autonomous
+    tool-result turn.
+
+    Args:
+        messages: The current conversation, as data.
+
+    Returns:
+        ``True`` when the latest message is a plain user ask, otherwise ``False``.
+    """
+    if not messages:
+        return False
+    last = messages[-1]
+    return last["role"] == "user" and not any("toolResult" in block for block in last["content"])
+
+
+def fold_into_last_user_message(messages: Messages, text: str) -> Messages:
+    """Fold ``text`` into the most recent ``user`` message as a text block, returning a NEW list.
+
+    Folding into the existing user message (rather than inserting a standalone message) keeps
+    role alternation valid in both chat and the autonomous tool loop. The block is placed to
+    keep the message valid for the model:
+
+    - A plain user ask: the text is **prepended**, leaving the user's own ask in the recency
+      slot — the last thing the model reads.
+    - A tool-result turn (the message carries a tool result block): the text is **appended**,
+      because providers require the tool result to be the first content block in the turn that
+      answers a tool use.
+
+    The input list and its messages are never mutated. When there is no ``user`` message, the
+    input list is returned unchanged.
+
+    Args:
+        messages: The conversation to fold into.
+        text: The text to fold into the most recent user message.
+
+    Returns:
+        A new list with the folded message, or the input list when there is no user message.
+    """
+    target_index = -1
+    for index in range(len(messages) - 1, -1, -1):
+        if messages[index]["role"] == "user":
+            target_index = index
+            break
+    if target_index < 0:
+        return messages
+
+    target = messages[target_index]
+    injected: ContentBlock = {"text": text}
+    # A tool result must stay the first block in the turn that answers a tool use, so append
+    # rather than prepend when the target carries one.
+    has_tool_result = any("toolResult" in block for block in target["content"])
+    content = [*target["content"], injected] if has_tool_result else [injected, *target["content"]]
+
+    folded: Message = {"role": target["role"], "content": content}
+    if "metadata" in target:
+        folded["metadata"] = target["metadata"]
+
+    result = list(messages)
+    result[target_index] = folded
+    return result

--- a/strands-py/src/strands/injection/types.py
+++ b/strands-py/src/strands/injection/types.py
@@ -1,0 +1,80 @@
+"""Configuration types shared by injection consumers.
+
+Consumed by the ``ContextInjector`` plugin and the ``MemoryManager``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+if TYPE_CHECKING:
+    from ..agent.agent import Agent
+    from ..agent.state import AgentState
+    from ..types.content import Messages
+
+InjectionTrigger = Literal["userTurn", "everyTurn"]
+"""Determines when injection runs before a model call.
+
+- ``"userTurn"``: only when the latest message is a fresh user ask (a ``user`` message with
+  no tool result) — the common case for chat agents, where it keeps the user's ask the final
+  message the model sees.
+- ``"everyTurn"``: before every model call, including mid-task tool-result turns — for
+  autonomous agents that should consult injected context at each step.
+
+For finer control, pass a predicate instead of a trigger name.
+"""
+
+
+@dataclass
+class InjectionContext:
+    """The context an injection consumer receives on each model call.
+
+    Passed to the ``render_content`` callback and to a predicate trigger.
+
+    Attributes:
+        messages: The current conversation, as data.
+        state: Durable agent state shared across calls, hooks, and tools — read what a tool
+            stashed last turn.
+        agent: The agent the injection is attached to (escape hatch for advanced consumers).
+    """
+
+    messages: Messages
+    state: AgentState
+    agent: Agent
+
+
+class TriggerCallback(Protocol):
+    """A predicate that decides whether to inject on a given model call.
+
+    Implemented by a plain function as well — the ``**kwargs`` tail lets the calling
+    convention grow new keyword arguments without breaking existing predicates.
+    """
+
+    def __call__(self, context: InjectionContext, **kwargs: Any) -> bool:
+        """Return whether to inject this call, given the injection context."""
+        ...
+
+
+# A trigger name, or a predicate over the injection context. The bare ``Callable`` arm keeps the
+# happy path (``lambda context: ...``) ergonomic; the ``TriggerCallback`` arm is the forward-
+# compatible Protocol for callers that opt into future keyword arguments.
+InjectionTriggerPredicate = InjectionTrigger | Callable[[InjectionContext], bool] | TriggerCallback
+
+
+@dataclass
+class InjectionConfig:
+    """Configuration common to every injection consumer: when to inject.
+
+    What text to inject is a consumer concern, added by the configs that extend this one
+    (e.g. ``MemoryInjectionConfig``).
+
+    Attributes:
+        trigger: When injection runs. An ``InjectionTrigger`` name selects a built-in policy;
+            a predicate is the escape hatch — it receives the ``InjectionContext`` and returns
+            whether to inject this call. A predicate that raises fails open (injection is
+            skipped, the model call proceeds). Defaults to ``"userTurn"``.
+    """
+
+    trigger: InjectionTriggerPredicate | None = None

--- a/strands-py/src/strands/injection/xml.py
+++ b/strands-py/src/strands/injection/xml.py
@@ -9,7 +9,7 @@ enough to keep a ``<memory>`` block well-formed, not a general-purpose serialize
 from __future__ import annotations
 
 
-def escape_xml_text(value: str) -> str:
+def _escape_xml_text(value: str) -> str:
     """Escape text content for placement between XML tags.
 
     Escapes ``&`` first (so later replacements are not double-escaped), then ``<`` and ``>``.
@@ -23,10 +23,10 @@ def escape_xml_text(value: str) -> str:
     return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-def escape_xml_attr(value: str) -> str:
+def _escape_xml_attr(value: str) -> str:
     """Escape a value for placement inside a double-quoted XML attribute.
 
-    Applies the :func:`escape_xml_text` rules plus ``"`` and ``'``.
+    Applies the :func:`_escape_xml_text` rules plus ``"`` and ``'``.
 
     Args:
         value: The raw attribute value to escape.
@@ -34,4 +34,4 @@ def escape_xml_attr(value: str) -> str:
     Returns:
         The escaped value, safe to place inside a quoted attribute.
     """
-    return escape_xml_text(value).replace('"', "&quot;").replace("'", "&#39;")
+    return _escape_xml_text(value).replace('"', "&quot;").replace("'", "&#39;")

--- a/strands-py/src/strands/injection/xml.py
+++ b/strands-py/src/strands/injection/xml.py
@@ -1,0 +1,37 @@
+"""Minimal XML escaping for folding untrusted text into an XML-shaped block.
+
+Memory entries and other injected content are frequently user-derived, so interpolating them
+raw into ``<entry>…</entry>`` both breaks the block structurally (a stray ``</entry>`` or
+``"``) and opens a stored-prompt-injection surface. These helpers are deliberately tiny —
+enough to keep a ``<memory>`` block well-formed, not a general-purpose serializer.
+"""
+
+from __future__ import annotations
+
+
+def escape_xml_text(value: str) -> str:
+    """Escape text content for placement between XML tags.
+
+    Escapes ``&`` first (so later replacements are not double-escaped), then ``<`` and ``>``.
+
+    Args:
+        value: The raw text to escape.
+
+    Returns:
+        The escaped text, safe to place in element content.
+    """
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def escape_xml_attr(value: str) -> str:
+    """Escape a value for placement inside a double-quoted XML attribute.
+
+    Applies the :func:`escape_xml_text` rules plus ``"`` and ``'``.
+
+    Args:
+        value: The raw attribute value to escape.
+
+    Returns:
+        The escaped value, safe to place inside a quoted attribute.
+    """
+    return escape_xml_text(value).replace('"', "&quot;").replace("'", "&#39;")

--- a/strands-py/src/strands/memory/__init__.py
+++ b/strands-py/src/strands/memory/__init__.py
@@ -5,6 +5,7 @@ This package gives agents cross-session recall and persistence through a
 tools, and runs automatic background extraction.
 """
 
+from ..injection import InjectionConfig, InjectionContext, InjectionTrigger
 from ..types.exceptions import AggregateMemoryError
 from .extraction.model_extractor import ModelExtractor
 from .extraction.triggers import IntervalTrigger, InvocationTrigger
@@ -21,9 +22,12 @@ from .extraction.types import (
 from .memory_manager import MemoryManager
 from .types import (
     AddMessagesContext,
+    InjectionFormatContext,
+    InjectionQueryContext,
     MemoryAddOptions,
     MemoryAddToolConfig,
     MemoryEntry,
+    MemoryInjectionConfig,
     MemoryManagerConfig,
     MemorySearchOptions,
     MemoryStore,
@@ -41,12 +45,18 @@ __all__ = [
     "ExtractionTriggerContext",
     "Extractor",
     "ExtractorContext",
+    "InjectionConfig",
+    "InjectionContext",
+    "InjectionFormatContext",
+    "InjectionQueryContext",
+    "InjectionTrigger",
     "IntervalTrigger",
     "InvocationTrigger",
     "MemoryAddOptions",
     "MemoryAddToolConfig",
     "MemoryContentBlockType",
     "MemoryEntry",
+    "MemoryInjectionConfig",
     "MemoryManager",
     "MemoryManagerConfig",
     "MemoryMessageFilter",

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
+from .._middleware.stages import InvokeModelStage
 from ..hooks.events import MessageAddedEvent
+from ..injection.message_injection import create_injection_middleware, is_user_turn
+from ..injection.xml import escape_xml_attr, escape_xml_text
 from ..plugins.plugin import Plugin
 from ..tools.decorator import tool
 from ..types.exceptions import AggregateMemoryError
@@ -15,9 +18,12 @@ from ..types.tools import AgentTool
 from .extraction.coordinator import ExtractionCoordinator
 from .extraction.types import ExtractionTrigger, ExtractionTriggerContext
 from .types import (
+    InjectionFormatContext,
+    InjectionQueryContext,
     MemoryAddOptions,
     MemoryAddToolConfig,
     MemoryEntry,
+    MemoryInjectionConfig,
     MemorySearchOptions,
     MemoryStore,
     MemoryToolConfig,
@@ -27,6 +33,7 @@ from .types import (
 
 if TYPE_CHECKING:
     from ..agent.agent import Agent
+    from ..types.content import Messages
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +49,9 @@ ADD_TOOL_DESCRIPTION = (
 
 # Default maximum results per store when neither caller nor store specifies one.
 DEFAULT_MAX_SEARCH_RESULTS = 3
+
+# Default number of entries injected per model call when injection does not specify one.
+DEFAULT_MAX_ENTRIES = 5
 
 
 def _normalize_triggers(trigger: ExtractionTrigger | list[ExtractionTrigger]) -> list[ExtractionTrigger]:
@@ -83,6 +93,7 @@ class MemoryManager(Plugin):
         stores: list[MemoryStore],
         search_tool_config: MemoryToolConfig | bool = True,
         add_tool_config: MemoryAddToolConfig | bool = False,
+        injection: MemoryInjectionConfig | bool = True,
     ) -> None:
         """Initialize the memory manager.
 
@@ -94,6 +105,11 @@ class MemoryManager(Plugin):
             add_tool_config: Add tool configuration. ``False`` (default) disables
                 the add tool; ``True`` lets it write to all writable stores; a
                 :class:`MemoryAddToolConfig` restricts/customizes it.
+            injection: Memory context injection. ``True`` (default) uses the
+                default injection settings; a :class:`MemoryInjectionConfig`
+                customizes retrieval, timing, and formatting; ``False`` disables
+                it. When enabled, retrieved memory is folded into the model input
+                before each call without touching durable history.
 
         Raises:
             ValueError: If ``stores`` is empty, a store name is duplicated, a
@@ -169,6 +185,16 @@ class MemoryManager(Plugin):
 
         # Extraction coordinator, created in ``init_agent`` when configured.
         self._coordinator: ExtractionCoordinator | None = None
+
+        # Resolved injection config, or ``False`` when injection is disabled. ``True`` resolves
+        # to a default ``MemoryInjectionConfig``; a config object passes through unchanged.
+        self._injection_config: MemoryInjectionConfig | Literal[False]
+        if injection is False:
+            self._injection_config = False
+        elif isinstance(injection, MemoryInjectionConfig):
+            self._injection_config = injection
+        else:
+            self._injection_config = MemoryInjectionConfig()
 
         # Build tools now; surfaced via the ``tools`` property.
         self._memory_tools: list[AgentTool] = self._build_tools()
@@ -508,14 +534,23 @@ class MemoryManager(Plugin):
     def init_agent(self, agent: Agent) -> None:
         """Initialize the plugin with the agent.
 
-        Wires up automatic extraction for any store configured with an
-        ``ExtractionConfig``. A no-op when no store uses extraction.
+        Wires up two independent behaviors:
 
-        Extraction runs in the background. The synchronous ``Agent(...)`` entry
-        point awaits :meth:`flush` after each invocation so writes persist;
-        callers driving the agent through their own event loop should await
-        :meth:`flush` at a shutdown boundary.
+        - **Extraction**: for any store configured with an ``ExtractionConfig``,
+          buffers conversation messages and attaches each store's triggers. A
+          no-op when no store uses extraction. Extraction runs in the background;
+          the synchronous ``Agent(...)`` entry point awaits :meth:`flush` after
+          each invocation so writes persist, and callers driving the agent through
+          their own event loop should await :meth:`flush` at a shutdown boundary.
+        - **Injection**: when enabled, registers an ``InvokeModelStage`` middleware
+          that folds retrieved memory into the model input for each call without
+          touching durable history. A no-op when injection is disabled.
         """
+        self._init_extraction(agent)
+        self._init_injection(agent)
+
+    def _init_extraction(self, agent: Agent) -> None:
+        """Wire background extraction for stores configured with an ``ExtractionConfig``."""
         if len(self._extraction_stores) == 0:
             return
 
@@ -529,6 +564,112 @@ class MemoryManager(Plugin):
             assert store.extraction is not None  # noqa: S101 - extraction stores always configure this.
             for trigger in _normalize_triggers(store.extraction.trigger):
                 trigger.attach(ExtractionTriggerContext(agent=agent, fire=self._make_fire(coordinator, store)))
+
+    def _init_injection(self, agent: Agent) -> None:
+        """Register the injection middleware when injection is enabled.
+
+        Folds retrieved memory into the model input for each call via
+        :meth:`_provide_memory_context`, without touching durable history. A no-op
+        when injection is disabled.
+        """
+        config = self._injection_config
+        if config is False:
+            return
+
+        agent._middleware_registry.add_middleware(
+            InvokeModelStage.Input,
+            create_injection_middleware(
+                lambda context: self._provide_memory_context(context.messages, config),
+                trigger=config.trigger,
+            ),
+        )
+
+    async def _provide_memory_context(self, messages: Messages, config: MemoryInjectionConfig) -> str | None:
+        """Produce the memory context text to inject for a model call, or ``None`` to skip.
+
+        This is the ``render_content`` callback the injection middleware invokes (see
+        :meth:`_init_injection`). Derives a query (the configured callback or an adaptive
+        default), searches memory, and renders the top entries. Skips silently
+        (returns ``None``) when no query can be derived or the search returns
+        nothing. The rendering callback raising fails open (returns ``None``).
+
+        Args:
+            messages: The current conversation, as data.
+            config: The resolved injection configuration.
+
+        Returns:
+            The injected text, or ``None`` when there is nothing to inject.
+        """
+        query = self._resolve_injection_query(messages, config)
+        if query is None or not query.strip():
+            return None
+
+        max_results = config.max_entries if config.max_entries is not None else DEFAULT_MAX_ENTRIES
+        # search caps each store at max_results; the slice caps the concatenation across stores.
+        entries = (await self.search(query, MemorySearchOptions(max_search_results=max_results)))[:max_results]
+        if len(entries) == 0:
+            return None
+
+        try:
+            if config.format is not None:
+                return config.format(InjectionFormatContext(entries=entries))
+            return self._default_injection_format(entries)
+        except Exception as error:  # noqa: BLE001 - fail open: a bad formatter must not abort the model call.
+            logger.warning("reason=<%s> | injection format raised | skipping injection", error)
+            return None
+
+    def _resolve_injection_query(self, messages: Messages, config: MemoryInjectionConfig) -> str | None:
+        """Derive the injection search query.
+
+        Uses the configured ``query`` callback when provided (a raise fails open,
+        skipping injection); otherwise an adaptive default: the latest user
+        message's text on a user turn, or the most recent assistant message's text
+        otherwise (the previous autonomous step).
+
+        Args:
+            messages: The current conversation, as data.
+            config: The resolved injection configuration.
+
+        Returns:
+            The query string, or ``None`` when none is available.
+        """
+        if config.query is not None:
+            try:
+                return config.query(InjectionQueryContext(messages=messages))
+            except Exception as error:  # noqa: BLE001 - fail open: a bad query must not abort the model call.
+                logger.warning("reason=<%s> | injection query raised | skipping injection", error)
+                return None
+
+        role = "user" if is_user_turn(messages) else "assistant"
+        index = next((index for index in range(len(messages) - 1, -1, -1) if messages[index]["role"] == role), -1)
+        if index < 0:
+            return None
+
+        text = "\n".join(block["text"] for block in messages[index]["content"] if "text" in block).strip()
+        return text if text else None
+
+    def _default_injection_format(self, entries: list[MemoryEntry]) -> str:
+        """Render the default injection format: a ``<memory>`` block with one ``<entry>`` per result.
+
+        Each entry carries a ``source`` attribute naming the originating store (when
+        known) so the model can attribute memories.
+
+        Args:
+            entries: The retrieved memory entries to render.
+
+        Returns:
+            The rendered ``<memory>`` block.
+        """
+        items = [
+            (
+                f'<entry source="{escape_xml_attr(entry.store_name)}">{escape_xml_text(entry.content)}</entry>'
+                if entry.store_name
+                else f"<entry>{escape_xml_text(entry.content)}</entry>"
+            )
+            for entry in entries
+        ]
+        joined = "\n".join(items)
+        return f"<memory>\n{joined}\n</memory>"
 
     @staticmethod
     def _make_fire(coordinator: ExtractionCoordinator, store: MemoryStore) -> Callable[[], None]:

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from .._middleware.stages import InvokeModelStage
 from ..hooks.events import MessageAddedEvent
-from ..injection.message_injection import create_injection_middleware, is_user_turn
-from ..injection.xml import escape_xml_attr, escape_xml_text
+from ..injection.message_injection import _create_injection_middleware, _is_user_turn
+from ..injection.xml import _escape_xml_attr, _escape_xml_text
 from ..plugins.plugin import Plugin
 from ..tools.decorator import tool
 from ..types.exceptions import AggregateMemoryError
@@ -578,7 +578,7 @@ class MemoryManager(Plugin):
 
         agent._middleware_registry.add_middleware(
             InvokeModelStage.Input,
-            create_injection_middleware(
+            _create_injection_middleware(
                 lambda context: self._provide_memory_context(context.messages, config),
                 trigger=config.trigger,
             ),
@@ -640,7 +640,7 @@ class MemoryManager(Plugin):
                 logger.warning("reason=<%s> | injection query raised | skipping injection", error)
                 return None
 
-        role = "user" if is_user_turn(messages) else "assistant"
+        role = "user" if _is_user_turn(messages) else "assistant"
         index = next((index for index in range(len(messages) - 1, -1, -1) if messages[index]["role"] == role), -1)
         if index < 0:
             return None
@@ -662,9 +662,9 @@ class MemoryManager(Plugin):
         """
         items = [
             (
-                f'<entry source="{escape_xml_attr(entry.store_name)}">{escape_xml_text(entry.content)}</entry>'
+                f'<entry source="{_escape_xml_attr(entry.store_name)}">{_escape_xml_text(entry.content)}</entry>'
                 if entry.store_name
-                else f"<entry>{escape_xml_text(entry.content)}</entry>"
+                else f"<entry>{_escape_xml_text(entry.content)}</entry>"
             )
             for entry in entries
         ]

--- a/strands-py/src/strands/memory/types.py
+++ b/strands-py/src/strands/memory/types.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
-from ..types.content import Message
+from ..injection import InjectionConfig
+from ..types.content import Message, Messages
 from ..types.tools import AgentTool
 
 if TYPE_CHECKING:
@@ -106,6 +108,93 @@ class MemoryAddToolConfig(MemoryToolConfig):
 
 
 @dataclass
+class InjectionQueryContext:
+    """Context passed to :attr:`MemoryInjectionConfig.query`.
+
+    Attributes:
+        messages: The current conversation, as data.
+    """
+
+    messages: Messages
+
+
+@dataclass
+class InjectionFormatContext:
+    """Context passed to :attr:`MemoryInjectionConfig.format`.
+
+    Attributes:
+        entries: The retrieved memory entries to render.
+    """
+
+    entries: list[MemoryEntry]
+
+
+class InjectionQueryCallback(Protocol):
+    """Derives the injection search query from the current conversation.
+
+    Implemented by a plain function as well — the ``**kwargs`` tail lets the calling convention
+    grow new keyword arguments without breaking existing callbacks.
+    """
+
+    def __call__(self, context: InjectionQueryContext, **kwargs: Any) -> str | None:
+        """Return the search query, or ``None``/``""`` to skip injection this call."""
+        ...
+
+
+class InjectionFormatCallback(Protocol):
+    """Renders retrieved memory entries into the injected text.
+
+    Implemented by a plain function as well — the ``**kwargs`` tail lets the calling convention
+    grow new keyword arguments without breaking existing callbacks.
+    """
+
+    def __call__(self, context: InjectionFormatContext, **kwargs: Any) -> str:
+        """Return the text to inject for the given entries."""
+        ...
+
+
+# The bare ``Callable`` arms keep the happy path (``lambda context: ...``) ergonomic; the
+# ``*Callback`` Protocol arms are the forward-compatible shape for callers that opt into future
+# keyword arguments.
+InjectionQuery = Callable[[InjectionQueryContext], "str | None"] | InjectionQueryCallback
+InjectionFormat = Callable[[InjectionFormatContext], str] | InjectionFormatCallback
+
+
+@dataclass
+class MemoryInjectionConfig(InjectionConfig):
+    """Configuration for memory context injection.
+
+    Extends the generic :class:`~strands.injection.InjectionConfig` (which carries ``trigger``)
+    with the memory-owned knobs: how many entries to retrieve, how to derive the query, and how
+    to render the results.
+
+    Attributes:
+        max_entries: Maximum number of entries to retrieve and inject per model call. A store
+            ranks by semantic similarity, which is not the same as contextual usefulness, so the
+            default injects a small candidate set rather than betting on the top hit. Raising it
+            improves recall at the cost of a larger prepend (context bloat); lower it for a
+            tighter injection. With multiple stores, results are concatenated in
+            store-registration order with no cross-store ranking, so this cap can favor entries
+            from earlier-registered stores. Defaults to 5.
+        query: Derives the search query from the current conversation. Return ``None`` or an
+            empty string to skip injection for this call. A callback that raises fails open
+            (injection is skipped). Defaults to an adaptive query: the latest user message's
+            text on a user turn, otherwise the most recent assistant message's text (the
+            previous step on an autonomous turn).
+        format: Renders retrieved entries into the injected text. A callback that raises fails
+            open (injection is skipped). Defaults to a ``<memory>`` XML block with one
+            ``<entry>`` per result, carrying a ``source`` attribute naming the originating store
+            (when known) so the model can attribute and weigh each memory. The default escapes
+            entry content and source, so a custom ``format`` that emits markup is responsible
+            for its own escaping.
+    """
+
+    max_entries: int | None = None
+    query: InjectionQuery | None = None
+    format: InjectionFormat | None = None
+
+
+@dataclass
 class MemoryManagerConfig:
     """Configuration for the ``MemoryManager``, mirroring the constructor kwargs.
 
@@ -115,11 +204,15 @@ class MemoryManagerConfig:
         add_tool_config: Add tool configuration. Defaults to ``False`` (opt-in);
             ``True`` allows all writable stores, or pass a
             :class:`MemoryAddToolConfig` to restrict it.
+        injection: Memory context injection. Defaults to ``True``. ``True`` uses the default
+            injection settings; pass a :class:`MemoryInjectionConfig` to customize retrieval,
+            timing, and formatting; ``False`` disables it.
     """
 
     stores: list[MemoryStore]
     search_tool_config: MemoryToolConfig | bool = True
     add_tool_config: MemoryAddToolConfig | bool = False
+    injection: MemoryInjectionConfig | bool = True
 
 
 class MemoryStoreConfig(Protocol):

--- a/strands-py/src/strands/vended_plugins/context_injector/__init__.py
+++ b/strands-py/src/strands/vended_plugins/context_injector/__init__.py
@@ -1,0 +1,26 @@
+"""Context-injection plugin for Strands Agents.
+
+This module provides the ContextInjector plugin, which folds just-in-time text into the model
+input before each call without touching durable history.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_plugins.context_injector import ContextInjector
+
+    agent = Agent(
+        plugins=[
+            ContextInjector(lambda context: f"<context>{derive(context.messages)}</context>")
+        ]
+    )
+    ```
+"""
+
+from ...injection import InjectionContext, InjectionTrigger
+from .plugin import ContextInjector
+
+__all__ = [
+    "ContextInjector",
+    "InjectionContext",
+    "InjectionTrigger",
+]

--- a/strands-py/src/strands/vended_plugins/context_injector/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_injector/plugin.py
@@ -1,0 +1,100 @@
+"""ContextInjector plugin for injecting just-in-time context into the model input.
+
+This module provides the ContextInjector plugin, which folds just-in-time text into the model
+input before each call without touching durable history.
+
+Example:
+    ```python
+    import datetime
+
+    from strands import Agent
+    from strands.vended_plugins.context_injector import ContextInjector
+
+    agent = Agent(
+        plugins=[
+            ContextInjector(lambda context: f"<now>{datetime.datetime.now().isoformat()}</now>")
+        ]
+    )
+    ```
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._middleware.stages import InvokeModelStage
+from ...injection.message_injection import RenderContent, create_injection_middleware
+from ...injection.types import InjectionTriggerPredicate
+from ...plugins import Plugin
+
+if TYPE_CHECKING:
+    from ...agent.agent import Agent
+
+_DEFAULT_NAME = "strands:context-injector"
+"""Default plugin name; override to tell multiple injectors apart."""
+
+
+class ContextInjector(Plugin):
+    """Plugin that injects just-in-time context into the model input before each call.
+
+    Before each model call, the plugin asks ``render_content`` for text and makes it available
+    to the model for that call, gated by ``trigger``. The injected text is ephemeral: it
+    augments the model input for that one call and never persists into the durable conversation
+    or session.
+
+    Multiple injectors may be registered; each contributes its text independently, in
+    plugin-registration order.
+
+    Args:
+        render_content: Renders the text to inject for this call, or ``None``/``""`` to skip.
+            Sync or async. The text reaches the model verbatim, so it is a prompt-injection
+            surface: escape any attacker-influenced fields yourself. A callback that raises
+            fails open (injection is skipped, the model call proceeds).
+        name: Plugin name, for logging and duplicate detection. Defaults to
+            ``"strands:context-injector"``. Set a distinct name when registering more than one
+            injector so they can be told apart.
+        trigger: When to inject. An ``InjectionTrigger`` name selects a built-in policy
+            (``"userTurn"`` — default — or ``"everyTurn"``); a predicate over the
+            ``InjectionContext`` is the escape hatch. A predicate that raises fails open
+            (injection is skipped). Defaults to ``"userTurn"``.
+
+    Example:
+        ```python
+        from strands import Agent
+        from strands.vended_plugins.context_injector import ContextInjector
+
+        agent = Agent(
+            plugins=[
+                ContextInjector(lambda context: f"<context>{derive(context.messages)}</context>")
+            ]
+        )
+        ```
+    """
+
+    name = _DEFAULT_NAME
+
+    def __init__(
+        self,
+        render_content: RenderContent,
+        *,
+        name: str | None = None,
+        trigger: InjectionTriggerPredicate | None = None,
+    ) -> None:
+        """Initialize the ContextInjector plugin.
+
+        Args:
+            render_content: Renders the text to inject for this call. Sync or async.
+            name: Plugin name. Defaults to ``"strands:context-injector"``.
+            trigger: When to inject. Defaults to ``"userTurn"``.
+        """
+        self.name = name or _DEFAULT_NAME
+        self._render_content = render_content
+        self._trigger = trigger
+        super().__init__()
+
+    def init_agent(self, agent: Agent) -> None:
+        """Register the injection middleware on the agent's ``InvokeModelStage`` input phase."""
+        agent._middleware_registry.add_middleware(
+            InvokeModelStage.Input,
+            create_injection_middleware(self._render_content, trigger=self._trigger),
+        )

--- a/strands-py/src/strands/vended_plugins/context_injector/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_injector/plugin.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..._middleware.stages import InvokeModelStage
-from ...injection.message_injection import RenderContent, create_injection_middleware
+from ...injection.message_injection import RenderContent, _create_injection_middleware
 from ...injection.types import InjectionTriggerPredicate
 from ...plugins import Plugin
 
@@ -96,5 +96,5 @@ class ContextInjector(Plugin):
         """Register the injection middleware on the agent's ``InvokeModelStage`` input phase."""
         agent._middleware_registry.add_middleware(
             InvokeModelStage.Input,
-            create_injection_middleware(self._render_content, trigger=self._trigger),
+            _create_injection_middleware(self._render_content, trigger=self._trigger),
         )

--- a/strands-py/tests/strands/injection/test_message_injection.py
+++ b/strands-py/tests/strands/injection/test_message_injection.py
@@ -1,0 +1,244 @@
+"""Tests for the injection delivery primitives."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands._middleware.stages import InvokeModelContext
+from strands.injection.message_injection import (
+    create_injection_middleware,
+    fold_into_last_user_message,
+    is_user_turn,
+    resolve_trigger,
+)
+
+
+def user(text: str) -> dict:
+    return {"role": "user", "content": [{"text": text}]}
+
+
+def assistant(text: str) -> dict:
+    return {"role": "assistant", "content": [{"text": text}]}
+
+
+def tool_result() -> dict:
+    return {
+        "role": "user",
+        "content": [{"toolResult": {"toolUseId": "t1", "status": "success", "content": [{"text": "done"}]}}],
+    }
+
+
+def injection_ctx(messages: list[dict]) -> Any:
+    # resolve_trigger predicates only read `messages`; a minimal stub suffices.
+    ctx = MagicMock()
+    ctx.messages = messages
+    return ctx
+
+
+def make_agent(state: Any = None) -> Any:
+    agent = MagicMock()
+    agent.state = state if state is not None else MagicMock()
+    return agent
+
+
+def invoke_ctx(messages: list[dict], agent: Any = None) -> InvokeModelContext:
+    """Build an InvokeModelContext; the handler reads messages and agent.state/agent."""
+    return InvokeModelContext(
+        agent=agent or make_agent(),
+        messages=messages,
+        system_prompt=None,
+        tool_specs=[],
+        tool_choice=None,
+        invocation_state={},
+    )
+
+
+class TestFoldIntoLastUserMessage:
+    def test_prepends_text_ahead_of_user_content(self):
+        messages = [user("original task"), assistant("prior step"), user("next ask")]
+        result = fold_into_last_user_message(messages, "INJECTED")
+
+        assert result == [
+            {"role": "user", "content": [{"text": "original task"}]},
+            {"role": "assistant", "content": [{"text": "prior step"}]},
+            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "next ask"}]},
+        ]
+
+    def test_returns_new_list_and_does_not_mutate_input(self):
+        original = user("ask")
+        messages = [assistant("prior"), original]
+        result = fold_into_last_user_message(messages, "INJECTED")
+
+        assert result is not messages
+        assert messages[1] is original
+        assert len(original["content"]) == 1  # untouched
+        assert result[1] is not original
+
+    def test_appends_after_tool_result_block(self):
+        tr = tool_result()
+        result = fold_into_last_user_message([user("task"), assistant("thinking"), tr], "INJECTED")
+
+        # Providers require the tool result to be the first block, so the text is appended.
+        assert result == [
+            {"role": "user", "content": [{"text": "task"}]},
+            {"role": "assistant", "content": [{"text": "thinking"}]},
+            {"role": "user", "content": [tr["content"][0], {"text": "INJECTED"}]},
+        ]
+
+    def test_targets_most_recent_user_message(self):
+        messages = [user("first"), assistant("a"), user("second")]
+        result = fold_into_last_user_message(messages, "INJECTED")
+
+        assert result == [
+            {"role": "user", "content": [{"text": "first"}]},
+            {"role": "assistant", "content": [{"text": "a"}]},
+            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "second"}]},
+        ]
+
+    def test_preserves_message_metadata(self):
+        tagged = {"role": "user", "content": [{"text": "ask"}], "metadata": {"custom": {"keep": "me"}}}
+        result = fold_into_last_user_message([tagged], "INJECTED")
+        assert result[0]["metadata"] == {"custom": {"keep": "me"}}
+
+    def test_returns_input_unchanged_when_no_user_message(self):
+        messages = [assistant("only assistant")]
+        result = fold_into_last_user_message(messages, "INJECTED")
+        assert result is messages
+
+
+class TestIsUserTurn:
+    def test_true_on_plain_user_ask(self):
+        assert is_user_turn([assistant("prior"), user("ask")]) is True
+
+    def test_false_on_user_tool_result_turn(self):
+        assert is_user_turn([user("task"), assistant("a"), tool_result()]) is False
+
+    def test_false_on_assistant_message(self):
+        assert is_user_turn([user("ask"), assistant("reply")]) is False
+
+    def test_false_on_empty_conversation(self):
+        assert is_user_turn([]) is False
+
+
+class TestResolveTrigger:
+    def test_default_uses_user_turn(self):
+        trigger = resolve_trigger(None)
+        assert trigger(injection_ctx([user("ask")])) is True
+        assert trigger(injection_ctx([tool_result()])) is False
+
+    def test_user_turn_uses_is_user_turn(self):
+        trigger = resolve_trigger("userTurn")
+        assert trigger(injection_ctx([user("ask")])) is True
+        assert trigger(injection_ctx([tool_result()])) is False
+
+    def test_every_turn_always_fires(self):
+        trigger = resolve_trigger("everyTurn")
+        assert trigger(injection_ctx([])) is True
+        assert trigger(injection_ctx([tool_result()])) is True
+
+    def test_custom_predicate_over_context(self):
+        trigger = resolve_trigger(lambda context: len(context.messages) >= 2)
+        assert trigger(injection_ctx([user("a")])) is False
+        assert trigger(injection_ctx([user("a"), assistant("b")])) is True
+
+    def test_fails_open_when_custom_predicate_raises(self, caplog):
+        def boom(context):
+            raise ValueError("boom")
+
+        trigger = resolve_trigger(boom)
+        assert trigger(injection_ctx([user("ask")])) is False
+        assert "skipping injection" in caplog.text
+
+
+@pytest.mark.asyncio
+class TestCreateInjectionMiddleware:
+    async def test_folds_text_into_latest_user_message(self):
+        handler = create_injection_middleware(lambda context: "INJECTED")
+        result = await handler(invoke_ctx([assistant("prior"), user("ask")]))
+
+        assert result.messages == [
+            {"role": "assistant", "content": [{"text": "prior"}]},
+            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "ask"}]},
+        ]
+
+    async def test_passes_conversation_to_render_content(self):
+        seen = []
+
+        def render(context):
+            seen.extend(message["role"] for message in context.messages)
+            return "x"
+
+        handler = create_injection_middleware(render)
+        await handler(invoke_ctx([assistant("prior"), user("ask")]))
+
+        assert seen == ["assistant", "user"]
+
+    async def test_exposes_state_and_agent_on_context(self):
+        agent = make_agent(state="stashed")
+        received = {}
+
+        def render(context):
+            received["state"] = context.state
+            received["agent"] = context.agent
+            return None
+
+        handler = create_injection_middleware(render)
+        await handler(invoke_ctx([user("ask")], agent=agent))
+
+        assert received == {"state": "stashed", "agent": agent}
+
+    async def test_supports_async_render_content(self):
+        async def render(context):
+            return "INJECTED"
+
+        handler = create_injection_middleware(render)
+        result = await handler(invoke_ctx([user("ask")]))
+
+        assert result.messages == [{"role": "user", "content": [{"text": "INJECTED"}, {"text": "ask"}]}]
+
+    async def test_returns_context_unchanged_when_trigger_does_not_fire(self):
+        render = MagicMock(return_value="x")
+        handler = create_injection_middleware(render)  # default 'userTurn'
+        ctx = invoke_ctx([user("task"), assistant("a"), tool_result()])
+        result = await handler(ctx)
+
+        assert result is ctx
+        render.assert_not_called()
+
+    async def test_every_turn_injects_on_tool_result_turn_keeping_tool_result_first(self):
+        handler = create_injection_middleware(lambda context: "INJECTED", trigger="everyTurn")
+        tr = tool_result()
+        result = await handler(invoke_ctx([user("task"), assistant("a"), tr]))
+
+        assert result.messages == [
+            {"role": "user", "content": [{"text": "task"}]},
+            {"role": "assistant", "content": [{"text": "a"}]},
+            {"role": "user", "content": [tr["content"][0], {"text": "INJECTED"}]},
+        ]
+
+    async def test_returns_context_unchanged_when_render_yields_empty(self):
+        handler = create_injection_middleware(lambda context: "   ")
+        ctx = invoke_ctx([assistant("prior"), user("ask")])
+        result = await handler(ctx)
+
+        assert result is ctx
+
+    async def test_fails_open_when_render_content_raises(self, caplog):
+        def render(context):
+            raise ValueError("boom")
+
+        handler = create_injection_middleware(render)
+        ctx = invoke_ctx([assistant("prior"), user("ask")])
+        result = await handler(ctx)
+
+        assert result is ctx
+        assert "skipping injection" in caplog.text
+
+    async def test_does_not_mutate_original_context_messages(self):
+        handler = create_injection_middleware(lambda context: "INJECTED")
+        ctx = invoke_ctx([assistant("prior"), user("ask")])
+        before = ctx.messages[1]
+        await handler(ctx)
+
+        assert len(before["content"]) == 1  # original user message untouched

--- a/strands-py/tests/strands/injection/test_message_injection.py
+++ b/strands-py/tests/strands/injection/test_message_injection.py
@@ -7,10 +7,10 @@ import pytest
 
 from strands._middleware.stages import InvokeModelContext
 from strands.injection.message_injection import (
-    create_injection_middleware,
-    fold_into_last_user_message,
-    is_user_turn,
-    resolve_trigger,
+    _create_injection_middleware,
+    _fold_into_last_user_message,
+    _is_user_turn,
+    _resolve_trigger,
 )
 
 
@@ -30,7 +30,7 @@ def tool_result() -> dict:
 
 
 def injection_ctx(messages: list[dict]) -> Any:
-    # resolve_trigger predicates only read `messages`; a minimal stub suffices.
+    # _resolve_trigger predicates only read `messages`; a minimal stub suffices.
     ctx = MagicMock()
     ctx.messages = messages
     return ctx
@@ -57,7 +57,7 @@ def invoke_ctx(messages: list[dict], agent: Any = None) -> InvokeModelContext:
 class TestFoldIntoLastUserMessage:
     def test_prepends_text_ahead_of_user_content(self):
         messages = [user("original task"), assistant("prior step"), user("next ask")]
-        result = fold_into_last_user_message(messages, "INJECTED")
+        result = _fold_into_last_user_message(messages, "INJECTED")
 
         assert result == [
             {"role": "user", "content": [{"text": "original task"}]},
@@ -68,7 +68,7 @@ class TestFoldIntoLastUserMessage:
     def test_returns_new_list_and_does_not_mutate_input(self):
         original = user("ask")
         messages = [assistant("prior"), original]
-        result = fold_into_last_user_message(messages, "INJECTED")
+        result = _fold_into_last_user_message(messages, "INJECTED")
 
         assert result is not messages
         assert messages[1] is original
@@ -77,7 +77,7 @@ class TestFoldIntoLastUserMessage:
 
     def test_appends_after_tool_result_block(self):
         tr = tool_result()
-        result = fold_into_last_user_message([user("task"), assistant("thinking"), tr], "INJECTED")
+        result = _fold_into_last_user_message([user("task"), assistant("thinking"), tr], "INJECTED")
 
         # Providers require the tool result to be the first block, so the text is appended.
         assert result == [
@@ -88,7 +88,7 @@ class TestFoldIntoLastUserMessage:
 
     def test_targets_most_recent_user_message(self):
         messages = [user("first"), assistant("a"), user("second")]
-        result = fold_into_last_user_message(messages, "INJECTED")
+        result = _fold_into_last_user_message(messages, "INJECTED")
 
         assert result == [
             {"role": "user", "content": [{"text": "first"}]},
@@ -98,47 +98,47 @@ class TestFoldIntoLastUserMessage:
 
     def test_preserves_message_metadata(self):
         tagged = {"role": "user", "content": [{"text": "ask"}], "metadata": {"custom": {"keep": "me"}}}
-        result = fold_into_last_user_message([tagged], "INJECTED")
+        result = _fold_into_last_user_message([tagged], "INJECTED")
         assert result[0]["metadata"] == {"custom": {"keep": "me"}}
 
     def test_returns_input_unchanged_when_no_user_message(self):
         messages = [assistant("only assistant")]
-        result = fold_into_last_user_message(messages, "INJECTED")
+        result = _fold_into_last_user_message(messages, "INJECTED")
         assert result is messages
 
 
 class TestIsUserTurn:
     def test_true_on_plain_user_ask(self):
-        assert is_user_turn([assistant("prior"), user("ask")]) is True
+        assert _is_user_turn([assistant("prior"), user("ask")]) is True
 
     def test_false_on_user_tool_result_turn(self):
-        assert is_user_turn([user("task"), assistant("a"), tool_result()]) is False
+        assert _is_user_turn([user("task"), assistant("a"), tool_result()]) is False
 
     def test_false_on_assistant_message(self):
-        assert is_user_turn([user("ask"), assistant("reply")]) is False
+        assert _is_user_turn([user("ask"), assistant("reply")]) is False
 
     def test_false_on_empty_conversation(self):
-        assert is_user_turn([]) is False
+        assert _is_user_turn([]) is False
 
 
 class TestResolveTrigger:
     def test_default_uses_user_turn(self):
-        trigger = resolve_trigger(None)
+        trigger = _resolve_trigger(None)
         assert trigger(injection_ctx([user("ask")])) is True
         assert trigger(injection_ctx([tool_result()])) is False
 
     def test_user_turn_uses_is_user_turn(self):
-        trigger = resolve_trigger("userTurn")
+        trigger = _resolve_trigger("userTurn")
         assert trigger(injection_ctx([user("ask")])) is True
         assert trigger(injection_ctx([tool_result()])) is False
 
     def test_every_turn_always_fires(self):
-        trigger = resolve_trigger("everyTurn")
+        trigger = _resolve_trigger("everyTurn")
         assert trigger(injection_ctx([])) is True
         assert trigger(injection_ctx([tool_result()])) is True
 
     def test_custom_predicate_over_context(self):
-        trigger = resolve_trigger(lambda context: len(context.messages) >= 2)
+        trigger = _resolve_trigger(lambda context: len(context.messages) >= 2)
         assert trigger(injection_ctx([user("a")])) is False
         assert trigger(injection_ctx([user("a"), assistant("b")])) is True
 
@@ -146,7 +146,7 @@ class TestResolveTrigger:
         def boom(context):
             raise ValueError("boom")
 
-        trigger = resolve_trigger(boom)
+        trigger = _resolve_trigger(boom)
         assert trigger(injection_ctx([user("ask")])) is False
         assert "skipping injection" in caplog.text
 
@@ -154,7 +154,7 @@ class TestResolveTrigger:
 @pytest.mark.asyncio
 class TestCreateInjectionMiddleware:
     async def test_folds_text_into_latest_user_message(self):
-        handler = create_injection_middleware(lambda context: "INJECTED")
+        handler = _create_injection_middleware(lambda context: "INJECTED")
         result = await handler(invoke_ctx([assistant("prior"), user("ask")]))
 
         assert result.messages == [
@@ -169,7 +169,7 @@ class TestCreateInjectionMiddleware:
             seen.extend(message["role"] for message in context.messages)
             return "x"
 
-        handler = create_injection_middleware(render)
+        handler = _create_injection_middleware(render)
         await handler(invoke_ctx([assistant("prior"), user("ask")]))
 
         assert seen == ["assistant", "user"]
@@ -183,7 +183,7 @@ class TestCreateInjectionMiddleware:
             received["agent"] = context.agent
             return None
 
-        handler = create_injection_middleware(render)
+        handler = _create_injection_middleware(render)
         await handler(invoke_ctx([user("ask")], agent=agent))
 
         assert received == {"state": "stashed", "agent": agent}
@@ -192,14 +192,14 @@ class TestCreateInjectionMiddleware:
         async def render(context):
             return "INJECTED"
 
-        handler = create_injection_middleware(render)
+        handler = _create_injection_middleware(render)
         result = await handler(invoke_ctx([user("ask")]))
 
         assert result.messages == [{"role": "user", "content": [{"text": "INJECTED"}, {"text": "ask"}]}]
 
     async def test_returns_context_unchanged_when_trigger_does_not_fire(self):
         render = MagicMock(return_value="x")
-        handler = create_injection_middleware(render)  # default 'userTurn'
+        handler = _create_injection_middleware(render)  # default 'userTurn'
         ctx = invoke_ctx([user("task"), assistant("a"), tool_result()])
         result = await handler(ctx)
 
@@ -207,7 +207,7 @@ class TestCreateInjectionMiddleware:
         render.assert_not_called()
 
     async def test_every_turn_injects_on_tool_result_turn_keeping_tool_result_first(self):
-        handler = create_injection_middleware(lambda context: "INJECTED", trigger="everyTurn")
+        handler = _create_injection_middleware(lambda context: "INJECTED", trigger="everyTurn")
         tr = tool_result()
         result = await handler(invoke_ctx([user("task"), assistant("a"), tr]))
 
@@ -218,7 +218,7 @@ class TestCreateInjectionMiddleware:
         ]
 
     async def test_returns_context_unchanged_when_render_yields_empty(self):
-        handler = create_injection_middleware(lambda context: "   ")
+        handler = _create_injection_middleware(lambda context: "   ")
         ctx = invoke_ctx([assistant("prior"), user("ask")])
         result = await handler(ctx)
 
@@ -228,7 +228,7 @@ class TestCreateInjectionMiddleware:
         def render(context):
             raise ValueError("boom")
 
-        handler = create_injection_middleware(render)
+        handler = _create_injection_middleware(render)
         ctx = invoke_ctx([assistant("prior"), user("ask")])
         result = await handler(ctx)
 
@@ -236,7 +236,7 @@ class TestCreateInjectionMiddleware:
         assert "skipping injection" in caplog.text
 
     async def test_does_not_mutate_original_context_messages(self):
-        handler = create_injection_middleware(lambda context: "INJECTED")
+        handler = _create_injection_middleware(lambda context: "INJECTED")
         ctx = invoke_ctx([assistant("prior"), user("ask")])
         before = ctx.messages[1]
         await handler(ctx)

--- a/strands-py/tests/strands/memory/test_injection_integration.py
+++ b/strands-py/tests/strands/memory/test_injection_integration.py
@@ -1,0 +1,74 @@
+"""End-to-end test for MemoryManager injection against a real Agent + event loop.
+
+Uses a hand-written in-memory store and a mocked model (no external services). Verifies the
+ephemerality contract: retrieved memory reaches the model for one call but never enters the
+agent's durable conversation history.
+"""
+
+from typing import Any
+
+import pytest
+
+from strands import Agent
+from strands.memory import MemoryEntry, MemoryManager
+from strands.memory.types import SearchOptions
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+class _FakeStore:
+    """Minimal read-only MemoryStore whose ``search`` returns a fixed entry."""
+
+    name = "kb"
+    description = "knowledge base"
+    max_search_results = None
+    writable = False
+    extraction = None
+
+    async def search(self, query: str, options: SearchOptions | None = None) -> list[MemoryEntry]:
+        return [MemoryEntry(content="user prefers dark mode")]
+
+
+def _texts(messages: list[dict]) -> str:
+    return " ".join(block["text"] for message in messages for block in message["content"] if "text" in block)
+
+
+@pytest.fixture
+def model() -> MockedModelProvider:
+    return MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello!"}]}])
+
+
+@pytest.fixture
+def model_seen(model: MockedModelProvider) -> list[list[dict]]:
+    """Capture the messages the model actually receives, wrapping the mock's stream()."""
+    seen: list[list[dict]] = []
+    original_stream = model.stream
+
+    def stream(messages: list[dict], *args: Any, **kwargs: Any) -> Any:
+        seen.append([dict(message) for message in messages])
+        return original_stream(messages, *args, **kwargs)
+
+    model.stream = stream  # type: ignore[method-assign]
+    return seen
+
+
+def test_memory_injection_reaches_model_but_not_durable_history(
+    model: MockedModelProvider, model_seen: list[list[dict]]
+) -> None:
+    agent = Agent(
+        model=model,
+        callback_handler=None,
+        plugins=[MemoryManager(stores=[_FakeStore()], injection=True)],
+    )
+
+    agent("what are my preferences?")
+
+    # (a) The model saw the retrieved memory folded into the user message.
+    assert len(model_seen) == 1
+    assert "user prefers dark mode" in _texts(model_seen[0])
+    assert "<memory>" in _texts(model_seen[0])
+    assert "what are my preferences?" in _texts(model_seen[0])
+
+    # (b) The durable conversation never contains the injected memory block.
+    assert "user prefers dark mode" not in _texts(agent.messages)
+    assert "<memory>" not in _texts(agent.messages)
+    assert "what are my preferences?" in _texts(agent.messages)

--- a/strands-py/tests/strands/memory/test_memory_manager.py
+++ b/strands-py/tests/strands/memory/test_memory_manager.py
@@ -39,16 +39,18 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from strands._middleware.stages import InvokeModelContext, InvokeModelStage
 from strands.hooks.events import AfterInvocationEvent, MessageAddedEvent
 from strands.hooks.registry import HookOrder
 from strands.memory import AggregateMemoryError
 from strands.memory.extraction.triggers import IntervalTrigger, InvocationTrigger
 from strands.memory.extraction.types import ExtractionConfig, ExtractionResult
-from strands.memory.memory_manager import DEFAULT_MAX_SEARCH_RESULTS, MemoryManager
+from strands.memory.memory_manager import DEFAULT_MAX_ENTRIES, DEFAULT_MAX_SEARCH_RESULTS, MemoryManager
 from strands.memory.types import (
     MemoryAddOptions,
     MemoryAddToolConfig,
     MemoryEntry,
+    MemoryInjectionConfig,
     MemorySearchOptions,
     MemoryToolConfig,
 )
@@ -195,14 +197,18 @@ def _assistant_msg(text: str) -> dict:
 class _FakeAgent:
     """Minimal agent stand-in for ``init_agent`` wiring.
 
-    The manager only uses ``agent.add_hook(callback, event_type, *, order=...)``
-    and ``agent.model``. Recorded hooks are kept as ``(callback, event_type,
-    order)`` triples so tests can fire the matching events manually.
+    The manager uses ``agent.add_hook(callback, event_type, *, order=...)``,
+    ``agent.model``, and ``agent._middleware_registry.add_middleware(...)`` (for
+    default-on injection). Recorded hooks are kept as ``(callback, event_type,
+    order)`` triples so tests can fire the matching events manually; the
+    middleware registry is a mock so injection registration is a no-op here.
     """
 
     def __init__(self, model: Any = None) -> None:
         self.model = model
+        self.state = MagicMock()
         self.hooks: list[tuple[Any, Any, float]] = []
+        self._middleware_registry = MagicMock()
 
     def add_hook(self, callback: Any, event_type: Any = None, *, order: float = HookOrder.DEFAULT) -> None:
         self.hooks.append((callback, event_type, order))
@@ -1075,3 +1081,307 @@ async def test_init_agent_background_save_does_not_block_hook_and_flush_awaits_i
     release.set()
     await flushed
     assert completed["v"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Injection
+#
+# Ported from the ``initAgent`` (injection registration) and ``injection``
+# describe blocks of ``strands-ts/src/memory/__tests__/memory-manager.test.ts``.
+#
+# The injection delivery (folding text into the model input) is wired through the
+# ``InvokeModelStage`` input middleware; the memory-owned provide pipeline (query
+# derivation, search, formatting) is exercised directly via
+# ``_provide_memory_context`` / ``_default_injection_format``, the callbacks the
+# middleware invokes.
+# --------------------------------------------------------------------------- #
+
+
+def _tool_use_msg() -> dict:
+    return {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "x", "input": {}}}]}
+
+
+def _tool_result_msg() -> dict:
+    return {
+        "role": "user",
+        "content": [{"toolResult": {"toolUseId": "t1", "status": "success", "content": [{"text": "done"}]}}],
+    }
+
+
+class _InjectionAgent:
+    """Agent stand-in that captures ``InvokeModelStage.Input`` middleware registrations."""
+
+    def __init__(self) -> None:
+        self.state = MagicMock()
+        self._middleware_registry = MagicMock()
+
+    @property
+    def add_middleware_calls(self) -> Any:
+        return self._middleware_registry.add_middleware.call_args_list
+
+
+def _invoke_ctx(messages: list[dict], agent: Any) -> Any:
+    return InvokeModelContext(
+        agent=agent,
+        messages=messages,
+        system_prompt=None,
+        tool_specs=[],
+        tool_choice=None,
+        invocation_state={},
+    )
+
+
+async def _provide(mm: MemoryManager, messages: list[dict]) -> str | None:
+    """Call the manager's provide pipeline with its resolved injection config (TS ``provide`` helper)."""
+    config = mm._injection_config if mm._injection_config is not False else MemoryInjectionConfig()
+    return await mm._provide_memory_context(messages, config)
+
+
+# --- config resolution ---
+
+
+def test_injection_defaults_to_enabled_when_omitted():
+    assert MemoryManager(stores=[_store("s")])._injection_config == MemoryInjectionConfig()
+
+
+def test_injection_is_disabled_when_explicitly_false():
+    assert MemoryManager(stores=[_store("s")], injection=False)._injection_config is False
+
+
+def test_injection_true_resolves_to_default_config():
+    config = MemoryManager(stores=[_store("s")], injection=True)._injection_config
+    assert config == MemoryInjectionConfig()
+
+
+def test_injection_config_object_passes_through_unchanged():
+    cfg = MemoryInjectionConfig(max_entries=5)
+    assert MemoryManager(stores=[_store("s")], injection=cfg)._injection_config is cfg
+
+
+# --- init_agent registration ---
+
+
+def test_init_agent_does_not_register_injection_middleware_when_disabled():
+    agent = _InjectionAgent()
+    MemoryManager(stores=[_store("s")], injection=False).init_agent(agent)
+    agent._middleware_registry.add_middleware.assert_not_called()
+
+
+def test_init_agent_registers_invoke_model_input_middleware_when_enabled():
+    agent = _InjectionAgent()
+    MemoryManager(stores=[_store("s")], injection=True).init_agent(agent)
+
+    agent._middleware_registry.add_middleware.assert_called_once()
+    stage_or_phase, handler = agent.add_middleware_calls[0].args
+    assert stage_or_phase is InvokeModelStage.Input
+    assert callable(handler)
+
+
+@pytest.mark.asyncio
+async def test_init_agent_wires_middleware_to_provide_pipeline_folds_a_search_hit():
+    store = _store("s", entries=[MemoryEntry(content="dark mode preferred")])
+    agent = _InjectionAgent()
+    MemoryManager(stores=[store], injection=True).init_agent(agent)
+
+    handler = agent.add_middleware_calls[0].args[1]
+    messages = [_assistant_msg("prior"), _user_msg("what is my plan")]
+    result = await handler(_invoke_ctx(messages, agent))
+
+    assert result.messages == [
+        {"role": "assistant", "content": [{"text": "prior"}]},
+        {
+            "role": "user",
+            "content": [
+                {"text": '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>'},
+                {"text": "what is my plan"},
+            ],
+        },
+    ]
+    store.search.assert_called_once()
+    assert store.search.call_args.args[0] == "what is my plan"
+
+
+@pytest.mark.asyncio
+async def test_init_agent_forwards_trigger_to_registered_middleware():
+    # Default 'userTurn' would skip a tool-result turn; 'everyTurn' must fold on it, proving the
+    # configured trigger is forwarded into the registered middleware.
+    store = _store("s", entries=[MemoryEntry(content="fact")])
+    agent = _InjectionAgent()
+    MemoryManager(stores=[store], injection=MemoryInjectionConfig(trigger="everyTurn")).init_agent(agent)
+
+    handler = agent.add_middleware_calls[0].args[1]
+    tool_result = _tool_result_msg()
+    result = await handler(_invoke_ctx([_user_msg("task"), _assistant_msg("prev"), tool_result], agent))
+
+    # everyTurn folds on the tool-result turn; the memory block is appended *after* the tool result
+    # (which must stay first), and the query is derived from the most recent assistant text.
+    assert result.messages == [
+        {"role": "user", "content": [{"text": "task"}]},
+        {"role": "assistant", "content": [{"text": "prev"}]},
+        {
+            "role": "user",
+            "content": [tool_result["content"][0], {"text": '<memory>\n<entry source="s">fact</entry>\n</memory>'}],
+        },
+    ]
+    assert store.search.call_args.args[0] == "prev"
+
+
+@pytest.mark.asyncio
+async def test_init_agent_default_trigger_skips_tool_result_turn():
+    # Default trigger is 'userTurn': a tool-result turn must be left untouched (no search, no fold).
+    store = _store("s", entries=[MemoryEntry(content="fact")])
+    agent = _InjectionAgent()
+    MemoryManager(stores=[store], injection=True).init_agent(agent)
+
+    handler = agent.add_middleware_calls[0].args[1]
+    messages = [_user_msg("task"), _assistant_msg("prev"), _tool_result_msg()]
+    result = await handler(_invoke_ctx(messages, agent))
+
+    assert result.messages == messages
+    store.search.assert_not_called()
+
+
+# --- query derivation ---
+
+
+@pytest.mark.asyncio
+async def test_injection_query_uses_latest_user_ask_on_user_turn():
+    store = _store("s", entries=[MemoryEntry(content="fact")])
+    mm = MemoryManager(stores=[store], injection=True)
+
+    await _provide(mm, [_assistant_msg("prior step"), _user_msg("what is my plan")])
+
+    assert store.search.call_args.args[0] == "what is my plan"
+    assert _forwarded_max(store.search) == DEFAULT_MAX_ENTRIES
+
+
+@pytest.mark.asyncio
+async def test_injection_query_uses_recent_assistant_text_on_tool_result_turn():
+    store = _store("s", entries=[MemoryEntry(content="fact")])
+    mm = MemoryManager(stores=[store], injection=True)
+
+    await _provide(mm, [_user_msg("task"), _assistant_msg("the previous step result"), _tool_result_msg()])
+
+    assert store.search.call_args.args[0] == "the previous step result"
+
+
+@pytest.mark.asyncio
+async def test_injection_honors_a_custom_query():
+    store = _store("s", entries=[MemoryEntry(content="fact")])
+    mm = MemoryManager(stores=[store], injection=MemoryInjectionConfig(query=lambda context: "custom query"))
+
+    await _provide(mm, [_assistant_msg("prior"), _user_msg("ask")])
+
+    assert store.search.call_args.args[0] == "custom query"
+
+
+@pytest.mark.asyncio
+async def test_injection_skips_when_custom_query_returns_none():
+    store = _store("s", entries=[MemoryEntry(content="fact")])
+    mm = MemoryManager(stores=[store], injection=MemoryInjectionConfig(query=lambda context: None))
+
+    assert await _provide(mm, [_assistant_msg("prior"), _user_msg("ask")]) is None
+    store.search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_injection_fails_open_when_custom_query_raises():
+    def boom(context: Any) -> str:
+        raise ValueError("boom")
+
+    store = _store("s", entries=[MemoryEntry(content="fact")])
+    mm = MemoryManager(stores=[store], injection=MemoryInjectionConfig(query=boom))
+
+    assert await _provide(mm, [_assistant_msg("prior"), _user_msg("ask")]) is None
+    store.search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_injection_skips_when_latest_assistant_message_has_no_text():
+    store = _store("s", entries=[MemoryEntry(content="fact")])
+    mm = MemoryManager(stores=[store], injection=True)
+
+    assert await _provide(mm, [_tool_use_msg(), _tool_result_msg()]) is None
+    store.search.assert_not_called()
+
+
+# --- search ---
+
+
+@pytest.mark.asyncio
+async def test_injection_returns_none_when_search_yields_no_entries():
+    store = _store("s", entries=[])
+    mm = MemoryManager(stores=[store], injection=True)
+
+    assert await _provide(mm, [_assistant_msg("prior"), _user_msg("ask")]) is None
+    store.search.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_injection_honors_max_entries_and_caps_rendered_entries():
+    store = _store("s", entries=[MemoryEntry(content="A"), MemoryEntry(content="B"), MemoryEntry(content="C")])
+    mm = MemoryManager(
+        stores=[store],
+        injection=MemoryInjectionConfig(
+            max_entries=2,
+            format=lambda context: ",".join(entry.content for entry in context.entries),
+        ),
+    )
+
+    text = await _provide(mm, [_assistant_msg("prior"), _user_msg("ask")])
+
+    assert store.search.call_args.args[0] == "ask"
+    assert _forwarded_max(store.search) == 2
+    assert text == "A,B"
+
+
+# --- format ---
+
+
+@pytest.mark.asyncio
+async def test_injection_default_format_renders_memory_block_with_source():
+    store = _store("s", entries=[MemoryEntry(content="dark mode preferred")])
+    mm = MemoryManager(stores=[store], injection=True)
+
+    # search() stamps store_name onto each entry, so the default format attributes the source.
+    text = await _provide(mm, [_assistant_msg("prior"), _user_msg("ask")])
+    assert text == '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>'
+
+
+def test_injection_default_format_omits_source_when_no_store_name():
+    mm = MemoryManager(stores=[_store("s")], injection=True)
+    text = mm._default_injection_format([MemoryEntry(content="no source")])
+    assert text == "<memory>\n<entry>no source</entry>\n</memory>"
+
+
+def test_injection_default_format_escapes_xml_in_content_and_source():
+    mm = MemoryManager(stores=[_store("s")], injection=True)
+    text = mm._default_injection_format([MemoryEntry(content="a < b & c > d </entry>", store_name='pre"f')])
+    assert text == '<memory>\n<entry source="pre&quot;f">a &lt; b &amp; c &gt; d &lt;/entry&gt;</entry>\n</memory>'
+
+
+@pytest.mark.asyncio
+async def test_injection_honors_a_custom_format():
+    store = _store("s", entries=[MemoryEntry(content="A")])
+    mm = MemoryManager(
+        stores=[store],
+        injection=MemoryInjectionConfig(
+            format=lambda context: f"[{'|'.join(entry.content for entry in context.entries)}]"
+        ),
+    )
+
+    text = await _provide(mm, [_assistant_msg("prior"), _user_msg("ask")])
+    assert text == "[A]"
+
+
+@pytest.mark.asyncio
+async def test_injection_fails_open_when_custom_format_raises(caplog):
+    def boom(context: Any) -> str:
+        raise ValueError("boom")
+
+    store = _store("s", entries=[MemoryEntry(content="A")])
+    mm = MemoryManager(stores=[store], injection=MemoryInjectionConfig(format=boom))
+
+    with caplog.at_level(logging.WARNING):
+        assert await _provide(mm, [_assistant_msg("prior"), _user_msg("ask")]) is None
+    assert "skipping injection" in caplog.text

--- a/strands-py/tests/strands/vended_plugins/context_injector/test_integration.py
+++ b/strands-py/tests/strands/vended_plugins/context_injector/test_integration.py
@@ -1,0 +1,54 @@
+"""End-to-end tests for ContextInjector against a real Agent + event loop.
+
+These verify the ephemerality contract: the injected text reaches the model for one call but
+never enters the agent's durable conversation history.
+"""
+
+import pytest
+
+from strands import Agent
+from strands.vended_plugins.context_injector import ContextInjector
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+def _texts(messages):
+    """Flatten all text blocks across a conversation into one string."""
+    return " ".join(block["text"] for message in messages for block in message["content"] if "text" in block)
+
+
+@pytest.fixture
+def model():
+    return MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello!"}]}])
+
+
+@pytest.fixture
+def model_seen(model):
+    """Capture the messages the model actually receives, wrapping the mock's stream()."""
+    seen: list[list] = []
+    original_stream = model.stream
+
+    def stream(messages, *args, **kwargs):
+        seen.append([dict(message) for message in messages])
+        return original_stream(messages, *args, **kwargs)
+
+    model.stream = stream
+    return seen
+
+
+def test_injected_text_reaches_model_but_not_durable_history(model, model_seen):
+    agent = Agent(
+        model=model,
+        callback_handler=None,
+        plugins=[ContextInjector(lambda context: "<ctx>EPHEMERAL</ctx>")],
+    )
+
+    agent("what is the weather?")
+
+    # (a) The model saw the injected block folded into the user message.
+    assert len(model_seen) == 1
+    assert "<ctx>EPHEMERAL</ctx>" in _texts(model_seen[0])
+    assert "what is the weather?" in _texts(model_seen[0])
+
+    # (b) The durable conversation never contains the injected text.
+    assert "<ctx>EPHEMERAL</ctx>" not in _texts(agent.messages)
+    assert "what is the weather?" in _texts(agent.messages)

--- a/strands-py/tests/strands/vended_plugins/context_injector/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_injector/test_plugin.py
@@ -1,0 +1,123 @@
+"""Tests for the ContextInjector plugin."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands._middleware.stages import InvokeModelContext, InvokeModelStage
+from strands.vended_plugins.context_injector import ContextInjector
+
+
+def user(text: str) -> dict:
+    return {"role": "user", "content": [{"text": text}]}
+
+
+def assistant(text: str) -> dict:
+    return {"role": "assistant", "content": [{"text": text}]}
+
+
+def make_agent() -> Any:
+    """Build a mock agent that captures add_middleware registrations and exposes state."""
+    agent = MagicMock()
+    agent.state = MagicMock()
+    return agent
+
+
+def register(plugin: ContextInjector) -> tuple[Any, Any]:
+    """Run the plugin's init_agent and return (agent, registered_handler)."""
+    agent = make_agent()
+    plugin.init_agent(agent)
+    call = agent._middleware_registry.add_middleware.call_args
+    return agent, call
+
+
+def invoke_ctx(messages: list[dict], agent: Any) -> InvokeModelContext:
+    return InvokeModelContext(
+        agent=agent,
+        messages=messages,
+        system_prompt=None,
+        tool_specs=[],
+        tool_choice=None,
+        invocation_state={},
+    )
+
+
+class TestPluginInterface:
+    def test_defaults_to_strands_context_injector_name(self):
+        assert ContextInjector(lambda context: "x").name == "strands:context-injector"
+
+    def test_honors_a_custom_name(self):
+        assert ContextInjector(lambda context: "x", name="now").name == "now"
+
+    def test_registers_invoke_model_input_middleware_on_init_agent(self):
+        _, call = register(ContextInjector(lambda context: "x"))
+
+        assert call is not None
+        stage_or_phase, handler = call.args
+        assert stage_or_phase is InvokeModelStage.Input
+        assert callable(handler)
+
+
+@pytest.mark.asyncio
+class TestRegisteredHandler:
+    async def run(self, plugin, messages):
+        agent, call = register(plugin)
+        handler = call.args[1]
+        return await handler(invoke_ctx(messages, agent))
+
+    async def test_folds_render_content_text_into_latest_user_message(self):
+        result = await self.run(
+            ContextInjector(lambda context: "INJECTED"),
+            [assistant("prior"), user("ask")],
+        )
+        assert result.messages == [
+            {"role": "assistant", "content": [{"text": "prior"}]},
+            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "ask"}]},
+        ]
+
+    async def test_skips_on_non_user_turn_by_default(self):
+        render = MagicMock(return_value="x")
+        ctx = invoke_ctx([user("ask"), assistant("reply")], make_agent())
+
+        agent, call = register(ContextInjector(render))
+        result = await call.args[1](ctx)
+
+        render.assert_not_called()
+        assert result is ctx
+
+    async def test_every_turn_injects_regardless_of_latest_role(self):
+        result = await self.run(
+            ContextInjector(lambda context: "INJECTED", trigger="everyTurn"),
+            [user("ask"), assistant("reply")],
+        )
+        # No later user message than index 0, so the fold targets it.
+        assert result.messages == [
+            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "ask"}]},
+            {"role": "assistant", "content": [{"text": "reply"}]},
+        ]
+
+    async def test_exposes_state_and_agent_to_render_content(self):
+        records: dict = {}
+
+        def record(context):
+            records["agent"] = context.agent
+            records["state"] = context.state
+            return None
+
+        agent, call = register(ContextInjector(record))
+        await call.args[1](invoke_ctx([user("ask")], agent))
+
+        assert records["agent"] is agent
+        assert records["state"] is agent.state
+
+    async def test_fails_open_when_render_content_raises(self):
+        def boom(context):
+            raise ValueError("boom")
+
+        result = await self.run(ContextInjector(boom), [assistant("prior"), user("ask")])
+        # Unchanged: the original messages, no injected block.
+        assert result.messages == [
+            {"role": "assistant", "content": [{"text": "prior"}]},
+            {"role": "user", "content": [{"text": "ask"}]},
+        ]

--- a/strands-ts/src/__fixtures__/agent-helpers.ts
+++ b/strands-ts/src/__fixtures__/agent-helpers.ts
@@ -81,6 +81,9 @@ export function createMockAgent(data?: MockAgentData): MockAgent {
       })
       return () => {}
     },
+    // No-op so plugins that register middleware in initAgent (e.g. MemoryManager injection) work
+    // out of the box. Tests that inspect registrations override this via `extra.addMiddleware`.
+    addMiddleware: () => () => {},
     ...data?.extra,
     trackedHooks,
   } as unknown as MockAgent

--- a/strands-ts/src/memory/__tests__/memory-manager.test.ts
+++ b/strands-ts/src/memory/__tests__/memory-manager.test.ts
@@ -614,11 +614,11 @@ describe('MemoryManager', () => {
   describe('initAgent', () => {
     it('does not throw', () => {
       const mm = new MemoryManager({ stores: [createMockStore('test')] })
-      expect(() => mm.initAgent({} as any)).not.toThrow()
+      expect(() => mm.initAgent(createMockAgent())).not.toThrow()
     })
 
     it('does not register injection middleware when injection is disabled', () => {
-      const mm = new MemoryManager({ stores: [createMockStore('test')] })
+      const mm = new MemoryManager({ stores: [createMockStore('test')], injection: false })
       const addMiddleware = vi.fn()
       mm.initAgent(createMockAgent({ extra: { addMiddleware } as never }))
       expect(addMiddleware).not.toHaveBeenCalled()
@@ -690,8 +690,8 @@ describe('MemoryManager', () => {
       const injectionConfig = (mm: MemoryManager) =>
         (mm as unknown as { _injectionConfig: object | false })._injectionConfig
 
-      it('defaults to false (disabled) when injection is omitted', () => {
-        expect(injectionConfig(new MemoryManager({ stores: [createMockStore('s')] }))).toBe(false)
+      it('defaults to an empty config (enabled) when injection is omitted', () => {
+        expect(injectionConfig(new MemoryManager({ stores: [createMockStore('s')] }))).toStrictEqual({})
       })
 
       it('is false when injection is explicitly false', () => {

--- a/strands-ts/src/memory/memory-manager.ts
+++ b/strands-ts/src/memory/memory-manager.ts
@@ -166,11 +166,7 @@ export class MemoryManager implements Plugin {
     }
 
     this._injectionConfig =
-      config.injection === undefined || config.injection === false
-        ? false
-        : typeof config.injection === 'object'
-          ? config.injection
-          : {}
+      config.injection === false ? false : typeof config.injection === 'object' ? config.injection : {}
   }
 
   /**

--- a/strands-ts/src/memory/types.ts
+++ b/strands-ts/src/memory/types.ts
@@ -266,8 +266,9 @@ export interface MemoryManagerConfig {
    */
   addToolConfig?: MemoryAddToolConfig | boolean
   /**
-   * Memory context injection. Defaults to `false` (opt-in). `true` uses the default injection
-   * settings; pass a {@link MemoryInjectionConfig} to customize retrieval, timing, and formatting.
+   * Memory context injection. Defaults to `true`. `true` uses the default injection settings;
+   * pass a {@link MemoryInjectionConfig} to customize retrieval, timing, and formatting; `false`
+   * disables it.
    *
    * `true` is equivalent to:
    * ```ts


### PR DESCRIPTION
## Description

Python port of #2631 

### Motivation

The TypeScript SDK ships context injection: a way to fold just-in-time text into the model's input *for a single call* without persisting it to the durable conversation. The `MemoryManager` builds on it to surface relevant memories to the model automatically, so the agent doesn't have to spend a tool call searching. Python had neither — `MemoryManager` (#2740) landed with extraction and search tools but no injection — so the Python `MemoryManager` could only recall memory reactively via the `search_memory` tool, never proactively.

This ports the injection primitive to Python and wires it into `MemoryManager`, bringing the two SDKs to parity. The design follows the TS source: a small, reusable `strands.injection` engine delivered as an `InvokeModelStage.Input` middleware, a thin `ContextInjector` vended plugin for arbitrary content, and a `MemoryManager` consumer for memory-specific retrieval. Behavior, fail-open semantics, the default `<memory>` format, the prepend-vs-append fold rule, and trigger policies all mirror the TS implementation.

Ephemerality is the core contract: injected text reaches the model for one call but never enters `agent.messages` or the session. This falls out of the middleware seam — the engine rewrites the per-call `InvokeModelContext.messages` (already a defensive copy of agent state), so durable history is untouched.

Memory injection is **on by default** in both SDKs: if you configure a `MemoryManager` with stores, the point is to use them, so proactive recall is the obvious-path default rather than a flag you have to discover. Because this also changes the already-shipped TS `MemoryManager`, it is a behavior change there — see Breaking Changes. Opt out with `injection: false` / `injection=False`.

### Public API Changes

**1. New `strands.injection` package** — shared configuration types for context injection. Delivery primitives are intentionally internal; the public surface is config only:

```python
from strands.injection import InjectionConfig, InjectionContext, InjectionTrigger
```

**2. New `ContextInjector` vended plugin** — folds arbitrary just-in-time text (current time, retrieved docs, request metadata, …) into the model input:

```python
from strands import Agent
from strands.vended_plugins.context_injector import ContextInjector

agent = Agent(
    plugins=[
        ContextInjector(lambda context: f"<context>{derive(context.messages)}</context>")
    ]
)
```

`render_content` is the only required argument (sync or async; returns the text, or `None`/`""` to skip). Optional keyword-only `name` (default `"strands:context-injector"`) and `trigger` (`"userTurn"` default, `"everyTurn"`, or a predicate over the `InjectionContext`). A callback that raises fails open — injection is skipped and the model call proceeds.

**3. `MemoryManager` gains an `injection` option** — on by default:

```python
from strands import Agent
from strands.memory import MemoryManager, MemoryInjectionConfig

# Default: inject up to 5 entries on a user turn, rendered as a <memory> block
agent = Agent(plugins=[MemoryManager(stores=[store])])

# Opt out
agent = Agent(plugins=[MemoryManager(stores=[store], injection=False)])

# Or customize retrieval, timing, and formatting
agent = Agent(
    plugins=[
        MemoryManager(
            stores=[store],
            injection=MemoryInjectionConfig(
                trigger="everyTurn",
                max_entries=3,
                query=lambda context: derive_query(context.messages),
                format=lambda context: render(context.entries),
            ),
        )
    ]
)
```

`MemoryInjectionConfig` extends `InjectionConfig`. When enabled, `MemoryManager` derives a query from the conversation (the latest user text on a user turn, else the most recent assistant text), searches its stores, and folds the top entries into the model input. `injection` defaults to `True` (`False` disables it). `strands.memory` also re-exports `InjectionConfig`/`InjectionContext`/`InjectionTrigger` so injection can be configured from a single import.

The same default flip is applied to the TypeScript `MemoryManager` (`injection?: boolean | MemoryInjectionConfig`, now defaulting to enabled) to keep the two SDKs aligned.

One deliberate cross-SDK divergence worth a reviewer's eye: the callback config fields (`trigger`, `render_content`, `query`, `format`) are typed as `Callable | Protocol`-with-`**kwargs` unions rather than the bare `Callable` the TS side uses. This follows the STYLE_GUIDE's "avoid `Callable` for extensible interfaces" rule (the `Protocol` arm lets the calling convention grow keyword arguments later) while the `Callable` arm keeps the plain-lambda happy path ergonomic under mypy strict — a pure `Protocol` rejects bare lambdas. This mirrors the existing `EdgeCondition` pattern in `multiagent/graph.py`.

## Breaking Changes

For the Python `MemoryManager`, memory injection is new in this PR, so default-on is a fresh default, not a change. For the **TypeScript `MemoryManager`** (shipped in #2631), this flips `injection` from opt-in (`false`) to opt-out (enabled). Existing TS agents that configure a `MemoryManager` will now, on each model call, derive a query from the conversation, search their stores, and prepend a `<memory>` block to the model input — adding tokens and a search round-trip per call, and potentially surfacing irrelevant recall. This is a behavior change under the "pay for play" tenet, called out here for explicit reviewer sign-off; it is not an API-signature break (the field and its type are unchanged).

### Migration

```typescript
// Restore the previous (no-injection) behavior:
new MemoryManager({ stores, injection: false })
```

```python
# Python equivalent:
MemoryManager(stores=stores, injection=False)
```

## Documentation PR

Follow-up: a docs page for `ContextInjector` and `MemoryManager` injection is not included here.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

Unit tests mirror the TS describe blocks (fold/trigger/query/format/fail-open), plus real-Agent integration tests on both the `ContextInjector` and `MemoryManager` paths asserting the injected text reaches the model but never `agent.messages`.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
