### PR TITLE
fix(ollama): avoid UnboundLocalError on empty model stream

### DIFF
--- a/strands-py/src/strands/models/ollama.py
+++ b/strands-py/src/strands/models/ollama.py
@@ -319,6 +319,7 @@ class OllamaModel(Model):
 
         logger.debug("invoking model")
         tool_requested = False
+        event = None
 
         client = ollama.AsyncClient(self.host, **self.client_args)
         response = await client.chat(**request)
@@ -336,11 +337,12 @@ class OllamaModel(Model):
 
             yield self.format_chunk({"chunk_type": "content_delta", "data_type": "text", "data": event.message.content})
 
+        stop_reason = "tool_use" if tool_requested else (event.done_reason if event else None)
+
         yield self.format_chunk({"chunk_type": "content_stop", "data_type": "text"})
-        yield self.format_chunk(
-            {"chunk_type": "message_stop", "data": "tool_use" if tool_requested else event.done_reason}
-        )
-        yield self.format_chunk({"chunk_type": "metadata", "data": event})
+        yield self.format_chunk({"chunk_type": "message_stop", "data": stop_reason})
+        if event is not None:
+            yield self.format_chunk({"chunk_type": "metadata", "data": event})
 
         logger.debug("finished streaming response from model")
 

--- a/strands-py/tests/strands/models/test_ollama.py
+++ b/strands-py/tests/strands/models/test_ollama.py
@@ -467,6 +467,24 @@ async def test_stream(ollama_client, model, agenerator, alist, captured_warnings
 
 
 @pytest.mark.asyncio
+async def test_stream_empty_response(ollama_client, model, agenerator, alist):
+    ollama_client.chat = unittest.mock.AsyncMock(return_value=agenerator([]))
+
+    messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+    response = model.stream(messages)
+
+    tru_events = await alist(response)
+    exp_events = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+    ]
+
+    assert tru_events == exp_events
+
+
+@pytest.mark.asyncio
 async def test_tool_choice_not_supported_warns(ollama_client, model, agenerator, alist, captured_warnings):
     """Test that non-None toolChoice emits warning for unsupported providers."""
     tool_choice = {"auto": {}}


### PR DESCRIPTION
## Description

`OllamaModel.stream` reads `event` after the `async for event in response` loop to build the `message_stop` and `metadata` chunks. When the model returns an empty stream (no chunks at all), `event` is never bound, so `event.done_reason` raises `UnboundLocalError` instead of closing the turn cleanly.

Repro against current `main`:

```python
async def empty():
    if False:
        yield None

# client.chat returns an empty async iterator
[x async for x in model.stream(messages)]
# UnboundLocalError: cannot access local variable 'event'
```

Fix:
- initialize `event = None` before the loop
- fall back to `None` for the stop reason when there was no event (`format_chunk` already maps anything that is not `tool_use`/`length` to `end_turn`)
- skip the `metadata` chunk when no event arrived, since there is no usage to report

This mirrors what `GeminiModel.stream` already does for the empty-stream case, so the providers stay consistent. An empty stream now ends with a normal `messageStop(end_turn)` and no metadata chunk.

## Related Issues

None tracked; found while auditing the model providers for the empty-stream edge case.

## Documentation PR

Not needed, no public API or behavior change beyond not raising.

## Type of Change

Bug fix

## Testing

Added `test_stream_empty_response`, which fails on `main` with the `UnboundLocalError` above and passes with the fix.

```
python -m pytest tests/strands/models/test_ollama.py
# 34 passed
ruff check / ruff format --check  # clean
mypy src/strands/models/ollama.py # Success: no issues found
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings
