### PR TITLE
feat(strands-py): add Presidio PII-redaction intervention handler

### DIFF
--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -58,6 +58,12 @@ sagemaker = [
     "openai>=1.68.0,<3.0.0",  # SageMaker uses OpenAI-compatible interface
 ]
 otel = ["opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0"]
+# PII detection/redaction for the PresidioRedaction intervention handler.
+# Requires a spaCy model at runtime, e.g. `python -m spacy download en_core_web_lg`.
+presidio = [
+    "presidio-analyzer>=2.2.0,<3.0.0",
+    "presidio-anonymizer>=2.2.0,<3.0.0",
+]
 docs = [
     "sphinx>=5.0.0,<10.0.0",
     "sphinx-rtd-theme>=1.0.0,<4.0.0",

--- a/strands-py/src/strands/vended_interventions/__init__.py
+++ b/strands-py/src/strands/vended_interventions/__init__.py
@@ -4,5 +4,6 @@ Ready-to-use InterventionHandler implementations for common control patterns.
 """
 
 from .hitl import HumanInTheLoop
+from .presidio import PresidioRedaction
 
-__all__ = ["HumanInTheLoop"]
+__all__ = ["HumanInTheLoop", "PresidioRedaction"]

--- a/strands-py/src/strands/vended_interventions/presidio/__init__.py
+++ b/strands-py/src/strands/vended_interventions/presidio/__init__.py
@@ -1,0 +1,29 @@
+"""PII redaction intervention for Strands agents.
+
+Detects and anonymizes personally identifiable information (PII) in tool I/O and
+model context using `Microsoft Presidio <https://github.com/microsoft/presidio>`_,
+wired to the ``Transform`` intervention action so redaction happens in-place before
+content reaches the model, downstream tools, or logs.
+
+Presidio is an optional dependency. Install it with::
+
+    pip install 'strands-agents[presidio]'
+    python -m spacy download en_core_web_lg
+
+Example:
+    ```python
+    from strands import Agent
+    from strands.vended_interventions.presidio import PresidioRedaction
+
+    agent = Agent(
+        interventions=[PresidioRedaction(entities=["EMAIL_ADDRESS", "PHONE_NUMBER"])],
+    )
+
+    # Tool I/O and model context now have detected PII redacted in-place.
+    result = agent("Email the report to alice@example.com")
+    ```
+"""
+
+from .presidio import PresidioRedaction
+
+__all__ = ["PresidioRedaction"]

--- a/strands-py/src/strands/vended_interventions/presidio/presidio.py
+++ b/strands-py/src/strands/vended_interventions/presidio/presidio.py
@@ -1,0 +1,466 @@
+"""Presidio-backed PII redaction intervention handler.
+
+Detects and anonymizes personally identifiable information (PII) in tool I/O and
+model context using `Microsoft Presidio <https://github.com/microsoft/presidio>`_,
+wired to the ``Transform`` intervention action so redaction happens in-place before
+content reaches the model, downstream tools, or logs.
+"""
+
+import logging
+from collections.abc import Iterable
+from typing import Any, Literal, cast, get_args
+
+from ...hooks.events import (
+    AfterModelCallEvent,
+    AfterToolCallEvent,
+    BeforeInvocationEvent,
+    BeforeModelCallEvent,
+    BeforeToolCallEvent,
+)
+from ...interventions.actions import LifecycleEvent, Proceed, Transform
+from ...interventions.handler import InterventionHandler
+from ...types.content import ContentBlock, Message
+from ...types.tools import ToolResult, ToolResultContent
+
+logger = logging.getLogger(__name__)
+
+RedactionEvent = Literal[
+    "before_invocation",
+    "before_tool_call",
+    "after_tool_call",
+    "before_model_call",
+    "after_model_call",
+]
+"""Lifecycle events that ``PresidioRedaction`` can scan for PII."""
+
+_DEFAULT_EVENTS: tuple[RedactionEvent, ...] = (
+    "before_tool_call",
+    "after_tool_call",
+    "before_model_call",
+    "after_model_call",
+)
+"""Default event set: redact tool arguments, tool results, and model context.
+
+``before_invocation`` is omitted because ``before_model_call`` already scans the
+full ``agent.messages`` list (which includes the initial user input) before each
+model call, so redaction is applied without scanning the same content twice.
+"""
+
+_OPERATOR_DEFAULTS: dict[str, dict[str, Any]] = {
+    "replace": {},
+    "redact": {},
+    "hash": {"hash_type": "sha256"},
+    "mask": {"masking_char": "*", "chars_to_mask": 100, "from_end": False},
+}
+"""Per-operator parameter defaults merged under any caller-supplied ``operator_params``.
+
+``mask`` requires explicit parameters (Presidio has no usable default), so a
+sensible full-value mask is provided; ``chars_to_mask`` is clamped to each match
+length by Presidio. ``replace`` with no ``new_value`` falls back to Presidio's
+``<ENTITY_TYPE>`` placeholder.
+"""
+
+_IMPORT_ERROR_MESSAGE = (
+    "PresidioRedaction requires the optional 'presidio' dependencies, which are not installed. "
+    "Install them with: pip install 'strands-agents[presidio]' "
+    "and download a spaCy model: python -m spacy download en_core_web_lg"
+)
+
+
+class PresidioRedaction(InterventionHandler):
+    """Redacts PII in tool I/O and model context using Microsoft Presidio.
+
+    Returns a ``Transform`` for each configured lifecycle event whose ``apply``
+    analyzes the relevant text with Presidio's ``AnalyzerEngine`` and anonymizes
+    detected PII in-place with its ``AnonymizerEngine``. Events that are not
+    configured (or carry no text) are a no-op (``Proceed``), so later handlers and
+    the agent see unredacted content only where redaction was not requested.
+
+    Presidio is an optional dependency. The engines are imported lazily on first
+    use and a clear ``ImportError`` is raised if they are missing.
+
+    Example:
+        ```python
+        from strands import Agent
+        from strands.vended_interventions.presidio import PresidioRedaction
+
+        # Redact emails and phone numbers in tool I/O and model context
+        agent = Agent(
+            interventions=[
+                PresidioRedaction(entities=["EMAIL_ADDRESS", "PHONE_NUMBER"]),
+            ],
+        )
+
+        # Mask instead of replacing, and only scan tool results
+        agent = Agent(
+            interventions=[
+                PresidioRedaction(operator="mask", events=["after_tool_call"]),
+            ],
+        )
+        ```
+
+    Note:
+        ``name`` is a fixed class attribute, so at most one ``PresidioRedaction``
+        can be registered per agent; layering two policies requires subclassing to
+        rename. Scanning ``before_model_call`` mutates ``agent.messages`` in place,
+        so PII is redacted from the persisted conversation history (not just the
+        model request) -- this is intentional, to avoid leaking PII through session
+        storage or logs.
+
+    Scope and limitations:
+        Redaction covers the text-bearing fields Presidio can analyze: ``text``
+        content blocks, ``json`` tool-result/content blocks (recursively, strings
+        only), tool-call inputs (``toolUse.input`` and ``before_tool_call`` args),
+        nested ``toolResult`` blocks, and ``reasoningContent`` text. Binary or opaque
+        content (``image``, ``document``, ``video``, encrypted reasoning) is left
+        untouched. Non-string scalars (e.g. a number that is really an SSN) are not
+        redacted because Presidio operates on text. Tokens streamed to a callback
+        during ``after_model_call`` generation are emitted before redaction runs, so
+        configure a downstream filter if real-time stream output must also be clean.
+
+        Detection is only as good as Presidio's recognizers and the configured
+        ``score_threshold``; treat this as defense-in-depth, not a guarantee. Redaction
+        is idempotent: re-scanning already-redacted text (e.g. when ``before_model_call``
+        sweeps the growing history each turn) does not double-redact, since the
+        placeholders contain no detectable PII. That per-call full-history sweep does
+        cost analyzer time proportional to conversation length; for long conversations,
+        prefer scanning at the write boundaries (``after_tool_call`` /
+        ``after_model_call``) so each piece of content is redacted once as it is added.
+    """
+
+    name = "strands:presidio-redaction"
+
+    def __init__(
+        self,
+        *,
+        entities: Iterable[str] | None = None,
+        events: Iterable[RedactionEvent] | None = None,
+        operator: Literal["replace", "mask", "hash", "redact"] = "replace",
+        operator_params: dict[str, Any] | None = None,
+        language: str = "en",
+        score_threshold: float = 0.5,
+        analyzer: Any | None = None,
+        anonymizer: Any | None = None,
+    ) -> None:
+        """Initialize the handler.
+
+        Args:
+            entities: PII entity types to detect (e.g. ``["EMAIL_ADDRESS",
+                "PHONE_NUMBER", "PERSON"]``). When ``None``, every entity supported
+                by the analyzer's recognizers is detected.
+            events: Lifecycle events to scan. Defaults to ``before_tool_call``,
+                ``after_tool_call``, ``before_model_call`` and ``after_model_call``.
+                Events not listed here are a no-op.
+            operator: Anonymization operator applied to detected PII. ``"replace"``
+                substitutes a placeholder (Presidio's ``<ENTITY_TYPE>`` by default),
+                ``"mask"`` overwrites characters with a mask character, ``"hash"``
+                replaces the value with its hash, and ``"redact"`` removes it.
+            operator_params: Extra parameters forwarded to Presidio's
+                ``OperatorConfig`` for ``operator``, merged over sensible defaults.
+                For example ``{"new_value": "<REDACTED>"}`` for ``"replace"`` or
+                ``{"masking_char": "#"}`` for ``"mask"``.
+            language: Language code passed to the analyzer. Defaults to ``"en"``.
+            score_threshold: Minimum detection confidence (``0.0``-``1.0``) for a
+                match to be redacted. Defaults to ``0.5``.
+            analyzer: Pre-built Presidio ``AnalyzerEngine`` (or compatible). When
+                ``None``, one is created lazily on first use. Supplying your own lets
+                you customize recognizers and avoids importing Presidio for tests.
+            anonymizer: Pre-built Presidio ``AnonymizerEngine`` (or compatible). When
+                ``None``, one is created lazily on first use.
+
+        Raises:
+            ValueError: If ``events`` is a bare string, or contains an unknown event
+                name, or if ``operator`` is not supported.
+        """
+        # A bare string is iterable, so ``set("before_tool_call")`` would silently
+        # become a per-char set; reject it the way HumanInTheLoop rejects allowed_tools.
+        if isinstance(events, str):
+            raise ValueError("events must be a list of event names, not a single string")
+
+        selected = tuple(events) if events is not None else _DEFAULT_EVENTS
+        valid_events = set(get_args(RedactionEvent))
+        unknown = [event for event in selected if event not in valid_events]
+        if unknown:
+            raise ValueError(f"Unknown redaction event(s): {unknown}. Valid events: {sorted(valid_events)}")
+
+        if operator not in _OPERATOR_DEFAULTS:
+            raise ValueError(f"Unsupported operator: '{operator}'. Valid operators: {sorted(_OPERATOR_DEFAULTS)}")
+
+        self._entities = list(entities) if entities is not None else None
+        self._events: frozenset[RedactionEvent] = frozenset(selected)
+        self._operator = operator
+        self._operator_params = {**_OPERATOR_DEFAULTS[operator], **(operator_params or {})}
+        self._language = language
+        self._score_threshold = score_threshold
+        # Typed as Any: these hold Presidio engines (an optional dependency without
+        # type stubs) and start as None until built lazily on first use.
+        self._analyzer: Any = analyzer
+        self._anonymizer: Any = anonymizer
+        self._operators: dict[str, Any] | None = None
+        self._reason = "Presidio PII redaction"
+
+    def before_invocation(self, event: BeforeInvocationEvent, **kwargs: Any) -> Proceed | Transform:
+        """Redact PII in the invocation's input messages before processing begins.
+
+        Args:
+            event: The before-invocation event under evaluation.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            A ``Transform`` that redacts ``event.messages`` when this event is
+            configured, otherwise ``Proceed``.
+        """
+        if "before_invocation" not in self._events:
+            return Proceed()
+        return Transform(apply=self._apply_before_invocation, reason=self._reason)
+
+    def before_tool_call(self, event: BeforeToolCallEvent, **kwargs: Any) -> Proceed | Transform:
+        """Redact PII in a tool call's input arguments before the tool runs.
+
+        Args:
+            event: The before-tool-call event under evaluation.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            A ``Transform`` that redacts ``event.tool_use["input"]`` when this event
+            is configured, otherwise ``Proceed``.
+        """
+        if "before_tool_call" not in self._events:
+            return Proceed()
+        return Transform(apply=self._apply_before_tool_call, reason=self._reason)
+
+    def after_tool_call(self, event: AfterToolCallEvent, **kwargs: Any) -> Proceed | Transform:
+        """Redact PII in a tool result before it reaches the model or logs.
+
+        Args:
+            event: The after-tool-call event under evaluation.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            A ``Transform`` that redacts ``event.result`` when this event is
+            configured, otherwise ``Proceed``.
+        """
+        if "after_tool_call" not in self._events:
+            return Proceed()
+        return Transform(apply=self._apply_after_tool_call, reason=self._reason)
+
+    def before_model_call(self, event: BeforeModelCallEvent, **kwargs: Any) -> Proceed | Transform:
+        """Redact PII in the conversation context before the model is invoked.
+
+        Args:
+            event: The before-model-call event under evaluation.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            A ``Transform`` that redacts ``event.agent.messages`` when this event is
+            configured, otherwise ``Proceed``.
+        """
+        if "before_model_call" not in self._events:
+            return Proceed()
+        return Transform(apply=self._apply_before_model_call, reason=self._reason)
+
+    def after_model_call(self, event: AfterModelCallEvent, **kwargs: Any) -> Proceed | Transform:
+        """Redact PII in the model's response before it is added to history or logged.
+
+        Args:
+            event: The after-model-call event under evaluation.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            A ``Transform`` that redacts ``event.stop_response.message`` when this
+            event is configured, otherwise ``Proceed``.
+        """
+        if "after_model_call" not in self._events:
+            return Proceed()
+        return Transform(apply=self._apply_after_model_call, reason=self._reason)
+
+    def _apply_before_invocation(self, event: LifecycleEvent) -> None:
+        """Redact PII in the invocation input messages in-place."""
+        if isinstance(event, BeforeInvocationEvent) and event.messages is not None:
+            self._redact_messages(event.messages)
+
+    def _apply_before_tool_call(self, event: LifecycleEvent) -> None:
+        """Redact PII in the tool input arguments in-place."""
+        if isinstance(event, BeforeToolCallEvent):
+            event.tool_use["input"] = self._redact_value(event.tool_use.get("input"))
+
+    def _apply_after_tool_call(self, event: LifecycleEvent) -> None:
+        """Redact PII in the tool result in-place."""
+        if isinstance(event, AfterToolCallEvent):
+            self._redact_tool_result(event.result)
+
+    def _apply_before_model_call(self, event: LifecycleEvent) -> None:
+        """Redact PII across the agent's conversation history in-place."""
+        if isinstance(event, BeforeModelCallEvent):
+            self._redact_messages(event.agent.messages)
+
+    def _apply_after_model_call(self, event: LifecycleEvent) -> None:
+        """Redact PII in the model's response message in-place."""
+        if isinstance(event, AfterModelCallEvent) and event.stop_response is not None:
+            self._redact_message(event.stop_response.message)
+
+    def _redact_messages(self, messages: Iterable[Message]) -> None:
+        """Redact PII across every content block of every message in-place.
+
+        Args:
+            messages: The messages whose content blocks should be scanned.
+        """
+        for message in messages:
+            self._redact_message(message)
+
+    def _redact_message(self, message: Message) -> None:
+        """Redact PII across every content block of a single message in-place.
+
+        Args:
+            message: The message whose content blocks should be scanned.
+        """
+        for block in message.get("content", []):
+            self._redact_content_block(block)
+
+    def _redact_tool_result(self, result: ToolResult) -> None:
+        """Redact PII across every content block of a tool result in-place.
+
+        Args:
+            result: The tool result whose content blocks should be scanned.
+        """
+        for block in result.get("content", []):
+            self._redact_content_block(block)
+
+    def _redact_content_block(self, block: ContentBlock | ToolResultContent) -> None:
+        """Redact PII in every text-bearing field of a single content block in-place.
+
+        Handles each content shape that can carry free text or string-valued data:
+        ``text`` blocks, ``json`` blocks (tool results), nested ``toolResult`` and
+        ``toolUse`` blocks, and ``reasoningContent`` (extended-thinking) text. Binary
+        and opaque blocks (``image``, ``document``, ``video``, encrypted
+        ``redactedContent``) are left untouched -- Presidio operates on text only.
+
+        Args:
+            block: A content block (``ContentBlock`` or ``ToolResultContent``).
+        """
+        # TypedDicts are plain dicts at runtime; cast to a mutable mapping so the
+        # heterogeneous key access/assignment below type-checks across both shapes.
+        data = cast("dict[str, Any]", block)
+        if "text" in data:
+            data["text"] = self._redact_text(data["text"])
+        if "json" in data:
+            data["json"] = self._redact_value(data["json"])
+        if "reasoningContent" in data:
+            reasoning_text = data["reasoningContent"].get("reasoningText")
+            if reasoning_text is not None and "text" in reasoning_text:
+                reasoning_text["text"] = self._redact_text(reasoning_text["text"])
+        if "toolUse" in data:
+            data["toolUse"]["input"] = self._redact_value(data["toolUse"].get("input"))
+        if "toolResult" in data:
+            self._redact_tool_result(data["toolResult"])
+
+    def _redact_value(self, value: Any) -> Any:
+        """Recursively redact PII in strings nested within a value.
+
+        Strings are redacted directly; dicts and lists are walked so PII in nested
+        argument or JSON structures is caught. Other types (numbers, bools, ``None``,
+        opaque objects) are returned unchanged -- Presidio operates on text only.
+
+        Args:
+            value: A tool input or JSON value (string, mapping, sequence, or scalar).
+
+        Returns:
+            The value with any string PII redacted.
+        """
+        if isinstance(value, str):
+            return self._redact_text(value)
+        if isinstance(value, dict):
+            return {key: self._redact_value(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [self._redact_value(item) for item in value]
+        return value
+
+    def _redact_text(self, text: str) -> str:
+        """Analyze and anonymize PII in a single string.
+
+        Args:
+            text: The text to scan.
+
+        Returns:
+            The text with detected PII anonymized, or the original text when it is
+            empty or contains no detectable PII.
+        """
+        if not text or not text.strip():
+            return text
+
+        self._ensure_engines()
+        results = self._analyzer.analyze(
+            text=text,
+            language=self._language,
+            entities=self._entities,
+            score_threshold=self._score_threshold,
+        )
+        if not results:
+            return text
+
+        logger.debug(
+            "matches=<%d>, operator=<%s>, language=<%s> | redacting detected pii",
+            len(results),
+            self._operator,
+            self._language,
+        )
+        anonymized = self._anonymizer.anonymize(
+            text=text,
+            analyzer_results=results,
+            operators=self._get_operators(),
+        )
+        redacted: str = anonymized.text
+        return redacted
+
+    def _ensure_engines(self) -> None:
+        """Lazily construct the Presidio analyzer and anonymizer engines.
+
+        Raises:
+            ImportError: If the optional Presidio dependencies are not installed.
+        """
+        if self._analyzer is not None and self._anonymizer is not None:
+            return
+
+        analyzer_engine, anonymizer_engine, _ = self._import_presidio()
+        if self._analyzer is None:
+            logger.debug(
+                "entities=<%s>, score_threshold=<%s> | building presidio analyzer engine",
+                self._entities,
+                self._score_threshold,
+            )
+            self._analyzer = analyzer_engine()
+        if self._anonymizer is None:
+            self._anonymizer = anonymizer_engine()
+
+    def _get_operators(self) -> dict[str, Any]:
+        """Build (and cache) the Presidio operator configuration.
+
+        Returns:
+            A mapping with a ``"DEFAULT"`` operator config applied to every entity.
+
+        Raises:
+            ImportError: If the optional Presidio dependencies are not installed.
+        """
+        if self._operators is None:
+            _, _, operator_config = self._import_presidio()
+            self._operators = {"DEFAULT": operator_config(self._operator, self._operator_params)}
+        return self._operators
+
+    @staticmethod
+    def _import_presidio() -> tuple[Any, Any, Any]:
+        """Import Presidio engines lazily with a helpful error if unavailable.
+
+        Returns:
+            The ``AnalyzerEngine`` class, ``AnonymizerEngine`` class, and
+            ``OperatorConfig`` class.
+
+        Raises:
+            ImportError: If the optional Presidio dependencies are not installed.
+        """
+        try:
+            from presidio_analyzer import AnalyzerEngine  # type: ignore[import-not-found]
+            from presidio_anonymizer import AnonymizerEngine  # type: ignore[import-not-found]
+            from presidio_anonymizer.entities import OperatorConfig  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(_IMPORT_ERROR_MESSAGE) from exc
+        return AnalyzerEngine, AnonymizerEngine, OperatorConfig

--- a/strands-py/tests/strands/vended_interventions/test_hitl.py
+++ b/strands-py/tests/strands/vended_interventions/test_hitl.py
@@ -571,7 +571,7 @@ class TestPublicExports:
         import strands.vended_interventions as vended
         import strands.vended_interventions.hitl as hitl
 
-        assert vended.__all__ == ["HumanInTheLoop"]
+        assert vended.__all__ == ["HumanInTheLoop", "PresidioRedaction"]
         assert hitl.__all__ == ["HumanInTheLoop"]
         assert vended.HumanInTheLoop is hitl.HumanInTheLoop
         assert hitl.HumanInTheLoop.name == "strands:human-in-the-loop"

--- a/strands-py/tests/strands/vended_interventions/test_presidio.py
+++ b/strands-py/tests/strands/vended_interventions/test_presidio.py
@@ -1,0 +1,803 @@
+"""Tests for the PresidioRedaction vended intervention handler.
+
+The Presidio engines are mocked throughout: a ``FakeAnalyzer`` finds configured
+substrings and a ``FakeAnonymizer`` replaces each match with a placeholder. This
+exercises the handler's wiring (which events return a ``Transform``, what each
+``apply`` mutates, and how the config knobs are honoured) without installing
+Presidio or downloading a spaCy model.
+"""
+
+import unittest.mock
+from dataclasses import dataclass
+
+import pytest
+
+from strands import Agent
+from strands.hooks.events import (
+    AfterModelCallEvent,
+    AfterToolCallEvent,
+    BeforeInvocationEvent,
+    BeforeModelCallEvent,
+    BeforeToolCallEvent,
+)
+from strands.interrupt import _InterruptState
+from strands.interventions.actions import Proceed, Transform
+from strands.tools import tool
+from strands.vended_interventions.presidio import PresidioRedaction
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+EMAIL = "alice@example.com"
+PLACEHOLDER = "<EMAIL_ADDRESS>"
+
+
+@dataclass
+class _FakeResult:
+    """Minimal stand-in for Presidio's ``RecognizerResult``."""
+
+    entity_type: str
+    start: int
+    end: int
+    score: float
+
+
+class _FakeAnalyzer:
+    """Finds every occurrence of configured substrings as PII matches.
+
+    Records the kwargs of the most recent ``analyze`` call so tests can assert that
+    config knobs (language, entities, score_threshold) are forwarded correctly.
+    """
+
+    def __init__(self, needles: list[str] | None = None) -> None:
+        self.needles = needles if needles is not None else [EMAIL]
+        self.calls: list[dict] = []
+
+    def analyze(self, *, text, language, entities, score_threshold):
+        self.calls.append(
+            {
+                "text": text,
+                "language": language,
+                "entities": entities,
+                "score_threshold": score_threshold,
+            }
+        )
+        results: list[_FakeResult] = []
+        for needle in self.needles:
+            start = text.find(needle)
+            while start != -1:
+                results.append(_FakeResult("EMAIL_ADDRESS", start, start + len(needle), 0.99))
+                start = text.find(needle, start + len(needle))
+        return results
+
+
+@dataclass
+class _FakeAnonymized:
+    """Minimal stand-in for Presidio's ``EngineResult`` (only ``.text`` is used)."""
+
+    text: str
+
+
+class _FakeAnonymizer:
+    """Replaces each analyzer match with a placeholder built from the operator.
+
+    Mirrors Presidio's contract closely enough for assertions: it sorts matches in
+    reverse so index-based splicing stays valid, and honours a ``new_value`` /
+    ``masking_char`` operator param so config-knob tests are meaningful.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def anonymize(self, *, text, analyzer_results, operators):
+        self.calls.append({"text": text, "analyzer_results": analyzer_results, "operators": operators})
+        config = operators["DEFAULT"]
+        replacement = self._replacement(config)
+        for result in sorted(analyzer_results, key=lambda r: r.start, reverse=True):
+            value = replacement if replacement is not None else f"<{result.entity_type}>"
+            text = text[: result.start] + value + text[result.end :]
+        return _FakeAnonymized(text=text)
+
+    @staticmethod
+    def _replacement(config) -> str | None:
+        params = config.params
+        if config.operator_name == "replace":
+            new_value = params.get("new_value")
+            return str(new_value) if new_value else None
+        if config.operator_name == "mask":
+            return params.get("masking_char", "*") * 4
+        return None
+
+
+class _FakeOperatorConfig:
+    """Stand-in for Presidio's ``OperatorConfig`` (name + params holder)."""
+
+    def __init__(self, operator_name, params=None) -> None:
+        self.operator_name = operator_name
+        self.params = params or {}
+
+
+@pytest.fixture(autouse=True)
+def patch_presidio(monkeypatch):
+    """Patch the single lazy-import seam so engines build without the real library.
+
+    Every handler in this module (whether it injects engines or builds them lazily)
+    resolves Presidio classes through ``_import_presidio``; patching it here keeps the
+    whole suite free of Presidio and spaCy. ``TestLazyImport`` overrides this within
+    its own tests to assert the missing-dependency behaviour.
+    """
+    monkeypatch.setattr(
+        PresidioRedaction,
+        "_import_presidio",
+        staticmethod(lambda: (_FakeAnalyzer, _FakeAnonymizer, _FakeOperatorConfig)),
+    )
+
+
+def make_handler(**kwargs) -> PresidioRedaction:
+    """Build a handler whose engines are built lazily from the patched fake import."""
+    return PresidioRedaction(**kwargs)
+
+
+def make_agent():
+    """A lightweight mock agent for direct event construction."""
+    agent = unittest.mock.Mock()
+    agent._interrupt_state = _InterruptState()
+    agent.messages = []
+    return agent
+
+
+def tool_use_message(name: str, tool_use_id: str = "tool-1", tool_input: dict | None = None) -> dict:
+    return {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": tool_use_id, "name": name, "input": tool_input or {}}}],
+    }
+
+
+def text_message(text: str) -> dict:
+    return {"role": "assistant", "content": [{"text": text}]}
+
+
+class TestTransformReturnedForConfiguredEvents:
+    """A Transform is returned only for configured events; others are a no-op Proceed."""
+
+    def test_default_events_return_transform(self):
+        handler = make_handler()
+        agent = make_agent()
+
+        before_tool = handler.before_tool_call(
+            BeforeToolCallEvent(
+                agent=agent,
+                selected_tool=None,
+                tool_use={"toolUseId": "t", "name": "x", "input": {}},
+                invocation_state={},
+            )
+        )
+        after_tool = handler.after_tool_call(
+            AfterToolCallEvent(
+                agent=agent,
+                selected_tool=None,
+                tool_use={"toolUseId": "t", "name": "x", "input": {}},
+                invocation_state={},
+                result={"toolUseId": "t", "status": "success", "content": []},
+            )
+        )
+        before_model = handler.before_model_call(BeforeModelCallEvent(agent=agent, invocation_state={}))
+        after_model = handler.after_model_call(AfterModelCallEvent(agent=agent, invocation_state={}))
+
+        assert isinstance(before_tool, Transform)
+        assert isinstance(after_tool, Transform)
+        assert isinstance(before_model, Transform)
+        assert isinstance(after_model, Transform)
+
+    def test_before_invocation_is_not_scanned_by_default(self):
+        handler = make_handler()
+        agent = make_agent()
+
+        action = handler.before_invocation(BeforeInvocationEvent(agent=agent, messages=[]))
+
+        assert isinstance(action, Proceed)
+
+    def test_unconfigured_events_return_proceed(self):
+        handler = make_handler(events=["after_tool_call"])
+        agent = make_agent()
+
+        before_tool = handler.before_tool_call(
+            BeforeToolCallEvent(
+                agent=agent,
+                selected_tool=None,
+                tool_use={"toolUseId": "t", "name": "x", "input": {}},
+                invocation_state={},
+            )
+        )
+        before_model = handler.before_model_call(BeforeModelCallEvent(agent=agent, invocation_state={}))
+        after_model = handler.after_model_call(AfterModelCallEvent(agent=agent, invocation_state={}))
+
+        assert isinstance(before_tool, Proceed)
+        assert isinstance(before_model, Proceed)
+        assert isinstance(after_model, Proceed)
+
+        # The one configured event still returns a Transform.
+        after_tool = handler.after_tool_call(
+            AfterToolCallEvent(
+                agent=agent,
+                selected_tool=None,
+                tool_use={"toolUseId": "t", "name": "x", "input": {}},
+                invocation_state={},
+                result={"toolUseId": "t", "status": "success", "content": []},
+            )
+        )
+        assert isinstance(after_tool, Transform)
+
+
+class TestApplyMutatesContent:
+    """The Transform's apply mutates event content in-place: PII -> placeholder."""
+
+    def test_before_tool_call_redacts_string_input(self):
+        handler = make_handler()
+        agent = make_agent()
+        event = BeforeToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "send", "input": {"to": EMAIL, "count": 3}},
+            invocation_state={},
+        )
+
+        action = handler.before_tool_call(event)
+        action.apply(event)
+
+        assert event.tool_use["input"]["to"] == PLACEHOLDER
+        # Non-string args are untouched.
+        assert event.tool_use["input"]["count"] == 3
+
+    def test_before_tool_call_redacts_nested_input(self):
+        handler = make_handler()
+        agent = make_agent()
+        event = BeforeToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={
+                "toolUseId": "t",
+                "name": "send",
+                "input": {"recipients": [EMAIL, "bob"], "meta": {"cc": EMAIL}},
+            },
+            invocation_state={},
+        )
+
+        action = handler.before_tool_call(event)
+        action.apply(event)
+
+        assert event.tool_use["input"]["recipients"] == [PLACEHOLDER, "bob"]
+        assert event.tool_use["input"]["meta"]["cc"] == PLACEHOLDER
+
+    def test_after_tool_call_redacts_result_text(self):
+        handler = make_handler()
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={
+                "toolUseId": "t",
+                "status": "success",
+                "content": [{"text": f"Reply to {EMAIL} now"}, {"image": {"format": "png"}}],
+            },
+        )
+
+        action = handler.after_tool_call(event)
+        action.apply(event)
+
+        assert event.result["content"][0]["text"] == f"Reply to {PLACEHOLDER} now"
+        # Non-text/non-json content blocks are left untouched.
+        assert event.result["content"][1]["image"] == {"format": "png"}
+
+    def test_before_model_call_redacts_message_history(self):
+        handler = make_handler()
+        agent = make_agent()
+        agent.messages = [
+            {"role": "user", "content": [{"text": f"Contact {EMAIL}"}]},
+            {"role": "assistant", "content": [{"text": "ok"}]},
+        ]
+        event = BeforeModelCallEvent(agent=agent, invocation_state={})
+
+        action = handler.before_model_call(event)
+        action.apply(event)
+
+        assert agent.messages[0]["content"][0]["text"] == f"Contact {PLACEHOLDER}"
+        assert agent.messages[1]["content"][0]["text"] == "ok"
+
+    def test_after_model_call_redacts_response_message(self):
+        handler = make_handler()
+        agent = make_agent()
+        stop_response = AfterModelCallEvent.ModelStopResponse(
+            message={"role": "assistant", "content": [{"text": f"Sent to {EMAIL}"}]},
+            stop_reason="end_turn",
+        )
+        event = AfterModelCallEvent(agent=agent, invocation_state={}, stop_response=stop_response)
+
+        action = handler.after_model_call(event)
+        action.apply(event)
+
+        assert event.stop_response.message["content"][0]["text"] == f"Sent to {PLACEHOLDER}"
+
+    def test_after_model_call_with_no_response_is_safe(self):
+        handler = make_handler()
+        agent = make_agent()
+        event = AfterModelCallEvent(agent=agent, invocation_state={}, stop_response=None)
+
+        action = handler.after_model_call(event)
+        action.apply(event)  # Must not raise when the model call failed.
+
+    def test_before_invocation_redacts_input_messages(self):
+        handler = make_handler(events=["before_invocation"])
+        agent = make_agent()
+        messages = [{"role": "user", "content": [{"text": f"My email is {EMAIL}"}]}]
+        event = BeforeInvocationEvent(agent=agent, messages=messages)
+
+        action = handler.before_invocation(event)
+        assert isinstance(action, Transform)
+        action.apply(event)
+
+        assert messages[0]["content"][0]["text"] == f"My email is {PLACEHOLDER}"
+
+    def test_text_without_pii_is_unchanged(self):
+        handler = make_handler()
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": "nothing sensitive here"}]},
+        )
+
+        handler.after_tool_call(event).apply(event)
+
+        assert event.result["content"][0]["text"] == "nothing sensitive here"
+
+    def test_empty_and_whitespace_text_skips_analyzer(self):
+        analyzer = _FakeAnalyzer()
+        handler = make_handler(analyzer=analyzer)
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": ""}, {"text": "   "}]},
+        )
+
+        handler.after_tool_call(event).apply(event)
+
+        assert analyzer.calls == []
+
+
+class TestConfigKnobs:
+    """Config knobs (entities, language, threshold, operator) are honoured."""
+
+    def test_language_entities_and_threshold_forwarded_to_analyzer(self):
+        analyzer = _FakeAnalyzer()
+        handler = make_handler(
+            analyzer=analyzer,
+            entities=["EMAIL_ADDRESS", "PERSON"],
+            language="de",
+            score_threshold=0.8,
+        )
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": f"hi {EMAIL}"}]},
+        )
+
+        handler.after_tool_call(event).apply(event)
+
+        call = analyzer.calls[0]
+        assert call["language"] == "de"
+        assert call["entities"] == ["EMAIL_ADDRESS", "PERSON"]
+        assert call["score_threshold"] == 0.8
+
+    def test_default_entities_is_none_meaning_all(self):
+        analyzer = _FakeAnalyzer()
+        handler = make_handler(analyzer=analyzer)
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": f"hi {EMAIL}"}]},
+        )
+
+        handler.after_tool_call(event).apply(event)
+
+        assert analyzer.calls[0]["entities"] is None
+
+    def test_replace_operator_uses_custom_new_value(self):
+        handler = PresidioRedaction(
+            analyzer=_FakeAnalyzer(),
+            anonymizer=_FakeAnonymizer(),
+            operator="replace",
+            operator_params={"new_value": "<REDACTED>"},
+        )
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": f"to {EMAIL}"}]},
+        )
+
+        handler.after_tool_call(event).apply(event)
+
+        assert event.result["content"][0]["text"] == "to <REDACTED>"
+
+    def test_mask_operator_uses_masking_char(self):
+        handler = PresidioRedaction(
+            analyzer=_FakeAnalyzer(),
+            anonymizer=_FakeAnonymizer(),
+            operator="mask",
+            operator_params={"masking_char": "#"},
+        )
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": f"to {EMAIL}"}]},
+        )
+
+        handler.after_tool_call(event).apply(event)
+
+        assert event.result["content"][0]["text"] == "to ####"
+
+    def test_operator_config_is_built_with_selected_operator(self):
+        anonymizer = _FakeAnonymizer()
+        handler = PresidioRedaction(analyzer=_FakeAnalyzer(), anonymizer=anonymizer, operator="hash")
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": f"to {EMAIL}"}]},
+        )
+
+        handler.after_tool_call(event).apply(event)
+
+        assert anonymizer.calls[0]["operators"]["DEFAULT"].operator_name == "hash"
+
+
+class TestComprehensiveContentCoverage:
+    """Redaction reaches every text-bearing content shape, not just plain text blocks."""
+
+    def test_after_tool_call_redacts_json_block(self):
+        handler = make_handler()
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={
+                "toolUseId": "t",
+                "status": "success",
+                "content": [{"json": {"contact": EMAIL, "rows": [{"email": EMAIL}], "count": 2}}],
+            },
+        )
+
+        handler.after_tool_call(event).apply(event)
+
+        redacted = event.result["content"][0]["json"]
+        assert redacted["contact"] == PLACEHOLDER
+        assert redacted["rows"][0]["email"] == PLACEHOLDER
+        # Non-string scalars in JSON are left untouched.
+        assert redacted["count"] == 2
+
+    def test_before_model_call_redacts_tool_use_input_in_history(self):
+        # The assistant's tool-call args persist in history; they must be redacted too.
+        handler = make_handler()
+        agent = make_agent()
+        agent.messages = [
+            {
+                "role": "assistant",
+                "content": [{"toolUse": {"toolUseId": "t", "name": "send", "input": {"to": EMAIL}}}],
+            }
+        ]
+        event = BeforeModelCallEvent(agent=agent, invocation_state={})
+
+        handler.before_model_call(event).apply(event)
+
+        assert agent.messages[0]["content"][0]["toolUse"]["input"]["to"] == PLACEHOLDER
+
+    def test_before_model_call_redacts_tool_result_block_in_history(self):
+        # Tool results live in user-role messages as toolResult blocks; sweep must reach them.
+        handler = make_handler()
+        agent = make_agent()
+        agent.messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "t",
+                            "status": "success",
+                            "content": [{"text": f"found {EMAIL}"}],
+                        }
+                    }
+                ],
+            }
+        ]
+        event = BeforeModelCallEvent(agent=agent, invocation_state={})
+
+        handler.before_model_call(event).apply(event)
+
+        result_text = agent.messages[0]["content"][0]["toolResult"]["content"][0]["text"]
+        assert result_text == f"found {PLACEHOLDER}"
+
+    def test_redacts_reasoning_content_text(self):
+        handler = make_handler()
+        agent = make_agent()
+        agent.messages = [
+            {
+                "role": "assistant",
+                "content": [{"reasoningContent": {"reasoningText": {"text": f"user is {EMAIL}"}}}],
+            }
+        ]
+        event = BeforeModelCallEvent(agent=agent, invocation_state={})
+
+        handler.before_model_call(event).apply(event)
+
+        assert agent.messages[0]["content"][0]["reasoningContent"]["reasoningText"]["text"] == f"user is {PLACEHOLDER}"
+
+    def test_non_text_blocks_pass_through_untouched(self):
+        handler = make_handler()
+        agent = make_agent()
+        image_block = {"image": {"format": "png", "source": {"bytes": b"data"}}}
+        agent.messages = [{"role": "user", "content": [image_block, {"text": f"see {EMAIL}"}]}]
+        event = BeforeModelCallEvent(agent=agent, invocation_state={})
+
+        handler.before_model_call(event).apply(event)
+
+        assert agent.messages[0]["content"][0] == {"image": {"format": "png", "source": {"bytes": b"data"}}}
+        assert agent.messages[0]["content"][1]["text"] == f"see {PLACEHOLDER}"
+
+
+class TestToolInputEdgeCases:
+    """before_tool_call handles missing / None / scalar inputs without raising."""
+
+    def test_missing_input_key_is_safe(self):
+        handler = make_handler()
+        agent = make_agent()
+        event = BeforeToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x"},  # no "input" key
+            invocation_state={},
+        )
+
+        handler.before_tool_call(event).apply(event)  # Must not raise.
+
+        assert event.tool_use["input"] is None
+
+    def test_none_input_is_safe(self):
+        handler = make_handler()
+        agent = make_agent()
+        event = BeforeToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": None},
+            invocation_state={},
+        )
+
+        handler.before_tool_call(event).apply(event)
+
+        assert event.tool_use["input"] is None
+
+    def test_scalar_input_is_left_unchanged(self):
+        handler = make_handler()
+        agent = make_agent()
+        event = BeforeToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": 42},
+            invocation_state={},
+        )
+
+        handler.before_tool_call(event).apply(event)
+
+        assert event.tool_use["input"] == 42
+
+
+class TestHistoryPersistenceAndIdempotency:
+    """after_model_call redacts the message that gets persisted; redaction is idempotent."""
+
+    def test_after_model_call_redacts_persisted_history(self):
+        @tool(name="noop")
+        def noop() -> str:
+            return "ok"
+
+        model = MockedModelProvider([text_message(f"Reply to {EMAIL}")])
+        agent = Agent(
+            model=model,
+            tools=[noop],
+            interventions=[make_handler(events=["after_model_call"])],
+        )
+
+        agent("hi")
+
+        # The final assistant message persisted to history must be redacted, not just
+        # the in-flight stop_response (they share the same object reference).
+        last = agent.messages[-1]
+        assert last["role"] == "assistant"
+        joined = " ".join(block.get("text", "") for block in last["content"])
+        assert EMAIL not in joined
+        assert PLACEHOLDER in joined
+
+    def test_redaction_is_idempotent(self):
+        handler = make_handler()
+        agent = make_agent()
+        message = {"role": "user", "content": [{"text": f"reach {EMAIL}"}]}
+        agent.messages = [message]
+        event = BeforeModelCallEvent(agent=agent, invocation_state={})
+
+        handler.before_model_call(event).apply(event)
+        once = message["content"][0]["text"]
+        # A second sweep over already-redacted history changes nothing.
+        handler.before_model_call(event).apply(event)
+        twice = message["content"][0]["text"]
+
+        assert once == twice == f"reach {PLACEHOLDER}"
+
+
+class TestValidation:
+    """Constructor validation mirrors HumanInTheLoop's defensive checks."""
+
+    def test_bare_string_events_raises(self):
+        with pytest.raises(ValueError, match="must be a list"):
+            PresidioRedaction(events="before_tool_call")
+
+    def test_unknown_event_raises(self):
+        with pytest.raises(ValueError, match="Unknown redaction event"):
+            PresidioRedaction(events=["before_tool_call", "not_an_event"])
+
+    def test_unsupported_operator_raises(self):
+        with pytest.raises(ValueError, match="Unsupported operator"):
+            PresidioRedaction(operator="encrypt")
+
+
+class TestLazyImport:
+    """Presidio is imported lazily; a clear error is raised when it's missing."""
+
+    def test_no_presidio_import_at_module_load(self):
+        # Importing the handler module must not import Presidio (optional dep).
+        import sys
+
+        assert "presidio_analyzer" not in sys.modules
+        assert "presidio_anonymizer" not in sys.modules
+
+    def test_helpful_error_when_presidio_missing(self, monkeypatch):
+        # Restore the genuine _import_presidio (the autouse fixture patched it), then
+        # rely on Presidio genuinely being absent so the real ImportError path runs.
+        monkeypatch.undo()
+        if "presidio_analyzer" in __import__("sys").modules:
+            pytest.skip("presidio is installed; cannot exercise the missing-dependency path")
+
+        handler = PresidioRedaction()
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": f"to {EMAIL}"}]},
+        )
+
+        with pytest.raises(ImportError, match="strands-agents\\[presidio\\]"):
+            handler.after_tool_call(event).apply(event)
+
+    def test_no_import_attempted_when_engines_injected(self, monkeypatch):
+        # Injected engines short-circuit the lazy import entirely.
+        def boom():
+            raise AssertionError("_import_presidio must not be called when engines are injected")
+
+        monkeypatch.setattr(PresidioRedaction, "_import_presidio", staticmethod(boom))
+        # OperatorConfig is also injected so no import is needed for anonymization.
+        handler = PresidioRedaction(
+            analyzer=_FakeAnalyzer(),
+            anonymizer=_FakeAnonymizer(),
+            operator_params={"new_value": "<REDACTED>"},
+        )
+        # Pre-seed the cached operator config so _get_operators skips the import too.
+        handler._operators = {"DEFAULT": _FakeOperatorConfig("replace", {"new_value": "<REDACTED>"})}
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": f"to {EMAIL}"}]},
+        )
+
+        handler.after_tool_call(event).apply(event)  # Must not raise.
+
+        assert event.result["content"][0]["text"] == "to <REDACTED>"
+
+    def test_engines_built_lazily_from_import(self):
+        # No injected engines: built lazily from the (patched) import on first use.
+        handler = PresidioRedaction()
+        agent = make_agent()
+        event = AfterToolCallEvent(
+            agent=agent,
+            selected_tool=None,
+            tool_use={"toolUseId": "t", "name": "x", "input": {}},
+            invocation_state={},
+            result={"toolUseId": "t", "status": "success", "content": [{"text": f"to {EMAIL}"}]},
+        )
+
+        handler.after_tool_call(event).apply(event)
+
+        assert event.result["content"][0]["text"] == f"to {PLACEHOLDER}"
+
+
+class TestEndToEndWithAgent:
+    """The handler integrates with a real Agent via the intervention registry."""
+
+    def test_redacts_tool_input_before_execution(self):
+        seen_args = []
+
+        @tool(name="send_email")
+        def send_email(to: str) -> str:
+            seen_args.append(to)
+            return "sent"
+
+        model = MockedModelProvider([tool_use_message("send_email", tool_input={"to": EMAIL}), text_message("Done")])
+        agent = Agent(
+            model=model,
+            tools=[send_email],
+            interventions=[make_handler(events=["before_tool_call"])],
+        )
+
+        result = agent("Email the report")
+
+        assert result.stop_reason == "end_turn"
+        # The tool received the redacted address, never the real PII.
+        assert seen_args == [PLACEHOLDER]
+
+    def test_redacts_tool_result_after_execution(self):
+        @tool(name="lookup")
+        def lookup() -> str:
+            return f"The contact is {EMAIL}"
+
+        model = MockedModelProvider([tool_use_message("lookup"), text_message("Done")])
+        agent = Agent(
+            model=model,
+            tools=[lookup],
+            interventions=[make_handler(events=["after_tool_call"])],
+        )
+
+        agent("Look it up")
+
+        tool_results = [
+            block["toolResult"]
+            for message in agent.messages
+            for block in message.get("content", [])
+            if "toolResult" in block
+        ]
+        assert tool_results, "expected a tool result in history"
+        redacted_text = tool_results[0]["content"][0]["text"]
+        assert EMAIL not in redacted_text
+        assert PLACEHOLDER in redacted_text
+
+
+class TestPublicExports:
+    def test_presidio_redaction_is_exported(self):
+        import strands.vended_interventions as vended
+        import strands.vended_interventions.presidio as presidio
+
+        assert "PresidioRedaction" in vended.__all__
+        assert presidio.__all__ == ["PresidioRedaction"]
+        assert vended.PresidioRedaction is presidio.PresidioRedaction
+        assert presidio.PresidioRedaction.name == "strands:presidio-redaction"


