### PR TITLE
feat(python): vended tools/plugins for sandbox

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -364,6 +364,21 @@ class Agent(AgentBase):
         if load_tools_from_directory:
             self.tool_watcher = ToolWatcher(tool_registry=self.tool_registry)
 
+        # Register tools vended by an explicitly-configured sandbox, applying the sandbox's
+        # tool_prefix to names (like MCP's prefix for server-vended tools). The host default
+        # vends nothing. A tool is skipped if the user already registered one with that name.
+        if not isinstance(self._sandbox, NotASandboxLocalEnvironment):
+            prefix = self._sandbox.tool_prefix
+            for sandbox_tool in self._sandbox.get_tools():
+                prefixed = sandbox_tool.with_prefix(prefix) if prefix else sandbox_tool
+                if prefixed.tool_name in self.tool_registry.registry:
+                    logger.debug(
+                        "tool_name=<%s> | sandbox-vended tool skipped, user already registered a tool with this name",
+                        prefixed.tool_name,
+                    )
+                else:
+                    self.tool_registry.register_tool(prefixed)
+
         self.event_loop_metrics = EventLoopMetrics()
 
         # Initialize tracer instance (no-op if not configured)

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -364,20 +364,16 @@ class Agent(AgentBase):
         if load_tools_from_directory:
             self.tool_watcher = ToolWatcher(tool_registry=self.tool_registry)
 
-        # Register tools vended by an explicitly-configured sandbox, applying the sandbox's
-        # tool_prefix to names (like MCP's prefix for server-vended tools). The host default
-        # vends nothing. A tool is skipped if the user already registered one with that name.
-        if not isinstance(self._sandbox, NotASandboxLocalEnvironment):
-            prefix = self._sandbox.tool_prefix
-            for sandbox_tool in self._sandbox.get_tools():
-                prefixed = sandbox_tool.with_prefix(prefix) if prefix else sandbox_tool
-                if prefixed.tool_name in self.tool_registry.registry:
-                    logger.debug(
-                        "tool_name=<%s> | sandbox-vended tool skipped, user already registered a tool with this name",
-                        prefixed.tool_name,
-                    )
-                else:
-                    self.tool_registry.register_tool(prefixed)
+        # Register tools vended by the sandbox. The host default vends nothing. A tool
+        # is skipped if the user already registered one with that name.
+        for sandbox_tool in self._sandbox.get_tools():
+            if sandbox_tool.tool_name in self.tool_registry.registry:
+                logger.debug(
+                    "tool_name=<%s> | sandbox-vended tool skipped, user already registered a tool with this name",
+                    sandbox_tool.tool_name,
+                )
+            else:
+                self.tool_registry.register_tool(sandbox_tool)
 
         self.event_loop_metrics = EventLoopMetrics()
 

--- a/strands-py/src/strands/sandbox/base.py
+++ b/strands-py/src/strands/sandbox/base.py
@@ -32,9 +32,6 @@ from .types import ExecutionResult, FileInfo, StreamChunk
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TOOL_PREFIX = "sandbox"
-"""Default prefix applied to sandbox-vended tool names (e.g. ``sandbox_bash``)."""
-
 
 class Sandbox(ABC):
     """Abstract execution environment.
@@ -205,16 +202,17 @@ class Sandbox(ABC):
 
     # ---- Tool vending ----
 
-    tool_prefix: str | None = DEFAULT_TOOL_PREFIX
-    """Prefix applied to tool names when registered on an agent (e.g. ``"sandbox"`` produces
-    ``sandbox_bash``). Set to ``None`` to disable prefixing. Defaults to ``"sandbox"``."""
+    @staticmethod
+    def _prefixed_name(name: str, prefix: str | None = "sandbox") -> str:
+        """Build a prefixed tool name (e.g. ``("bash", "sandbox")`` -> ``"sandbox_bash"``)."""
+        return f"{prefix}_{name}" if prefix else name
 
     def get_tools(self) -> list[AgentTool]:
         """Tools this sandbox vends to an agent.
 
-        Returned tools are registered when the agent initializes, with
-        :attr:`tool_prefix` applied to their names. A tool is skipped if the user
-        already registered one with the same (prefixed) name. The base
+        Returned tools are registered when the agent initializes; a tool is
+        skipped if the user already registered one with the same name. Overrides
+        use :meth:`_prefixed_name` to build namespaced tool names. The base
         implementation vends nothing; concrete sandboxes override this to provide
         sandbox-routed tools (e.g. bash, file editor).
 

--- a/strands-py/src/strands/sandbox/base.py
+++ b/strands-py/src/strands/sandbox/base.py
@@ -27,9 +27,13 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from ..types.tools import AgentTool
 from .types import ExecutionResult, FileInfo, StreamChunk
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_TOOL_PREFIX = "sandbox"
+"""Default prefix applied to sandbox-vended tool names (e.g. ``sandbox_bash``)."""
 
 
 class Sandbox(ABC):
@@ -198,6 +202,26 @@ class Sandbox(ABC):
             FileNotFoundError: If the directory does not exist.
         """
         ...
+
+    # ---- Tool vending ----
+
+    tool_prefix: str | None = DEFAULT_TOOL_PREFIX
+    """Prefix applied to tool names when registered on an agent (e.g. ``"sandbox"`` produces
+    ``sandbox_bash``). Set to ``None`` to disable prefixing. Defaults to ``"sandbox"``."""
+
+    def get_tools(self) -> list[AgentTool]:
+        """Tools this sandbox vends to an agent.
+
+        Returned tools are registered when the agent initializes, with
+        :attr:`tool_prefix` applied to their names. A tool is skipped if the user
+        already registered one with the same (prefixed) name. The base
+        implementation vends nothing; concrete sandboxes override this to provide
+        sandbox-routed tools (e.g. bash, file editor).
+
+        Returns:
+            The tools to register, or an empty list.
+        """
+        return []
 
     # ---- Non-streaming convenience methods ----
 

--- a/strands-py/src/strands/sandbox/base.py
+++ b/strands-py/src/strands/sandbox/base.py
@@ -202,19 +202,12 @@ class Sandbox(ABC):
 
     # ---- Tool vending ----
 
-    @staticmethod
-    def _prefixed_name(name: str, prefix: str | None = "sandbox") -> str:
-        """Build a prefixed tool name (e.g. ``("bash", "sandbox")`` -> ``"sandbox_bash"``)."""
-        return f"{prefix}_{name}" if prefix else name
-
     def get_tools(self) -> list[AgentTool]:
         """Tools this sandbox vends to an agent.
 
         Returned tools are registered when the agent initializes; a tool is
-        skipped if the user already registered one with the same name. Overrides
-        use :meth:`_prefixed_name` to build namespaced tool names. The base
-        implementation vends nothing; concrete sandboxes override this to provide
-        sandbox-routed tools (e.g. bash, file editor).
+        skipped if the user already registered one with the same name. The base
+        implementation vends nothing; concrete sandboxes override this.
 
         Returns:
             The tools to register, or an empty list.

--- a/strands-py/src/strands/sandbox/docker.py
+++ b/strands-py/src/strands/sandbox/docker.py
@@ -7,10 +7,12 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from ..types.tools import AgentTool
-from ..vended_tools.bash import SANDBOX_BASH_DESCRIPTION, make_bash
-from ..vended_tools.file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, make_file_editor
+from ..vended_tools.bash import make_bash
+from ..vended_tools.bash.types import SANDBOX_BASH_DESCRIPTION
+from ..vended_tools.file_editor import make_file_editor
+from ..vended_tools.file_editor.file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION
 from .posix_shell import PosixShellSandbox, validate_env_keys
-from .stream_process import stream_process
+from .stream_process import _stream_process
 from .types import ExecutionResult, StreamChunk
 
 
@@ -89,7 +91,7 @@ class DockerSandbox(PosixShellSandbox):
         # above.
         args += ["--", self.container, "sh", "-c", command]
 
-        async for chunk in stream_process(
+        async for chunk in _stream_process(
             "docker", args, timeout=timeout, enoent_message="docker is not installed or not on PATH"
         ):
             yield chunk
@@ -104,10 +106,12 @@ class DockerSandbox(PosixShellSandbox):
         return [
             make_file_editor(
                 self,
+                name=self._prefixed_name("file_editor", "sandbox"),
                 description=f'{DEFAULT_FILE_EDITOR_DESCRIPTION} Files are in Docker container "{self.container}".',
             ),
             make_bash(
                 self,
+                name=self._prefixed_name("bash", "sandbox"),
                 description=f'{SANDBOX_BASH_DESCRIPTION} Runs in Docker container "{self.container}".{cwd}',
             ),
         ]

--- a/strands-py/src/strands/sandbox/docker.py
+++ b/strands-py/src/strands/sandbox/docker.py
@@ -105,13 +105,13 @@ class DockerSandbox(PosixShellSandbox):
         cwd = f" Working directory: {self.working_dir}." if self.working_dir else ""
         return [
             make_file_editor(
-                self,
-                name=self._prefixed_name("file_editor", "sandbox"),
+                sandbox=self,
+                name="sandbox_file_editor",
                 description=f'{DEFAULT_FILE_EDITOR_DESCRIPTION} Files are in Docker container "{self.container}".',
             ),
             make_bash(
-                self,
-                name=self._prefixed_name("bash", "sandbox"),
+                sandbox=self,
+                name="sandbox_bash",
                 description=f'{SANDBOX_BASH_DESCRIPTION} Runs in Docker container "{self.container}".{cwd}',
             ),
         ]

--- a/strands-py/src/strands/sandbox/docker.py
+++ b/strands-py/src/strands/sandbox/docker.py
@@ -6,6 +6,9 @@ Mirrors ``strands-ts/src/sandbox/docker.ts``.
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from ..types.tools import AgentTool
+from ..vended_tools.bash import SANDBOX_BASH_DESCRIPTION, make_bash
+from ..vended_tools.file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, make_file_editor
 from .posix_shell import PosixShellSandbox, validate_env_keys
 from .stream_process import stream_process
 from .types import ExecutionResult, StreamChunk
@@ -90,3 +93,21 @@ class DockerSandbox(PosixShellSandbox):
             "docker", args, timeout=timeout, enoent_message="docker is not installed or not on PATH"
         ):
             yield chunk
+
+    def get_tools(self) -> list[AgentTool]:
+        """Default sandbox-compatible tools auto-registered with this sandbox.
+
+        Returns:
+            The tools bound to this sandbox, with descriptions naming this container.
+        """
+        cwd = f" Working directory: {self.working_dir}." if self.working_dir else ""
+        return [
+            make_file_editor(
+                self,
+                description=f'{DEFAULT_FILE_EDITOR_DESCRIPTION} Files are in Docker container "{self.container}".',
+            ),
+            make_bash(
+                self,
+                description=f'{SANDBOX_BASH_DESCRIPTION} Runs in Docker container "{self.container}".{cwd}',
+            ),
+        ]

--- a/strands-py/src/strands/sandbox/not_a_sandbox_local_environment.py
+++ b/strands-py/src/strands/sandbox/not_a_sandbox_local_environment.py
@@ -24,7 +24,7 @@ from .base import Sandbox
 from .constants import LANGUAGE_PATTERN
 from .errors import SandboxPathNotFoundError
 from .posix_shell import build_shell_env_prefix
-from .stream_process import stream_process
+from .stream_process import _stream_process
 from .types import ExecutionResult, FileInfo, StreamChunk
 
 
@@ -76,7 +76,7 @@ class NotASandboxLocalEnvironment(Sandbox):
         target_cwd = cwd if cwd is not None else os.getcwd()
         env_prefix = build_shell_env_prefix(env)
         full_command = f"cd {shlex.quote(target_cwd)} && {env_prefix}{command}"
-        async for chunk in stream_process("sh", ["-c", full_command], timeout=timeout):
+        async for chunk in _stream_process("sh", ["-c", full_command], timeout=timeout):
             yield chunk
 
     async def execute_code_streaming(

--- a/strands-py/src/strands/sandbox/ssh.py
+++ b/strands-py/src/strands/sandbox/ssh.py
@@ -187,13 +187,13 @@ class SshSandbox(PosixShellSandbox):
         """
         return [
             make_file_editor(
-                self,
-                name=self._prefixed_name("file_editor", "sandbox"),
+                sandbox=self,
+                name="sandbox_file_editor",
                 description=f'{DEFAULT_FILE_EDITOR_DESCRIPTION} Files are on host "{self.host}".',
             ),
             make_bash(
-                self,
-                name=self._prefixed_name("bash", "sandbox"),
+                sandbox=self,
+                name="sandbox_bash",
                 description=(
                     f'{SANDBOX_BASH_DESCRIPTION} Runs on host "{self.host}". Working directory: {self.working_dir}.'
                 ),

--- a/strands-py/src/strands/sandbox/ssh.py
+++ b/strands-py/src/strands/sandbox/ssh.py
@@ -9,10 +9,12 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from ..types.tools import AgentTool
-from ..vended_tools.bash import SANDBOX_BASH_DESCRIPTION, make_bash
-from ..vended_tools.file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, make_file_editor
+from ..vended_tools.bash import make_bash
+from ..vended_tools.bash.types import SANDBOX_BASH_DESCRIPTION
+from ..vended_tools.file_editor import make_file_editor
+from ..vended_tools.file_editor.file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION
 from .posix_shell import PosixShellSandbox, build_shell_env_prefix
-from .stream_process import stream_process
+from .stream_process import _stream_process
 from .types import ExecutionResult, StreamChunk
 
 # Known-safe SSH options. Options that execute commands, tunnel traffic, or load
@@ -172,7 +174,7 @@ class SshSandbox(PosixShellSandbox):
         # command execution on the local machine.
         args += ["--", self.host, remote_command]
 
-        async for chunk in stream_process(
+        async for chunk in _stream_process(
             "ssh", args, timeout=timeout, enoent_message="ssh is not installed or not on PATH"
         ):
             yield chunk
@@ -186,10 +188,12 @@ class SshSandbox(PosixShellSandbox):
         return [
             make_file_editor(
                 self,
+                name=self._prefixed_name("file_editor", "sandbox"),
                 description=f'{DEFAULT_FILE_EDITOR_DESCRIPTION} Files are on host "{self.host}".',
             ),
             make_bash(
                 self,
+                name=self._prefixed_name("bash", "sandbox"),
                 description=(
                     f'{SANDBOX_BASH_DESCRIPTION} Runs on host "{self.host}". Working directory: {self.working_dir}.'
                 ),

--- a/strands-py/src/strands/sandbox/ssh.py
+++ b/strands-py/src/strands/sandbox/ssh.py
@@ -8,6 +8,9 @@ import shlex
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from ..types.tools import AgentTool
+from ..vended_tools.bash import SANDBOX_BASH_DESCRIPTION, make_bash
+from ..vended_tools.file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, make_file_editor
 from .posix_shell import PosixShellSandbox, build_shell_env_prefix
 from .stream_process import stream_process
 from .types import ExecutionResult, StreamChunk
@@ -173,3 +176,22 @@ class SshSandbox(PosixShellSandbox):
             "ssh", args, timeout=timeout, enoent_message="ssh is not installed or not on PATH"
         ):
             yield chunk
+
+    def get_tools(self) -> list[AgentTool]:
+        """Default sandbox-compatible tools auto-registered with this sandbox.
+
+        Returns:
+            The tools bound to this sandbox, with descriptions naming the remote host.
+        """
+        return [
+            make_file_editor(
+                self,
+                description=f'{DEFAULT_FILE_EDITOR_DESCRIPTION} Files are on host "{self.host}".',
+            ),
+            make_bash(
+                self,
+                description=(
+                    f'{SANDBOX_BASH_DESCRIPTION} Runs on host "{self.host}". Working directory: {self.working_dir}.'
+                ),
+            ),
+        ]

--- a/strands-py/src/strands/sandbox/stream_process.py
+++ b/strands-py/src/strands/sandbox/stream_process.py
@@ -39,7 +39,7 @@ def _kill_tree(proc: asyncio.subprocess.Process) -> None:
             proc.kill()
 
 
-async def stream_process(
+async def _stream_process(
     program: str,
     args: list[str],
     *,

--- a/strands-py/src/strands/types/tools.py
+++ b/strands-py/src/strands/types/tools.py
@@ -271,22 +271,6 @@ class AgentTool(ABC):
         """
         ...
 
-    def with_prefix(self, prefix: str) -> "AgentTool":
-        """Return a view of this tool with ``{prefix}_`` prepended to its name.
-
-        Used when registering vended tools on an agent so their names are
-        namespaced (e.g. ``sandbox_bash``), mirroring how MCP prefixes
-        server-vended tools. The returned view delegates execution to this tool
-        and overrides only the name; the original is left unchanged.
-
-        Args:
-            prefix: The prefix to prepend (the separating underscore is added).
-
-        Returns:
-            A tool that behaves identically but reports the prefixed name.
-        """
-        return _PrefixedTool(self, prefix)
-
     @property
     def is_dynamic(self) -> bool:
         """Whether the tool was dynamically loaded during runtime.
@@ -314,48 +298,3 @@ class AgentTool(ABC):
             "Name": self.tool_name,
             "Type": self.tool_type,
         }
-
-
-class _PrefixedTool(AgentTool):
-    """A view of another tool that reports a prefixed name.
-
-    Overrides only the name (and the ``name`` field of the tool spec). The other
-    abstract members (``tool_type``, ``stream``) must be defined to satisfy the
-    ABC, so they delegate to the wrapped tool; everything else delegates via
-    ``__getattr__``. Created by :meth:`AgentTool.with_prefix`; not instantiated
-    directly.
-    """
-
-    def __init__(self, wrapped: AgentTool, prefix: str) -> None:
-        """Initialize the prefixed view.
-
-        Args:
-            wrapped: The tool to delegate to.
-            prefix: The prefix prepended to the wrapped tool's name.
-        """
-        super().__init__()
-        self._wrapped = wrapped
-        self._prefixed_name = f"{prefix}_{wrapped.tool_name}"
-
-    @property
-    def tool_name(self) -> str:
-        """The wrapped tool's name with the prefix applied."""
-        return self._prefixed_name
-
-    @property
-    def tool_spec(self) -> ToolSpec:
-        """The wrapped tool's spec with the prefixed name."""
-        return {**self._wrapped.tool_spec, "name": self._prefixed_name}
-
-    @property
-    def tool_type(self) -> str:
-        """The wrapped tool's type (delegated)."""
-        return self._wrapped.tool_type
-
-    def stream(self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any) -> ToolGenerator:
-        """Delegate execution to the wrapped tool."""
-        return self._wrapped.stream(tool_use, invocation_state, **kwargs)
-
-    def __getattr__(self, name: str) -> Any:
-        """Delegate any non-overridden attribute to the wrapped tool."""
-        return getattr(self._wrapped, name)

--- a/strands-py/src/strands/types/tools.py
+++ b/strands-py/src/strands/types/tools.py
@@ -271,6 +271,22 @@ class AgentTool(ABC):
         """
         ...
 
+    def with_prefix(self, prefix: str) -> "AgentTool":
+        """Return a view of this tool with ``{prefix}_`` prepended to its name.
+
+        Used when registering vended tools on an agent so their names are
+        namespaced (e.g. ``sandbox_bash``), mirroring how MCP prefixes
+        server-vended tools. The returned view delegates execution to this tool
+        and overrides only the name; the original is left unchanged.
+
+        Args:
+            prefix: The prefix to prepend (the separating underscore is added).
+
+        Returns:
+            A tool that behaves identically but reports the prefixed name.
+        """
+        return _PrefixedTool(self, prefix)
+
     @property
     def is_dynamic(self) -> bool:
         """Whether the tool was dynamically loaded during runtime.
@@ -298,3 +314,48 @@ class AgentTool(ABC):
             "Name": self.tool_name,
             "Type": self.tool_type,
         }
