### PR TITLE
feat(strands-py): support sync & async intervention lifecycle overrides

### DIFF
--- a/strands-py/src/strands/interventions/__init__.py
+++ b/strands-py/src/strands/interventions/__init__.py
@@ -28,4 +28,5 @@ from .actions import InterventionAction as InterventionAction
 from .actions import Proceed as Proceed
 from .actions import Transform as Transform
 from .handler import InterventionHandler as InterventionHandler
+from .handler import MaybeAwaitable as MaybeAwaitable
 from .handler import OnError as OnError

--- a/strands-py/src/strands/interventions/handler.py
+++ b/strands-py/src/strands/interventions/handler.py
@@ -6,7 +6,8 @@ registers hook callbacks for those.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal
+from collections.abc import Awaitable
+from typing import Any, Literal, TypeAlias, TypeVar
 
 from ..hooks.events import (
     AfterModelCallEvent,
@@ -16,6 +17,17 @@ from ..hooks.events import (
     BeforeToolCallEvent,
 )
 from .actions import Confirm, Deny, Guide, Proceed, Transform
+
+T = TypeVar("T")
+
+MaybeAwaitable: TypeAlias = T | Awaitable[T]
+"""A value that may be returned directly or as an awaitable.
+
+Lifecycle methods are annotated with this so an override can be a plain ``def``
+that returns its action, or an ``async def`` that returns a coroutine the
+registry awaits. Mirrors the TypeScript ``Awaitable<T>`` alias so both ports
+express the sync-or-async contract the same way.
+"""
 
 OnError = Literal["throw", "proceed", "deny"]
 """What to do when a handler throws during evaluation.
@@ -35,6 +47,13 @@ class InterventionHandler(ABC):
     methods they care about at the **class level**. The framework detects which
     methods are overridden and only calls those. Instance-level assignments
     (e.g., ``handler.before_tool_call = my_func``) are not detected.
+
+    Lifecycle methods may be implemented as either sync or ``async`` functions.
+    The registry awaits any awaitable an override returns, so an ``async``
+    handler can await I/O (a database lookup, an HTTP authorization call, a
+    human approval prompt) before deciding on an action. The return annotations
+    use :data:`MaybeAwaitable` to reflect that an override is free to return its
+    action directly or as a coroutine.
 
     Example:
         ```python
@@ -59,24 +78,30 @@ class InterventionHandler(ABC):
         """What to do when this handler throws. Defaults to 'throw'."""
         return "throw"
 
-    def before_invocation(self, event: BeforeInvocationEvent, **kwargs: Any) -> Proceed | Deny | Guide | Transform:
+    def before_invocation(
+        self, event: BeforeInvocationEvent, **kwargs: Any
+    ) -> MaybeAwaitable[Proceed | Deny | Guide | Transform]:
         """Called before an agent invocation begins."""
         return Proceed()
 
     def before_tool_call(
         self, event: BeforeToolCallEvent, **kwargs: Any
-    ) -> Proceed | Deny | Guide | Confirm | Transform:
+    ) -> MaybeAwaitable[Proceed | Deny | Guide | Confirm | Transform]:
         """Called before a tool is executed."""
         return Proceed()
 
-    def after_tool_call(self, event: AfterToolCallEvent, **kwargs: Any) -> Proceed | Transform:
+    def after_tool_call(self, event: AfterToolCallEvent, **kwargs: Any) -> MaybeAwaitable[Proceed | Transform]:
         """Called after a tool execution completes."""
         return Proceed()
 
-    def before_model_call(self, event: BeforeModelCallEvent, **kwargs: Any) -> Proceed | Deny | Guide | Transform:
+    def before_model_call(
+        self, event: BeforeModelCallEvent, **kwargs: Any
+    ) -> MaybeAwaitable[Proceed | Deny | Guide | Transform]:
         """Called before the model is invoked."""
         return Proceed()
 
-    def after_model_call(self, event: AfterModelCallEvent, **kwargs: Any) -> Proceed | Guide | Transform:
+    def after_model_call(
+        self, event: AfterModelCallEvent, **kwargs: Any
+    ) -> MaybeAwaitable[Proceed | Guide | Transform]:
         """Called after the model invocation completes."""
         return Proceed()

--- a/strands-py/src/strands/interventions/registry.py
+++ b/strands-py/src/strands/interventions/registry.py
@@ -206,7 +206,12 @@ class InterventionRegistry:
             try:
                 method_fn = getattr(handler, method)
                 result = method_fn(event)
-                action = await result if inspect.iscoroutinefunction(method_fn) else result
+                # Await on the returned value, not iscoroutinefunction(method_fn): the
+                # lifecycle contract (MaybeAwaitable) lets an override be sync or async,
+                # and a sync method is free to return a coroutine/awaitable of its own.
+                # Inspecting the result covers all of those; inspecting the function would
+                # miss a sync def that returns an awaitable and pass it through un-awaited.
+                action = await result if inspect.isawaitable(result) else result
             except Exception as error:
                 action = self._handle_error(handler, method, error)
                 if action is None:

--- a/strands-py/tests/strands/interventions/test_registry.py
+++ b/strands-py/tests/strands/interventions/test_registry.py
@@ -761,3 +761,94 @@ class TestUnsupportedActionWarning:
             await hook_registry.invoke_callbacks_async(event)
 
         assert any("has no effect" in record.message for record in caplog.records)
+
+
+class TestSyncAndAsyncOverrides:
+    """The lifecycle contract (MaybeAwaitable) allows sync or async overrides.
+
+    The registry awaits based on whether the *returned value* is awaitable
+    (inspect.isawaitable), not whether the method is `async def`. These tests
+    lock in that all three shapes resolve to the same action.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sync_def_override_is_applied(self, hook_registry, agent):
+        """A plain `def` override returning an action directly is honored."""
+
+        class SyncDeny(InterventionHandler):
+            name = "sync-deny"
+
+            def before_tool_call(self, event):
+                return Deny(reason="sync denial")
+
+        InterventionRegistry([SyncDeny()], hook_registry)
+
+        event = make_before_tool_call_event(agent)
+        await hook_registry.invoke_callbacks_async(event)
+        assert event.cancel_tool == "DENIED: sync denial"
+
+    @pytest.mark.asyncio
+    async def test_async_def_override_is_awaited(self, hook_registry, agent):
+        """An `async def` override is awaited and applied."""
+
+        class AsyncDeny(InterventionHandler):
+            name = "async-deny"
+
+            async def before_tool_call(self, event):
+                return Deny(reason="async denial")
+
+        InterventionRegistry([AsyncDeny()], hook_registry)
+
+        event = make_before_tool_call_event(agent)
+        await hook_registry.invoke_callbacks_async(event)
+        assert event.cancel_tool == "DENIED: async denial"
+
+    @pytest.mark.asyncio
+    async def test_sync_def_returning_coroutine_is_awaited(self, hook_registry, agent):
+        """A sync `def` that returns a coroutine has it awaited, not passed through.
+
+        This is the case the previous `iscoroutinefunction(method_fn)` dispatch
+        missed: the method itself is sync, so the coroutine it returned would
+        have leaked through un-awaited (RuntimeWarning + a non-action value).
+        """
+
+        async def _decide():
+            return Deny(reason="deferred denial")
+
+        class SyncReturnsCoroutine(InterventionHandler):
+            name = "sync-returns-coro"
+
+            def before_tool_call(self, event):
+                return _decide()
+
+        InterventionRegistry([SyncReturnsCoroutine()], hook_registry)
+
+        event = make_before_tool_call_event(agent)
+        await hook_registry.invoke_callbacks_async(event)
+        assert event.cancel_tool == "DENIED: deferred denial"
+
+    @pytest.mark.asyncio
+    async def test_sync_proceed_does_not_short_circuit(self, hook_registry, agent):
+        """A sync Proceed lets later handlers run (no accidental short-circuit)."""
+        later_called = False
+
+        class SyncProceed(InterventionHandler):
+            name = "sync-proceed"
+
+            def before_tool_call(self, event):
+                return Proceed()
+
+        class LaterDeny(InterventionHandler):
+            name = "later-deny"
+
+            def before_tool_call(self, event):
+                nonlocal later_called
+                later_called = True
+                return Deny(reason="blocked by later handler")
+
+        InterventionRegistry([SyncProceed(), LaterDeny()], hook_registry)
+
+        event = make_before_tool_call_event(agent)
+        await hook_registry.invoke_callbacks_async(event)
+        assert later_called
+        assert event.cancel_tool == "DENIED: blocked by later handler"


### PR DESCRIPTION
## What

Makes `InterventionHandler` lifecycle methods work as **either sync `def` or `async def`** — at both the type level and the runtime — and adds a `MaybeAwaitable[T]` alias so the contract is expressed once.

Split out of #2750 (HITL port) per @lizradway's request — this touches the shared intervention primitive (all handlers), so it belongs in its own PR rather than riding in the HITL feature.

## Why

The registry dispatched on `inspect.iscoroutinefunction(method_fn)` — i.e. it only awaited methods *declared* `async def`. If the type signature advertises `... | Awaitable[...]` (to let overrides be async), then a perfectly legal handler:

```python
class MyHandler(InterventionHandler):
    name = "x"
    def before_tool_call(self, event, **kwargs):
        return self._decide(event)   # sync def, returns a coroutine
```

would have its returned coroutine **passed through un-awaited** — `RuntimeWarning: coroutine was never awaited` plus a non-action value flowing into `apply()`. The type said one thing; the runtime did another.

Fix: dispatch on whether the **returned value** is awaitable (`inspect.isawaitable(result)`), which correctly handles all three shapes:
- sync `def` returning an action → used directly
- `async def` → awaited
- sync `def` returning a coroutine/awaitable → awaited

(Picked `isawaitable(result)` over `iscoroutinefunction` per the review thread on #2750 — @lizradway: *"+1 to switch the registry to inspect.isawaitable(result) on the returned value"*.)

## Changes

- **`interventions/handler.py`**: add `MaybeAwaitable: TypeAlias = T | Awaitable[T]` (mirrors the TS `Awaitable<T>` in [`strands-ts/src/interventions/handler.ts`](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/interventions/handler.ts), as @lizradway suggested), and annotate all five lifecycle methods with it — replacing the repeated `... | Awaitable[...]` unions.
- **`interventions/registry.py`**: dispatch via `inspect.isawaitable(result)` instead of `inspect.iscoroutinefunction(method_fn)`, with a comment explaining why we inspect the value, not the function.
- **`interventions/__init__.py`**: export `MaybeAwaitable` (it appears in the public lifecycle signatures; `OnError` is already exported here for the same reason).
- **Tests**: new `TestSyncAndAsyncOverrides` covering sync `def`, `async def`, **sync `def` returning a coroutine** (the previously-broken case), and a sync `Proceed` not short-circuiting later handlers.

## Verification

```
pytest tests/strands/interventions tests/strands/test_interrupt.py tests/strands/hooks tests/strands/agent/test_agent_hooks.py
→ 157 passed
```
The interventions suite also passes under `-W error::RuntimeWarning`, which would fail loudly on any un-awaited coroutine leak. `ruff format --check`, `ruff check`, and `mypy src/strands/interventions/` are all clean.

## Follow-up

Once this lands, #2750 (HITL) drops its `# type: ignore[override]` on the now-natively-async `before_tool_call` and rebases onto the widened contract.

cc @mkmeral @lizradway