### PR TITLE
test(context-offloader): raise timeout for sandbox isolation test

### DIFF
--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.node.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.node.ts
@@ -68,6 +68,10 @@ afterEach(() => {
 })
 
 describe.skipIf(process.platform === 'win32')('ContextOffloader with FileStorage', () => {
+  // Drives a real PosixShellSandbox, so every FileStorage operation spawns an `sh`
+  // subprocess (~9 spawns across both agents). Solo this is ~1.4s, but under the
+  // parallel coverage run the spawns serialize on CPU and push wall time past the
+  // 5s default, so allow extra headroom.
   it('isolates a shared storage config by agent sandbox', async () => {
     const dirA = makeTempDir()
     const dirB = makeTempDir()
@@ -106,5 +110,5 @@ describe.skipIf(process.platform === 'win32')('ContextOffloader with FileStorage
     await expect(retrievalTool.invoke({ reference: refA }, makeToolContext(agentB, refA))).resolves.toContain(
       'Error: reference not found'
     )
-  })
+  }, 15_000)
 })


### PR DESCRIPTION
## Description

The context-offloader test `isolates a shared storage config by agent sandbox` flakes during the pre-commit hook, failing intermittently with `Test timed out in 5000ms`.

The test exercises `FileStorage` against a real `PosixShellSandbox` (`TestSandbox`) on purpose, so it covers the actual sandbox code paths — base64 encoding, shell quoting, metadata sidecar I/O. That fidelity has a cost: every storage operation spawns an `sh` subprocess, and the test performs ~9 of them across its two agents. Run on its own the test finishes in ~1.4s, comfortably under the 5s default.

The flake only appears under the pre-commit hook, which runs `npm run test:coverage` — the full `unit-node` suite in parallel with v8 coverage. Other subprocess-heavy suites (e.g. `posix-shell.test.node.ts`, 46 such tests) are spawning `sh` at the same time, so the spawns serialize on CPU and each balloons from ~150ms to ~600ms. Wall time climbs to ~6s and trips the 5s ceiling. Isolating either variable confirms the cause: single-fork runs (with or without coverage) pass consistently at ~1.3s; only the parallel run fails.

Rather than weaken the test by faking the sandbox, this gives the test a 15s timeout — roughly 2.5x the observed ~6s peak under load. That absorbs a slower or busier CI machine while staying low enough that a genuine hang still fails fast.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

No documentation changes required.

## Type of Change

Bug fix

## Testing

Reproduced the flake by running the exact pre-commit command (`vitest run --coverage --project unit-node`), which failed on the timeout consistently. After the change, ran the same command repeatedly — the test now lands at ~5.8–6.4s and passes every time, with all 3495 unit tests green. Lint, format, and type-check pass.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
