### PR TITLE
test(memory): assert S3 sidecar metadata and scope round-trip

### DIFF
--- a/strands-py/tests_integ/memory/test_bedrock_knowledge_base_store.py
+++ b/strands-py/tests_integ/memory/test_bedrock_knowledge_base_store.py
@@ -290,7 +290,10 @@ class TestS3DataSource:
         wait_for_indexed(kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "S3", "s3": {"uri": result.document_id}})
 
         entries = await store.search(marker, SearchOptions(max_search_results=10))
-        assert any(marker in entry.content for entry in entries)
+        match = next((entry for entry in entries if marker in entry.content), None)
+        assert match is not None
+        assert match.metadata is not None
+        assert match.metadata.get("namespace") == scope
 
     async def test_scope_isolates_s3_documents_from_other_scopes(
         self, skip_if_no_kb, bedrock_kb_context, kb_clients, cleanup_registrar
@@ -350,7 +353,7 @@ class TestS3DataSource:
     async def test_adds_with_metadata_in_the_sidecar(
         self, skip_if_no_kb, bedrock_kb_context, kb_clients, cleanup_registrar
     ):
-        """Caller metadata supplied to an S3 ``add`` is persisted via the sidecar, and the content stays searchable."""
+        """Caller metadata supplied to an S3 ``add`` round-trips through search via the sidecar."""
         kb_id = bedrock_kb_context.knowledge_base_id
         ds_id = bedrock_kb_context.s3_data_source_id
         bucket = bedrock_kb_context.s3_bucket
@@ -378,7 +381,11 @@ class TestS3DataSource:
         wait_for_indexed(kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "S3", "s3": {"uri": result.document_id}})
 
         entries = await store.search(marker, SearchOptions(max_search_results=10))
-        assert any(marker in entry.content for entry in entries)
+        match = next((entry for entry in entries if marker in entry.content), None)
+        assert match is not None
+        assert match.metadata is not None
+        assert match.metadata.get("category") == "testing"
+        assert match.metadata.get("count") == 7
 
 
 # --------------------------------------------------------------------------- #

--- a/strands-ts/test/integ/memory/bedrock-knowledge-base-store.test.node.ts
+++ b/strands-ts/test/integ/memory/bedrock-knowledge-base-store.test.node.ts
@@ -271,7 +271,9 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       })
 
       const entries = await store.search(marker, { maxSearchResults: 10 })
-      expect(entries.find((e: MemoryEntry) => e.content.includes(marker))).toBeDefined()
+      const match = entries.find((e: MemoryEntry) => e.content.includes(marker))
+      expect(match).toBeDefined()
+      expect(match!.metadata?.namespace).toBe(scope)
     }, 60_000)
 
     it('scope isolates S3 documents from other scopes', async () => {
@@ -351,7 +353,10 @@ describe('BedrockKnowledgeBaseStore Integration Tests', () => {
       })
 
       const entries = await store.search(marker, { maxSearchResults: 10 })
-      expect(entries.find((e: MemoryEntry) => e.content.includes(marker))).toBeDefined()
+      const match = entries.find((e: MemoryEntry) => e.content.includes(marker))
+      expect(match).toBeDefined()
+      expect(match!.metadata?.category).toBe('testing')
+      expect(match!.metadata?.count).toBe(7)
     }, 60_000)
   })
 


### PR DESCRIPTION
## Description

The two S3-data-source sidecar integration tests for `BedrockKnowledgeBaseStore` (`adds with metadata in the sidecar`, `adds with scope and writes a sidecar`) only asserted that the written content was searchable. That assertion is already covered by the non-scoped `adds and searches a document via S3` test, so despite their names, neither test verified anything about the `.metadata.json` sidecar they exist to exercise. Each would have passed even if the sidecar were never written, carried the wrong values, or the store ignored `scope` entirely.

This strengthens both to assert the sidecar round-trips through retrieval:

- **metadata test**: asserts caller metadata (`category`, `count`) comes back on the search result's `metadata`.
- **scope test**: asserts the store's `scope` is written to the sidecar as the `namespace` attribute and comes back on retrieval.

This mirrors how the CUSTOM-data-source metadata test (`adds with metadata attributes and returns them in search`) already asserts inline-attribute round-trip, so the S3 path now has equivalent coverage. Applied to both the Python and TypeScript integ suites to keep them in parity.

Verified against a live Bedrock Knowledge Base: both tests pass in Python and TypeScript.

## Type of Change

Other: test coverage (strengthens existing integration tests; no product code change)

## Testing

- [x] Ran the affected integ tests against a live Bedrock Knowledge Base (Python via `hatch test`, TypeScript via `npm run test:integ`); both pass.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)