### PR TITLE
docs(context-management): document agentic context mode

### DIFF
--- a/site/src/content/docs/user-guide/concepts/context-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/context-management.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 As conversations grow, your agent's context window fills with messages, tool results, and system prompts. Without management, this leads to token limit errors, degraded performance, and loss of relevant information.
 
-The SDK provides several layers of context management that you can use independently or together.
+The SDK ships context management configurations that work out of the box, so you don't have to assemble conversation managers, offloaders, and thresholds by hand. Pick a mode and the SDK wires up the pieces with tuned defaults. You can still drop down to explicit configuration when you need it.
 
 ## Automatic context management
 
@@ -80,8 +80,62 @@ agent = Agent(
 </Tab>
 </Tabs>
 
-### Limitations
+## Agentic context management
 
-**Stateful models**: Stateful models manage conversation state server-side. Setting <Syntax py='context_manager="auto"' ts='contextManager: "auto"' /> with a stateful model raises a <Syntax py="ValueError" ts="Error" />.
+Auto mode compresses on a fixed threshold the SDK controls. Agentic mode hands that control to the model. Pass <Syntax py='context_manager="agentic"' ts='contextManager: "agentic"' /> and the model manages its own working memory: it sees how full the context window is and chooses when to compress, what to compress, and what to protect.
 
-The auto-composed offloader uses in-memory storage that does not persist across process restarts. If your agent uses session management and needs durable offloaded content, configure an explicit `ContextOffloader` with `FileStorage` or `S3Storage`. See [Storage Backends](./plugins/context-offloader#storage-backends).
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+
+agent = Agent(context_manager="agentic")
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/context-management_imports.ts:agentic_imports"
+
+--8<-- "user-guide/concepts/context-management.ts:agentic"
+```
+</Tab>
+</Tabs>
+
+The model is better positioned than a threshold to know which messages still matter. A coding agent can drop a stale file it already edited while pinning the failing test it is working toward. A threshold cannot tell the difference; it compresses by age. Agentic mode trades tokens for that judgment.
+
+### What it sets up
+
+Two things give the model the information and the levers to manage context.
+
+**Token-usage telemetry.** Before each model call, the SDK appends a status block to the latest message reporting how much of the window is in use:
+
+```
+<context-status>
+<used>50,000 / 200,000 tokens (25.0%)</used>
+<remaining>~150,000 tokens</remaining>
+</context-status>
+```
+
+This is the signal the model acts on. It decides whether the window is full enough to compress, instead of waiting for a fixed cutoff.
+
+**Three tools the model can call**, each a different lever with its own choices:
+
+- `summarize_context` folds older messages into a model-written summary. The model chooses how many recent messages to keep verbatim, how aggressively to summarize, and whether to target tool results, discussion, or both.
+- `truncate_context` drops older messages outright when they no longer need preserving. The model again chooses how much recent history to keep and what kind of messages to target.
+- `pin_context` marks messages that must survive compression: a user constraint, a key fact, the current task. Pinned messages are never evicted by either tool. The model can pin the current exchange, the last few messages, or specific ones.
+
+Recent messages stay verbatim regardless, and the first user message is always preserved so the conversation stays valid. New tools may be added to agentic mode in future releases.
+
+Behind the tools, agentic mode also composes a `SummarizingConversationManager` with no proactive compression and a `ContextOffloader`. The conversation manager is only a safety net: if the model lets the window overflow anyway, it compresses reactively. The offloader uses a higher inline threshold than auto mode (8,000 tokens versus 1,500), since the model is already managing context and benefits from seeing more tool output inline before it is offloaded.
+
+### Choosing between auto and agentic
+
+Use `"auto"` for most agents. It manages context in the background, with no model involvement and no extra tool calls. Reach for `"agentic"` when you want the model itself to decide what stays in context: it judges relevance per message rather than compressing on a fixed threshold. The tradeoff is the tokens the model spends reading telemetry and calling the tools.
+
+## Limitations
+
+**Stateful models**: Stateful models manage conversation state server-side. Setting <Syntax py="context_manager" ts="contextManager" /> to either mode with a stateful model raises a <Syntax py="ValueError" ts="Error" />.
+
+Both modes compose an offloader that uses in-memory storage, which does not persist across process restarts. If your agent uses session management and needs durable offloaded content, configure an explicit `ContextOffloader` with `FileStorage` or `S3Storage`. See [Storage Backends](./plugins/context-offloader#storage-backends).

--- a/site/src/content/docs/user-guide/concepts/context-management.ts
+++ b/site/src/content/docs/user-guide/concepts/context-management.ts
@@ -8,6 +8,14 @@ async function basic() {
   // --8<-- [end:basic]
 }
 
+async function agentic() {
+  // --8<-- [start:agentic]
+  const agent = new Agent({
+    contextManager: 'agentic',
+  })
+  // --8<-- [end:agentic]
+}
+
 async function customConversationManager() {
   // --8<-- [start:custom_conversation_manager]
   // Your conversation manager is used;

--- a/site/src/content/docs/user-guide/concepts/context-management_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/context-management_imports.ts
@@ -4,9 +4,10 @@
 import { Agent } from '@strands-agents/sdk'
 // --8<-- [end:basic_imports]
 
+// --8<-- [start:agentic_imports]
+import { Agent } from '@strands-agents/sdk'
+// --8<-- [end:agentic_imports]
+
 // --8<-- [start:custom_conversation_manager_imports]
-import {
-  Agent,
-  SlidingWindowConversationManager,
-} from '@strands-agents/sdk'
+import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
 // --8<-- [end:custom_conversation_manager_imports]


### PR DESCRIPTION
## Description

Documents the new `"agentic"` context-management mode on the Context Management page, alongside the existing `"auto"` mode, for both the Python and TypeScript SDKs.

Auto mode compresses conversation history on a fixed threshold the SDK controls. Agentic mode hands that control to the model: the SDK injects three context-management tools (`summarize_context`, `truncate_context`, `pin_context`) and appends a token-usage status block before each model call, so the model decides when to compress, what to compress, and what to protect. This is a meaningfully different mental model from auto, and it shipped without user-facing docs, so a reader had no way to discover the mode, the tools the model gets, or when to choose it over auto.

The new section follows the page's existing `"auto"` pattern: a short framing of the model-driven approach, a tabbed setup snippet, a "What it sets up" breakdown (telemetry, the three tools and the choices each gives the model, the reactive `SummarizingConversationManager` safety net, and the higher inline offload threshold), and a "Choosing between auto and agentic" guide framed around model-driven decision-making rather than specific task domains. The page intro is reframed around the out-of-the-box configurations, and "Limitations" is promoted to a shared top-level section since the stateful-model and in-memory-storage constraints apply to both modes.

Both SDKs ship this mode: the TypeScript implementation, and the Python port merged in #2808, which is a faithful port (identical tool names, parameters, status-block format, and constants). The documented surface matches both.

## Related Issues

Relates to #2808

## Documentation PR

This is the documentation. Changes are under `site/`.

## Type of Change

Documentation update

## Testing

Verified the doc content against the SDK source rather than runtime behavior:

- TypeScript snippets typecheck via `npm run typecheck:snippets` (the only failure is a pre-existing, unrelated `pino` import in `logs.ts`).
- TypeScript snippet files pass `prettier --check`.
- Every documented claim (tool names, parameters, the `<context-status>` block format, the 8,000 vs 1,500 offload thresholds, the `SummarizingConversationManager` safety net, and the stateful-model error) was checked against `strands-ts/src/conversation-manager/modes/agentic/agentic-context.ts`, `strands-ts/src/agent/agent.ts`, and the merged Python port (#2808).

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