+
+
+class _PrefixedTool(AgentTool):
+    """A view of another tool that reports a prefixed name.
+
+    Overrides only the name (and the ``name`` field of the tool spec). The other
+    abstract members (``tool_type``, ``stream``) must be defined to satisfy the
+    ABC, so they delegate to the wrapped tool; everything else delegates via
+    ``__getattr__``. Created by :meth:`AgentTool.with_prefix`; not instantiated
+    directly.
+    """
+
+    def __init__(self, wrapped: AgentTool, prefix: str) -> None:
+        """Initialize the prefixed view.
+
+        Args:
+            wrapped: The tool to delegate to.
+            prefix: The prefix prepended to the wrapped tool's name.
+        """
+        super().__init__()
+        self._wrapped = wrapped
+        self._prefixed_name = f"{prefix}_{wrapped.tool_name}"
+
+    @property
+    def tool_name(self) -> str:
+        """The wrapped tool's name with the prefix applied."""
+        return self._prefixed_name
+
+    @property
+    def tool_spec(self) -> ToolSpec:
+        """The wrapped tool's spec with the prefixed name."""
+        return {**self._wrapped.tool_spec, "name": self._prefixed_name}
+
+    @property
+    def tool_type(self) -> str:
+        """The wrapped tool's type (delegated)."""
+        return self._wrapped.tool_type
+
+    def stream(self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any) -> ToolGenerator:
+        """Delegate execution to the wrapped tool."""
+        return self._wrapped.stream(tool_use, invocation_state, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate any non-overridden attribute to the wrapped tool."""
+        return getattr(self._wrapped, name)

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import logging
+import weakref
 from typing import TYPE_CHECKING
 
 from ...hooks.events import AfterToolCallEvent, BeforeModelCallEvent
@@ -41,7 +42,7 @@ from ...plugins import Plugin, hook
 from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
-from .storage import InMemoryStorage, Storage
+from .storage import FileStorage, InMemoryStorage, Storage
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
@@ -134,15 +135,41 @@ class ContextOffloader(Plugin):
             raise ValueError("preview_tokens must be less than max_result_tokens")
 
         self._storage = storage
+        # Per-agent FileStorage bound to that agent's sandbox; other backends are shared as-is.
+        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, Storage] = weakref.WeakKeyDictionary()
         self._max_result_tokens = max_result_tokens
         self._preview_tokens = preview_tokens
         self._include_retrieval_tool = include_retrieval_tool
         super().__init__()
 
+    def _storage_for_agent(self, agent: Agent) -> Storage:
+        """Return the storage for an agent, binding FileStorage to its sandbox.
+
+        Non-FileStorage backends are shared across agents unchanged. A FileStorage
+        is bound once per agent to that agent's sandbox via
+        :meth:`FileStorage.for_sandbox`, so a shared plugin isolates artifacts per
+        agent sandbox.
+
+        Args:
+            agent: The agent whose storage to resolve.
+
+        Returns:
+            The storage instance for this agent.
+        """
+        if not isinstance(self._storage, FileStorage):
+            return self._storage
+        storage = self._storage_by_agent.get(agent)
+        if storage is None:
+            storage = self._storage.for_sandbox(agent.sandbox)
+            self._storage_by_agent[agent] = storage
+        return storage
+
     def init_agent(self, agent: Agent) -> None:
         """Conditionally register the retrieval tool and bind storage."""
         if isinstance(self._storage, InMemoryStorage):
             self._storage._bind(id(agent))
+        # Bind FileStorage to this agent's sandbox up front (no-op for other backends).
+        self._storage_for_agent(agent)
         if not self._include_retrieval_tool:
             # Remove the auto-discovered retrieval tool
             self._tools = [t for t in self._tools if t.tool_name != "retrieve_offloaded_content"]
@@ -154,7 +181,7 @@ class ContextOffloader(Plugin):
             self._storage._evict(event.agent.event_loop_metrics.cycle_count)
 
     @tool(context=True)
-    def retrieve_offloaded_content(
+    async def retrieve_offloaded_content(
         self,
         reference: str,
         tool_context: ToolContext,
@@ -169,8 +196,9 @@ class ContextOffloader(Plugin):
             reference: The reference string from the offload placeholder.
             tool_context: Injected by the framework. Not user-facing.
         """
+        storage = self._storage_for_agent(tool_context.agent)
         try:
-            content_bytes, content_type = self._storage.retrieve(reference)
+            content_bytes, content_type = await storage.retrieve(reference)
         except KeyError:
             return f"Error: reference not found: {reference}"
 
@@ -226,23 +254,24 @@ class ContextOffloader(Plugin):
         full_text = "\n".join(text_preview_parts) if text_preview_parts else ""
 
         # Store each content block individually
+        storage = self._storage_for_agent(event.agent)
         references: list[tuple[str, str, str]] = []  # (ref, content_type, description)
         try:
             for i, block in enumerate(content):
                 key = f"{tool_use_id}_{i}"
                 if block.get("text"):
-                    ref = self._storage.store(key, block["text"].encode("utf-8"), "text/plain")
+                    ref = await storage.store(key, block["text"].encode("utf-8"), "text/plain")
                     references.append((ref, "text/plain", f"text, {len(block['text']):,} chars"))
                 elif "json" in block:
                     json_bytes = json.dumps(block["json"], indent=2).encode("utf-8")
-                    ref = self._storage.store(key, json_bytes, "application/json")
+                    ref = await storage.store(key, json_bytes, "application/json")
                     references.append((ref, "application/json", f"json, {len(json_bytes):,} bytes"))
                 elif "image" in block:
                     image = block["image"]
                     img_format = image.get("format", "unknown")
                     img_bytes = image.get("source", {}).get("bytes", b"")
                     if img_bytes:
-                        ref = self._storage.store(key, img_bytes, f"image/{img_format}")
+                        ref = await storage.store(key, img_bytes, f"image/{img_format}")
                         references.append((ref, f"image/{img_format}", f"image/{img_format}, {len(img_bytes):,} bytes"))
                     else:
                         references.append(("", f"image/{img_format}", f"image/{img_format}, 0 bytes"))
@@ -252,7 +281,7 @@ class ContextOffloader(Plugin):
                     doc_name = doc.get("name", "unknown")
                     doc_bytes = doc.get("source", {}).get("bytes", b"")
                     if doc_bytes:
-                        ref = self._storage.store(key, doc_bytes, f"application/{doc_format}")
+                        ref = await storage.store(key, doc_bytes, f"application/{doc_format}")
                         references.append((ref, f"application/{doc_format}", f"{doc_name}, {len(doc_bytes):,} bytes"))
                     else:
                         references.append(("", f"application/{doc_format}", f"{doc_name}, 0 bytes"))

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -31,11 +31,14 @@ import re
 import threading
 import time
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import boto3
 from botocore.config import Config as BotocoreConfig
 from botocore.exceptions import ClientError
+
+if TYPE_CHECKING:
+    from ...sandbox.base import Sandbox
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +76,7 @@ class Storage(Protocol):
         backend with built-in lifecycle management (e.g., S3 lifecycle policies).
     """
 
-    def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
+    async def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
         """Store content and return a reference identifier.
 
         Args:
@@ -87,7 +90,7 @@ class Storage(Protocol):
         """
         ...
 
-    def retrieve(self, reference: str) -> tuple[bytes, str]:
+    async def retrieve(self, reference: str) -> tuple[bytes, str]:
         """Retrieve stored content by reference.
 
         Args:
@@ -103,28 +106,60 @@ class Storage(Protocol):
 
 
 class FileStorage:
-    """Store offloaded content as files on disk.
+    """Store offloaded content as files, on the host filesystem or through a sandbox.
 
     Files are written to the configured artifact directory with unique names.
     File extensions are derived from the content type. A ``.metadata.json``
     sidecar file tracks content types so they survive process restarts.
 
+    When constructed without a ``sandbox``, writes go to the host filesystem.
+    When used by :class:`ContextOffloader`, the plugin binds a per-agent copy to
+    that agent's sandbox (which may be the host default) via :meth:`for_sandbox`.
+
     Args:
         artifact_dir: Directory path where artifact files will be stored.
+        sandbox: Optional sandbox to route file I/O through. When ``None``,
+            the host filesystem is used directly.
     """
 
     _METADATA_FILE = ".metadata.json"
 
-    def __init__(self, artifact_dir: str = "./artifacts") -> None:
+    def __init__(self, artifact_dir: str = "./artifacts", *, sandbox: "Sandbox | None" = None) -> None:
         """Initialize file-based storage.
 
         Args:
             artifact_dir: Directory path where artifact files will be stored.
+            sandbox: Optional sandbox to route file I/O through.
         """
         self._artifact_dir = Path(artifact_dir)
+        self._sandbox = sandbox
         self._counter: int = 0
         self._lock = threading.Lock()
-        self._content_types: dict[str, str] = self._load_metadata()
+        self._metadata_loaded = False
+        # Host metadata can load eagerly; sandbox metadata loads lazily on first use
+        # (the sandbox may be remote, so we avoid I/O during construction).
+        if sandbox is None:
+            self._content_types: dict[str, str] = self._load_metadata()
+            self._metadata_loaded = True
+        else:
+            self._content_types = {}
+
+    def for_sandbox(self, sandbox: "Sandbox") -> "FileStorage":
+        """Return a storage instance bound to the given sandbox.
+
+        Instances constructed with an explicit sandbox keep using it (returns
+        ``self``). Otherwise a new instance is returned so a shared
+        :class:`ContextOffloader` can isolate artifacts per agent sandbox.
+
+        Args:
+            sandbox: Sandbox to bind the returned instance to.
+
+        Returns:
+            A FileStorage routed through ``sandbox``.
+        """
+        if self._sandbox is not None:
+            return self
+        return FileStorage(str(self._artifact_dir), sandbox=sandbox)
 
     @staticmethod
     def _extension_for(content_type: str) -> str:
@@ -133,7 +168,11 @@ class FileStorage:
             return ".txt"
         return f".{content_type.split('/')[-1]}"
 
-    def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
+    def _artifact_path(self, filename: str) -> str:
+        """Join a filename onto the artifact dir, preserving its string form."""
+        return f"{str(self._artifact_dir).rstrip('/')}/{filename}"
+
+    async def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
         """Store content as a file and return the path as reference.
 
         The returned path preserves the form of ``artifact_dir`` passed to
@@ -148,24 +187,34 @@ class FileStorage:
         Returns:
             The file path (e.g., ``./artifacts/1234_1_key.txt``).
         """
-        self._artifact_dir.mkdir(parents=True, exist_ok=True)
-
         sanitized_key = _sanitize_id(key)
         timestamp_ms = int(time.time() * 1000)
         ext = self._extension_for(content_type)
+
+        if self._sandbox is not None:
+            await self._ensure_sandbox_metadata()
+            with self._lock:
+                self._counter += 1
+                filename = f"{timestamp_ms}_{self._counter}_{sanitized_key}{ext}"
+                self._content_types[filename] = content_type
+            # Persist the content-type sidecar, then the artifact itself.
+            await self._sandbox.write_text(self._artifact_path(self._METADATA_FILE), json.dumps(self._content_types))
+            file_path = self._artifact_path(filename)
+            await self._sandbox.write_file(file_path, content)
+            return file_path
+
+        self._artifact_dir.mkdir(parents=True, exist_ok=True)
         with self._lock:
             self._counter += 1
-            counter = self._counter
-            filename = f"{timestamp_ms}_{counter}_{sanitized_key}{ext}"
+            filename = f"{timestamp_ms}_{self._counter}_{sanitized_key}{ext}"
             self._content_types[filename] = content_type
             self._save_metadata()
 
-        file_path = self._artifact_dir / filename
-        file_path.write_bytes(content)
+        host_path = self._artifact_dir / filename
+        host_path.write_bytes(content)
+        return str(host_path)
 
-        return str(file_path)
-
-    def retrieve(self, reference: str) -> tuple[bytes, str]:
+    async def retrieve(self, reference: str) -> tuple[bytes, str]:
         """Retrieve content from a stored file.
 
         Accepts both full paths (as returned by ``store()``) and bare
@@ -180,6 +229,18 @@ class FileStorage:
         Raises:
             KeyError: If the file does not exist.
         """
+        if self._sandbox is not None:
+            await self._ensure_sandbox_metadata()
+            prefix = f"{str(self._artifact_dir).rstrip('/')}/"
+            if not reference.startswith(prefix) or ".." in reference:
+                raise KeyError(f"Reference not found: {reference}")
+            filename = reference.split("/")[-1]
+            try:
+                content = await self._sandbox.read_file(reference)
+            except Exception as e:
+                raise KeyError(f"Reference not found: {reference}") from e
+            return content, self._content_types.get(filename, "application/octet-stream")
+
         resolved_dir = self._artifact_dir.resolve()
         ref_path = Path(reference)
         file_path = ref_path.resolve() if len(ref_path.parts) > 1 else (self._artifact_dir / reference).resolve()
@@ -193,8 +254,21 @@ class FileStorage:
         content_type = self._content_types.get(filename, "application/octet-stream")
         return file_path.read_bytes(), content_type
 
+    async def _ensure_sandbox_metadata(self) -> None:
+        """Lazily load the content-type sidecar from the sandbox on first use."""
+        if self._metadata_loaded:
+            return
+        assert self._sandbox is not None
+        try:
+            raw = await self._sandbox.read_text(self._artifact_path(self._METADATA_FILE))
+            loaded = json.loads(raw)
+            self._content_types = loaded if isinstance(loaded, dict) else {}
+        except Exception:
+            self._content_types = {}
+        self._metadata_loaded = True
+
     def _load_metadata(self) -> dict[str, str]:
-        """Load content type metadata from the sidecar file."""
+        """Load content type metadata from the sidecar file (host filesystem)."""
         metadata_path = self._artifact_dir / self._METADATA_FILE
         if metadata_path.is_file():
             try:
@@ -205,7 +279,7 @@ class FileStorage:
         return {}
 
     def _save_metadata(self) -> None:
-        """Save content type metadata to the sidecar file."""
+        """Save content type metadata to the sidecar file (host filesystem)."""
         metadata_path = self._artifact_dir / self._METADATA_FILE
         metadata_path.write_text(json.dumps(self._content_types), encoding="utf-8")
 
@@ -259,7 +333,7 @@ class InMemoryStorage:
         self._bound_agent_id: int | None = None
         self._lock = threading.Lock()
 
-    def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
+    async def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
         """Store content in memory and return a reference.
 
         Args:
@@ -276,7 +350,7 @@ class InMemoryStorage:
             self._store[reference] = (content, content_type, self._current_cycle)
         return reference
 
-    def retrieve(self, reference: str) -> tuple[bytes, str]:
+    async def retrieve(self, reference: str) -> tuple[bytes, str]:
         """Retrieve content from memory.
 
         Refreshes the last-accessed turn so the entry stays alive longer
@@ -405,7 +479,7 @@ class S3Storage:
         self._counter: int = 0
         self._lock = threading.Lock()
 
-    def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
+    async def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
         """Store content as an S3 object and return an ``s3://`` URI as reference.
 
         Args:
@@ -436,7 +510,7 @@ class S3Storage:
 
         return f"s3://{self._bucket}/{s3_key}"
 
-    def retrieve(self, reference: str) -> tuple[bytes, str]:
+    async def retrieve(self, reference: str) -> tuple[bytes, str]:
         """Retrieve content from an S3 object.
 
         Accepts both ``s3://`` URIs (as returned by ``store()``) and raw

--- a/strands-py/src/strands/vended_plugins/skills/agent_skills.py
+++ b/strands-py/src/strands/vended_plugins/skills/agent_skills.py
@@ -3,11 +3,24 @@
 This module provides the AgentSkills class that extends the Plugin base class
 to add Agent Skills support. The plugin registers a tool for activating
 skills, and injects skill metadata into the system prompt.
+
+Filesystem skill sources are loaded through the agent's sandbox (host or
+container) at ``init_agent`` time, not at construction, so each agent sees the
+skills present on its own filesystem. Skill instances and ``https://`` URLs are
+sandbox-independent and resolve eagerly at construction.
+
+Mirrors ``strands-ts/src/vended-plugins/skills/agent-skills.ts``. One idiomatic
+divergence: TypeScript defers URL loading behind a ``ready`` promise and resolves
+it in ``initAgent`` because ``Skill.fromUrl`` is async; Python's
+:meth:`Skill.from_url` is synchronous, so URLs resolve at construction and no
+readiness barrier is needed. The observable effect is benign: URL skills are
+available from ``get_available_skills()`` slightly earlier than in TypeScript.
 """
 
 from __future__ import annotations
 
 import logging
+import weakref
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
 from xml.sax.saxutils import escape
@@ -21,12 +34,14 @@ from .skill import Skill
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
+    from ...sandbox import FileInfo, Sandbox
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_STATE_KEY = "agent_skills"
 _RESOURCE_DIRS = ("scripts", "references", "assets")
 _DEFAULT_MAX_RESOURCE_FILES = 20
+_MAX_RESOURCE_DEPTH = 3
 
 SkillSource: TypeAlias = str | Path | Skill
 """A single skill source: path string, Path object, or Skill instance."""
@@ -42,6 +57,24 @@ def _normalize_sources(sources: SkillSources) -> list[SkillSource]:
     return [sources]
 
 
+def _find_skill_md_name(entries: list[FileInfo]) -> str | None:
+    """Find the SKILL.md filename among directory entries.
+
+    Prefers ``SKILL.md`` over ``skill.md`` (matching :meth:`Skill.from_file`
+    precedence). Returns ``None`` if neither is present.
+
+    Args:
+        entries: Directory entries from a sandbox ``list_files`` call.
+
+    Returns:
+        The SKILL.md filename, or ``None`` if not found.
+    """
+    for name in ("SKILL.md", "skill.md"):
+        if any(not entry.is_dir and entry.name == name for entry in entries):
+            return name
+    return None
+
+
 class AgentSkills(Plugin):
     """Plugin that integrates Agent Skills into a Strands agent.
 
@@ -52,7 +85,14 @@ class AgentSkills(Plugin):
     3. Session persistence of active skill state via ``agent.state``
 
     Skills can be provided as filesystem paths (to individual skill directories or
-    parent directories containing multiple skills) or as pre-built ``Skill`` instances.
+    parent directories containing multiple skills), ``https://`` URLs pointing to
+    raw SKILL.md content, or as pre-built ``Skill`` instances.
+
+    Filesystem paths are read through the agent's sandbox at ``init_agent`` time,
+    so each agent loads the skills present on its own filesystem (host or
+    container). Skill instances and URLs are sandbox-independent and resolve at
+    construction. As a result, ``get_available_skills`` returns filesystem skills
+    only when passed the agent they were loaded for.
 
     Example:
         ```python
@@ -93,25 +133,36 @@ class AgentSkills(Plugin):
             strict: If True, raise on skill validation issues. If False (default), warn and load anyway.
         """
         self._strict = strict
-        self._skills: dict[str, Skill] = self._resolve_skills(_normalize_sources(skills))
         self._state_key = state_key
         self._max_resource_files = max_resource_files
+        # Skill instances and URLs resolve now (both sandbox-independent and synchronous in
+        # Python). Filesystem paths are deferred to init_agent, where the agent's sandbox is
+        # available, so a path may resolve differently per agent (host vs. container).
+        self._skills, self._skill_paths = self._resolve_skills(_normalize_sources(skills))
+        # Per-agent full skill set (base skills + path-loaded skills from that agent's sandbox).
+        # WeakKeyDictionary mirrors the TypeScript oracle's WeakMap<agent, ...>: a single plugin
+        # instance can serve multiple agents without leaking references once an agent is collected.
+        self._agent_skills: weakref.WeakKeyDictionary[Agent, dict[str, Skill]] = weakref.WeakKeyDictionary()
         super().__init__()
 
-    def init_agent(self, agent: Agent) -> None:
+    async def init_agent(self, agent: Agent) -> None:
         """Initialize the plugin with an agent instance.
 
-        Decorated hooks and tools are auto-registered by the plugin registry.
+        Loads any deferred filesystem skill paths through the agent's sandbox,
+        building the agent's full skill set. Decorated hooks and tools are
+        auto-registered by the plugin registry.
 
         Args:
             agent: The agent instance to extend with skills support.
         """
-        if not self._skills:
+        await self._load_skill_paths(agent)
+        skills = self._agent_skills.get(agent, self._skills)
+        if not skills:
             logger.warning("no skills were loaded, the agent will have no skills available")
-        logger.debug("skill_count=<%d> | skills plugin initialized", len(self._skills))
+        logger.debug("skill_count=<%d> | skills plugin initialized", len(skills))
 
     @tool(context=True)
-    def skills(self, skill_name: str, tool_context: ToolContext) -> str:  # noqa: D417
+    async def skills(self, skill_name: str, tool_context: ToolContext) -> str:
         """Activate a skill to load its full instructions.
 
         Use this tool to load the complete instructions for a skill listed in
@@ -119,28 +170,34 @@ class AgentSkills(Plugin):
 
         Args:
             skill_name: Name of the skill to activate.
+            tool_context: Injected by the framework. Not user-facing.
         """
+        agent = tool_context.agent
+        skills = self._skills_for(agent)
+
         if not skill_name:
-            available = ", ".join(self._skills)
+            available = ", ".join(skills)
             return f"Error: skill_name is required. Available skills: {available}"
 
-        found = self._skills.get(skill_name)
+        found = skills.get(skill_name)
         if found is None:
-            available = ", ".join(self._skills)
+            available = ", ".join(skills)
             return f"Skill '{skill_name}' not found. Available skills: {available}"
 
         logger.debug("skill_name=<%s> | skill activated", skill_name)
-        self._track_activated_skill(tool_context.agent, skill_name)
-        return self._format_skill_response(found)
+        self._track_activated_skill(agent, skill_name)
+        return await self._format_skill_response(found, agent.sandbox)
 
     @hook
-    def _on_before_invocation(self, event: BeforeInvocationEvent) -> None:
+    async def _on_before_invocation(self, event: BeforeInvocationEvent) -> None:
         """Inject skill metadata into the system prompt before each invocation.
 
-        Removes the previously injected XML block (if any) via exact match,
-        then appends a fresh one. Uses agent state to track the injected XML
-        per-agent, so a single plugin instance can be shared across multiple
-        agents safely.
+        On first invocation for an agent (or after ``set_available_skills`` reset
+        the per-agent cache), loads that agent's deferred filesystem skill paths
+        through its sandbox. Then removes the previously injected XML block (if
+        any) via exact match and appends a fresh one. Uses agent state to track
+        the injected XML per-agent, so a single plugin instance can be shared
+        across multiple agents safely.
 
         When the agent has a structured system prompt (list of SystemContentBlock),
         the injection is done at the block level so that cache points and other
@@ -151,10 +208,16 @@ class AgentSkills(Plugin):
         """
         agent = event.agent
 
+        # Lazily load filesystem skills if this agent has not been initialized yet
+        # (mirrors the TypeScript oracle's before-invocation hook). Keeps skills correct
+        # after set_available_skills, which clears the per-agent cache.
+        if agent not in self._agent_skills:
+            await self._load_skill_paths(agent)
+
         state_data = agent.state.get(self._state_key)
         last_injected_xml = state_data.get("last_injected_xml") if isinstance(state_data, dict) else None
 
-        skills_xml = self._generate_skills_xml()
+        skills_xml = self._generate_skills_xml(agent)
         content = agent.system_prompt_content
 
         if content is not None:
@@ -183,13 +246,21 @@ class AgentSkills(Plugin):
             self._set_state_field(agent, "last_injected_xml", new_injected_xml)
             agent.system_prompt = new_prompt
 
-    def get_available_skills(self) -> list[Skill]:
+    def get_available_skills(self, agent: Agent | None = None) -> list[Skill]:
         """Get the list of available skills.
 
+        Args:
+            agent: When provided, returns that agent's full skill set (base skills
+                plus filesystem skills loaded from its sandbox). When omitted,
+                returns only the sandbox-independent base skills (Skill instances
+                and URLs); filesystem skills are excluded because they are loaded
+                per-agent at ``init_agent`` time.
+
         Returns:
-            A copy of the current skills list.
+            A copy of the resolved skills list.
         """
-        return list(self._skills.values())
+        skills = self._skills_for(agent) if agent is not None else self._skills
+        return list(skills.values())
 
     def set_available_skills(self, skills: SkillSources) -> None:
         """Set the available skills, replacing any existing ones.
@@ -199,24 +270,118 @@ class AgentSkills(Plugin):
         parent directory containing skill subdirectories, or an ``https://``
         URL pointing directly to raw SKILL.md content.
 
-        Note: this does not persist state or deactivate skills on any agent.
-        Active skill state is managed per-agent and will be reconciled on the
-        next tool call or invocation.
+        Filesystem paths are re-loaded per-agent on the next invocation. Note:
+        this does not persist state or deactivate skills on any agent. Active
+        skill state is managed per-agent and will be reconciled on the next tool
+        call or invocation.
 
         Args:
             skills: One or more skill sources to resolve and set.
         """
-        self._skills = self._resolve_skills(_normalize_sources(skills))
+        self._skills, self._skill_paths = self._resolve_skills(_normalize_sources(skills))
+        # Drop per-agent caches so deferred paths reload against each agent's sandbox.
+        self._agent_skills = weakref.WeakKeyDictionary()
 
-    def _format_skill_response(self, skill: Skill) -> str:
+    def _skills_for(self, agent: Agent | None) -> dict[str, Skill]:
+        """Return the skill set for an agent, falling back to base skills.
+
+        An agent appears in the per-agent map once :meth:`init_agent` (or the
+        before-invocation hook) has loaded its filesystem paths. Before that (or
+        for agents that only use Skill instances and URLs), the base skills are
+        returned.
+
+        Args:
+            agent: The agent whose skill set to retrieve, or ``None``.
+
+        Returns:
+            The agent's full skill set, or the base skills.
+        """
+        if agent is None:
+            return self._skills
+        return self._agent_skills.get(agent, self._skills)
+
+    async def _load_skill_paths(self, agent: Agent) -> None:
+        """Load deferred filesystem skill paths through the agent's sandbox.
+
+        Mirrors :meth:`Skill.from_file` / :meth:`Skill.from_directory`: a path may
+        be a SKILL.md file, a skill directory, or a parent directory of skill
+        subdirectories. Per-path failures are logged and skipped so one bad skill
+        does not abort its siblings. The resulting full skill set is stored in the
+        per-agent map.
+
+        Args:
+            agent: The agent whose sandbox is used to read skill files.
+        """
+        skills = dict(self._skills)
+        if not self._skill_paths:
+            self._agent_skills[agent] = skills
+            return
+
+        # Falls back to the default NotASandboxLocalEnvironment when the agent has no explicit sandbox.
+        sandbox = agent.sandbox
+
+        async def load_skill(skill_dir: str, md_path: str) -> None:
+            # A failure (e.g. malformed SKILL.md) is logged and skipped so it does not abort
+            # sibling skills, matching Skill.from_directory's per-skill resilience.
+            try:
+                skill = Skill.from_content(await sandbox.read_text(md_path), strict=self._strict)
+                # Set the sandbox path as-is (not host-resolved): the file may live in a container.
+                # Then replicate Skill.from_file's directory-name check, which from_content does not
+                # perform (Python's from_content takes no path, unlike the TS oracle's fromContent).
+                skill.path = Path(skill_dir)
+                if skill.path.name != skill.name:
+                    msg = "name=<%s>, directory=<%s> | skill name does not match parent directory name"
+                    if self._strict:
+                        raise ValueError(msg % (skill.name, skill.path.name))
+                    logger.warning(msg, skill.name, skill.path.name)
+                if skill.name in skills:
+                    logger.warning("name=<%s> | duplicate skill name, overwriting previous skill", skill.name)
+                skills[skill.name] = skill
+            except Exception as e:
+                logger.warning("path=<%s> | failed to load skill: %s", skill_dir, e)
+
+        for skill_path in self._skill_paths:
+            skill_path_str = str(skill_path)
+            try:
+                entries = await sandbox.list_files(skill_path_str)
+            except Exception:
+                # Not a directory: accept a direct path to a SKILL.md file, as Skill.from_file does.
+                if skill_path_str.lower().endswith("skill.md"):
+                    slash_index = skill_path_str.rfind("/")
+                    await load_skill("." if slash_index == -1 else skill_path_str[:slash_index], skill_path_str)
+                else:
+                    logger.warning("path=<%s> | skill source does not exist or is not a valid path", skill_path_str)
+                continue
+
+            md_name = _find_skill_md_name(entries)
+            if md_name:
+                await load_skill(skill_path_str, f"{skill_path_str}/{md_name}")
+                continue
+
+            # Parent directory: load each subdirectory that contains a skill.
+            for entry in sorted((e for e in entries if e.is_dir), key=lambda e: e.name):
+                child_dir = f"{skill_path_str}/{entry.name}"
+                try:
+                    child_entries = await sandbox.list_files(child_dir)
+                except Exception as e:
+                    logger.warning("path=<%s> | failed to load skill from sandbox: %s", child_dir, e)
+                    continue
+                child_md = _find_skill_md_name(child_entries)
+                if child_md:
+                    await load_skill(child_dir, f"{child_dir}/{child_md}")
+
+        self._agent_skills[agent] = skills
+
+    async def _format_skill_response(self, skill: Skill, sandbox: Sandbox) -> str:
         """Format the tool response when a skill is activated.
 
         Includes the full instructions along with relevant metadata fields
         and a listing of available resource files (scripts, references, assets)
-        for filesystem-based skills.
+        read through the sandbox for filesystem-based skills.
 
         Args:
             skill: The activated skill.
+            sandbox: The agent's sandbox, used to list resource files.
 
         Returns:
             Formatted string with skill instructions and metadata.
@@ -238,58 +403,79 @@ class AgentSkills(Plugin):
             parts.append("\n---\n" + "\n".join(metadata_lines))
 
         if skill.path is not None:
-            resources = self._list_skill_resources(skill.path)
+            resources = await self._list_skill_resources(sandbox, str(skill.path))
             if resources:
                 parts.append("\nAvailable resources:\n" + "\n".join(f"  {r}" for r in resources))
 
         return "\n".join(parts)
 
-    def _list_skill_resources(self, skill_path: Path) -> list[str]:
-        """List resource files in a skill's optional directories.
+    async def _list_skill_resources(self, sandbox: Sandbox, skill_path: str) -> list[str]:
+        """List resource files in a skill's optional directories through the sandbox.
 
         Scans the ``scripts/``, ``references/``, and ``assets/`` subdirectories
         for files, returning relative paths. Results are capped at
         ``max_resource_files`` to avoid context bloat.
 
         Args:
-            skill_path: Path to the skill directory.
+            sandbox: The agent's sandbox, used to list directory contents.
+            skill_path: Path to the skill directory (a sandbox path).
 
         Returns:
             List of relative file paths (e.g. ``scripts/extract.py``).
         """
         files: list[str] = []
 
+        # List a directory recursively through the sandbox, returning paths relative to its root.
+        # Replaces Path.rglob, which has no sandbox equivalent.
+        async def list_files_recursive(directory: str, depth: int = 0) -> list[str]:
+            if depth >= _MAX_RESOURCE_DEPTH:
+                return []
+            result: list[str] = []
+            for entry in await sandbox.list_files(directory):
+                if entry.is_dir:
+                    nested = await list_files_recursive(f"{directory}/{entry.name}", depth + 1)
+                    result.extend(f"{entry.name}/{p}" for p in nested)
+                else:
+                    result.append(entry.name)
+            return result
+
         for dir_name in _RESOURCE_DIRS:
-            resource_dir = skill_path / dir_name
-            if not resource_dir.is_dir():
+            resource_dir = f"{skill_path}/{dir_name}"
+            try:
+                entries = await list_files_recursive(resource_dir)
+            except Exception:
+                # Missing directory (or unreadable): skip, as the optional dirs need not exist.
                 continue
 
-            for file_path in sorted(resource_dir.rglob("*")):
-                if not file_path.is_file():
-                    continue
-                files.append(file_path.relative_to(skill_path).as_posix())
+            for entry in sorted(entries):
+                files.append(f"{dir_name}/{entry}")
                 if len(files) >= self._max_resource_files:
                     files.append(f"... (truncated at {self._max_resource_files} files)")
                     return files
 
         return files
 
-    def _generate_skills_xml(self) -> str:
+    def _generate_skills_xml(self, agent: Agent | None = None) -> str:
         """Generate the XML block listing available skills for the system prompt.
 
         When no skills are loaded, returns a block indicating no skills are available.
         Otherwise includes a ``<location>`` element for skills loaded from the filesystem,
         following the AgentSkills.io integration spec.
 
+        Args:
+            agent: When provided, lists that agent's full skill set; otherwise lists
+                only the base skills.
+
         Returns:
             XML-formatted string with skill metadata.
         """
-        if not self._skills:
+        skills = self._skills_for(agent)
+        if not skills:
             return "<available_skills>\nNo skills are currently available.\n</available_skills>"
 
         lines: list[str] = ["<available_skills>"]
 
-        for skill in self._skills.values():
+        for skill in skills.values():
             lines.append("<skill>")
             lines.append(f"<name>{escape(skill.name)}</name>")
             lines.append(f"<description>{escape(skill.description)}</description>")
@@ -300,20 +486,22 @@ class AgentSkills(Plugin):
         lines.append("</available_skills>")
         return "\n".join(lines)
 
-    def _resolve_skills(self, sources: list[SkillSource]) -> dict[str, Skill]:
-        """Resolve a list of skill sources into Skill instances.
+    def _resolve_skills(self, sources: list[SkillSource]) -> tuple[dict[str, Skill], list[SkillSource]]:
+        """Resolve sandbox-independent sources and collect deferred filesystem paths.
 
-        Each source can be a Skill instance, a path to a skill directory,
-        a path to a parent directory containing multiple skills, or an
-        HTTPS URL pointing to a SKILL.md file.
+        Skill instances and ``https://`` URLs resolve immediately (both are
+        synchronous and filesystem-independent). Filesystem paths (``str`` or
+        ``Path``) are collected and returned unresolved, to be loaded per-agent
+        through the sandbox in :meth:`_load_skill_paths`.
 
         Args:
             sources: List of skill sources to resolve.
 
         Returns:
-            Dict mapping skill names to Skill instances.
+            A tuple of (base skills mapping name to Skill, deferred filesystem paths).
         """
         resolved: dict[str, Skill] = {}
+        skill_paths: list[SkillSource] = []
 
         for source in sources:
             if isinstance(source, Skill):
@@ -329,44 +517,16 @@ class AgentSkills(Plugin):
                 except (RuntimeError, ValueError) as e:
                     logger.warning("url=<%s> | failed to load skill from URL: %s", source, e)
             else:
-                path = Path(source).resolve()
-                if not path.exists():
-                    logger.warning("path=<%s> | skill source path does not exist, skipping", path)
-                    continue
+                # Filesystem path: defer to init_agent, where the agent's sandbox is available.
+                skill_paths.append(source)
 
-                if path.is_dir():
-                    # Check if this directory itself is a skill (has SKILL.md)
-                    has_skill_md = (path / "SKILL.md").is_file() or (path / "skill.md").is_file()
-
-                    if has_skill_md:
-                        try:
-                            skill = Skill.from_file(path, strict=self._strict)
-                            if skill.name in resolved:
-                                logger.warning(
-                                    "name=<%s> | duplicate skill name, overwriting previous skill", skill.name
-                                )
-                            resolved[skill.name] = skill
-                        except (ValueError, FileNotFoundError) as e:
-                            logger.warning("path=<%s> | failed to load skill: %s", path, e)
-                    else:
-                        # Treat as parent directory containing skill subdirectories
-                        for skill in Skill.from_directory(path, strict=self._strict):
-                            if skill.name in resolved:
-                                logger.warning(
-                                    "name=<%s> | duplicate skill name, overwriting previous skill", skill.name
-                                )
-                            resolved[skill.name] = skill
-                elif path.is_file() and path.name.lower() == "skill.md":
-                    try:
-                        skill = Skill.from_file(path, strict=self._strict)
-                        if skill.name in resolved:
-                            logger.warning("name=<%s> | duplicate skill name, overwriting previous skill", skill.name)
-                        resolved[skill.name] = skill
-                    except (ValueError, FileNotFoundError) as e:
-                        logger.warning("path=<%s> | failed to load skill: %s", path, e)
-
-        logger.debug("source_count=<%d>, resolved_count=<%d> | skills resolved", len(sources), len(resolved))
-        return resolved
+        logger.debug(
+            "source_count=<%d>, resolved_count=<%d>, deferred_path_count=<%d> | skills resolved",
+            len(sources),
+            len(resolved),
+            len(skill_paths),
+        )
+        return resolved, skill_paths
 
     def _set_state_field(self, agent: Agent, key: str, value: Any) -> None:
         """Set a single field in the plugin's agent state dict.

--- a/strands-py/src/strands/vended_plugins/skills/agent_skills.py
+++ b/strands-py/src/strands/vended_plugins/skills/agent_skills.py
@@ -9,12 +9,8 @@ container) at ``init_agent`` time, not at construction, so each agent sees the
 skills present on its own filesystem. Skill instances and ``https://`` URLs are
 sandbox-independent and resolve eagerly at construction.
 
-Mirrors ``strands-ts/src/vended-plugins/skills/agent-skills.ts``. One idiomatic
-divergence: TypeScript defers URL loading behind a ``ready`` promise and resolves
-it in ``initAgent`` because ``Skill.fromUrl`` is async; Python's
 :meth:`Skill.from_url` is synchronous, so URLs resolve at construction and no
 readiness barrier is needed. The observable effect is benign: URL skills are
-available from ``get_available_skills()`` slightly earlier than in TypeScript.
 """
 
 from __future__ import annotations
@@ -140,7 +136,7 @@ class AgentSkills(Plugin):
         # available, so a path may resolve differently per agent (host vs. container).
         self._skills, self._skill_paths = self._resolve_skills(_normalize_sources(skills))
         # Per-agent full skill set (base skills + path-loaded skills from that agent's sandbox).
-        # WeakKeyDictionary mirrors the TypeScript oracle's WeakMap<agent, ...>: a single plugin
+        # Per-agent map (WeakKeyDictionary) so a single plugin
         # instance can serve multiple agents without leaking references once an agent is collected.
         self._agent_skills: weakref.WeakKeyDictionary[Agent, dict[str, Skill]] = weakref.WeakKeyDictionary()
         super().__init__()
@@ -209,7 +205,7 @@ class AgentSkills(Plugin):
         agent = event.agent
 
         # Lazily load filesystem skills if this agent has not been initialized yet
-        # (mirrors the TypeScript oracle's before-invocation hook). Keeps skills correct
+        # Keeps skills correct
         # after set_available_skills, which clears the per-agent cache.
         if agent not in self._agent_skills:
             await self._load_skill_paths(agent)
@@ -327,7 +323,7 @@ class AgentSkills(Plugin):
                 skill = Skill.from_content(await sandbox.read_text(md_path), strict=self._strict)
                 # Set the sandbox path as-is (not host-resolved): the file may live in a container.
                 # Then replicate Skill.from_file's directory-name check, which from_content does not
-                # perform (Python's from_content takes no path, unlike the TS oracle's fromContent).
+                # perform (Python's from_content takes no path parameter).
                 skill.path = Path(skill_dir)
                 if skill.path.name != skill.name:
                     msg = "name=<%s>, directory=<%s> | skill name does not match parent directory name"

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,6 +1,6 @@
 """Built-in tools for executing commands and editing files.
 
-These tools mirror ``strands-ts/src/vended-tools/``. The :data:`bash` tool runs a
+The :data:`bash` tool runs a
 persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
 factories produce sandbox-routed tools that either bind to a
 :class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
