### PR TITLE
feat(memory): add GraphitiMemoryStore vended memory backend

### DIFF
--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -58,6 +58,7 @@ sagemaker = [
     "openai>=1.68.0,<3.0.0",  # SageMaker uses OpenAI-compatible interface
 ]
 otel = ["opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0"]
+graphiti = ["graphiti-core>=0.3.0,<1.0.0"]
 docs = [
     "sphinx>=5.0.0,<10.0.0",
     "sphinx-rtd-theme>=1.0.0,<4.0.0",
@@ -221,6 +222,14 @@ exclude = ["src/strands/experimental/bidi"]
 [[tool.mypy.overrides]]
 module = ["strands.experimental.bidi.*"]
 follow_imports = "skip"
+
+# ``graphiti-core`` is an optional dependency (the ``graphiti`` extra) and is intentionally kept
+# out of the ``all`` group because it pulls a heavy backend stack (neo4j, openai, numpy, ...). It is
+# imported lazily in ``strands.memory.stores.graphiti``, so static analysis runs without it
+# installed; ignore the missing import rather than bloat the analysis environment.
+[[tool.mypy.overrides]]
+module = ["graphiti_core.*"]
+ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 120

--- a/strands-py/src/strands/memory/__init__.py
+++ b/strands-py/src/strands/memory/__init__.py
@@ -20,6 +20,7 @@ from .extraction.types import (
     MemoryMessageFilter,
 )
 from .memory_manager import MemoryManager
+from .stores import GraphitiMemoryStore
 from .types import (
     AddMessagesContext,
     InjectionFormatContext,
@@ -45,6 +46,7 @@ __all__ = [
     "ExtractionTriggerContext",
     "Extractor",
     "ExtractorContext",
+    "GraphitiMemoryStore",
     "InjectionConfig",
     "InjectionContext",
     "InjectionFormatContext",

--- a/strands-py/src/strands/memory/stores/__init__.py
+++ b/strands-py/src/strands/memory/stores/__init__.py
@@ -1,0 +1,18 @@
+"""Vended :class:`~strands.memory.types.MemoryStore` backends for Strands Agents.
+
+Each store here is an optional, self-contained implementation of the
+:class:`~strands.memory.types.MemoryStore` Protocol that a
+:class:`~strands.memory.memory_manager.MemoryManager` can manage. Stores that
+depend on a third-party backend pull it from an ``extras`` group and import it
+lazily, so importing this subpackage never requires the optional dependency to
+be installed.
+
+Example:
+    ```python
+    from strands.memory.stores import GraphitiMemoryStore
+    ```
+"""
+
+from .graphiti import GraphitiMemoryStore
+
+__all__ = ["GraphitiMemoryStore"]

--- a/strands-py/src/strands/memory/stores/graphiti.py
+++ b/strands-py/src/strands/memory/stores/graphiti.py
@@ -1,0 +1,381 @@
+"""A :class:`~strands.memory.types.MemoryStore` backed by Graphiti.
+
+`Graphiti <https://github.com/getzep/graphiti>`_ (by Zep, Apache-2.0) is a
+temporal knowledge-graph library purpose-built for agent memory. It ingests
+discrete *episodes* and extracts a bi-temporal graph of entities and
+relationships server-side, then answers hybrid (semantic + keyword + graph)
+queries over them.
+
+This store maps the :class:`~strands.memory.types.MemoryStore` contract onto
+Graphiti's client:
+
+- :meth:`GraphitiMemoryStore.search` -> ``Graphiti.search`` (hybrid retrieval),
+  returning one :class:`~strands.memory.types.MemoryEntry` per retrieved
+  ``EntityEdge``. The edge's ``fact`` becomes the entry content, and its
+  identifiers and bi-temporal timestamps are surfaced in ``metadata``.
+- :meth:`GraphitiMemoryStore.add` -> ``Graphiti.add_episode`` (a ``text``
+  episode) for single-fact writes from the ``add_memory`` tool, programmatic
+  ``MemoryManager.add``, or a client-side extractor.
+- :meth:`GraphitiMemoryStore.add_messages` -> ``Graphiti.add_episode`` (a
+  ``message`` episode) for server-side extraction: the manager hands a raw
+  message batch straight to Graphiti, which extracts it with no extra model
+  call.
+
+``graphiti-core`` is an optional dependency. It is imported lazily so importing
+this module never requires it; a missing install raises a clear
+:class:`ImportError` only when a write is attempted. The store accepts an
+already-configured ``Graphiti`` client, so the choice of graph backend (Neo4j,
+FalkorDB, Kuzu, ...) is the caller's and no database is needed to construct or
+unit-test the store.
+
+Example:
+    ```python
+    from graphiti_core import Graphiti
+    from strands import Agent
+    from strands.memory import MemoryManager
+    from strands.memory.stores import GraphitiMemoryStore
+
+    client = Graphiti("bolt://localhost:7687", "neo4j", "password")
+    await client.build_indices_and_constraints()
+
+    store = GraphitiMemoryStore(client=client, name="graph", writable=True)
+    agent = Agent(memory_manager=MemoryManager(stores=[store]))
+    ```
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from ..types import AddMessagesContext, MemoryEntry, Metadata, SearchOptions
+
+if TYPE_CHECKING:
+    from ...types.content import Message
+    from ..extraction.types import ExtractionConfig
+
+logger = logging.getLogger(__name__)
+
+# Graphiti's own default page size for ``search``; used when neither the caller nor the store
+# specifies one.
+DEFAULT_MAX_SEARCH_RESULTS = 10
+
+# Shown when ``graphiti-core`` is not installed but a write is attempted.
+_GRAPHITI_IMPORT_ERROR = (
+    "GraphitiMemoryStore requires the 'graphiti-core' package, which is not installed. "
+    "Install it with: pip install 'strands-agents[graphiti]' (or: pip install graphiti-core). "
+    "Graphiti pairs with a graph backend such as Neo4j, FalkorDB, or Kuzu."
+)
+
+# Metadata keys that parameterize the Graphiti episode on a write rather than being stored as
+# opaque payload (``add_episode`` takes no free-form metadata map).
+_EPISODE_NAME_KEY = "name"
+_SOURCE_DESCRIPTION_KEY = "source_description"
+_REFERENCE_TIME_KEY = "reference_time"
+_GROUP_ID_KEY = "group_id"
+
+
+def _resolve_episode_type(source: str) -> Any:
+    """Resolve a Graphiti ``EpisodeType`` member by name, importing ``graphiti-core`` lazily.
+
+    Args:
+        source: The ``EpisodeType`` member name (e.g. ``"text"`` or ``"message"``).
+
+    Returns:
+        The matching ``EpisodeType`` member.
+
+    Raises:
+        ImportError: If ``graphiti-core`` is not installed.
+    """
+    try:
+        from graphiti_core.nodes import EpisodeType
+    except ImportError as error:
+        raise ImportError(_GRAPHITI_IMPORT_ERROR) from error
+    return EpisodeType[source]
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    """Render a datetime as an ISO 8601 string for JSON-compatible metadata, or ``None``."""
+    return value.isoformat() if value is not None else None
+
+
+class GraphitiMemoryStore:
+    """A :class:`~strands.memory.types.MemoryStore` backed by a Graphiti temporal knowledge graph.
+
+    Wraps an already-configured ``graphiti_core.Graphiti`` client. Searches map to Graphiti's
+    hybrid retrieval and writes map to ``add_episode``. The store is namespaced by an optional
+    ``group_id`` (Graphiti's tenancy primitive): it scopes every search and stamps every write,
+    so one client can back many isolated stores.
+
+    Attributes:
+        name: Unique identifier for this store, used to target it in tools.
+        description: Human-readable description; included in tool descriptions.
+        max_search_results: Default maximum results per search.
+        writable: Whether this store accepts writes.
+        extraction: Resolved automatic-extraction configuration, or ``None``/``False`` when off.
+    """
+
+    name: str
+    description: str | None
+    max_search_results: int | None
+    writable: bool
+    extraction: ExtractionConfig | bool | None
+
+    def __init__(
+        self,
+        *,
+        client: Any,
+        name: str,
+        description: str | None = None,
+        max_search_results: int | None = None,
+        writable: bool = False,
+        extraction: ExtractionConfig | bool | None = None,
+        group_id: str | None = None,
+        source_description: str = "strands-agent-memory",
+    ) -> None:
+        """Initialize the store.
+
+        Args:
+            client: A configured ``graphiti_core.Graphiti`` instance. The store never constructs
+                one itself, so the graph backend (Neo4j, FalkorDB, Kuzu, ...) and any LLM/embedder
+                clients are the caller's to wire up. Typed as ``Any`` so importing this module does
+                not require ``graphiti-core``.
+            name: Unique identifier for this store, used to target it in tools.
+            description: Human-readable description; included in tool descriptions.
+            max_search_results: Default maximum results per search. Must be at least 1 when set.
+            writable: Whether this store accepts writes. A writable store exposes ``add`` and
+                ``add_messages``.
+            extraction: Automatic-extraction configuration for this writable store. Because the
+                store implements ``add_messages``, the default (``True``) extracts server-side:
+                Graphiti receives the raw messages and extracts them with no extra model call.
+            group_id: Graphiti group identifier used to namespace this store. Scopes every search
+                and is stamped on every write, isolating this store's episodes from others sharing
+                the same client. Omit for Graphiti's default group.
+            source_description: Default ``source_description`` stamped on episodes written by this
+                store. A per-write ``metadata['source_description']`` overrides it.
+
+        Raises:
+            ValueError: If ``max_search_results`` is set below 1.
+        """
+        if max_search_results is not None and max_search_results < 1:
+            raise ValueError("GraphitiMemoryStore: max_search_results must be at least 1")
+
+        self.name = name
+        self.description = description
+        self.max_search_results = max_search_results
+        self.writable = writable
+        self.extraction = extraction
+
+        self._client = client
+        # An empty group id is meaningless to Graphiti (it would scope to a nonexistent group on
+        # search and pin episodes to a "" group on write), so normalize it to "unscoped".
+        self._group_id = group_id or None
+        self._source_description = source_description
+
+    async def search(self, query: str, options: SearchOptions | None = None) -> list[MemoryEntry]:
+        """Search the graph for facts matching the query, ordered by relevance.
+
+        Delegates to ``Graphiti.search`` (hybrid semantic + keyword + graph retrieval) and maps
+        each returned ``EntityEdge`` to a :class:`~strands.memory.types.MemoryEntry`. The edge's
+        ``fact`` becomes the entry content; its identifiers and bi-temporal timestamps are surfaced
+        in ``metadata`` so callers can attribute and weigh each fact:
+
+        - ``uuid``, ``name``, ``group_id``, ``source_node_uuid``, ``target_node_uuid``,
+          ``episodes`` — graph identifiers.
+        - ``created_at`` / ``expired_at`` — *transaction time*: when the fact was recorded and,
+          if superseded, retracted.
+        - ``valid_at`` / ``invalid_at`` — *valid time*: when the fact became and ceased to be true
+          in the world.
+
+        Only present (non-``None``) keys are included. Timestamps are rendered as ISO 8601 strings.
+
+        Args:
+            query: What to search for.
+            options: Optional search configuration. ``max_search_results`` caps the results,
+                falling back to the store's ``max_search_results`` and then
+                :data:`DEFAULT_MAX_SEARCH_RESULTS`.
+
+        Returns:
+            Matching memory entries ordered by relevance.
+
+        Raises:
+            ValueError: If ``options['max_search_results']`` is set below 1.
+        """
+        caller_max = options.get("max_search_results") if options is not None else None
+        if caller_max is not None and caller_max < 1:
+            raise ValueError("GraphitiMemoryStore: max_search_results must be at least 1")
+
+        limit = (
+            caller_max
+            if caller_max is not None
+            else self.max_search_results
+            if self.max_search_results is not None
+            else DEFAULT_MAX_SEARCH_RESULTS
+        )
+        group_ids = [self._group_id] if self._group_id is not None else None
+
+        logger.debug(
+            "store=<%s>, group_id=<%s>, num_results=<%s> | searching graphiti",
+            self.name,
+            self._group_id,
+            limit,
+        )
+
+        edges = await self._client.search(query, group_ids=group_ids, num_results=limit)
+
+        entries = [MemoryEntry(content=edge.fact, metadata=self._edge_metadata(edge)) for edge in edges]
+        logger.debug("store=<%s>, results=<%d> | graphiti search complete", self.name, len(entries))
+        return entries
+
+    async def add(self, content: str, metadata: Metadata | None = None) -> Any:
+        """Add a single fact to the graph as a ``text`` episode.
+
+        Wraps ``Graphiti.add_episode``, which extracts entities and relationships from ``content``
+        server-side. Used by the ``add_memory`` tool, programmatic ``MemoryManager.add``, and any
+        client-side extractor. ``add_episode`` is idempotent on a stable ``metadata['uuid']``, so
+        the at-least-once extraction path tolerates duplicate writes when one is supplied.
+
+        Args:
+            content: The fact to store. Must not be empty.
+            metadata: Optional episode parameters. Recognized keys: ``name`` (episode name),
+                ``source_description`` (overrides the store default), ``reference_time`` (a
+                ``datetime`` or ISO 8601 string; defaults to now in UTC), ``group_id`` (overrides
+                the store's namespace), and ``uuid`` (a stable id for idempotent writes). Other
+                keys are ignored, since ``add_episode`` takes no free-form metadata map.
+
+        Returns:
+            The Graphiti ``AddEpisodeResults`` (store-specific; not consumed by the manager).
+
+        Raises:
+            ImportError: If ``graphiti-core`` is not installed.
+            ValueError: If the store is not writable or ``content`` is empty.
+        """
+        return await self._add_episode(content, source="text", metadata=metadata)
+
+    async def add_messages(self, messages: list[Message], context: AddMessagesContext | None = None) -> Any:
+        """Ingest a batch of conversation messages as a single ``message`` episode.
+
+        The server-side extraction sink: the manager hands the filtered batch here and Graphiti
+        extracts it into the graph with no extra model call. Messages are serialized to a
+        ``role: text`` transcript preserving turn order, then written via ``Graphiti.add_episode``
+        as a ``message`` episode.
+
+        Args:
+            messages: The conversation messages to ingest.
+            context: Manager-supplied context (currently unused).
+
+        Returns:
+            The Graphiti ``AddEpisodeResults`` (store-specific; not consumed by the manager), or
+            ``None`` when ``messages`` has no text to ingest.
+
+        Raises:
+            ImportError: If ``graphiti-core`` is not installed.
+            ValueError: If the store is not writable.
+        """
+        transcript = self._serialize_messages(messages)
+        if not transcript:
+            logger.debug("store=<%s> | no text in message batch | skipping graphiti write", self.name)
+            return None
+        return await self._add_episode(transcript, source="message", metadata=None)
+
+    async def _add_episode(self, body: str, *, source: str, metadata: Metadata | None) -> Any:
+        """Write one episode to Graphiti, resolving episode parameters from ``metadata``.
+
+        Args:
+            body: The episode body to ingest.
+            source: The ``EpisodeType`` member name (``"text"`` or ``"message"``).
+            metadata: Optional episode parameters; see :meth:`add`.
+
+        Returns:
+            The Graphiti ``AddEpisodeResults``.
+
+        Raises:
+            ImportError: If ``graphiti-core`` is not installed.
+            ValueError: If the store is not writable or ``body`` is empty.
+        """
+        if not self.writable:
+            raise ValueError(f"GraphitiMemoryStore: store '{self.name}' is not writable")
+        if not body.strip():
+            raise ValueError("GraphitiMemoryStore: content must not be empty")
+
+        metadata = metadata or {}
+        episode_type = _resolve_episode_type(source)
+        name = str(metadata.get(_EPISODE_NAME_KEY, f"{self.name} {source} episode"))
+        source_description = str(metadata.get(_SOURCE_DESCRIPTION_KEY, self._source_description))
+        reference_time = self._resolve_reference_time(metadata.get(_REFERENCE_TIME_KEY))
+        # Truthiness, not ``is not None``: an empty group id is meaningless to Graphiti, so fall
+        # back to the store's namespace rather than pinning the episode to a "" group.
+        group_id = metadata.get(_GROUP_ID_KEY) or self._group_id
+        uuid = metadata.get("uuid")
+
+        kwargs: dict[str, Any] = {
+            "name": name,
+            "episode_body": body,
+            "source_description": source_description,
+            "reference_time": reference_time,
+            "source": episode_type,
+        }
+        if group_id is not None:
+            kwargs["group_id"] = group_id
+        if uuid is not None:
+            kwargs["uuid"] = uuid
+
+        logger.debug(
+            "store=<%s>, group_id=<%s>, source=<%s> | adding graphiti episode",
+            self.name,
+            group_id,
+            source,
+        )
+        return await self._client.add_episode(**kwargs)
+
+    def _edge_metadata(self, edge: Any) -> Metadata:
+        """Build a JSON-compatible metadata mapping from a Graphiti ``EntityEdge``.
+
+        Surfaces graph identifiers and the bi-temporal timestamps, dropping ``None`` values and
+        rendering datetimes as ISO 8601 strings.
+        """
+        candidates: Metadata = {
+            "uuid": getattr(edge, "uuid", None),
+            "name": getattr(edge, "name", None),
+            "group_id": getattr(edge, "group_id", None),
+            "source_node_uuid": getattr(edge, "source_node_uuid", None),
+            "target_node_uuid": getattr(edge, "target_node_uuid", None),
+            "episodes": getattr(edge, "episodes", None),
+            "created_at": _isoformat(getattr(edge, "created_at", None)),
+            "expired_at": _isoformat(getattr(edge, "expired_at", None)),
+            "valid_at": _isoformat(getattr(edge, "valid_at", None)),
+            "invalid_at": _isoformat(getattr(edge, "invalid_at", None)),
+        }
+        return {key: value for key, value in candidates.items() if value is not None}
+
+    def _resolve_reference_time(self, value: Any) -> datetime:
+        """Resolve a reference time from metadata into a tz-aware UTC ``datetime``.
+
+        Graphiti's bi-temporal layer works in timezone-aware UTC, so a naive datetime (a bare
+        ``datetime`` or an ISO string without an offset) is treated as UTC and made aware; an aware
+        value is converted to UTC. Defaults to now in UTC when unset.
+        """
+        if isinstance(value, datetime):
+            resolved = value
+        elif isinstance(value, str):
+            resolved = datetime.fromisoformat(value)
+        else:
+            return datetime.now(timezone.utc)
+
+        if resolved.tzinfo is None:
+            return resolved.replace(tzinfo=timezone.utc)
+        return resolved.astimezone(timezone.utc)
+
+    @staticmethod
+    def _serialize_messages(messages: list[Message]) -> str:
+        """Serialize messages into a ``role: text`` transcript, preserving turn order.
+
+        Only text content blocks are included; messages with no text are skipped.
+        """
+        lines: list[str] = []
+        for message in messages:
+            text = "\n".join(block["text"] for block in message["content"] if "text" in block).strip()
+            if text:
+                lines.append(f"{message['role']}: {text}")
+        return "\n".join(lines)

--- a/strands-py/tests/strands/memory/stores/__init__.py
+++ b/strands-py/tests/strands/memory/stores/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for vended memory stores."""

--- a/strands-py/tests/strands/memory/stores/test_graphiti.py
+++ b/strands-py/tests/strands/memory/stores/test_graphiti.py
@@ -1,0 +1,570 @@
+"""Tests for :class:`~strands.memory.stores.graphiti.GraphitiMemoryStore`.
+
+Graphiti is an optional dependency that is not installed in the unit-test
+environment, so these tests never import ``graphiti-core``. Instead they:
+
+- mock the ``Graphiti`` client (an :class:`~unittest.mock.AsyncMock` whose
+  ``search`` / ``add_episode`` are programmed and inspected), so no graph
+  database is required; and
+- install a fake ``graphiti_core.nodes`` module (carrying an ``EpisodeType``
+  enum) for the writes that resolve the episode type lazily, and assert the bare
+  :class:`ImportError` path when that module is absent.
+
+Search results are faked as ``EntityEdge``-shaped objects
+(:func:`_edge`) carrying the ``fact`` and the bi-temporal timestamps the store
+maps into entry metadata.
+"""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from datetime import datetime, timezone
+from enum import Enum
+from types import ModuleType, SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from strands.memory import GraphitiMemoryStore as ExportedGraphitiMemoryStore
+from strands.memory.memory_manager import MemoryManager
+from strands.memory.stores.graphiti import (
+    DEFAULT_MAX_SEARCH_RESULTS,
+    GraphitiMemoryStore,
+)
+from strands.memory.types import (
+    MemoryEntry,
+    MemorySearchOptions,
+    SearchOptions,
+    _has_method,
+    _has_write_sink,
+)
+
+# --------------------------------------------------------------------------- #
+# Test fakes / helpers
+# --------------------------------------------------------------------------- #
+
+
+class _FakeEpisodeType(Enum):
+    """Stand-in for ``graphiti_core.nodes.EpisodeType`` keyed by member name."""
+
+    message = "message"
+    json = "json"
+    text = "text"
+
+
+@pytest.fixture
+def fake_graphiti_nodes() -> Any:
+    """Install a fake ``graphiti_core.nodes`` module exposing ``EpisodeType``.
+
+    The store imports ``graphiti_core.nodes`` lazily on a write; without the real package installed
+    the import would fail, so we inject a minimal stand-in for the duration of a test.
+    """
+    package = ModuleType("graphiti_core")
+    nodes = ModuleType("graphiti_core.nodes")
+    nodes.EpisodeType = _FakeEpisodeType  # type: ignore[attr-defined]
+    package.nodes = nodes  # type: ignore[attr-defined]
+
+    sys.modules["graphiti_core"] = package
+    sys.modules["graphiti_core.nodes"] = nodes
+    try:
+        yield nodes
+    finally:
+        sys.modules.pop("graphiti_core.nodes", None)
+        sys.modules.pop("graphiti_core", None)
+
+
+def _edge(
+    *,
+    fact: str,
+    uuid: str = "edge-uuid",
+    name: str = "RELATES_TO",
+    group_id: str = "g1",
+    source_node_uuid: str = "src",
+    target_node_uuid: str = "tgt",
+    episodes: list[str] | None = None,
+    created_at: datetime | None = None,
+    expired_at: datetime | None = None,
+    valid_at: datetime | None = None,
+    invalid_at: datetime | None = None,
+) -> SimpleNamespace:
+    """Build a fake Graphiti ``EntityEdge`` carrying ``fact`` and bi-temporal timestamps."""
+    return SimpleNamespace(
+        fact=fact,
+        uuid=uuid,
+        name=name,
+        group_id=group_id,
+        source_node_uuid=source_node_uuid,
+        target_node_uuid=target_node_uuid,
+        episodes=episodes if episodes is not None else ["ep-1"],
+        created_at=created_at,
+        expired_at=expired_at,
+        valid_at=valid_at,
+        invalid_at=invalid_at,
+    )
+
+
+def _client(*, search_result: list[Any] | None = None, add_result: Any = None) -> AsyncMock:
+    """Build a mock ``Graphiti`` client with programmed ``search`` / ``add_episode``."""
+    client = AsyncMock()
+    client.search = AsyncMock(return_value=search_result if search_result is not None else [])
+    client.add_episode = AsyncMock(return_value=add_result if add_result is not None else SimpleNamespace())
+    return client
+
+
+def _store(client: AsyncMock | None = None, **kwargs: Any) -> GraphitiMemoryStore:
+    """Build a store with sensible defaults over a mock client."""
+    params: dict[str, Any] = {"name": "graph", "writable": True}
+    params.update(kwargs)
+    return GraphitiMemoryStore(client=client if client is not None else _client(), **params)
+
+
+# --------------------------------------------------------------------------- #
+# Construction / identity
+# --------------------------------------------------------------------------- #
+
+
+def test_exposes_config_fields_as_attributes() -> None:
+    store = GraphitiMemoryStore(
+        client=_client(),
+        name="graph",
+        description="a graph",
+        max_search_results=7,
+        writable=True,
+        extraction=True,
+    )
+
+    assert store.name == "graph"
+    assert store.description == "a graph"
+    assert store.max_search_results == 7
+    assert store.writable is True
+    assert store.extraction is True
+
+
+def test_defaults_are_read_only_and_unconfigured() -> None:
+    store = GraphitiMemoryStore(client=_client(), name="graph")
+
+    assert store.writable is False
+    assert store.description is None
+    assert store.max_search_results is None
+    assert store.extraction is None
+
+
+def test_rejects_non_positive_max_search_results() -> None:
+    with pytest.raises(ValueError, match="at least 1"):
+        GraphitiMemoryStore(client=_client(), name="graph", max_search_results=0)
+
+
+def test_exported_from_memory_package() -> None:
+    assert ExportedGraphitiMemoryStore is GraphitiMemoryStore
+
+
+# --------------------------------------------------------------------------- #
+# Optional-method detection (Protocol conformance)
+# --------------------------------------------------------------------------- #
+
+
+def test_detects_write_sinks_via_has_method() -> None:
+    store = _store()
+
+    # ``_has_method`` inspects ``type(store)``; concrete methods (not the Protocol stubs) count.
+    assert _has_method(store, "add") is True
+    assert _has_method(store, "add_messages") is True
+    assert _has_write_sink(store) is True
+    # ``get_tools`` is intentionally not implemented, so the manager won't call it.
+    assert _has_method(store, "get_tools") is False
+
+
+# --------------------------------------------------------------------------- #
+# search
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_search_maps_edges_to_entries() -> None:
+    client = _client(search_result=[_edge(fact="user prefers dark mode"), _edge(fact="user is in Berlin")])
+    store = _store(client)
+
+    entries = await store.search("preferences")
+
+    assert [entry.content for entry in entries] == ["user prefers dark mode", "user is in Berlin"]
+    assert all(isinstance(entry, MemoryEntry) for entry in entries)
+
+
+@pytest.mark.asyncio
+async def test_search_surfaces_identifiers_and_bitemporal_metadata() -> None:
+    created = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    valid = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+    client = _client(
+        search_result=[
+            _edge(
+                fact="user moved to Berlin",
+                uuid="e1",
+                name="MOVED_TO",
+                group_id="tenant-a",
+                source_node_uuid="user",
+                target_node_uuid="berlin",
+                episodes=["ep-9"],
+                created_at=created,
+                valid_at=valid,
+            )
+        ]
+    )
+    store = _store(client)
+
+    [entry] = await store.search("where does the user live")
+
+    assert entry.metadata == {
+        "uuid": "e1",
+        "name": "MOVED_TO",
+        "group_id": "tenant-a",
+        "source_node_uuid": "user",
+        "target_node_uuid": "berlin",
+        "episodes": ["ep-9"],
+        "created_at": created.isoformat(),
+        "valid_at": valid.isoformat(),
+    }
+    # ``None`` timestamps (expired_at / invalid_at here) are dropped, not rendered.
+    assert "expired_at" not in entry.metadata
+    assert "invalid_at" not in entry.metadata
+
+
+@pytest.mark.asyncio
+async def test_search_does_not_set_store_name() -> None:
+    # Attribution is the manager's job; the store leaves ``store_name`` unset.
+    client = _client(search_result=[_edge(fact="x")])
+    store = _store(client)
+
+    [entry] = await store.search("q")
+
+    assert entry.store_name is None
+
+
+@pytest.mark.asyncio
+async def test_search_uses_default_limit_when_unspecified() -> None:
+    client = _client()
+    store = _store(client, max_search_results=None)
+
+    await store.search("q")
+
+    _, kwargs = client.search.call_args
+    assert kwargs["num_results"] == DEFAULT_MAX_SEARCH_RESULTS
+
+
+@pytest.mark.asyncio
+async def test_search_uses_store_default_limit() -> None:
+    client = _client()
+    store = _store(client, max_search_results=5)
+
+    await store.search("q")
+
+    _, kwargs = client.search.call_args
+    assert kwargs["num_results"] == 5
+
+
+@pytest.mark.asyncio
+async def test_search_caller_limit_overrides_store_default() -> None:
+    client = _client()
+    store = _store(client, max_search_results=5)
+
+    await store.search("q", SearchOptions(max_search_results=2))
+
+    _, kwargs = client.search.call_args
+    assert kwargs["num_results"] == 2
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_non_positive_caller_limit() -> None:
+    store = _store()
+
+    with pytest.raises(ValueError, match="at least 1"):
+        await store.search("q", SearchOptions(max_search_results=0))
+
+
+@pytest.mark.asyncio
+async def test_search_scopes_by_group_id() -> None:
+    client = _client()
+    store = _store(client, group_id="tenant-a")
+
+    await store.search("q")
+
+    _, kwargs = client.search.call_args
+    assert kwargs["group_ids"] == ["tenant-a"]
+
+
+@pytest.mark.asyncio
+async def test_search_omits_group_ids_when_unscoped() -> None:
+    client = _client()
+    store = _store(client, group_id=None)
+
+    await store.search("q")
+
+    _, kwargs = client.search.call_args
+    assert kwargs["group_ids"] is None
+
+
+@pytest.mark.asyncio
+async def test_search_treats_empty_group_id_as_unscoped() -> None:
+    # An empty group id would scope search to a nonexistent group; normalize it to unscoped.
+    client = _client()
+    store = _store(client, group_id="")
+
+    await store.search("q")
+
+    _, kwargs = client.search.call_args
+    assert kwargs["group_ids"] is None
+
+
+@pytest.mark.asyncio
+async def test_search_passes_query_positionally() -> None:
+    client = _client()
+    store = _store(client)
+
+    await store.search("find this")
+
+    args, _ = client.search.call_args
+    assert args[0] == "find this"
+
+
+# --------------------------------------------------------------------------- #
+# add
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_add_writes_text_episode(fake_graphiti_nodes: Any) -> None:
+    result = SimpleNamespace(episode="ok")
+    client = _client(add_result=result)
+    store = _store(client, group_id="tenant-a")
+
+    returned = await store.add("user prefers dark mode")
+
+    assert returned is result
+    _, kwargs = client.add_episode.call_args
+    assert kwargs["episode_body"] == "user prefers dark mode"
+    assert kwargs["source"] is _FakeEpisodeType.text
+    assert kwargs["group_id"] == "tenant-a"
+    assert isinstance(kwargs["reference_time"], datetime)
+    assert kwargs["source_description"] == "strands-agent-memory"
+
+
+@pytest.mark.asyncio
+async def test_add_honours_metadata_episode_parameters(fake_graphiti_nodes: Any) -> None:
+    client = _client()
+    store = _store(client, group_id="tenant-a")
+    reference = datetime(2026, 5, 1, 9, 30, tzinfo=timezone.utc)
+
+    await store.add(
+        "fact",
+        metadata={
+            "name": "custom-name",
+            "source_description": "import job",
+            "reference_time": reference,
+            "group_id": "tenant-b",
+            "uuid": "stable-id",
+            "ignored": "dropped",
+        },
+    )
+
+    _, kwargs = client.add_episode.call_args
+    assert kwargs["name"] == "custom-name"
+    assert kwargs["source_description"] == "import job"
+    assert kwargs["reference_time"] == reference
+    assert kwargs["group_id"] == "tenant-b"  # per-write override beats the store namespace
+    assert kwargs["uuid"] == "stable-id"
+    assert "ignored" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_add_accepts_iso_reference_time(fake_graphiti_nodes: Any) -> None:
+    client = _client()
+    store = _store(client)
+
+    await store.add("fact", metadata={"reference_time": "2026-05-01T09:30:00+00:00"})
+
+    _, kwargs = client.add_episode.call_args
+    assert kwargs["reference_time"] == datetime(2026, 5, 1, 9, 30, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_add_makes_naive_reference_time_utc_aware(fake_graphiti_nodes: Any) -> None:
+    # Graphiti's bi-temporal layer compares against tz-aware UTC, so a naive input must be made
+    # aware (interpreted as UTC) rather than passed through naive.
+    client = _client()
+    store = _store(client)
+
+    await store.add("fact", metadata={"reference_time": datetime(2026, 5, 1, 9, 30)})
+
+    _, kwargs = client.add_episode.call_args
+    assert kwargs["reference_time"] == datetime(2026, 5, 1, 9, 30, tzinfo=timezone.utc)
+    assert kwargs["reference_time"].tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_add_converts_aware_reference_time_to_utc(fake_graphiti_nodes: Any) -> None:
+    from datetime import timedelta
+
+    client = _client()
+    store = _store(client)
+    plus_two = timezone(timedelta(hours=2))
+
+    await store.add("fact", metadata={"reference_time": datetime(2026, 5, 1, 11, 30, tzinfo=plus_two)})
+
+    _, kwargs = client.add_episode.call_args
+    assert kwargs["reference_time"] == datetime(2026, 5, 1, 9, 30, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_add_defaults_reference_time_to_utc_now(fake_graphiti_nodes: Any) -> None:
+    client = _client()
+    store = _store(client)
+
+    await store.add("fact")
+
+    _, kwargs = client.add_episode.call_args
+    assert kwargs["reference_time"].tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_add_empty_metadata_group_id_falls_back_to_store(fake_graphiti_nodes: Any) -> None:
+    # An empty per-write group id is meaningless; fall back to the store's namespace.
+    client = _client()
+    store = _store(client, group_id="tenant-a")
+
+    await store.add("fact", metadata={"group_id": ""})
+
+    _, kwargs = client.add_episode.call_args
+    assert kwargs["group_id"] == "tenant-a"
+
+
+@pytest.mark.asyncio
+async def test_add_omits_uuid_when_not_supplied(fake_graphiti_nodes: Any) -> None:
+    client = _client()
+    store = _store(client)
+
+    await store.add("fact")
+
+    _, kwargs = client.add_episode.call_args
+    assert "uuid" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_add_rejects_when_not_writable(fake_graphiti_nodes: Any) -> None:
+    store = _store(writable=False)
+
+    with pytest.raises(ValueError, match="not writable"):
+        await store.add("fact")
+
+
+@pytest.mark.asyncio
+async def test_add_rejects_empty_content(fake_graphiti_nodes: Any) -> None:
+    store = _store()
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        await store.add("   ")
+
+
+@pytest.mark.asyncio
+async def test_add_raises_helpful_error_when_graphiti_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Ensure ``graphiti_core`` is absent and its import fails, simulating a missing optional dep.
+    monkeypatch.delitem(sys.modules, "graphiti_core", raising=False)
+    monkeypatch.delitem(sys.modules, "graphiti_core.nodes", raising=False)
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "graphiti_core.nodes" or name == "graphiti_core":
+            raise ImportError("No module named 'graphiti_core'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    store = _store()
+
+    with pytest.raises(ImportError, match=r"strands-agents\[graphiti\]"):
+        await store.add("fact")
+
+
+# --------------------------------------------------------------------------- #
+# add_messages
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_add_messages_writes_message_episode_transcript(fake_graphiti_nodes: Any) -> None:
+    client = _client()
+    store = _store(client)
+    messages = [
+        {"role": "user", "content": [{"text": "I love hiking"}]},
+        {"role": "assistant", "content": [{"text": "Noted!"}]},
+    ]
+
+    await store.add_messages(messages)  # type: ignore[arg-type]
+
+    _, kwargs = client.add_episode.call_args
+    assert kwargs["source"] is _FakeEpisodeType.message
+    assert kwargs["episode_body"] == "user: I love hiking\nassistant: Noted!"
+
+
+@pytest.mark.asyncio
+async def test_add_messages_skips_non_text_blocks(fake_graphiti_nodes: Any) -> None:
+    client = _client()
+    store = _store(client)
+    messages = [
+        {"role": "user", "content": [{"text": "keep this"}, {"toolUse": {"name": "x"}}]},
+    ]
+
+    await store.add_messages(messages)  # type: ignore[arg-type]
+
+    _, kwargs = client.add_episode.call_args
+    assert kwargs["episode_body"] == "user: keep this"
+
+
+@pytest.mark.asyncio
+async def test_add_messages_returns_none_for_empty_transcript(fake_graphiti_nodes: Any) -> None:
+    client = _client()
+    store = _store(client)
+    messages = [{"role": "user", "content": [{"toolResult": {"content": []}}]}]
+
+    result = await store.add_messages(messages)  # type: ignore[arg-type]
+
+    assert result is None
+    client.add_episode.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_messages_rejects_when_not_writable(fake_graphiti_nodes: Any) -> None:
+    store = _store(writable=False)
+    messages = [{"role": "user", "content": [{"text": "hi"}]}]
+
+    with pytest.raises(ValueError, match="not writable"):
+        await store.add_messages(messages)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# Integration with MemoryManager (Protocol conformance end to end)
+# --------------------------------------------------------------------------- #
+
+
+def test_manager_accepts_writable_store_without_error() -> None:
+    # A writable store must expose a write sink; the manager validates this at construction.
+    store = _store(name="graph", writable=True)
+    manager = MemoryManager(stores=[store], add_tool_config=True)
+
+    tool_names = {agent_tool.tool_name for agent_tool in manager.tools}
+    assert "search_memory" in tool_names
+    assert "add_memory" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_manager_search_attributes_entries_to_store() -> None:
+    client = _client(search_result=[_edge(fact="user prefers dark mode")])
+    store = _store(client, name="graph")
+    manager = MemoryManager(stores=[store], injection=False)
+
+    results = await manager.search("preferences", MemorySearchOptions(max_search_results=4))
+
+    assert [entry.content for entry in results] == ["user prefers dark mode"]
+    assert results[0].store_name == "graph"
+    # The manager forwards its per-store limit down to the store, which forwards it to Graphiti.
+    _, kwargs = client.search.call_args
+    assert kwargs["num_results"] == 4


### PR DESCRIPTION
## Description

Adds `GraphitiMemoryStore`, the first concrete `MemoryStore` shipped in the Python SDK, backed by [Graphiti](https://github.com/getzep/graphiti) — Zep's Apache-2.0 temporal knowledge-graph library purpose-built for agent memory.

**Why Graphiti.** Most memory backends are flat vector stores; Graphiti maintains a *bi-temporal* knowledge graph that tracks both when a fact was recorded (transaction time) and when it was true in the world (valid time). That distinction is what lets an agent reason about corrections and stale facts instead of just returning the nearest embedding. It maps almost 1:1 onto our `MemoryStore` contract: hybrid `search()` → `MemoryStore.search()`, `add_episode()` → `add()`/`add_messages()`. Chosen in #296 as the in-core memory pick over cognee (a heavier ECL/control-plane framework).

**Optional, zero-friction by default.** `graphiti-core` lands under a new `graphiti` extra and is imported lazily — importing `strands.memory` never requires it, and a missing install raises a clear `ImportError` only when a write is attempted. The store takes an already-configured `Graphiti` client, so the graph backend (Neo4j / FalkorDB / Kuzu) and any LLM/embedder clients are the caller's to wire up. No database is needed to construct or unit-test the store.

## Public API

```python
from graphiti_core import Graphiti
from strands import Agent
from strands.memory import MemoryManager
from strands.memory.stores import GraphitiMemoryStore

client = Graphiti("bolt://localhost:7687", "neo4j", "password")
await client.build_indices_and_constraints()

store = GraphitiMemoryStore(client=client, name="graph", writable=True, group_id="user-123")
agent = Agent(memory_manager=MemoryManager(stores=[store]))
```

Search results surface graph identifiers and the bi-temporal timestamps (`created_at`/`expired_at`, `valid_at`/`invalid_at`) in `MemoryEntry.metadata`. The store implements both write sinks, so by default the `MemoryManager` routes extraction to `add_messages` (server-side extraction, no extra model call); single-fact writes go through `add` as `text` episodes. An optional `group_id` namespaces the store (Graphiti's tenancy primitive), scoping every search and stamping every write so one client can back many isolated stores.

## Related Issues

Refs #296

## Type of Change

New feature

## Testing

Unit tests mock the Graphiti client and require no graph database: search/add mapping, bi-temporal metadata propagation, `max_search_results` precedence, `group_id` scoping (incl. empty-string normalization), `reference_time` UTC normalization, lazy-import `ImportError`, `_has_method`/`_has_write_sink` detection, and end-to-end `MemoryManager` integration. `ruff format`/`ruff check` clean and `mypy ./src` passes strict with `graphiti-core` absent.

- [x] I ran the relevant checks (`pytest tests/strands/memory`, `ruff`, `mypy`)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR
- [x] My change is focused and reasonably small
- [x] I have added tests that prove the feature works
- [x] My changes generate no new warnings

---

cc @mkmeral — first concrete vended `MemoryStore` in the Python SDK; would value your eyes on the protocol mapping and the `graphiti` extra placement (kept out of `all` since it pulls neo4j/openai/numpy).

_Note: `graphiti-core` requires a graph backend to exercise end to end; that path was not run here (no provisioned DB), but the client boundary is fully mocked in unit tests._