### PR TITLE
chore: add CLAUDE.md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,6 @@ Thumbs.db
 bin/
 
 # LLM
-CLAUDE.md
 .claude/settings.local.json
 
 # dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -21,6 +21,5 @@ docs/api-reference/
 __*__/
 .build
 
-CLAUDE.md
 mise.toml
 *.log

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/strands-py/.gitignore
+++ b/strands-py/.gitignore
@@ -14,4 +14,3 @@ repl_state
 .kiro
 uv.lock
 .audio_cache
-CLAUDE.md

--- a/strands-py/AGENTS.md
+++ b/strands-py/AGENTS.md
@@ -179,7 +179,7 @@ from .tools import Tool
 - **Variables/Functions**: `snake_case`
 - **Classes**: `PascalCase`
 - **Constants**: `UPPER_SNAKE_CASE`
-- **Private members**: Prefix with `_`
+- **Private members, functions, and modules**: Prefix with `_` (e.g. `_helper()`, `_internal.py`)
 
 ### Error Handling
 

--- a/strands-py/CLAUDE.md
+++ b/strands-py/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/strands-ts/AGENTS.md
+++ b/strands-ts/AGENTS.md
@@ -220,6 +220,7 @@ export class AgentSkillsPlugin implements Plugin { ... }
 - Do NOT include `@example` for type definitions, interfaces, or internal types
 - Interface properties MUST have single-line descriptions
 - TSDoc validation enforced by ESLint
+- Mark exported symbols that are not part of the public API with the `@internal` TSDoc tag. Use this for exports that other modules need but SDK consumers should not depend on.
 
 ### Code Style Guidelines
 

--- a/strands-ts/CLAUDE.md
+++ b/strands-ts/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/test-infra/CLAUDE.md
+++ b/test-infra/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Description

Two unrelated-looking but mutually reinforcing gaps in our agent guidance, fixed together because they share a root cause: the rules agents rely on either weren't stated clearly or weren't reliably loaded.

**Sharpened naming conventions.** `strands-py/AGENTS.md` only said "Private members: Prefix with `_`". Read literally, "members" suggests class attributes, and the adjacent "Variables/Functions" line covers casing only — so an agent had no explicit instruction that private *functions* and *modules* take a leading underscore. It now reads "Private members, functions, and modules" with examples. On the TypeScript side, `@internal` is already used in ~70 places across the SDK to mark exported-but-non-public symbols, yet `strands-ts/AGENTS.md` never mentioned it; the TSDoc section now documents the convention so agents apply it consistently instead of inferring it from surrounding code.

**Reliable AGENTS.md loading.** The harness auto-loads `CLAUDE.md` from the repo root and any subdirectory it touches, but it does not reliably auto-load nested `AGENTS.md`. Our per-package guides were therefore only entering context via a soft, monorepo-ambiguous nudge ("go read the repo's AGENTS.md"). This adds a one-line `CLAUDE.md` (`@AGENTS.md`) at the root and in each package that has an `AGENTS.md` (`strands-py`, `strands-ts`, `site`, `test-infra`). Each file just imports its sibling `AGENTS.md`, so the correct package guide loads automatically based on which subtree is being edited, with zero content duplication — `AGENTS.md` remains the single source of truth.

To make those import files trackable, this also removes the `CLAUDE.md` entries from `.gitignore`, `site/.gitignore`, and `strands-py/.gitignore`.

> [!NOTE]
> `CLAUDE.md` was previously gitignored on purpose. Un-ignoring it is a deliberate reversal: it means these import stubs are shared with everyone, and any contributor's previously-ignored local `CLAUDE.md` will now surface as untracked. Flagging for explicit sign-off rather than slipping it in.

## Related Issues

<!-- none -->

## Documentation PR

No `site/` documentation changes. The edits are to agent-facing guidance files (`AGENTS.md`), not the published docs site.

## Type of Change

Documentation update

## Testing

Documentation- and config-only change; no runtime behavior is affected.

- Verified `git check-ignore` no longer matches any `CLAUDE.md`, so the new import files are trackable.
- Confirmed each new `CLAUDE.md` contains exactly `@AGENTS.md` and sits beside an existing `AGENTS.md`.
- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.