@@ -15,22 +15,10 @@ Example Usage:
     ```
 """
 
-from .bash import (
-    DEFAULT_BASH_DESCRIPTION,
-    SANDBOX_BASH_DESCRIPTION,
-    BashSessionError,
-    BashTimeoutError,
-    bash,
-    make_bash,
-)
-from .file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, file_editor, make_file_editor
+from .bash import bash, make_bash
+from .file_editor import file_editor, make_file_editor
 
 __all__ = [
-    "DEFAULT_BASH_DESCRIPTION",
-    "DEFAULT_FILE_EDITOR_DESCRIPTION",
-    "SANDBOX_BASH_DESCRIPTION",
-    "BashSessionError",
-    "BashTimeoutError",
     "bash",
     "file_editor",
     "make_bash",

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,0 +1,38 @@
+"""Built-in tools for executing commands and editing files.
+
+These tools mirror ``strands-ts/src/vended-tools/``. The :data:`bash` tool runs a
+persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
+factories produce sandbox-routed tools that either bind to a
+:class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
+sandboxes do when vending tools) or read the sandbox from the agent at call time.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import bash, file_editor
+
+    agent = Agent(tools=[bash, file_editor])
+    ```
+"""
+
+from .bash import (
+    DEFAULT_BASH_DESCRIPTION,
+    SANDBOX_BASH_DESCRIPTION,
+    BashSessionError,
+    BashTimeoutError,
+    bash,
+    make_bash,
+)
+from .file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, file_editor, make_file_editor
+
+__all__ = [
+    "DEFAULT_BASH_DESCRIPTION",
+    "DEFAULT_FILE_EDITOR_DESCRIPTION",
+    "SANDBOX_BASH_DESCRIPTION",
+    "BashSessionError",
+    "BashTimeoutError",
+    "bash",
+    "file_editor",
+    "make_bash",
+    "make_file_editor",
+]

--- a/strands-py/src/strands/vended_tools/bash/__init__.py
+++ b/strands-py/src/strands/vended_tools/bash/__init__.py
@@ -1,0 +1,33 @@
+"""Bash tools for executing shell commands.
+
+Two tools are provided, mirroring ``strands-ts/src/vended-tools/bash/``:
+
+- :data:`bash` — a host-session tool whose shell state (variables, working
+  directory) persists across calls. Runs on the host without sandboxing.
+- :func:`make_bash` — a factory for a stateless, sandbox-routed bash tool. Each
+  call runs in a fresh shell through the agent's (or a bound) sandbox.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools.bash import bash, make_bash
+
+    # Persistent host session
+    agent = Agent(tools=[bash])
+
+    # Stateless, routed through a sandbox
+    agent = Agent(tools=[make_bash()])
+    ```
+"""
+
+from .bash import DEFAULT_BASH_DESCRIPTION, bash, make_bash
+from .types import SANDBOX_BASH_DESCRIPTION, BashSessionError, BashTimeoutError
+
+__all__ = [
+    "DEFAULT_BASH_DESCRIPTION",
+    "SANDBOX_BASH_DESCRIPTION",
+    "BashSessionError",
+    "BashTimeoutError",
+    "bash",
+    "make_bash",
+]

--- a/strands-py/src/strands/vended_tools/bash/__init__.py
+++ b/strands-py/src/strands/vended_tools/bash/__init__.py
@@ -1,6 +1,6 @@
 """Bash tools for executing shell commands.
 
-Two tools are provided, mirroring ``strands-ts/src/vended-tools/bash/``:
+Two tools are provided:
 
 - :data:`bash` — a host-session tool whose shell state (variables, working
   directory) persists across calls. Runs on the host without sandboxing.
@@ -20,14 +20,9 @@ Example Usage:
     ```
 """
 
-from .bash import DEFAULT_BASH_DESCRIPTION, bash, make_bash
-from .types import SANDBOX_BASH_DESCRIPTION, BashSessionError, BashTimeoutError
+from .bash import bash, make_bash
 
 __all__ = [
-    "DEFAULT_BASH_DESCRIPTION",
-    "SANDBOX_BASH_DESCRIPTION",
-    "BashSessionError",
-    "BashTimeoutError",
     "bash",
     "make_bash",
 ]

--- a/strands-py/src/strands/vended_tools/bash/__init__.py
+++ b/strands-py/src/strands/vended_tools/bash/__init__.py
@@ -1,22 +1,11 @@
-"""Bash tools for executing shell commands.
-
-Two tools are provided:
-
-- :data:`bash` — a host-session tool whose shell state (variables, working
-  directory) persists across calls. Runs on the host without sandboxing.
-- :func:`make_bash` — a factory for a stateless, sandbox-routed bash tool. Each
-  call runs in a fresh shell through the agent's (or a bound) sandbox.
+"""Bash tool for executing shell commands through a sandbox.
 
 Example Usage:
     ```python
     from strands import Agent
-    from strands.vended_tools.bash import bash, make_bash
+    from strands.vended_tools import bash
 
-    # Persistent host session
     agent = Agent(tools=[bash])
-
-    # Stateless, routed through a sandbox
-    agent = Agent(tools=[make_bash()])
     ```
 """
 

--- a/strands-py/src/strands/vended_tools/bash/bash.py
+++ b/strands-py/src/strands/vended_tools/bash/bash.py
@@ -1,8 +1,8 @@
 """Bash tools for executing shell commands.
 
-Mirrors ``strands-ts/src/vended-tools/bash/`` (``bash.ts`` + ``make-bash.ts``,
-combined here since Python has no browser target requiring the Node-dependency
-split). Provides two tools:
+Provides both the host-session bash tool and the sandbox-routed factory (
+combined here since Python has no browser target requiring a
+dependency split). Two tools:
 
 - :data:`bash` — a persistent host session per agent: variables and the working
   directory are retained between calls. Supports ``execute`` and ``restart``
@@ -13,14 +13,17 @@ split). Provides two tools:
 The persistent shell is driven with a single :class:`subprocess.Popen` process,
 background reader threads, and a unique sentinel echoed after each command to
 detect completion. stdout and stderr are captured separately to match the
-TypeScript oracle's ``BashOutput``.
+the ``BashOutput`` type.
 """
 
 from __future__ import annotations
 
+import asyncio
 import atexit
 import os
+import subprocess
 import threading
+import time
 import uuid
 import weakref
 from typing import TYPE_CHECKING, Any, Literal
@@ -31,8 +34,6 @@ from ...types.tools import ToolContext
 from .types import SANDBOX_BASH_DESCRIPTION, BashOutput, BashSessionError, BashTimeoutError
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from ...sandbox.base import Sandbox
     from ...tools.decorator import DecoratedFunctionTool
 
@@ -67,12 +68,10 @@ class _BashSession:
 
     def start(self) -> None:
         """Start the bash process if it is not already running."""
-        import subprocess
-
         if self._process is not None and self._process.poll() is None:
             return
         try:
