### PR TITLE
feat(strands-py): add BubblewrapSandbox backend

### DIFF
--- a/strands-py/src/strands/sandbox/__init__.py
+++ b/strands-py/src/strands/sandbox/__init__.py
@@ -11,6 +11,9 @@ interface from ``strands-ts/src/sandbox/`` (the behavioral oracle):
   :meth:`~strands.sandbox.base.Sandbox.execute_streaming`.
 - :class:`DockerSandbox` — run commands in a Docker container via ``docker exec``.
 - :class:`SshSandbox` — run commands on a remote host via OpenSSH.
+- :class:`BubblewrapSandbox` — run commands inside an unprivileged ``bwrap``
+  Linux user-namespace jail (no daemon, namespace-level isolation, Linux-only),
+  configured via :class:`BubblewrapConfig` and :class:`BindMount`.
 - Data types: :class:`StreamChunk`, :class:`FileInfo`, :class:`OutputFile`,
   :class:`ExecutionResult`, and the :data:`StreamType` literal.
 - :data:`LANGUAGE_PATTERN` — interpreter-name validation pattern.
@@ -32,6 +35,12 @@ Example:
 """
 
 from .base import Sandbox
+from .bubblewrap import (
+    BindMount,
+    BubblewrapConfig,
+    BubblewrapSandbox,
+    is_bubblewrap_available,
+)
 from .constants import LANGUAGE_PATTERN
 from .docker import DockerSandbox
 from .shell import PosixShellSandbox
@@ -39,6 +48,9 @@ from .ssh import SshSandbox
 from .types import ExecutionResult, FileInfo, OutputFile, StreamChunk, StreamType
 
 __all__ = [
+    "BindMount",
+    "BubblewrapConfig",
+    "BubblewrapSandbox",
     "DockerSandbox",
     "ExecutionResult",
     "FileInfo",
@@ -49,4 +61,5 @@ __all__ = [
     "SshSandbox",
     "StreamChunk",
     "StreamType",
+    "is_bubblewrap_available",
 ]

--- a/strands-py/src/strands/sandbox/bubblewrap.py
+++ b/strands-py/src/strands/sandbox/bubblewrap.py
@@ -1,0 +1,387 @@
+"""Bubblewrap sandbox -- runs commands inside an unprivileged ``bwrap`` jail.
+
+:class:`BubblewrapSandbox` hardens :class:`~strands.sandbox.shell.PosixShellSandbox`
+with real OS-level isolation. It composes the shell backend: file and code
+operations are inherited (they run as shell commands), and only
+:meth:`~BubblewrapSandbox.execute_streaming` is implemented -- it wraps the
+shell command in a configurable `bubblewrap <https://github.com/containers/bubblewrap>`_
+``bwrap`` argv that places execution inside fresh Linux namespaces (user, mount,
+PID, IPC, UTS, cgroup, and -- by default -- network).
+
+Bubblewrap is the unprivileged sandboxing engine behind Flatpak: a single
+``setuid``-or-userns ``bwrap`` binary, no daemon, no server, no microVM. It is
+**Linux-only** and provides **namespace-level** (not VM-level) isolation.
+
+Security model (secure-by-default):
+
+- All namespaces are unshared (``--unshare-all``); network access is **denied**
+  unless :attr:`BubblewrapConfig.network` is ``True`` (which re-shares the net
+  namespace via ``--share-net``).
+- The process is killed if the parent dies (``--die-with-parent``) and runs in a
+  fresh session (``--new-session``) to block TIOCSTI terminal-injection escapes.
+- The environment is cleared (``--clearenv``); only explicitly passed (``env``)
+  or passed-through (:attr:`BubblewrapConfig.env_passthrough`) variables reach
+  the jail.
+- By default a curated set of read-only system directories (``/usr``, ``/bin``,
+  ``/lib`` ...) is mounted via ``--ro-bind-try`` so a shell works out of the box
+  **without** exposing ``/home``, ``/root``, ``/etc``, or ``/var``. Callers add
+  exactly what their workload needs through :attr:`BubblewrapConfig.ro_binds`
+  and :attr:`BubblewrapConfig.rw_binds`.
+
+This backend has no TypeScript oracle counterpart; it is a Python-first addition
+that mirrors the structure of :mod:`strands.sandbox.docker` and
+:mod:`strands.sandbox.ssh`.
+"""
+
+import logging
+import os
+import shutil
+import sys
+from collections.abc import AsyncGenerator
+from contextlib import aclosing
+from dataclasses import dataclass, field
+from typing import Any
+
+from .constants import ENV_KEY_PATTERN
+from .shell import PosixShellSandbox, validate_env_keys
+from .stream_process import stream_process
+from .types import ExecutionResult, StreamChunk
+
+logger = logging.getLogger(__name__)
+
+#: Default executable name for the bubblewrap binary.
+_DEFAULT_BWRAP_BINARY = "bwrap"
+
+#: Curated read-only system directories mounted by default via ``--ro-bind-try``.
+#:
+#: These give a functional shell (the interpreter, its shared libraries) while
+#: deliberately omitting ``/home``, ``/root``, ``/etc``, ``/var``, and ``/srv``
+#: so host configuration and secrets are not exposed. ``--ro-bind-try`` skips
+#: any path that does not exist, so the same list is safe across distributions
+#: that do or do not use the usr-merge layout.
+_DEFAULT_SYSTEM_PATHS: tuple[str, ...] = (
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib32",
+    "/lib64",
+)
+
+#: Message surfaced (with exit code 127) when the ``bwrap`` binary is not found.
+_ENOENT_MESSAGE = (
+    "bwrap (bubblewrap) is not installed or not on PATH. "
+    "Bubblewrap is Linux-only; install it via your distribution's package manager "
+    "(e.g. 'apt install bubblewrap' or 'dnf install bubblewrap')."
+)
+
+
+def _is_valid_env_name(name: str) -> bool:
+    """Return whether ``name`` is a valid POSIX environment variable name.
+
+    Mirrors the check in :func:`strands.sandbox.shell.validate_env_keys` for a
+    single name, returning a bool instead of raising so the caller can build a
+    message that names the offending source (``env_passthrough``).
+
+    Args:
+        name: The environment variable name to validate.
+
+    Returns:
+        ``True`` if ``name`` matches :data:`~strands.sandbox.constants.ENV_KEY_PATTERN`.
+    """
+    return ENV_KEY_PATTERN.fullmatch(name) is not None
+
+
+@dataclass(frozen=True)
+class BindMount:
+    """A single bind mount exposing a host path inside the sandbox.
+
+    Attributes:
+        source: Path on the host to expose.
+        dest: Mount point inside the sandbox. Defaults to ``source`` (mounted at
+            the same path) when ``None``.
+    """
+
+    source: str
+    dest: str | None = None
+
+    @property
+    def target(self) -> str:
+        """The in-sandbox mount point (``dest`` if set, otherwise ``source``)."""
+        return self.dest if self.dest is not None else self.source
+
+
+@dataclass
+class BubblewrapConfig:
+    """Configuration for :class:`BubblewrapSandbox` with secure defaults.
+
+    Every default is chosen to minimize the sandbox's authority: no network, a
+    cleared environment, all namespaces unshared, and only read-only system
+    directories visible. Relax these deliberately for the workload at hand.
+
+    Attributes:
+        bwrap_path: Path to (or name of) the ``bwrap`` binary. Defaults to
+            ``"bwrap"`` (resolved on ``PATH``).
+        ro_binds: Additional read-only bind mounts (``--ro-bind``). Unlike the
+            default system directories these use the strict ``--ro-bind`` (the
+            command fails if the source is missing), making the caller's intent
+            explicit.
+        rw_binds: Read-write bind mounts (``--bind``). Use sparingly -- these are
+            the only host paths the jail can modify.
+        tmpfs: Paths to mount as fresh, writable, in-memory ``tmpfs`` filesystems.
+            Defaults to ``["/tmp"]``.
+        network: Whether to allow network access. ``False`` (default) leaves the
+            network namespace unshared (no connectivity); ``True`` re-shares the
+            host network via ``--share-net``.
+        bind_system_dirs: Whether to mount the curated read-only system
+            directories (:data:`_DEFAULT_SYSTEM_PATHS`) so a shell works out of
+            the box. Set ``False`` for a near-empty root you populate entirely
+            via ``ro_binds``/``rw_binds``.
+        proc: Mount point for a new ``proc`` filesystem (``--proc``), or ``None``
+            to omit it. Defaults to ``"/proc"`` (many tools require it).
+        dev: Mount point for a minimal ``/dev`` (``--dev``), or ``None`` to omit
+            it. Defaults to ``"/dev"``.
+        clear_env: Whether to clear the environment (``--clearenv``) before
+            applying ``env_passthrough`` and per-command ``env``. Defaults to
+            ``True``. Setting this ``False`` forwards the **entire** host
+            environment into the jail (including secrets), which undermines the
+            secure-by-default posture -- prefer ``env_passthrough`` to forward
+            only named variables.
+        env_passthrough: Names of host environment variables to forward into the
+            jail (read from :data:`os.environ` at execution time). Missing names
+            are skipped. Per-command ``env`` values override these.
+        die_with_parent: Whether to kill the sandboxed process if the supervising
+            process dies (``--die-with-parent``). Defaults to ``True``.
+        new_session: Whether to run in a new session (``--new-session``) to block
+            TIOCSTI terminal-injection escapes. Defaults to ``True``.
+        working_dir: Default working directory inside the sandbox (``--chdir``).
+            The per-command ``cwd`` overrides it. The directory must exist inside
+            the jail (i.e. be covered by a bind mount or tmpfs).
+        extra_args: Raw extra arguments appended verbatim to the ``bwrap`` argv
+            (before the ``--`` terminator) for options not modeled above.
+    """
+
+    bwrap_path: str = _DEFAULT_BWRAP_BINARY
+    ro_binds: list[BindMount] = field(default_factory=list)
+    rw_binds: list[BindMount] = field(default_factory=list)
+    tmpfs: list[str] = field(default_factory=lambda: ["/tmp"])
+    network: bool = False
+    bind_system_dirs: bool = True
+    proc: str | None = "/proc"
+    dev: str | None = "/dev"
+    clear_env: bool = True
+    env_passthrough: list[str] = field(default_factory=list)
+    die_with_parent: bool = True
+    new_session: bool = True
+    working_dir: str | None = None
+    extra_args: list[str] = field(default_factory=list)
+
+
+def is_bubblewrap_available(bwrap_path: str = _DEFAULT_BWRAP_BINARY) -> bool:
+    """Return whether a usable ``bwrap`` binary is present on this host.
+
+    Bubblewrap is Linux-only, so this returns ``False`` on any other platform
+    without probing. On Linux it returns ``True`` if ``bwrap_path`` resolves on
+    ``PATH`` (via :func:`shutil.which`), or -- when given an **absolute** path --
+    if that path is an executable file. It does **not** verify that unprivileged
+    user namespaces are enabled -- that surfaces at execution time as a clear
+    ``bwrap`` error on stderr (e.g. ``"No permissions to creating new namespace"``).
+
+    Use this to skip integration tests or to preflight a sandbox before relying
+    on it.
+
+    Args:
+        bwrap_path: Path to (or name of) the ``bwrap`` binary.
+
+    Returns:
+        ``True`` if running on Linux and the binary is resolvable, else ``False``.
+    """
+    if sys.platform != "linux":
+        return False
+    if shutil.which(bwrap_path) is not None:
+        return True
+    # Only honor os.access for an explicit path. A bare name like "bwrap" would
+    # otherwise resolve against the CWD, a false positive if a file named "bwrap"
+    # happens to sit there; PATH resolution is shutil.which's job above.
+    return os.path.isabs(bwrap_path) and os.access(bwrap_path, os.X_OK)
+
+
+class BubblewrapSandbox(PosixShellSandbox):
+    """Execute commands inside an unprivileged bubblewrap (``bwrap``) jail.
+
+    A :class:`~strands.sandbox.shell.PosixShellSandbox` backend: file and code
+    operations are inherited (they run as shell commands), and only
+    :meth:`execute_streaming` is implemented -- it prefixes the shell command
+    with a ``bwrap`` argv built from :class:`BubblewrapConfig`.
+
+    Stateless: each :meth:`execute_streaming` call spawns a fresh ``bwrap``
+    process. Bubblewrap is **Linux-only** and provides **namespace-level** (not
+    VM) isolation with **no daemon**.
+
+    Example:
+        Run an untrusted command with no network and a writable workspace::
+
+            from strands.sandbox import BindMount, BubblewrapConfig, BubblewrapSandbox
+
+            sandbox = BubblewrapSandbox(
+                BubblewrapConfig(
+                    rw_binds=[BindMount("/tmp/workspace", "/work")],
+                    working_dir="/work",
+                )
+            )
+            result = await sandbox.execute("echo hello")
+    """
+
+    def __init__(self, config: BubblewrapConfig | None = None) -> None:
+        """Initialize the bubblewrap sandbox.
+
+        Args:
+            config: Sandbox configuration. Defaults to a fresh
+                :class:`BubblewrapConfig` (secure defaults: no network, cleared
+                environment, read-only system directories, all namespaces
+                unshared).
+        """
+        self.config = config if config is not None else BubblewrapConfig()
+        # Mirror the other backends' public attribute for the effective default cwd.
+        self.working_dir = self.config.working_dir
+
+    def _build_bwrap_args(
+        self,
+        command: str,
+        *,
+        cwd: str | None,
+        env: dict[str, str] | None,
+    ) -> list[str]:
+        """Build the ``bwrap`` argument vector for a single command.
+
+        Pure apart from reading :data:`os.environ` for
+        :attr:`BubblewrapConfig.env_passthrough`, so the produced argv is
+        deterministic for a given config and inputs.
+
+        Args:
+            command: The shell command to run inside the jail (via ``sh -c``).
+            cwd: Per-command working directory, overriding
+                :attr:`BubblewrapConfig.working_dir`.
+            env: Per-command environment variables, applied via ``--setenv`` and
+                overriding any matching :attr:`BubblewrapConfig.env_passthrough`
+                value.
+
+        Returns:
+            The full argument vector for ``bwrap`` (excluding the program name).
+
+        Raises:
+            ValueError: If an environment variable name is invalid.
+        """
+        config = self.config
+        args: list[str] = ["--unshare-all"]
+
+        # --unshare-all unshares the network namespace; re-share it only on opt-in.
+        if config.network:
+            args.append("--share-net")
+
+        if config.die_with_parent:
+            args.append("--die-with-parent")
+        if config.new_session:
+            args.append("--new-session")
+
+        # Clear the environment before any --setenv so passed values survive.
+        if config.clear_env:
+            args.append("--clearenv")
+
+        # Read-only system directories first. --ro-bind-try skips missing sources,
+        # keeping the default usable across distros without runtime stat() calls.
+        if config.bind_system_dirs:
+            for path in _DEFAULT_SYSTEM_PATHS:
+                args += ["--ro-bind-try", path, path]
+
+        # tmpfs mounts go before the caller's binds: bwrap applies mount ops in
+        # argv order, so a tmpfs must be laid down first for a bind nested under
+        # it (e.g. a rw-bind at /tmp/work) to survive rather than be shadowed.
+        for path in config.tmpfs:
+            args += ["--tmpfs", path]
+
+        # Explicit caller binds use strict --ro-bind/--bind: a missing source is a
+        # configuration error and should fail loudly.
+        for mount in config.ro_binds:
+            args += ["--ro-bind", mount.source, mount.target]
+        for mount in config.rw_binds:
+            args += ["--bind", mount.source, mount.target]
+
+        if config.proc is not None:
+            args += ["--proc", config.proc]
+        if config.dev is not None:
+            args += ["--dev", config.dev]
+
+        # Environment: passthrough first, then per-command env (which overrides).
+        # --setenv writes argv values verbatim (no shell evaluation), so values
+        # containing shell metacharacters reach the process literally.
+        for name in config.env_passthrough:
+            if not _is_valid_env_name(name):
+                raise ValueError(f"Invalid environment variable name: {name}")
+            value = os.environ.get(name)
+            if value is not None:
+                args += ["--setenv", name, value]
+        if env:
+            validate_env_keys(env)
+            for key, value in env.items():
+                args += ["--setenv", key, value]
+
+        effective_cwd = cwd if cwd is not None else self.working_dir
+        if effective_cwd is not None:
+            args += ["--chdir", effective_cwd]
+
+        args += list(config.extra_args)
+
+        # '--' terminates bwrap option parsing so the command and its arguments are
+        # never mistaken for bwrap flags. The command runs through 'sh -c' so the
+        # inherited shell-based file/code operations (heredocs, pipes) work.
+        args += ["--", "sh", "-c", command]
+        return args
+
+    async def execute_streaming(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        """Execute a command inside the bubblewrap jail, streaming output.
+
+        Args:
+            command: The shell command to execute.
+            timeout: Maximum wall-clock execution time in seconds. ``None`` means
+                no timeout.
+            cwd: Working directory for this command, overriding
+                :attr:`BubblewrapConfig.working_dir`. Must exist inside the jail.
+            env: Environment variables to set, applied via ``bwrap --setenv``
+                (verbatim, not shell-evaluated).
+            **kwargs: Additional keyword arguments for forward compatibility.
+
+        Yields:
+            :class:`StreamChunk` objects for output, then a final
+            :class:`ExecutionResult`. If ``bwrap`` is missing, a single
+            :class:`ExecutionResult` with exit code 127 and an explanatory
+            ``stderr`` is yielded.
+
+        Raises:
+            ValueError: If an environment variable name is invalid.
+            TimeoutError: If execution exceeds ``timeout`` seconds.
+        """
+        args = self._build_bwrap_args(command, cwd=cwd, env=env)
+        logger.debug(
+            "bwrap_path=<%s>, network=<%s>, arg_count=<%d> | running command in bubblewrap jail",
+            self.config.bwrap_path,
+            self.config.network,
+            len(args),
+        )
+        # aclosing() guarantees stream_process's finally (which kills the bwrap
+        # process tree) runs deterministically when the consumer cancels or breaks
+        # out early -- a plain "async for" would defer that cleanup to the event
+        # loop's async-generator finalizer, leaving the jailed process running.
+        async with aclosing(
+            stream_process(self.config.bwrap_path, args, timeout=timeout, enoent_message=_ENOENT_MESSAGE)
+        ) as stream:
+            async for chunk in stream:
+                yield chunk

--- a/strands-py/tests/strands/sandbox/test_bubblewrap.py
+++ b/strands-py/tests/strands/sandbox/test_bubblewrap.py
@@ -1,0 +1,440 @@
+"""Tests for :class:`~strands.sandbox.bubblewrap.BubblewrapSandbox`.
+
+Mirrors the argv-assertion style of ``tests/strands/sandbox/test_docker.py``:
+the process pump (``stream_process``) is mocked, so **no ``bwrap`` binary is
+required** to run these tests. They assert the ``bwrap`` argv the sandbox builds
+from a :class:`~strands.sandbox.bubblewrap.BubblewrapConfig`, exercising the
+secure defaults, the namespace/mount/env flags, and the security-sensitive
+boundaries (``--`` flag terminator, no-network default, env verbatim handling).
+"""
+
+import unittest.mock
+
+import pytest
+
+from strands.sandbox import (
+    BindMount,
+    BubblewrapConfig,
+    BubblewrapSandbox,
+    is_bubblewrap_available,
+)
+from strands.sandbox.bubblewrap import (
+    _DEFAULT_SYSTEM_PATHS,
+    _ENOENT_MESSAGE,
+)
+from strands.sandbox.types import ExecutionResult, StreamChunk
+
+
+@pytest.fixture
+def mock_stream_process(agenerator):
+    """Patch ``stream_process`` in the bubblewrap module, returning a no-op result.
+
+    Yields the mock so tests can inspect the ``(program, args, kwargs)`` it was
+    called with via ``mock.call_args``.
+    """
+    with unittest.mock.patch("strands.sandbox.bubblewrap.stream_process") as mock:
+        mock.return_value = agenerator([ExecutionResult(exit_code=0, stdout="", stderr="")])
+        yield mock
+
+
+def _program(mock_stream_process) -> str:
+    """The program passed to ``stream_process`` (its first positional argument)."""
+    return mock_stream_process.call_args.args[0]
+
+
+def _args(mock_stream_process) -> list[str]:
+    """The argv passed to ``stream_process`` (its second positional argument)."""
+    return mock_stream_process.call_args.args[1]
+
+
+# ---- constructor ----
+
+
+def test_defaults_to_secure_config():
+    sandbox = BubblewrapSandbox()
+    assert sandbox.config.network is False
+    assert sandbox.config.clear_env is True
+    assert sandbox.config.die_with_parent is True
+    assert sandbox.config.new_session is True
+    assert sandbox.config.bind_system_dirs is True
+    assert sandbox.working_dir is None
+
+
+def test_working_dir_mirrors_config():
+    sandbox = BubblewrapSandbox(BubblewrapConfig(working_dir="/work"))
+    assert sandbox.working_dir == "/work"
+
+
+# ---- argv construction: secure defaults ----
+
+
+@pytest.mark.asyncio
+async def test_default_argv_is_secure(mock_stream_process):
+    await BubblewrapSandbox().execute("echo hi")
+    args = _args(mock_stream_process)
+
+    # Namespaces fully unshared, no opt-in network share.
+    assert "--unshare-all" in args
+    assert "--share-net" not in args
+    # Hardening flags on by default.
+    assert "--die-with-parent" in args
+    assert "--new-session" in args
+    assert "--clearenv" in args
+    # proc/dev/tmpfs defaults.
+    assert args[args.index("--proc") + 1] == "/proc"
+    assert args[args.index("--dev") + 1] == "/dev"
+    assert args[args.index("--tmpfs") + 1] == "/tmp"
+
+
+@pytest.mark.asyncio
+async def test_default_binds_system_dirs_readonly(mock_stream_process):
+    await BubblewrapSandbox().execute("echo hi")
+    args = _args(mock_stream_process)
+    for path in _DEFAULT_SYSTEM_PATHS:
+        # Each default system dir is mounted read-only-try at the same path.
+        assert ["--ro-bind-try", path, path] == _triple_at(args, "--ro-bind-try", path)
+
+
+def _triple_at(args: list[str], flag: str, source: str) -> list[str]:
+    """Return the ``[flag, source, dest]`` slice starting at the matching flag+source."""
+    for i in range(len(args) - 2):
+        if args[i] == flag and args[i + 1] == source:
+            return args[i : i + 3]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_command_runs_through_sh_after_double_dash(mock_stream_process):
+    # The command must be positional after '--' so it is never parsed as a bwrap flag.
+    await BubblewrapSandbox().execute("echo hi")
+    args = _args(mock_stream_process)
+    assert args[-4:] == ["--", "sh", "-c", "echo hi"]
+
+
+@pytest.mark.asyncio
+async def test_uses_configured_bwrap_path(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(bwrap_path="/opt/bin/bwrap")).execute("echo hi")
+    assert _program(mock_stream_process) == "/opt/bin/bwrap"
+
+
+@pytest.mark.asyncio
+async def test_malicious_command_cannot_inject_bwrap_flags(mock_stream_process):
+    # A command that looks like a bwrap flag stays a single sh -c argument.
+    await BubblewrapSandbox().execute("--share-net; rm -rf /")
+    args = _args(mock_stream_process)
+    assert args[-4:] == ["--", "sh", "-c", "--share-net; rm -rf /"]
+    # The injected text is only the sh -c payload, never a real flag before '--'.
+    assert args.index("--") == len(args) - 4
+
+
+# ---- network ----
+
+
+@pytest.mark.asyncio
+async def test_network_opt_in_shares_net(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(network=True)).execute("curl x")
+    args = _args(mock_stream_process)
+    assert "--unshare-all" in args
+    assert "--share-net" in args
+
+
+@pytest.mark.asyncio
+async def test_network_denied_by_default(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(network=False)).execute("curl x")
+    assert "--share-net" not in _args(mock_stream_process)
+
+
+# ---- hardening toggles ----
+
+
+@pytest.mark.asyncio
+async def test_hardening_flags_can_be_disabled(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(die_with_parent=False, new_session=False, clear_env=False)).execute(
+        "echo hi"
+    )
+    args = _args(mock_stream_process)
+    assert "--die-with-parent" not in args
+    assert "--new-session" not in args
+    assert "--clearenv" not in args
+
+
+@pytest.mark.asyncio
+async def test_system_dirs_can_be_disabled(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(bind_system_dirs=False)).execute("echo hi")
+    assert "--ro-bind-try" not in _args(mock_stream_process)
+
+
+@pytest.mark.asyncio
+async def test_proc_and_dev_can_be_omitted(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(proc=None, dev=None)).execute("echo hi")
+    args = _args(mock_stream_process)
+    assert "--proc" not in args
+    assert "--dev" not in args
+
+
+@pytest.mark.asyncio
+async def test_custom_proc_and_dev_mount_points(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(proc="/p", dev="/d")).execute("echo hi")
+    args = _args(mock_stream_process)
+    assert args[args.index("--proc") + 1] == "/p"
+    assert args[args.index("--dev") + 1] == "/d"
+
+
+# ---- bind mounts ----
+
+
+@pytest.mark.asyncio
+async def test_ro_and_rw_binds(mock_stream_process):
+    await BubblewrapSandbox(
+        BubblewrapConfig(
+            ro_binds=[BindMount("/host/ro", "/ro")],
+            rw_binds=[BindMount("/host/rw", "/rw")],
+        )
+    ).execute("echo hi")
+    args = _args(mock_stream_process)
+    assert _triple_at(args, "--ro-bind", "/host/ro") == ["--ro-bind", "/host/ro", "/ro"]
+    assert _triple_at(args, "--bind", "/host/rw") == ["--bind", "/host/rw", "/rw"]
+
+
+@pytest.mark.asyncio
+async def test_bind_mount_defaults_dest_to_source(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(rw_binds=[BindMount("/same/path")])).execute("echo hi")
+    args = _args(mock_stream_process)
+    assert _triple_at(args, "--bind", "/same/path") == ["--bind", "/same/path", "/same/path"]
+
+
+def test_bind_mount_target_property():
+    assert BindMount("/a").target == "/a"
+    assert BindMount("/a", "/b").target == "/b"
+
+
+@pytest.mark.asyncio
+async def test_multiple_tmpfs_paths(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(tmpfs=["/tmp", "/run"])).execute("echo hi")
+    args = _args(mock_stream_process)
+    tmpfs_targets = [args[i + 1] for i, a in enumerate(args) if a == "--tmpfs"]
+    assert tmpfs_targets == ["/tmp", "/run"]
+
+
+@pytest.mark.asyncio
+async def test_tmpfs_mounted_before_caller_binds(mock_stream_process):
+    # bwrap applies mount ops in argv order. A rw-bind nested under a tmpfs must
+    # come AFTER the tmpfs, or the tmpfs would shadow it. Lock the ordering.
+    await BubblewrapSandbox(BubblewrapConfig(tmpfs=["/tmp"], rw_binds=[BindMount("/host/work", "/tmp/work")])).execute(
+        "echo hi"
+    )
+    args = _args(mock_stream_process)
+    assert args.index("--tmpfs") < args.index("--bind")
+
+
+# ---- working dir ----
+
+
+@pytest.mark.asyncio
+async def test_working_dir_sets_chdir(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(working_dir="/work")).execute("pwd")
+    args = _args(mock_stream_process)
+    assert args[args.index("--chdir") + 1] == "/work"
+
+
+@pytest.mark.asyncio
+async def test_cwd_option_overrides_working_dir(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(working_dir="/work")).execute("pwd", cwd="/override")
+    args = _args(mock_stream_process)
+    assert args[args.index("--chdir") + 1] == "/override"
+
+
+@pytest.mark.asyncio
+async def test_no_chdir_when_unset(mock_stream_process):
+    await BubblewrapSandbox().execute("pwd")
+    assert "--chdir" not in _args(mock_stream_process)
+
+
+# ---- environment ----
+
+
+@pytest.mark.asyncio
+async def test_env_passed_as_setenv(mock_stream_process):
+    await BubblewrapSandbox().execute("echo $FOO", env={"FOO": "bar", "BAZ": "qux"})
+    args = _args(mock_stream_process)
+    assert _triple_at(args, "--setenv", "FOO") == ["--setenv", "FOO", "bar"]
+    assert _triple_at(args, "--setenv", "BAZ") == ["--setenv", "BAZ", "qux"]
+
+
+@pytest.mark.asyncio
+async def test_env_values_are_verbatim_not_shell_evaluated(mock_stream_process):
+    # --setenv values are argv, not shell input: metacharacters reach the process literally.
+    await BubblewrapSandbox().execute("printenv FOO", env={"FOO": "$(whoami) `id`"})
+    args = _args(mock_stream_process)
+    assert _triple_at(args, "--setenv", "FOO") == ["--setenv", "FOO", "$(whoami) `id`"]
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_env_var_names(mock_stream_process):
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        await BubblewrapSandbox().execute("cmd", env={"BAD-KEY": "v"})
+
+
+@pytest.mark.asyncio
+async def test_env_passthrough_reads_from_os_environ(mock_stream_process, monkeypatch):
+    monkeypatch.setenv("PASS_ME", "from-host")
+    monkeypatch.delenv("ABSENT_VAR", raising=False)
+    await BubblewrapSandbox(BubblewrapConfig(env_passthrough=["PASS_ME", "ABSENT_VAR"])).execute("echo hi")
+    args = _args(mock_stream_process)
+    # Present var is forwarded; absent var is silently skipped.
+    assert _triple_at(args, "--setenv", "PASS_ME") == ["--setenv", "PASS_ME", "from-host"]
+    assert "ABSENT_VAR" not in args
+
+
+@pytest.mark.asyncio
+async def test_per_command_env_overrides_passthrough(mock_stream_process, monkeypatch):
+    monkeypatch.setenv("SHARED", "from-host")
+    await BubblewrapSandbox(BubblewrapConfig(env_passthrough=["SHARED"])).execute(
+        "echo hi", env={"SHARED": "from-call"}
+    )
+    args = _args(mock_stream_process)
+    setenv_values = [args[i + 1 : i + 3] for i, a in enumerate(args) if a == "--setenv"]
+    # Both appear, but the per-command value comes last so it wins at exec time.
+    assert ["SHARED", "from-host"] in setenv_values
+    assert ["SHARED", "from-call"] in setenv_values
+    assert setenv_values[-1] == ["SHARED", "from-call"]
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_env_passthrough_name(mock_stream_process):
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        await BubblewrapSandbox(BubblewrapConfig(env_passthrough=["BAD-KEY"])).execute("echo hi")
+
+
+# ---- extra args ----
+
+
+@pytest.mark.asyncio
+async def test_extra_args_appended_before_terminator(mock_stream_process):
+    await BubblewrapSandbox(BubblewrapConfig(extra_args=["--hostname", "jail"])).execute("echo hi")
+    args = _args(mock_stream_process)
+    terminator = args.index("--")
+    assert args[terminator - 2 : terminator] == ["--hostname", "jail"]
+
+
+# ---- timeout / enoent passthrough to stream_process ----
+
+
+@pytest.mark.asyncio
+async def test_forwards_timeout_and_enoent_message(mock_stream_process):
+    await BubblewrapSandbox().execute("sleep 10", timeout=5)
+    assert mock_stream_process.call_args.kwargs == {
+        "timeout": 5,
+        "enoent_message": _ENOENT_MESSAGE,
+    }
+
+
+# ---- inherited shell ops build the right wrapped command ----
+
+
+@pytest.mark.asyncio
+async def test_execute_code_runs_through_bwrap(mock_stream_process):
+    # The inherited PosixShellSandbox.execute_code path must still wrap in bwrap:
+    # the base64 heredoc pipeline becomes the sh -c payload inside the jail.
+    await BubblewrapSandbox().execute_code("print(1)", "python3")
+    args = _args(mock_stream_process)
+    assert args[-4:-1] == ["--", "sh", "-c"]
+    payload = args[-1]
+    assert "base64 -d" in payload
+    assert "| python3" in payload
+
+
+@pytest.mark.asyncio
+async def test_read_file_runs_through_bwrap(mock_stream_process):
+    await BubblewrapSandbox().read_file("/x.txt")
+    args = _args(mock_stream_process)
+    assert args[-4:-1] == ["--", "sh", "-c"]
+    assert "base64 < /x.txt" in args[-1]
+
+
+# ---- execute_streaming body (real call path, no bwrap binary required) ----
+
+
+@pytest.mark.asyncio
+async def test_execute_streaming_surfaces_missing_binary_as_127():
+    # Drives the real execute_streaming/stream_process path (not mocked) with a
+    # bogus binary: bwrap is never spawned, so this needs no bwrap installed and
+    # still exercises the live wiring -- guarding against regressions like a stale
+    # local name in the stream_process call.
+    sandbox = BubblewrapSandbox(BubblewrapConfig(bwrap_path="strands-bwrap-does-not-exist-xyz"))
+    result = await sandbox.execute("echo hi")
+    assert result.exit_code == 127
+    assert "bubblewrap" in result.stderr.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_streaming_yields_chunks_then_result(agenerator):
+    # Patch only the process pump; assert execute_streaming faithfully relays the
+    # chunk(s) and final result from stream_process.
+    chunks = [
+        StreamChunk(data="out", stream_type="stdout"),
+        ExecutionResult(exit_code=0, stdout="out", stderr=""),
+    ]
+    with unittest.mock.patch("strands.sandbox.bubblewrap.stream_process") as mock:
+        mock.return_value = agenerator(chunks)
+        relayed = [c async for c in BubblewrapSandbox().execute_streaming("echo out")]
+    assert relayed == chunks
+
+
+@pytest.mark.asyncio
+async def test_execute_streaming_closes_inner_generator_on_early_break():
+    # On an early break the consumer must close our generator, which (via
+    # aclosing) must close stream_process so its finally -- killing the bwrap
+    # process tree -- runs deterministically rather than at GC time.
+    closed = False
+
+    async def fake_stream(*_args, **_kwargs):
+        nonlocal closed
+        try:
+            yield StreamChunk(data="first", stream_type="stdout")
+            yield ExecutionResult(exit_code=0, stdout="", stderr="")
+        finally:
+            closed = True
+
+    with unittest.mock.patch("strands.sandbox.bubblewrap.stream_process", fake_stream):
+        gen = BubblewrapSandbox().execute_streaming("echo hi")
+        first = await gen.__anext__()
+        assert isinstance(first, StreamChunk)
+        await gen.aclose()
+
+    assert closed is True
+
+
+# ---- is_bubblewrap_available ----
+def test_is_bubblewrap_available_false_off_linux(monkeypatch):
+    monkeypatch.setattr("strands.sandbox.bubblewrap.sys.platform", "darwin")
+    assert is_bubblewrap_available() is False
+
+
+def test_is_bubblewrap_available_true_when_resolvable(monkeypatch):
+    monkeypatch.setattr("strands.sandbox.bubblewrap.sys.platform", "linux")
+    monkeypatch.setattr("strands.sandbox.bubblewrap.shutil.which", lambda _: "/usr/bin/bwrap")
+    assert is_bubblewrap_available() is True
+
+
+def test_is_bubblewrap_available_false_when_missing(monkeypatch):
+    monkeypatch.setattr("strands.sandbox.bubblewrap.sys.platform", "linux")
+    monkeypatch.setattr("strands.sandbox.bubblewrap.shutil.which", lambda _: None)
+    monkeypatch.setattr("strands.sandbox.bubblewrap.os.access", lambda *a: False)
+    assert is_bubblewrap_available() is False
+
+
+def test_is_bubblewrap_available_ignores_relative_path_access(monkeypatch):
+    # A bare name must NOT be probed with os.access (would resolve against CWD);
+    # only shutil.which may resolve it on PATH.
+    monkeypatch.setattr("strands.sandbox.bubblewrap.sys.platform", "linux")
+    monkeypatch.setattr("strands.sandbox.bubblewrap.shutil.which", lambda _: None)
+    monkeypatch.setattr("strands.sandbox.bubblewrap.os.access", lambda *a: True)
+    assert is_bubblewrap_available("bwrap") is False
+
+
+def test_is_bubblewrap_available_honors_absolute_path_access(monkeypatch):
+    monkeypatch.setattr("strands.sandbox.bubblewrap.sys.platform", "linux")
+    monkeypatch.setattr("strands.sandbox.bubblewrap.shutil.which", lambda _: None)
+    monkeypatch.setattr("strands.sandbox.bubblewrap.os.access", lambda *a: True)
+    assert is_bubblewrap_available("/opt/bin/bwrap") is True

--- a/strands-py/tests_integ/sandbox/test_bubblewrap.py
+++ b/strands-py/tests_integ/sandbox/test_bubblewrap.py
@@ -1,0 +1,159 @@
+"""Integration tests for :class:`~strands.sandbox.BubblewrapSandbox`.
+
+These run real ``bwrap`` commands inside an unprivileged Linux user-namespace
+jail, so they are skipped unless ``bwrap`` is installed *and* unprivileged user
+namespaces actually work on this host (a smoke ``bwrap true`` must succeed --
+some hardened kernels ship ``bwrap`` but disable unprivileged userns).
+
+The default :class:`~strands.sandbox.BubblewrapConfig` mounts the read-only
+system directories needed for a shell, a fresh ``/tmp`` tmpfs, and ``/proc`` +
+``/dev`` -- enough for ``sh``, ``base64``, ``printenv``, and the inherited
+file/code operations. A writable workspace is bind-mounted per test.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from strands.sandbox import BindMount, BubblewrapConfig, BubblewrapSandbox, is_bubblewrap_available
+
+
+def _userns_works() -> bool:
+    """Return whether ``bwrap`` can actually create an unprivileged namespace.
+
+    Presence of the binary is necessary but not sufficient: hardened kernels may
+    disable unprivileged user namespaces. A trivial ``bwrap ... true`` proves the
+    jail can be created before the suite relies on it.
+    """
+    if not is_bubblewrap_available():
+        return False
+    try:
+        proc = subprocess.run(
+            ["bwrap", "--unshare-all", "--ro-bind", "/usr", "/usr", "--", "true"],
+            capture_output=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform != "linux", reason="bubblewrap is Linux-only"),
+    pytest.mark.skipif(not _userns_works(), reason="bwrap unavailable or unprivileged userns disabled"),
+    pytest.mark.asyncio,
+]
+
+
+async def test_runs_commands_capturing_stdout_stderr_and_exit_code():
+    sandbox = BubblewrapSandbox()
+
+    result = await sandbox.execute("echo hello && echo err >&2")
+    assert result.exit_code == 0
+    assert result.stdout == "hello\n"
+    assert result.stderr == "err\n"
+
+    failed = await sandbox.execute("exit 42")
+    assert failed.exit_code == 42
+
+
+async def test_network_is_denied_by_default():
+    # With the network namespace unshared and no interfaces, even loopback DNS
+    # fails. We assert the command cannot reach out, not a specific errno.
+    sandbox = BubblewrapSandbox()
+    result = await sandbox.execute("getent hosts example.com >/dev/null 2>&1 && echo ONLINE || echo OFFLINE")
+    assert result.stdout.strip() == "OFFLINE"
+
+
+async def test_environment_is_cleared_by_default(monkeypatch):
+    # A host env var must NOT leak into the jail when clear_env is on (default).
+    monkeypatch.setenv("HOST_SECRET", "leaked")
+    sandbox = BubblewrapSandbox()
+    result = await sandbox.execute("printenv HOST_SECRET || echo ABSENT")
+    assert result.stdout.strip() == "ABSENT"
+
+
+async def test_passes_env_vars_to_the_command():
+    result = await BubblewrapSandbox().execute("printenv MY_VAR", env={"MY_VAR": "hello-from-env"})
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello-from-env"
+
+
+async def test_passes_env_values_with_metacharacters_literally():
+    # --setenv values are argv, not shell input, so they reach printenv verbatim.
+    value = "$(whoami) $HOME `id`"
+    result = await BubblewrapSandbox().execute("printenv MY_VAR", env={"MY_VAR": value})
+    assert result.exit_code == 0
+    assert result.stdout.strip() == value
+
+
+async def test_env_passthrough_forwards_host_var(monkeypatch):
+    monkeypatch.setenv("FORWARD_ME", "from-host")
+    sandbox = BubblewrapSandbox(BubblewrapConfig(env_passthrough=["FORWARD_ME"]))
+    result = await sandbox.execute("printenv FORWARD_ME")
+    assert result.stdout.strip() == "from-host"
+
+
+async def test_runs_code_via_execute_code():
+    result = await BubblewrapSandbox().execute_code("echo $((6 * 7))", "sh")
+    assert result.exit_code == 0
+    assert result.stdout == "42\n"
+
+
+async def test_round_trips_files_in_a_writable_bind(tmp_path):
+    # File ops are inherited shell commands; they need a writable path in the jail.
+    work = tmp_path / "work"
+    work.mkdir()
+    sandbox = BubblewrapSandbox(BubblewrapConfig(rw_binds=[BindMount(str(work), "/work")], working_dir="/work"))
+
+    await sandbox.write_text("greeting.txt", "hello bwrap")
+    assert await sandbox.read_text("greeting.txt") == "hello bwrap"
+
+    data = bytes([0, 1, 2, 127, 128, 254, 255])
+    await sandbox.write_file("binary.bin", data)
+    assert await sandbox.read_file("binary.bin") == data
+
+
+async def test_lists_and_removes_files_in_a_writable_bind(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    sandbox = BubblewrapSandbox(BubblewrapConfig(rw_binds=[BindMount(str(work), "/work")], working_dir="/work"))
+
+    await sandbox.write_text("a.txt", "a")
+    await sandbox.write_text("b.txt", "b")
+
+    names = [f.name for f in await sandbox.list_files(".")]
+    assert "a.txt" in names
+    assert "b.txt" in names
+
+    await sandbox.remove_file("a.txt")
+    with pytest.raises(FileNotFoundError):
+        await sandbox.read_file("a.txt")
+
+
+async def test_read_only_system_dirs_cannot_be_written():
+    # /usr is mounted --ro-bind; writing to it must fail inside the jail.
+    result = await BubblewrapSandbox().execute("touch /usr/should-not-write 2>&1")
+    assert result.exit_code != 0
+
+
+async def test_respects_per_command_cwd_override(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    sandbox = BubblewrapSandbox(BubblewrapConfig(rw_binds=[BindMount(str(work), "/work")]))
+    result = await sandbox.execute("pwd", cwd="/work")
+    assert result.stdout.strip() == "/work"
+
+
+async def test_kills_command_on_timeout():
+    with pytest.raises(TimeoutError, match="timed out"):
+        await BubblewrapSandbox().execute("sleep 60", timeout=0.5)
+
+
+async def test_missing_binary_returns_127():
+    # A bogus bwrap path surfaces as exit 127 with the install hint, not a crash.
+    sandbox = BubblewrapSandbox(BubblewrapConfig(bwrap_path="bwrap-does-not-exist-xyz"))
+    result = await sandbox.execute("echo hi")
+    assert result.exit_code == 127
+    assert "bubblewrap" in result.stderr.lower()


### PR DESCRIPTION
## Motivation

The sandbox module ships Docker and SSH backends, but both delegate isolation to an external runtime: Docker needs a daemon, SSH needs a remote host. There is no way to harden the *local* `PosixShellSandbox` with real OS-level isolation and zero infrastructure.

Per the in-core sandbox decision in #296, `BubblewrapSandbox` fills that gap. It wraps command/code execution in an unprivileged [bubblewrap](https://github.com/containers/bubblewrap) (`bwrap`) Linux user-namespace jail — the same engine behind Flatpak. It was chosen over microsandbox (which requires a daemon + microVM): bubblewrap is a single `bwrap` binary, **no daemon, no server, no vendor auth**.

**Scope of isolation:** Linux-only, **namespace-level** (user/mount/PID/IPC/UTS/cgroup/net) — *not* VM-level. It hardens the existing shell sandbox; it is not a hypervisor boundary.

## Public API

```python
from strands.sandbox import BindMount, BubblewrapConfig, BubblewrapSandbox

# Secure by default: no network, cleared env, all namespaces unshared,
# only read-only system dirs visible.
sandbox = BubblewrapSandbox(
    BubblewrapConfig(
        rw_binds=[BindMount("/tmp/workspace", "/work")],
        working_dir="/work",
        network=False,  # default
    )
)
result = await sandbox.execute("echo hello")
```

`BubblewrapSandbox` subclasses `PosixShellSandbox`, so file and code operations are inherited; it implements only `execute_streaming`, prefixing the shell command with a configurable `bwrap` argv. `BubblewrapConfig` exposes bind mounts (ro/rw), tmpfs paths, a network toggle (`--unshare-net` by default), env passthrough, working dir, the `bwrap` binary path, and raw `extra_args`. `is_bubblewrap_available()` reports support so callers (and tests) can degrade gracefully.

## Design notes

- **Secure-by-default**: `--unshare-all` (network re-shared only on opt-in via `--share-net`), `--die-with-parent`, `--new-session` (TIOCSTI hardening), `--clearenv`. Only a curated read-only set of system dirs (`/usr`, `/bin`, `/lib`…) is mounted — `/home`, `/root`, `/etc`, `/var` are not exposed.
- **No shell injection**: the command is positional after `--`; env vars are passed as discrete `--setenv` argv (verbatim, never shell-evaluated), mirroring the Docker backend's `-e` handling.
- **Cancellation-safe**: the inner `stream_process` generator is wrapped in `contextlib.aclosing`, so its process-tree kill runs deterministically on cancel/early-break.
- **Graceful detection**: missing `bwrap` surfaces as exit code 127 with an install hint rather than a crash; non-Linux short-circuits.

## Testing

Unit tests mock the subprocess and require **no** `bwrap` install. Integration tests under `tests_integ/sandbox/` run a real jail and skip cleanly when `bwrap` is absent or unprivileged user namespaces are disabled. The implementation was additionally exercised end-to-end against a real `bwrap` (file round-trips, env clearing, read-only enforcement, timeout, cancellation).

Refs #296.

cc @mkmeral