### PR TITLE
docs(interventions): add Cedar Authorization documentation page 

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -92,6 +92,7 @@ sidebar:
             items:
               - label: "Overview"
                 slug: docs/user-guide/concepts/agents/interventions
+              - docs/user-guide/concepts/agents/interventions/cedar-authorization
               - docs/user-guide/concepts/agents/interventions/steering
               - docs/user-guide/concepts/agents/interventions/human-in-the-loop
           - label: Streaming

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -1,0 +1,140 @@
+---
+title: Cedar Authorization
+description: "Control which tools an agent can invoke using Cedar policies. Enforce identity-aware access control, role-based permissions, and rate limits at the tool-call boundary."
+languages: [typescript]
+tags: [safety, interventions, tool-execution]
+sidebar:
+  badge:
+    text: New
+    variant: tip
+---
+
+Cedar Authorization evaluates [Cedar](https://cedarpolicy.com) policies before each tool call, giving you declarative, identity-aware access control over agent behavior. It ships as a vended intervention in the TypeScript SDK.
+
+## How it works
+
+The handler sits at the tool-call boundary. When the agent attempts to invoke a tool, Cedar Authorization maps the call to a Cedar authorization request and evaluates your policies. If no `permit` statement matches, the tool call is denied and the agent receives feedback explaining the denial.
+
+| Cedar concept | Maps to | Example |
+|---|---|---|
+| **Principal** | User identity | `User::"alice@acme.com"` |
+| **Action** | Tool name | `Action::"search"` |
+| **Resource** | Static (unconstrained) | `Resource::"agent"` |
+| **Context.input** | Tool arguments | `{ query: "quarterly report" }` |
+| **Context.session** | Invocation metadata | `{ hour_utc: 14, call_count: 3, role: "admin" }` |
+
+The design is fail-closed: if principal identity cannot be resolved, all tool calls are denied.
+
+## Basic usage
+
+Permit specific tools and deny everything else:
+
+```typescript
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:basic_example_imports"
+
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:basic_example"
+```
+
+Cedar uses default-deny semantics. Tools without a matching `permit` statement are automatically blocked.
+
+## Role-based access control
+
+For multi-tenant agents where each request carries user identity, use `principalResolver` to extract the principal from `invocationState` and `contextEnricher` to forward role information into Cedar context:
+
+```typescript
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:role_based_imports"
+
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:role_based"
+```
+
+When `principalResolver` returns `undefined` (no identity found), the handler denies all tool calls for that request.
+
+## Rate limiting
+
+Cedar policies can reference `context.session.call_count`, which tracks how many times each tool has been invoked successfully during the session:
+
+```typescript
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:rate_limit_imports"
+
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:rate_limit"
+```
+
+Call counts persist with the agent's `appState` and survive session reloads. Only successful tool calls increment the counter.
+
+## Schema validation
+
+Pass your `tools` array to catch policy typos at construction time. The handler generates a Cedar schema from tool definitions and validates policies against it:
+
+```typescript
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:schema_validation_imports"
+
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:schema_validation"
+```
+
+Schema validation integrates with the [`cedar-for-agents`](https://github.com/cedar-policy/cedar-for-agents) ecosystem via `@cedar-policy/mcp-schema-generator-wasm`.
+
+## Environment gating
+
+Block tools based on deployment context by forwarding environment metadata through `contextEnricher`:
+
+```typescript
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:env_gating_imports"
+
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:env_gating"
+```
+
+## File-based policies
+
+For production deployments, keep policies in `.cedar` files rather than inline strings:
+
+```typescript
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:file_policies_imports"
+
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:file_policies"
+```
+
+The handler reads and parses files at construction time. Invalid syntax throws immediately.
+
+## Hot reload
+
+Update policies without restarting your agent process:
+
+```typescript
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:hot_reload_imports"
+
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:hot_reload"
+```
+
+`reload()` reads fresh policy, entity, and schema files, validates them, and atomically swaps the active policy set. If validation fails, the previous policies remain in effect and the method throws.
+
+## Context structure
+
+Every authorization request includes a structured context object:
+
+```json
+{
+  "input": { "query": "quarterly report" },
+  "session": {
+    "hour_utc": 14,
+    "call_count": 3,
+    "role": "admin"
+  }
+}
+```
+
+- `context.input` contains the tool's input arguments, accessible in policies via `context.input.fieldName`
+- `context.session.hour_utc` is auto-populated with the current UTC hour (0-23)
+- `context.session.call_count` tracks per-tool invocation count
+- Additional `context.session` fields come from your `contextEnricher`
+
+## Error handling
+
+The `onError` option controls behavior when Cedar evaluation itself fails (malformed context, WASM errors):
+
+- `'throw'` (default): raises the error to the caller
+- `'deny'`: treats evaluation failure as a denial (fail-closed)
+- `'proceed'`: allows the tool call despite the error (fail-open, use with caution)
+
+## Cedar policy syntax
+
+For the full policy language grammar, operators, and built-in functions, see the [Cedar policy language reference](https://docs.cedarpolicy.com/syntax-policy.html).

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
@@ -1,0 +1,233 @@
+// @ts-nocheck
+import { Agent, tool } from '@strands-agents/sdk'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+import { z } from 'zod'
+
+async function basicExample() {
+  // --8<-- [start:basic_example]
+  const searchTool = tool({
+    name: 'search',
+    description: 'Search for information',
+    inputSchema: z.object({ query: z.string() }),
+    callback: (input) => `Results for: ${input.query}`,
+  })
+
+  const deleteTool = tool({
+    name: 'delete_record',
+    description: 'Delete a record by ID',
+    inputSchema: z.object({ record_id: z.string() }),
+    callback: (input) => `Deleted ${input.record_id}`,
+  })
+
+  const cedar = new CedarAuthorization({
+    policies: `
+      permit(principal, action == Action::"search", resource);
+    `,
+  })
+
+  const agent = new Agent({
+    tools: [searchTool, deleteTool],
+    interventions: [cedar],
+  })
+
+  await agent.invoke('Search for quarterly reports then delete record 42')
+  // If the agent calls search, it's permitted; a delete_record call is denied (no matching permit)
+  // --8<-- [end:basic_example]
+}
+
+async function roleBasedExample() {
+  // --8<-- [start:role_based]
+  const searchTool = tool({
+    name: 'search',
+    description: 'Search for information',
+    inputSchema: z.object({ query: z.string() }),
+    callback: (input) => `Results for: ${input.query}`,
+  })
+
+  const deleteTool = tool({
+    name: 'delete_record',
+    description: 'Delete a record by ID',
+    inputSchema: z.object({ record_id: z.string() }),
+    callback: (input) => `Deleted ${input.record_id}`,
+  })
+
+  const cedar = new CedarAuthorization({
+    policies: `
+      permit(principal, action, resource)
+      when { context.session.role == "admin" };
+
+      permit(principal, action == Action::"search", resource)
+      when { context.session.role == "analyst" };
+    `,
+    principalResolver: (state) => {
+      if (!state.user_id) return undefined
+      return { type: 'User', id: String(state.user_id) }
+    },
+    contextEnricher: ({ invocationState }) => ({
+      role: String(invocationState.role ?? 'none'),
+    }),
+  })
+
+  const agent = new Agent({
+    tools: [searchTool, deleteTool],
+    interventions: [cedar],
+  })
+
+  // admin can use any tool
+  await agent.invoke('Delete record 42', {
+    invocationState: { user_id: 'alice', role: 'admin' },
+  })
+
+  // analyst can only search
+  await agent.invoke('Delete record 42', {
+    invocationState: { user_id: 'bob', role: 'analyst' },
+  })
+  // denied: no permit matches for delete_record with role "analyst"
+  // --8<-- [end:role_based]
+}
+
+async function rateLimitExample() {
+  // --8<-- [start:rate_limit]
+  const sendEmailTool = tool({
+    name: 'send_email',
+    description: 'Send an email',
+    inputSchema: z.object({ to: z.string(), body: z.string() }),
+    callback: (input) => `Sent to ${input.to}`,
+  })
+
+  const searchTool = tool({
+    name: 'search',
+    description: 'Search for information',
+    inputSchema: z.object({ query: z.string() }),
+    callback: (input) => `Results for: ${input.query}`,
+  })
+
+  const cedar = new CedarAuthorization({
+    policies: `
+      permit(principal, action == Action::"send_email", resource)
+      when { context.session.call_count < 5 };
+
+      permit(principal, action == Action::"search", resource);
+    `,
+  })
+
+  const agent = new Agent({
+    tools: [sendEmailTool, searchTool],
+    interventions: [cedar],
+  })
+
+  // send_email is permitted for the first 4 calls, then denied on the 5th
+  // search is unlimited
+  // --8<-- [end:rate_limit]
+}
+
+async function schemaValidationExample() {
+  // --8<-- [start:schema_validation]
+  const searchTool = tool({
+    name: 'search',
+    description: 'Search for information',
+    inputSchema: z.object({ query: z.string() }),
+    callback: (input) => `Results for: ${input.query}`,
+  })
+
+  const deleteTool = tool({
+    name: 'delete_record',
+    description: 'Delete a record by ID',
+    inputSchema: z.object({ record_id: z.string() }),
+    callback: (input) => `Deleted ${input.record_id}`,
+  })
+
+  const cedar = new CedarAuthorization({
+    policies: `
+      permit(principal, action == Action::"search", resource);
+      permit(principal, action == Action::"delete_record", resource)
+      when { context.session.role == "admin" };
+    `,
+    tools: [searchTool, deleteTool],
+    contextEnricher: ({ invocationState }) => ({
+      role: String(invocationState.role ?? 'none'),
+    }),
+  })
+  // If a policy references Action::"deleet_record" (typo),
+  // construction throws a "Cedar policy validation failed" error naming the unrecognized action
+  // --8<-- [end:schema_validation]
+}
+
+async function envGatingExample() {
+  // --8<-- [start:env_gating]
+  const deployTool = tool({
+    name: 'deploy',
+    description: 'Deploy the service',
+    inputSchema: z.object({ version: z.string() }),
+    callback: (input) => `Deployed ${input.version}`,
+  })
+
+  const cedar = new CedarAuthorization({
+    policies: `
+      permit(principal, action == Action::"deploy", resource)
+      when { context.session has environment &&
+             context.session.environment != "production" };
+    `,
+    contextEnricher: ({ invocationState }) => ({
+      environment: String(invocationState.environment ?? 'unknown'),
+    }),
+  })
+
+  const agent = new Agent({
+    tools: [deployTool],
+    interventions: [cedar],
+  })
+
+  // works in staging
+  await agent.invoke('Deploy the service', {
+    invocationState: { environment: 'staging' },
+  })
+
+  // denied in production
+  await agent.invoke('Deploy the service', {
+    invocationState: { environment: 'production' },
+  })
+  // --8<-- [end:env_gating]
+}
+
+async function filePoliciesExample() {
+  // --8<-- [start:file_policies]
+  const cedar = new CedarAuthorization({
+    policies: './policies/agent.cedar',
+    entities: './policies/entities.json',
+  })
+  // --8<-- [end:file_policies]
+}
+
+async function hotReloadExample() {
+  // --8<-- [start:hot_reload]
+  const searchTool = tool({
+    name: 'search',
+    description: 'Search for information',
+    inputSchema: z.object({ query: z.string() }),
+    callback: (input) => `Results for: ${input.query}`,
+  })
+
+  const cedar = new CedarAuthorization({
+    policies: './policies/agent.cedar',
+  })
+
+  const agent = new Agent({
+    tools: [searchTool],
+    interventions: [cedar],
+  })
+
+  // After editing agent.cedar on disk:
+  cedar.reload()
+  // Validates new policies before applying. Throws if invalid.
+  // --8<-- [end:hot_reload]
+}
+
+// suppress unused warnings
+void basicExample
+void roleBasedExample
+void rateLimitExample
+void schemaValidationExample
+void envGatingExample
+void filePoliciesExample
+void hotReloadExample

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization_imports.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+
+// --8<-- [start:basic_example_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+import { z } from 'zod'
+// --8<-- [end:basic_example_imports]
+
+// --8<-- [start:role_based_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+import { z } from 'zod'
+// --8<-- [end:role_based_imports]
+
+// --8<-- [start:rate_limit_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+import { z } from 'zod'
+// --8<-- [end:rate_limit_imports]
+
+// --8<-- [start:schema_validation_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+import { z } from 'zod'
+// --8<-- [end:schema_validation_imports]
+
+// --8<-- [start:env_gating_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+import { z } from 'zod'
+// --8<-- [end:env_gating_imports]
+
+// --8<-- [start:file_policies_imports]
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+// --8<-- [end:file_policies_imports]
+
+// --8<-- [start:hot_reload_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+import { z } from 'zod'
+// --8<-- [end:hot_reload_imports]

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
@@ -98,6 +98,7 @@ Interventions return typed actions that the framework interprets. This enables:
 
 ## Related topics
 
+- [Cedar Authorization](./cedar-authorization.mdx) — Declarative, identity-aware access control using Cedar policies
 - [Steering](./steering.mdx) — LLM-based contextual guidance using the steering handler
 - [Human in the Loop](./human-in-the-loop.mdx) — Ready-to-use intervention handler for tool approval workflows
 - [Hooks](../hooks.mdx) — Low-level event callbacks for observing and modifying agent behavior


### PR DESCRIPTION


## Description

Adds documentation for the Cedar Authorization vended intervention handler introduced in #2365. Covers basic usage, role-based access control, rate limiting, schema validation, environment gating, file-based policies, and hot reload.


Cedar Builder to be added after ship + publish to NPM: https://github.com/cedar-policy/cedar-for-agents/pull/137
## Related Issues

#2365

## Documentation PR

N/A (this PR is the documentation)

## Type of Change

Documentation update

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.