### PR TITLE
fix(site): inject sitemap lastmod by matching git path prefix

### DIFF
--- a/site/src/plugins/sitemap-lastmod.ts
+++ b/site/src/plugins/sitemap-lastmod.ts
@@ -28,11 +28,10 @@ function buildLastModMap(contentDir: string): Map<string, string> {
   try {
     // Single git command: output all commits with dates and affected files
     // Format: each commit outputs its ISO date, then the list of files
-    const output = execFileSync(
-      'git',
-      ['log', '--format=%cI', '--name-only', '--diff-filter=ACMR', '--', contentDir],
-      { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 }
-    )
+    const output = execFileSync('git', ['log', '--format=%cI', '--name-only', '--diff-filter=ACMR', '--', contentDir], {
+      encoding: 'utf-8',
+      maxBuffer: 50 * 1024 * 1024,
+    })
 
     // Parse: lines alternate between date lines and file path lines,
     // separated by blank lines. First occurrence of each file = most recent.
@@ -59,21 +58,40 @@ function buildLastModMap(contentDir: string): Map<string, string> {
 }
 
 /**
- * Convert a URL path to likely content file paths.
- * e.g., /docs/user-guide/quickstart/python/ → src/content/docs/user-guide/quickstart/python.mdx
+ * Determine the path from the git repo root to the current working directory.
+ *
+ * `git log --name-only` emits file paths relative to the repo root, but the
+ * build runs from `site/`, so those paths carry a `site/` prefix. We prepend
+ * the same prefix to lookup candidates so both sides share one path space.
+ * Returns '' when the build runs from the repo root (e.g. a Docker build) or
+ * when git is unavailable, which keeps the plugin correct in both layouts.
  */
-function urlToContentPaths(urlPath: string, contentDir: string): string[] {
+function getGitPrefix(): string {
+  try {
+    // git uses forward slashes with a trailing slash (e.g. "site/"), or "" at the repo root
+    return execFileSync('git', ['rev-parse', '--show-prefix'], { encoding: 'utf-8' }).trim()
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Convert a URL path to likely content file paths.
+ * e.g., /docs/user-guide/quickstart/python/ → site/src/content/docs/user-guide/quickstart/python.mdx
+ *
+ * `gitPrefix` is prepended so candidates match the repo-root-relative paths
+ * that `git log --name-only` produces.
+ */
+function urlToContentPaths(urlPath: string, contentDir: string, gitPrefix: string): string[] {
   const slug = urlPath.replace(/^\//, '').replace(/\/$/, '')
 
-  return [
-    path.join(contentDir, `${slug}.mdx`),
-    path.join(contentDir, `${slug}.md`),
-    path.join(contentDir, slug, 'index.mdx'),
-    path.join(contentDir, slug, 'index.md'),
-  ]
+  return [`${slug}.mdx`, `${slug}.md`, path.join(slug, 'index.mdx'), path.join(slug, 'index.md')].map(
+    (rel) => gitPrefix + path.join(contentDir, rel)
+  )
 }
 
 export function sitemapWithLastmod(contentDir: string = 'src/content') {
+  const gitPrefix = getGitPrefix()
   const lastModMap = buildLastModMap(contentDir)
   console.log(`[sitemap-lastmod] Loaded ${lastModMap.size} git dates`)
 
@@ -84,7 +102,7 @@ export function sitemapWithLastmod(contentDir: string = 'src/content') {
       // Skip API reference pages — generated at build time, not git-tracked
       if (url.pathname.includes('/api/')) return item
 
-      const candidates = urlToContentPaths(url.pathname, contentDir)
+      const candidates = urlToContentPaths(url.pathname, contentDir, gitPrefix)
 
       for (const candidate of candidates) {
         const date = lastModMap.get(candidate)

--- a/site/src/plugins/sitemap-lastmod.ts
+++ b/site/src/plugins/sitemap-lastmod.ts
@@ -80,13 +80,16 @@ function getGitPrefix(): string {
  * e.g., /docs/user-guide/quickstart/python/ → site/src/content/docs/user-guide/quickstart/python.mdx
  *
  * `gitPrefix` is prepended so candidates match the repo-root-relative paths
- * that `git log --name-only` produces.
+ * that `git log --name-only` produces. Uses `path.posix.join` (not `path.join`)
+ * because both the git paths and `gitPrefix` use forward slashes — joining with
+ * the OS-native separator would reintroduce a separator mismatch on Windows,
+ * the same bug class this lookup is built to avoid.
  */
-function urlToContentPaths(urlPath: string, contentDir: string, gitPrefix: string): string[] {
+export function urlToContentPaths(urlPath: string, contentDir: string, gitPrefix: string): string[] {
   const slug = urlPath.replace(/^\//, '').replace(/\/$/, '')
 
-  return [`${slug}.mdx`, `${slug}.md`, path.join(slug, 'index.mdx'), path.join(slug, 'index.md')].map(
-    (rel) => gitPrefix + path.join(contentDir, rel)
+  return [`${slug}.mdx`, `${slug}.md`, path.posix.join(slug, 'index.mdx'), path.posix.join(slug, 'index.md')].map(
+    (rel) => gitPrefix + path.posix.join(contentDir, rel)
   )
 }
 

--- a/site/test/sitemap-lastmod.test.ts
+++ b/site/test/sitemap-lastmod.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { urlToContentPaths } from '../src/plugins/sitemap-lastmod'
+
+// The sitemap lastmod lookup matches URLs against keys produced by
+// `git log --name-only`, which are repo-root-relative with forward slashes
+// (e.g. `site/src/content/...` when the build runs from `site/`). These cases
+// lock in that path space so a future change can't silently reintroduce the
+// prefix/separator mismatch this plugin exists to avoid.
+describe('urlToContentPaths', () => {
+  it('builds repo-root-relative candidates with the git prefix', () => {
+    expect(urlToContentPaths('/docs/user-guide/quickstart/python/', 'src/content', 'site/')).toEqual([
+      'site/src/content/docs/user-guide/quickstart/python.mdx',
+      'site/src/content/docs/user-guide/quickstart/python.md',
+      'site/src/content/docs/user-guide/quickstart/python/index.mdx',
+      'site/src/content/docs/user-guide/quickstart/python/index.md',
+    ])
+  })
+
+  it('omits the prefix when built from the repo root (empty gitPrefix)', () => {
+    expect(urlToContentPaths('/changelog/harness/python-v1.43.0/', 'src/content', '')).toEqual([
+      'src/content/changelog/harness/python-v1.43.0.mdx',
+      'src/content/changelog/harness/python-v1.43.0.md',
+      'src/content/changelog/harness/python-v1.43.0/index.mdx',
+      'src/content/changelog/harness/python-v1.43.0/index.md',
+    ])
+  })
+
+  it('always emits forward slashes regardless of platform', () => {
+    // path.posix.join keeps `/` so candidates match git output on Windows too.
+    for (const candidate of urlToContentPaths('/docs/a/b/', 'src/content', 'site/')) {
+      expect(candidate).not.toContain('\\')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The `sitemap-lastmod` plugin (`site/src/plugins/sitemap-lastmod.ts`) was emitting zero `<lastmod>` entries for the entire sitemap (all ~665 URLs missing).

Root cause is a path-prefix mismatch. The build runs from `site/`, so `git log --name-only` reports file paths relative to the repo root (e.g. `site/src/content/docs/...`), and those become the keys in the lastmod map. But `urlToContentPaths()` built lookup candidates without the `site/` prefix (e.g. `src/content/docs/...`), so `lastModMap.get(candidate)` never matched.

The fix reconciles both sides onto the same repo-root-relative path space. It derives the prefix from `git rev-parse --show-prefix` (returns `site/` when run from `site/`, empty at the repo root) and prepends it to each lookup candidate. When git is unavailable the prefix falls back to empty and the existing graceful-degradation behavior is preserved, so the sitemap simply lacks lastmod rather than failing the build. The `/api/` skip behavior is unchanged.

## Test plan

- `npm run build` from `site/` succeeds.
- `<lastmod>` count in `dist/sitemap-0.xml`: before fix 0, after fix 199.
- Spot-checked a docs URL: `https://strandsagents.com/docs/user-guide/build-with-ai/` now has `<lastmod>2026-05-22T14:49:05.000Z</lastmod>`, a plausible ISO commit date.
- Remaining URLs without lastmod are the 407 `/api/` pages (intentionally skipped) plus dynamically generated routes (homepage, blog index, blog author pages) that do not map to a single content file.
- `npm test` (316 passed) and `npm run typecheck` pass.