### PR TITLE
refactor(memory): drop redundant `| None` from optional config fields

### DIFF
--- a/strands-py/src/strands/injection/types.py
+++ b/strands-py/src/strands/injection/types.py
@@ -78,4 +78,4 @@ class InjectionConfig(TypedDict, total=False):
             skipped, the model call proceeds). Defaults to ``"userTurn"``.
     """
 
-    trigger: InjectionTriggerPredicate | None
+    trigger: InjectionTriggerPredicate

--- a/strands-py/src/strands/memory/extraction/types.py
+++ b/strands-py/src/strands/memory/extraction/types.py
@@ -144,6 +144,6 @@ class ExtractionConfig(TypedDict, total=False):
             blocks.
     """
 
-    trigger: ExtractionTrigger | list[ExtractionTrigger] | None
-    extractor: Extractor | None
-    filter: MemoryMessageFilter | None
+    trigger: ExtractionTrigger | list[ExtractionTrigger]
+    extractor: Extractor
+    filter: MemoryMessageFilter

--- a/strands-py/src/strands/memory/memory_manager.py
+++ b/strands-py/src/strands/memory/memory_manager.py
@@ -443,10 +443,10 @@ class MemoryManager(Plugin):
                 Matching memory entries, each attributed to its store.
             """
             targets = self._resolve_tool_targets(scoped_names, stores)
-            results = await self.search(
-                query,
-                MemorySearchOptions(max_search_results=max_search_results, stores=targets),
-            )
+            options = MemorySearchOptions(stores=targets)
+            if max_search_results is not None:
+                options["max_search_results"] = max_search_results
+            results = await self.search(query, options)
             payload: list[dict[str, Any]] = []
             for entry in results:
                 item: dict[str, Any] = {"content": entry.content}

--- a/strands-py/src/strands/memory/types.py
+++ b/strands-py/src/strands/memory/types.py
@@ -42,7 +42,7 @@ class SearchOptions(TypedDict, total=False):
     ``MemoryManager.search`` forwards only these base fields across its stores.
     """
 
-    max_search_results: int | None
+    max_search_results: int
 
 
 @dataclass
@@ -64,7 +64,7 @@ class MemorySearchOptions(SearchOptions, total=False):
             in-scope stores".
     """
 
-    stores: list[str] | None
+    stores: list[str]
 
 
 class MemoryAddOptions(TypedDict, total=False):
@@ -77,15 +77,15 @@ class MemoryAddOptions(TypedDict, total=False):
             in-scope stores".
     """
 
-    metadata: Metadata | None
-    stores: list[str] | None
+    metadata: Metadata
+    stores: list[str]
 
 
 class MemoryToolConfig(TypedDict, total=False):
     """Configuration for customizing a memory tool's name or description."""
 
-    name: str | None
-    description: str | None
+    name: str
+    description: str
 
 
 class MemoryAddToolConfig(MemoryToolConfig, total=False):
@@ -100,7 +100,7 @@ class MemoryAddToolConfig(MemoryToolConfig, total=False):
             are dispatched; per-store failures are logged.
     """
 
-    stores: list[str | MemoryStore] | None
+    stores: list[str | MemoryStore]
     wait_for_writes: bool
 
 
@@ -185,9 +185,9 @@ class MemoryInjectionConfig(InjectionConfig, total=False):
             for its own escaping.
     """
 
-    max_entries: int | None
-    query: InjectionQuery | None
-    format: InjectionFormat | None
+    max_entries: int
+    query: InjectionQuery
+    format: InjectionFormat
 
 
 class MemoryManagerConfig(TypedDict, total=False):
@@ -222,7 +222,7 @@ class MemoryStoreConfig(TypedDict, total=False):
             sink (:meth:`MemoryStore.add` or :meth:`MemoryStore.add_messages`).
         extraction: Automatic-extraction configuration for this writable store, as
             a ``bool | config`` shorthand. ``True`` enables it with defaults; an
-            :class:`ExtractionConfig` defaults any unset field; ``False``/``None``
+            :class:`ExtractionConfig` defaults any unset field; ``False``/omitted
             is off. The defaults run every 5 turns, and the extraction method
             depends on the store's write methods: a store implementing only ``add``
             uses a :class:`~strands.memory.extraction.model_extractor.ModelExtractor`
@@ -232,10 +232,10 @@ class MemoryStoreConfig(TypedDict, total=False):
     """
 
     name: Required[str]
-    description: str | None
-    max_search_results: int | None
+    description: str
+    max_search_results: int
     writable: bool
-    extraction: ExtractionConfig | bool | None
+    extraction: ExtractionConfig | bool
 
 
 class MemoryStore(Protocol):


### PR DESCRIPTION
## Description

The memory and injection config `TypedDict`s (`MemoryStoreConfig`, `MemoryToolConfig`, `MemoryAddToolConfig`, `MemorySearchOptions`, `MemoryAddOptions`, `SearchOptions`, `MemoryInjectionConfig`, `InjectionConfig`, `ExtractionConfig`) are ports of TS interfaces compiled under `exactOptionalPropertyTypes: true`, where a bare optional field (`description?: string`) means "absent or string", never `undefined`.

The ports added `| None` to these fields, which also accepts an explicit `None`, a value the source rejects. Since the fields are already `total=False`, absence is expressed by a missing key, so `| None` only permitted a redundant explicit `None`. This drops it.

`| None` is kept where `None` is a real value, not a stand-in for "absent":

- **`MemoryStore` Protocol attributes**, runtime attributes populated via `config.get(...)`, matching how TS exposes a resolved optional property (`readonly scope: string | undefined`).
- **`_resolve_extraction_config(extraction: ... | None)`**, whose TS counterpart's parameter is explicitly `... | undefined`.
- **`MemoryEntry`**, a returned value object, not an input config.

No behavioral change: reads go through `.get()`, which yields `None` on absence regardless of the field type. This only tightens what is accepted at construction sites.

## Type of Change

Other: type-accuracy refactor (no runtime behavior change)

## Testing

- [x] I ran `hatch run prepare`

`hatch fmt --linter` (ruff + mypy) clean; full unit suite green (3721 passed).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)