### PR DESCRIPTION
## Motivation

The interventions framework ships `Transform` (mutate event content in-place) but no vended handler exercises it for the most common real-world need: **stripping PII before it reaches the model, downstream tools, or persisted history/logs**. Per #296, Presidio is the in-core interventions pick — it's a pure-Python, Microsoft-maintained PII detection/redaction library with no server or auth dependency, so it slots cleanly behind the existing `Transform` action.

This is **additive and non-overlapping** with the Cedar authorization bet in design 0006 (authz answers *"may this happen?"* via `Deny`; redaction answers *"sanitize what flows through"* via `Transform`). It was preferred over OPA precisely because OPA collides with the Cedar authz direction, whereas Presidio fills a distinct gap.

## Public API

New vended handler `PresidioRedaction`, mirroring the `HumanInTheLoop` package structure under `vended_interventions/presidio/`:

```python
from strands import Agent
from strands.vended_interventions.presidio import PresidioRedaction

# Redact emails/phones across tool I/O and model context (default events)
agent = Agent(interventions=[PresidioRedaction(entities=["EMAIL_ADDRESS", "PHONE_NUMBER"])])

# Mask instead of replace, scanning only tool results
agent = Agent(interventions=[PresidioRedaction(operator="mask", events=["after_tool_call"])])
```

