### PR TITLE
feat: add default for memory extraction trigger

### DIFF
--- a/strands-py/src/strands/memory/extraction/coordinator.py
+++ b/strands-py/src/strands/memory/extraction/coordinator.py
@@ -17,7 +17,8 @@ from ...models.model import Model
 from ...types.content import ContentBlock, Message
 from ...types.exceptions import AggregateMemoryError
 from ..types import MemoryStore
-from .types import DEFAULT_MEMORY_MESSAGE_FILTER, Extractor, ExtractorContext, MemoryMessageFilter
+from .resolve_extraction_config import _ResolvedExtractionConfig
+from .types import Extractor, ExtractorContext, MemoryMessageFilter
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,20 @@ SAVE_FAILURES_BEFORE_BACKOFF = 10
 
 # While backed off, a store retries only once every this many save attempts.
 BACKOFF_PROBE_INTERVAL = 3
+
+
+@dataclass
+class _ExtractionBinding:
+    """A store paired with its fully-resolved extraction config.
+
+    Attributes:
+        store: The memory store to extract into.
+        config: The store's fully-resolved extraction config (triggers, extractor,
+            filter).
+    """
+
+    store: MemoryStore
+    config: _ResolvedExtractionConfig
 
 
 @dataclass
@@ -46,22 +61,27 @@ class ExtractionCoordinator:
     for repeatedly failing stores.
     """
 
-    def __init__(self, stores: list[MemoryStore], default_model: Model) -> None:
+    def __init__(self, bindings: list[_ExtractionBinding], default_model: Model) -> None:
         """Initialize the coordinator.
 
         Args:
-            stores: The extraction-configured stores this coordinator manages.
+            bindings: The extraction-configured stores this coordinator manages,
+                each paired with its fully-resolved config.
             default_model: The agent's model, passed to extractors that do not
                 configure their own.
         """
-        self._stores = list(stores)
+        self._stores = [binding.store for binding in bindings]
+        # Per store: its resolved extraction config (triggers, extractor, filter).
+        self._configs: dict[int, _ResolvedExtractionConfig] = {
+            id(binding.store): binding.config for binding in bindings
+        }
         self._default_model = default_model
         # Messages waiting to be saved, oldest first.
         self._pending: list[_Buffered] = []
         # The ``seq`` to assign the next buffered message.
         self._next_seq = 0
         # Per store: ``seq`` of the last message it has saved (-1 means none).
-        self._marks: dict[int, int] = {id(store): -1 for store in stores}
+        self._marks: dict[int, int] = {id(binding.store): -1 for binding in bindings}
         # Per store: the currently-running save task, so the next save waits its turn.
         self._chains: dict[int, asyncio.Task] = {}
         # Per store: consecutive save failures, reset to 0 on success.
@@ -161,20 +181,17 @@ class ExtractionCoordinator:
         if not fresh:
             return
 
-        extraction = store.extraction
-        if extraction is None:
-            return
+        config = self._configs[id(store)]
 
         # Mark saved before saving so a queued save won't pick these up again;
         # rolled back below on failure.
         self._marks[id(store)] = fresh[-1].seq
 
-        message_filter = extraction.filter or DEFAULT_MEMORY_MESSAGE_FILTER
-        filtered = self._filter_messages([buffered.message for buffered in fresh], message_filter)
+        filtered = self._filter_messages([buffered.message for buffered in fresh], config.filter)
 
         try:
             if filtered:
-                await self._write(store, filtered, extraction.extractor)
+                await self._write(store, filtered, config.extractor)
                 # Successful write clears the failure streak and ends backoff. A
                 # fully filtered (empty) turn never touched the backend, so it
                 # leaves backoff state untouched.

--- a/strands-py/src/strands/memory/extraction/resolve_extraction_config.py
+++ b/strands-py/src/strands/memory/extraction/resolve_extraction_config.py
@@ -1,0 +1,106 @@
+"""Resolves a store's ``extraction`` setting into a concrete config.
+
+The single place the ``bool | ExtractionConfig`` shorthand is interpreted and
+per-store defaults are applied, so the :class:`~strands.memory.memory_manager.MemoryManager`
+and :class:`~strands.memory.extraction.coordinator.ExtractionCoordinator` never
+re-apply defaults or normalize shapes themselves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..types import MemoryStore, _has_method
+from .model_extractor import ModelExtractor
+from .triggers import IntervalTrigger
+from .types import (
+    DEFAULT_MEMORY_MESSAGE_FILTER,
+    ExtractionConfig,
+    ExtractionTrigger,
+    Extractor,
+    MemoryMessageFilter,
+)
+
+# Default cadence when an ``ExtractionConfig`` omits its ``trigger``: extract every N turns.
+DEFAULT_EXTRACTION_TRIGGER_TURNS = 5
+
+
+@dataclass
+class _ResolvedExtractionConfig:
+    """An :class:`ExtractionConfig` with every field resolved to a concrete value.
+
+    Produced by :func:`_resolve_extraction_config` so the ``MemoryManager`` and
+    ``ExtractionCoordinator`` never have to re-apply defaults or normalize shapes.
+
+    Attributes:
+        triggers: Normalized to a list (a single trigger is wrapped). Never empty
+            for a resolved config (an explicit empty list is left empty for the
+            manager to reject).
+        extractor: The extractor that distills facts client-side and stores them
+            via the store's ``add`` method, or ``None`` to use the store's
+            ``add_messages`` method (server-side extraction).
+        filter: The content-block filter applied before extraction.
+    """
+
+    triggers: list[ExtractionTrigger]
+    extractor: Extractor | None
+    filter: MemoryMessageFilter
+
+
+def _resolve_extraction_config(
+    extraction: bool | ExtractionConfig | None,
+    store: MemoryStore,
+) -> _ResolvedExtractionConfig | None:
+    """Resolve a store's ``extraction`` setting into a :class:`_ResolvedExtractionConfig`.
+
+    The single place the ``bool | ExtractionConfig`` shorthand is interpreted:
+    ``False``/``None`` is off (returns ``None``), ``True`` enables all defaults, an
+    :class:`ExtractionConfig` defaults its unset fields. The defaults are:
+
+    - **triggers**: every :data:`DEFAULT_EXTRACTION_TRIGGER_TURNS` turns. An
+      explicit empty list is left empty for the ``MemoryManager`` to reject.
+    - **extractor**: chosen from the methods the store implements. A store that
+      implements only ``add`` cannot extract server-side, so it defaults to a
+      :class:`~strands.memory.extraction.model_extractor.ModelExtractor` that
+      distills facts client-side (via model calls) and stores each one through
+      ``add``. A store that implements ``add_messages`` supports server-side
+      extraction, so it defaults to no extractor: the manager hands raw messages
+      to ``add_messages`` and the backend extracts them itself, with no model call.
+    - **filter**: :data:`DEFAULT_MEMORY_MESSAGE_FILTER`.
+
+    Args:
+        extraction: The store's ``extraction`` setting.
+        store: The store, inspected for the write methods it implements to pick the
+            default extractor.
+
+    Returns:
+        The resolved config, or ``None`` when extraction is disabled.
+    """
+    if not extraction:
+        return None
+    config = ExtractionConfig() if extraction is True else extraction
+
+    triggers: list[ExtractionTrigger]
+    if config.trigger is None:
+        triggers = [IntervalTrigger(turns=DEFAULT_EXTRACTION_TRIGGER_TURNS)]
+    elif isinstance(config.trigger, list):
+        triggers = config.trigger
+    else:
+        triggers = [config.trigger]
+
+    extractor = config.extractor
+    if extractor is None:
+        # Pick the default extractor from the store's write methods:
+        # - implements only ``add``: it cannot extract server-side, so default to a
+        #   ModelExtractor that distills facts client-side and stores each via ``add``.
+        # - implements ``add_messages`` (whether or not it also implements ``add``): extract
+        #   server-side. Leave the extractor None so raw messages go straight to
+        #   ``add_messages`` with no model call.
+        if _has_method(store, "add") and not _has_method(store, "add_messages"):
+            extractor = ModelExtractor()
+
+    return _ResolvedExtractionConfig(
+        triggers=triggers,
+        extractor=extractor,
+        filter=config.filter or DEFAULT_MEMORY_MESSAGE_FILTER,
+    )

--- a/strands-py/src/strands/memory/extraction/types.py
+++ b/strands-py/src/strands/memory/extraction/types.py
@@ -127,18 +127,22 @@ class ExtractionConfig:
     """Per-store automatic-extraction configuration.
 
     Attributes:
-        trigger: When to run extraction. A single trigger or a non-empty list;
-            multiple triggers compose (extraction runs whenever any fires).
+        trigger: When to run extraction. A single trigger or a list; multiple
+            triggers compose (extraction runs whenever any fires). Omit to default
+            to every 5 turns; an explicit empty list is rejected at construction.
         extractor: How to turn messages into entries. When set, the store must
-            implement ``add``. When omitted, the manager hands the filtered
-            messages straight to the store's ``add_messages`` (for backends that
-            extract server-side).
+            implement ``add``. When omitted, the default depends on the store's
+            write methods: a store implementing only ``add`` defaults to a
+            :class:`~strands.memory.extraction.model_extractor.ModelExtractor`
+            that distills facts client-side, while a store implementing
+            ``add_messages`` uses server-side extraction (the manager hands the
+            filtered messages straight to ``add_messages``, no model call).
         filter: Content blocks to strip before extraction. Defaults to
             :data:`DEFAULT_MEMORY_MESSAGE_FILTER` (excludes ``toolUse`` /
             ``toolResult``). Pass ``MemoryMessageFilter(exclude=[])`` to keep tool
             blocks.
     """
 
