### PR TITLE
refactor(memory): represent ExtractionConfig as a TypedDict

### DIFF
--- a/strands-py/src/strands/memory/extraction/resolve_extraction_config.py
+++ b/strands-py/src/strands/memory/extraction/resolve_extraction_config.py
@@ -76,19 +76,20 @@ def _resolve_extraction_config(
     Returns:
         The resolved config, or ``None`` when extraction is disabled.
     """
-    if not extraction:
+    if extraction is None or extraction is False:
         return None
     config = ExtractionConfig() if extraction is True else extraction
 
+    config_trigger = config.get("trigger")
     triggers: list[ExtractionTrigger]
-    if config.trigger is None:
+    if config_trigger is None:
         triggers = [IntervalTrigger(turns=_DEFAULT_EXTRACTION_TRIGGER_TURNS)]
-    elif isinstance(config.trigger, list):
-        triggers = config.trigger
+    elif isinstance(config_trigger, list):
+        triggers = config_trigger
     else:
-        triggers = [config.trigger]
+        triggers = [config_trigger]
 
-    extractor = config.extractor
+    extractor = config.get("extractor")
     if extractor is None:
         # Pick the default extractor from the store's write methods:
         # - implements only ``add``: it cannot extract server-side, so default to a
@@ -102,5 +103,5 @@ def _resolve_extraction_config(
     return _ResolvedExtractionConfig(
         triggers=triggers,
         extractor=extractor,
-        filter=config.filter or DEFAULT_MEMORY_MESSAGE_FILTER,
+        filter=config.get("filter") or DEFAULT_MEMORY_MESSAGE_FILTER,
     )

--- a/strands-py/src/strands/memory/extraction/types.py
+++ b/strands-py/src/strands/memory/extraction/types.py
@@ -7,6 +7,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
+from typing_extensions import TypedDict
+
 from ...models.model import Model
 from ...types.content import Message
 
@@ -122,8 +124,7 @@ class ExtractionTrigger(ABC):
         ...
 
 
-@dataclass
-class ExtractionConfig:
+class ExtractionConfig(TypedDict, total=False):
     """Per-store automatic-extraction configuration.
 
     Attributes:
@@ -143,6 +144,6 @@ class ExtractionConfig:
             blocks.
     """
 
-    trigger: ExtractionTrigger | list[ExtractionTrigger] | None = None
-    extractor: Extractor | None = None
-    filter: MemoryMessageFilter | None = None
+    trigger: ExtractionTrigger | list[ExtractionTrigger] | None
+    extractor: Extractor | None
+    filter: MemoryMessageFilter | None


### PR DESCRIPTION
## Description

Follow-up to #2824. That PR converted the memory option bags to `TypedDict` but deliberately left `ExtractionConfig` for a separate change (it lives in the `memory/extraction/` subsystem). `ExtractionConfig` is the same kind of thing, a **passed-in option bag** (`trigger`, `extractor`, `filter`, all optional) provided via the `bool | ExtractionConfig` shorthand, so this converts it to a `TypedDict` for consistency and to let callers pass plain dict literals.

```python
# Still valid (call form):
ExtractionConfig(trigger=IntervalTrigger(turns=5))

# Now also valid and type-checked (dict literal):
{"trigger": IntervalTrigger(turns=5)}
```

Converted: `ExtractionConfig` → `TypedDict` (`total=False`). `_resolve_extraction_config` now reads its fields via `.get(...)`.

Left unchanged by design (not passed-in config bags):
- **`ExtractionResult`, `ExtractorContext`, `ExtractionTriggerContext`, `MemoryMessageFilter`** — returned / callback-context **value objects**.
- **`Extractor`, `ExtractionTrigger`** — a `Protocol` / `ABC` (behavior contracts).
- **`_ResolvedExtractionConfig`** — the internal resolved output `ExtractionConfig` is normalized into; a value object, not a passed-in config.

### Behavioral fix exposed by the conversion

`_resolve_extraction_config` gated disabled extraction with `if not extraction`. With `ExtractionConfig` now a dict, an **empty** config (`ExtractionConfig()` → `{}`) is falsy and would have been wrongly treated as disabled. The check now tests the disabled sentinels explicitly (`extraction is None or extraction is False`), so an empty config stays enabled (and resolves to the documented defaults). A unit test for this exact case (`test_defaults_an_omitted_trigger_to_interval_of_default_turns`) covers it.

## Related Issues

Follow-up to #2824.

## Documentation PR

Not applicable; no behavior change beyond the fix above, construction is a superset of before.

## Type of Change

Other (please describe): internal refactor of a config type's representation (construction is backward compatible; includes one falsiness-guard fix the conversion exposes)

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Ran the relevant checks (full `prepare` includes the multi-version test matrix):
- `hatch run test-lint` → ruff `All checks passed`; `mypy ./src` no issues in 194 source files
- `hatch run test-format` → all files formatted
- Full unit suite (`hatch test`) → **3668 passed**. No test changes were needed (call-form construction stays valid for TypedDicts); the empty-config path is covered by an existing test.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.