### PR TITLE
docs(cedar-authorization): add Python examples to Cedar docs page 

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -115,7 +115,7 @@ Pass your tool definitions to catch policy typos at construction time. The handl
 </Tab>
 </Tabs>
 
-Schema validation integrates with the [`cedar-for-agents`](https://github.com/cedar-policy/cedar-for-agents) ecosystem via `@cedar-policy/mcp-schema-generator-wasm` (TypeScript) and `cedar-mcp-schema-generator` (Python).
+Schema validation integrates with the [`cedar-for-agents`](https://github.com/cedar-policy/cedar-for-agents) ecosystem via `@cedar-policy/mcp-schema-generator-wasm` (TypeScript) and `cedar-policy-mcp-schema-generator` (Python).
 
 ## Environment gating
 
@@ -221,7 +221,7 @@ The <Syntax py="on_error" ts="onError" /> option controls behavior when Cedar ev
 pip install strands-agents[cedar]
 ```
 
-Requires `cedarpy` and `cedar-mcp-schema-generator` (installed automatically with the extra).
+Requires `cedarpy` and `cedar-policy-mcp-schema-generator` (installed automatically with the extra).
 </Tab>
 <Tab label="TypeScript">
 

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cedar Authorization
 description: "Control which tools an agent can invoke using Cedar policies. Enforce identity-aware access control, role-based permissions, and rate limits at the tool-call boundary."
-languages: [python, typescript]
 tags: [safety, interventions, tool-execution]
 sidebar:
   badge:

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -205,11 +205,13 @@ Every authorization request includes a structured context object:
 
 ## Error handling
 
-The <Syntax py="on_error" ts="onError" /> option controls behavior when Cedar evaluation itself fails (malformed context, engine errors):
+Cedar engine failures (malformed policies, evaluation errors) are always fail-closed: the tool call is denied regardless of configuration.
 
-- `'throw'` (default): raises the error to the caller
-- `'deny'`: treats evaluation failure as a denial (fail-closed)
-- `'proceed'`: allows the tool call despite the error (fail-open, use with caution)
+The <Syntax py="on_error" ts="onError" /> option controls what happens when your user-supplied callbacks (<Syntax py="principal_resolver" ts="principalResolver" /> or <Syntax py="context_enricher" ts="contextEnricher" />) raise an exception:
+
+- `'throw'` (default): re-raises the exception to the caller
+- `'deny'`: treats the callback failure as a denial (fail-closed)
+- `'proceed'`: allows the tool call despite the callback error (fail-open, use with caution)
 
 ## Installation
 

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cedar Authorization
 description: "Control which tools an agent can invoke using Cedar policies. Enforce identity-aware access control, role-based permissions, and rate limits at the tool-call boundary."
-languages: [typescript]
+languages: [python, typescript]
 tags: [safety, interventions, tool-execution]
 sidebar:
   badge:
@@ -9,7 +9,7 @@ sidebar:
     variant: tip
 ---
 
-Cedar Authorization evaluates [Cedar](https://cedarpolicy.com) policies before each tool call, giving you declarative, identity-aware access control over agent behavior. It ships as a vended intervention in the TypeScript SDK.
+Cedar Authorization evaluates [Cedar](https://cedarpolicy.com) policies before each tool call, giving you declarative, identity-aware access control over agent behavior. It ships as a vended intervention handler in both the Python and TypeScript SDKs.
 
 ## How it works
 
@@ -29,69 +29,135 @@ The design is fail-closed: if principal identity cannot be resolved, all tool ca
 
 Permit specific tools and deny everything else:
 
+<Tabs>
+<Tab label="Python">
+
+```python
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.py:basic_example"
+```
+</Tab>
+<Tab label="TypeScript">
+
 ```typescript
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:basic_example_imports"
 
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:basic_example"
 ```
+</Tab>
+</Tabs>
 
 Cedar uses default-deny semantics. Tools without a matching `permit` statement are automatically blocked.
 
 ## Role-based access control
 
-For multi-tenant agents where each request carries user identity, use `principalResolver` to extract the principal from `invocationState` and `contextEnricher` to forward role information into Cedar context:
+For multi-tenant agents where each request carries user identity, use <Syntax py="principal_resolver" ts="principalResolver" /> to extract the principal from <Syntax py="invocation_state" ts="invocationState" /> and <Syntax py="context_enricher" ts="contextEnricher" /> to forward role information into Cedar context:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.py:role_based"
+```
+</Tab>
+<Tab label="TypeScript">
 
 ```typescript
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:role_based_imports"
 
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:role_based"
 ```
+</Tab>
+</Tabs>
 
-When `principalResolver` returns `undefined` (no identity found), the handler denies all tool calls for that request.
+When <Syntax py="principal_resolver" ts="principalResolver" /> returns <Syntax py="None" ts="undefined" /> (no identity found), the handler denies all tool calls for that request.
 
 ## Rate limiting
 
 Cedar policies can reference `context.session.call_count`, which tracks how many times each tool has been invoked successfully during the session:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.py:rate_limit"
+```
+</Tab>
+<Tab label="TypeScript">
 
 ```typescript
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:rate_limit_imports"
 
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:rate_limit"
 ```
+</Tab>
+</Tabs>
 
-Call counts persist with the agent's `appState` and survive session reloads. Only successful tool calls increment the counter.
+Call counts persist with the agent's state and survive session reloads. Only successful tool calls increment the counter.
 
 ## Schema validation
 
-Pass your `tools` array to catch policy typos at construction time. The handler generates a Cedar schema from tool definitions and validates policies against it:
+Pass your tool definitions to catch policy typos at construction time. The handler generates a Cedar schema from tool definitions and validates policies against it:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.py:schema_validation"
+```
+</Tab>
+<Tab label="TypeScript">
 
 ```typescript
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:schema_validation_imports"
 
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:schema_validation"
 ```
+</Tab>
+</Tabs>
 
-Schema validation integrates with the [`cedar-for-agents`](https://github.com/cedar-policy/cedar-for-agents) ecosystem via `@cedar-policy/mcp-schema-generator-wasm`.
+Schema validation integrates with the [`cedar-for-agents`](https://github.com/cedar-policy/cedar-for-agents) ecosystem via `@cedar-policy/mcp-schema-generator-wasm` (TypeScript) and `cedar-mcp-schema-generator` (Python).
 
 ## Environment gating
 
-Block tools based on deployment context by forwarding environment metadata through `contextEnricher`:
+Block tools based on deployment context by forwarding environment metadata through <Syntax py="context_enricher" ts="contextEnricher" />:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.py:env_gating"
+```
+</Tab>
+<Tab label="TypeScript">
 
 ```typescript
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:env_gating_imports"
 
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:env_gating"
 ```
+</Tab>
+</Tabs>
 
 ## File-based policies
 
 For production deployments, keep policies in `.cedar` files rather than inline strings:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.py:file_policies"
+```
+</Tab>
+<Tab label="TypeScript">
 
 ```typescript
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:file_policies_imports"
 
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:file_policies"
 ```
+</Tab>
+</Tabs>
 
 The handler reads and parses files at construction time. Invalid syntax throws immediately.
 
@@ -99,11 +165,22 @@ The handler reads and parses files at construction time. Invalid syntax throws i
 
 Update policies without restarting your agent process:
 
+<Tabs>
+<Tab label="Python">
+
+```python
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.py:hot_reload"
+```
+</Tab>
+<Tab label="TypeScript">
+
 ```typescript
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:hot_reload_imports"
 
 --8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:hot_reload"
 ```
+</Tab>
+</Tabs>
 
 `reload()` reads fresh policy, entity, and schema files, validates them, and atomically swaps the active policy set. If validation fails, the previous policies remain in effect and the method throws.
 
@@ -125,15 +202,36 @@ Every authorization request includes a structured context object:
 - `context.input` contains the tool's input arguments, accessible in policies via `context.input.fieldName`
 - `context.session.hour_utc` is auto-populated with the current UTC hour (0-23)
 - `context.session.call_count` tracks per-tool invocation count
-- Additional `context.session` fields come from your `contextEnricher`
+- Additional `context.session` fields come from your <Syntax py="context_enricher" ts="contextEnricher" />
 
 ## Error handling
 
-The `onError` option controls behavior when Cedar evaluation itself fails (malformed context, WASM errors):
+The <Syntax py="on_error" ts="onError" /> option controls behavior when Cedar evaluation itself fails (malformed context, engine errors):
 
 - `'throw'` (default): raises the error to the caller
 - `'deny'`: treats evaluation failure as a denial (fail-closed)
 - `'proceed'`: allows the tool call despite the error (fail-open, use with caution)
+
+## Installation
+
+<Tabs>
+<Tab label="Python">
+
+```bash
+pip install strands-agents[cedar]
+```
+
+Requires `cedarpy` and `cedar-mcp-schema-generator` (installed automatically with the extra).
+</Tab>
+<Tab label="TypeScript">
+
+```bash
+npm install @strands-agents/sdk
+```
+
+Cedar support is included in the core package via `@cedar-policy/mcp-schema-generator-wasm`.
+</Tab>
+</Tabs>
 
 ## Cedar policy syntax
 

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.py
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.py
@@ -1,0 +1,319 @@
+from strands import Agent, tool
+from strands.vended_interventions.cedar import CedarAuthorization
+
+
+@tool
+def search(query: str) -> str:
+    """Search for information."""
+    return f"Results for: {query}"
+
+
+@tool
+def delete_record(record_id: str) -> str:
+    """Delete a record by ID."""
+    return f"Deleted {record_id}"
+
+
+@tool
+def send_email(to: str, body: str) -> str:
+    """Send an email."""
+    return f"Sent to {to}"
+
+
+@tool
+def deploy(version: str) -> str:
+    """Deploy the service."""
+    return f"Deployed {version}"
+
+
+def basic_example():
+    # --8<-- [start:basic_example]
+    from strands import Agent, tool
+    from strands.vended_interventions.cedar import (
+        CedarAuthorization,
+    )
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results for: {query}"
+
+    @tool
+    def delete_record(record_id: str) -> str:
+        """Delete a record by ID."""
+        return f"Deleted {record_id}"
+
+    cedar = CedarAuthorization(
+        policies=(
+            'permit(principal, action == Action::"search",'
+            " resource);"
+        ),
+    )
+
+    agent = Agent(
+        tools=[search, delete_record],
+        interventions=[cedar],
+    )
+
+    agent(
+        "Search for quarterly reports then delete record 42"
+    )
+    # search is permitted; delete_record is denied
+    # (no matching permit)
+    # --8<-- [end:basic_example]
+
+
+def role_based_example():
+    # --8<-- [start:role_based]
+    from strands import Agent, tool
+    from strands.vended_interventions.cedar import (
+        CedarAuthorization,
+    )
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results for: {query}"
+
+    @tool
+    def delete_record(record_id: str) -> str:
+        """Delete a record by ID."""
+        return f"Deleted {record_id}"
+
+    cedar = CedarAuthorization(
+        policies="""
+          permit(principal, action, resource)
+          when { context.session.role == "admin" };
+
+          permit(
+            principal,
+            action == Action::"search",
+            resource
+          )
+          when { context.session.role == "analyst" };
+        """,
+        principal_resolver=lambda state: (
+            {"type": "User", "id": state["user_id"]}
+            if state.get("user_id")
+            else None
+        ),
+        context_enricher=lambda ctx: {
+            "role": ctx["invocation_state"].get(
+                "role", "none"
+            ),
+        },
+    )
+
+    agent = Agent(
+        tools=[search, delete_record],
+        interventions=[cedar],
+    )
+
+    # admin can use any tool
+    agent(
+        "Delete record 42",
+        invocation_state={
+            "user_id": "alice",
+            "role": "admin",
+        },
+    )
+
+    # analyst can only search
+    agent(
+        "Delete record 42",
+        invocation_state={
+            "user_id": "bob",
+            "role": "analyst",
+        },
+    )
+    # denied: no permit for delete_record with "analyst"
+    # --8<-- [end:role_based]
+
+
+def rate_limit_example():
+    # --8<-- [start:rate_limit]
+    from strands import Agent, tool
+    from strands.vended_interventions.cedar import (
+        CedarAuthorization,
+    )
+
+    @tool
+    def send_email(to: str, body: str) -> str:
+        """Send an email."""
+        return f"Sent to {to}"
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results for: {query}"
+
+    cedar = CedarAuthorization(
+        policies="""
+          permit(
+            principal,
+            action == Action::"send_email",
+            resource
+          )
+          when { context.session.call_count < 5 };
+
+          permit(
+            principal,
+            action == Action::"search",
+            resource
+          );
+        """,
+    )
+
+    agent = Agent(
+        tools=[send_email, search],
+        interventions=[cedar],
+    )
+
+    # send_email permitted for calls 1-4, denied on 5th
+    # search is unlimited
+    # --8<-- [end:rate_limit]
+
+
+def schema_validation_example():
+    # --8<-- [start:schema_validation]
+    from strands.vended_interventions.cedar import (
+        CedarAuthorization,
+        ToolDefinition,
+    )
+
+    search_def: ToolDefinition = {
+        "name": "search",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"}
+            },
+        },
+    }
+
+    delete_def: ToolDefinition = {
+        "name": "delete_record",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "record_id": {"type": "string"}
+            },
+        },
+    }
+
+    cedar = CedarAuthorization(
+        policies="""
+          permit(
+            principal,
+            action == Action::"search",
+            resource
+          );
+          permit(
+            principal,
+            action == Action::"delete_record",
+            resource
+          )
+          when { context.session.role == "admin" };
+        """,
+        tools=[search_def, delete_def],
+        context_enricher=lambda ctx: {
+            "role": ctx["invocation_state"].get(
+                "role", "none"
+            ),
+        },
+    )
+    # If a policy references Action::"deleet_record"
+    # (typo), construction raises ValueError naming the
+    # unrecognized action
+    # --8<-- [end:schema_validation]
+
+
+def env_gating_example():
+    # --8<-- [start:env_gating]
+    from strands import Agent, tool
+    from strands.vended_interventions.cedar import (
+        CedarAuthorization,
+    )
+
+    @tool
+    def deploy(version: str) -> str:
+        """Deploy the service."""
+        return f"Deployed {version}"
+
+    cedar = CedarAuthorization(
+        policies="""
+          permit(
+            principal,
+            action == Action::"deploy",
+            resource
+          )
+          when {
+            context.session has environment &&
+            context.session.environment != "production"
+          };
+        """,
+        context_enricher=lambda ctx: {
+            "environment": ctx["invocation_state"].get(
+                "environment", "unknown"
+            ),
+        },
+    )
+
+    agent = Agent(
+        tools=[deploy],
+        interventions=[cedar],
+    )
+
+    # works in staging
+    agent(
+        "Deploy the service",
+        invocation_state={"environment": "staging"},
+    )
+
+    # denied in production
+    agent(
+        "Deploy the service",
+        invocation_state={"environment": "production"},
+    )
+    # --8<-- [end:env_gating]
+
+
+def file_policies_example():
+    # --8<-- [start:file_policies]
+    from strands.vended_interventions.cedar import (
+        CedarAuthorization,
+    )
+
+    cedar = CedarAuthorization(
+        policies="./policies/agent.cedar",
+        entities="./policies/entities.json",
+    )
+    # --8<-- [end:file_policies]
+
+
+def hot_reload_example():
+    # --8<-- [start:hot_reload]
+    from strands import Agent, tool
+    from strands.vended_interventions.cedar import (
+        CedarAuthorization,
+    )
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results for: {query}"
+
+    cedar = CedarAuthorization(
+        policies="./policies/agent.cedar",
+    )
+
+    agent = Agent(
+        tools=[search],
+        interventions=[cedar],
+    )
+
+    # After editing agent.cedar on disk:
+    cedar.reload()
+    # Validates new policies before applying.
+    # Raises ValueError if invalid.
+    # --8<-- [end:hot_reload]

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.py
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.py
@@ -201,6 +201,7 @@ def schema_validation_example():
         },
     }
 