-            env: Mapping[str, str] = {**os.environ, "PS1": "", "PS2": ""}
+            env = {**os.environ, "PS1": "", "PS2": ""}
             self._process = subprocess.Popen(
                 ["bash", "--noprofile", "--norc"],
                 stdin=subprocess.PIPE,
@@ -127,6 +126,9 @@ class _BashSession:
                 for raw in iter(stream.readline, b""):
                     line = raw.decode("utf-8", errors="replace")
                     if sentinel in line:
+                        # Keep any output that shares the sentinel's line (e.g. `printf foo`
+                        # with no trailing newline), dropping only the sentinel itself.
+                        chunks.append(line.split(sentinel, 1)[0])
                         break
                     chunks.append(line)
                 done.set()
@@ -154,10 +156,13 @@ class _BashSession:
                 self.stop()
                 raise BashSessionError(f"Failed to write command: {e}") from e
 
-            deadline = effective_timeout
-            if not stdout_done.wait(timeout=deadline) or not stderr_done.wait(timeout=deadline):
-                self.stop()
-                raise BashTimeoutError(f"Command timed out after {effective_timeout} seconds")
+            # Single absolute deadline so the total wait is bounded by effective_timeout
+            # (waiting on both events sequentially must not let the timeout double).
+            deadline = time.monotonic() + effective_timeout
+            for event in (stdout_done, stderr_done):
+                if not event.wait(timeout=max(0.0, deadline - time.monotonic())):
+                    self.stop()
+                    raise BashTimeoutError(f"Command timed out after {effective_timeout} seconds")
 
             # The process died before emitting the sentinel.
             if proc.poll() is not None:
@@ -199,8 +204,6 @@ async def bash(  # noqa: D417
         command: The bash command to execute (required when mode is "execute").
         timeout: Timeout in seconds (default: 120, applies only to execute mode).
     """
-    import asyncio
-
     agent = tool_context.agent
 
     if mode == "restart":

--- a/strands-py/src/strands/vended_tools/bash/bash.py
+++ b/strands-py/src/strands/vended_tools/bash/bash.py
@@ -1,0 +1,271 @@
+"""Bash tools for executing shell commands.
+
+Mirrors ``strands-ts/src/vended-tools/bash/`` (``bash.ts`` + ``make-bash.ts``,
+combined here since Python has no browser target requiring the Node-dependency
+split). Provides two tools:
+
+- :data:`bash` — a persistent host session per agent: variables and the working
+  directory are retained between calls. Supports ``execute`` and ``restart``
+  modes. Runs on the host without sandboxing, so use only with trusted input.
+- :func:`make_bash` — a factory for a stateless, sandbox-routed bash tool. Each
+  call runs in a fresh shell through the agent's (or a bound) sandbox.
+
+The persistent shell is driven with a single :class:`subprocess.Popen` process,
+background reader threads, and a unique sentinel echoed after each command to
+detect completion. stdout and stderr are captured separately to match the
+TypeScript oracle's ``BashOutput``.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import threading
+import uuid
+import weakref
+from typing import TYPE_CHECKING, Any, Literal
+
+from ...sandbox.errors import SandboxTimeoutError
+from ...tools.decorator import tool
+from ...types.tools import ToolContext
+from .types import SANDBOX_BASH_DESCRIPTION, BashOutput, BashSessionError, BashTimeoutError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from ...sandbox.base import Sandbox
+    from ...tools.decorator import DecoratedFunctionTool
+
+_DEFAULT_TIMEOUT = 120
+
+DEFAULT_BASH_DESCRIPTION = (
+    "Executes bash shell commands in a persistent session. Supports execute and restart modes. "
+    "Commands persist state (variables, directory) within the session."
+)
+"""Description for the host-session bash tool."""
+
+
+class _BashSession:
+    """A persistent host bash process.
+
+    Each call to :meth:`run` executes a command in the same shell, so state
+    (variables, working directory) is retained. Completion is detected by
+    echoing a unique sentinel after the command; output produced before the
+    sentinel is the command's stdout.
+    """
+
+    def __init__(self, timeout: float = _DEFAULT_TIMEOUT) -> None:
+        """Initialize the session.
+
+        Args:
+            timeout: Default per-command timeout in seconds.
+        """
+        self._timeout = timeout
+        self._sentinel = f"__BASH_DONE_{uuid.uuid4().hex}__"
+        self._process: Any = None
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        """Start the bash process if it is not already running."""
+        import subprocess
+
+        if self._process is not None and self._process.poll() is None:
+            return
+        try:
+            env: Mapping[str, str] = {**os.environ, "PS1": "", "PS2": ""}
+            self._process = subprocess.Popen(
+                ["bash", "--noprofile", "--norc"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=dict(env),
+                bufsize=0,
+            )
+        except OSError as e:
+            raise BashSessionError(f"Failed to start bash session: {e}") from e
+        _active_sessions.add(self)
+
+    def stop(self) -> None:
+        """Terminate the bash process and forget it."""
+        if self._process is not None:
+            try:
+                self._process.kill()
+            except OSError:
+                pass
+            self._process = None
+        _active_sessions.discard(self)
+
+    def run(self, command: str, timeout: float | None = None) -> BashOutput:
+        """Run a command in the session and return its output.
+
+        Args:
+            command: The bash command to execute.
+            timeout: Per-command timeout in seconds; falls back to the session default.
+
+        Returns:
+            A mapping with ``output`` (stdout) and ``error`` (stderr).
+
+        Raises:
+            BashTimeoutError: If the command does not complete within the timeout.
+            BashSessionError: If the session is not running or the process exits unexpectedly.
+        """
+        # Serialize commands: the persistent shell handles one at a time.
+        with self._lock:
+            self.start()
+            proc = self._process
+            if proc is None or proc.stdin is None or proc.stdout is None or proc.stderr is None:
+                raise BashSessionError("Bash session not properly initialized")
+
+            effective_timeout = self._timeout if timeout is None else timeout
+            sentinel = self._sentinel
+
+            def drain(stream: Any, done: threading.Event) -> list[str]:
+                # Read until the sentinel line is seen (collecting everything before it),
+                # then signal completion. The sentinel is echoed to both stdout and stderr
+                # so each reader knows when its stream is complete for this command.
+                chunks: list[str] = []
+                for raw in iter(stream.readline, b""):
+                    line = raw.decode("utf-8", errors="replace")
+                    if sentinel in line:
+                        break
+                    chunks.append(line)
+                done.set()
+                return chunks
+
+            stdout_done = threading.Event()
+            stderr_done = threading.Event()
+            stdout_chunks: list[str] = []
+            stderr_chunks: list[str] = []
+
+            def read_stdout() -> None:
+                stdout_chunks.extend(drain(proc.stdout, stdout_done))
+
+            def read_stderr() -> None:
+                stderr_chunks.extend(drain(proc.stderr, stderr_done))
+
+            threading.Thread(target=read_stdout, daemon=True).start()
+            threading.Thread(target=read_stderr, daemon=True).start()
+
+            try:
+                # Echo the sentinel to both streams so both readers terminate deterministically.
+                proc.stdin.write(f"{command}\necho {sentinel}\necho {sentinel} >&2\n".encode())
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError) as e:
+                self.stop()
+                raise BashSessionError(f"Failed to write command: {e}") from e
+
+            deadline = effective_timeout
+            if not stdout_done.wait(timeout=deadline) or not stderr_done.wait(timeout=deadline):
+                self.stop()
+                raise BashTimeoutError(f"Command timed out after {effective_timeout} seconds")
+
+            # The process died before emitting the sentinel.
+            if proc.poll() is not None:
+                self.stop()
+                raise BashSessionError(f"Bash process exited unexpectedly with code {proc.returncode}")
+
+            return {"output": "".join(stdout_chunks).strip(), "error": "".join(stderr_chunks).strip()}
+
+
+# Per-agent sessions, cleaned up automatically when the agent is garbage collected.
+_sessions: weakref.WeakKeyDictionary[Any, _BashSession] = weakref.WeakKeyDictionary()
+
+# Live sessions tracked for cleanup at interpreter exit.
+_active_sessions: set[_BashSession] = set()
+
+
+@atexit.register
+def _cleanup_all_sessions() -> None:
+    """Terminate any live bash sessions at interpreter exit."""
+    for session in list(_active_sessions):
+        session.stop()
+    _active_sessions.clear()
+
+
+@tool(context=True)
+async def bash(  # noqa: D417
+    mode: Literal["execute", "restart"],
+    tool_context: ToolContext,
+    command: str | None = None,
+    timeout: int = _DEFAULT_TIMEOUT,
+) -> BashOutput | str:
+    """Executes bash commands in a persistent session that retains state across calls.
+
+    State such as variables and the working directory persists within the
+    session. Runs on the host without sandboxing; use only with trusted input.
+
+    Args:
+        mode: Operation mode: "execute" to run a command, "restart" to restart the session.
+        command: The bash command to execute (required when mode is "execute").
+        timeout: Timeout in seconds (default: 120, applies only to execute mode).
+    """
+    import asyncio
+
+    agent = tool_context.agent
+
+    if mode == "restart":
+        existing = _sessions.get(agent)
+        if existing is not None:
+            existing.stop()
+            del _sessions[agent]
+        _sessions[agent] = _BashSession(_DEFAULT_TIMEOUT)
+        return "Bash session restarted"
+
+    if mode != "execute":
+        raise BashSessionError(f'Unknown mode: {mode}. Expected "execute" or "restart".')
+
+    if not command:
+        raise BashSessionError('command is required when mode is "execute"')
+
+    session = _sessions.get(agent)
+    if session is None:
+        session = _BashSession(timeout)
+        _sessions[agent] = session
+
+    # The session is blocking (subprocess + threads); run it off the event loop.
+    return await asyncio.to_thread(session.run, command, timeout)
+
+
+def make_bash(
+    sandbox: Sandbox | None = None,
+    *,
+    name: str = "bash",
+    description: str = SANDBOX_BASH_DESCRIPTION,
+) -> DecoratedFunctionTool:
+    """Create a stateless, sandbox-routed bash tool.
+
+    If a ``sandbox`` is passed, it is bound at creation time. Otherwise the tool
+    reads the sandbox from ``tool_context.agent.sandbox`` at call time. Used by
+    sandbox implementations in :meth:`~strands.sandbox.base.Sandbox.get_tools`
+    and by users who want a customized bash tool. Unlike :data:`bash`, each call
+    runs in a fresh shell; state does not persist across calls.
+
+    Args:
+        sandbox: Sandbox to bind at creation. When ``None``, the agent's
+            configured sandbox is used at call time.
+        name: Tool name. Defaults to ``"bash"``.
+        description: Tool description shown to the model.
+
+    Returns:
+        A decorated tool that executes shell commands through the sandbox.
+    """
+
+    @tool(name=name, description=description, context="tool_context")
+    async def bash_tool(command: str, tool_context: ToolContext, timeout: int = _DEFAULT_TIMEOUT) -> BashOutput:
+        """Executes a bash shell command and returns its output.
+
+        Args:
+            command: The bash command to execute.
+            tool_context: Injected by the framework. Not user-facing.
+            timeout: Timeout in seconds (default: 120).
+        """
+        active = sandbox if sandbox is not None else tool_context.agent.sandbox
+        try:
+            result = await active.execute(command, timeout=timeout)
+        except SandboxTimeoutError as e:
+            raise BashTimeoutError(str(e)) from e
+        except Exception as e:
+            raise BashSessionError(str(e)) from e
+        return {"output": result.stdout, "error": result.stderr}
+
+    return bash_tool

--- a/strands-py/src/strands/vended_tools/bash/bash.py
+++ b/strands-py/src/strands/vended_tools/bash/bash.py
@@ -1,37 +1,19 @@
-"""Bash tools for executing shell commands.
+"""Bash tool for executing shell commands through a sandbox.
 
-Provides both the host-session bash tool and the sandbox-routed factory (
-combined here since Python has no browser target requiring a
-dependency split). Two tools:
-
-- :data:`bash` — a persistent host session per agent: variables and the working
-  directory are retained between calls. Supports ``execute`` and ``restart``
-  modes. Runs on the host without sandboxing, so use only with trusted input.
-- :func:`make_bash` — a factory for a stateless, sandbox-routed bash tool. Each
-  call runs in a fresh shell through the agent's (or a bound) sandbox.
-
-The persistent shell is driven with a single :class:`subprocess.Popen` process,
-background reader threads, and a unique sentinel echoed after each command to
-detect completion. stdout and stderr are captured separately to match the
-the ``BashOutput`` type.
+Provides :func:`make_bash` (a factory for a stateless, sandbox-routed bash tool)
+and :data:`bash` (the default instance that reads the sandbox from the agent at
+call time). Each call runs in a fresh shell; state such as variables and the
+working directory does not persist across calls.
 """
 
 from __future__ import annotations
 
-import asyncio
-import atexit
-import os
-import subprocess
-import threading
-import time
-import uuid
-import weakref
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 from ...sandbox.errors import SandboxTimeoutError
 from ...tools.decorator import tool
 from ...types.tools import ToolContext
-from .types import SANDBOX_BASH_DESCRIPTION, BashOutput, BashSessionError, BashTimeoutError
+from .types import SANDBOX_BASH_DESCRIPTION, BashOutput
 
 if TYPE_CHECKING:
     from ...sandbox.base import Sandbox
@@ -39,199 +21,10 @@ if TYPE_CHECKING:
 
 _DEFAULT_TIMEOUT = 120
 
-DEFAULT_BASH_DESCRIPTION = (
-    "Executes bash shell commands in a persistent session. Supports execute and restart modes. "
-    "Commands persist state (variables, directory) within the session."
-)
-"""Description for the host-session bash tool."""
-
-
-class _BashSession:
-    """A persistent host bash process.
-
-    Each call to :meth:`run` executes a command in the same shell, so state
-    (variables, working directory) is retained. Completion is detected by
-    echoing a unique sentinel after the command; output produced before the
-    sentinel is the command's stdout.
-    """
-
-    def __init__(self, timeout: float = _DEFAULT_TIMEOUT) -> None:
-        """Initialize the session.
-
-        Args:
-            timeout: Default per-command timeout in seconds.
-        """
-        self._timeout = timeout
-        self._sentinel = f"__BASH_DONE_{uuid.uuid4().hex}__"
-        self._process: Any = None
-        self._lock = threading.Lock()
-
-    def start(self) -> None:
-        """Start the bash process if it is not already running."""
-        if self._process is not None and self._process.poll() is None:
-            return
-        try:
-            env = {**os.environ, "PS1": "", "PS2": ""}
-            self._process = subprocess.Popen(
-                ["bash", "--noprofile", "--norc"],
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=dict(env),
-                bufsize=0,
-            )
-        except OSError as e:
-            raise BashSessionError(f"Failed to start bash session: {e}") from e
-        _active_sessions.add(self)
-
-    def stop(self) -> None:
-        """Terminate the bash process and forget it."""
-        if self._process is not None:
-            try:
-                self._process.kill()
-            except OSError:
-                pass
-            self._process = None
-        _active_sessions.discard(self)
-
-    def run(self, command: str, timeout: float | None = None) -> BashOutput:
-        """Run a command in the session and return its output.
-
-        Args:
-            command: The bash command to execute.
-            timeout: Per-command timeout in seconds; falls back to the session default.
-
-        Returns:
-            A mapping with ``output`` (stdout) and ``error`` (stderr).
-
-        Raises:
-            BashTimeoutError: If the command does not complete within the timeout.
-            BashSessionError: If the session is not running or the process exits unexpectedly.
-        """
-        # Serialize commands: the persistent shell handles one at a time.
-        with self._lock:
-            self.start()
-            proc = self._process
-            if proc is None or proc.stdin is None or proc.stdout is None or proc.stderr is None:
-                raise BashSessionError("Bash session not properly initialized")
-
-            effective_timeout = self._timeout if timeout is None else timeout
-            sentinel = self._sentinel
-
-            def drain(stream: Any, done: threading.Event) -> list[str]:
-                # Read until the sentinel line is seen (collecting everything before it),
-                # then signal completion. The sentinel is echoed to both stdout and stderr
-                # so each reader knows when its stream is complete for this command.
-                chunks: list[str] = []
-                for raw in iter(stream.readline, b""):
-                    line = raw.decode("utf-8", errors="replace")
-                    if sentinel in line:
-                        # Keep any output that shares the sentinel's line (e.g. `printf foo`
-                        # with no trailing newline), dropping only the sentinel itself.
-                        chunks.append(line.split(sentinel, 1)[0])
-                        break
-                    chunks.append(line)
-                done.set()
-                return chunks
-
-            stdout_done = threading.Event()
-            stderr_done = threading.Event()
-            stdout_chunks: list[str] = []
-            stderr_chunks: list[str] = []
-
-            def read_stdout() -> None:
-                stdout_chunks.extend(drain(proc.stdout, stdout_done))
-
-            def read_stderr() -> None:
-                stderr_chunks.extend(drain(proc.stderr, stderr_done))
-
-            threading.Thread(target=read_stdout, daemon=True).start()
-            threading.Thread(target=read_stderr, daemon=True).start()
-
-            try:
-                # Echo the sentinel to both streams so both readers terminate deterministically.
-                proc.stdin.write(f"{command}\necho {sentinel}\necho {sentinel} >&2\n".encode())
-                proc.stdin.flush()
-            except (BrokenPipeError, OSError) as e:
-                self.stop()
-                raise BashSessionError(f"Failed to write command: {e}") from e
-
-            # Single absolute deadline so the total wait is bounded by effective_timeout
-            # (waiting on both events sequentially must not let the timeout double).
-            deadline = time.monotonic() + effective_timeout
-            for event in (stdout_done, stderr_done):
-                if not event.wait(timeout=max(0.0, deadline - time.monotonic())):
-                    self.stop()
-                    raise BashTimeoutError(f"Command timed out after {effective_timeout} seconds")
-
-            # The process died before emitting the sentinel.
-            if proc.poll() is not None:
-                self.stop()
-                raise BashSessionError(f"Bash process exited unexpectedly with code {proc.returncode}")
-
-            return {"output": "".join(stdout_chunks).strip(), "error": "".join(stderr_chunks).strip()}
-
-
-# Per-agent sessions, cleaned up automatically when the agent is garbage collected.
-_sessions: weakref.WeakKeyDictionary[Any, _BashSession] = weakref.WeakKeyDictionary()
-
-# Live sessions tracked for cleanup at interpreter exit.
-_active_sessions: set[_BashSession] = set()
-
-
-@atexit.register
-def _cleanup_all_sessions() -> None:
-    """Terminate any live bash sessions at interpreter exit."""
-    for session in list(_active_sessions):
-        session.stop()
-    _active_sessions.clear()
-
-
-@tool(context=True)
-async def bash(  # noqa: D417
-    mode: Literal["execute", "restart"],
-    tool_context: ToolContext,
-    command: str | None = None,
-    timeout: int = _DEFAULT_TIMEOUT,
-) -> BashOutput | str:
-    """Executes bash commands in a persistent session that retains state across calls.
-
-    State such as variables and the working directory persists within the
-    session. Runs on the host without sandboxing; use only with trusted input.
-
-    Args:
-        mode: Operation mode: "execute" to run a command, "restart" to restart the session.
-        command: The bash command to execute (required when mode is "execute").
-        timeout: Timeout in seconds (default: 120, applies only to execute mode).
-    """
-    agent = tool_context.agent
-
-    if mode == "restart":
-        existing = _sessions.get(agent)
-        if existing is not None:
-            existing.stop()
-            del _sessions[agent]
-        _sessions[agent] = _BashSession(_DEFAULT_TIMEOUT)
-        return "Bash session restarted"
-
-    if mode != "execute":
-        raise BashSessionError(f'Unknown mode: {mode}. Expected "execute" or "restart".')
-
-    if not command:
-        raise BashSessionError('command is required when mode is "execute"')
-
-    session = _sessions.get(agent)
-    if session is None:
-        session = _BashSession(timeout)
-        _sessions[agent] = session
-
-    # The session is blocking (subprocess + threads); run it off the event loop.
-    return await asyncio.to_thread(session.run, command, timeout)
-
 
 def make_bash(
-    sandbox: Sandbox | None = None,
     *,
+    sandbox: Sandbox | None = None,
     name: str = "bash",
     description: str = SANDBOX_BASH_DESCRIPTION,
 ) -> DecoratedFunctionTool:
@@ -240,8 +33,7 @@ def make_bash(
     If a ``sandbox`` is passed, it is bound at creation time. Otherwise the tool
     reads the sandbox from ``tool_context.agent.sandbox`` at call time. Used by
     sandbox implementations in :meth:`~strands.sandbox.base.Sandbox.get_tools`
-    and by users who want a customized bash tool. Unlike :data:`bash`, each call
-    runs in a fresh shell; state does not persist across calls.
+    and by users who want a customized bash tool.
 
     Args:
         sandbox: Sandbox to bind at creation. When ``None``, the agent's
@@ -265,10 +57,14 @@ def make_bash(
         active = sandbox if sandbox is not None else tool_context.agent.sandbox
         try:
             result = await active.execute(command, timeout=timeout)
-        except SandboxTimeoutError as e:
-            raise BashTimeoutError(str(e)) from e
+        except SandboxTimeoutError:
+            raise
         except Exception as e:
-            raise BashSessionError(str(e)) from e
+            raise RuntimeError(str(e)) from e
         return {"output": result.stdout, "error": result.stderr}
 
     return bash_tool
+
+
+bash = make_bash()
+"""Default bash tool. Reads the sandbox from the agent's context at call time."""

--- a/strands-py/src/strands/vended_tools/bash/types.py
+++ b/strands-py/src/strands/vended_tools/bash/types.py
@@ -1,0 +1,35 @@
+"""Shared types and constants for the bash tools.
+
+Mirrors ``strands-ts/src/vended-tools/bash/types.ts``. Used by both the
+host-session :data:`~strands.vended_tools.bash.bash.bash` tool and the
+sandbox-routed :func:`~strands.vended_tools.bash.bash.make_bash` factory.
+"""
+
+from typing import TypedDict
+
+
+class BashOutput(TypedDict):
+    """Output of a bash command execution.
+
+    Attributes:
+        output: Standard output captured from the command.
+        error: Standard error captured from the command. Empty when there was none.
+    """
+
+    output: str
+    error: str
+
+
+SANDBOX_BASH_DESCRIPTION = (
+    "Executes bash shell commands. Each call runs in a fresh shell; "
+    "state such as variables and the working directory does not persist across calls."
+)
+"""Description for the sandbox-routed, stateless bash tool."""
+
+
+class BashTimeoutError(Exception):
+    """Raised when a bash command exceeds its timeout."""
+
+
+class BashSessionError(Exception):
+    """Raised when a bash session encounters an error."""

--- a/strands-py/src/strands/vended_tools/bash/types.py
+++ b/strands-py/src/strands/vended_tools/bash/types.py
@@ -1,6 +1,6 @@
 """Shared types and constants for the bash tools.
 
-Mirrors ``strands-ts/src/vended-tools/bash/types.ts``. Used by both the
+Shared types and constants for the bash tools. Used by both the
 host-session :data:`~strands.vended_tools.bash.bash.bash` tool and the
 sandbox-routed :func:`~strands.vended_tools.bash.bash.make_bash` factory.
 """

--- a/strands-py/src/strands/vended_tools/bash/types.py
+++ b/strands-py/src/strands/vended_tools/bash/types.py
@@ -1,9 +1,4 @@
-"""Shared types and constants for the bash tools.
-
-Shared types and constants for the bash tools. Used by both the
-host-session :data:`~strands.vended_tools.bash.bash.bash` tool and the
-sandbox-routed :func:`~strands.vended_tools.bash.bash.make_bash` factory.
-"""
+"""Shared types and constants for the bash tool."""
 
 from typing import TypedDict
 
@@ -24,12 +19,4 @@ SANDBOX_BASH_DESCRIPTION = (
     "Executes bash shell commands. Each call runs in a fresh shell; "
     "state such as variables and the working directory does not persist across calls."
 )
-"""Description for the sandbox-routed, stateless bash tool."""
-
-
-class BashTimeoutError(Exception):
-    """Raised when a bash command exceeds its timeout."""
-
-
-class BashSessionError(Exception):
-    """Raised when a bash session encounters an error."""
+"""Description for the bash tool."""

--- a/strands-py/src/strands/vended_tools/file_editor/__init__.py
+++ b/strands-py/src/strands/vended_tools/file_editor/__init__.py
@@ -1,7 +1,6 @@
 """Sandbox-routed file editor tool for viewing, creating, and editing files.
 
 Supports view (with line ranges), create, str_replace, and insert operations.
-Mirrors ``strands-ts/src/vended-tools/file-editor/``.
 
 Example Usage:
     ```python
@@ -12,10 +11,9 @@ Example Usage:
     ```
 """
 
-from .file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, file_editor, make_file_editor
+from .file_editor import file_editor, make_file_editor
 
 __all__ = [
-    "DEFAULT_FILE_EDITOR_DESCRIPTION",
     "file_editor",
     "make_file_editor",
 ]

--- a/strands-py/src/strands/vended_tools/file_editor/__init__.py
+++ b/strands-py/src/strands/vended_tools/file_editor/__init__.py
@@ -1,0 +1,21 @@
+"""Sandbox-routed file editor tool for viewing, creating, and editing files.
+
+Supports view (with line ranges), create, str_replace, and insert operations.
+Mirrors ``strands-ts/src/vended-tools/file-editor/``.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import file_editor
+
+    agent = Agent(tools=[file_editor])
+    ```
+"""
+
+from .file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, file_editor, make_file_editor
+
+__all__ = [
+    "DEFAULT_FILE_EDITOR_DESCRIPTION",
+    "file_editor",
+    "make_file_editor",
+]

--- a/strands-py/src/strands/vended_tools/file_editor/file_editor.py
+++ b/strands-py/src/strands/vended_tools/file_editor/file_editor.py
@@ -1,6 +1,6 @@
 """Sandbox-routed file editor tool.
 
-Mirrors ``strands-ts/src/vended-tools/file-editor/file-editor.ts``. Provides
+Provides
 ``view`` (with line ranges), ``create``, ``str_replace``, and ``insert``
 operations, all routed through a :class:`~strands.sandbox.base.Sandbox`: either
 one bound at creation (as the built-in Docker/SSH sandboxes do when vending
@@ -79,7 +79,7 @@ def make_file_editor(
             insert_line: Line number where text should be inserted (0-indexed, required for insert command).
         """
         active = sandbox if sandbox is not None else tool_context.agent.sandbox
-        # Strip trailing slashes, matching the TS oracle's input.path.replace(/[/\\]+$/, '').
+        # Strip trailing slashes from the path.
         file_path = re.sub(r"[/\\]+$", "", path)
 
         if command == "view":
@@ -324,7 +324,7 @@ async def _list_directory(sandbox: Sandbox, dir_path: str) -> str:
         try:
             entries = await sandbox.list_files(current_path)
         except Exception:
-            # Ignore permission errors and continue, matching the TS oracle.
+            # Ignore permission errors and continue.
             return
         for entry in entries:
             if entry.name.startswith("."):

--- a/strands-py/src/strands/vended_tools/file_editor/file_editor.py
+++ b/strands-py/src/strands/vended_tools/file_editor/file_editor.py
@@ -1,0 +1,432 @@
+"""Sandbox-routed file editor tool.
+
+Mirrors ``strands-ts/src/vended-tools/file-editor/file-editor.ts``. Provides
+``view`` (with line ranges), ``create``, ``str_replace``, and ``insert``
+operations, all routed through a :class:`~strands.sandbox.base.Sandbox`: either
+one bound at creation (as the built-in Docker/SSH sandboxes do when vending
+tools) or the agent's configured sandbox read from ``tool_context.agent.sandbox``
+at call time.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from typing import TYPE_CHECKING, Literal
+
+from ...sandbox.errors import SandboxPathNotFoundError
+from ...tools.decorator import tool
+from ...types.tools import ToolContext
+
+if TYPE_CHECKING:
+    from ...sandbox.base import Sandbox
+    from ...tools.decorator import DecoratedFunctionTool
+
+_SNIPPET_LINES = 4
+_DEFAULT_MAX_FILE_SIZE = 1048576  # 1MB
+_MAX_DIRECTORY_DEPTH = 2
+
+DEFAULT_FILE_EDITOR_DESCRIPTION = (
+    "Filesystem editor tool for viewing, creating, and editing files. Supports view "
+    "(with line ranges), create, str_replace, and insert operations. Files must use absolute paths."
+)
+
+
+def make_file_editor(
+    sandbox: Sandbox | None = None,
+    *,
+    name: str = "file_editor",
+    description: str = DEFAULT_FILE_EDITOR_DESCRIPTION,
+) -> DecoratedFunctionTool:
+    """Create a sandbox-routed file editor tool.
+
+    If a ``sandbox`` is passed, it is bound at creation time. Otherwise the tool
+    reads the sandbox from ``tool_context.agent.sandbox`` at call time. Used by
+    sandbox implementations in :meth:`~strands.sandbox.base.Sandbox.get_tools`
+    and by users who want a customized file editor.
+
+    Args:
+        sandbox: Sandbox to bind at creation. When ``None``, the agent's
+            configured sandbox is used at call time.
+        name: Tool name. Defaults to ``"file_editor"``.
+        description: Tool description shown to the model.
+
+    Returns:
+        A decorated tool that performs file operations through the sandbox.
+    """
+
+    @tool(name=name, description=description, context="tool_context")
+    async def file_editor_tool(
+        command: Literal["view", "create", "str_replace", "insert"],
+        path: str,
+        tool_context: ToolContext,
+        file_text: str | None = None,
+        view_range: list[int] | None = None,
+        old_str: str | None = None,
+        new_str: str | None = None,
+        insert_line: int | None = None,
+    ) -> str:
+        """Filesystem editor for viewing, creating, and editing files.
+
+        Args:
+            command: The operation to perform: `view`, `create`, `str_replace`, `insert`.
+            path: Absolute path to the file or directory.
+            tool_context: Injected by the framework. Not user-facing.
+            file_text: Content for new file (required for create command).
+            view_range: Line range to view [start, end]. 1-indexed. End can be -1 for end of file.
+            old_str: Exact string to find and replace (required for str_replace command).
+            new_str: Replacement string (for str_replace and insert commands).
+            insert_line: Line number where text should be inserted (0-indexed, required for insert command).
+        """
+        active = sandbox if sandbox is not None else tool_context.agent.sandbox
+        # Strip trailing slashes, matching the TS oracle's input.path.replace(/[/\\]+$/, '').
+        file_path = re.sub(r"[/\\]+$", "", path)
+
+        if command == "view":
+            return await _handle_view(active, file_path, view_range)
+        if command == "create":
+            return await _handle_create(active, file_path, file_text)
+        if command == "str_replace":
+            return await _handle_str_replace(active, file_path, old_str, new_str)
+        if command == "insert":
+            return await _handle_insert(active, file_path, insert_line, new_str)
+        raise ValueError(f"Unknown command: {command}")
+
+    return file_editor_tool
+
+
+file_editor = make_file_editor()
+"""Default sandbox-routed file editor tool. Reads the sandbox from the agent's context at call time."""
+
+
+def _validate_path(file_path: str) -> None:
+    """Validate that a path is absolute and contains no directory traversal.
+
+    Args:
+        file_path: The path to validate.
+
+    Raises:
+        ValueError: If the path is not absolute or contains a ``..`` segment.
+    """
+    # Absolute means POSIX-absolute (leading "/"), matching the sandbox path model.
+    if not posixpath.isabs(file_path):
+        suggested = posixpath.abspath(file_path)
+        raise ValueError(
+            f"The path {file_path} is not an absolute path, it should start with `/`. Maybe you meant {suggested}?"
+        )
+    # Check for '..' segments on the raw input -- normalizing first would resolve them away.
+    if ".." in re.split(r"[/\\]", file_path):
+        raise ValueError("Invalid path: path traversal is not allowed")
+
+
+def _apply_view_range(file_content: str, view_range: list[int] | None) -> tuple[str, int]:
+    """Slice file content to a 1-indexed [start, end] range (end -1 means end of file).
+
+    Args:
+        file_content: The full file content.
+        view_range: The [start, end] range, or ``None`` for the whole file.
+
+    Returns:
+        A tuple of (visible content, first line number for output numbering).
+
+    Raises:
+        ValueError: If the range is out of bounds or malformed.
+    """
+    if not view_range:
+        return file_content, 1
+    lines = file_content.split("\n")
+    n_lines = len(lines)
+    start, end = view_range[0], view_range[1]
+
+    if start < 1 or start > n_lines:
+        raise ValueError(
+            f"Invalid `view_range`: [{start}, {end}]. Its first element `{start}` should be within the "
+            f"range of lines of the file: [1, {n_lines}]"
+        )
+    if end != -1 and end > n_lines:
+        raise ValueError(
+            f"Invalid `view_range`: [{start}, {end}]. Its second element `{end}` should be smaller than "
+            f"the number of lines in the file: `{n_lines}`"
+        )
+    if end != -1 and end < start:
+        raise ValueError(
+            f"Invalid `view_range`: [{start}, {end}]. Its second element `{end}` should be larger or "
+            f"equal than its first `{start}`"
+        )
+
+    content = "\n".join(lines[start - 1 :]) if end == -1 else "\n".join(lines[start - 1 : end])
+    return content, start
+
+
+def _build_str_replace_result(
+    original_content: str, old_str: str, new_str: str | None, file_path: str
+) -> tuple[str, str, int]:
+    """Perform a unique str_replace and return (new content, change snippet, 0-indexed snippet start).
+
+    Args:
+        original_content: The current file content.
+        old_str: The exact string to replace (must appear exactly once).
+        new_str: The replacement string (``None`` deletes the match).
+        file_path: The file path, for error messages.
+
+    Returns:
+        A tuple of (new content, snippet around the change, 0-indexed snippet start line).
+
+    Raises:
+        ValueError: If ``old_str`` does not appear exactly once.
+    """
+    file_content = original_content.replace("\t", "        ")
+    expanded_old = old_str.replace("\t", "        ")
+    expanded_new = new_str.replace("\t", "        ") if new_str else ""
+
+    occurrences = file_content.count(expanded_old)
+    if occurrences == 0:
+        raise ValueError(f"No replacement was performed, old_str `{old_str}` did not appear verbatim in {file_path}.")
+    if occurrences > 1:
+        lines = file_content.split("\n")
+        line_numbers = [i + 1 for i, line in enumerate(lines) if expanded_old in line]
+        raise ValueError(
+            f"No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines "
+            f"{line_numbers}. Please ensure it is unique"
+        )
+
+    new_content = file_content.replace(expanded_old, expanded_new, 1)
+    replacement_line = len(file_content[: file_content.index(expanded_old)].split("\n")) - 1
+    inserted_lines = len(expanded_new.split("\n"))
+    original_lines = len(expanded_old.split("\n"))
+    line_difference = inserted_lines - original_lines
+
+    new_lines = new_content.split("\n")
+    start_line = max(0, replacement_line - _SNIPPET_LINES)
+    end_line = min(len(new_lines), replacement_line + _SNIPPET_LINES + line_difference + 1)
+    snippet = "\n".join(new_lines[start_line:end_line])
+
+    return new_content, snippet, start_line
+
+
+def _build_insert_result(original_content: str, insert_line: int, new_str: str) -> tuple[str, str, int]:
+    """Insert text at a 0-indexed line and return (new content, snippet, 0-indexed snippet start).
+
+    Args:
+        original_content: The current file content.
+        insert_line: The 0-indexed line after which to insert.
+        new_str: The text to insert.
+
+    Returns:
+        A tuple of (new content, snippet around the insertion, 0-indexed snippet start line).
+
+    Raises:
+        ValueError: If ``insert_line`` is out of bounds.
+    """
+    file_text = original_content.replace("\t", "        ")
+    expanded_new = new_str.replace("\t", "        ")
+
+    file_text_lines = file_text.split("\n")
+    n_lines = len(file_text_lines)
+
+    if insert_line < 0 or insert_line > n_lines:
+        raise ValueError(
+            f"Invalid `insert_line` parameter: {insert_line}. It should be within the range of lines "
+            f"of the file: [0, {n_lines}]"
+        )
+
+    new_str_lines = expanded_new.split("\n")
+    new_file_text_lines = (
+        new_str_lines
+        if file_text == ""
+        else [*file_text_lines[:insert_line], *new_str_lines, *file_text_lines[insert_line:]]
+    )
+
+    new_content = "\n".join(new_file_text_lines)
+    snippet_start_line = max(0, insert_line - _SNIPPET_LINES)
+    snippet_end_line = min(len(new_file_text_lines), insert_line + len(new_str_lines) + _SNIPPET_LINES)
+    snippet = "\n".join(new_file_text_lines[snippet_start_line:snippet_end_line])
+
+    return new_content, snippet, snippet_start_line
+
+
+def _make_output(file_content: str, file_descriptor: str, init_line: int = 1) -> str:
+    """Format file content with ``cat -n`` style line numbers.
+
+    Args:
+        file_content: The content to number.
+        file_descriptor: A description of the source (file path or snippet label).
+        init_line: The line number of the first line.
+
+    Returns:
+        The formatted, line-numbered output.
+    """
+    expanded_content = file_content.replace("\t", "        ")
+    numbered_lines = [f"{index + init_line:>6}  {line}" for index, line in enumerate(expanded_content.split("\n"))]
+    return f"Here's the result of running `cat -n` on {file_descriptor}:\n" + "\n".join(numbered_lines) + "\n"
+
+
+# ---- Sandbox-routed I/O helpers ----
+
+
+async def _probe_sandbox_path(sandbox: Sandbox, file_path: str) -> tuple[bool, bool]:
+    """Probe a path through the sandbox, returning (exists, is_dir).
+
+    Lists the parent directory and looks for the entry. A missing parent or entry
+    resolves to ``(False, False)``; permission, transport, and other failures
+    propagate so they are not disguised as non-existence.
+
+    Args:
+        sandbox: The sandbox to probe through.
+        file_path: The path to check.
+
+    Returns:
+        A tuple of (exists, is_dir).
+    """
+    normalized = file_path.replace("\\", "/")
+    parent = "/".join(normalized.split("/")[:-1]) or "/"
+    name = normalized.split("/")[-1]
+    try:
+        entry = next((e for e in await sandbox.list_files(parent) if e.name == name), None)
+    except SandboxPathNotFoundError:
+        return False, False
+    if entry is None:
+        return False, False
+    return True, entry.is_dir or False
+
+
+def _assert_within_size_limit(content: str, max_size: int = _DEFAULT_MAX_FILE_SIZE) -> None:
+    """Assert content is within the size limit.
+
+    Checked after reading because ``list_files`` does not reliably report size
+    across sandbox backends.
+
+    Args:
+        content: The content to measure.
+        max_size: The maximum allowed size in bytes.
+
+    Raises:
+        ValueError: If the content exceeds ``max_size``.
+    """
+    size = len(content.encode("utf-8"))
+    if size > max_size:
+        raise ValueError(f"File size ({size} bytes) exceeds maximum allowed size ({max_size} bytes)")
+
+
+async def _list_directory(sandbox: Sandbox, dir_path: str) -> str:
+    """List directory contents up to 2 levels deep through the sandbox, excluding hidden files.
+
+    Args:
+        sandbox: The sandbox to list through.
+        dir_path: The directory to list.
+
+    Returns:
+        A formatted listing of relative paths.
+    """
+    items: list[str] = []
+
+    async def walk(current_path: str, prefix: str, depth: int) -> None:
+        try:
+            entries = await sandbox.list_files(current_path)
+        except Exception:
+            # Ignore permission errors and continue, matching the TS oracle.
+            return
+        for entry in entries:
+            if entry.name.startswith("."):
+                continue
+            relative_path = f"{prefix}/{entry.name}" if prefix else entry.name
+            items.append(relative_path)
+            if entry.is_dir and depth < _MAX_DIRECTORY_DEPTH:
+                await walk(f"{current_path}/{entry.name}", relative_path, depth + 1)
+
+    await walk(dir_path, "", 0)
+    result = "\n".join(sorted(items))
+    return f"Here's the files and directories up to 2 levels deep in {dir_path}, excluding hidden items:\n{result}\n"
+
+
+# ---- Sandbox-path handlers ----
+
+
+async def _handle_view(sandbox: Sandbox, file_path: str, view_range: list[int] | None) -> str:
+    """Handle the ``view`` command: render a file with line numbers or list a directory."""
+    _validate_path(file_path)
+
+    exists, is_dir = await _probe_sandbox_path(sandbox, file_path)
+    if not exists:
+        raise ValueError(f"The path {file_path} does not exist. Please provide a valid path.")
+
+    if is_dir:
+        if view_range:
+            raise ValueError("The `view_range` parameter is not allowed when `path` points to a directory.")
+        return await _list_directory(sandbox, file_path)
+
+    file_content = await sandbox.read_text(file_path)
+    _assert_within_size_limit(file_content)
+
+    content, init_line = _apply_view_range(file_content, view_range)
+    return _make_output(content, file_path, init_line)
+
+
+async def _handle_create(sandbox: Sandbox, file_path: str, file_text: str | None) -> str:
+    """Handle the ``create`` command: write a new file, refusing to overwrite."""
+    if file_text is None:
+        raise ValueError("Parameter `file_text` is required for command: create")
+
+    _validate_path(file_path)
+
+    exists, _ = await _probe_sandbox_path(sandbox, file_path)
+    if exists:
+        raise ValueError(f"File already exists at: {file_path}. Cannot overwrite files using command `create`.")
+
+    await sandbox.write_text(file_path, file_text)
+    return f"File created successfully at: {file_path}"
+
+
+async def _handle_str_replace(sandbox: Sandbox, file_path: str, old_str: str | None, new_str: str | None) -> str:
+    """Handle the ``str_replace`` command: replace a unique occurrence of ``old_str``."""
+    if old_str is None:
+        raise ValueError("Parameter `old_str` is required for command: str_replace")
+
+    _validate_path(file_path)
+
+    exists, is_dir = await _probe_sandbox_path(sandbox, file_path)
+    if not exists:
+        raise ValueError(f"The path {file_path} does not exist. Please provide a valid path.")
+    if is_dir:
+        raise ValueError(f"The path {file_path} is a directory and only the `view` command can be used on directories")
+
+    file_content = await sandbox.read_text(file_path)
+    _assert_within_size_limit(file_content)
+
+    new_content, snippet, start_line = _build_str_replace_result(file_content, old_str, new_str, file_path)
+
+    await sandbox.write_text(file_path, new_content)
+
+    return (
+        f"The file {file_path} has been edited. "
+        f"{_make_output(snippet, f'a snippet of {file_path}', start_line + 1)}"
+        "Review the changes and make sure they are as expected. Edit the file again if necessary."
+    )
+
+
+async def _handle_insert(sandbox: Sandbox, file_path: str, insert_line: int | None, new_str: str | None) -> str:
+    """Handle the ``insert`` command: insert text at a 0-indexed line."""
+    if insert_line is None or new_str is None:
+        raise ValueError("Parameters `insert_line` and `new_str` are required for command: insert")
+
+    _validate_path(file_path)
+
+    exists, is_dir = await _probe_sandbox_path(sandbox, file_path)
+    if not exists:
+        raise ValueError(f"The path {file_path} does not exist. Please provide a valid path.")
+    if is_dir:
+        raise ValueError(f"The path {file_path} is a directory and only the `view` command can be used on directories")
+
+    file_text = await sandbox.read_text(file_path)
+    _assert_within_size_limit(file_text)
+
+    new_content, snippet, start_line = _build_insert_result(file_text, insert_line, new_str)
+
+    await sandbox.write_text(file_path, new_content)
+
+    return (
+        f"The file {file_path} has been edited. "
+        f"{_make_output(snippet, 'a snippet of the edited file', start_line + 1)}"
+        "Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). "
+        "Edit the file again if necessary."
+    )

--- a/strands-py/src/strands/vended_tools/file_editor/file_editor.py
+++ b/strands-py/src/strands/vended_tools/file_editor/file_editor.py
@@ -33,8 +33,8 @@ DEFAULT_FILE_EDITOR_DESCRIPTION = (
 
 
 def make_file_editor(
-    sandbox: Sandbox | None = None,
     *,
+    sandbox: Sandbox | None = None,
     name: str = "file_editor",
     description: str = DEFAULT_FILE_EDITOR_DESCRIPTION,
 ) -> DecoratedFunctionTool:
@@ -323,8 +323,8 @@ async def _list_directory(sandbox: Sandbox, dir_path: str) -> str:
     async def walk(current_path: str, prefix: str, depth: int) -> None:
         try:
             entries = await sandbox.list_files(current_path)
-        except Exception:
-            # Ignore permission errors and continue.
+        except OSError:
+            # Ignore permission/path errors and continue.
             return
         for entry in entries:
             if entry.name.startswith("."):

--- a/strands-py/tests/fixtures/sandbox.py
+++ b/strands-py/tests/fixtures/sandbox.py
@@ -1,0 +1,46 @@
+"""Shared ``TestSandbox`` fixture for exercising sandbox-routed code paths.
+
+Mirrors ``strands-ts/src/__fixtures__/test-sandbox.node.ts``: a concrete
+:class:`~strands.sandbox.posix_shell.PosixShellSandbox` rooted at a working
+directory, so tests drive the real sandbox code paths (base64 file transport,
+shell quoting, ``ls`` parsing) against a temp dir instead of the host filesystem.
+"""
+
+import shlex
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from strands.sandbox.posix_shell import PosixShellSandbox, build_shell_env_prefix
+from strands.sandbox.stream_process import stream_process
+from strands.sandbox.types import ExecutionResult, StreamChunk
+
+
+class TestSandbox(PosixShellSandbox):
+    """Run commands in a working directory via ``sh -c``, exercising real shell paths."""
+
+    # Not a pytest test class despite the ``Test`` prefix (matches the TS fixture name).
+    __test__ = False
+
+    def __init__(self, working_dir: str) -> None:
+        """Initialize the sandbox rooted at ``working_dir``.
+
+        Args:
+            working_dir: Directory commands run in unless ``cwd`` overrides it.
+        """
+        self.working_dir = working_dir
+
+    async def execute_streaming(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        """Execute ``command`` via ``sh -c`` in the working directory, streaming output."""
+        target_cwd = cwd if cwd is not None else self.working_dir
+        env_prefix = build_shell_env_prefix(env)
+        full_command = f"cd {shlex.quote(target_cwd)} && {env_prefix}{command}"
+        async for chunk in stream_process("sh", ["-c", full_command], timeout=timeout):
+            yield chunk

--- a/strands-py/tests/fixtures/sandbox.py
+++ b/strands-py/tests/fixtures/sandbox.py
@@ -1,6 +1,6 @@
 """Shared ``TestSandbox`` fixture for exercising sandbox-routed code paths.
 
-Mirrors ``strands-ts/src/__fixtures__/test-sandbox.node.ts``: a concrete
+A concrete
 :class:`~strands.sandbox.posix_shell.PosixShellSandbox` rooted at a working
 directory, so tests drive the real sandbox code paths (base64 file transport,
 shell quoting, ``ls`` parsing) against a temp dir instead of the host filesystem.
@@ -11,14 +11,14 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from strands.sandbox.posix_shell import PosixShellSandbox, build_shell_env_prefix
-from strands.sandbox.stream_process import stream_process
+from strands.sandbox.stream_process import _stream_process
 from strands.sandbox.types import ExecutionResult, StreamChunk
 
 
 class TestSandbox(PosixShellSandbox):
     """Run commands in a working directory via ``sh -c``, exercising real shell paths."""
 
-    # Not a pytest test class despite the ``Test`` prefix (matches the TS fixture name).
+    # Not a pytest test class despite the ``Test`` prefix .
     __test__ = False
 
     def __init__(self, working_dir: str) -> None:
@@ -42,5 +42,5 @@ class TestSandbox(PosixShellSandbox):
         target_cwd = cwd if cwd is not None else self.working_dir
         env_prefix = build_shell_env_prefix(env)
         full_command = f"cd {shlex.quote(target_cwd)} && {env_prefix}{command}"
-        async for chunk in stream_process("sh", ["-c", full_command], timeout=timeout):
+        async for chunk in _stream_process("sh", ["-c", full_command], timeout=timeout):
             yield chunk

--- a/strands-py/tests/strands/agent/test_agent_sandbox.py
+++ b/strands-py/tests/strands/agent/test_agent_sandbox.py
@@ -1,8 +1,8 @@
 """Tests for the ``Agent.sandbox`` getter.
 
 A configured sandbox is returned as-is; an unconfigured agent falls back to a per-agent
-:class:`NotASandboxLocalEnvironment`. Unlike the TS oracle's module-level singleton, each
-agent gets its own default instance so state can't leak across agents. The TS browser-throw
+:class:`NotASandboxLocalEnvironment`. Each
+agent gets its own default instance so state can't leak across agents. The browser-throw
 case has no Python analog (core Python always runs on a host), so it is omitted.
 """
 
@@ -48,7 +48,7 @@ def test_invalid_sandbox_raises_type_error():
 
 
 def test_configured_sandbox_vends_prefixed_tools():
-    # An explicitly-configured sandbox registers its tools, prefixed with its tool_prefix.
+    # A configured sandbox registers its tools (named by the sandbox's get_tools implementation).
     agent = Agent(model="nonsense", sandbox=DockerSandbox("my-container"))
     registered = _registered(agent)
     assert "sandbox_bash" in registered
@@ -59,14 +59,6 @@ def test_host_default_vends_nothing():
     # The unconfigured host default must not auto-register any tools.
     agent = Agent(model="nonsense")
     assert _registered(agent) == []
-
-
-def test_tool_prefix_none_registers_unprefixed():
-    sandbox = DockerSandbox("my-container")
-    sandbox.tool_prefix = None
-    registered = _registered(Agent(model="nonsense", sandbox=sandbox))
-    assert "bash" in registered
-    assert "file_editor" in registered
 
 
 def test_user_registered_tool_wins_over_vended():

--- a/strands-py/tests/strands/agent/test_agent_sandbox.py
+++ b/strands-py/tests/strands/agent/test_agent_sandbox.py
@@ -8,8 +8,14 @@ case has no Python analog (core Python always runs on a host), so it is omitted.
 
 import pytest
 
-from strands import Agent
+from strands import Agent, tool
+from strands.sandbox.docker import DockerSandbox
 from strands.sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
+
+
+def _registered(agent: Agent) -> list[str]:
+    """Names of tools registered on the agent."""
+    return list(agent.tool_registry.registry.keys())
 
 
 def test_returns_configured_sandbox():
@@ -36,3 +42,43 @@ def test_invalid_sandbox_raises_type_error():
     # Bad input is rejected at construction rather than silently falling back to the host default.
     with pytest.raises(TypeError, match="sandbox must be a Sandbox instance"):
         Agent(model="nonsense", sandbox="not-a-sandbox")
+
+
+# ---- tool vending ----
+
+
+def test_configured_sandbox_vends_prefixed_tools():
+    # An explicitly-configured sandbox registers its tools, prefixed with its tool_prefix.
+    agent = Agent(model="nonsense", sandbox=DockerSandbox("my-container"))
+    registered = _registered(agent)
+    assert "sandbox_bash" in registered
+    assert "sandbox_file_editor" in registered
+
+
+def test_host_default_vends_nothing():
+    # The unconfigured host default must not auto-register any tools.
+    agent = Agent(model="nonsense")
+    assert _registered(agent) == []
+
+
+def test_tool_prefix_none_registers_unprefixed():
+    sandbox = DockerSandbox("my-container")
+    sandbox.tool_prefix = None
+    registered = _registered(Agent(model="nonsense", sandbox=sandbox))
+    assert "bash" in registered
+    assert "file_editor" in registered
+
+
+def test_user_registered_tool_wins_over_vended():
+    # A user tool with the same (prefixed) name is kept; the vended one is skipped.
+    @tool(name="sandbox_bash")
+    def sandbox_bash(x: str) -> str:
+        """User tool that shadows the vended bash.
+
+        Args:
+            x: ignored.
+        """
+        return x
+
+    agent = Agent(model="nonsense", tools=[sandbox_bash], sandbox=DockerSandbox("my-container"))
+    assert agent.tool_registry.registry["sandbox_bash"] is sandbox_bash

--- a/strands-py/tests/strands/sandbox/test_docker.py
+++ b/strands-py/tests/strands/sandbox/test_docker.py
@@ -11,6 +11,7 @@ import pytest
 
 from strands.sandbox.docker import DockerSandbox
 from strands.sandbox.types import ExecutionResult
+from strands.vended_tools.bash import SANDBOX_BASH_DESCRIPTION
 
 
 @pytest.fixture
@@ -96,3 +97,15 @@ async def test_forwards_timeout_and_enoent_message(mock_stream_process):
 async def test_rejects_invalid_env_var_names(mock_stream_process):
     with pytest.raises(ValueError, match="Invalid environment variable name"):
         await DockerSandbox("my-container").execute("cmd", env={"FOO=bar BAZ": "val"})
+
+
+def test_get_tools_vends_file_editor_and_bash():
+    tools = DockerSandbox("my-container").get_tools()
+    assert [t.tool_name for t in tools] == ["file_editor", "bash"]
+
+
+def test_get_tools_bash_description_names_container():
+    tools = DockerSandbox("my-container").get_tools()
+    bash_tool = next(t for t in tools if t.tool_name == "bash")
+    assert SANDBOX_BASH_DESCRIPTION in bash_tool.tool_spec["description"]
+    assert "my-container" in bash_tool.tool_spec["description"]

--- a/strands-py/tests/strands/sandbox/test_docker.py
+++ b/strands-py/tests/strands/sandbox/test_docker.py
@@ -2,7 +2,7 @@
 
 Mirrors ``strands-ts/src/sandbox/__tests__/docker.test.node.ts``. These tests
 assert the ``docker exec`` argv the sandbox builds; the process pump
-(``stream_process``) is mocked, so no Docker daemon is required.
+(``_stream_process``) is mocked, so no Docker daemon is required.
 """
 
 import unittest.mock
@@ -11,23 +11,23 @@ import pytest
 
 from strands.sandbox.docker import DockerSandbox
 from strands.sandbox.types import ExecutionResult
-from strands.vended_tools.bash import SANDBOX_BASH_DESCRIPTION
+from strands.vended_tools.bash.types import SANDBOX_BASH_DESCRIPTION
 
 
 @pytest.fixture
 def mock_stream_process(agenerator):
-    """Patch ``stream_process`` in the docker module, returning a no-op result.
+    """Patch ``_stream_process`` in the docker module, returning a no-op result.
 
     Yields the mock so tests can inspect the ``(program, args, kwargs)`` it was
     called with via ``mock.call_args``.
     """
-    with unittest.mock.patch("strands.sandbox.docker.stream_process") as mock:
+    with unittest.mock.patch("strands.sandbox.docker._stream_process") as mock:
         mock.return_value = agenerator([ExecutionResult(exit_code=0, stdout="", stderr="")])
         yield mock
 
 
 def _args(mock_stream_process) -> list[str]:
-    """The argv passed to ``stream_process`` (its second positional argument)."""
+    """The argv passed to ``_stream_process`` (its second positional argument)."""
     return mock_stream_process.call_args.args[1]
 
 
@@ -101,11 +101,11 @@ async def test_rejects_invalid_env_var_names(mock_stream_process):
 
 def test_get_tools_vends_file_editor_and_bash():
     tools = DockerSandbox("my-container").get_tools()
-    assert [t.tool_name for t in tools] == ["file_editor", "bash"]
+    assert [t.tool_name for t in tools] == ["sandbox_file_editor", "sandbox_bash"]
 
 
 def test_get_tools_bash_description_names_container():
     tools = DockerSandbox("my-container").get_tools()
-    bash_tool = next(t for t in tools if t.tool_name == "bash")
+    bash_tool = next(t for t in tools if t.tool_name == "sandbox_bash")
     assert SANDBOX_BASH_DESCRIPTION in bash_tool.tool_spec["description"]
     assert "my-container" in bash_tool.tool_spec["description"]

--- a/strands-py/tests/strands/sandbox/test_ssh.py
+++ b/strands-py/tests/strands/sandbox/test_ssh.py
@@ -17,6 +17,7 @@ import pytest
 
 from strands.sandbox.ssh import SshSandbox
 from strands.sandbox.types import ExecutionResult
+from strands.vended_tools.bash import SANDBOX_BASH_DESCRIPTION
 
 # Leading SSH flags shared by every invocation, with default host-key checking.
 BASE = ["-o", "StrictHostKeyChecking=accept-new", "-o", "BatchMode=yes", "-p", "22"]
@@ -184,3 +185,15 @@ async def test_forwards_timeout_and_enoent_message(mock_stream_process):
 async def test_rejects_invalid_env_var_names(mock_stream_process):
     with pytest.raises(ValueError, match="Invalid environment variable name"):
         await SshSandbox("h", working_dir="/w").execute("cmd", env={"FOO=bar BAZ": "val"})
+
+
+def test_get_tools_vends_file_editor_and_bash():
+    tools = SshSandbox("myhost", working_dir="/workspace").get_tools()
+    assert [t.tool_name for t in tools] == ["file_editor", "bash"]
+
+
+def test_get_tools_bash_description_names_host():
+    tools = SshSandbox("myhost", working_dir="/workspace").get_tools()
+    bash_tool = next(t for t in tools if t.tool_name == "bash")
+    assert SANDBOX_BASH_DESCRIPTION in bash_tool.tool_spec["description"]
+    assert "myhost" in bash_tool.tool_spec["description"]

--- a/strands-py/tests/strands/sandbox/test_ssh.py
+++ b/strands-py/tests/strands/sandbox/test_ssh.py
@@ -2,7 +2,7 @@
 
 Mirrors ``strands-ts/src/sandbox/__tests__/ssh.test.node.ts``. These tests assert
 the ``ssh`` argv the sandbox builds and the SSH-option allowlist; the process
-pump (``stream_process``) is mocked, so no remote host is required.
+pump (``_stream_process``) is mocked, so no remote host is required.
 
 The remote command strings use stdlib ``shlex.quote`` (the core port's choice
 over the oracle's hand-rolled ``shellQuote``). The two render shell-equivalent
@@ -17,7 +17,7 @@ import pytest
 
 from strands.sandbox.ssh import SshSandbox
 from strands.sandbox.types import ExecutionResult
-from strands.vended_tools.bash import SANDBOX_BASH_DESCRIPTION
+from strands.vended_tools.bash.types import SANDBOX_BASH_DESCRIPTION
 
 # Leading SSH flags shared by every invocation, with default host-key checking.
 BASE = ["-o", "StrictHostKeyChecking=accept-new", "-o", "BatchMode=yes", "-p", "22"]
@@ -25,14 +25,14 @@ BASE = ["-o", "StrictHostKeyChecking=accept-new", "-o", "BatchMode=yes", "-p", "
 
 @pytest.fixture
 def mock_stream_process(agenerator):
-    """Patch ``stream_process`` in the ssh module, returning a no-op result."""
-    with unittest.mock.patch("strands.sandbox.ssh.stream_process") as mock:
+    """Patch ``_stream_process`` in the ssh module, returning a no-op result."""
+    with unittest.mock.patch("strands.sandbox.ssh._stream_process") as mock:
         mock.return_value = agenerator([ExecutionResult(exit_code=0, stdout="", stderr="")])
         yield mock
 
 
 def _args(mock_stream_process) -> list[str]:
-    """The argv passed to ``stream_process`` (its second positional argument)."""
+    """The argv passed to ``_stream_process`` (its second positional argument)."""
     return mock_stream_process.call_args.args[1]
 
 
@@ -189,11 +189,11 @@ async def test_rejects_invalid_env_var_names(mock_stream_process):
 
 def test_get_tools_vends_file_editor_and_bash():
     tools = SshSandbox("myhost", working_dir="/workspace").get_tools()
-    assert [t.tool_name for t in tools] == ["file_editor", "bash"]
+    assert [t.tool_name for t in tools] == ["sandbox_file_editor", "sandbox_bash"]
 
 
 def test_get_tools_bash_description_names_host():
     tools = SshSandbox("myhost", working_dir="/workspace").get_tools()
-    bash_tool = next(t for t in tools if t.tool_name == "bash")
+    bash_tool = next(t for t in tools if t.tool_name == "sandbox_bash")
     assert SANDBOX_BASH_DESCRIPTION in bash_tool.tool_spec["description"]
     assert "myhost" in bash_tool.tool_spec["description"]

--- a/strands-py/tests/strands/sandbox/test_stream_process.py
+++ b/strands-py/tests/strands/sandbox/test_stream_process.py
@@ -14,7 +14,7 @@ import sys
 import pytest
 
 from strands.sandbox.errors import SandboxTimeoutError
-from strands.sandbox.stream_process import stream_process
+from strands.sandbox.stream_process import _stream_process
 from strands.sandbox.types import ExecutionResult, StreamChunk
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell required")
@@ -34,7 +34,7 @@ async def _collect(gen) -> tuple[list[StreamChunk], ExecutionResult | None]:
 
 @pytest.mark.asyncio
 async def test_captures_stdout_stderr_and_exit_code():
-    chunks, result = await _collect(stream_process("sh", ["-c", "echo out; echo err >&2; exit 3"]))
+    chunks, result = await _collect(_stream_process("sh", ["-c", "echo out; echo err >&2; exit 3"]))
     assert result == ExecutionResult(exit_code=3, stdout="out\n", stderr="err\n")
     # Output is also delivered incrementally as typed chunks.
     assert any(c.stream_type == "stdout" and "out" in c.data for c in chunks)
@@ -44,14 +44,14 @@ async def test_captures_stdout_stderr_and_exit_code():
 @pytest.mark.asyncio
 @pytest.mark.parametrize("code", [0, 1, 2, 42, 255])
 async def test_exit_codes_preserved(code):
-    _, result = await _collect(stream_process("sh", ["-c", f"exit {code}"]))
+    _, result = await _collect(_stream_process("sh", ["-c", f"exit {code}"]))
     assert result.exit_code == code
 
 
 @pytest.mark.asyncio
 async def test_signal_termination_maps_to_128_plus_signal():
     # The shell kills itself with SIGKILL (9); Python reports returncode -9 -> 137.
-    _, result = await _collect(stream_process("sh", ["-c", "kill -9 $$"]))
+    _, result = await _collect(_stream_process("sh", ["-c", "kill -9 $$"]))
     assert result.exit_code == 137
 
 
@@ -62,7 +62,7 @@ async def test_timeout_is_wall_clock_even_with_steady_output():
     loop = asyncio.get_event_loop()
     start = loop.time()
     with pytest.raises(SandboxTimeoutError, match="timed out after 0.3 seconds"):
-        await _collect(stream_process("sh", ["-c", "while true; do echo x; sleep 0.02; done"], timeout=0.3))
+        await _collect(_stream_process("sh", ["-c", "while true; do echo x; sleep 0.02; done"], timeout=0.3))
     assert loop.time() - start < 3
 
 
@@ -75,13 +75,13 @@ async def test_timeout_kills_child_processes_that_outlive_the_parent():
     loop = asyncio.get_event_loop()
     start = loop.time()
     with pytest.raises(SandboxTimeoutError, match="timed out after 0.5 seconds"):
-        await _collect(stream_process("sh", ["-c", "echo hi; sleep 60"], timeout=0.5))
+        await _collect(_stream_process("sh", ["-c", "echo hi; sleep 60"], timeout=0.5))
     assert loop.time() - start < 3
 
 
 @pytest.mark.asyncio
 async def test_fast_command_completes_under_timeout():
-    _, result = await _collect(stream_process("sh", ["-c", "echo fast"], timeout=5))
+    _, result = await _collect(_stream_process("sh", ["-c", "echo fast"], timeout=5))
     assert result.exit_code == 0
     assert result.stdout == "fast\n"
 
@@ -89,7 +89,7 @@ async def test_fast_command_completes_under_timeout():
 @pytest.mark.asyncio
 async def test_enoent_with_message_returns_127():
     _, result = await _collect(
-        stream_process("definitely_not_a_real_binary_xyz", [], enoent_message="nope not installed")
+        _stream_process("definitely_not_a_real_binary_xyz", [], enoent_message="nope not installed")
     )
     assert result.exit_code == 127
     assert result.stderr == "nope not installed"
@@ -98,7 +98,7 @@ async def test_enoent_with_message_returns_127():
 @pytest.mark.asyncio
 async def test_enoent_without_message_propagates():
     with pytest.raises(FileNotFoundError):
-        await _collect(stream_process("definitely_not_a_real_binary_xyz", []))
+        await _collect(_stream_process("definitely_not_a_real_binary_xyz", []))
 
 
 @pytest.mark.asyncio
@@ -107,7 +107,7 @@ async def test_cancellation_kills_the_process():
     pid_box: dict[str, int] = {}
 
     async def consume() -> None:
-        async for item in stream_process("sh", ["-c", "echo $$; sleep 60"]):
+        async for item in _stream_process("sh", ["-c", "echo $$; sleep 60"]):
             if isinstance(item, StreamChunk) and item.data.strip().isdigit():
                 pid_box["pid"] = int(item.data.strip())
 

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -14,6 +14,7 @@ from strands.vended_plugins.context_offloader import (
     FileStorage,
     InMemoryStorage,
 )
+from tests.fixtures.sandbox import TestSandbox
 
 
 @pytest.fixture
@@ -32,10 +33,13 @@ def plugin(storage):
 
 
 @pytest.fixture
-def mock_agent():
+def mock_agent(tmp_path):
     agent = MagicMock()
     agent.model = MagicMock()
     agent.model.count_tokens = AsyncMock(side_effect=_heuristic_count_tokens)
+    # A real sandbox rooted at a temp dir so FileStorage.for_sandbox binds to a working
+    # backend (mirrors the TS suite injecting a TestSandbox into the mock agent).
+    agent.sandbox = TestSandbox(str(tmp_path))
     return agent
 
 
@@ -120,7 +124,7 @@ class TestContextOffloader:
         # Verify stored content
         assert len(storage._store) == 1
         ref = list(storage._store.keys())[0]
-        content, content_type = storage.retrieve(ref)
+        content, content_type = await storage.retrieve(ref)
         assert content == large_text.encode("utf-8")
         assert content_type == "text/plain"
 
@@ -227,7 +231,7 @@ class TestContextOffloader:
         # Verify image was stored
         assert len(storage._store) == 2  # text + image
         img_ref = placeholder.split("ref: ")[1].rstrip("]")
-        img_content, img_type = storage.retrieve(img_ref)
+        img_content, img_type = await storage.retrieve(img_ref)
         assert img_content == img_bytes
         assert img_type == "image/png"
 
@@ -249,7 +253,7 @@ class TestContextOffloader:
 
         # Verify document was stored
         doc_ref = placeholder.split("ref: ")[1].rstrip("]")
-        doc_content, doc_type = storage.retrieve(doc_ref)
+        doc_content, doc_type = await storage.retrieve(doc_ref)
         assert doc_content == doc_bytes
         assert doc_type == "application/pdf"
 
@@ -266,8 +270,8 @@ class TestContextOffloader:
         # Two text blocks stored separately
         assert len(storage._store) == 2
         refs = list(storage._store.keys())
-        assert storage.retrieve(refs[0]) == (b"a" * 60, "text/plain")
-        assert storage.retrieve(refs[1]) == (b"b" * 60, "text/plain")
+        assert await storage.retrieve(refs[0]) == (b"a" * 60, "text/plain")
+        assert await storage.retrieve(refs[1]) == (b"b" * 60, "text/plain")
 
     @pytest.mark.asyncio
     async def test_json_content_stored_as_json(self, plugin, storage, mock_agent):
@@ -279,7 +283,7 @@ class TestContextOffloader:
 
         assert len(storage._store) == 1
         ref = list(storage._store.keys())[0]
-        stored_content, content_type = storage.retrieve(ref)
+        stored_content, content_type = await storage.retrieve(ref)
         assert content_type == "application/json"
         assert json.loads(stored_content) == large_json
 
@@ -296,8 +300,8 @@ class TestContextOffloader:
         # Both stored separately with correct types
         assert len(storage._store) == 2
         refs = list(storage._store.keys())
-        assert storage.retrieve(refs[0])[1] == "text/plain"
-        assert storage.retrieve(refs[1])[1] == "application/json"
+        assert (await storage.retrieve(refs[0]))[1] == "text/plain"
+        assert (await storage.retrieve(refs[1]))[1] == "application/json"
 
     @pytest.mark.asyncio
     async def test_small_json_passes_through(self, plugin, mock_agent):
@@ -482,38 +486,44 @@ class TestRetrievalTool:
         tool_names = [t.tool_name for t in plugin.tools]
         assert "retrieve_offloaded_content" not in tool_names
 
-    def test_retrieve_text_content(self, plugin, storage, tool_context):
-        ref = storage.store("key_1", b"hello world", "text/plain")
-        result = plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
+    @pytest.mark.asyncio
+    async def test_retrieve_text_content(self, plugin, storage, tool_context):
+        ref = await storage.store("key_1", b"hello world", "text/plain")
+        result = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
         assert result == "hello world"
 
-    def test_retrieve_json_content(self, plugin, storage, tool_context):
-        ref = storage.store("key_1", b'{"key": "value"}', "application/json")
-        result = plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
+    @pytest.mark.asyncio
+    async def test_retrieve_json_content(self, plugin, storage, tool_context):
+        ref = await storage.store("key_1", b'{"key": "value"}', "application/json")
+        result = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
         assert result["content"][0]["json"] == {"key": "value"}
 
-    def test_retrieve_large_text_returns_full_content(self, plugin, storage, tool_context):
+    @pytest.mark.asyncio
+    async def test_retrieve_large_text_returns_full_content(self, plugin, storage, tool_context):
         large_text = "a" * 50_000
-        ref = storage.store("key_1", large_text.encode("utf-8"), "text/plain")
-        result = plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
+        ref = await storage.store("key_1", large_text.encode("utf-8"), "text/plain")
+        result = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
         assert result == large_text
 
-    def test_retrieve_missing_reference(self, plugin, tool_context):
-        result = plugin.retrieve_offloaded_content(reference="nonexistent", tool_context=tool_context)
+    @pytest.mark.asyncio
+    async def test_retrieve_missing_reference(self, plugin, tool_context):
+        result = await plugin.retrieve_offloaded_content(reference="nonexistent", tool_context=tool_context)
         assert "Error: reference not found" in result
 
-    def test_retrieve_image_content(self, plugin, storage, tool_context):
+    @pytest.mark.asyncio
+    async def test_retrieve_image_content(self, plugin, storage, tool_context):
         img_bytes = b"\x89PNG\x00\x00"
-        ref = storage.store("key_1", img_bytes, "image/png")
-        result = plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
+        ref = await storage.store("key_1", img_bytes, "image/png")
+        result = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
         assert result["status"] == "success"
         assert result["content"][0]["image"]["format"] == "png"
         assert result["content"][0]["image"]["source"]["bytes"] == img_bytes
 
-    def test_retrieve_document_content(self, plugin, storage, tool_context):
+    @pytest.mark.asyncio
+    async def test_retrieve_document_content(self, plugin, storage, tool_context):
         doc_bytes = b"%PDF-1.4 content"
-        ref = storage.store("key_1", doc_bytes, "application/pdf")
-        result = plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
+        ref = await storage.store("key_1", doc_bytes, "application/pdf")
+        result = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
         assert result["status"] == "success"
         assert result["content"][0]["document"]["format"] == "pdf"
         assert result["content"][0]["document"]["source"]["bytes"] == doc_bytes
@@ -614,13 +624,14 @@ class TestBeforeModelCallHook:
 
         plugin._on_before_model_call(self._make_event(1))
 
-    def test_eviction_triggered_via_hook(self):
+    @pytest.mark.asyncio
+    async def test_eviction_triggered_via_hook(self):
         storage = InMemoryStorage(evict_after_turns=2)
         plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
 
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
 
         # stored at cycle 0, evict at cycle 3: threshold = 3 - 2 = 1, 0 < 1 → evicted
         plugin._on_before_model_call(self._make_event(3))
         with pytest.raises(KeyError):
-            storage.retrieve(ref)
+            await storage.retrieve(ref)

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -1,5 +1,11 @@
-"""Tests for offload storage backends."""
+"""Tests for offload storage backends.
 
+The ``Storage`` protocol is async (``store``/``retrieve`` are coroutines), so
+these tests await those calls. The thread-safety tests drive the async API from
+real OS threads via ``asyncio.run`` to keep exercising the backends' locks.
+"""
+
+import asyncio
 import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -15,44 +21,50 @@ from strands.vended_plugins.context_offloader import (
 
 
 class TestInMemoryStorage:
-    def test_round_trip(self):
+    @pytest.mark.asyncio
+    async def test_round_trip(self):
         storage = InMemoryStorage()
-        ref = storage.store("key_1", b"hello world")
-        content, content_type = storage.retrieve(ref)
+        ref = await storage.store("key_1", b"hello world")
+        content, content_type = await storage.retrieve(ref)
         assert content == b"hello world"
         assert content_type == "text/plain"
 
-    def test_preserves_content_type(self):
+    @pytest.mark.asyncio
+    async def test_preserves_content_type(self):
         storage = InMemoryStorage()
-        ref = storage.store("key_1", b'{"a": 1}', "application/json")
-        content, content_type = storage.retrieve(ref)
+        ref = await storage.store("key_1", b'{"a": 1}', "application/json")
+        content, content_type = await storage.retrieve(ref)
         assert content == b'{"a": 1}'
         assert content_type == "application/json"
 
-    def test_stores_binary_content(self):
+    @pytest.mark.asyncio
+    async def test_stores_binary_content(self):
         storage = InMemoryStorage()
         img_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-        ref = storage.store("key_1", img_bytes, "image/png")
-        content, content_type = storage.retrieve(ref)
+        ref = await storage.store("key_1", img_bytes, "image/png")
+        content, content_type = await storage.retrieve(ref)
         assert content == img_bytes
         assert content_type == "image/png"
 
-    def test_retrieve_missing_raises_key_error(self):
+    @pytest.mark.asyncio
+    async def test_retrieve_missing_raises_key_error(self):
         storage = InMemoryStorage()
         with pytest.raises(KeyError, match="Reference not found"):
-            storage.retrieve("nonexistent_ref")
+            await storage.retrieve("nonexistent_ref")
 
-    def test_unique_references(self):
+    @pytest.mark.asyncio
+    async def test_unique_references(self):
         storage = InMemoryStorage()
-        ref1 = storage.store("key_1", b"content a")
-        ref2 = storage.store("key_1", b"content b")
+        ref1 = await storage.store("key_1", b"content a")
+        ref2 = await storage.store("key_1", b"content b")
         assert ref1 != ref2
-        assert storage.retrieve(ref1)[0] == b"content a"
-        assert storage.retrieve(ref2)[0] == b"content b"
+        assert (await storage.retrieve(ref1))[0] == b"content a"
+        assert (await storage.retrieve(ref2))[0] == b"content b"
 
-    def test_reference_format(self):
+    @pytest.mark.asyncio
+    async def test_reference_format(self):
         storage = InMemoryStorage()
-        ref = storage.store("tool_abc", b"content")
+        ref = await storage.store("tool_abc", b"content")
         assert ref.startswith("mem_")
         assert "tool_abc" in ref
 
@@ -63,7 +75,7 @@ class TestInMemoryStorage:
 
         def store_item(i: int):
             try:
-                ref = storage.store(f"key_{i}", f"content_{i}".encode())
+                ref = asyncio.run(storage.store(f"key_{i}", f"content_{i}".encode()))
                 refs.append(ref)
             except Exception as e:
                 errors.append(e)
@@ -77,17 +89,19 @@ class TestInMemoryStorage:
         assert not errors
         assert len(set(refs)) == 50
 
-    def test_stores_empty_content(self):
+    @pytest.mark.asyncio
+    async def test_stores_empty_content(self):
         storage = InMemoryStorage()
-        ref = storage.store("key_1", b"")
-        assert storage.retrieve(ref) == (b"", "text/plain")
+        ref = await storage.store("key_1", b"")
+        assert await storage.retrieve(ref) == (b"", "text/plain")
 
-    def test_clear(self):
+    @pytest.mark.asyncio
+    async def test_clear(self):
         storage = InMemoryStorage()
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
         storage.clear()
         with pytest.raises(KeyError):
-            storage.retrieve(ref)
+            await storage.retrieve(ref)
 
     def test_clear_empty_storage(self):
         storage = InMemoryStorage()
@@ -101,77 +115,84 @@ class TestInMemoryStorageEviction:
         with pytest.raises(ValueError, match="evict_after_turns must be a positive integer"):
             InMemoryStorage(evict_after_turns=-1)
 
-    def test_eviction_enabled_by_default(self):
+    @pytest.mark.asyncio
+    async def test_eviction_enabled_by_default(self):
         storage = InMemoryStorage()
         assert storage._evict_after_turns == 20
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
         for _ in range(21):
             storage._evict(storage._current_cycle + 1)
         with pytest.raises(KeyError):
-            storage.retrieve(ref)
+            await storage.retrieve(ref)
 
-    def test_eviction_disabled_with_none(self):
+    @pytest.mark.asyncio
+    async def test_eviction_disabled_with_none(self):
         storage = InMemoryStorage(evict_after_turns=None)
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
         for _ in range(100):
             storage._evict(storage._current_cycle + 1)
-        assert storage.retrieve(ref) == (b"content", "text/plain")
+        assert await storage.retrieve(ref) == (b"content", "text/plain")
 
-    def test_entry_evicted_after_n_turns(self):
+    @pytest.mark.asyncio
+    async def test_entry_evicted_after_n_turns(self):
         storage = InMemoryStorage(evict_after_turns=3)
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
 
         storage._evict(storage._current_cycle + 1)  # turn 1
         storage._evict(storage._current_cycle + 1)  # turn 2
         storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 3 - 3 = 0, stored at 0, 0 < 0 is false
-        assert storage.retrieve(ref) == (b"content", "text/plain")
+        assert await storage.retrieve(ref) == (b"content", "text/plain")
 
         storage._evict(storage._current_cycle + 1)  # turn 4 — refreshed by retrieve to 3, 3 < 1 is false
-        assert storage.retrieve(ref) == (b"content", "text/plain")
+        assert await storage.retrieve(ref) == (b"content", "text/plain")
 
-    def test_entry_evicted_without_access(self):
+    @pytest.mark.asyncio
+    async def test_entry_evicted_without_access(self):
         storage = InMemoryStorage(evict_after_turns=2)
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
 
         storage._evict(storage._current_cycle + 1)  # turn 1
         storage._evict(storage._current_cycle + 1)  # turn 2 — threshold = 2 - 2 = 0, stored at 0, 0 < 0 is false
         # Entry still alive at exact boundary
-        content, _ = storage.retrieve(ref)
+        content, _ = await storage.retrieve(ref)
         assert content == b"content"
 
-    def test_entry_evicted_past_boundary(self):
+    @pytest.mark.asyncio
+    async def test_entry_evicted_past_boundary(self):
         storage = InMemoryStorage(evict_after_turns=2)
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
 
         storage._evict(storage._current_cycle + 1)  # turn 1
         storage._evict(storage._current_cycle + 1)  # turn 2
         storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 1, 0 < 1 → evicted
         with pytest.raises(KeyError):
-            storage.retrieve(ref)
+            await storage.retrieve(ref)
 
-    def test_retrieve_refreshes_last_accessed(self):
+    @pytest.mark.asyncio
+    async def test_retrieve_refreshes_last_accessed(self):
         storage = InMemoryStorage(evict_after_turns=2)
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
 
         storage._evict(storage._current_cycle + 1)  # turn 1
-        storage.retrieve(ref)  # refreshes last_accessed to turn 1
+        await storage.retrieve(ref)  # refreshes last_accessed to turn 1
 
         storage._evict(storage._current_cycle + 1)  # turn 2
         storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 1, last_accessed = 1, 1 < 1 is false
-        assert storage.retrieve(ref) == (b"content", "text/plain")
+        assert await storage.retrieve(ref) == (b"content", "text/plain")
 
-    def test_multiple_entries_evicted_independently(self):
+    @pytest.mark.asyncio
+    async def test_multiple_entries_evicted_independently(self):
         storage = InMemoryStorage(evict_after_turns=2)
-        ref1 = storage.store("key_1", b"first")
+        ref1 = await storage.store("key_1", b"first")
 
         storage._evict(storage._current_cycle + 1)  # turn 1
-        ref2 = storage.store("key_2", b"second")
+        ref2 = await storage.store("key_2", b"second")
 
         storage._evict(storage._current_cycle + 1)  # turn 2
         storage._evict(storage._current_cycle + 1)  # turn 3 — threshold = 1. ref1 evicted, ref2 survives
         with pytest.raises(KeyError):
-            storage.retrieve(ref1)
-        assert storage.retrieve(ref2) == (b"second", "text/plain")
+            await storage.retrieve(ref1)
+        assert await storage.retrieve(ref2) == (b"second", "text/plain")
 
     def test_evict_updates_current_cycle(self):
         storage = InMemoryStorage()
@@ -197,7 +218,7 @@ class TestInMemoryStorageEviction:
 
         def store_and_tick(i: int):
             try:
-                ref = storage.store(f"key_{i}", f"content_{i}".encode())
+                ref = asyncio.run(storage.store(f"key_{i}", f"content_{i}".encode()))
                 refs.append(ref)
                 storage._evict(storage._current_cycle + 1)
             except Exception as e:
@@ -213,91 +234,103 @@ class TestInMemoryStorageEviction:
 
 
 class TestFileStorage:
-    def test_round_trip(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_round_trip(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path / "artifacts"))
-        ref = storage.store("key_1", b"hello world")
-        content, content_type = storage.retrieve(ref)
+        ref = await storage.store("key_1", b"hello world")
+        content, content_type = await storage.retrieve(ref)
         assert content == b"hello world"
         assert content_type == "text/plain"
 
-    def test_preserves_content_type(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_preserves_content_type(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path))
-        ref = storage.store("key_1", b'{"a": 1}', "application/json")
-        content, content_type = storage.retrieve(ref)
+        ref = await storage.store("key_1", b'{"a": 1}', "application/json")
+        content, content_type = await storage.retrieve(ref)
         assert content == b'{"a": 1}'
         assert content_type == "application/json"
 
-    def test_stores_binary_content(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_stores_binary_content(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path))
         img_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-        ref = storage.store("key_1", img_bytes, "image/png")
-        content, content_type = storage.retrieve(ref)
+        ref = await storage.store("key_1", img_bytes, "image/png")
+        content, content_type = await storage.retrieve(ref)
         assert content == img_bytes
         assert content_type == "image/png"
 
-    def test_extension_from_content_type(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_extension_from_content_type(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path))
-        assert storage.store("k", b"text", "text/plain").endswith(".txt")
-        assert storage.store("k", b"{}", "application/json").endswith(".json")
-        assert storage.store("k", b"img", "image/png").endswith(".png")
-        assert storage.store("k", b"pdf", "application/pdf").endswith(".pdf")
+        assert (await storage.store("k", b"text", "text/plain")).endswith(".txt")
+        assert (await storage.store("k", b"{}", "application/json")).endswith(".json")
+        assert (await storage.store("k", b"img", "image/png")).endswith(".png")
+        assert (await storage.store("k", b"pdf", "application/pdf")).endswith(".pdf")
 
-    def test_auto_creates_directory(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_auto_creates_directory(self, tmp_path):
         artifact_dir = tmp_path / "nested" / "dir" / "artifacts"
         assert not artifact_dir.exists()
         storage = FileStorage(artifact_dir=str(artifact_dir))
-        storage.store("key_1", b"content")
+        await storage.store("key_1", b"content")
         assert artifact_dir.exists()
 
-    def test_retrieve_missing_raises_key_error(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_retrieve_missing_raises_key_error(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path))
         with pytest.raises(KeyError, match="Reference not found"):
-            storage.retrieve("nonexistent.txt")
+            await storage.retrieve("nonexistent.txt")
 
-    def test_unique_references(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_unique_references(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path))
-        ref1 = storage.store("key_1", b"content a")
-        ref2 = storage.store("key_1", b"content b")
+        ref1 = await storage.store("key_1", b"content a")
+        ref2 = await storage.store("key_1", b"content b")
         assert ref1 != ref2
-        assert storage.retrieve(ref1)[0] == b"content a"
-        assert storage.retrieve(ref2)[0] == b"content b"
+        assert (await storage.retrieve(ref1))[0] == b"content a"
+        assert (await storage.retrieve(ref2))[0] == b"content b"
 
-    def test_sanitizes_path_traversal(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_sanitizes_path_traversal(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path))
-        ref = storage.store("../../etc/passwd", b"content")
+        ref = await storage.store("../../etc/passwd", b"content")
         assert ".." not in ref
         assert "/" not in Path(ref).name
 
-    def test_reference_includes_artifact_dir(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_reference_includes_artifact_dir(self, tmp_path):
         artifact_dir = str(tmp_path / "artifacts")
         storage = FileStorage(artifact_dir=artifact_dir)
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
         assert Path(ref).parent == Path(artifact_dir)
 
-    def test_relative_artifact_dir_gives_relative_reference(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_relative_artifact_dir_gives_relative_reference(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         storage = FileStorage(artifact_dir="./artifacts")
-        ref = storage.store("key_1", b"content")
+        ref = await storage.store("key_1", b"content")
         assert Path(ref).parent == Path("artifacts")
-        content, content_type = storage.retrieve(ref)
+        content, content_type = await storage.retrieve(ref)
         assert content == b"content"
         assert content_type == "text/plain"
 
-    def test_retrieve_accepts_bare_filename(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_retrieve_accepts_bare_filename(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path))
-        ref = storage.store("key_1", b"hello world")
+        ref = await storage.store("key_1", b"hello world")
         filename = Path(ref).name
-        content, content_type = storage.retrieve(filename)
+        content, content_type = await storage.retrieve(filename)
         assert content == b"hello world"
         assert content_type == "text/plain"
 
-    def test_metadata_survives_across_instances(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_metadata_survives_across_instances(self, tmp_path):
         artifact_dir = str(tmp_path / "artifacts")
         storage1 = FileStorage(artifact_dir=artifact_dir)
-        ref = storage1.store("key_1", b"hello", "image/png")
+        ref = await storage1.store("key_1", b"hello", "image/png")
 
         storage2 = FileStorage(artifact_dir=artifact_dir)
-        content, content_type = storage2.retrieve(ref)
+        content, content_type = await storage2.retrieve(ref)
         assert content == b"hello"
         assert content_type == "image/png"
 
@@ -306,18 +339,20 @@ class TestFileStorage:
         storage = FileStorage(artifact_dir=str(tmp_path))
         assert storage._content_types == {}
 
-    def test_missing_metadata_fallback(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_missing_metadata_fallback(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path))
-        ref = storage.store("key_1", b"content", "image/png")
+        ref = await storage.store("key_1", b"content", "image/png")
 
         storage._content_types.clear()
-        _, content_type = storage.retrieve(ref)
+        _, content_type = await storage.retrieve(ref)
         assert content_type == "application/octet-stream"
 
-    def test_retrieve_rejects_path_traversal(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_retrieve_rejects_path_traversal(self, tmp_path):
         storage = FileStorage(artifact_dir=str(tmp_path))
         with pytest.raises(KeyError, match="Reference not found"):
-            storage.retrieve("../../etc/passwd")
+            await storage.retrieve("../../etc/passwd")
 
 
 class TestS3Storage:
@@ -352,57 +387,66 @@ class TestS3Storage:
             mock_session_cls.return_value = mock_session
             return S3Storage(bucket="test-bucket", prefix="artifacts")
 
-    def test_round_trip(self, storage):
-        ref = storage.store("key_1", b"hello world")
-        content, content_type = storage.retrieve(ref)
+    @pytest.mark.asyncio
+    async def test_round_trip(self, storage):
+        ref = await storage.store("key_1", b"hello world")
+        content, content_type = await storage.retrieve(ref)
         assert content == b"hello world"
         assert content_type == "text/plain"
 
-    def test_preserves_content_type(self, storage):
-        ref = storage.store("key_1", b"img", "image/png")
-        content, content_type = storage.retrieve(ref)
+    @pytest.mark.asyncio
+    async def test_preserves_content_type(self, storage):
+        ref = await storage.store("key_1", b"img", "image/png")
+        content, content_type = await storage.retrieve(ref)
         assert content == b"img"
         assert content_type == "image/png"
 
-    def test_retrieve_missing_raises_key_error(self, storage):
+    @pytest.mark.asyncio
+    async def test_retrieve_missing_raises_key_error(self, storage):
         with pytest.raises(KeyError, match="Reference not found"):
-            storage.retrieve("nonexistent_key")
+            await storage.retrieve("nonexistent_key")
 
-    def test_unique_references(self, storage):
-        ref1 = storage.store("key_1", b"content a")
-        ref2 = storage.store("key_1", b"content b")
+    @pytest.mark.asyncio
+    async def test_unique_references(self, storage):
+        ref1 = await storage.store("key_1", b"content a")
+        ref2 = await storage.store("key_1", b"content b")
         assert ref1 != ref2
-        assert storage.retrieve(ref1)[0] == b"content a"
-        assert storage.retrieve(ref2)[0] == b"content b"
+        assert (await storage.retrieve(ref1))[0] == b"content a"
+        assert (await storage.retrieve(ref2))[0] == b"content b"
 
-    def test_reference_is_s3_uri(self, storage):
-        ref = storage.store("tool_abc", b"content")
+    @pytest.mark.asyncio
+    async def test_reference_is_s3_uri(self, storage):
+        ref = await storage.store("tool_abc", b"content")
         assert ref.startswith("s3://test-bucket/artifacts/")
 
-    def test_empty_prefix(self, mock_s3_client):
+    @pytest.mark.asyncio
+    async def test_empty_prefix(self, mock_s3_client):
         with patch("boto3.Session") as mock_session_cls:
             mock_session = MagicMock()
             mock_session.client.return_value = mock_s3_client
             mock_session_cls.return_value = mock_session
             storage = S3Storage(bucket="test-bucket", prefix="")
 
-        ref = storage.store("tool_abc", b"content")
+        ref = await storage.store("tool_abc", b"content")
         assert ref.startswith("s3://test-bucket/")
-        assert storage.retrieve(ref)[0] == b"content"
+        assert (await storage.retrieve(ref))[0] == b"content"
 
-    def test_retrieve_accepts_raw_key(self, storage, mock_s3_client):
-        ref = storage.store("key_1", b"hello world")
+    @pytest.mark.asyncio
+    async def test_retrieve_accepts_raw_key(self, storage, mock_s3_client):
+        ref = await storage.store("key_1", b"hello world")
         raw_key = ref.removeprefix("s3://test-bucket/")
-        content, content_type = storage.retrieve(raw_key)
+        content, content_type = await storage.retrieve(raw_key)
         assert content == b"hello world"
         assert content_type == "text/plain"
 
-    def test_retrieve_rejects_wrong_bucket_uri(self, storage):
+    @pytest.mark.asyncio
+    async def test_retrieve_rejects_wrong_bucket_uri(self, storage):
         with pytest.raises(KeyError, match="Reference not found"):
-            storage.retrieve("s3://wrong-bucket/artifacts/some_key")
+            await storage.retrieve("s3://wrong-bucket/artifacts/some_key")
 
-    def test_put_object_called_with_correct_params(self, storage, mock_s3_client):
-        storage.store("key_1", b"test content", "application/json")
+    @pytest.mark.asyncio
+    async def test_put_object_called_with_correct_params(self, storage, mock_s3_client):
+        await storage.store("key_1", b"test content", "application/json")
 
         mock_s3_client.put_object.assert_called_once()
         call_kwargs = mock_s3_client.put_object.call_args[1]
@@ -411,9 +455,10 @@ class TestS3Storage:
         assert call_kwargs["Body"] == b"test content"
         assert call_kwargs["ContentType"] == "application/json"
 
-    def test_non_nosuchkey_error_propagates(self, storage, mock_s3_client):
+    @pytest.mark.asyncio
+    async def test_non_nosuchkey_error_propagates(self, storage, mock_s3_client):
         error_response = {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}
         mock_s3_client.get_object.side_effect = ClientError(error_response, "GetObject")
 
         with pytest.raises(ClientError, match="Forbidden"):
-            storage.retrieve("some_key")
+            await storage.retrieve("some_key")

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -18,6 +18,7 @@ from strands.vended_plugins.context_offloader import (
     InMemoryStorage,
     S3Storage,
 )
+from tests.fixtures.sandbox import TestSandbox
 
 
 class TestInMemoryStorage:
@@ -462,3 +463,67 @@ class TestS3Storage:
 
         with pytest.raises(ClientError, match="Forbidden"):
             await storage.retrieve("some_key")
+
+
+class TestFileStorageWithSandbox:
+    """FileStorage routed through a sandbox (the path the plugin uses per agent)."""
+
+    @pytest.fixture
+    def storage(self, tmp_path):
+        return FileStorage(artifact_dir=str(tmp_path / "artifacts"), sandbox=TestSandbox(str(tmp_path)))
+
+    @pytest.mark.asyncio
+    async def test_round_trip_through_sandbox(self, storage):
+        ref = await storage.store("key_1", b"hello sandbox", "text/plain")
+        content, content_type = await storage.retrieve(ref)
+        assert content == b"hello sandbox"
+        assert content_type == "text/plain"
+
+    @pytest.mark.asyncio
+    async def test_preserves_content_type_through_sandbox(self, storage):
+        ref = await storage.store("key_1", b"\x89PNG", "image/png")
+        content, content_type = await storage.retrieve(ref)
+        assert content == b"\x89PNG"
+        assert content_type == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_reference_under_artifact_dir(self, storage, tmp_path):
+        ref = await storage.store("key_1", b"data")
+        assert ref.startswith(f"{tmp_path / 'artifacts'}/")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_rejects_path_outside_artifact_dir(self, storage):
+        with pytest.raises(KeyError, match="Reference not found"):
+            await storage.retrieve("/etc/passwd")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_rejects_path_traversal(self, storage, tmp_path):
+        with pytest.raises(KeyError, match="Reference not found"):
+            await storage.retrieve(f"{tmp_path / 'artifacts'}/../secret.txt")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_missing_reference(self, storage, tmp_path):
+        with pytest.raises(KeyError, match="Reference not found"):
+            await storage.retrieve(f"{tmp_path / 'artifacts'}/nope.txt")
+
+    @pytest.mark.asyncio
+    async def test_metadata_survives_across_instances(self, tmp_path):
+        artifact_dir = str(tmp_path / "artifacts")
+        sandbox = TestSandbox(str(tmp_path))
+        ref = await FileStorage(artifact_dir=artifact_dir, sandbox=sandbox).store("key_1", b"hello", "image/png")
+
+        # A fresh instance lazily loads the content-type sidecar from the sandbox.
+        _, content_type = await FileStorage(artifact_dir=artifact_dir, sandbox=sandbox).retrieve(ref)
+        assert content_type == "image/png"
+
+    def test_for_sandbox_keeps_explicit_sandbox(self, tmp_path):
+        # An instance constructed with a sandbox is returned unchanged by for_sandbox.
+        sandbox = TestSandbox(str(tmp_path))
+        storage = FileStorage(artifact_dir=str(tmp_path), sandbox=sandbox)
+        assert storage.for_sandbox(TestSandbox(str(tmp_path))) is storage
+
+    def test_for_sandbox_binds_detached_instance(self, tmp_path):
+        # A host instance (no sandbox) produces a new, sandbox-bound instance.
+        host = FileStorage(artifact_dir=str(tmp_path))
+        bound = host.for_sandbox(TestSandbox(str(tmp_path)))
+        assert bound is not host

--- a/strands-py/tests/strands/vended_plugins/skills/test_agent_skills.py
+++ b/strands-py/tests/strands/vended_plugins/skills/test_agent_skills.py
@@ -1,12 +1,25 @@
-"""Tests for the AgentSkills plugin."""
+"""Tests for the AgentSkills plugin.
+
+Filesystem skill sources are loaded through the agent's sandbox at
+``init_agent`` time, so tests that use path-based skills construct a real
+``NotASandboxLocalEnvironment`` on the mock agent, call ``await
+plugin.init_agent(agent)``, and assert via ``get_available_skills(agent)`` (the
+per-agent skill set). Skill instances and URLs remain available at construction
+via ``get_available_skills()`` with no agent.
+
+Mirrors ``strands-ts/src/vended-plugins/skills/__tests__/agent-skills.test.node.ts``.
+"""
 
 import logging
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from strands.hooks.events import BeforeInvocationEvent
 from strands.hooks.registry import HookRegistry
 from strands.plugins.registry import _PluginRegistry
+from strands.sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
 from strands.types.tools import ToolContext
 from strands.vended_plugins.skills.agent_skills import AgentSkills
 from strands.vended_plugins.skills.skill import Skill
@@ -27,7 +40,13 @@ def _make_skill_dir(parent: Path, name: str, description: str = "A test skill") 
 
 
 def _mock_agent():
-    """Create a mock agent for testing."""
+    """Create a mock agent for testing.
+
+    Exposes a real ``NotASandboxLocalEnvironment`` as ``.sandbox`` so filesystem
+    skill loading and resource listing exercise the actual sandbox code paths,
+    mirroring the TypeScript fixture's ``createMockAgent`` (which returns the
+    environment default sandbox).
+    """
     agent = MagicMock()
     agent._system_prompt = "You are an agent."
     agent._system_prompt_content = [{"text": "You are an agent."}]
@@ -45,6 +64,9 @@ def _mock_agent():
     )
     agent.tool_registry = MagicMock()
     agent.tool_registry.process_tools = MagicMock(return_value=["skills"])
+
+    # Real host sandbox: filesystem skills load through it (not a MagicMock).
+    agent.sandbox = NotASandboxLocalEnvironment()
 
     # Use a real dict-backed state so get/set work correctly
     state_store: dict[str, object] = {}
@@ -78,43 +100,81 @@ class TestSkillsPluginInit:
     """Tests for AgentSkills initialization."""
 
     def test_init_with_skill_instances(self):
-        """Test initialization with Skill instances."""
+        """Test initialization with Skill instances (available without an agent)."""
         skill = _make_skill()
         plugin = AgentSkills(skills=[skill])
 
         assert len(plugin.get_available_skills()) == 1
         assert plugin.get_available_skills()[0].name == "test-skill"
 
-    def test_init_with_filesystem_paths(self, tmp_path):
-        """Test initialization with filesystem paths."""
+    @pytest.mark.asyncio
+    async def test_init_with_filesystem_paths(self, tmp_path):
+        """Test initialization with filesystem paths (loaded per-agent via sandbox)."""
         _make_skill_dir(tmp_path, "fs-skill")
         plugin = AgentSkills(skills=[str(tmp_path / "fs-skill")])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
 
-        assert len(plugin.get_available_skills()) == 1
-        assert plugin.get_available_skills()[0].name == "fs-skill"
+        assert len(plugin.get_available_skills(agent)) == 1
+        assert plugin.get_available_skills(agent)[0].name == "fs-skill"
 
-    def test_init_with_parent_directory(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_init_with_parent_directory(self, tmp_path):
         """Test initialization with a parent directory containing skills."""
         _make_skill_dir(tmp_path, "skill-a")
         _make_skill_dir(tmp_path, "skill-b")
         plugin = AgentSkills(skills=[tmp_path])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
 
-        assert len(plugin.get_available_skills()) == 2
+        assert len(plugin.get_available_skills(agent)) == 2
 
-    def test_init_with_mixed_sources(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_init_with_mixed_sources(self, tmp_path):
         """Test initialization with mixed skill sources."""
         _make_skill_dir(tmp_path, "fs-skill")
         direct_skill = _make_skill(name="direct-skill", description="Direct")
         plugin = AgentSkills(skills=[str(tmp_path / "fs-skill"), direct_skill])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
 
-        assert len(plugin.get_available_skills()) == 2
-        names = {s.name for s in plugin.get_available_skills()}
+        assert len(plugin.get_available_skills(agent)) == 2
+        names = {s.name for s in plugin.get_available_skills(agent)}
         assert names == {"fs-skill", "direct-skill"}
 
-    def test_init_skips_nonexistent_paths(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_init_skips_nonexistent_paths(self, tmp_path):
         """Test that nonexistent paths are skipped gracefully."""
         plugin = AgentSkills(skills=[str(tmp_path / "nonexistent")])
-        assert len(plugin.get_available_skills()) == 0
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
+        assert len(plugin.get_available_skills(agent)) == 0
+
+    @pytest.mark.asyncio
+    async def test_init_with_malformed_skill_md(self, tmp_path):
+        """Test that a path with a malformed SKILL.md is skipped gracefully."""
+        bad_dir = tmp_path / "bad-skill"
+        bad_dir.mkdir()
+        (bad_dir / "SKILL.md").write_text("totally broken, no frontmatter at all")
+        plugin = AgentSkills(skills=[str(bad_dir)])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
+        assert len(plugin.get_available_skills(agent)) == 0
+
+    @pytest.mark.asyncio
+    async def test_init_loads_valid_siblings_despite_malformed(self, tmp_path):
+        """Test that valid skills load from a parent dir containing malformed siblings."""
+        _make_skill_dir(tmp_path, "good-skill")
+        bad_dir = tmp_path / "bad-skill"
+        bad_dir.mkdir()
+        (bad_dir / "SKILL.md").write_text("no frontmatter")
+        plugin = AgentSkills(skills=[tmp_path])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
+
+        skills = plugin.get_available_skills(agent)
+        assert len(skills) == 1
+        assert skills[0].name == "good-skill"
 
     def test_init_empty_skills(self):
         """Test initialization with empty skills list."""
@@ -160,12 +220,13 @@ class TestSkillsPluginInitAgent:
 
         assert agent.hooks.has_callbacks()
 
-    def test_does_not_store_agent_reference(self):
+    @pytest.mark.asyncio
+    async def test_does_not_store_agent_reference(self):
         """Test that init_agent does not store the agent on the plugin."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
 
-        plugin.init_agent(agent)
+        await plugin.init_agent(agent)
 
         assert not hasattr(plugin, "_agent")
 
@@ -193,56 +254,65 @@ class TestSkillsPluginProperties:
         assert len(plugin.get_available_skills()) == 1
         assert plugin.get_available_skills()[0].name == "new-skill"
 
-    def test_set_available_skills_with_paths(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_set_available_skills_with_paths(self, tmp_path):
         """Test setting skills via set_available_skills with filesystem paths."""
         plugin = AgentSkills(skills=[_make_skill()])
         _make_skill_dir(tmp_path, "fs-skill")
 
         plugin.set_available_skills([str(tmp_path / "fs-skill")])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
 
-        assert len(plugin.get_available_skills()) == 1
-        assert plugin.get_available_skills()[0].name == "fs-skill"
+        assert len(plugin.get_available_skills(agent)) == 1
+        assert plugin.get_available_skills(agent)[0].name == "fs-skill"
 
-    def test_set_available_skills_with_mixed_sources(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_set_available_skills_with_mixed_sources(self, tmp_path):
         """Test setting skills via set_available_skills with mixed sources."""
         plugin = AgentSkills(skills=[])
         _make_skill_dir(tmp_path, "fs-skill")
         direct = _make_skill(name="direct", description="Direct")
 
         plugin.set_available_skills([str(tmp_path / "fs-skill"), direct])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
 
-        assert len(plugin.get_available_skills()) == 2
-        names = {s.name for s in plugin.get_available_skills()}
+        assert len(plugin.get_available_skills(agent)) == 2
+        names = {s.name for s in plugin.get_available_skills(agent)}
         assert names == {"fs-skill", "direct"}
 
 
 class TestSkillsTool:
     """Tests for the skills tool method."""
 
-    def test_activate_skill(self):
+    @pytest.mark.asyncio
+    async def test_activate_skill(self):
         """Test activating a skill returns its instructions."""
         skill = _make_skill(instructions="Full instructions here.")
         plugin = AgentSkills(skills=[skill])
         agent = _mock_agent()
         tool_context = _mock_tool_context(agent)
 
-        result = plugin.skills(skill_name="test-skill", tool_context=tool_context)
+        result = await plugin.skills(skill_name="test-skill", tool_context=tool_context)
 
         assert "Full instructions here." in result
 
-    def test_activate_nonexistent_skill(self):
+    @pytest.mark.asyncio
+    async def test_activate_nonexistent_skill(self):
         """Test activating a nonexistent skill returns error message."""
         skill = _make_skill()
         plugin = AgentSkills(skills=[skill])
         agent = _mock_agent()
         tool_context = _mock_tool_context(agent)
 
-        result = plugin.skills(skill_name="nonexistent", tool_context=tool_context)
+        result = await plugin.skills(skill_name="nonexistent", tool_context=tool_context)
 
         assert "not found" in result
         assert "test-skill" in result
 
-    def test_activate_replaces_previous(self):
+    @pytest.mark.asyncio
+    async def test_activate_replaces_previous(self):
         """Test that activating a new skill replaces the previous one."""
         skill1 = _make_skill(name="skill-a", description="A", instructions="A instructions")
         skill2 = _make_skill(name="skill-b", description="B", instructions="B instructions")
@@ -250,33 +320,36 @@ class TestSkillsTool:
         agent = _mock_agent()
         tool_context = _mock_tool_context(agent)
 
-        result_a = plugin.skills(skill_name="skill-a", tool_context=tool_context)
+        result_a = await plugin.skills(skill_name="skill-a", tool_context=tool_context)
         assert "A instructions" in result_a
 
-        result_b = plugin.skills(skill_name="skill-b", tool_context=tool_context)
+        result_b = await plugin.skills(skill_name="skill-b", tool_context=tool_context)
         assert "B instructions" in result_b
 
-    def test_activate_without_name(self):
+    @pytest.mark.asyncio
+    async def test_activate_without_name(self):
         """Test activating without a skill name returns error."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
         tool_context = _mock_tool_context(agent)
 
-        result = plugin.skills(skill_name="", tool_context=tool_context)
+        result = await plugin.skills(skill_name="", tool_context=tool_context)
 
         assert "required" in result.lower()
 
-    def test_activate_tracks_in_agent_state(self):
+    @pytest.mark.asyncio
+    async def test_activate_tracks_in_agent_state(self):
         """Test that activating a skill records it in agent state."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
         tool_context = _mock_tool_context(agent)
 
-        plugin.skills(skill_name="test-skill", tool_context=tool_context)
+        await plugin.skills(skill_name="test-skill", tool_context=tool_context)
 
         assert plugin.get_activated_skills(agent) == ["test-skill"]
 
-    def test_activate_multiple_tracks_order(self):
+    @pytest.mark.asyncio
+    async def test_activate_multiple_tracks_order(self):
         """Test that multiple activations are tracked in order."""
         skill_a = _make_skill(name="skill-a", description="A", instructions="A")
         skill_b = _make_skill(name="skill-b", description="B", instructions="B")
@@ -284,12 +357,13 @@ class TestSkillsTool:
         agent = _mock_agent()
         tool_context = _mock_tool_context(agent)
 
-        plugin.skills(skill_name="skill-a", tool_context=tool_context)
-        plugin.skills(skill_name="skill-b", tool_context=tool_context)
+        await plugin.skills(skill_name="skill-a", tool_context=tool_context)
+        await plugin.skills(skill_name="skill-b", tool_context=tool_context)
 
         assert plugin.get_activated_skills(agent) == ["skill-a", "skill-b"]
 
-    def test_activate_same_skill_twice_deduplicates(self):
+    @pytest.mark.asyncio
+    async def test_activate_same_skill_twice_deduplicates(self):
         """Test that re-activating a skill moves it to the end without duplicates."""
         skill_a = _make_skill(name="skill-a", description="A", instructions="A")
         skill_b = _make_skill(name="skill-b", description="B", instructions="B")
@@ -297,9 +371,9 @@ class TestSkillsTool:
         agent = _mock_agent()
         tool_context = _mock_tool_context(agent)
 
-        plugin.skills(skill_name="skill-a", tool_context=tool_context)
-        plugin.skills(skill_name="skill-b", tool_context=tool_context)
-        plugin.skills(skill_name="skill-a", tool_context=tool_context)
+        await plugin.skills(skill_name="skill-a", tool_context=tool_context)
+        await plugin.skills(skill_name="skill-b", tool_context=tool_context)
+        await plugin.skills(skill_name="skill-a", tool_context=tool_context)
 
         assert plugin.get_activated_skills(agent) == ["skill-b", "skill-a"]
 
@@ -310,13 +384,14 @@ class TestSkillsTool:
 
         assert plugin.get_activated_skills(agent) == []
 
-    def test_get_activated_skills_returns_copy(self):
+    @pytest.mark.asyncio
+    async def test_get_activated_skills_returns_copy(self):
         """Test that get_activated_skills returns a copy, not a reference."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
         tool_context = _mock_tool_context(agent)
 
-        plugin.skills(skill_name="test-skill", tool_context=tool_context)
+        await plugin.skills(skill_name="test-skill", tool_context=tool_context)
         result = plugin.get_activated_skills(agent)
         result.append("injected")
 
@@ -326,20 +401,22 @@ class TestSkillsTool:
 class TestSystemPromptInjection:
     """Tests for system prompt injection via hooks."""
 
-    def test_before_invocation_appends_skills_xml(self):
+    @pytest.mark.asyncio
+    async def test_before_invocation_appends_skills_xml(self):
         """Test that before_invocation appends skills XML to system prompt."""
         skill = _make_skill()
         plugin = AgentSkills(skills=[skill])
         agent = _mock_agent()
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         assert "<available_skills>" in agent.system_prompt
         assert "<name>test-skill</name>" in agent.system_prompt
         assert "<description>A test skill</description>" in agent.system_prompt
 
-    def test_before_invocation_preserves_existing_prompt(self):
+    @pytest.mark.asyncio
+    async def test_before_invocation_preserves_existing_prompt(self):
         """Test that existing system prompt content is preserved."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
@@ -347,12 +424,13 @@ class TestSystemPromptInjection:
         agent._system_prompt_content = [{"text": "Original prompt."}]
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         assert agent.system_prompt.startswith("Original prompt.")
         assert "<available_skills>" in agent.system_prompt
 
-    def test_repeated_invocations_do_not_accumulate(self):
+    @pytest.mark.asyncio
+    async def test_repeated_invocations_do_not_accumulate(self):
         """Test that repeated invocations rebuild from current prompt without accumulation."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
@@ -360,15 +438,16 @@ class TestSystemPromptInjection:
         agent._system_prompt_content = [{"text": "Original prompt."}]
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
         first_prompt = agent.system_prompt
 
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
         second_prompt = agent.system_prompt
 
         assert first_prompt == second_prompt
 
-    def test_no_skills_injects_empty_message(self):
+    @pytest.mark.asyncio
+    async def test_no_skills_injects_empty_message(self):
         """Test that a 'no skills available' message is injected when no skills are loaded."""
         plugin = AgentSkills(skills=[])
         agent = _mock_agent()
@@ -377,12 +456,13 @@ class TestSystemPromptInjection:
         agent._system_prompt_content = [{"text": original_prompt}]
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         assert "No skills are currently available" in agent.system_prompt
         assert agent.system_prompt.startswith("Original prompt.")
 
-    def test_none_system_prompt_handled(self):
+    @pytest.mark.asyncio
+    async def test_none_system_prompt_handled(self):
         """Test handling when system prompt is None."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
@@ -390,11 +470,12 @@ class TestSystemPromptInjection:
         agent._system_prompt_content = None
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         assert "<available_skills>" in agent.system_prompt
 
-    def test_preserves_other_plugin_modifications(self):
+    @pytest.mark.asyncio
+    async def test_preserves_other_plugin_modifications(self):
         """Test that modifications by other plugins/hooks are preserved."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
@@ -402,17 +483,18 @@ class TestSystemPromptInjection:
         agent._system_prompt_content = [{"text": "Original prompt."}]
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         # Simulate another plugin modifying the prompt
         agent.system_prompt = agent.system_prompt + "\n\nExtra context from another plugin."
 
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         assert "Extra context from another plugin." in agent.system_prompt
         assert "<available_skills>" in agent.system_prompt
 
-    def test_uses_public_system_prompt_setter(self):
+    @pytest.mark.asyncio
+    async def test_uses_public_system_prompt_setter(self):
         """Test that the hook uses the public system_prompt setter."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
@@ -420,7 +502,7 @@ class TestSystemPromptInjection:
         agent._system_prompt_content = [{"text": "Original."}]
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         # The public setter should have been used via the content-block path:
         # original block is preserved and the skills XML is appended as a new block.
@@ -428,7 +510,8 @@ class TestSystemPromptInjection:
         assert agent.system_prompt_content[0] == {"text": "Original."}
         assert "<available_skills>" in agent.system_prompt_content[1]["text"]
 
-    def test_preserves_cache_points_in_system_prompt(self):
+    @pytest.mark.asyncio
+    async def test_preserves_cache_points_in_system_prompt(self):
         """Test that cachePoint blocks in the system prompt are preserved after injection."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
@@ -438,10 +521,10 @@ class TestSystemPromptInjection:
             {"cachePoint": {"type": "default"}},
         ]
 
-        expected_skills_xml = plugin._generate_skills_xml()
+        expected_skills_xml = plugin._generate_skills_xml(agent)
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         # Exact block structure: original text, cachePoint, skills XML
         assert agent.system_prompt_content == [
@@ -451,14 +534,15 @@ class TestSystemPromptInjection:
         ]
 
         # Repeated invocation: identical result, no accumulation
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
         assert agent.system_prompt_content == [
             {"text": "Base instructions."},
             {"cachePoint": {"type": "default"}},
             {"text": expected_skills_xml},
         ]
 
-    def test_warns_when_previous_xml_not_found(self, caplog):
+    @pytest.mark.asyncio
+    async def test_warns_when_previous_xml_not_found(self, caplog):
         """Test that a warning is logged when the previously injected XML is missing from the prompt."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
@@ -466,13 +550,13 @@ class TestSystemPromptInjection:
         agent._system_prompt_content = [{"text": "Original prompt."}]
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         # Completely replace the system prompt, removing the injected XML
         agent.system_prompt = "Totally new prompt."
 
         with caplog.at_level(logging.WARNING):
-            plugin._on_before_invocation(event)
+            await plugin._on_before_invocation(event)
 
         assert "unable to find previously injected skills XML in system prompt" in caplog.text
         assert "<available_skills>" in agent.system_prompt
@@ -481,7 +565,8 @@ class TestSystemPromptInjection:
 class TestStringPathInjection:
     """Tests for the string-path branch of _on_before_invocation (system_prompt_content is None)."""
 
-    def test_string_path_replaces_previous_xml(self):
+    @pytest.mark.asyncio
+    async def test_string_path_replaces_previous_xml(self):
         """Test that old injected XML is replaced when found in the string prompt."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
@@ -492,13 +577,14 @@ class TestStringPathInjection:
         agent.state.set(plugin._state_key, {"last_injected_xml": old_xml})
 
         event = BeforeInvocationEvent(agent=agent)
-        plugin._on_before_invocation(event)
+        await plugin._on_before_invocation(event)
 
         assert "<old>xml</old>" not in agent.system_prompt
         assert "<available_skills>" in agent.system_prompt
         assert agent.system_prompt.startswith("Base prompt.")
 
-    def test_string_path_warns_when_previous_xml_not_found(self, caplog):
+    @pytest.mark.asyncio
+    async def test_string_path_warns_when_previous_xml_not_found(self, caplog):
         """Test that a warning is logged when old XML is missing from the string prompt."""
         plugin = AgentSkills(skills=[_make_skill()])
         agent = _mock_agent()
@@ -509,7 +595,7 @@ class TestStringPathInjection:
 
         event = BeforeInvocationEvent(agent=agent)
         with caplog.at_level(logging.WARNING):
-            plugin._on_before_invocation(event)
+            await plugin._on_before_invocation(event)
 
         assert "unable to find previously injected skills XML in system prompt" in caplog.text
         assert "<available_skills>" in agent.system_prompt
@@ -580,58 +666,64 @@ class TestSkillsXmlGeneration:
 class TestSkillResponseFormat:
     """Tests for _format_skill_response."""
 
-    def test_instructions_only(self):
+    @pytest.mark.asyncio
+    async def test_instructions_only(self):
         """Test response with just instructions."""
         skill = _make_skill(instructions="Do the thing.")
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert result == "Do the thing."
 
-    def test_no_instructions(self):
+    @pytest.mark.asyncio
+    async def test_no_instructions(self):
         """Test response when skill has no instructions."""
         skill = _make_skill(instructions="")
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert "no instructions available" in result.lower()
 
-    def test_includes_allowed_tools(self):
+    @pytest.mark.asyncio
+    async def test_includes_allowed_tools(self):
         """Test response includes allowed tools when set."""
         skill = _make_skill(instructions="Do the thing.")
         skill.allowed_tools = ["Bash", "Read"]
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert "Do the thing." in result
         assert "Allowed tools: Bash, Read" in result
 
-    def test_includes_compatibility(self):
+    @pytest.mark.asyncio
+    async def test_includes_compatibility(self):
         """Test response includes compatibility when set."""
         skill = _make_skill(instructions="Do the thing.")
         skill.compatibility = "Requires docker"
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert "Compatibility: Requires docker" in result
 
-    def test_includes_location(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_includes_location(self, tmp_path):
         """Test response includes location when path is set."""
         skill = _make_skill(instructions="Do the thing.")
         skill.path = tmp_path / "test-skill"
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert f"Location: {tmp_path / 'test-skill' / 'SKILL.md'}" in result
 
-    def test_all_metadata(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_all_metadata(self, tmp_path):
         """Test response with all metadata fields."""
         skill = _make_skill(instructions="Do the thing.")
         skill.allowed_tools = ["Bash"]
         skill.compatibility = "Requires git"
         skill.path = tmp_path / "test-skill"
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert "Do the thing." in result
         assert "---" in result
@@ -639,7 +731,8 @@ class TestSkillResponseFormat:
         assert "Compatibility: Requires git" in result
         assert "Location:" in result
 
-    def test_includes_resource_listing(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_includes_resource_listing(self, tmp_path):
         """Test response includes resource files from optional directories."""
         skill_dir = tmp_path / "test-skill"
         skill_dir.mkdir()
@@ -651,21 +744,23 @@ class TestSkillResponseFormat:
         skill = _make_skill(instructions="Do the thing.")
         skill.path = skill_dir
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert "Available resources:" in result
         assert "scripts/extract.py" in result
         assert "references/REFERENCE.md" in result
 
-    def test_no_resources_when_no_path(self):
+    @pytest.mark.asyncio
+    async def test_no_resources_when_no_path(self):
         """Test that resources section is omitted for programmatic skills."""
         skill = _make_skill(instructions="Do the thing.")
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert "Available resources:" not in result
 
-    def test_no_resources_when_dirs_empty(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_no_resources_when_dirs_empty(self, tmp_path):
         """Test that resources section is omitted when optional dirs don't exist."""
         skill_dir = tmp_path / "test-skill"
         skill_dir.mkdir()
@@ -673,11 +768,12 @@ class TestSkillResponseFormat:
         skill = _make_skill(instructions="Do the thing.")
         skill.path = skill_dir
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert "Available resources:" not in result
 
-    def test_resource_listing_truncated(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_resource_listing_truncated(self, tmp_path):
         """Test that resource listing is truncated at the max file limit."""
         skill_dir = tmp_path / "test-skill"
         scripts_dir = skill_dir / "scripts"
@@ -688,51 +784,72 @@ class TestSkillResponseFormat:
         skill = _make_skill(instructions="Do the thing.")
         skill.path = skill_dir
         plugin = AgentSkills(skills=[skill])
-        result = plugin._format_skill_response(skill)
+        result = await plugin._format_skill_response(skill, NotASandboxLocalEnvironment())
 
         assert "Available resources:" in result
         assert "truncated at 20 files" in result
 
 
 class TestResolveSkills:
-    """Tests for _resolve_skills."""
+    """Tests for _resolve_skills and per-agent path loading."""
 
     def test_resolve_skill_instances(self):
-        """Test resolving Skill instances (pass-through)."""
+        """Test resolving Skill instances (pass-through into base skills)."""
         skill = _make_skill()
         plugin = AgentSkills(skills=[skill])
 
         assert len(plugin._skills) == 1
         assert plugin._skills["test-skill"] is skill
 
-    def test_resolve_skill_directory_path(self, tmp_path):
-        """Test resolving a path to a skill directory."""
+    def test_filesystem_paths_deferred_not_in_base_skills(self, tmp_path):
+        """Test that filesystem paths are deferred, not resolved into base skills at construction."""
         _make_skill_dir(tmp_path, "path-skill")
         plugin = AgentSkills(skills=[tmp_path / "path-skill"])
 
-        assert len(plugin._skills) == 1
-        assert "path-skill" in plugin._skills
+        # Deferred: not in base _skills, collected in _skill_paths instead
+        assert len(plugin._skills) == 0
+        assert len(plugin._skill_paths) == 1
 
-    def test_resolve_parent_directory_path(self, tmp_path):
-        """Test resolving a path to a parent directory."""
+    @pytest.mark.asyncio
+    async def test_resolve_skill_directory_path(self, tmp_path):
+        """Test loading a path to a skill directory through the sandbox."""
+        _make_skill_dir(tmp_path, "path-skill")
+        plugin = AgentSkills(skills=[tmp_path / "path-skill"])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
+
+        skills = {s.name for s in plugin.get_available_skills(agent)}
+        assert "path-skill" in skills
+
+    @pytest.mark.asyncio
+    async def test_resolve_parent_directory_path(self, tmp_path):
+        """Test loading a path to a parent directory through the sandbox."""
         _make_skill_dir(tmp_path, "child-a")
         _make_skill_dir(tmp_path, "child-b")
         plugin = AgentSkills(skills=[tmp_path])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
 
-        assert len(plugin._skills) == 2
+        assert len(plugin.get_available_skills(agent)) == 2
 
-    def test_resolve_skill_md_file_path(self, tmp_path):
-        """Test resolving a path to a SKILL.md file."""
+    @pytest.mark.asyncio
+    async def test_resolve_skill_md_file_path(self, tmp_path):
+        """Test loading a path to a SKILL.md file through the sandbox."""
         skill_dir = _make_skill_dir(tmp_path, "file-skill")
         plugin = AgentSkills(skills=[skill_dir / "SKILL.md"])
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
 
-        assert len(plugin._skills) == 1
-        assert "file-skill" in plugin._skills
+        skills = {s.name for s in plugin.get_available_skills(agent)}
+        assert "file-skill" in skills
 
-    def test_resolve_nonexistent_path(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_resolve_nonexistent_path(self, tmp_path):
         """Test that nonexistent paths are skipped."""
         plugin = AgentSkills(skills=[str(tmp_path / "ghost")])
-        assert len(plugin._skills) == 0
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
+        assert len(plugin.get_available_skills(agent)) == 0
 
 
 class TestResolveUrlSkills:
@@ -750,7 +867,7 @@ class TestResolveUrlSkills:
         return mock_response
 
     def test_resolve_url_source(self):
-        """Test resolving a URL string as a skill source."""
+        """Test resolving a URL string as a skill source (available without an agent)."""
         from unittest.mock import patch
 
         with patch(
@@ -761,7 +878,8 @@ class TestResolveUrlSkills:
         assert len(plugin.get_available_skills()) == 1
         assert plugin.get_available_skills()[0].name == "url-skill"
 
-    def test_resolve_mixed_url_and_local(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_resolve_mixed_url_and_local(self, tmp_path):
         """Test resolving a mix of URL and local filesystem sources."""
         from unittest.mock import patch
 
@@ -777,8 +895,11 @@ class TestResolveUrlSkills:
                 ]
             )
 
-        assert len(plugin.get_available_skills()) == 2
-        names = {s.name for s in plugin.get_available_skills()}
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
+
+        assert len(plugin.get_available_skills(agent)) == 2
+        names = {s.name for s in plugin.get_available_skills(agent)}
         assert names == {"url-skill", "local-skill"}
 
     def test_resolve_url_failure_skips_gracefully(self, caplog):

--- a/strands-py/tests/strands/vended_plugins/skills/test_agent_skills.py
+++ b/strands-py/tests/strands/vended_plugins/skills/test_agent_skills.py
@@ -7,7 +7,6 @@ plugin.init_agent(agent)``, and assert via ``get_available_skills(agent)`` (the
 per-agent skill set). Skill instances and URLs remain available at construction
 via ``get_available_skills()`` with no agent.
 
-Mirrors ``strands-ts/src/vended-plugins/skills/__tests__/agent-skills.test.node.ts``.
 """
 
 import logging
@@ -44,8 +43,8 @@ def _mock_agent():
 
     Exposes a real ``NotASandboxLocalEnvironment`` as ``.sandbox`` so filesystem
     skill loading and resource listing exercise the actual sandbox code paths,
-    mirroring the TypeScript fixture's ``createMockAgent`` (which returns the
-    environment default sandbox).
+    exposing a real sandbox (which returns the
+    default host sandbox).
     """
     agent = MagicMock()
     agent._system_prompt = "You are an agent."
@@ -973,3 +972,58 @@ class TestImports:
 
         plugin = AgentSkills(skills=[])
         assert isinstance(plugin, Plugin)
+
+
+def _make_skill_dir_named(parent: Path, dir_name: str, skill_name: str) -> Path:
+    """Create a skill directory whose SKILL.md ``name`` differs from the directory name."""
+    skill_dir = parent / dir_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {skill_name}\ndescription: A skill\n---\n# Body\n")
+    return skill_dir
+
+
+class TestSkillPathLoadingEdgeCases:
+    """Coverage for sandbox path-loading branches: name/dir mismatch and resource nesting."""
+
+    @pytest.mark.asyncio
+    async def test_name_dir_mismatch_warns_but_loads(self, tmp_path, caplog):
+        # Non-strict: a skill whose name doesn't match its directory loads with a warning.
+        _make_skill_dir_named(tmp_path, dir_name="wrong-dir", skill_name="actual-name")
+        plugin = AgentSkills(skills=[str(tmp_path / "wrong-dir")])
+        agent = _mock_agent()
+        with caplog.at_level(logging.WARNING):
+            await plugin.init_agent(agent)
+        assert "does not match parent directory name" in caplog.text
+        assert {s.name for s in plugin.get_available_skills(agent)} == {"actual-name"}
+
+    @pytest.mark.asyncio
+    async def test_name_dir_mismatch_strict_skips(self, tmp_path):
+        # Strict: the mismatch raises, is caught per-skill, and the skill is skipped.
+        _make_skill_dir_named(tmp_path, dir_name="wrong-dir", skill_name="actual-name")
+        plugin = AgentSkills(skills=[str(tmp_path / "wrong-dir")], strict=True)
+        agent = _mock_agent()
+        await plugin.init_agent(agent)
+        assert plugin.get_available_skills(agent) == []
+
+    @pytest.mark.asyncio
+    async def test_lists_nested_resource_directories(self, tmp_path):
+        # Resource listing recurses into subdirectories under scripts/.
+        skill_dir = _make_skill_dir(tmp_path, "nested-skill")
+        nested = skill_dir / "scripts" / "helpers"
+        nested.mkdir(parents=True)
+        (nested / "util.py").write_text("# util")
+        skill = _make_skill(name="nested-skill")
+        skill.path = skill_dir
+        result = await AgentSkills(skills=[skill])._format_skill_response(skill, NotASandboxLocalEnvironment())
+        assert "scripts/helpers/util.py" in result
+
+
+class TestSetStateField:
+    """Coverage for the agent-state type guard."""
+
+    def test_rejects_non_dict_state(self):
+        plugin = AgentSkills(skills=[])
+        agent = _mock_agent()
+        agent.state.set(plugin._state_key, "not-a-dict")
+        with pytest.raises(TypeError, match="expected dict for state key"):
+            plugin._set_state_field(agent, "k", "v")

--- a/strands-py/tests/strands/vended_tools/test_bash.py
+++ b/strands-py/tests/strands/vended_tools/test_bash.py
@@ -1,15 +1,8 @@
-"""Tests for the bash tools.
+"""Tests for the bash tool.
 
-Tests for the bash tools:
-
-- ``TestBash`` covers the host-session :data:`bash` tool (persistent shell,
-  execute/restart, state persistence, stderr, timeout).
-- ``TestMakeBash`` covers the stateless sandbox-routed :func:`make_bash` factory,
-  exercised against a real ``NotASandboxLocalEnvironment``.
-
-Tools are called directly (like a normal async function), equivalent to
-calling the tool with arguments. These spawn a shell and require POSIX, so they are skipped
-on Windows.
+The bash tool routes commands through the agent's sandbox (or a bound one).
+Each call runs in a fresh shell; state does not persist across calls. These
+spawn ``sh`` and require POSIX, so they are skipped on Windows.
 """
 
 import sys
@@ -17,219 +10,87 @@ from types import SimpleNamespace
 
 import pytest
 
+from strands.sandbox.errors import SandboxTimeoutError
 from strands.sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
 from strands.types.tools import ToolContext
 from strands.vended_tools.bash import bash, make_bash
-from strands.vended_tools.bash.types import SANDBOX_BASH_DESCRIPTION, BashSessionError, BashTimeoutError
+from strands.vended_tools.bash.types import SANDBOX_BASH_DESCRIPTION
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell required")
 
 
-class _Agent:
-    """Minimal weak-referenceable stand-in for an agent (host bash keys sessions by agent)."""
-
-
-def _host_context() -> ToolContext:
-    """ToolContext for the host bash tool; its agent only needs to be weak-referenceable."""
-    return ToolContext(tool_use={"name": "bash", "toolUseId": "id", "input": {}}, agent=_Agent(), invocation_state={})
-
-
-def _sandbox_context(sandbox: NotASandboxLocalEnvironment | None = None) -> ToolContext:
-    """ToolContext whose agent exposes a sandbox, for the sandbox-routed tool."""
+def _tool_context(sandbox: NotASandboxLocalEnvironment | None = None) -> ToolContext:
+    """Build a ToolContext whose agent exposes a sandbox (or a fresh one)."""
     agent = SimpleNamespace(sandbox=sandbox or NotASandboxLocalEnvironment())
     return ToolContext(tool_use={"name": "bash", "toolUseId": "id", "input": {}}, agent=agent, invocation_state={})
 
 
-class TestBash:
-    """Tests for the host-session ``bash`` tool."""
-
-    @pytest.mark.asyncio
-    async def test_executes_and_returns_output(self):
-        result = await bash(mode="execute", command='echo "Hello World"', tool_context=_host_context())
-        assert "Hello World" in result["output"]
-        assert result["error"] == ""
-
-    @pytest.mark.asyncio
-    async def test_restart_returns_message(self):
-        assert await bash(mode="restart", tool_context=_host_context()) == "Bash session restarted"
-
-    @pytest.mark.asyncio
-    async def test_rejects_invalid_mode(self):
-        with pytest.raises(BashSessionError, match="Unknown mode"):
-            await bash(mode="invalid", tool_context=_host_context())
-
-    @pytest.mark.asyncio
-    async def test_execute_requires_command(self):
-        with pytest.raises(BashSessionError, match="command is required"):
-            await bash(mode="execute", tool_context=_host_context())
-
-    @pytest.mark.asyncio
-    async def test_persists_environment_variables(self):
-        ctx = _host_context()
-        await bash(mode="execute", command='MY_VAR="persistent_value"', tool_context=ctx)
-        result = await bash(mode="execute", command="echo $MY_VAR", tool_context=ctx)
-        assert result["output"].strip() == "persistent_value"
-
-    @pytest.mark.asyncio
-    async def test_persists_working_directory(self):
-        ctx = _host_context()
-        await bash(mode="execute", command="cd /tmp", tool_context=ctx)
-        result = await bash(mode="execute", command="pwd", tool_context=ctx)
-        assert result["output"].strip().endswith("/tmp")
-
-    @pytest.mark.asyncio
-    async def test_restart_clears_state(self):
-        ctx = _host_context()
-        await bash(mode="execute", command='MY_VAR="exists"', tool_context=ctx)
-        await bash(mode="restart", tool_context=ctx)
-        result = await bash(mode="execute", command='echo "${MY_VAR:-empty}"', tool_context=ctx)
-        assert result["output"].strip() == "empty"
-
-    @pytest.mark.asyncio
-    async def test_isolated_sessions_per_agent(self):
-        ctx1, ctx2 = _host_context(), _host_context()
-        await bash(mode="execute", command='AGENT_VAR="agent1"', tool_context=ctx1)
-        result = await bash(mode="execute", command='echo "${AGENT_VAR:-empty}"', tool_context=ctx2)
-        assert result["output"].strip() == "empty"
-
-    @pytest.mark.asyncio
-    async def test_restart_with_no_existing_session(self):
-        ctx = _host_context()
-        assert await bash(mode="restart", tool_context=ctx) == "Bash session restarted"
-        result = await bash(mode="execute", command='echo "works"', tool_context=ctx)
-        assert result["output"].strip() == "works"
-
-    @pytest.mark.asyncio
-    async def test_returns_empty_stderr_on_success(self):
-        result = await bash(mode="execute", command='echo "success"', tool_context=_host_context())
-        assert result["error"] == ""
-
-    @pytest.mark.asyncio
-    async def test_captures_stderr(self):
-        result = await bash(mode="execute", command="nonexistent_command_xyz", tool_context=_host_context())
-        assert "not found" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_separates_stdout_and_stderr(self):
-        result = await bash(mode="execute", command="echo out; echo err >&2", tool_context=_host_context())
-        assert result["output"].strip() == "out"
-        assert result["error"].strip() == "err"
-
-    @pytest.mark.asyncio
-    async def test_empty_output(self):
-        result = await bash(mode="execute", command="true", tool_context=_host_context())
-        assert result["output"] == ""
-        assert result["error"] == ""
-
-    @pytest.mark.asyncio
-    async def test_output_without_trailing_newline(self):
-        # Output with no trailing newline shares the line with the completion sentinel;
-        # only the sentinel is stripped, not the preceding output.
-        result = await bash(mode="execute", command="printf foo", tool_context=_host_context())
-        assert result["output"] == "foo"
-
-    @pytest.mark.asyncio
-    async def test_long_output(self):
-        result = await bash(
-            mode="execute", command='for i in $(seq 1 100); do echo "Line $i"; done', tool_context=_host_context()
-        )
-        assert "Line 1" in result["output"]
-        assert "Line 100" in result["output"]
-
-    @pytest.mark.asyncio
-    async def test_completes_before_timeout(self):
-        result = await bash(mode="execute", command='echo "fast"', timeout=5, tool_context=_host_context())
-        assert "fast" in result["output"]
-
-    @pytest.mark.asyncio
-    async def test_raises_on_timeout(self):
-        with pytest.raises(BashTimeoutError):
-            await bash(mode="execute", command="sleep 10", timeout=1, tool_context=_host_context())
-
-
 class TestMakeBash:
-    """Tests for the stateless sandbox-routed ``make_bash`` factory."""
+    """Tests for a bash tool with a sandbox bound at creation."""
 
     @pytest.fixture
     def sandbox_bash(self):
-        return make_bash(NotASandboxLocalEnvironment())
+        return make_bash(sandbox=NotASandboxLocalEnvironment())
 
     @pytest.mark.asyncio
     async def test_executes_command_via_sandbox(self, sandbox_bash):
-        result = await sandbox_bash(command='echo "hello sandbox"', tool_context=_sandbox_context())
+        result = await sandbox_bash(command='echo "hello sandbox"', tool_context=_tool_context())
         assert "hello sandbox" in result["output"]
         assert result["error"] == ""
 
     @pytest.mark.asyncio
     async def test_captures_stderr_via_sandbox(self, sandbox_bash):
-        result = await sandbox_bash(command='echo "oops" >&2', tool_context=_sandbox_context())
+        result = await sandbox_bash(command='echo "oops" >&2', tool_context=_tool_context())
         assert "oops" in result["error"]
 
     @pytest.mark.asyncio
     async def test_does_not_persist_state_between_calls(self, sandbox_bash):
-        # Each call runs in a fresh shell; an exported var must not survive to the next call.
-        await sandbox_bash(command="export MY_VAR=hello", tool_context=_sandbox_context())
-        result = await sandbox_bash(command='echo "${MY_VAR:-empty}"', tool_context=_sandbox_context())
+        await sandbox_bash(command="export MY_VAR=hello", tool_context=_tool_context())
+        result = await sandbox_bash(command='echo "${MY_VAR:-empty}"', tool_context=_tool_context())
         assert result["output"].strip() == "empty"
 
     @pytest.mark.asyncio
     async def test_respects_timeout(self, sandbox_bash):
-        with pytest.raises(BashTimeoutError):
-            await sandbox_bash(command="sleep 10", tool_context=_sandbox_context(), timeout=0.1)
+        with pytest.raises(SandboxTimeoutError):
+            await sandbox_bash(command="sleep 10", tool_context=_tool_context(), timeout=0.1)
 
     @pytest.mark.asyncio
-    async def test_reads_sandbox_from_agent_context_when_unbound(self):
-        unbound = make_bash()
-        result = await unbound(command="echo via-context", tool_context=_sandbox_context())
-        assert "via-context" in result["output"]
-
-    @pytest.mark.asyncio
-    async def test_wraps_sandbox_error_as_session_error(self):
-        # A non-timeout failure from the sandbox surfaces as BashSessionError.
+    async def test_wraps_sandbox_error_as_runtime_error(self):
         class _BoomSandbox(NotASandboxLocalEnvironment):
             async def execute(self, *args, **kwargs):
-                raise RuntimeError("boom")
+                raise ValueError("boom")
 
-        tool = make_bash(_BoomSandbox())
-        with pytest.raises(BashSessionError, match="boom"):
-            await tool(command="echo hi", tool_context=_sandbox_context())
+        t = make_bash(sandbox=_BoomSandbox())
+        with pytest.raises(RuntimeError, match="boom"):
+            await t(command="echo hi", tool_context=_tool_context())
+
+
+class TestDefaultBash:
+    """Tests for the default unbound ``bash`` instance (reads sandbox from agent context)."""
+
+    @pytest.mark.asyncio
+    async def test_reads_sandbox_from_agent_context(self):
+        result = await bash(command="echo via-context", tool_context=_tool_context())
+        assert "via-context" in result["output"]
 
 
 class TestToolMetadata:
     """Tests for tool names, descriptions, and input schemas."""
 
-    def test_bash_name(self):
+    def test_default_name(self):
         assert bash.tool_name == "bash"
 
-    def test_bash_mode_is_enum(self):
-        props = bash.tool_spec["inputSchema"]["json"]["properties"]
-        assert props["mode"]["enum"] == ["execute", "restart"]
-        assert "tool_context" not in props
-
-    def test_make_bash_default_name(self):
-        assert make_bash().tool_name == "bash"
-
-    def test_make_bash_custom_name(self):
+    def test_custom_name(self):
         assert make_bash(name="sandbox_bash").tool_name == "sandbox_bash"
 
-    def test_make_bash_default_description(self):
+    def test_default_description(self):
         assert make_bash().tool_spec["description"] == SANDBOX_BASH_DESCRIPTION
 
-    def test_make_bash_custom_description(self):
+    def test_custom_description(self):
         assert make_bash(description="custom desc").tool_spec["description"] == "custom desc"
 
-    def test_make_bash_schema_excludes_context(self):
-        props = make_bash().tool_spec["inputSchema"]["json"]["properties"]
+    def test_schema_excludes_context(self):
+        props = bash.tool_spec["inputSchema"]["json"]["properties"]
         assert "command" in props
         assert "timeout" in props
         assert "tool_context" not in props
-
-
-class TestErrorClasses:
-    """Tests for the bash error classes."""
-
-    def test_bash_timeout_error_is_exception(self):
-        assert isinstance(BashTimeoutError("x"), Exception)
-
-    def test_bash_session_error_is_exception(self):
-        assert isinstance(BashSessionError("x"), Exception)

--- a/strands-py/tests/strands/vended_tools/test_bash.py
+++ b/strands-py/tests/strands/vended_tools/test_bash.py
@@ -1,0 +1,222 @@
+"""Tests for the bash tools.
+
+Mirrors ``strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts``:
+
+- ``TestBash`` covers the host-session :data:`bash` tool (persistent shell,
+  execute/restart, state persistence, stderr, timeout).
+- ``TestMakeBash`` covers the stateless sandbox-routed :func:`make_bash` factory,
+  exercised against a real ``NotASandboxLocalEnvironment``.
+
+Tools are called directly (like a normal async function), mirroring TS's
+``bash.invoke(...)``. These spawn a shell and require POSIX, so they are skipped
+on Windows.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from strands.sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
+from strands.types.tools import ToolContext
+from strands.vended_tools.bash import (
+    SANDBOX_BASH_DESCRIPTION,
+    BashSessionError,
+    BashTimeoutError,
+    bash,
+    make_bash,
+)
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell required")
+
+
+class _Agent:
+    """Minimal weak-referenceable stand-in for an agent (host bash keys sessions by agent)."""
+
+
+def _host_context() -> ToolContext:
+    """ToolContext for the host bash tool; its agent only needs to be weak-referenceable."""
+    return ToolContext(tool_use={"name": "bash", "toolUseId": "id", "input": {}}, agent=_Agent(), invocation_state={})
+
+
+def _sandbox_context(sandbox: NotASandboxLocalEnvironment | None = None) -> ToolContext:
+    """ToolContext whose agent exposes a sandbox, for the sandbox-routed tool."""
+    agent = SimpleNamespace(sandbox=sandbox or NotASandboxLocalEnvironment())
+    return ToolContext(tool_use={"name": "bash", "toolUseId": "id", "input": {}}, agent=agent, invocation_state={})
+
+
+class TestBash:
+    """Tests for the host-session ``bash`` tool."""
+
+    @pytest.mark.asyncio
+    async def test_executes_and_returns_output(self):
+        result = await bash(mode="execute", command='echo "Hello World"', tool_context=_host_context())
+        assert "Hello World" in result["output"]
+        assert result["error"] == ""
+
+    @pytest.mark.asyncio
+    async def test_restart_returns_message(self):
+        assert await bash(mode="restart", tool_context=_host_context()) == "Bash session restarted"
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_mode(self):
+        with pytest.raises(BashSessionError, match="Unknown mode"):
+            await bash(mode="invalid", tool_context=_host_context())
+
+    @pytest.mark.asyncio
+    async def test_execute_requires_command(self):
+        with pytest.raises(BashSessionError, match="command is required"):
+            await bash(mode="execute", tool_context=_host_context())
+
+    @pytest.mark.asyncio
+    async def test_persists_environment_variables(self):
+        ctx = _host_context()
+        await bash(mode="execute", command='MY_VAR="persistent_value"', tool_context=ctx)
+        result = await bash(mode="execute", command="echo $MY_VAR", tool_context=ctx)
+        assert result["output"].strip() == "persistent_value"
+
+    @pytest.mark.asyncio
+    async def test_persists_working_directory(self):
+        ctx = _host_context()
+        await bash(mode="execute", command="cd /tmp", tool_context=ctx)
+        result = await bash(mode="execute", command="pwd", tool_context=ctx)
+        assert result["output"].strip().endswith("/tmp")
+
+    @pytest.mark.asyncio
+    async def test_restart_clears_state(self):
+        ctx = _host_context()
+        await bash(mode="execute", command='MY_VAR="exists"', tool_context=ctx)
+        await bash(mode="restart", tool_context=ctx)
+        result = await bash(mode="execute", command='echo "${MY_VAR:-empty}"', tool_context=ctx)
+        assert result["output"].strip() == "empty"
+
+    @pytest.mark.asyncio
+    async def test_isolated_sessions_per_agent(self):
+        ctx1, ctx2 = _host_context(), _host_context()
+        await bash(mode="execute", command='AGENT_VAR="agent1"', tool_context=ctx1)
+        result = await bash(mode="execute", command='echo "${AGENT_VAR:-empty}"', tool_context=ctx2)
+        assert result["output"].strip() == "empty"
+
+    @pytest.mark.asyncio
+    async def test_restart_with_no_existing_session(self):
+        ctx = _host_context()
+        assert await bash(mode="restart", tool_context=ctx) == "Bash session restarted"
+        result = await bash(mode="execute", command='echo "works"', tool_context=ctx)
+        assert result["output"].strip() == "works"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_stderr_on_success(self):
+        result = await bash(mode="execute", command='echo "success"', tool_context=_host_context())
+        assert result["error"] == ""
+
+    @pytest.mark.asyncio
+    async def test_captures_stderr(self):
+        result = await bash(mode="execute", command="nonexistent_command_xyz", tool_context=_host_context())
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_separates_stdout_and_stderr(self):
+        result = await bash(mode="execute", command="echo out; echo err >&2", tool_context=_host_context())
+        assert result["output"].strip() == "out"
+        assert result["error"].strip() == "err"
+
+    @pytest.mark.asyncio
+    async def test_empty_output(self):
+        result = await bash(mode="execute", command="true", tool_context=_host_context())
+        assert result["output"] == ""
+        assert result["error"] == ""
+
+    @pytest.mark.asyncio
+    async def test_long_output(self):
+        result = await bash(
+            mode="execute", command='for i in $(seq 1 100); do echo "Line $i"; done', tool_context=_host_context()
+        )
+        assert "Line 1" in result["output"]
+        assert "Line 100" in result["output"]
+
+    @pytest.mark.asyncio
+    async def test_completes_before_timeout(self):
+        result = await bash(mode="execute", command='echo "fast"', timeout=5, tool_context=_host_context())
+        assert "fast" in result["output"]
+
+    @pytest.mark.asyncio
+    async def test_raises_on_timeout(self):
+        with pytest.raises(BashTimeoutError):
+            await bash(mode="execute", command="sleep 10", timeout=1, tool_context=_host_context())
+
+
+class TestMakeBash:
+    """Tests for the stateless sandbox-routed ``make_bash`` factory."""
+
+    @pytest.fixture
+    def sandbox_bash(self):
+        return make_bash(NotASandboxLocalEnvironment())
+
+    @pytest.mark.asyncio
+    async def test_executes_command_via_sandbox(self, sandbox_bash):
+        result = await sandbox_bash(command='echo "hello sandbox"', tool_context=_sandbox_context())
+        assert "hello sandbox" in result["output"]
+        assert result["error"] == ""
+
+    @pytest.mark.asyncio
+    async def test_captures_stderr_via_sandbox(self, sandbox_bash):
+        result = await sandbox_bash(command='echo "oops" >&2', tool_context=_sandbox_context())
+        assert "oops" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_does_not_persist_state_between_calls(self, sandbox_bash):
+        # Each call runs in a fresh shell; an exported var must not survive to the next call.
+        await sandbox_bash(command="export MY_VAR=hello", tool_context=_sandbox_context())
+        result = await sandbox_bash(command='echo "${MY_VAR:-empty}"', tool_context=_sandbox_context())
+        assert result["output"].strip() == "empty"
+
+    @pytest.mark.asyncio
+    async def test_respects_timeout(self, sandbox_bash):
+        with pytest.raises(BashTimeoutError):
+            await sandbox_bash(command="sleep 10", tool_context=_sandbox_context(), timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_reads_sandbox_from_agent_context_when_unbound(self):
+        unbound = make_bash()
+        result = await unbound(command="echo via-context", tool_context=_sandbox_context())
+        assert "via-context" in result["output"]
+
+
+class TestToolMetadata:
+    """Tests for tool names, descriptions, and input schemas."""
+
+    def test_bash_name(self):
+        assert bash.tool_name == "bash"
+
+    def test_bash_mode_is_enum(self):
+        props = bash.tool_spec["inputSchema"]["json"]["properties"]
+        assert props["mode"]["enum"] == ["execute", "restart"]
+        assert "tool_context" not in props
+
+    def test_make_bash_default_name(self):
+        assert make_bash().tool_name == "bash"
+
+    def test_make_bash_custom_name(self):
+        assert make_bash(name="sandbox_bash").tool_name == "sandbox_bash"
+
+    def test_make_bash_default_description(self):
+        assert make_bash().tool_spec["description"] == SANDBOX_BASH_DESCRIPTION
+
+    def test_make_bash_custom_description(self):
+        assert make_bash(description="custom desc").tool_spec["description"] == "custom desc"
+
+    def test_make_bash_schema_excludes_context(self):
+        props = make_bash().tool_spec["inputSchema"]["json"]["properties"]
+        assert "command" in props
+        assert "timeout" in props
+        assert "tool_context" not in props
+
+
+class TestErrorClasses:
+    """Tests for the bash error classes."""
+
+    def test_bash_timeout_error_is_exception(self):
+        assert isinstance(BashTimeoutError("x"), Exception)
+
+    def test_bash_session_error_is_exception(self):
+        assert isinstance(BashSessionError("x"), Exception)

--- a/strands-py/tests/strands/vended_tools/test_bash.py
+++ b/strands-py/tests/strands/vended_tools/test_bash.py
@@ -1,14 +1,14 @@
 """Tests for the bash tools.
 
-Mirrors ``strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts``:
+Tests for the bash tools:
 
 - ``TestBash`` covers the host-session :data:`bash` tool (persistent shell,
   execute/restart, state persistence, stderr, timeout).
 - ``TestMakeBash`` covers the stateless sandbox-routed :func:`make_bash` factory,
   exercised against a real ``NotASandboxLocalEnvironment``.
 
-Tools are called directly (like a normal async function), mirroring TS's
-``bash.invoke(...)``. These spawn a shell and require POSIX, so they are skipped
+Tools are called directly (like a normal async function), equivalent to
+calling the tool with arguments. These spawn a shell and require POSIX, so they are skipped
 on Windows.
 """
 
@@ -19,13 +19,8 @@ import pytest
 
 from strands.sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
 from strands.types.tools import ToolContext
-from strands.vended_tools.bash import (
-    SANDBOX_BASH_DESCRIPTION,
-    BashSessionError,
-    BashTimeoutError,
-    bash,
-    make_bash,
-)
+from strands.vended_tools.bash import bash, make_bash
+from strands.vended_tools.bash.types import SANDBOX_BASH_DESCRIPTION, BashSessionError, BashTimeoutError
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell required")
 
@@ -127,6 +122,13 @@ class TestBash:
         assert result["error"] == ""
 
     @pytest.mark.asyncio
+    async def test_output_without_trailing_newline(self):
+        # Output with no trailing newline shares the line with the completion sentinel;
+        # only the sentinel is stripped, not the preceding output.
+        result = await bash(mode="execute", command="printf foo", tool_context=_host_context())
+        assert result["output"] == "foo"
+
+    @pytest.mark.asyncio
     async def test_long_output(self):
         result = await bash(
             mode="execute", command='for i in $(seq 1 100); do echo "Line $i"; done', tool_context=_host_context()
@@ -180,6 +182,17 @@ class TestMakeBash:
         unbound = make_bash()
         result = await unbound(command="echo via-context", tool_context=_sandbox_context())
         assert "via-context" in result["output"]
+
+    @pytest.mark.asyncio
+    async def test_wraps_sandbox_error_as_session_error(self):
+        # A non-timeout failure from the sandbox surfaces as BashSessionError.
+        class _BoomSandbox(NotASandboxLocalEnvironment):
+            async def execute(self, *args, **kwargs):
+                raise RuntimeError("boom")
+
+        tool = make_bash(_BoomSandbox())
+        with pytest.raises(BashSessionError, match="boom"):
+            await tool(command="echo hi", tool_context=_sandbox_context())
 
 
 class TestToolMetadata:

--- a/strands-py/tests/strands/vended_tools/test_file_editor.py
+++ b/strands-py/tests/strands/vended_tools/test_file_editor.py
@@ -1,0 +1,439 @@
+"""Tests for the sandbox-routed file editor tool.
+
+Mirrors ``strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts``.
+The tool is exercised against a real ``NotASandboxLocalEnvironment`` (host
+filesystem), the same way the TS tests use ``TestSandbox``, and called directly
+(like a normal async function) mirroring TS's ``fileEditor.invoke(...)``. Errors
+surface as raised ``ValueError`` (the raw function raises; the error->status
+wrapping only happens through the tool's ``stream`` path). Path semantics assume
+POSIX, so these are skipped on Windows.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from strands.sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
+from strands.types.tools import ToolContext
+from strands.vended_tools.file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, file_editor, make_file_editor
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX path semantics assumed")
+
+
+def _tool_context(sandbox: NotASandboxLocalEnvironment | None = None) -> ToolContext:
+    """Build a ToolContext whose agent exposes the given sandbox (or a fresh one)."""
+    agent = SimpleNamespace(sandbox=sandbox or NotASandboxLocalEnvironment())
+    return ToolContext(
+        tool_use={"name": "file_editor", "toolUseId": "test-id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+
+
+def _write(path, content: str) -> str:
+    """Write content to a path and return it as a string (test helper)."""
+    path.write_text(content)
+    return str(path)
+
+
+@pytest.fixture
+def editor():
+    """A file editor bound to a host sandbox, mirroring TS's makeFileEditor(new TestSandbox(...))."""
+    return make_file_editor(NotASandboxLocalEnvironment())
+
+
+@pytest.fixture
+def ctx():
+    return _tool_context()
+
+
+class TestViewFile:
+    """Viewing an entire file or a line range."""
+
+    @pytest.mark.asyncio
+    async def test_returns_content_with_line_numbers(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        result = await editor(command="view", path=file_path, tool_context=ctx)
+        assert "Here's the result of running `cat -n`" in result
+        assert "     1  Line 1" in result
+        assert "     2  Line 2" in result
+        assert "     3  Line 3" in result
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_file(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "empty.txt", "")
+        result = await editor(command="view", path=file_path, tool_context=ctx)
+        assert "Here's the result of running `cat -n`" in result
+
+    @pytest.mark.asyncio
+    async def test_handles_single_line(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "single.txt", "Only one line")
+        result = await editor(command="view", path=file_path, tool_context=ctx)
+        assert "     1  Only one line" in result
+
+    @pytest.mark.asyncio
+    async def test_range_returns_specified_lines(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3\nLine 4\nLine 5")
+        result = await editor(command="view", path=file_path, tool_context=ctx, view_range=[2, 4])
+        assert "     2  Line 2" in result
+        assert "     3  Line 3" in result
+        assert "     4  Line 4" in result
+        assert "     1  " not in result
+        assert "     5  " not in result
+
+    @pytest.mark.asyncio
+    async def test_range_negative_end_means_to_end(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3\nLine 4\nLine 5")
+        result = await editor(command="view", path=file_path, tool_context=ctx, view_range=[3, -1])
+        assert "     3  Line 3" in result
+        assert "     5  Line 5" in result
+        assert "     1  " not in result
+        assert "     2  " not in result
+
+    @pytest.mark.asyncio
+    async def test_range_single_line(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        result = await editor(command="view", path=file_path, tool_context=ctx, view_range=[2, 2])
+        assert "     2  Line 2" in result
+        assert "     1  " not in result
+        assert "     3  " not in result
+
+
+class TestViewDirectory:
+    """Viewing a directory lists its contents."""
+
+    @pytest.mark.asyncio
+    async def test_lists_two_levels_deep(self, editor, ctx, tmp_path):
+        d = tmp_path / "testdir"
+        (d / "subdir" / "nested").mkdir(parents=True)
+        _write(d / "file1.txt", "content")
+        _write(d / "file2.txt", "content")
+        _write(d / "subdir" / "file3.txt", "content")
+        _write(d / "subdir" / "nested" / "file4.txt", "content")
+        result = await editor(command="view", path=str(d), tool_context=ctx)
+        assert "file1.txt" in result
+        assert "file2.txt" in result
+        assert "subdir" in result
+        assert "file3.txt" in result
+        assert "file4.txt" in result
+
+    @pytest.mark.asyncio
+    async def test_excludes_hidden(self, editor, ctx, tmp_path):
+        d = tmp_path / "testdir"
+        d.mkdir()
+        _write(d / "visible.txt", "content")
+        _write(d / ".hidden.txt", "content")
+        result = await editor(command="view", path=str(d), tool_context=ctx)
+        assert "visible.txt" in result
+        assert ".hidden" not in result
+
+
+class TestViewErrors:
+    """Error cases for the view command."""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_raises(self, editor, ctx, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            await editor(command="view", path=str(tmp_path / "nope.txt"), tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_relative_path_raises(self, editor, ctx):
+        with pytest.raises(ValueError, match="not an absolute path"):
+            await editor(command="view", path="relative/path.txt", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_raises(self, editor, ctx):
+        with pytest.raises(ValueError, match="path traversal"):
+            await editor(command="view", path="/tmp/../etc/passwd", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_range_invalid_start_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        with pytest.raises(ValueError, match="view_range"):
+            await editor(command="view", path=file_path, tool_context=ctx, view_range=[0, 2])
+
+    @pytest.mark.asyncio
+    async def test_range_end_beyond_length_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        with pytest.raises(ValueError, match="view_range"):
+            await editor(command="view", path=file_path, tool_context=ctx, view_range=[1, 10])
+
+    @pytest.mark.asyncio
+    async def test_range_end_before_start_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        with pytest.raises(ValueError, match="view_range"):
+            await editor(command="view", path=file_path, tool_context=ctx, view_range=[3, 1])
+
+    @pytest.mark.asyncio
+    async def test_range_on_directory_raises(self, editor, ctx, tmp_path):
+        d = tmp_path / "testdir"
+        d.mkdir()
+        _write(d / "file.txt", "content")
+        with pytest.raises(ValueError, match="not allowed when"):
+            await editor(command="view", path=str(d), tool_context=ctx, view_range=[1, 2])
+
+
+class TestCreate:
+    """The create command."""
+
+    @pytest.mark.asyncio
+    async def test_new_file(self, editor, ctx, tmp_path):
+        file_path = str(tmp_path / "new-file.txt")
+        content = "Hello World\nLine 2"
+        result = await editor(command="create", path=file_path, tool_context=ctx, file_text=content)
+        assert "File created successfully" in result
+        assert file_path in result
+        assert (tmp_path / "new-file.txt").read_text() == content
+
+    @pytest.mark.asyncio
+    async def test_in_nonexistent_directory(self, editor, ctx, tmp_path):
+        file_path = str(tmp_path / "newdir" / "subdir" / "new-file.txt")
+        result = await editor(command="create", path=file_path, tool_context=ctx, file_text="Content")
+        assert "File created successfully" in result
+        assert (tmp_path / "newdir" / "subdir" / "new-file.txt").read_text() == "Content"
+
+    @pytest.mark.asyncio
+    async def test_empty_file(self, editor, ctx, tmp_path):
+        file_path = str(tmp_path / "empty.txt")
+        result = await editor(command="create", path=file_path, tool_context=ctx, file_text="")
+        assert "File created successfully" in result
+        assert (tmp_path / "empty.txt").read_text() == ""
+
+    @pytest.mark.asyncio
+    async def test_existing_file_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "existing.txt", "content")
+        with pytest.raises(ValueError, match="already exists"):
+            await editor(command="create", path=file_path, tool_context=ctx, file_text="new content")
+
+    @pytest.mark.asyncio
+    async def test_relative_path_raises(self, editor, ctx):
+        with pytest.raises(ValueError, match="not an absolute path"):
+            await editor(command="create", path="relative/path.txt", tool_context=ctx, file_text="content")
+
+    @pytest.mark.asyncio
+    async def test_on_directory_raises(self, editor, ctx, tmp_path):
+        d = tmp_path / "testdir"
+        d.mkdir()
+        with pytest.raises(ValueError, match="already exists"):
+            await editor(command="create", path=str(d), tool_context=ctx, file_text="content")
+
+
+class TestStrReplace:
+    """The str_replace command."""
+
+    @pytest.mark.asyncio
+    async def test_unique_occurrence(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2 OLD\nLine 3\nLine 4")
+        result = await editor(command="str_replace", path=file_path, tool_context=ctx, old_str="OLD", new_str="NEW")
+        assert "has been edited" in result
+        assert "NEW" in result
+        assert (tmp_path / "test.txt").read_text() == "Line 1\nLine 2 NEW\nLine 3\nLine 4"
+
+    @pytest.mark.asyncio
+    async def test_snippet_window(self, editor, ctx, tmp_path):
+        content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5 OLD\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10"
+        file_path = _write(tmp_path / "test.txt", content)
+        result = await editor(command="str_replace", path=file_path, tool_context=ctx, old_str="OLD", new_str="NEW")
+        assert "Line 1" in result
+        assert "Line 9" in result
+        assert "Line 10" not in result
+
+    @pytest.mark.asyncio
+    async def test_deletion(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2 DELETE_ME\nLine 3")
+        result = await editor(command="str_replace", path=file_path, tool_context=ctx, old_str=" DELETE_ME", new_str="")
+        assert "has been edited" in result
+        assert (tmp_path / "test.txt").read_text() == "Line 1\nLine 2\nLine 3"
+
+    @pytest.mark.asyncio
+    async def test_multiline(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nOLD LINE 1\nOLD LINE 2\nLine 4")
+        await editor(
+            command="str_replace",
+            path=file_path,
+            tool_context=ctx,
+            old_str="OLD LINE 1\nOLD LINE 2",
+            new_str="NEW LINE",
+        )
+        assert (tmp_path / "test.txt").read_text() == "Line 1\nNEW LINE\nLine 4"
+
+    @pytest.mark.asyncio
+    async def test_preserves_dollar_patterns_literally(self, editor, ctx, tmp_path):
+        # Python's str.replace is literal, so $&/$1/$$ must survive verbatim (TS guards against regex semantics).
+        file_path = _write(tmp_path / "test.txt", "const value = getPrice()")
+        await editor(
+            command="str_replace", path=file_path, tool_context=ctx, old_str="getPrice()", new_str="$& is not $1 or $$"
+        )
+        assert (tmp_path / "test.txt").read_text() == "const value = $& is not $1 or $$"
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        with pytest.raises(ValueError, match="did not appear"):
+            await editor(command="str_replace", path=file_path, tool_context=ctx, old_str="NOTFOUND", new_str="NEW")
+
+    @pytest.mark.asyncio
+    async def test_multiple_occurrences_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "DUP Line 1\nLine 2\nDUP Line 3")
+        with pytest.raises(ValueError, match="Multiple occurrences"):
+            await editor(command="str_replace", path=file_path, tool_context=ctx, old_str="DUP", new_str="NEW")
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_raises(self, editor, ctx, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            await editor(
+                command="str_replace", path=str(tmp_path / "nope.txt"), tool_context=ctx, old_str="OLD", new_str="NEW"
+            )
+
+    @pytest.mark.asyncio
+    async def test_on_directory_raises(self, editor, ctx, tmp_path):
+        d = tmp_path / "testdir"
+        d.mkdir()
+        with pytest.raises(ValueError, match="directory"):
+            await editor(command="str_replace", path=str(d), tool_context=ctx, old_str="OLD", new_str="NEW")
+
+
+class TestInsert:
+    """The insert command."""
+
+    @pytest.mark.asyncio
+    async def test_at_beginning(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        await editor(command="insert", path=file_path, tool_context=ctx, insert_line=0, new_str="NEW LINE")
+        assert (tmp_path / "test.txt").read_text() == "NEW LINE\nLine 1\nLine 2\nLine 3"
+
+    @pytest.mark.asyncio
+    async def test_in_middle(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        await editor(command="insert", path=file_path, tool_context=ctx, insert_line=2, new_str="NEW LINE")
+        assert (tmp_path / "test.txt").read_text() == "Line 1\nLine 2\nNEW LINE\nLine 3"
+
+    @pytest.mark.asyncio
+    async def test_at_end(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        await editor(command="insert", path=file_path, tool_context=ctx, insert_line=3, new_str="NEW LINE")
+        assert (tmp_path / "test.txt").read_text() == "Line 1\nLine 2\nLine 3\nNEW LINE"
+
+    @pytest.mark.asyncio
+    async def test_snippet_window(self, editor, ctx, tmp_path):
+        content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9"
+        file_path = _write(tmp_path / "test.txt", content)
+        result = await editor(command="insert", path=file_path, tool_context=ctx, insert_line=5, new_str="INSERTED")
+        assert "Line 2" in result
+        assert "Line 9" in result
+        assert "INSERTED" in result
+
+    @pytest.mark.asyncio
+    async def test_multiline(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2")
+        await editor(command="insert", path=file_path, tool_context=ctx, insert_line=1, new_str="NEW 1\nNEW 2\nNEW 3")
+        assert (tmp_path / "test.txt").read_text() == "Line 1\nNEW 1\nNEW 2\nNEW 3\nLine 2"
+
+    @pytest.mark.asyncio
+    async def test_in_empty_file(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "empty.txt", "")
+        await editor(command="insert", path=file_path, tool_context=ctx, insert_line=0, new_str="First line")
+        assert (tmp_path / "empty.txt").read_text() == "First line"
+
+    @pytest.mark.asyncio
+    async def test_negative_line_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2")
+        with pytest.raises(ValueError, match="insert_line"):
+            await editor(command="insert", path=file_path, tool_context=ctx, insert_line=-1, new_str="NEW")
+
+    @pytest.mark.asyncio
+    async def test_beyond_length_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2")
+        with pytest.raises(ValueError, match="insert_line"):
+            await editor(command="insert", path=file_path, tool_context=ctx, insert_line=10, new_str="NEW")
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_raises(self, editor, ctx, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            await editor(
+                command="insert", path=str(tmp_path / "nope.txt"), tool_context=ctx, insert_line=0, new_str="NEW"
+            )
+
+    @pytest.mark.asyncio
+    async def test_on_directory_raises(self, editor, ctx, tmp_path):
+        d = tmp_path / "testdir"
+        d.mkdir()
+        with pytest.raises(ValueError, match="directory"):
+            await editor(command="insert", path=str(d), tool_context=ctx, insert_line=0, new_str="NEW")
+
+
+class TestFileSizeLimit:
+    """The 1MB content size guard."""
+
+    @pytest.mark.asyncio
+    async def test_view_exceeds_size_limit_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "large.txt", "x" * 1048577)  # 1MB + 1 byte
+        with pytest.raises(ValueError, match="exceeds"):
+            await editor(command="view", path=file_path, tool_context=ctx)
+
+
+class TestEdgeCases:
+    """Content edge cases: special characters, unicode, tabs, trailing slashes."""
+
+    @pytest.mark.asyncio
+    async def test_special_characters(self, editor, ctx, tmp_path):
+        content = 'Special chars: @#$%^&*()_+-={}[]|:;"<>,.?/~`'
+        file_path = _write(tmp_path / "special.txt", content)
+        result = await editor(command="view", path=file_path, tool_context=ctx)
+        assert "Special chars:" in result
+
+    @pytest.mark.asyncio
+    async def test_unicode(self, editor, ctx, tmp_path):
+        content = "你好世界\n🚀 Emoji test\nΣ Greek letters"
+        file_path = _write(tmp_path / "unicode.txt", content)
+        result = await editor(command="view", path=file_path, tool_context=ctx)
+        assert "你好世界" in result
+        assert "🚀" in result
+
+    @pytest.mark.asyncio
+    async def test_expands_tabs(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "tabs.txt", "Line 1\tTab\tSeparated")
+        result = await editor(command="view", path=file_path, tool_context=ctx)
+        assert "\t" not in result
+
+    @pytest.mark.asyncio
+    async def test_handles_trailing_slash_on_file_path(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "trailing.txt", "content here")
+        result = await editor(command="view", path=f"{file_path}/", tool_context=ctx)
+        assert "content here" in result
+
+
+class TestSandboxErrorPropagation:
+    """A non-'not found' listing error must propagate, not be disguised as non-existence."""
+
+    @pytest.mark.asyncio
+    async def test_propagates_non_not_found_list_errors(self):
+        sandbox = NotASandboxLocalEnvironment()
+
+        async def boom(path, **kwargs):
+            raise OSError("EACCES: permission denied")
+
+        sandbox.list_files = boom  # type: ignore[method-assign]
+        editor = make_file_editor(sandbox)
+        with pytest.raises(OSError, match="permission denied"):
+            await editor(command="view", path="/tmp/x.txt", tool_context=_tool_context(sandbox))
+
+
+class TestToolMetadata:
+    """Tests for the file editor tool's name, description, and input schema."""
+
+    def test_default_name(self):
+        assert file_editor.tool_name == "file_editor"
+
+    def test_custom_name(self):
+        assert make_file_editor(name="sandbox_file_editor").tool_name == "sandbox_file_editor"
+
+    def test_default_description(self):
+        assert make_file_editor().tool_spec["description"] == DEFAULT_FILE_EDITOR_DESCRIPTION
+
+    def test_input_schema_excludes_context(self):
+        props = file_editor.tool_spec["inputSchema"]["json"]["properties"]
+        assert "command" in props
+        assert "path" in props
+        assert "tool_context" not in props

--- a/strands-py/tests/strands/vended_tools/test_file_editor.py
+++ b/strands-py/tests/strands/vended_tools/test_file_editor.py
@@ -41,7 +41,7 @@ def _write(path, content: str) -> str:
 @pytest.fixture
 def editor():
     """A file editor bound to a host sandbox, bound to a host sandbox."""
-    return make_file_editor(NotASandboxLocalEnvironment())
+    return make_file_editor(sandbox=NotASandboxLocalEnvironment())
 
 
 @pytest.fixture
@@ -416,7 +416,7 @@ class TestSandboxErrorPropagation:
             raise OSError("EACCES: permission denied")
 
         sandbox.list_files = boom  # type: ignore[method-assign]
-        editor = make_file_editor(sandbox)
+        editor = make_file_editor(sandbox=sandbox)
         with pytest.raises(OSError, match="permission denied"):
             await editor(command="view", path="/tmp/x.txt", tool_context=_tool_context(sandbox))
 

--- a/strands-py/tests/strands/vended_tools/test_file_editor.py
+++ b/strands-py/tests/strands/vended_tools/test_file_editor.py
@@ -1,9 +1,9 @@
 """Tests for the sandbox-routed file editor tool.
 
-Mirrors ``strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts``.
+Tests for the sandbox-routed file editor tool.
 The tool is exercised against a real ``NotASandboxLocalEnvironment`` (host
-filesystem), the same way the TS tests use ``TestSandbox``, and called directly
-(like a normal async function) mirroring TS's ``fileEditor.invoke(...)``. Errors
+filesystem), and called directly
+(like a normal async function). Errors
 surface as raised ``ValueError`` (the raw function raises; the error->status
 wrapping only happens through the tool's ``stream`` path). Path semantics assume
 POSIX, so these are skipped on Windows.
@@ -16,7 +16,8 @@ import pytest
 
 from strands.sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
 from strands.types.tools import ToolContext
-from strands.vended_tools.file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION, file_editor, make_file_editor
+from strands.vended_tools.file_editor import file_editor, make_file_editor
+from strands.vended_tools.file_editor.file_editor import DEFAULT_FILE_EDITOR_DESCRIPTION
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX path semantics assumed")
 
@@ -39,7 +40,7 @@ def _write(path, content: str) -> str:
 
 @pytest.fixture
 def editor():
-    """A file editor bound to a host sandbox, mirroring TS's makeFileEditor(new TestSandbox(...))."""
+    """A file editor bound to a host sandbox, bound to a host sandbox."""
     return make_file_editor(NotASandboxLocalEnvironment())
 
 
@@ -260,7 +261,7 @@ class TestStrReplace:
 
     @pytest.mark.asyncio
     async def test_preserves_dollar_patterns_literally(self, editor, ctx, tmp_path):
-        # Python's str.replace is literal, so $&/$1/$$ must survive verbatim (TS guards against regex semantics).
+        # Python's str.replace is literal, so $&/$1/$$ must survive verbatim
         file_path = _write(tmp_path / "test.txt", "const value = getPrice()")
         await editor(
             command="str_replace", path=file_path, tool_context=ctx, old_str="getPrice()", new_str="$& is not $1 or $$"


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

- Add vended tools (bash, file_editor), sandbox-compatible
- Update vended plugins (context_offloader, skills) to be sandbox-compatible
- Update agent init to auto register default tools set on sandbox

## Related Issues

<!-- Link to related issues using #issue-number format -->

- https://github.com/strands-agents/harness-sdk/pull/2563

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
