### PR TITLE
refactor(memory): represent passed-in config types as TypedDicts

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -520,12 +520,8 @@ class Agent(AgentBase):
 
         if isinstance(memory_manager, MemoryManager):
             return memory_manager
-        if isinstance(memory_manager, MemoryManagerConfig):
-            return MemoryManager(
-                stores=memory_manager.stores,
-                search_tool_config=memory_manager.search_tool_config,
-                add_tool_config=memory_manager.add_tool_config,
-            )
+        if isinstance(memory_manager, dict):
+            return MemoryManager(**memory_manager)
         raise ValueError("memory_manager must be a MemoryManager or MemoryManagerConfig")
 
     def cancel(self) -> None:

--- a/strands-py/src/strands/injection/types.py
+++ b/strands-py/src/strands/injection/types.py
@@ -9,6 +9,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
+from typing_extensions import TypedDict
+
 if TYPE_CHECKING:
     from ..agent.agent import Agent
     from ..agent.state import AgentState
@@ -63,8 +65,7 @@ class TriggerCallback(Protocol):
 InjectionTriggerPredicate = InjectionTrigger | Callable[[InjectionContext], bool] | TriggerCallback
 
 
-@dataclass
-class InjectionConfig:
+class InjectionConfig(TypedDict, total=False):
     """Configuration common to every injection consumer: when to inject.
 
     What text to inject is a consumer concern, added by the configs that extend this one
@@ -77,4 +78,4 @@ class InjectionConfig:
             skipped, the model call proceeds). Defaults to ``"userTurn"``.
     """
 
-    trigger: InjectionTriggerPredicate | None = None
+    trigger: InjectionTriggerPredicate | None

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -159,15 +159,15 @@ class MemoryManager(Plugin):
         # Stores with extraction enabled, each paired with its resolved config; wired up in ``init_agent``.
         self._extraction_stores = extraction_bindings
 
-        self._search_tool_config: MemoryToolConfig | bool
-        if search_tool_config is False:
-            self._search_tool_config = False
-        elif isinstance(search_tool_config, MemoryToolConfig):
+        self._search_tool_config: MemoryToolConfig | Literal[False]
+        if isinstance(search_tool_config, dict):
             self._search_tool_config = search_tool_config
-        else:
+        elif search_tool_config:
             self._search_tool_config = MemoryToolConfig()
+        else:
+            self._search_tool_config = False
 
-        self._add_tool_config: MemoryAddToolConfig | bool
+        self._add_tool_config: MemoryAddToolConfig | Literal[False]
         self._add_tool_stores: list[MemoryStore]
         if add_tool_config is None or add_tool_config is False:
             self._add_tool_config = False
@@ -176,9 +176,7 @@ class MemoryManager(Plugin):
             # The `add_memory` tool writes via `add`, so needs an `add`-capable store.
             if len(self._add_stores) == 0:
                 raise ValueError("MemoryManager: add_tool_config is enabled but no writable stores implement add")
-            resolved_config = (
-                add_tool_config if isinstance(add_tool_config, MemoryAddToolConfig) else MemoryAddToolConfig()
-            )
+            resolved_config = add_tool_config if isinstance(add_tool_config, dict) else MemoryAddToolConfig()
             self._add_tool_config = resolved_config
             self._add_tool_stores = self._resolve_add_tool_stores(resolved_config)
 
@@ -191,12 +189,12 @@ class MemoryManager(Plugin):
         # Resolved injection config, or ``False`` when injection is disabled. ``True`` resolves
         # to a default ``MemoryInjectionConfig``; a config object passes through unchanged.
         self._injection_config: MemoryInjectionConfig | Literal[False]
-        if injection is False:
-            self._injection_config = False
-        elif isinstance(injection, MemoryInjectionConfig):
+        if isinstance(injection, dict):
             self._injection_config = injection
-        else:
+        elif injection:
             self._injection_config = MemoryInjectionConfig()
+        else:
+            self._injection_config = False
 
         # Build tools now; surfaced via the ``tools`` property.
         self._memory_tools: list[AgentTool] = self._build_tools()