+    # Valid policies pass schema validation
     cedar = CedarAuthorization(
         policies="""
           permit(
@@ -222,9 +223,14 @@ def schema_validation_example():
             ),
         },
     )
-    # If a policy references Action::"deleet_record"
-    # (typo), construction raises ValueError naming the
-    # unrecognized action
+
+    # A typo in the action name raises at construction:
+    # CedarAuthorization(
+    #     policies='permit(principal, action == Action::"deleet_record", resource);',
+    #     tools=[search_def, delete_def],
+    # )
+    # raises ValueError: Cedar policy validation failed:
+    #   unrecognized action "deleet_record"
     # --8<-- [end:schema_validation]
 
 

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
@@ -137,6 +137,7 @@ async function schemaValidationExample() {
     callback: (input) => `Deleted ${input.record_id}`,
   })
 
+  // Valid policies pass schema validation
   const cedar = new CedarAuthorization({
     policies: `
       permit(principal, action == Action::"search", resource);
@@ -148,8 +149,13 @@ async function schemaValidationExample() {
       role: String(invocationState.role ?? 'none'),
     }),
   })
-  // If a policy references Action::"deleet_record" (typo),
-  // construction throws a "Cedar policy validation failed" error naming the unrecognized action
+
+  // A typo in the action name throws at construction:
+  // new CedarAuthorization({
+  //   policies: 'permit(principal, action == Action::"deleet_record", resource);',
+  //   tools: [searchTool, deleteTool],
+  // })
+  // throws "Cedar policy validation failed: unrecognized action"
   // --8<-- [end:schema_validation]
 }
 


### PR DESCRIPTION
## Description

Adds Python SDK examples to the Cedar Authorization intervention handler docs page, reflecting the Python implementation added in #2802. 

Changes:
- Created `cedar-authorization.py` snippet file with Python examples for all sections (basic usage, role-based access control, rate limiting, schema validation, environment gating, file-based policies, hot reload)
- Rewrote `cedar-authorization.mdx` to use `<Tabs>/<Tab>` components showing both Python and TypeScript side-by-side
- Uses `<Syntax py="..." ts="..." />` for inline cross-language variable naming (e.g., `principal_resolver` vs `principalResolver`)
- Updated frontmatter from `languages: [typescript]` to `languages: [python, typescript]`
- Added an Installation section with language-specific install instructions

## Related Issues

- strands-agents/harness-sdk#2802 (Python Cedar authorization handler implementation)
- strands-agents/harness-sdk#2365 (original TypeScript Cedar authorization handler)

## Documentation PR

This PR *is* the documentation update for the Python Cedar authorization handler.

## Type of Change

Documentation update

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] Site builds successfully (`astro build` completes with no errors)
- [x] No broken links detected by `astro-broken-links-checker`
- [x] Python code examples verified against SDK source in PR #2802 (parameter names, types, import paths)
- [x] TypeScript snippet references all resolve to existing `[start:...]`/`[end:...]` pairs
- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.