-    trigger: ExtractionTrigger | list[ExtractionTrigger]
+    trigger: ExtractionTrigger | list[ExtractionTrigger] | None = None
     extractor: Extractor | None = None
     filter: MemoryMessageFilter | None = None

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -12,8 +12,9 @@ from ..plugins.plugin import Plugin
 from ..tools.decorator import tool
 from ..types.exceptions import AggregateMemoryError
 from ..types.tools import AgentTool
-from .extraction.coordinator import ExtractionCoordinator
-from .extraction.types import ExtractionTrigger, ExtractionTriggerContext
+from .extraction.coordinator import ExtractionCoordinator, _ExtractionBinding
+from .extraction.resolve_extraction_config import _resolve_extraction_config
+from .extraction.types import ExtractionTriggerContext
 from .types import (
     MemoryAddOptions,
     MemoryAddToolConfig,
@@ -42,11 +43,6 @@ ADD_TOOL_DESCRIPTION = (
 
 # Default maximum results per store when neither caller nor store specifies one.
 DEFAULT_MAX_SEARCH_RESULTS = 3
-
-
-def _normalize_triggers(trigger: ExtractionTrigger | list[ExtractionTrigger]) -> list[ExtractionTrigger]:
-    """Normalize a store's ``trigger`` field (a single trigger or a list) to a list."""
-    return list(trigger) if isinstance(trigger, list) else [trigger]
 
 
 def _flatten_reasons(reasons: list[BaseException]) -> list[BaseException]:
@@ -105,6 +101,7 @@ class MemoryManager(Plugin):
             raise ValueError("MemoryManager: at least one store is required")
 
         seen_names: set[str] = set()
+        extraction_bindings: list[_ExtractionBinding] = []
         for store in stores:
             if store.name in seen_names:
                 raise ValueError(f"MemoryManager: duplicate store name '{store.name}'")
@@ -115,13 +112,16 @@ class MemoryManager(Plugin):
                     f"MemoryManager: store '{store.name}' is writable but has no add or add_messages method"
                 )
 
-            if store.extraction is not None:
+            extraction_config = _resolve_extraction_config(store.extraction, store)
+            if extraction_config is not None:
                 if not store.writable:
                     raise ValueError(f"MemoryManager: store '{store.name}' has extraction config but is not writable")
-                if len(_normalize_triggers(store.extraction.trigger)) == 0:
+                if len(extraction_config.triggers) == 0:
                     raise ValueError(f"MemoryManager: store '{store.name}' has extraction config but no triggers")
-                # Each extraction shape needs its matching write sink.
-                if store.extraction.extractor is not None:
+                # Each extraction shape needs its matching write sink. An extractor produces discrete
+                # entries written via `add`; without an extractor the raw message batch goes to
+                # `add_messages`.
+                if extraction_config.extractor is not None:
                     if not _has_method(store, "add"):
                         raise ValueError(
                             f"MemoryManager: store '{store.name}' has an extractor but no add method "
@@ -132,6 +132,7 @@ class MemoryManager(Plugin):
                         f"MemoryManager: store '{store.name}' has extraction config without an extractor "
                         "but no add_messages method"
                     )
+                extraction_bindings.append(_ExtractionBinding(store=store, config=extraction_config))
 
         super().__init__()
 
@@ -139,7 +140,8 @@ class MemoryManager(Plugin):
         self._search_stores = list(stores)
         # `add`-targeting paths (tool / programmatic) need an `add` method specifically.
         self._add_stores = [store for store in stores if store.writable and _has_method(store, "add")]
-        self._extraction_stores = [store for store in stores if store.writable and store.extraction is not None]
+        # Stores with extraction enabled, each paired with its resolved config; wired up in ``init_agent``.
+        self._extraction_stores = extraction_bindings
 
         self._search_tool_config: MemoryToolConfig | bool
         if search_tool_config is False:
@@ -525,10 +527,9 @@ class MemoryManager(Plugin):
         # Buffer every message so extraction has its own copy to save from.
         agent.add_hook(lambda event: coordinator.record(event.message), MessageAddedEvent)
 
-        for store in self._extraction_stores:
-            assert store.extraction is not None  # noqa: S101 - extraction stores always configure this.
-            for trigger in _normalize_triggers(store.extraction.trigger):
-                trigger.attach(ExtractionTriggerContext(agent=agent, fire=self._make_fire(coordinator, store)))
+        for binding in self._extraction_stores:
+            for trigger in binding.config.triggers:
+                trigger.attach(ExtractionTriggerContext(agent=agent, fire=self._make_fire(coordinator, binding.store)))
 
     @staticmethod
     def _make_fire(coordinator: ExtractionCoordinator, store: MemoryStore) -> Callable[[], None]:

--- a/strands-py/src/strands/memory/types.py
+++ b/strands-py/src/strands/memory/types.py
@@ -133,15 +133,22 @@ class MemoryStoreConfig(Protocol):
         writable: Whether this store accepts writes. A writable store requires at
             least one write sink (:meth:`MemoryStore.add` or
             :meth:`MemoryStore.add_messages`).
-        extraction: Automatic-extraction configuration. Requires the store to be
-            writable.
+        extraction: Automatic-extraction configuration for this writable store, as
+            a ``bool | config`` shorthand. ``True`` enables it with defaults; an
+            :class:`ExtractionConfig` defaults any unset field; ``False``/``None``
+            is off. The defaults run every 5 turns, and the extraction method
+            depends on the store's write methods: a store implementing only ``add``
+            uses a :class:`~strands.memory.extraction.model_extractor.ModelExtractor`
+            for client-side extraction (a model call to distill facts, stored via
+            ``add``), while a store implementing ``add_messages`` uses server-side
+            extraction (the backend extracts the raw messages, no model call).
     """
 
     name: str
     description: str | None
     max_search_results: int | None
     writable: bool
-    extraction: ExtractionConfig | None
+    extraction: ExtractionConfig | bool | None
 
 
 class MemoryStore(MemoryStoreConfig, Protocol):

--- a/strands-py/tests/strands/memory/test_extraction.py
+++ b/strands-py/tests/strands/memory/test_extraction.py
@@ -27,7 +27,9 @@ from strands.memory.extraction.coordinator import (
     BACKOFF_PROBE_INTERVAL,
     SAVE_FAILURES_BEFORE_BACKOFF,
     ExtractionCoordinator,
+    _ExtractionBinding,
 )
+from strands.memory.extraction.resolve_extraction_config import _resolve_extraction_config
 from strands.memory.extraction.types import (
     ExtractionConfig,
     ExtractionResult,
@@ -105,6 +107,19 @@ def _make_extractor(entries: list[ExtractionResult]) -> Any:
     return extractor
 
 
+def _coordinator(*stores: Any) -> ExtractionCoordinator:
+    """Build an ``ExtractionCoordinator`` over the given fake stores.
+
+    Resolves each store's ``extraction`` setting through the real
+    :func:`_resolve_extraction_config` (the manager's job in production) so the
+    coordinator receives ``_ExtractionBinding``s, matching how it is wired.
+    """
+    bindings = [
+        _ExtractionBinding(store=store, config=_resolve_extraction_config(store.extraction, store)) for store in stores
+    ]
+    return ExtractionCoordinator(bindings, _DEFAULT_MODEL)
+
+
 def _user_msg(text: str) -> Message:
     return {"role": "user", "content": [{"text": text}]}
 
@@ -167,7 +182,7 @@ async def _drive(coordinator: ExtractionCoordinator, store: Any) -> None:
 @pytest.mark.asyncio
 async def test_no_extractor_passthrough_hands_raw_batch_to_add_messages():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("I prefer dark mode"))
     coordinator.record(_assistant_msg("Noted"))
@@ -191,7 +206,7 @@ async def test_extractor_route_calls_extractor_and_writes_each_entry_via_add():
         [ExtractionResult(content="fact one"), ExtractionResult(content="fact two", metadata={"k": "v"})]
     )
     store = _make_store("s", ExtractionConfig(trigger=_trigger(), extractor=extractor), sink="both")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("something happened"))
     await _drive(coordinator, store)
@@ -209,7 +224,7 @@ async def test_extractor_route_calls_extractor_and_writes_each_entry_via_add():
 async def test_extractor_route_passes_default_model_in_context():
     extractor = _make_extractor([])
     store = _make_store("s", ExtractionConfig(trigger=_trigger(), extractor=extractor), sink="both")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("hi"))
     await _drive(coordinator, store)
@@ -242,7 +257,7 @@ async def test_extractor_route_writes_entries_concurrently():
     extractor = _make_extractor([ExtractionResult(content="a"), ExtractionResult(content="b")])
     store = _make_store("s", ExtractionConfig(trigger=_trigger(), extractor=extractor), sink="add")
     store.add.side_effect = add_impl
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("x"))
     await _drive(coordinator, store)
@@ -257,7 +272,7 @@ async def test_extractor_route_rolls_back_and_retries_batch_on_entry_failure():
     store = _make_store("s", ExtractionConfig(trigger=_trigger(), extractor=extractor), sink="add")
     # First batch: second entry write fails -> whole batch rolled back.
     store.add.side_effect = [None, RuntimeError("write failed"), None, None]
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("x"))
     await _drive(coordinator, store)  # fails, mark rolled back
@@ -276,7 +291,7 @@ async def test_extractor_route_rolls_back_and_retries_batch_on_entry_failure():
 @pytest.mark.asyncio
 async def test_filter_drops_tool_blocks_by_default_and_empties():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("keep me"))
     coordinator.record(_tool_use_msg())  # tool-only message -> emptied -> dropped
@@ -295,7 +310,7 @@ async def test_filter_honors_a_custom_filter():
         ExtractionConfig(trigger=_trigger(), filter=MemoryMessageFilter(exclude=["text"])),
         sink="add_messages",
     )
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("this is text and should be excluded"))
     await _drive(coordinator, store)
@@ -312,7 +327,7 @@ async def test_filter_honors_a_custom_filter():
 @pytest.mark.asyncio
 async def test_hwm_processes_only_messages_added_since_the_last_save():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("turn one"))
     await _drive(coordinator, store)
@@ -329,7 +344,7 @@ async def test_hwm_processes_only_messages_added_since_the_last_save():
 @pytest.mark.asyncio
 async def test_hwm_does_nothing_when_no_new_messages_since_the_mark():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("only turn"))
     await _drive(coordinator, store)
@@ -342,7 +357,7 @@ async def test_hwm_does_nothing_when_no_new_messages_since_the_mark():
 async def test_hwm_retries_the_same_messages_on_the_next_save_if_a_write_fails():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
     store.add_messages.side_effect = [RuntimeError("backend down"), None]
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("important"))
     await _drive(coordinator, store)  # fails, mark rolled back
@@ -361,7 +376,7 @@ async def test_hwm_retries_the_same_messages_on_the_next_save_if_a_write_fails()
 async def test_backs_off_to_periodic_probes_after_threshold_failures():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
     store.add_messages.side_effect = RuntimeError("backend down")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     # Each call buffers a message and requests a save; every save fails. Run
     # enough backed-off requests for exactly two probe intervals.
@@ -379,7 +394,7 @@ async def test_backs_off_to_periodic_probes_after_threshold_failures():
 async def test_recovers_and_saves_the_buffered_backlog_when_the_store_comes_back():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
     store.add_messages.side_effect = RuntimeError("down")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     # Drive the store into backoff.
     for index in range(SAVE_FAILURES_BEFORE_BACKOFF):
@@ -406,7 +421,7 @@ async def test_a_healthy_store_keeps_saving_every_request_while_a_sibling_is_bac
     bad = _make_store("bad", ExtractionConfig(trigger=_trigger()), sink="add_messages")
     bad.add_messages.side_effect = RuntimeError("down")
     good = _make_store("good", ExtractionConfig(trigger=_trigger()), sink="add_messages")
-    coordinator = ExtractionCoordinator([bad, good], _DEFAULT_MODEL)
+    coordinator = _coordinator(bad, good)
 
     probes = 2
     requests = SAVE_FAILURES_BEFORE_BACKOFF + BACKOFF_PROBE_INTERVAL * probes
@@ -424,7 +439,7 @@ async def test_a_healthy_store_keeps_saving_every_request_while_a_sibling_is_bac
 async def test_flush_resolves_even_when_a_store_is_failing():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
     store.add_messages.side_effect = RuntimeError("down")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("x"))
     await _drive(coordinator, store)  # fails (swallowed)
@@ -436,7 +451,7 @@ async def test_flush_resolves_even_when_a_store_is_failing():
 async def test_flush_bypasses_backoff_and_writes_the_backlog_of_a_recovered_store():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
     store.add_messages.side_effect = RuntimeError("down")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     # Drive the store into backoff.
     for index in range(SAVE_FAILURES_BEFORE_BACKOFF):
@@ -466,7 +481,7 @@ async def test_a_fully_filtered_empty_turn_does_not_reset_the_failure_streak():
     # by showing backoff still engages and the next request is probe-gated.
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
     store.add_messages.side_effect = RuntimeError("down")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     # One short of backoff.
     for index in range(SAVE_FAILURES_BEFORE_BACKOFF - 1):
@@ -496,7 +511,7 @@ async def test_a_fully_filtered_empty_turn_does_not_reset_the_failure_streak():
 @pytest.mark.asyncio
 async def test_flush_force_extracts_a_buffered_tail_whose_trigger_never_fired():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     # Buffer messages but never call process (the trigger never fired).
     coordinator.record(_user_msg("a"))
@@ -512,7 +527,7 @@ async def test_flush_force_extracts_a_buffered_tail_whose_trigger_never_fired():
 @pytest.mark.asyncio
 async def test_flush_does_not_re_extract_messages_already_processed():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("a"))
     await _drive(coordinator, store)  # already extracted
@@ -525,7 +540,7 @@ async def test_flush_does_not_re_extract_messages_already_processed():
 @pytest.mark.asyncio
 async def test_flush_is_a_no_op_when_nothing_is_buffered():
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     await coordinator.flush()
 
@@ -543,7 +558,7 @@ async def test_flush_awaits_an_in_flight_write():
 
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
     store.add_messages.side_effect = add_messages_impl
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("hello"))
     coordinator.schedule(store)  # non-blocking background save
@@ -575,7 +590,7 @@ async def test_background_save_does_not_block_scheduling_and_flush_awaits_it():
 
     store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
     store.add_messages.side_effect = add_messages_impl
-    coordinator = ExtractionCoordinator([store], _DEFAULT_MODEL)
+    coordinator = _coordinator(store)
 
     coordinator.record(_user_msg("hello"))
     coordinator.schedule(store)  # returns immediately, write runs in background

--- a/strands-py/tests/strands/memory/test_memory_manager.py
+++ b/strands-py/tests/strands/memory/test_memory_manager.py
@@ -42,6 +42,7 @@ import pytest
 from strands.hooks.events import AfterInvocationEvent, MessageAddedEvent
 from strands.hooks.registry import HookOrder
 from strands.memory import AggregateMemoryError
+from strands.memory.extraction.model_extractor import ModelExtractor
 from strands.memory.extraction.triggers import IntervalTrigger, InvocationTrigger
 from strands.memory.extraction.types import ExtractionConfig, ExtractionResult
 from strands.memory.memory_manager import DEFAULT_MAX_SEARCH_RESULTS, MemoryManager
@@ -361,10 +362,71 @@ def test_constructor_raises_when_extraction_has_extractor_but_no_add():
         MemoryManager(stores=[store])
 
 
-def test_constructor_raises_when_extraction_no_extractor_but_no_add_messages():
+def test_constructor_defaults_add_only_store_to_model_extractor():
+    # An add-only store with no explicit extractor resolves to a ModelExtractor
+    # (capability-based default), so it is accepted -- its distilled entries are
+    # written via ``add``. (In TS this is the ``boolean | ExtractionConfig`` shape;
+    # Python mirrors it by resolving the same default extractor.)
     store = _store("s", writable=True, sinks={"add"}, extraction=ExtractionConfig(trigger=InvocationTrigger()))
-    with pytest.raises(Exception, match="without an extractor but no add_messages"):
-        MemoryManager(stores=[store])
+    mm = MemoryManager(stores=[store])
+    binding = mm._extraction_stores[0]
+    assert isinstance(binding.config.extractor, ModelExtractor)
+
+
+def test_constructor_accepts_extraction_true_shorthand_on_add_messages_store():
+    # ``extraction=True`` resolves to defaults: an add_messages store uses the
+    # server-side passthrough (no extractor) and so requires only add_messages.
+    store = _store("s", writable=True, sinks={"add_messages"}, extraction=True)
+    # Should not raise.
+    MemoryManager(stores=[store])
+
+
+def test_constructor_accepts_extraction_true_shorthand_on_add_only_store():
+    # ``extraction=True`` on an add-only store resolves to a ModelExtractor, whose
+    # entries are written via ``add`` -- so the add-only sink satisfies validation.
+    store = _store("s", writable=True, sinks={"add"}, extraction=True)
+    # Should not raise.
+    MemoryManager(stores=[store])
+
+
+def test_constructor_accepts_extraction_config_with_omitted_trigger():
+    # An ``ExtractionConfig`` with no trigger defaults to an interval cadence, so it
+    # has triggers and passes the "no triggers" validation.
+    store = _store("s", writable=True, sinks={"add_messages"}, extraction=ExtractionConfig())
+    # Should not raise.
+    MemoryManager(stores=[store])
+
+
+@pytest.mark.asyncio
+async def test_init_agent_extraction_true_defaults_to_interval_of_five():
+    # With the default IntervalTrigger(turns=5), four invocations do not fire; the
+    # fifth does. Drive the raw hook so interval gating is observable.
+    store = _store("s", writable=True, sinks={"add_messages"}, extraction=True)
+    mm = MemoryManager(stores=[store])
+    agent = _FakeAgent()
+    mm.init_agent(agent)
+
+    await _add_messages(agent, _user_msg("a"))
+    for _turn in range(4):
+        await _invoke_all(agent, AfterInvocationEvent(agent=agent))
+    store.add_messages.assert_not_called()
+
+    await _invoke_all(agent, AfterInvocationEvent(agent=agent))  # fifth invocation fires
+    await mm.flush()
+    store.add_messages.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_init_agent_extraction_true_on_add_only_store_uses_model_extractor():
+    # ``extraction=True`` on an add-only store resolves to a ModelExtractor, which
+    # calls the agent's model and writes distilled entries via ``add``.
+    store = _store("s", writable=True, sinks={"add"}, extraction=True)
+    mm = MemoryManager(stores=[store])
+    agent = _FakeAgent()
+    mm.init_agent(agent)
+
+    binding = mm._extraction_stores[0]
+    assert isinstance(binding.config.extractor, ModelExtractor)
 
 
 # --------------------------------------------------------------------------- #

--- a/strands-py/tests/strands/memory/test_resolve_extraction_config.py
+++ b/strands-py/tests/strands/memory/test_resolve_extraction_config.py
@@ -1,0 +1,150 @@
+"""Tests for ``_resolve_extraction_config``.
+
+Ported from ``strands-ts/src/memory/extraction/__tests__/resolve-extraction-config.test.ts``.
+Each TS ``it(...)`` maps to a ``test_...`` case here.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from strands.memory.extraction.model_extractor import ModelExtractor
+from strands.memory.extraction.resolve_extraction_config import (
+    DEFAULT_EXTRACTION_TRIGGER_TURNS,
+    _resolve_extraction_config,
+)
+from strands.memory.extraction.triggers import IntervalTrigger, InvocationTrigger
+from strands.memory.extraction.types import (
+    DEFAULT_MEMORY_MESSAGE_FILTER,
+    ExtractionConfig,
+    MemoryMessageFilter,
+)
+
+
+def _sinks(have: str) -> Any:
+    """A minimal store stub exposing only the write sinks the resolver inspects.
+
+    ``have`` is one of ``"add"``, ``"add_messages"``, or ``"both"``. The write
+    methods live on a freshly-created class (not the instance) because the
+    resolver's ``_has_method`` inspects ``type(store)``.
+    """
+    methods: dict[str, Any] = {}
+    if have in ("add", "both"):
+        methods["add"] = AsyncMock(return_value=None)
+    if have in ("add_messages", "both"):
+        methods["add_messages"] = AsyncMock(return_value=None)
+    store_cls = type(f"_FakeStore_{have}", (), methods)
+    return store_cls()
+
+
+def _make_extractor() -> Any:
+    extractor = SimpleNamespace()
+    extractor.extract = AsyncMock(return_value=[])
+    return extractor
+
+
+# --------------------------------------------------------------------------- #
+# Enablement shorthand
+# --------------------------------------------------------------------------- #
+
+
+def test_returns_none_when_extraction_is_false():
+    assert _resolve_extraction_config(False, _sinks("add")) is None
+
+
+def test_returns_none_when_extraction_is_none():
+    assert _resolve_extraction_config(None, _sinks("add")) is None
+
+
+def test_resolves_true_to_a_fully_defaulted_config():
+    resolved_config = _resolve_extraction_config(True, _sinks("add"))
+    assert resolved_config is not None
+    assert len(resolved_config.triggers) == 1
+    assert isinstance(resolved_config.triggers[0], IntervalTrigger)
+    assert resolved_config.filter is DEFAULT_MEMORY_MESSAGE_FILTER
+
+
+# --------------------------------------------------------------------------- #
+# Trigger defaulting and normalization
+# --------------------------------------------------------------------------- #
+
+
+def test_defaults_an_omitted_trigger_to_interval_of_default_turns():
+    # IntervalTrigger has no value equality, so assert on type + cadence rather than ``==``.
+    resolved_config = _resolve_extraction_config(ExtractionConfig(), _sinks("add_messages"))
+    assert resolved_config is not None
+    assert len(resolved_config.triggers) == 1
+    trigger = resolved_config.triggers[0]
+    assert isinstance(trigger, IntervalTrigger)
+    assert trigger._turns == DEFAULT_EXTRACTION_TRIGGER_TURNS
+    assert DEFAULT_EXTRACTION_TRIGGER_TURNS == 5
+
+
+def test_wraps_a_single_trigger_into_a_list():
+    trigger = InvocationTrigger()
+    resolved_config = _resolve_extraction_config(ExtractionConfig(trigger=trigger), _sinks("add_messages"))
+    assert resolved_config is not None
+    assert resolved_config.triggers == [trigger]
+
+
+def test_passes_an_explicit_trigger_list_through_unchanged():
+    triggers = [InvocationTrigger(), IntervalTrigger(turns=2)]
+    resolved_config = _resolve_extraction_config(ExtractionConfig(trigger=triggers), _sinks("add_messages"))
+    assert resolved_config is not None
+    assert resolved_config.triggers == triggers
+
+
+def test_leaves_an_explicit_empty_trigger_list_empty():
+    resolved_config = _resolve_extraction_config(ExtractionConfig(trigger=[]), _sinks("add_messages"))
+    assert resolved_config is not None
+    assert resolved_config.triggers == []
+
+
+# --------------------------------------------------------------------------- #
+# Capability-based extractor default
+# --------------------------------------------------------------------------- #
+
+
+def test_defaults_an_add_only_store_to_a_model_extractor():
+    resolved_config = _resolve_extraction_config(True, _sinks("add"))
+    assert resolved_config is not None
+    assert isinstance(resolved_config.extractor, ModelExtractor)
+
+
+def test_defaults_an_add_messages_only_store_to_the_passthrough():
+    resolved_config = _resolve_extraction_config(True, _sinks("add_messages"))
+    assert resolved_config is not None
+    assert resolved_config.extractor is None
+
+
+def test_defaults_a_both_sinks_store_to_the_passthrough():
+    resolved_config = _resolve_extraction_config(True, _sinks("both"))
+    assert resolved_config is not None
+    assert resolved_config.extractor is None
+
+
+def test_keeps_an_explicit_extractor_even_on_an_add_messages_store():
+    extractor = _make_extractor()
+    resolved_config = _resolve_extraction_config(ExtractionConfig(extractor=extractor), _sinks("both"))
+    assert resolved_config is not None
+    assert resolved_config.extractor is extractor
+
+
+# --------------------------------------------------------------------------- #
+# Filter defaulting
+# --------------------------------------------------------------------------- #
+
+
+def test_defaults_to_default_memory_message_filter():
+    resolved_config = _resolve_extraction_config(True, _sinks("add"))
+    assert resolved_config is not None
+    assert resolved_config.filter is DEFAULT_MEMORY_MESSAGE_FILTER
+
+
+def test_passes_an_explicit_filter_through():
+    message_filter = MemoryMessageFilter(exclude=[])
+    resolved_config = _resolve_extraction_config(ExtractionConfig(filter=message_filter), _sinks("add"))
+    assert resolved_config is not None
+    assert resolved_config.filter is message_filter


### PR DESCRIPTION
## Description

Python's memory-extraction API diverged from the TypeScript SDK in three ways that made the
Python happy path noticeably heavier than its TS counterpart. In TS a store opts into automatic
extraction with `extraction: true` and gets sensible defaults; in Python the caller had to
construct an `ExtractionConfig`, pick a trigger explicitly (it was required), and choose an
extractor by hand. The shared documentation ("the simplest form turns it on with defaults",
"defaults to an interval of 5") only held for TS — there was no Python equivalent.

This brings Python in line. A store can now enable extraction with `extraction=True`, the
`trigger` is optional (defaulting to every 5 turns), and the extractor is selected automatically
from the store's write methods — matching TS's `boolean | ExtractionConfig` shape and its
`resolveExtractionConfig` behavior.

The change is opt-in and pay-for-play: existing `ExtractionConfig(trigger=...)` call sites keep
working unchanged. Defaulting is now centralized in a single internal `_resolve_extraction_config`
(mirroring TS's `resolve-extraction-config.ts`), so the `MemoryManager` and `ExtractionCoordinator`
no longer re-interpret raw config or re-apply defaults — the manager resolves once and passes
`_ExtractionBinding`s downstream.

### Public API Changes

A store's `extraction` field accepts a `bool` shorthand, and `ExtractionConfig.trigger` is now
optional:

```python
# Before: extraction required an explicit ExtractionConfig with an explicit trigger
class MyStore:
    extraction = ExtractionConfig(trigger=IntervalTrigger(turns=5))

# After: bool shorthand enables extraction with defaults (every 5 turns;
# extractor chosen from the store's write methods)
class MyStore:
    extraction = True

# After: trigger is optional — omit it to default to every 5 turns
class MyStore:
    extraction = ExtractionConfig()  # interval trigger of 5, default extractor + filter
```

Default extractor is now resolved from the store's write methods, matching TS:

- A store implementing only `add` → defaults to a `ModelExtractor` (client-side fact distillation,
  written via `add`).
- A store implementing `add_messages` → defaults to server-side extraction (raw messages handed to
  `add_messages`, no model call).

An explicit `extractor` or `filter` still overrides the default. An explicit empty trigger list is
still rejected at construction.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Added a `test_resolve_extraction_config` suite (ported from the TS resolver tests) covering the
bool shorthand, trigger defaulting/normalization, capability-based extractor selection, and filter
defaulting. Existing coordinator and manager tests were updated to drive the resolved-config path;
the previously-raising "add-only store without an extractor" case now asserts the new
`ModelExtractor` default behavior.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
