### PR TITLE
fix(site): send analytics events in the WebSDK's XDM shape

### DIFF
--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -51,11 +51,14 @@
   // redirect). Those are dispatched via beacon so the request isn't cancelled on unload - the
   // same reason scroll depth uses the beacon path. In-page clicks (tabs, copy) pass false.
   function dispatchCTAClick(name, type, navigates) {
+    // Collapse whitespace so labels stay clean regardless of the source (textContent from
+    // elements with icons/SVG/newlines, hrefs, etc.) - keeps every caller consistent.
+    var cleanName = String(name).replace(/\s+/g, ' ').trim()
     dispatchXdmEvent(
       'web.awsm.customCTAClick',
       {
         pageInteraction: {
-          click: { name: name, type: type || 'customClick' },
+          click: { name: cleanName, type: type || 'customClick' },
         },
       },
       !!navigates
@@ -138,9 +141,7 @@
       // large block of text, so use their href (stable, concise) instead of textContent.
       var homeCta = e.target.closest('a.cta-button, a.le-card')
       if (homeCta) {
-        var ctaLabel = homeCta.matches('a.le-card')
-          ? homeCta.getAttribute('href')
-          : homeCta.textContent.trim().replace(/\s+/g, ' ')
+        var ctaLabel = homeCta.matches('a.le-card') ? homeCta.getAttribute('href') : homeCta.textContent
         dispatchCTAClick('home-cta:' + ctaLabel, 'linkClick', true)
         return
       }
@@ -165,7 +166,8 @@
         var copyLabel
         if (copyBtn.matches('button.install-copy')) {
           var installEl = copyBtn.closest('[data-copy]')
-          copyLabel = 'install:' + (installEl ? installEl.getAttribute('data-copy') : '')
+          var cmd = installEl && installEl.getAttribute('data-copy')
+          copyLabel = cmd ? 'install:' + cmd : 'install'
         } else {
           copyLabel = pageHierarchy(window.location.pathname)
         }
@@ -177,6 +179,7 @@
       var link = e.target.closest('a[href]')
       if (link && link.hostname && link.hostname !== window.location.hostname) {
         dispatchCTAClick('outbound:' + link.hostname + link.pathname, 'linkClick', true)
+        return
       }
     })
   }

--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -26,11 +26,14 @@
 
   // --- Helpers ---
 
-  // Pipe-delimited page hierarchy from the URL path (the 'docs' prefix is dropped),
-  // e.g. /docs/user-guide/quickstart/ -> "user-guide|quickstart". Used to label code-copy events.
+  // Pipe-delimited page hierarchy from the URL path, used to label code-copy events.
+  // Anchors on the 'docs' segment and takes everything after it, so any leading base
+  // path (e.g. a "/pr-xxxx/" preview deploy) is ignored:
+  // /pr-x/docs/user-guide/quickstart/ -> "user-guide|quickstart".
   function pageHierarchy(pathname) {
     var segments = pathname.replace(/^\/|\/$/g, '').split('/').filter(Boolean)
-    var start = segments[0] === 'docs' ? 1 : 0
+    var docsIndex = segments.indexOf('docs')
+    var start = docsIndex >= 0 ? docsIndex + 1 : 0
     return segments.slice(start).join('|') || 'home'
   }
 

--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -15,38 +15,38 @@
   if (window.__strandsAnalyticsInit) return
   window.__strandsAnalyticsInit = true
 
-  var CUSTOM_EVENT_LISTENER = 'custom-awsm-acs-analytics-event-listener'
-  var SEARCH_EVENT_LISTENER = 'custom-awsm-acs-search-event-listener'
+  // The AWS WebSDK listens on this single event name and reads event content from the
+  // XDM `_aws` namespace (detail.xdm._aws.<namespace>). Events sent in any other shape are
+  // rejected by its validators and silently dropped. Values verified against the upstream
+  // source: AWSMarketingAdobeWebSDKHelpers (constants + helpers/*-event.ts).
+  var ANALYTICS_EVENT_LISTENER = 'custom-awsm-acs-event-listener'
 
   var scrollData = { initial: 0, max: 0, latest: 0 }
   var scrollSent = false
 
   // --- Helpers ---
 