@@ -211,10 +209,11 @@ class MemoryManager(Plugin):
             ValueError: If a referenced store is not configured, not writable, or
                 has no ``add`` method.
         """
-        if tool_config.stores is None:
+        config_stores = tool_config.get("stores")
+        if config_stores is None:
             return self._add_stores
 
-        names = [store if isinstance(store, str) else store.name for store in tool_config.stores]
+        names = [store if isinstance(store, str) else store.name for store in config_stores]
 
         resolved: list[MemoryStore] = []
         seen: set[str] = set()
@@ -241,10 +240,10 @@ class MemoryManager(Plugin):
         """
         tools: list[AgentTool] = []
 
-        if isinstance(self._search_tool_config, MemoryToolConfig):
+        if isinstance(self._search_tool_config, dict):
             tools.append(self._create_search_tool(self._search_tool_config))
 
-        if isinstance(self._add_tool_config, MemoryAddToolConfig):
+        if isinstance(self._add_tool_config, dict):
             tools.append(self._create_add_tool(self._add_tool_config, self._add_tool_stores))
 
         for store in self._stores:
@@ -273,8 +272,8 @@ class MemoryManager(Plugin):
         Raises:
             ValueError: If a named store is not found (raised before querying).
         """
-        requested_stores = options.stores if options is not None else None
-        caller_max = options.max_search_results if options is not None else None
+        requested_stores = options.get("stores") if options is not None else None
+        caller_max = options.get("max_search_results") if options is not None else None
 
         logger.debug(
             "query=<%s>, max_search_results=<%s>, stores=<%s> | searching stores",
@@ -340,8 +339,8 @@ class MemoryManager(Plugin):
                 writable store matched.
             AggregateMemoryError: If any targeted store write fails.
         """
-        requested_stores = options.stores if options is not None else None
-        metadata = options.metadata if options is not None else None
+        requested_stores = options.get("stores") if options is not None else None
+        metadata = options.get("metadata") if options is not None else None
 
         if requested_stores is not None:
             writable_stores: list[MemoryStore] = []
@@ -413,7 +412,8 @@ class MemoryManager(Plugin):
 
     def _create_search_tool(self, config: MemoryToolConfig) -> AgentTool:
         """Build the ``search_memory`` tool."""
-        description = config.description if config.description is not None else SEARCH_TOOL_DESCRIPTION
+        custom_description = config.get("description")
+        description = custom_description if custom_description is not None else SEARCH_TOOL_DESCRIPTION
         store_descriptions = [
             f"- {store.name}: {store.description}" for store in self._search_stores if store.description
         ]
@@ -457,14 +457,16 @@ class MemoryManager(Plugin):
                 payload.append(item)
             return payload
 
+        custom_name = config.get("name")
         return tool(
-            name=config.name if config.name is not None else "search_memory",
+            name=custom_name if custom_name is not None else "search_memory",
             description=description,
         )(search_memory)
 
     def _create_add_tool(self, config: MemoryAddToolConfig, stores: list[MemoryStore]) -> AgentTool:
         """Build the ``add_memory`` tool."""
-        description = config.description if config.description is not None else ADD_TOOL_DESCRIPTION
+        custom_description = config.get("description")
+        description = custom_description if custom_description is not None else ADD_TOOL_DESCRIPTION
         store_descriptions = [f"- {store.name}: {store.description}" for store in stores if store.description]
         if store_descriptions:
             description += "\n\nAvailable writable stores:\n" + "\n".join(store_descriptions)
@@ -474,7 +476,7 @@ class MemoryManager(Plugin):
             )
 
         scoped_names = [store.name for store in stores]
