### PR TITLE
refactor(memory): type the Bedrock KB store's S3 client via boto3-stubs

### DIFF
--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -128,7 +128,7 @@ dependencies = [
   "mypy>=1.15.0,<2.0.0",
   "ruff>=0.13.0,<0.15.0",
   # Include required package dependencies for mypy
-  "boto3-stubs[bedrock-agent,bedrock-agent-runtime]>=1.26.0,<2.0.0",
+  "boto3-stubs[bedrock-agent,bedrock-agent-runtime,s3]>=1.26.0,<2.0.0",
   "strands-agents @ {root:uri}",
 ]
 python = "3.10"

--- a/strands-py/src/strands/session/s3_session_manager.py
+++ b/strands-py/src/strands/session/s3_session_manager.py
@@ -16,6 +16,8 @@ from .repository_session_manager import RepositorySessionManager
 from .session_repository import SessionRepository
 
 if TYPE_CHECKING:
+    from mypy_boto3_s3.type_defs import ObjectIdentifierTypeDef
+
     from ..multiagent.base import MultiAgentBase
 
 logger = logging.getLogger(__name__)
@@ -193,7 +195,7 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             paginator = self.client.get_paginator("list_objects_v2")
             pages = paginator.paginate(Bucket=self.bucket, Prefix=session_prefix)
 
-            objects_to_delete = []
+            objects_to_delete: list[ObjectIdentifierTypeDef] = []
             for page in pages:
                 if "Contents" in page:
                     objects_to_delete.extend([{"Key": obj["Key"]} for obj in page["Contents"]])

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from mypy_boto3_bedrock_agent.type_defs import KnowledgeBaseDocumentTypeDef
     from mypy_boto3_bedrock_agent_runtime import AgentsforBedrockRuntimeClient
     from mypy_boto3_bedrock_agent_runtime.type_defs import KnowledgeBaseVectorSearchConfigurationTypeDef
+    from mypy_boto3_s3 import S3Client
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +111,7 @@ class BedrockKnowledgeBaseStore(MemoryStore):
         self._config = kb_config
         self._agent_client: AgentsforBedrockClient | None = kb_config.get("agent_client")
         s3_config = kb_config.get("s3")
-        self._s3_client: Any | None = s3_config.get("client") if s3_config else None
+        self._s3_client: S3Client | None = s3_config.get("client") if s3_config else None
         self._s3_config = s3_config
         self._knowledge_base_id = kb_config["knowledge_base_id"]
         self._data_source_type = kb_config.get("data_source_type")
@@ -425,7 +426,7 @@ class BedrockKnowledgeBaseStore(MemoryStore):
             )
         return self._data_source_id, self._data_source_type
 
-    def _get_s3_client(self) -> Any:
+    def _get_s3_client(self) -> S3Client:
         """Return the S3 client, constructing a default one lazily on first use.
 
         A default client is built with no extra configuration. Callers needing a specific region,

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
@@ -12,6 +12,7 @@ from ...memory.types import MemoryStoreConfig
 if TYPE_CHECKING:
     from mypy_boto3_bedrock_agent import AgentsforBedrockClient
     from mypy_boto3_bedrock_agent_runtime import AgentsforBedrockRuntimeClient
+    from mypy_boto3_s3 import S3Client
 
 
 class BedrockKnowledgeBaseS3Config(TypedDict, total=False):
@@ -47,7 +48,7 @@ class BedrockKnowledgeBaseS3Config(TypedDict, total=False):
 
     bucket: Required[str]
     prefix: Required[str]
-    client: Any
+    client: S3Client
 
 
 class BedrockKnowledgeBaseConfig(TypedDict, total=False):


### PR DESCRIPTION
## Description

The `BedrockKnowledgeBaseStore`'s S3 client was typed `Any` (on the `BedrockKnowledgeBaseS3Config.client` field, the cached `_s3_client`, and the lazy `_get_s3_client` getter), while its bedrock-agent clients were precisely typed via `boto3-stubs`. The S3 stub was deliberately omitted at the time because adding it sharpens `client("s3")` **repo-wide**, which surfaced a latent typing issue in the S3 session manager. This addresses both.

- Add the `s3` extra to the static-analysis `boto3-stubs` dependency and type the KB store's S3 client as `S3Client`.
- Fix the one issue the stub exposes: in `S3SessionManager.delete_session`, annotate `objects_to_delete` as `list[ObjectIdentifierTypeDef]` so the `delete_objects(Delete={"Objects": ...})` payload type-checks. The runtime payload (`[{"Key": ...}]`) was already correct; this only gives mypy the TypedDict it expects.

The session-manager change is a **required consequence** of adding the stub (mypy fails repo-wide otherwise), not unrelated work. Both are part of the single change "turn on S3 typing."

No runtime behavior changes; this is types-only.

## Type of Change

Other: type-accuracy refactor (no runtime behavior change)

## Testing

- [x] I ran `hatch run prepare`

`hatch fmt --linter --check` (ruff + `mypy ./src`, 213 files) clean; full unit suite green (3929 passed).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)