### PR TITLE
fix(cedar): correct fixture path in integration test

### DIFF
--- a/strands-ts/test/integ/cedar.test.node.ts
+++ b/strands-ts/test/integ/cedar.test.node.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { resolve } from 'node:path'
 import { bedrock } from './__fixtures__/model-providers.js'
 
-const FIXTURES = resolve(import.meta.dirname!, '../../../src/vended-interventions/cedar/__tests__/fixtures')
+const FIXTURES = resolve(import.meta.dirname!, '../../src/vended-interventions/cedar/__tests__/fixtures')
 
 const searchTool = tool({
   name: 'search',


### PR DESCRIPTION
## Description
The relative path went up 3 levels from test/integ/, escaping the strands-ts/ directory. It should only go up 2 levels.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change
Bug fix


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [X] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