The handler returns a `Transform` for each configured lifecycle event whose `apply` runs Presidio's `AnalyzerEngine` + `AnonymizerEngine` and rewrites detected PII in-place; unconfigured events are a no-op `Proceed`. Configurable knobs: entity types, which events to scan, anonymization operator (`replace`/`mask`/`hash`/`redact`) + params, language, and confidence threshold.

Redaction reaches every text-bearing content shape — `text`, `json` (recursively, strings only), `toolUse.input`, nested `toolResult`, and `reasoningContent` — so PII does not slip through non-text paths. Scanning `before_model_call`/`after_model_call` mutates `agent.messages` in place, redacting the **persisted** history (not just the request), which keeps PII out of session storage and logs. Scope, idempotency, streaming, and the cost of full-history sweeps are documented on the class.

## Dependency

Presidio is an **optional** dependency under a new `presidio` extra (`presidio-analyzer`, `presidio-anonymizer`; spaCy model required at runtime, e.g. `python -m spacy download en_core_web_lg`). It is lazily imported with a clear `ImportError`, and the unit tests mock the engines so neither Presidio nor a spaCy model is needed in CI.

Refs #296. Engines were additionally smoke-tested against real Presidio to confirm the `replace`/`mask`/`hash`/`redact` operator wiring.

cc @mkmeral