-  function deriveSections(pathname) {
+  // Pipe-delimited page hierarchy from the URL path (the 'docs' prefix is dropped),
+  // e.g. /docs/user-guide/quickstart/ -> "user-guide|quickstart". Used to label code-copy events.
+  function pageHierarchy(pathname) {
     var segments = pathname.replace(/^\/|\/$/g, '').split('/').filter(Boolean)
     var start = segments[0] === 'docs' ? 1 : 0
-    return {
-      siteSection: segments[start] || 'home',
-      subSection1: segments[start + 1] || '',
-      subSection2: segments[start + 2] || '',
-      hierarchy: segments.slice(start).join('|'),
-    }
+    return segments.slice(start).join('|') || 'home'
   }
 
   // Consent is enforced by the WebSDK listener itself - events dispatched here
   // are silently dropped if the user has not accepted performance cookies via Shortbread.
-  function dispatchAnalyticsEvent(eventType, data, useBeacon) {
+  function dispatchXdmEvent(eventType, awsContent, useBeacon) {
     var detail = {
       eventType: eventType,
-      data: data,
+      xdm: { _aws: awsContent },
       useBeacon: !!useBeacon,
     }
-    window.dispatchEvent(new CustomEvent(CUSTOM_EVENT_LISTENER, { detail: detail }))
+    window.dispatchEvent(new CustomEvent(ANALYTICS_EVENT_LISTENER, { detail: detail }))
   }
 
   function dispatchCTAClick(name, type) {
-    dispatchAnalyticsEvent('web.awsm.customCTAClick', {
+    dispatchXdmEvent('web.awsm.customCTAClick', {
       pageInteraction: {
         click: { name: name, type: type || 'customClick' },
       },
@@ -54,38 +54,16 @@
   }
 
   function dispatchSearchEvent(searchTerm, resultCount) {
-    window.dispatchEvent(
-      new CustomEvent(SEARCH_EVENT_LISTENER, {
-        detail: {
-          eventType: 'web.awsm.search',
-          data: {
-            searchOperations: {
-              searchTerm: searchTerm,
-              searchFilter: [],
-              resultCount: resultCount,
-            },
-          },
-        },
-      })
-    )
-  }
-
-  // --- 1. Page View with Site Sections ---
-
-  function trackPageView() {
-    var sections = deriveSections(window.location.pathname)
-    dispatchAnalyticsEvent('web.awsm.pageInteraction', {
-      pageInteraction: {
-        name: 'pageView',
-        siteSection: sections.siteSection,
-        subSection1: sections.subSection1,
-        subSection2: sections.subSection2,
-        hierarchy: sections.hierarchy,
+    dispatchXdmEvent('web.awsm.search', {
+      searchOperations: {
+        searchTerm: searchTerm,
+        searchFilter: [],
+        resultCount: resultCount,
       },
     })
   }
 
-  // --- 2. Click Tracking (anchors, nav tabs, code copy, outbound) ---
+  // --- 1. Click Tracking (anchors, nav tabs, code copy, outbound, UI controls) ---
 
   function setupClickTracking() {
     document.addEventListener('click', function (e) {
@@ -110,11 +88,78 @@
         return
       }
 
-      // Code copy button
-      var copyBtn = e.target.closest('.copy button, button.copy, [data-code] button')
+      // Language toggle (Python / TypeScript) - language-toggle > button.lang-option[data-lang]
+      var langControl = e.target.closest('.language-toggle .lang-option')
+      if (langControl) {
+        var lang = (langControl.getAttribute('data-lang') || '').trim()
+        dispatchCTAClick('lang-toggle:' + lang, 'click')
+        return
+      }
+
+      // GitHub dropdown menu links (.github-dropdown .github-link, label in .github-link-text)
+      var ghLink = e.target.closest('.github-dropdown a.github-link')
+      if (ghLink) {
+        var ghTextEl = ghLink.querySelector('.github-link-text')
+        var ghLabel = (ghTextEl ? ghTextEl.textContent : ghLink.textContent).trim().replace(/\s*↗$/, '')
+        dispatchCTAClick('github-menu:' + ghLabel, 'linkClick')
+        return
+      }
+
+      // Sidebar collapsible group expand/collapse (nav.sidebar > details > summary).
+      // Skip the inner group-link anchor so its navigation is tracked as a normal link, not an expand.
+      var sidebarSummary = e.target.closest('nav.sidebar summary')
+      if (sidebarSummary && !e.target.closest('.group-link')) {
+        var groupLabelEl = sidebarSummary.querySelector('.group-label, .section-label')
+        var groupLabel = (groupLabelEl ? groupLabelEl.textContent : sidebarSummary.textContent).trim()
+        dispatchCTAClick('sidebar-expand:' + groupLabel, 'click')
+        return
+      }
+
+      // Tab clicks (npm/yarn, OS, etc.). AutoSyncTabs hides the Python/TypeScript language
+      // tablists (display:none) and routes language switching through the header toggle, so a
+      // real click only lands on a visible tablist - which excludes those redundant language tabs.
+      var tab = e.target.closest('[role="tab"]')
+      if (tab) {
+        dispatchCTAClick('tab:' + tab.textContent.trim(), 'click')
+        return
+      }
+
+      // Landing page CTAs. Buttons have short text labels; the Labs/Evals cards wrap a
+      // large block of text, so use their href (stable, concise) instead of textContent.
+      var homeCta = e.target.closest('a.cta-button, a.le-card')
+      if (homeCta) {
+        var ctaLabel = homeCta.matches('a.le-card')
+          ? homeCta.getAttribute('href')
+          : homeCta.textContent.trim().replace(/\s+/g, ' ')
+        dispatchCTAClick('home-cta:' + ctaLabel, 'linkClick')
+        return
+      }
+
+      // Blog post cards and navigation
+      var blogCard = e.target.closest('a.blog-card')
+      if (blogCard) {
+        dispatchCTAClick('blog-card:' + blogCard.getAttribute('href'), 'linkClick')
+        return
+      }
+      var blogNav = e.target.closest('a.blog-post-author, a.blog-back-link')
+      if (blogNav) {
+        dispatchCTAClick('blog-nav:' + blogNav.textContent.trim(), 'linkClick')
+        return
+      }
+
+      // Code copy button (docs Starlight + landing CodeBlock + install commands)
+      var copyBtn = e.target.closest(
+        '.copy button, button.copy, [data-code] button, button.copy-button, button.copy-button-floating, button.install-copy'
+      )
       if (copyBtn) {
-        var pageSections = deriveSections(window.location.pathname)
-        dispatchCTAClick('code-copy:' + pageSections.hierarchy, 'customClick')
+        var copyLabel
+        if (copyBtn.matches('button.install-copy')) {
+          var installEl = copyBtn.closest('[data-copy]')
+          copyLabel = 'install:' + (installEl ? installEl.getAttribute('data-copy') : '')
+        } else {
+          copyLabel = pageHierarchy(window.location.pathname)
+        }
+        dispatchCTAClick('code-copy:' + copyLabel, 'customClick')
         return
       }
 
@@ -126,7 +171,7 @@
     })
   }
 
-  // --- 3. Search Events ---
+  // --- 2. Search Events ---
 
   function setupSearchTracking() {
     var searchTimeout = null
@@ -147,7 +192,7 @@
     })
   }
 
-  // --- 4. Scroll Depth ---
+  // --- 3. Scroll Depth ---
 
   function updateScroll() {
     var scrollTop = window.scrollY || document.documentElement.scrollTop
@@ -161,7 +206,7 @@
     if (scrollSent) return
     scrollSent = true
     updateScroll()
-    dispatchAnalyticsEvent(
+    dispatchXdmEvent(
       'web.awsm.pageInteraction',
       {
         pageInteraction: {
@@ -205,16 +250,16 @@
     }, 500)
   }
 
-  // --- 5. SPA / View Transition Support ---
+  // --- 4. SPA / View Transition Support ---
+  // The WebSDK auto-fires the standard page view (web.webpagedetails.pageViews)
+  // and derives Base URL, entry/exit, and section data from the URL server-side.
+  // Reset scroll tracking on each navigation so depth is measured per page.
 
   document.addEventListener('astro:page-load', function () {
-    trackPageView()
     resetScrollData()
   })
 
   // --- Initial setup (runs once) ---
-  // astro:page-load fires on initial load and all subsequent navigations,
-  // so it handles trackPageView() and resetScrollData() for every page.
   setupClickTracking()
   setupSearchTracking()
   setupScrollTracking()

--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -10,8 +10,7 @@
 ;(function () {
   'use strict'
 
-  // Prevent duplicate initialization on View Transition re-executions.
-  // The astro:page-load listener (registered on first init) handles transitions.
+  // Guard against this inline script running more than once on a page.
   if (window.__strandsAnalyticsInit) return
   window.__strandsAnalyticsInit = true
 
@@ -48,12 +47,19 @@
     window.dispatchEvent(new CustomEvent(ANALYTICS_EVENT_LISTENER, { detail: detail }))
   }
 
-  function dispatchCTAClick(name, type) {
-    dispatchXdmEvent('web.awsm.customCTAClick', {
-      pageInteraction: {
-        click: { name: name, type: type || 'customClick' },
+  // navigates: pass true for clicks that take the user to another page (links, toggles that
+  // redirect). Those are dispatched via beacon so the request isn't cancelled on unload - the
+  // same reason scroll depth uses the beacon path. In-page clicks (tabs, copy) pass false.
+  function dispatchCTAClick(name, type, navigates) {
+    dispatchXdmEvent(
+      'web.awsm.customCTAClick',
+      {
+        pageInteraction: {
+          click: { name: name, type: type || 'customClick' },
+        },
       },
-    })
+      !!navigates
+    )
   }
 
   function dispatchSearchEvent(searchTerm, resultCount) {
@@ -87,7 +93,7 @@
       var navTab = e.target.closest('.nav-tab, .mobile-nav-link')
       if (navTab) {
         var label = navTab.textContent.trim().replace(/\s*↗$/, '')
-        dispatchCTAClick('nav-tab:' + label, 'click')
+        dispatchCTAClick('nav-tab:' + label, 'click', true)
         return
       }
 
@@ -95,7 +101,8 @@
       var langControl = e.target.closest('.language-toggle .lang-option')
       if (langControl) {
         var lang = (langControl.getAttribute('data-lang') || '').trim()
-        dispatchCTAClick('lang-toggle:' + lang, 'click')
+        // The toggle navigates to the paired page in the other language, so beacon it.
+        dispatchCTAClick('lang-toggle:' + lang, 'click', true)
         return
       }
 
@@ -104,7 +111,7 @@
       if (ghLink) {
         var ghTextEl = ghLink.querySelector('.github-link-text')
         var ghLabel = (ghTextEl ? ghTextEl.textContent : ghLink.textContent).trim().replace(/\s*↗$/, '')
-        dispatchCTAClick('github-menu:' + ghLabel, 'linkClick')
+        dispatchCTAClick('github-menu:' + ghLabel, 'linkClick', true)
         return
       }
 
@@ -134,19 +141,19 @@
         var ctaLabel = homeCta.matches('a.le-card')
           ? homeCta.getAttribute('href')
           : homeCta.textContent.trim().replace(/\s+/g, ' ')
-        dispatchCTAClick('home-cta:' + ctaLabel, 'linkClick')
+        dispatchCTAClick('home-cta:' + ctaLabel, 'linkClick', true)
         return
       }
 
       // Blog post cards and navigation
       var blogCard = e.target.closest('a.blog-card')
       if (blogCard) {
-        dispatchCTAClick('blog-card:' + blogCard.getAttribute('href'), 'linkClick')
+        dispatchCTAClick('blog-card:' + blogCard.getAttribute('href'), 'linkClick', true)
         return
       }
       var blogNav = e.target.closest('a.blog-post-author, a.blog-back-link')
       if (blogNav) {
-        dispatchCTAClick('blog-nav:' + blogNav.textContent.trim(), 'linkClick')
+        dispatchCTAClick('blog-nav:' + blogNav.textContent.trim(), 'linkClick', true)
         return
       }
 
@@ -169,7 +176,7 @@
       // Outbound links
       var link = e.target.closest('a[href]')
       if (link && link.hostname && link.hostname !== window.location.hostname) {
-        dispatchCTAClick('outbound:' + link.hostname + link.pathname, 'linkClick')
+        dispatchCTAClick('outbound:' + link.hostname + link.pathname, 'linkClick', true)
       }
     })
   }
@@ -253,18 +260,16 @@
     }, 500)
   }
 
-  // --- 4. SPA / View Transition Support ---
-  // The WebSDK auto-fires the standard page view (web.webpagedetails.pageViews)
-  // and derives Base URL, entry/exit, and section data from the URL server-side.
-  // Reset scroll tracking on each navigation so depth is measured per page.
-
-  document.addEventListener('astro:page-load', function () {
-    resetScrollData()
-  })
-
-  // --- Initial setup (runs once) ---
+  // --- 4. Setup ---
+  // The WebSDK auto-fires the standard page view (web.webpagedetails.pageViews) and derives
+  // Base URL, entry/exit, and section data from the URL server-side, so no page-view event is
+  // sent here. Each full page load re-runs this IIFE, so setup below runs fresh per page.
   setupClickTracking()
   setupSearchTracking()
   setupScrollTracking()
+
+  // If view transitions (ClientRouter) are enabled later, navigations won't reload the page,
+  // so reset the per-page scroll baseline on astro:page-load. No-op while full reloads are used.
+  document.addEventListener('astro:page-load', resetScrollData)
 })()
 </script>


### PR DESCRIPTION
## Description

The custom analytics events dispatched from `site/src/components/Analytics.astro` were never reaching Adobe. Two independent bugs in the dispatch layer caused every custom event to be silently dropped:

1. **Wrong listener name.** The AWS WebSDK listens on a single event name, `custom-awsm-acs-event-listener`. Our code dispatched to two names that the SDK does not listen on: `custom-awsm-acs-analytics-event-listener` and `custom-awsm-acs-search-event-listener`.
2. **Wrong payload shape.** The SDK reads event content from the XDM namespace `detail.xdm._aws.<namespace>` and validates it before sending. Our code wrapped content in `detail.data.<namespace>`, so the validators rejected and dropped each event.

Because of this, the page-view / scroll / link-click data visible in Adobe actually came from the **SDK's own auto-instrumentation** (auto page views, scroll detection, `clickCollectionEnabled` link tracking) — not from this code. Internal search has no SDK auto-equivalent, which is why search reporting showed zero and surfaced the bug.

I verified the correct contract against the upstream packages `AWSMarketingAdobeWebSDKClientSideLibs` and `AWSMarketingAdobeWebSDKHelpers` (the `helpers/*-event.ts` builders and the listener constant), and confirmed it against the production `wsdk.js` bundle served from `d0.m.awsstatic.com` (it listens only on `custom-awsm-acs-event-listener` and reads `_aws` / `searchOperations` / `customCTAClick`).

### What changed

- Dispatch through the single correct listener `custom-awsm-acs-event-listener`, wrapping content as `detail.xdm._aws.<namespace>` (search, custom CTA, and scroll all updated).
- Remove the invalid page-view event. It used `pageInteraction` with `name: 'pageView'`, but the only valid `PageInteractionName` values are `impression` and `scroll`; the SDK auto-fires the standard `web.webpagedetails.pageViews` itself. The dead `siteSection` / `hierarchy` fields it carried had no destination variable on the report suite and are removed.
- Make the code-copy hierarchy label base-path aware (anchors on the `docs` path segment) so a deploy base path like `/pr-xxxx/` does not leak into the label.
- Now that custom events actually land, extend click tracking to cover existing interactive UI that was previously untracked or only captured generically:
  - **Language toggle** (Python/TypeScript) → `lang-toggle:<lang>`
  - **GitHub dropdown links** → `github-menu:<label>`
  - **Sidebar group expand** → `sidebar-expand:<group>`
  - **Content tabs** (npm/yarn, OS; language tabs are excluded because AutoSyncTabs hides them) → `tab:<label>`
  - **Landing CTAs** → `home-cta:<text-or-href>`
  - **Blog cards and post nav** → `blog-card:<href>`, `blog-nav:<label>`
  - **Code-copy** broadened to landing `CodeBlock` and install-command buttons → `code-copy:<hierarchy|install:cmd>`

## Related Issues

<!-- none -->

## Type of Change

Bug fix

## Testing

Verified end to end against the deployed PR preview build (`https://d3ehv1nix5p99z.cloudfront.net/pr-cms-2815/`) using browser automation. Attached listeners for both the correct event name and the two old (buggy) names, then triggered real clicks and inspected each dispatched event.

**Result — every custom event now fires on `custom-awsm-acs-event-listener` with the `detail.xdm._aws.*` shape; zero events on the old listener names, and no `detail.data` payloads:**

| Action | `eventType` | `xdm._aws` content |
|---|---|---|
| Language toggle | `web.awsm.customCTAClick` | `pageInteraction.click = { name: "lang-toggle:Python", type: "click" }` |
| GitHub dropdown link | `web.awsm.customCTAClick` | `pageInteraction.click = { name: "github-menu:Python SDK", type: "linkClick" }` |
| Install copy button | `web.awsm.customCTAClick` | `pageInteraction.click = { name: "code-copy:install:pip install strands-agents", type: "customClick" }` |
| Docs code copy | `web.awsm.customCTAClick` | `pageInteraction.click = { name: "code-copy:user-guide|observability-evaluation|logs", type: "customClick" }` |
| Sidebar group expand | `web.awsm.customCTAClick` | `pageInteraction.click = { name: "sidebar-expand:Tools", type: "click" }` |

Preview testing also surfaced the base-path bug: on the `/pr-cms-2815/` preview the code-copy label was originally `code-copy:pr-cms-2815|docs|user-guide|...`. After the base-path-aware fix it correctly resolves to `user-guide|observability-evaluation|logs` on both preview and production-style paths (and `home` for `/`).

**Not yet confirmed:** that the SDK forwards an accepted beacon to `edge.adobedc.net/ee/.../v1/interact` after consent. A reviewer can confirm by loading the preview, accepting performance cookies, and watching the Network tab while searching/clicking — the dispatched event shape is verified correct, so this is the only remaining link in the chain.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published