### PR TITLE
chore: apply ruff format to fix pre-existing drift in strands-py

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -462,18 +462,14 @@ class Agent(AgentBase):
 
         supported = get_args(ContextManagerStrategy)
         if context_manager not in supported:
-            raise ValueError(
-                f"Unsupported context_manager value: {context_manager!r}. Supported values: {supported}"
-            )
+            raise ValueError(f"Unsupported context_manager value: {context_manager!r}. Supported values: {supported}")
 
         from ..vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
         from .conversation_manager import SummarizingConversationManager
 
         resolved_plugins = list(plugins) if plugins else []
 
-        has_offloader = any(
-            isinstance(p, ContextOffloader) for p in resolved_plugins
-        )
+        has_offloader = any(isinstance(p, ContextOffloader) for p in resolved_plugins)
         if not has_offloader:
             offloader = ContextOffloader(
                 storage=InMemoryStorage(),

--- a/strands-py/src/strands/agent/conversation_manager/pin_message.py
+++ b/strands-py/src/strands/agent/conversation_manager/pin_message.py
@@ -55,7 +55,6 @@ def is_pinned(messages: Messages, index: int) -> bool:
     return False
 
 
-
 def apply_pin_first(messages: Messages, count: int) -> None:
     """Pin the first N messages in the array permanently.
 

--- a/strands-py/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
+++ b/strands-py/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
@@ -202,9 +202,7 @@ class SummarizingConversationManager(ConversationManager):
         protected_to_preserve, to_summarize = partition_pinned(agent.messages, 0, messages_to_summarize_count)
 
         if not to_summarize:
-            raise ContextWindowOverflowException(
-                "Cannot summarize: all messages in summarize range are pinned"
-            )
+            raise ContextWindowOverflowException("Cannot summarize: all messages in summarize range are pinned")
 
         remaining_messages = agent.messages[messages_to_summarize_count:]
 
@@ -379,4 +377,3 @@ class SummarizingConversationManager(ConversationManager):
             raise ContextWindowOverflowException("Unable to trim conversation context!")
 
         return split_point
-

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -530,9 +530,7 @@ async def _handle_model_execution(
             # Build middleware context with defensive copies to prevent accidental mutation.
             # invocation_state is intentionally shared by reference (hooks/tools write to it).
             system_prompt_value = (
-                agent._system_prompt_content
-                if agent._system_prompt_content is not None
-                else agent.system_prompt
+                agent._system_prompt_content if agent._system_prompt_content is not None else agent.system_prompt
             )
             middleware_context = InvokeModelContext(
                 agent=agent,
@@ -679,12 +677,14 @@ def _make_invoke_model_terminal(
 
                 stop_reason, message, usage, metrics = event["stop"]
                 tracer.end_model_invoke_span(model_invoke_span, message, usage, metrics, stop_reason)
-                yield MiddlewareResult(InvokeModelResult(
-                    stop_reason=stop_reason,
-                    message=message,
-                    usage=usage,
-                    metrics=metrics,
-                ))
+                yield MiddlewareResult(
+                    InvokeModelResult(
+                        stop_reason=stop_reason,
+                        message=message,
+                        usage=usage,
+                        metrics=metrics,
+                    )
+                )
             except Exception as e:
                 tracer.end_span_with_error(model_invoke_span, str(e), e)
                 raise

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -948,7 +948,6 @@ class MCPClient(ToolProvider):
             self._log_debug_with_thread("unhandled content type: %s - dropping content", content.__class__.__name__)
             return None
 
-
     def _log_debug_with_thread(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Logger helper to help differentiate logs coming from MCPClient background thread."""
         formatted_msg = msg % args if args else msg

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -328,9 +328,7 @@ class InMemoryStorage:
             if self._evict_after_turns is None:
                 return
             threshold = cycle - self._evict_after_turns
-            stale_refs = [
-                ref for ref, (_, _, last_cycle) in self._store.items() if last_cycle < threshold
-            ]
+            stale_refs = [ref for ref, (_, _, last_cycle) in self._store.items() if last_cycle < threshold]
             for ref in stale_refs:
                 del self._store[ref]
             if stale_refs:

--- a/strands-py/src/strands/vended_plugins/goal/plugin.py
+++ b/strands-py/src/strands/vended_plugins/goal/plugin.py
@@ -76,6 +76,7 @@ the dict form ``{"passed": bool, "feedback": str}`` or ``ValidationOutcome``
 when you have actionable feedback for the next attempt.
 """
 
+
 @runtime_checkable
 class Validator(Protocol):
     """Programmatic validator callable.
@@ -88,11 +89,10 @@ class Validator(Protocol):
     the validator needs.
     """
 
-    def __call__(
-        self, response: Message, agent: Agent, **kwargs: Any
-    ) -> ValidatorReturn | Awaitable[ValidatorReturn]:
+    def __call__(self, response: Message, agent: Agent, **kwargs: Any) -> ValidatorReturn | Awaitable[ValidatorReturn]:
         """Validate the agent's response."""
         ...
+
 
 GoalStopReason = Literal["satisfied", "max_attempts", "timeout"]
 """Why a goal run ended."""

--- a/strands-py/tests/strands/agent/test_conversation_manager.py
+++ b/strands-py/tests/strands/agent/test_conversation_manager.py
@@ -1106,10 +1106,12 @@ def test_pin_first_only_applies_once():
     assert agent.messages[0].get("metadata", {}).get("custom", {}).get("pinned") is True
 
     # Second reduction — should not re-apply (flag is set)
-    agent.messages.extend([
-        {"role": "user", "content": [{"text": "seventh"}]},
-        {"role": "assistant", "content": [{"text": "eighth"}]},
-    ])
+    agent.messages.extend(
+        [
+            {"role": "user", "content": [{"text": "seventh"}]},
+            {"role": "assistant", "content": [{"text": "eighth"}]},
+        ]
+    )
     manager.reduce_context(agent)
     # Still works without error
     assert "first" in [m["content"][0]["text"] for m in agent.messages]

--- a/strands-py/tests/strands/middleware/test_agent_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_middleware.py
@@ -71,7 +71,6 @@ def test_wrap_context_transformation(agent):
     transformed_system_prompt = None
 
     async def inject_prompt(context, next_fn):
-
         modified = replace(context, system_prompt="Injected prompt")
         async for event in next_fn(modified):
             yield event
@@ -94,7 +93,6 @@ def test_wrap_context_transformation_tool_specs(agent):
     received_tool_specs = None
 
     async def modify_specs(context, next_fn):
-
         modified = replace(context, tool_specs=[])
         async for event in next_fn(modified):
             yield event
@@ -220,7 +218,6 @@ def test_input_transforms_context(agent):
             yield event
 
     def inject_prompt(context):
-
         return replace(context, system_prompt="From input handler")
 
     agent._middleware_registry.add_middleware(InvokeModelStage.Input, inject_prompt)
@@ -240,7 +237,6 @@ def test_input_async_handler(agent):
             yield event
 
     async def async_inject(context):
-
         return replace(context, system_prompt="Async input")
 
     agent._middleware_registry.add_middleware(InvokeModelStage.Input, async_inject)
@@ -257,7 +253,6 @@ def test_output_transforms_result(agent):
     transformed_results: list[InvokeModelResult] = []
 
     def output_handler(result):
-
         new_result = replace(result, stop_reason="custom_stop")
         transformed_results.append(new_result)
         return new_result
@@ -318,7 +313,6 @@ def test_after_model_call_fires_after_middleware(model):
 
 
 def test_plugin_can_register_middleware(model):
-
     class TimingPlugin(Plugin):
         name = "timing"
 
@@ -394,7 +388,6 @@ def test_passthrough_middleware_preserves_result():
 def test_short_circuit_model_not_called(model):
     """When middleware short-circuits, model.stream is never invoked."""
 
-
     agent = Agent(model=model, callback_handler=None)
     agent.model.stream = AsyncMock(wraps=agent.model.stream)
 
@@ -459,7 +452,6 @@ def test_phase_ordering_at_agent_level(model):
 
     agent("test")
     assert order == ["input", "wrap", "output"]
-
 
 
 def test_retry_on_error_use_case():

--- a/strands-py/tests/strands/middleware/test_registry.py
+++ b/strands-py/tests/strands/middleware/test_registry.py
@@ -382,7 +382,6 @@ async def test_output_runs_after_wrap(registry, stage):
     assert result == "base_out"
 
 
-
 # --- error propagation ---
 
 
@@ -575,5 +574,3 @@ async def test_two_layer_finally_on_generator_close(registry, stage):
     await gen.aclose()
     assert "inner_finally" in order
     assert "outer_finally" in order
-
-

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -872,9 +872,7 @@ async def test_stream_response_max_tokens(gemini_client, model, messages, agener
 
 
 @pytest.mark.asyncio
-async def test_stream_response_safety_block_with_missing_counts(
-    gemini_client, model, messages, agenerator, alist
-):
+async def test_stream_response_safety_block_with_missing_counts(gemini_client, model, messages, agenerator, alist):
     gemini_client.aio.models.generate_content_stream.return_value = agenerator(
         [
             genai.types.GenerateContentResponse(

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -624,4 +624,3 @@ class TestBeforeModelCallHook:
         plugin._on_before_model_call(self._make_event(3))
         with pytest.raises(KeyError):
             storage.retrieve(ref)
-

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -101,7 +101,6 @@ class TestInMemoryStorageEviction:
         with pytest.raises(ValueError, match="evict_after_turns must be a positive integer"):
             InMemoryStorage(evict_after_turns=-1)
 
-
     def test_eviction_enabled_by_default(self):
         storage = InMemoryStorage()
         assert storage._evict_after_turns == 20

--- a/strands-py/tests_integ/test_goal_loop.py
+++ b/strands-py/tests_integ/test_goal_loop.py
@@ -46,11 +46,7 @@ class TestStandardRefinementLoop:
         roles = [m["role"] for m in agent.messages]
         assert roles == ["user", "assistant", "user", "assistant"]
         user_texts = [
-            block["text"]
-            for m in agent.messages
-            if m["role"] == "user"
-            for block in m["content"]
-            if "text" in block
+            block["text"] for m in agent.messages if m["role"] == "user" for block in m["content"] if "text" in block
         ]
         assert any("TRIGGER_RETRY_MARKER" in t for t in user_texts)
 


### PR DESCRIPTION
## Description

14 files under `strands-py/` were not conformant with the repo's own ruff formatter (`line-length = 120`) on `main`. Running `hatch fmt --formatter` reformats them. Every change is line-reflow (collapsing wrapped statements that now fit in 120 cols) or blank-line normalization; there are **no logic changes**.

This drift was most likely introduced by files committed under an older ruff. Splitting it into its own PR keeps unrelated formatting churn out of feature branches.

Reproduce:
```
cd strands-py && hatch fmt --formatter --check   # 14 files flagged on main
hatch fmt --formatter                            # reformats exactly those 14
```

Files touched: `agent/agent.py`, `agent/conversation_manager/{pin_message,summarizing_conversation_manager}.py`, `event_loop/event_loop.py`, `tools/mcp/mcp_client.py`, `vended_plugins/{context_offloader/storage,goal/plugin}.py`, and several existing test files under `tests/` and `tests_integ/`.

## Related Issues

<!-- none -->

## Documentation PR

Not applicable; no behavior or API change.

## Type of Change

Other (please describe): formatting-only cleanup (no logic change)

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Ran the relevant subset for a formatting-only change instead of the full `prepare` (which includes the multi-version `hatch test --all` matrix, unrelated to formatting):
- `hatch run test-format` → 440 files already formatted
- `hatch run test-lint` → `ruff check` all checks passed; `mypy ./src` no issues in 184 source files

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.