### PR TITLE
refactor(sandbox): inline tool prefixing into getTools implementations

### DIFF
--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -770,23 +770,16 @@ export class Agent implements LocalAgent, InvokableAgent {
       })
     )
 
-    // Register tools vended by an explicitly-configured sandbox, applying the sandbox's
-    // toolPrefix to names (like MCP's prefix for server-vended tools).
+    // Register tools vended by the sandbox. The host default vends nothing. A tool
+    // is skipped if the user already registered one with that name.
     if (this._sandbox) {
-      const prefix = this._sandbox.toolPrefix
-      for (const tool of this._sandbox.getTools()) {
-        const prefixed = prefix
-          ? Object.create(tool, {
-              name: { value: `${prefix}_${tool.name}` },
-              toolSpec: { value: { ...tool.toolSpec, name: `${prefix}_${tool.name}` } },
-            })
-          : tool
-        if (this._toolRegistry.get(prefixed.name)) {
+      for (const sandboxTool of this._sandbox.getTools()) {
+        if (this._toolRegistry.get(sandboxTool.name)) {
           logger.debug(
-            `tool_name=<${prefixed.name}> | sandbox-vended tool skipped, user has already registered tool with this name`
+            `tool_name=<${sandboxTool.name}> | sandbox-vended tool skipped, user already registered a tool with this name`
           )
         } else {
-          this._toolRegistry.add(prefixed)
+          this._toolRegistry.add(sandboxTool)
         }
       }
     }

--- a/strands-ts/src/sandbox/__tests__/docker.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/docker.test.node.ts
@@ -97,12 +97,12 @@ describe('DockerSandbox', () => {
   describe('getTools', () => {
     it('vends the sandbox-routed fileEditor and bash tools', () => {
       const tools = new DockerSandbox({ container: 'my-container' }).getTools()
-      expect(tools.map((t) => t.name)).toStrictEqual(['fileEditor', 'bash'])
+      expect(tools.map((t) => t.name)).toStrictEqual(['sandbox_file_editor', 'sandbox_bash'])
     })
 
     it('vends bash with the sandbox description', () => {
       const tools = new DockerSandbox({ container: 'my-container' }).getTools()
-      const bashTool = tools.find((t) => t.name === 'bash')!
+      const bashTool = tools.find((t) => t.name === 'sandbox_bash')!
       expect(bashTool.description).toContain(SANDBOX_BASH_DESCRIPTION)
       expect(bashTool.description).toContain('my-container')
     })

--- a/strands-ts/src/sandbox/__tests__/ssh.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/ssh.test.node.ts
@@ -313,12 +313,12 @@ describe('SshSandbox', () => {
   describe('getTools', () => {
     it('vends the sandbox-routed fileEditor and bash tools', () => {
       const tools = new SshSandbox({ host: 'myhost', workingDir: '/workspace' }).getTools()
-      expect(tools.map((t) => t.name)).toStrictEqual(['fileEditor', 'bash'])
+      expect(tools.map((t) => t.name)).toStrictEqual(['sandbox_file_editor', 'sandbox_bash'])
     })
 
     it('vends bash with the sandbox description', () => {
       const tools = new SshSandbox({ host: 'myhost', workingDir: '/workspace' }).getTools()
-      const bashTool = tools.find((t) => t.name === 'bash')!
+      const bashTool = tools.find((t) => t.name === 'sandbox_bash')!
       expect(bashTool.description).toContain(SANDBOX_BASH_DESCRIPTION)
       expect(bashTool.description).toContain('myhost')
     })

--- a/strands-ts/src/sandbox/base.ts
+++ b/strands-ts/src/sandbox/base.ts
@@ -112,12 +112,6 @@ export abstract class Sandbox {
   abstract listFiles(path: string): Promise<FileInfo[]>
 
   /**
-   * Prefix applied to tool names when registered on an agent (e.g. `'sandbox'` produces
-   * `sandbox_bash`). Set to `undefined` to disable prefixing. Defaults to `'sandbox'`.
-   */
-  toolPrefix: string | undefined = 'sandbox'
-
-  /**
    * Tools this sandbox vends to an agent, registered during `Agent.initialize()`.
    * A tool is skipped if the user already registered one with the same name.
    * Override to provide them.

--- a/strands-ts/src/sandbox/docker.ts
+++ b/strands-ts/src/sandbox/docker.ts
@@ -84,9 +84,11 @@ export class DockerSandbox extends PosixShellSandbox {
     const cwd = this.workingDir ? ` Working directory: ${this.workingDir}.` : ''
     return [
       makeFileEditor(this, {
+        name: 'sandbox_file_editor',
         description: `${DEFAULT_FILE_EDITOR_DESCRIPTION} Files are in Docker container "${this.container}".`,
       }),
       makeBash(this, {
+        name: 'sandbox_bash',
         description: `${SANDBOX_BASH_DESCRIPTION} Runs in Docker container "${this.container}".${cwd}`,
       }),
     ]

--- a/strands-ts/src/sandbox/ssh.ts
+++ b/strands-ts/src/sandbox/ssh.ts
@@ -157,9 +157,11 @@ export class SshSandbox extends PosixShellSandbox {
   override getTools(): Tool[] {
     return [
       makeFileEditor(this, {
+        name: 'sandbox_file_editor',
         description: `${DEFAULT_FILE_EDITOR_DESCRIPTION} Files are on host "${this.host}".`,
       }),
       makeBash(this, {
+        name: 'sandbox_bash',
         description: `${SANDBOX_BASH_DESCRIPTION} Runs on host "${this.host}". Working directory: ${this.workingDir}.`,
       }),
     ]


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

- Move tool prefixing into `getTools()` implementations

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Refactor

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