-        wait_for_writes = config.wait_for_writes
+        wait_for_writes = config.get("wait_for_writes", True)
 
         async def add_memory(entries: list[str], stores: list[str] | None = None) -> dict[str, int]:
             """Add data to long-term memory.
@@ -515,8 +517,9 @@ class MemoryManager(Plugin):
 
             return {"stored": len(entries)}
 
+        custom_name = config.get("name")
         return tool(
-            name=config.name if config.name is not None else "add_memory",
+            name=custom_name if custom_name is not None else "add_memory",
             description=description,
         )(add_memory)
 
@@ -581,7 +584,7 @@ class MemoryManager(Plugin):
             InvokeModelStage.Input,
             _create_injection_middleware(
                 lambda context: self._provide_memory_context(context.messages, config),
-                trigger=config.trigger,
+                trigger=config.get("trigger"),
             ),
         )
 
@@ -605,15 +608,17 @@ class MemoryManager(Plugin):
         if query is None or not query.strip():
             return None
 
-        max_results = config.max_entries if config.max_entries is not None else DEFAULT_MAX_ENTRIES
+        max_entries = config.get("max_entries")
+        max_results = max_entries if max_entries is not None else DEFAULT_MAX_ENTRIES
         # search caps each store at max_results; the slice caps the concatenation across stores.
         entries = (await self.search(query, MemorySearchOptions(max_search_results=max_results)))[:max_results]
         if len(entries) == 0:
             return None
 
         try:
-            if config.format is not None:
-                return config.format(InjectionFormatContext(entries=entries))
+            custom_format = config.get("format")
+            if custom_format is not None:
+                return custom_format(InjectionFormatContext(entries=entries))
             return self._default_injection_format(entries)
         except Exception as error:  # noqa: BLE001 - fail open: a bad formatter must not abort the model call.
             logger.warning("reason=<%s> | injection format raised | skipping injection", error)
@@ -634,9 +639,10 @@ class MemoryManager(Plugin):
         Returns:
             The query string, or ``None`` when none is available.
         """
-        if config.query is not None:
+        custom_query = config.get("query")
+        if custom_query is not None:
             try:
-                return config.query(InjectionQueryContext(messages=messages))
+                return custom_query(InjectionQueryContext(messages=messages))
             except Exception as error:  # noqa: BLE001 - fail open: a bad query must not abort the model call.
                 logger.warning("reason=<%s> | injection query raised | skipping injection", error)
                 return None

--- a/strands-py/src/strands/memory/types.py
+++ b/strands-py/src/strands/memory/types.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
+from typing_extensions import Required, TypedDict
+
 from ..injection import InjectionConfig
 from ..types.content import Message, Messages
 from ..types.tools import AgentTool
@@ -33,15 +35,14 @@ class MemoryEntry:
     metadata: Metadata | None = None
 
 
-@dataclass
-class SearchOptions:
+class SearchOptions(TypedDict, total=False):
     """Options passed to :meth:`MemoryStore.search`.
 
     Store implementations may extend this with backend-specific fields; note that
     ``MemoryManager.search`` forwards only these base fields across its stores.
     """
 
-    max_search_results: int | None = None
+    max_search_results: int | None
 
 
 @dataclass
@@ -53,8 +54,7 @@ class AddMessagesContext:
     """
 
 
-@dataclass
-class MemorySearchOptions(SearchOptions):
+class MemorySearchOptions(SearchOptions, total=False):
     """Options for ``MemoryManager.search``.
 
     Attributes:
@@ -64,11 +64,10 @@ class MemorySearchOptions(SearchOptions):
             in-scope stores".
     """
 
-    stores: list[str] | None = None
+    stores: list[str] | None
 
 
-@dataclass
-class MemoryAddOptions:
+class MemoryAddOptions(TypedDict, total=False):
     """Options for ``MemoryManager.add``.
 
     Attributes:
@@ -78,20 +77,18 @@ class MemoryAddOptions:
             in-scope stores".
     """
 
-    metadata: Metadata | None = None
-    stores: list[str] | None = None
+    metadata: Metadata | None
+    stores: list[str] | None
 
 
-@dataclass
-class MemoryToolConfig:
+class MemoryToolConfig(TypedDict, total=False):
     """Configuration for customizing a memory tool's name or description."""
 
-    name: str | None = None
-    description: str | None = None
+    name: str | None
+    description: str | None
 
 
-@dataclass
-class MemoryAddToolConfig(MemoryToolConfig):
+class MemoryAddToolConfig(MemoryToolConfig, total=False):
     """Configuration for the ``add_memory`` tool.
 
     Attributes:
@@ -103,8 +100,8 @@ class MemoryAddToolConfig(MemoryToolConfig):
             are dispatched; per-store failures are logged.
     """
 
