### PR TITLE
test(memory): isolate KB search/add tool tests from auto-injection

### DIFF
--- a/strands-ts/test/integ/memory/bedrock-knowledge-base-memory-manager.test.node.ts
+++ b/strands-ts/test/integ/memory/bedrock-knowledge-base-memory-manager.test.node.ts
@@ -323,8 +323,9 @@ describe('BedrockKnowledgeBaseStore MemoryManager E2E', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // search_memory tool — explicit, model-driven retrieval. Injection off (default) so the only path
-  // to the fact is the tool.
+  // search_memory tool — explicit, model-driven retrieval. Injection is disabled so the only path to
+  // the fact is the tool: injection is on by default and would otherwise fold the seeded fact into
+  // the prompt, letting a correct answer bypass the tool.
   // ---------------------------------------------------------------------------
 
   describe.skipIf(shouldSkip())('search_memory tool', () => {
@@ -333,7 +334,7 @@ describe('BedrockKnowledgeBaseStore MemoryManager E2E', () => {
       const fact = doveFact()
       await seedFact(store, fact.text)
 
-      const memoryManager = new MemoryManager({ stores: [store] })
+      const memoryManager = new MemoryManager({ stores: [store], injection: false })
       const agent = new Agent({ model: bedrock.createModel({ maxTokens: 1024 }), memoryManager, printer: false })
       await forceToolOnce(agent, SEARCH_TOOL)
 
@@ -352,7 +353,7 @@ describe('BedrockKnowledgeBaseStore MemoryManager E2E', () => {
       const fact = doveFact()
       await seedFact(storeB, fact.text)
 
-      const memoryManager = new MemoryManager({ stores: [storeA, storeB] })
+      const memoryManager = new MemoryManager({ stores: [storeA, storeB], injection: false })
       const agent = new Agent({ model: bedrock.createModel({ maxTokens: 1024 }), memoryManager, printer: false })
       await forceToolOnce(agent, SEARCH_TOOL)
 
@@ -375,7 +376,12 @@ describe('BedrockKnowledgeBaseStore MemoryManager E2E', () => {
       const store = makeStore('integ-mm-add-tool')
       const ids = captureAddedIds(store)
 
-      const memoryManager = new MemoryManager({ stores: [store], addToolConfig: true, searchToolConfig: false })
+      const memoryManager = new MemoryManager({
+        stores: [store],
+        addToolConfig: true,
+        searchToolConfig: false,
+        injection: false,
+      })
       const agent = new Agent({ model: bedrock.createModel({ maxTokens: 1024 }), memoryManager, printer: false })
       await forceToolOnce(agent, ADD_TOOL)
 


### PR DESCRIPTION
## Description

The `BedrockKnowledgeBaseStore` MemoryManager integration tests for the `search_memory` and `add_memory` tools seed a fact, then assert the model surfaces it via the tool. But memory injection is **on by default**, so the seeded fact was also auto-folded into the prompt, letting a correct answer come from the injected context rather than the tool. That weakens the "only path is the tool" guarantee these tests are meant to provide.

The `search_memory` block comment also claimed injection was off "by default", which is not the manager's behavior (it defaults on).

This sets `injection: false` on those tests so the tool is genuinely the only path to the seeded fact, and corrects the comment. No change to the injection tests themselves, which already set `injection: true` explicitly.

```ts
// before — injection defaults on, so the seeded fact is also auto-injected:
const memoryManager = new MemoryManager({ stores: [store] })

// after — the tool is the only path to the fact:
const memoryManager = new MemoryManager({ stores: [store], injection: false })
```

## Related Issues

<!-- none -->

## Documentation PR

Not applicable; test-only change.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

These are TypeScript integration tests that require live AWS (a provisioned Bedrock Knowledge Base) and are not run locally. The change is confined to one `*.test.node.ts` file, sets a documented `MemoryManager` option (`injection: false`), and prettier-checks clean. CI runs the integration suite against pre-provisioned resources.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.