### PR TITLE
fix(openai): handle non-string error code in classifyOpenAIError

### DIFF
--- a/strands-ts/src/models/openai/__tests__/errors.test.ts
+++ b/strands-ts/src/models/openai/__tests__/errors.test.ts
@@ -31,4 +31,15 @@ describe('classifyOpenAIError', () => {
   it('returns undefined for unrelated errors', () => {
     expect(classifyOpenAIError(new Error('a totally unrelated failure'))).toBeUndefined()
   })
+
+  it('handles numeric error codes without throwing', () => {
+    const err = Object.assign(new Error('some error'), { code: 400 })
+    expect(() => classifyOpenAIError(err as any)).not.toThrow()
+    expect(classifyOpenAIError(err as any)).toBeUndefined()
+  })
+
+  it('handles null error code without throwing', () => {
+    const err = Object.assign(new Error('some error'), { code: null })
+    expect(() => classifyOpenAIError(err as any)).not.toThrow()
+  })
 })

--- a/strands-ts/src/models/openai/errors.ts
+++ b/strands-ts/src/models/openai/errors.ts
@@ -36,8 +36,11 @@ export type OpenAIErrorKind = 'contextOverflow' | 'throttling'
  *
  * @internal
  */
-export function classifyOpenAIError(err: Error & { status?: number; code?: string | number }): OpenAIErrorKind | undefined {
+export function classifyOpenAIError(err: Error & { status?: number; code?: string }): OpenAIErrorKind | undefined {
   const message = err.message?.toLowerCase() ?? ''
+  // The OpenAI SDK types `code` as a string, but OpenAI-compatible providers (e.g. OpenRouter)
+  // can return a number (`{ "error": { "code": 400 } }`). Guard with `typeof` before calling
+  // `.toLowerCase()` so a non-string code falls back to '' instead of throwing a TypeError.
   const code = typeof err.code === 'string' ? err.code.toLowerCase() : ''
 
   if (err.status === 429 || code === 'rate_limit_exceeded' || RATE_LIMIT_PATTERNS.some((p) => message.includes(p))) {

--- a/strands-ts/src/models/openai/errors.ts
+++ b/strands-ts/src/models/openai/errors.ts
@@ -36,9 +36,9 @@ export type OpenAIErrorKind = 'contextOverflow' | 'throttling'
  *
  * @internal
  */
-export function classifyOpenAIError(err: Error & { status?: number; code?: string }): OpenAIErrorKind | undefined {
+export function classifyOpenAIError(err: Error & { status?: number; code?: string | number }): OpenAIErrorKind | undefined {
   const message = err.message?.toLowerCase() ?? ''
-  const code = err.code?.toLowerCase() ?? ''
+  const code = typeof err.code === 'string' ? err.code.toLowerCase() : ''
 
   if (err.status === 429 || code === 'rate_limit_exceeded' || RATE_LIMIT_PATTERNS.some((p) => message.includes(p))) {
     return 'throttling'


### PR DESCRIPTION
## Summary

`classifyOpenAIError` crashes with `TypeError: err.code?.toLowerCase is not a function` when used with OpenAI-compatible APIs (e.g., OpenRouter) that return a numeric `code` in error responses.

## Root Cause

The OpenAI SDK's `APIError` class declares `code: string | null | undefined` but assigns it directly from the response body without type coercion (`this.code = data?.['code']`). When an OpenAI-compatible provider like OpenRouter returns `{ "error": { "code": 400, ... } }`, `err.code` is a number at runtime.

`classifyOpenAIError` then calls `err.code?.toLowerCase()` which throws because `Number.prototype` has no `toLowerCase` method.

## Fix

Use a `typeof` guard before calling `.toLowerCase()`:

```typescript
const code = typeof err.code === 'string' ? err.code.toLowerCase() : ''
```

Also widened the type signature to `code?: string | number` to reflect runtime reality.

## Testing

- Added test cases for numeric and null error codes
- All existing tests in `errors.test.ts` continue to pass

## Reproduction

Use the OpenAI model provider with OpenRouter's endpoint (`https://openrouter.ai/api/v1`) and trigger any error — the agent crashes instead of classifying the error properly.