-    stores: list[str | MemoryStore] | None = None
-    wait_for_writes: bool = True
+    stores: list[str | MemoryStore] | None
+    wait_for_writes: bool
 
 
 @dataclass
@@ -160,8 +157,7 @@ InjectionQuery = Callable[[InjectionQueryContext], "str | None"] | InjectionQuer
 InjectionFormat = Callable[[InjectionFormatContext], str] | InjectionFormatCallback
 
 
-@dataclass
-class MemoryInjectionConfig(InjectionConfig):
+class MemoryInjectionConfig(InjectionConfig, total=False):
     """Configuration for memory context injection.
 
     Extends the generic :class:`~strands.injection.InjectionConfig` (which carries ``trigger``)
@@ -189,13 +185,12 @@ class MemoryInjectionConfig(InjectionConfig):
             for its own escaping.
     """
 
-    max_entries: int | None = None
-    query: InjectionQuery | None = None
-    format: InjectionFormat | None = None
+    max_entries: int | None
+    query: InjectionQuery | None
+    format: InjectionFormat | None
 
 
-@dataclass
-class MemoryManagerConfig:
+class MemoryManagerConfig(TypedDict, total=False):
     """Configuration for the ``MemoryManager``, mirroring the constructor kwargs.
 
     Attributes:
@@ -209,23 +204,22 @@ class MemoryManagerConfig:
             timing, and formatting; ``False`` disables it.
     """
 
-    stores: list[MemoryStore]
-    search_tool_config: MemoryToolConfig | bool = True
-    add_tool_config: MemoryAddToolConfig | bool = False
-    injection: MemoryInjectionConfig | bool = True
+    stores: Required[list[MemoryStore]]
+    search_tool_config: MemoryToolConfig | bool
+    add_tool_config: MemoryAddToolConfig | bool
+    injection: MemoryInjectionConfig | bool
 
 
-class MemoryStoreConfig(Protocol):
-    """Declarative identity and behavior fields shared by every memory store.
+class MemoryStoreConfig(TypedDict, total=False):
+    """Declarative identity and behavior fields a store is configured with.
 
     Attributes:
         name: Unique identifier for this store, used to target it in tools.
         description: Human-readable description; included in tool descriptions.
         max_search_results: Default maximum results per search, used when a caller
             does not pass a per-call value.
-        writable: Whether this store accepts writes. A writable store requires at
-            least one write sink (:meth:`MemoryStore.add` or
-            :meth:`MemoryStore.add_messages`).
+        writable: Whether this store accepts writes. A writable store requires at least one write
+            sink (:meth:`MemoryStore.add` or :meth:`MemoryStore.add_messages`).
         extraction: Automatic-extraction configuration for this writable store, as
             a ``bool | config`` shorthand. ``True`` enables it with defaults; an
             :class:`ExtractionConfig` defaults any unset field; ``False``/``None``
@@ -237,21 +231,33 @@ class MemoryStoreConfig(Protocol):
             extraction (the backend extracts the raw messages, no model call).
     """
 
-    name: str
+    name: Required[str]
     description: str | None
     max_search_results: int | None
     writable: bool
     extraction: ExtractionConfig | bool | None
 
 
-class MemoryStore(MemoryStoreConfig, Protocol):
+class MemoryStore(Protocol):
     """Runtime contract for a memory store backend.
 
