### PR TITLE
fix(strands-py): allow sync or async InterventionHandler lifecycle overrides

### DIFF
--- a/strands-py/src/strands/interventions/__init__.py
+++ b/strands-py/src/strands/interventions/__init__.py
@@ -28,4 +28,5 @@ from .actions import InterventionAction as InterventionAction
 from .actions import Proceed as Proceed
 from .actions import Transform as Transform
 from .handler import InterventionHandler as InterventionHandler
+from .handler import MaybeAwaitable as MaybeAwaitable
 from .handler import OnError as OnError

--- a/strands-py/src/strands/interventions/__init__.py
+++ b/strands-py/src/strands/interventions/__init__.py
@@ -28,5 +28,4 @@ from .actions import InterventionAction as InterventionAction
 from .actions import Proceed as Proceed
 from .actions import Transform as Transform
 from .handler import InterventionHandler as InterventionHandler
-from .handler import MaybeAwaitable as MaybeAwaitable
 from .handler import OnError as OnError

--- a/strands-py/src/strands/interventions/handler.py
+++ b/strands-py/src/strands/interventions/handler.py
@@ -6,7 +6,8 @@ registers hook callbacks for those.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal
+from collections.abc import Awaitable
+from typing import Any, Literal, TypeAlias, TypeVar
 
 from ..hooks.events import (
     AfterModelCallEvent,
@@ -16,6 +17,15 @@ from ..hooks.events import (
     BeforeToolCallEvent,
 )
 from .actions import Confirm, Deny, Guide, Proceed, Transform
+
+_T = TypeVar("_T")
+MaybeAwaitable: TypeAlias = _T | Awaitable[_T]
+"""A value that may be returned directly or as a coroutine.
+
+Lifecycle methods are annotated with this so an override can be a plain ``def``
+(returning the action) or an ``async def`` (returning a coroutine the registry
+awaits). Mirrors the TypeScript ``Awaitable<T>`` alias in ``interventions/handler.ts``.
+"""
 
 OnError = Literal["throw", "proceed", "deny"]
 """What to do when a handler throws during evaluation.
@@ -35,6 +45,13 @@ class InterventionHandler(ABC):
     methods they care about at the **class level**. The framework detects which
     methods are overridden and only calls those. Instance-level assignments
     (e.g., ``handler.before_tool_call = my_func``) are not detected.
+
+    Lifecycle methods may be implemented as either sync or ``async`` functions.
+    The registry awaits any override that returns an awaitable, so an ``async``
+    handler can await I/O (a database lookup, an HTTP authorization call, a human
+    approval prompt) before deciding on an action. The return annotations use
+    ``MaybeAwaitable`` to reflect that an override is free to return its action
+    directly or as a coroutine.
 
     Example:
         ```python
@@ -59,24 +76,30 @@ class InterventionHandler(ABC):
         """What to do when this handler throws. Defaults to 'throw'."""
         return "throw"
 
-    def before_invocation(self, event: BeforeInvocationEvent, **kwargs: Any) -> Proceed | Deny | Guide | Transform:
+    def before_invocation(
+        self, event: BeforeInvocationEvent, **kwargs: Any
+    ) -> MaybeAwaitable[Proceed | Deny | Guide | Transform]:
         """Called before an agent invocation begins."""
         return Proceed()
 
     def before_tool_call(
         self, event: BeforeToolCallEvent, **kwargs: Any
-    ) -> Proceed | Deny | Guide | Confirm | Transform:
+    ) -> MaybeAwaitable[Proceed | Deny | Guide | Confirm | Transform]:
         """Called before a tool is executed."""
         return Proceed()
 
-    def after_tool_call(self, event: AfterToolCallEvent, **kwargs: Any) -> Proceed | Transform:
+    def after_tool_call(self, event: AfterToolCallEvent, **kwargs: Any) -> MaybeAwaitable[Proceed | Transform]:
         """Called after a tool execution completes."""
         return Proceed()
 
-    def before_model_call(self, event: BeforeModelCallEvent, **kwargs: Any) -> Proceed | Deny | Guide | Transform:
+    def before_model_call(
+        self, event: BeforeModelCallEvent, **kwargs: Any
+    ) -> MaybeAwaitable[Proceed | Deny | Guide | Transform]:
         """Called before the model is invoked."""
         return Proceed()
 
-    def after_model_call(self, event: AfterModelCallEvent, **kwargs: Any) -> Proceed | Guide | Transform:
+    def after_model_call(
+        self, event: AfterModelCallEvent, **kwargs: Any
+    ) -> MaybeAwaitable[Proceed | Guide | Transform]:
         """Called after the model invocation completes."""
         return Proceed()

--- a/strands-py/src/strands/interventions/handler.py
+++ b/strands-py/src/strands/interventions/handler.py
@@ -19,12 +19,14 @@ from ..hooks.events import (
 from .actions import Confirm, Deny, Guide, Proceed, Transform
 
 _T = TypeVar("_T")
-MaybeAwaitable: TypeAlias = _T | Awaitable[_T]
+_MaybeAwaitable: TypeAlias = _T | Awaitable[_T]
 """A value that may be returned directly or as a coroutine.
 
-Lifecycle methods are annotated with this so an override can be a plain ``def``
-(returning the action) or an ``async def`` (returning a coroutine the registry
-awaits). Mirrors the TypeScript ``Awaitable<T>`` alias in ``interventions/handler.ts``.
+Internal annotation alias (underscore-prefixed, not exported): it only widens
+the lifecycle return signatures so an override can be a plain ``def`` (returning
+the action) or an ``async def`` (returning a coroutine the registry awaits). It
+is an implementation detail of supporting both styles, not part of the public
+contract. Mirrors the TypeScript ``Awaitable<T>`` alias in ``interventions/handler.ts``.
 """
 
 OnError = Literal["throw", "proceed", "deny"]
@@ -50,7 +52,7 @@ class InterventionHandler(ABC):
     The registry awaits any override that returns an awaitable, so an ``async``
     handler can await I/O (a database lookup, an HTTP authorization call, a human
     approval prompt) before deciding on an action. The return annotations use
-    ``MaybeAwaitable`` to reflect that an override is free to return its action
+    ``_MaybeAwaitable`` to reflect that an override is free to return its action
     directly or as a coroutine.
 
     Example:
@@ -78,28 +80,28 @@ class InterventionHandler(ABC):
 
     def before_invocation(
         self, event: BeforeInvocationEvent, **kwargs: Any
-    ) -> MaybeAwaitable[Proceed | Deny | Guide | Transform]:
+    ) -> _MaybeAwaitable[Proceed | Deny | Guide | Transform]:
         """Called before an agent invocation begins."""
         return Proceed()
 
     def before_tool_call(
         self, event: BeforeToolCallEvent, **kwargs: Any
-    ) -> MaybeAwaitable[Proceed | Deny | Guide | Confirm | Transform]:
+    ) -> _MaybeAwaitable[Proceed | Deny | Guide | Confirm | Transform]:
         """Called before a tool is executed."""
         return Proceed()
 
-    def after_tool_call(self, event: AfterToolCallEvent, **kwargs: Any) -> MaybeAwaitable[Proceed | Transform]:
+    def after_tool_call(self, event: AfterToolCallEvent, **kwargs: Any) -> _MaybeAwaitable[Proceed | Transform]:
         """Called after a tool execution completes."""
         return Proceed()
 
     def before_model_call(
         self, event: BeforeModelCallEvent, **kwargs: Any
-    ) -> MaybeAwaitable[Proceed | Deny | Guide | Transform]:
+    ) -> _MaybeAwaitable[Proceed | Deny | Guide | Transform]:
         """Called before the model is invoked."""
         return Proceed()
 
     def after_model_call(
         self, event: AfterModelCallEvent, **kwargs: Any
-    ) -> MaybeAwaitable[Proceed | Guide | Transform]:
+    ) -> _MaybeAwaitable[Proceed | Guide | Transform]:
         """Called after the model invocation completes."""
         return Proceed()

--- a/strands-py/src/strands/interventions/registry.py
+++ b/strands-py/src/strands/interventions/registry.py
@@ -206,7 +206,10 @@ class InterventionRegistry:
             try:
                 method_fn = getattr(handler, method)
                 result = method_fn(event)
-                action = await result if inspect.iscoroutinefunction(method_fn) else result
+                # Await based on the *returned value*, not iscoroutinefunction(method_fn):
+                # lifecycle overrides may be sync or async (the base class annotates them
+                # as MaybeAwaitable), and a sync def can still hand back a coroutine/future.
+                action = await result if inspect.isawaitable(result) else result
             except Exception as error:
                 action = self._handle_error(handler, method, error)
                 if action is None:

--- a/strands-py/src/strands/interventions/registry.py
+++ b/strands-py/src/strands/interventions/registry.py
@@ -206,9 +206,7 @@ class InterventionRegistry:
             try:
                 method_fn = getattr(handler, method)
                 result = method_fn(event)
-                # Await based on the *returned value*, not iscoroutinefunction(method_fn):
-                # lifecycle overrides may be sync or async (the base class annotates them
-                # as MaybeAwaitable), and a sync def can still hand back a coroutine/future.
+                # Overrides may be sync or async, so branch on the returned value.
                 action = await result if inspect.isawaitable(result) else result
             except Exception as error:
                 action = self._handle_error(handler, method, error)

--- a/strands-py/tests/strands/interventions/test_registry.py
+++ b/strands-py/tests/strands/interventions/test_registry.py
@@ -805,7 +805,7 @@ class TestSyncAndAsyncOverrides:
 
         This is the case iscoroutinefunction(method_fn) misses (the *method* is
         sync) but isawaitable(result) catches (the *value* is awaitable). Guards
-        against the un-awaited-coroutine regression the MaybeAwaitable annotation
+        against the un-awaited-coroutine regression the _MaybeAwaitable annotation
         would otherwise invite.
         """
 

--- a/strands-py/tests/strands/interventions/test_registry.py
+++ b/strands-py/tests/strands/interventions/test_registry.py
@@ -761,3 +761,65 @@ class TestUnsupportedActionWarning:
             await hook_registry.invoke_callbacks_async(event)
 
         assert any("has no effect" in record.message for record in caplog.records)
+
+
+class TestSyncAndAsyncOverrides:
+    """Lifecycle overrides may be sync or async; the registry awaits based on
+    the returned value (inspect.isawaitable), not on iscoroutinefunction."""
+
+    @pytest.mark.asyncio
+    async def test_sync_def_override_is_dispatched(self, hook_registry, agent):
+        """A plain sync `def` override returns its action directly."""
+
+        class SyncDeny(InterventionHandler):
+            name = "sync-deny"
+
+            def before_tool_call(self, event):
+                return Deny(reason="sync denial")
+
+        InterventionRegistry([SyncDeny()], hook_registry)
+
+        event = make_before_tool_call_event(agent)
+        await hook_registry.invoke_callbacks_async(event)
+        assert event.cancel_tool == "DENIED: sync denial"
+
+    @pytest.mark.asyncio
+    async def test_async_def_override_is_awaited(self, hook_registry, agent):
+        """An `async def` override returns a coroutine that the registry awaits."""
+
+        class AsyncDeny(InterventionHandler):
+            name = "async-deny-override"
+
+            async def before_tool_call(self, event):
+                return Deny(reason="async denial")
+
+        InterventionRegistry([AsyncDeny()], hook_registry)
+
+        event = make_before_tool_call_event(agent)
+        await hook_registry.invoke_callbacks_async(event)
+        assert event.cancel_tool == "DENIED: async denial"
+
+    @pytest.mark.asyncio
+    async def test_sync_def_returning_coroutine_is_awaited(self, hook_registry, agent):
+        """A sync `def` that hands back a coroutine is still awaited.
+
+        This is the case iscoroutinefunction(method_fn) misses (the *method* is
+        sync) but isawaitable(result) catches (the *value* is awaitable). Guards
+        against the un-awaited-coroutine regression the MaybeAwaitable annotation
+        would otherwise invite.
+        """
+
+        async def _decide():
+            return Deny(reason="deferred denial")
+
+        class SyncReturnsCoroutine(InterventionHandler):
+            name = "sync-returns-coroutine"
+
+            def before_tool_call(self, event):
+                return _decide()
+
+        InterventionRegistry([SyncReturnsCoroutine()], hook_registry)
+
+        event = make_before_tool_call_event(agent)
+        await hook_registry.invoke_callbacks_async(event)
+        assert event.cancel_tool == "DENIED: deferred denial"


### PR DESCRIPTION
## Description

Split out of #2750 (the HITL port) per @lizradway's review request: *"can you raise this in a separate PR?"*

`InterventionHandler` lifecycle methods could only be reliably implemented as `async def` before this change. The registry decided whether to await using `inspect.iscoroutinefunction(method_fn)` — `True` only for `async def`. A **sync** override that returned a coroutine/future would be passed through **un-awaited** (`RuntimeWarning: coroutine was never awaited` + a type error downstream). This is the exact mismatch the bot review and @lizradway flagged on #2750 when the base-class returns were widened to `... | Awaitable[...]` without a matching runtime change.

## Changes

1. **`_MaybeAwaitable[T]` type alias.** `_MaybeAwaitable: TypeAlias = _T | Awaitable[_T]`, mirroring the TypeScript [`Awaitable<T>`](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/interventions/handler.ts) alias (@lizradway's suggestion — avoids repeating the union twice per method). All five `InterventionHandler` lifecycle methods are annotated with it, so overrides may be **sync or async**. It is an **internal** annotation alias (underscore-prefixed, **not exported**): it only widens the lifecycle return signatures so an override can be a plain `def` or an `async def`. It is an implementation detail of supporting both styles, not part of the public contract.
2. **Runtime matches the type.** Dispatch now awaits based on the *returned value* — `inspect.isawaitable(result)` — instead of `inspect.iscoroutinefunction(method_fn)`. A sync `def` that hands back an awaitable is now awaited correctly; an `async def` still works exactly as before.
3. **Tests** for all three paths: a plain sync `def` override, an `async def` override, and the sync-`def`-returning-a-coroutine case that `iscoroutinefunction` missed (locks in the contract the new annotation advertises).

## Why separate from #2750

This touches the shared intervention **primitive** (all handlers), not just the HITL vended handler. Keeping it isolated makes the runtime+type change reviewable on its own and keeps #2750 scoped to the new `HumanInTheLoop` handler. With this merged, #2750's `HumanInTheLoop.before_tool_call` can drop its `# type: ignore[override]` (it's restored there for now).

## Type of Change

Bug fix / API refinement (non-breaking — async handlers keep working; sync handlers now work too).

## Testing

- `pytest tests/strands/interventions tests/strands/test_interrupt.py tests/strands/hooks` → **128 passed**
- Broader sweep `tests/strands/agent` (a2a optional extra skipped) → **671 passed**
- `ruff format --check` / `ruff check` → clean
- `mypy src/strands/interventions/handler.py src/strands/interventions/registry.py` → clean (no `type: ignore`)

- [x] I ran lint/format/type checks and the test suite for changed files

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR
- [x] My change is focused and reasonably small; unrelated work is split out
- [x] I have added tests that prove the fix works
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.