-    Extends :class:`MemoryStoreConfig` with runtime methods. Every store is
-    searchable; ``writable`` declares whether it also accepts writes. A store
-    author implements the config fields plus :meth:`search`, and optionally
-    :meth:`add`, :meth:`add_messages`, and :meth:`get_tools`.
+    A store exposes the :class:`MemoryStoreConfig` fields as attributes and implements :meth:`search`,
+    plus optionally :meth:`add`, :meth:`add_messages`, and :meth:`get_tools`. The fields are
+    re-declared here because a ``Protocol`` cannot extend a ``TypedDict``.
+
+    Attributes:
+        name: Unique identifier for this store, used to target it in tools.
+        description: Human-readable description; included in tool descriptions.
+        max_search_results: Default maximum results per search.
+        writable: Whether this store accepts writes.
+        extraction: Resolved automatic-extraction configuration, or ``None``/``False`` when off.
     """
+
+    name: str
+    description: str | None
+    max_search_results: int | None
+    writable: bool
+    extraction: ExtractionConfig | bool | None
 
     async def search(self, query: str, options: SearchOptions | None = None) -> list[MemoryEntry]:
         """Search the store for entries matching the query, ordered by relevance."""


### PR DESCRIPTION
## Description

The memory config/option types were dataclasses, but they are **passed-in option bags**, not value objects with behavior. This converts them to `TypedDict`, the more idiomatic representation for "a bag of optional fields a caller provides," and the one that matches how config bags are constructed elsewhere in the SDK. It also lets callers pass plain dict literals, which mirrors how these configs are written in the TypeScript SDK (object literals).

Converted to `TypedDict` (`total=False`): `SearchOptions`, `MemorySearchOptions`, `MemoryAddOptions`, `MemoryToolConfig`, `MemoryAddToolConfig`, `MemoryInjectionConfig`, `MemoryManagerConfig`, plus `InjectionConfig` and `MemoryStoreConfig`. `MemoryManagerConfig` marks `stores` as `Required`.

Left unchanged by design:
- **`MemoryStore`** stays a `Protocol` (it carries methods) and re-declares the config fields as attributes, since a `Protocol` cannot extend a `TypedDict`.
- **`MemoryEntry`** and the `*Context` types stay dataclasses, they are returned/callback **value objects**, not passed-in config.

### Public API impact

Construction is a **superset** of before, no breakage:

```python
# Still valid (call form):
MemoryManager(stores=[s], search_tool_config=MemoryToolConfig(name="recall"))

# Now also valid and type-checked (dict literal):
MemoryManager(stores=[s], search_tool_config={"name": "recall"})
```

Internally, the manager's discrimination over the `Config | bool` unions switches from `isinstance(<config-class>)` (not usable on a `TypedDict`) to `isinstance(x, dict)` for selecting the config arm and `is False` for the disabled-sentinel guards. Attribute reads become `.get(...)`. All previously-defaulted fields are preserved: `wait_for_writes` defaults at its read site, and the `MemoryManagerConfig` fields default via `MemoryManager.__init__` (an omitted TypedDict key is simply absent, so the constructor's own defaults apply).

### Prior art in the SDK

Accepting a `TypedDict` config as a single parameter is an established pattern:

- **`ConversationManager` / `proactive_compression`** (`conversation_manager.py`) — `bool | ProactiveCompressionConfig | None`, the closest precedent to this PR. It discriminates the union exactly as this PR does: `if proactive_compression is True: ... elif isinstance(proactive_compression, dict): threshold = proactive_compression.get("compression_threshold", DEFAULT)`. Its docstring shows both `proactive_compression=True` and `proactive_compression={"compression_threshold": 0.8}`.
- **`MCPClient` / `tasks_config: TasksConfig | None`** (`mcp_client.py`) — a config TypedDict passed as one parameter.
- **`OpenAIResponsesModel` / `bedrock_mantle_config: BedrockMantleConfig | None`** (`openai_responses.py`) — passed as one param and read directly (`_resolve_region(config: BedrockMantleConfig)`).
- **bidi models / `default_audio: AudioConfig`** (`nova_sonic.py`, `gemini_live.py`, `openai_realtime.py`) — a TypedDict config with an inline dict-literal default.
- **`CitationsContentBlock` / `citations: CitationsConfig | None`** (`types/media.py`).

So this PR's `MemoryToolConfig | bool` / `MemoryInjectionConfig | bool` parameters, the `isinstance(x, dict)` / `is False` discrimination, and the `.get(key, default)` reads all match the existing `proactive_compression` precedent.

## Related Issues

<!-- none -->

## Documentation PR

Not applicable; no behavior change, construction is a superset of before.

## Type of Change

Other (please describe): internal refactor of config type representation (no behavior change; construction is backward compatible)

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

Ran the relevant checks (full `prepare` includes the multi-version test matrix):
- `hatch run test-lint` → ruff `All checks passed`; `mypy ./src` no issues in 188 source files
- `hatch run test-format` → all files formatted
- Full unit suite (`hatch test`) → **3602 passed**. No test changes were needed, call-form construction stays valid for TypedDicts.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.