### PR TITLE
docs(sandbox): add Sandbox concept section

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -89,6 +89,7 @@ sidebar:
               - docs/user-guide/concepts/plugins/steering
               - docs/user-guide/concepts/plugins/context-offloader
               - docs/user-guide/concepts/plugins/goal-loop
+          - docs/user-guide/concepts/sandbox
           - label: Interventions
             items:
               - label: "Overview"

--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -89,7 +89,12 @@ sidebar:
               - docs/user-guide/concepts/plugins/steering
               - docs/user-guide/concepts/plugins/context-offloader
               - docs/user-guide/concepts/plugins/goal-loop
-          - docs/user-guide/concepts/sandbox
+          - label: Sandbox
+            items:
+              - label: "Overview"
+                slug: docs/user-guide/concepts/sandbox
+              - docs/user-guide/concepts/sandbox/available-sandboxes
+              - docs/user-guide/concepts/sandbox/custom-sandbox
           - label: Interventions
             items:
               - label: "Overview"

--- a/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.mdx
+++ b/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.mdx
@@ -1,0 +1,164 @@
+---
+title: Available Sandboxes
+description: "Use the built-in Docker and SSH sandboxes to run an agent's work in a container or on a remote host, and drive a sandbox from your own code."
+tags: [tool-execution]
+---
+
+The SDK ships two concrete sandboxes. Both run commands by spawning a process on the host that targets the isolated environment, so neither needs an in-process runtime for the container or remote machine.
+
+| Sandbox | Runs commands in | Import from |
+|---------|------------------|-------------|
+| Docker | A running Docker container, via `docker exec` | <Syntax py="strands.sandbox.docker" ts="@strands-agents/sdk/sandbox/docker" plain /> |
+| SSH | A remote host, via OpenSSH | <Syntax py="strands.sandbox.ssh" ts="@strands-agents/sdk/sandbox/ssh" plain /> |
+
+This page assumes you have read the [Sandbox overview](./index.mdx): a sandbox routes an agent's command and file operations into an environment you provision, and vends the `sandbox_bash` and `sandbox_file_editor` tools bound to it.
+
+## Docker
+
+Use the Docker sandbox when you want the agent's work confined to a container you control. You start and manage the container; the sandbox runs commands in it with `docker exec`.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.sandbox.docker import DockerSandbox
+
+# working_dir and user are optional; omit them to use the container's defaults
+sandbox = DockerSandbox(
+    container="agent-workspace",
+    working_dir="/workspace",
+    user="1000:1000",
+)
+agent = Agent(sandbox=sandbox)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/available-sandboxes_imports.ts:docker_imports"
+
+--8<-- "user-guide/concepts/sandbox/available-sandboxes.ts:docker"
+```
+</Tab>
+</Tabs>
+
+The container is yours to scope. Drop its capabilities, run it read-only with a writable workspace volume, set a non-root user, and cut off the network unless the task needs it. The sandbox confines the agent to whatever that container can do, so the container's configuration is the actual boundary.
+
+## SSH
+
+Use the SSH sandbox to run the agent's work on a remote host. Each command spawns a fresh `ssh` process in batch mode, so authentication must be key-based: interactive password prompts are disabled. The working directory on the remote host is required.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.sandbox.ssh import SshSandbox
+
+sandbox = SshSandbox(
+    host="ubuntu@10.0.1.5",
+    working_dir="/home/ubuntu/workspace",
+    identity_file="~/.ssh/agent_key",
+)
+agent = Agent(sandbox=sandbox)
+```
+
+By default the SSH sandbox trusts a host key on first connect and rejects it if it later changes. It also rejects SSH options outside a vetted allowlist. Both guards can be loosened (`allow_unknown_hosts`, `allow_unsafe_ssh_options`) when you understand the tradeoff.
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/available-sandboxes_imports.ts:ssh_imports"
+
+--8<-- "user-guide/concepts/sandbox/available-sandboxes.ts:ssh"
+```
+
+By default the SSH sandbox trusts a host key on first connect and rejects it if it later changes. It also rejects SSH options outside a vetted allowlist. Both guards can be loosened (<Syntax ts="allowUnknownHosts" plain />, <Syntax ts="allowUnsafeSshOptions" plain />) when you understand the tradeoff.
+</Tab>
+</Tabs>
+
+The remote account is the boundary here. Scope it to the least privilege the task needs, and treat the host key pinning and option allowlist as defense in depth, not a license to feed the sandbox untrusted commands.
+
+## Working With a Sandbox Directly
+
+The sandbox is not only for the model. You can drive it from your own code through <Syntax py="agent.sandbox" ts="agent.sandbox" />, which is useful for setup, verification, and teardown around an agent run.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+import asyncio
+
+from strands import Agent
+from strands.sandbox.docker import DockerSandbox
+
+agent = Agent(sandbox=DockerSandbox(container="agent-workspace", working_dir="/workspace"))
+
+async def main():
+    # Seed an input file, let the agent work, then read the result back
+    await agent.sandbox.write_text("/workspace/input.csv", "id,value\n1,42\n")
+
+    agent("Summarize /workspace/input.csv and write the summary to /workspace/out.txt")
+
+    result = await agent.sandbox.execute("cat /workspace/out.txt")
+    print(result.exit_code, result.stdout)
+
+asyncio.run(main())
+```
+
+The file helpers come in two forms. `read_file` and `write_file` move raw `bytes` for binary content; `read_text` and `write_text` wrap them with UTF-8 encoding for the common case. `list_files` returns `FileInfo` entries, and `remove_file` deletes one.
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/available-sandboxes_imports.ts:direct_use_imports"
+
+--8<-- "user-guide/concepts/sandbox/available-sandboxes.ts:direct_use"
+```
+
+The file helpers come in two forms. <Syntax ts="readFile" plain /> and <Syntax ts="writeFile" plain /> move raw bytes for binary content; <Syntax ts="readText" plain /> and <Syntax ts="writeText" plain /> wrap them with UTF-8 encoding for the common case. <Syntax ts="listFiles" plain /> returns `FileInfo` entries, and <Syntax ts="removeFile" plain /> deletes one.
+</Tab>
+</Tabs>
+
+### Streaming Output
+
+`execute` waits for the command to finish and returns the full result. When you want output as it arrives, for a long-running build or a live log, use the streaming form. It yields stdout and stderr chunks as they are produced, then a final result with the exit code:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+import asyncio
+
+from strands import Agent
+from strands.sandbox import ExecutionResult, StreamChunk
+from strands.sandbox.docker import DockerSandbox
+
+agent = Agent(sandbox=DockerSandbox(container="agent-workspace", working_dir="/workspace"))
+
+async def main():
+    async for chunk in agent.sandbox.execute_streaming("npm run build"):
+        if isinstance(chunk, StreamChunk):
+            print(chunk.data, end="")
+        elif isinstance(chunk, ExecutionResult):
+            print(f"\nexit code: {chunk.exit_code}")
+
+asyncio.run(main())
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/available-sandboxes_imports.ts:streaming_imports"
+
+--8<-- "user-guide/concepts/sandbox/available-sandboxes.ts:streaming"
+```
+</Tab>
+</Tabs>
+
+## Next Steps
+
+- [Building a Custom Sandbox](./custom-sandbox.mdx): target a backend the built-ins do not cover
+- [Sandbox Overview](./index.mdx): what a sandbox is and the tools it vends
+- [Responsible AI](../../safety-security/responsible-ai.md): the shared-responsibility model for tool execution

--- a/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.mdx
+++ b/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.mdx
@@ -31,6 +31,8 @@ sandbox = DockerSandbox(
     user="1000:1000",
 )
 agent = Agent(sandbox=sandbox)
+
+agent("Run the test suite and summarize any failures")
 ```
 </Tab>
 <Tab label="TypeScript">
@@ -62,6 +64,8 @@ sandbox = SshSandbox(
     identity_file="~/.ssh/agent_key",
 )
 agent = Agent(sandbox=sandbox)
+
+agent("Run the test suite and summarize any failures")
 ```
 
 By default the SSH sandbox trusts a host key on first connect and rejects it if it later changes. It also rejects SSH options outside a vetted allowlist. Both guards can be loosened (`allow_unknown_hosts`, `allow_unsafe_ssh_options`) when you understand the tradeoff.
@@ -82,7 +86,7 @@ The remote account is the boundary here. Scope it to the least privilege the tas
 
 ## Working With a Sandbox Directly
 
-The sandbox is not only for the model. You can drive it from your own code through <Syntax py="agent.sandbox" ts="agent.sandbox" />, which is useful for setup, verification, and teardown around an agent run.
+A sandbox is a standalone object. You can construct one and drive it directly from your own code, independent of any agent, which is useful for setup, verification, and teardown, or for running commands in the environment without a model in the loop. The same instance can also be handed to an agent through the `sandbox` option so both share one environment.
 
 <Tabs>
 <Tab label="Python">
@@ -90,18 +94,16 @@ The sandbox is not only for the model. You can drive it from your own code throu
 ```python
 import asyncio
 
-from strands import Agent
 from strands.sandbox.docker import DockerSandbox
 
-agent = Agent(sandbox=DockerSandbox(container="agent-workspace", working_dir="/workspace"))
+sandbox = DockerSandbox(container="agent-workspace", working_dir="/workspace")
 
 async def main():
-    # Seed an input file, let the agent work, then read the result back
-    await agent.sandbox.write_text("/workspace/input.csv", "id,value\n1,42\n")
+    # Write an input file, run a command against it, then read the result back
+    await sandbox.write_text("/workspace/input.csv", "id,value\n1,42\n")
+    await sandbox.execute("wc -l < /workspace/input.csv > /workspace/out.txt")
 
-    agent("Summarize /workspace/input.csv and write the summary to /workspace/out.txt")
-
-    result = await agent.sandbox.execute("cat /workspace/out.txt")
+    result = await sandbox.execute("cat /workspace/out.txt")
     print(result.exit_code, result.stdout)
 
 asyncio.run(main())
@@ -131,14 +133,13 @@ The file helpers come in two forms. <Syntax ts="readFile" plain /> and <Syntax t
 ```python
 import asyncio
 
-from strands import Agent
 from strands.sandbox import ExecutionResult, StreamChunk
 from strands.sandbox.docker import DockerSandbox
 
-agent = Agent(sandbox=DockerSandbox(container="agent-workspace", working_dir="/workspace"))
+sandbox = DockerSandbox(container="agent-workspace", working_dir="/workspace")
 
 async def main():
-    async for chunk in agent.sandbox.execute_streaming("npm run build"):
+    async for chunk in sandbox.execute_streaming("npm run build"):
         if isinstance(chunk, StreamChunk):
             print(chunk.data, end="")
         elif isinstance(chunk, ExecutionResult):

--- a/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.ts
@@ -2,7 +2,7 @@ import { Agent } from '@strands-agents/sdk'
 import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
 import { SshSandbox } from '@strands-agents/sdk/sandbox/ssh'
 
-function docker() {
+async function docker() {
   // --8<-- [start:docker]
   // workingDir and user are optional; omit them to use the container's defaults
   const sandbox = new DockerSandbox({
@@ -11,11 +11,11 @@ function docker() {
     user: '1000:1000',
   })
   const agent = new Agent({ sandbox })
-  void agent
+  await agent.invoke('Run the test suite and summarize any failures')
   // --8<-- [end:docker]
 }
 
-function ssh() {
+async function ssh() {
   // --8<-- [start:ssh]
   const sandbox = new SshSandbox({
     host: 'ubuntu@10.0.1.5',
@@ -23,41 +23,34 @@ function ssh() {
     identityFile: '~/.ssh/agent_key',
   })
   const agent = new Agent({ sandbox })
-  void agent
+  await agent.invoke('Run the test suite and summarize any failures')
   // --8<-- [end:ssh]
 }
 
 async function directUse() {
   // --8<-- [start:direct_use]
-  const agent = new Agent({
-    sandbox: new DockerSandbox({
-      container: 'agent-workspace',
-      workingDir: '/workspace',
-    }),
+  const sandbox = new DockerSandbox({
+    container: 'agent-workspace',
+    workingDir: '/workspace',
   })
 
-  // Seed an input file, let the agent work, then read the result back
-  await agent.sandbox.writeText('/workspace/input.csv', 'id,value\n1,42\n')
+  // Write an input file, run a command against it, then read the result back
+  await sandbox.writeText('/workspace/input.csv', 'id,value\n1,42\n')
+  await sandbox.execute('wc -l < /workspace/input.csv > /workspace/out.txt')
 
-  await agent.invoke(
-    'Summarize /workspace/input.csv and write the summary to /workspace/out.txt'
-  )
-
-  const result = await agent.sandbox.execute('cat /workspace/out.txt')
+  const result = await sandbox.execute('cat /workspace/out.txt')
   console.log(result.exitCode, result.stdout)
   // --8<-- [end:direct_use]
 }
 
 async function streaming() {
   // --8<-- [start:streaming]
-  const agent = new Agent({
-    sandbox: new DockerSandbox({
-      container: 'agent-workspace',
-      workingDir: '/workspace',
-    }),
+  const sandbox = new DockerSandbox({
+    container: 'agent-workspace',
+    workingDir: '/workspace',
   })
 
-  for await (const chunk of agent.sandbox.executeStreaming('npm run build')) {
+  for await (const chunk of sandbox.executeStreaming('npm run build')) {
     if (chunk.type === 'streamChunk') {
       process.stdout.write(chunk.data)
     } else {

--- a/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.ts
@@ -1,0 +1,73 @@
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+import { SshSandbox } from '@strands-agents/sdk/sandbox/ssh'
+
+function docker() {
+  // --8<-- [start:docker]
+  // workingDir and user are optional; omit them to use the container's defaults
+  const sandbox = new DockerSandbox({
+    container: 'agent-workspace',
+    workingDir: '/workspace',
+    user: '1000:1000',
+  })
+  const agent = new Agent({ sandbox })
+  void agent
+  // --8<-- [end:docker]
+}
+
+function ssh() {
+  // --8<-- [start:ssh]
+  const sandbox = new SshSandbox({
+    host: 'ubuntu@10.0.1.5',
+    workingDir: '/home/ubuntu/workspace',
+    identityFile: '~/.ssh/agent_key',
+  })
+  const agent = new Agent({ sandbox })
+  void agent
+  // --8<-- [end:ssh]
+}
+
+async function directUse() {
+  // --8<-- [start:direct_use]
+  const agent = new Agent({
+    sandbox: new DockerSandbox({
+      container: 'agent-workspace',
+      workingDir: '/workspace',
+    }),
+  })
+
+  // Seed an input file, let the agent work, then read the result back
+  await agent.sandbox.writeText('/workspace/input.csv', 'id,value\n1,42\n')
+
+  await agent.invoke(
+    'Summarize /workspace/input.csv and write the summary to /workspace/out.txt'
+  )
+
+  const result = await agent.sandbox.execute('cat /workspace/out.txt')
+  console.log(result.exitCode, result.stdout)
+  // --8<-- [end:direct_use]
+}
+
+async function streaming() {
+  // --8<-- [start:streaming]
+  const agent = new Agent({
+    sandbox: new DockerSandbox({
+      container: 'agent-workspace',
+      workingDir: '/workspace',
+    }),
+  })
+
+  for await (const chunk of agent.sandbox.executeStreaming('npm run build')) {
+    if (chunk.type === 'streamChunk') {
+      process.stdout.write(chunk.data)
+    } else {
+      console.log(`\nexit code: ${chunk.exitCode}`)
+    }
+  }
+  // --8<-- [end:streaming]
+}
+
+void docker
+void ssh
+void directUse
+void streaming

--- a/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes_imports.ts
@@ -1,0 +1,22 @@
+// @ts-nocheck
+// Imports for the Available Sandboxes page snippets.
+
+// --8<-- [start:docker_imports]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+// --8<-- [end:docker_imports]
+
+// --8<-- [start:ssh_imports]
+import { Agent } from '@strands-agents/sdk'
+import { SshSandbox } from '@strands-agents/sdk/sandbox/ssh'
+// --8<-- [end:ssh_imports]
+
+// --8<-- [start:direct_use_imports]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+// --8<-- [end:direct_use_imports]
+
+// --8<-- [start:streaming_imports]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+// --8<-- [end:streaming_imports]

--- a/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes_imports.ts
@@ -12,11 +12,9 @@ import { SshSandbox } from '@strands-agents/sdk/sandbox/ssh'
 // --8<-- [end:ssh_imports]
 
 // --8<-- [start:direct_use_imports]
-import { Agent } from '@strands-agents/sdk'
 import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
 // --8<-- [end:direct_use_imports]
 
 // --8<-- [start:streaming_imports]
-import { Agent } from '@strands-agents/sdk'
 import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
 // --8<-- [end:streaming_imports]

--- a/site/src/content/docs/user-guide/concepts/sandbox/custom-sandbox.mdx
+++ b/site/src/content/docs/user-guide/concepts/sandbox/custom-sandbox.mdx
@@ -1,0 +1,114 @@
+---
+title: Building a Custom Sandbox
+description: "Target an execution environment the built-in sandboxes do not cover: a microVM, a remote code-execution API, or a managed runtime, and vend its tools."
+tags: [tool-execution]
+---
+
+Write a custom sandbox when your execution environment is not a local Docker container or an SSH host: a remote code-execution API, a microVM, or a managed runtime. The agent loop, the model, and the vended tools do not change. Only the transport between a tool and the environment does, and that lives behind a handful of methods on the `Sandbox` interface.
+
+This page assumes you have read the [Sandbox overview](./index.mdx) and seen the [built-in sandboxes](./available-sandboxes.mdx). You have two starting points, depending on whether your backend runs a POSIX shell.
+
+## Start From the Shell Base
+
+Most backends run a POSIX shell, so start from `PosixShellSandbox`. It implements code execution and every file operation in terms of shell commands, which means you implement exactly one method: <Syntax py="execute_streaming" ts="executeStreaming" />. Build the command line for your backend, run it, and yield the output.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from strands.sandbox import ExecutionResult, PosixShellSandbox, StreamChunk
+
+class FirecrackerSandbox(PosixShellSandbox):
+    """Run commands in a Firecracker microVM addressed by id."""
+
+    def __init__(self, vm_id: str) -> None:
+        self.vm_id = vm_id
+
+    async def execute_streaming(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        proc = await asyncio.create_subprocess_exec(
+            "fc-exec", self.vm_id, "sh", "-c", command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if stdout:
+            yield StreamChunk(data=stdout.decode(), stream_type="stdout")
+        if stderr:
+            yield StreamChunk(data=stderr.decode(), stream_type="stderr")
+        yield ExecutionResult(
+            exit_code=proc.returncode or 0,
+            stdout=stdout.decode(),
+            stderr=stderr.decode(),
+        )
+```
+
+The inherited methods now route through your `execute_streaming`: `execute_code` base64-encodes the source and pipes it to an interpreter, and the file operations run `cat`, `mkdir`, `ls`, and `rm` for you.
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/custom-sandbox_imports.ts:custom_posix_imports"
+
+--8<-- "user-guide/concepts/sandbox/custom-sandbox.ts:custom_posix"
+```
+
+The inherited methods now route through your <Syntax ts="executeStreaming" plain />: <Syntax ts="executeCode" plain /> base64-encodes the source and pipes it to an interpreter, and the file operations run `cat`, `mkdir`, `ls`, and `rm` for you.
+</Tab>
+</Tabs>
+
+## Extend the Base Interface Directly
+
+Extend the `Sandbox` base directly only when your backend is not shell-based, for example an HTTP code-execution API that returns structured results and generated files. Then you implement all six operations yourself: the two streaming methods plus <Syntax py="read_file" ts="readFile" />, <Syntax py="write_file" ts="writeFile" />, <Syntax py="remove_file" ts="removeFile" />, and <Syntax py="list_files" ts="listFiles" />.
+
+Prefer the shell base whenever your backend can run `sh -c`. Reach for the raw interface only when shaping every file operation as a shell command would be a worse fit than calling your backend's native API.
+
+## Vending Tools From a Custom Sandbox
+
+To give your sandbox the same `sandbox_bash` and `sandbox_file_editor` tools the built-in sandboxes provide, override <Syntax py="get_tools" ts="getTools" /> and return tools bound to it. The factories take the sandbox instance, so the tools route through it:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.types.tools import AgentTool
+from strands.vended_tools import make_bash, make_file_editor
+
+class FirecrackerSandbox(PosixShellSandbox):
+    # ... execute_streaming as above ...
+
+    def get_tools(self) -> list[AgentTool]:
+        return [
+            make_file_editor(sandbox=self, name="sandbox_file_editor"),
+            make_bash(sandbox=self, name="sandbox_bash"),
+        ]
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/custom-sandbox_imports.ts:custom_tools_imports"
+
+--8<-- "user-guide/concepts/sandbox/custom-sandbox.ts:custom_tools"
+```
+</Tab>
+</Tabs>
+
+A custom sandbox is a boundary only when the environment behind it is isolated. The interface routes operations; it does not confine them. Whatever the agent can reach through your `execute_streaming`, it can reach. See [Responsible AI](../../safety-security/responsible-ai.md) for the shared-responsibility model.
+
+## Next Steps
+
+- [Available Sandboxes](./available-sandboxes.mdx): the built-in Docker and SSH sandboxes
+- [Sandbox Overview](./index.mdx): what a sandbox is and the tools it vends
+- [Vended Tools](../tools/vended-tools.mdx): the bash and file editor factories a custom sandbox binds

--- a/site/src/content/docs/user-guide/concepts/sandbox/custom-sandbox.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/custom-sandbox.ts
@@ -1,0 +1,56 @@
+import { spawn } from 'node:child_process'
+import { PosixShellSandbox } from '@strands-agents/sdk/sandbox'
+import type {
+  ExecuteOptions,
+  ExecutionResult,
+  StreamChunk,
+} from '@strands-agents/sdk/sandbox'
+import type { Tool } from '@strands-agents/sdk'
+import { makeBash } from '@strands-agents/sdk/vended-tools/bash'
+import { makeFileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
+
+// --8<-- [start:custom_posix]
+class FirecrackerSandbox extends PosixShellSandbox {
+  constructor(private readonly vmId: string) {
+    super()
+  }
+
+  async *executeStreaming(
+    command: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    void options
+    const proc = spawn('fc-exec', [this.vmId, 'sh', '-c', command])
+
+    let stdout = ''
+    let stderr = ''
+    for await (const data of proc.stdout) {
+      const text = data.toString()
+      stdout += text
+      yield { type: 'streamChunk', data: text, streamType: 'stdout' }
+    }
+    for await (const data of proc.stderr) {
+      const text = data.toString()
+      stderr += text
+      yield { type: 'streamChunk', data: text, streamType: 'stderr' }
+    }
+    const exitCode: number = await new Promise((resolve) =>
+      proc.on('close', (code) => resolve(code ?? 0))
+    )
+    yield { type: 'executionResult', exitCode, stdout, stderr, outputFiles: [] }
+  }
+}
+// --8<-- [end:custom_posix]
+
+class FirecrackerSandboxWithTools extends FirecrackerSandbox {
+  // --8<-- [start:custom_tools]
+  override getTools(): Tool[] {
+    return [
+      makeFileEditor(this, { name: 'sandbox_file_editor' }),
+      makeBash(this, { name: 'sandbox_bash' }),
+    ]
+  }
+  // --8<-- [end:custom_tools]
+}
+
+void FirecrackerSandboxWithTools

--- a/site/src/content/docs/user-guide/concepts/sandbox/custom-sandbox_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/custom-sandbox_imports.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck
+// Imports for the Building a Custom Sandbox page snippets.
+
+// --8<-- [start:custom_posix_imports]
+import { spawn } from 'node:child_process'
+import { PosixShellSandbox } from '@strands-agents/sdk/sandbox'
+import type {
+  ExecuteOptions,
+  ExecutionResult,
+  StreamChunk,
+} from '@strands-agents/sdk/sandbox'
+// --8<-- [end:custom_posix_imports]
+
+// --8<-- [start:custom_tools_imports]
+import type { Tool } from '@strands-agents/sdk'
+import { makeBash } from '@strands-agents/sdk/vended-tools/bash'
+import { makeFileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
+// --8<-- [end:custom_tools_imports]

--- a/site/src/content/docs/user-guide/concepts/sandbox/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index.mdx
@@ -1,0 +1,392 @@
+---
+title: Sandbox
+description: "Run an agent's commands, code, and file operations inside an isolated sandbox: a Docker container or a remote host over SSH, with tools bound for you."
+tags: [tool-execution]
+---
+
+A sandbox is the execution environment where your agent runs commands, executes code, and reads or writes files. When you give an agent a sandbox, the tools that do this work stop touching the host process and route everything through the sandbox instead: a Docker container, a remote host over SSH, or your own backend.
+
+Without a sandbox, an agent that runs shell commands runs them directly on the machine hosting the agent, with that process's full permissions. That is fine for a trusted script on your own laptop. It is a liability the moment the agent acts on untrusted input or runs unattended in production. A sandbox draws the boundary: the agent decides *what* to run, the sandbox decides *where* it runs and what it can reach.
+
+The same sandbox also vends the tools the agent uses to act on it. Attach a Docker sandbox and the agent gains a `sandbox_bash` tool and a `sandbox_file_editor` tool already pointed at that container. You do not wire them up yourself.
+
+## Configuring a Sandbox
+
+You attach a sandbox when you create the agent. The agent registers the sandbox's tools during initialization, so the model can use them on the first turn:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.sandbox.docker import DockerSandbox
+
+# Point at a running container; the agent's shell and file tools run inside it
+sandbox = DockerSandbox(container="agent-workspace", working_dir="/workspace")
+agent = Agent(sandbox=sandbox)
+
+agent("Clone the repo at /workspace and run the test suite")
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/index_imports.ts:configuring_imports"
+
+--8<-- "user-guide/concepts/sandbox/index.ts:configuring"
+```
+</Tab>
+</Tabs>
+
+When you omit the sandbox, the agent falls back to a host execution environment with no isolation. The fallback exists so sandbox-aware tools work out of the box during development, not as a security boundary. Its deliberately blunt name says so:
+
+<Tabs>
+<Tab label="Python">
+
+`NotASandboxLocalEnvironment` runs commands and file operations directly on the host. Reach for an explicit sandbox whenever isolation matters.
+
+```python
+from strands import Agent
+
+# No sandbox: command and file tools run on the host with no isolation
+agent = Agent()
+print(type(agent.sandbox).__name__)
+
+# Typical output:
+# NotASandboxLocalEnvironment
+```
+</Tab>
+<Tab label="TypeScript">
+
+In Node.js, omitting the sandbox uses a host execution environment (`NotASandboxLocalEnvironment`). In the browser there is no host default, so reading <Syntax ts="agent.sandbox" plain /> throws until you configure one. Pass `false` to opt out explicitly and keep that intent stable even if the default changes later.
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/index_imports.ts:host_default_imports"
+
+--8<-- "user-guide/concepts/sandbox/index.ts:host_default"
+```
+</Tab>
+</Tabs>
+
+## Tools a Sandbox Vends
+
+Every built-in sandbox provides two tools, already bound to that sandbox instance:
+
+| Tool | What the agent does with it |
+|------|------------------------------|
+| `sandbox_bash` | Runs a shell command inside the sandbox and reads the output |
+| `sandbox_file_editor` | Views, creates, and edits files in the sandbox filesystem |
+
+These are the same building blocks as the standalone bash and file editor tools, with one difference: their operations execute inside the sandbox, and their descriptions name the target so the model knows where it is working ("Runs in Docker container ...").
+
+Registration follows one rule worth knowing. If you have already registered a tool with the same name, the sandbox's version is skipped and yours wins. That lets you override `sandbox_bash` with a stricter variant without fighting the sandbox:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.sandbox.docker import DockerSandbox
+from strands.vended_tools import make_bash
+
+sandbox = DockerSandbox(container="agent-workspace")
+
+# A read-only bash under the same name the sandbox uses
+locked_bash = make_bash(
+    sandbox=sandbox,
+    name="sandbox_bash",
+    description="Run read-only shell commands. Do not modify files.",
+)
+
+# The agent keeps locked_bash; the sandbox's own sandbox_bash is skipped
+agent = Agent(sandbox=sandbox, tools=[locked_bash])
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/index_imports.ts:override_tool_imports"
+
+--8<-- "user-guide/concepts/sandbox/index.ts:override_tool"
+```
+</Tab>
+</Tabs>
+
+## Available Sandboxes
+
+The SDK ships two concrete sandboxes. Both run commands by spawning a process on the host that targets the isolated environment, so neither needs an in-process runtime for the container or remote machine.
+
+| Sandbox | Runs commands in | Import from |
+|---------|------------------|-------------|
+| Docker | A running Docker container, via `docker exec` | <Syntax py="strands.sandbox.docker" ts="@strands-agents/sdk/sandbox/docker" plain /> |
+| SSH | A remote host, via OpenSSH | <Syntax py="strands.sandbox.ssh" ts="@strands-agents/sdk/sandbox/ssh" plain /> |
+
+### Docker
+
+Use the Docker sandbox when you want the agent's work confined to a container you control. You start and manage the container; the sandbox runs commands in it with `docker exec`.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.sandbox.docker import DockerSandbox
+
+# working_dir and user are optional; omit them to use the container's defaults
+sandbox = DockerSandbox(
+    container="agent-workspace",
+    working_dir="/workspace",
+    user="1000:1000",
+)
+agent = Agent(sandbox=sandbox)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/index_imports.ts:docker_imports"
+
+--8<-- "user-guide/concepts/sandbox/index.ts:docker"
+```
+</Tab>
+</Tabs>
+
+### SSH
+
+Use the SSH sandbox to run the agent's work on a remote host. Each command spawns a fresh `ssh` process in batch mode, so authentication must be key-based: interactive password prompts are disabled.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.sandbox.ssh import SshSandbox
+
+sandbox = SshSandbox(
+    host="ubuntu@10.0.1.5",
+    working_dir="/home/ubuntu/workspace",
+    identity_file="~/.ssh/agent_key",
+)
+agent = Agent(sandbox=sandbox)
+```
+
+By default the SSH sandbox trusts a host key on first connect and rejects it if it later changes. It also rejects SSH options outside a vetted allowlist. Both guards can be loosened (`allow_unknown_hosts`, `allow_unsafe_ssh_options`) when you understand the tradeoff.
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/index_imports.ts:ssh_imports"
+
+--8<-- "user-guide/concepts/sandbox/index.ts:ssh"
+```
+
+By default the SSH sandbox trusts a host key on first connect and rejects it if it later changes. It also rejects SSH options outside a vetted allowlist. Both guards can be loosened (<Syntax ts="allowUnknownHosts" plain />, <Syntax ts="allowUnsafeSshOptions" plain />) when you understand the tradeoff.
+</Tab>
+</Tabs>
+
+## Working With a Sandbox Directly
+
+The sandbox is not only for the model. You can drive it from your own code through <Syntax py="agent.sandbox" ts="agent.sandbox" />, which is useful for setup, verification, and teardown around an agent run.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+import asyncio
+
+from strands import Agent
+from strands.sandbox.docker import DockerSandbox
+
+agent = Agent(sandbox=DockerSandbox(container="agent-workspace", working_dir="/workspace"))
+
+async def main():
+    # Seed an input file, let the agent work, then read the result back
+    await agent.sandbox.write_text("/workspace/input.csv", "id,value\n1,42\n")
+
+    agent("Summarize /workspace/input.csv and write the summary to /workspace/out.txt")
+
+    result = await agent.sandbox.execute("cat /workspace/out.txt")
+    print(result.exit_code, result.stdout)
+
+asyncio.run(main())
+```
+
+The file helpers come in two forms. `read_file` and `write_file` move raw `bytes` for binary content; `read_text` and `write_text` wrap them with UTF-8 encoding for the common case. `list_files` returns `FileInfo` entries, and `remove_file` deletes one.
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/index_imports.ts:direct_use_imports"
+
+--8<-- "user-guide/concepts/sandbox/index.ts:direct_use"
+```
+
+The file helpers come in two forms. <Syntax ts="readFile" plain /> and <Syntax ts="writeFile" plain /> move raw bytes for binary content; <Syntax ts="readText" plain /> and <Syntax ts="writeText" plain /> wrap them with UTF-8 encoding for the common case. <Syntax ts="listFiles" plain /> returns `FileInfo` entries, and <Syntax ts="removeFile" plain /> deletes one.
+</Tab>
+</Tabs>
+
+### Streaming Output
+
+`execute` waits for the command to finish and returns the full result. When you want output as it arrives, for a long-running build or a live log, use the streaming form. It yields stdout and stderr chunks as they are produced, then a final result with the exit code:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+import asyncio
+
+from strands.sandbox import ExecutionResult, StreamChunk
+
+async def main():
+    async for chunk in agent.sandbox.execute_streaming("npm run build"):
+        if isinstance(chunk, StreamChunk):
+            print(chunk.data, end="")
+        elif isinstance(chunk, ExecutionResult):
+            print(f"\nexit code: {chunk.exit_code}")
+
+asyncio.run(main())
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/index_imports.ts:streaming_imports"
+
+--8<-- "user-guide/concepts/sandbox/index.ts:streaming"
+```
+</Tab>
+</Tabs>
+
+## How It Works
+
+The agent process and the sandbox are separate. The agent runs the model, holds conversation state, and decides which tools to call. The sandbox is the environment those tool calls reach into. A sandbox-aware tool does not run the command itself: it hands the command to the sandbox and waits for the result.
+
+```mermaid
+flowchart LR
+    subgraph runtime["Agent runtime (host process)"]
+        M[Model]
+        L[Agent loop]
+        T["sandbox_bash /\nsandbox_file_editor"]
+        M --> L
+        L --> T
+    end
+    subgraph sb["Sandbox (isolated environment)"]
+        E[Command / file operation]
+    end
+    T -->|execute, read_file, write_file| E
+    E -->|stdout, stderr, exit code| T
+```
+
+This separation is why a custom sandbox is small to write. The tools, the agent loop, and the model do not change when you swap environments. Only the transport between the tool and the execution environment changes, and that lives behind a handful of methods on the `Sandbox` interface.
+
+## Building a Custom Sandbox
+
+Write a custom sandbox when your execution environment is not a local Docker container or an SSH host: a remote code-execution API, a microVM, or a managed runtime. You have two starting points.
+
+Most backends run a POSIX shell, so start from `PosixShellSandbox`. It implements code execution and every file operation in terms of shell commands, which means you implement exactly one method: <Syntax py="execute_streaming" ts="executeStreaming" />. Build the command line for your backend, run it, and yield the output.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from strands.sandbox import ExecutionResult, PosixShellSandbox, StreamChunk
+
+class FirecrackerSandbox(PosixShellSandbox):
+    """Run commands in a Firecracker microVM addressed by id."""
+
+    def __init__(self, vm_id: str) -> None:
+        self.vm_id = vm_id
+
+    async def execute_streaming(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        proc = await asyncio.create_subprocess_exec(
+            "fc-exec", self.vm_id, "sh", "-c", command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if stdout:
+            yield StreamChunk(data=stdout.decode(), stream_type="stdout")
+        if stderr:
+            yield StreamChunk(data=stderr.decode(), stream_type="stderr")
+        yield ExecutionResult(
+            exit_code=proc.returncode or 0,
+            stdout=stdout.decode(),
+            stderr=stderr.decode(),
+        )
+```
+
+The inherited methods now route through your `execute_streaming`: `execute_code` base64-encodes the source and pipes it to an interpreter, and the file operations run `cat`, `mkdir`, `ls`, and `rm` for you.
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/index_imports.ts:custom_posix_imports"
+
+--8<-- "user-guide/concepts/sandbox/index.ts:custom_posix"
+```
+
+The inherited methods now route through your <Syntax ts="executeStreaming" plain />: <Syntax ts="executeCode" plain /> base64-encodes the source and pipes it to an interpreter, and the file operations run `cat`, `mkdir`, `ls`, and `rm` for you.
+</Tab>
+</Tabs>
+
+Extend the `Sandbox` base directly only when your backend is not shell-based, for example an HTTP code-execution API that returns structured results and generated files. Then you implement all six operations yourself: the two streaming methods plus <Syntax py="read_file" ts="readFile" />, <Syntax py="write_file" ts="writeFile" />, <Syntax py="remove_file" ts="removeFile" />, and <Syntax py="list_files" ts="listFiles" />.
+
+### Vending Tools From a Custom Sandbox
+
+To give your sandbox the same `sandbox_bash` and `sandbox_file_editor` tools the built-in sandboxes provide, override <Syntax py="get_tools" ts="getTools" /> and return tools bound to it. The factories take the sandbox instance, so the tools route through it:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.types.tools import AgentTool
+from strands.vended_tools import make_bash, make_file_editor
+
+class FirecrackerSandbox(PosixShellSandbox):
+    # ... execute_streaming as above ...
+
+    def get_tools(self) -> list[AgentTool]:
+        return [
+            make_file_editor(sandbox=self, name="sandbox_file_editor"),
+            make_bash(sandbox=self, name="sandbox_bash"),
+        ]
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/sandbox/index_imports.ts:custom_tools_imports"
+
+--8<-- "user-guide/concepts/sandbox/index.ts:custom_tools"
+```
+</Tab>
+</Tabs>
+
+## Security
+
+A sandbox is a boundary only when the environment behind it is isolated. The built-in Docker and SSH sandboxes confine the agent to a container or a remote host you control. The host fallback (`NotASandboxLocalEnvironment`) does not isolate anything: commands run with the full permissions of the agent process.
+
+:::caution[The default is not a sandbox]
+Omitting a sandbox runs the agent's command and file tools directly on the host. Treat this as convenience for trusted, local development only. For untrusted input or unattended production runs, pass an explicit Docker or SSH sandbox and scope the container or remote account to the least privilege the task needs.
+:::
+
+The shell-based sandboxes validate inputs that would otherwise let a command break out of its intended context: interpreter names and environment variable names are checked against strict patterns, and source code is transported base64-encoded rather than interpolated into a shell string. The SSH sandbox additionally pins host keys on first use and gates SSH options behind an allowlist. These are defense in depth, not a license to feed the sandbox untrusted commands without thought. See [Responsible AI](../../safety-security/responsible-ai.md) for the broader shared-responsibility model.
+
+## See also
+
+- [Vended Tools](../tools/vended-tools.mdx): the standalone bash and file editor tools the sandboxes bind
+- [Tools Overview](../tools/index.mdx): how tools extend agent capabilities
+- [Interrupts](../interrupts.mdx): require human approval before sensitive sandbox operations
+- [Responsible AI](../../safety-security/responsible-ai.md): the shared-responsibility model for tool execution

--- a/site/src/content/docs/user-guide/concepts/sandbox/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index.mdx
@@ -1,14 +1,26 @@
 ---
 title: Sandbox
-description: "Run an agent's commands, code, and file operations inside an isolated sandbox: a Docker container or a remote host over SSH, with tools bound for you."
+description: "Route an agent's commands, code, and file operations into an execution environment you provision: a Docker container, a remote host over SSH, or your own backend."
+sidebar:
+  label: "Overview"
 tags: [tool-execution]
 ---
 
-A sandbox is the execution environment where your agent runs commands, executes code, and reads or writes files. When you give an agent a sandbox, the tools that do this work stop touching the host process and route everything through the sandbox instead: a Docker container, a remote host over SSH, or your own backend.
+A sandbox is the interface an agent uses to reach an execution environment you provision. When you attach one, the tools that run commands, execute code, and read or write files stop touching the host process and route every operation through the sandbox instead: a Docker container, a remote host over SSH, or a backend you write.
 
-Without a sandbox, an agent that runs shell commands runs them directly on the machine hosting the agent, with that process's full permissions. That is fine for a trusted script on your own laptop. It is a liability the moment the agent acts on untrusted input or runs unattended in production. A sandbox draws the boundary: the agent decides *what* to run, the sandbox decides *where* it runs and what it can reach.
+The name invites a misread worth clearing up first. A sandbox does not sandbox the agent. The agent process, the model calls, and the agent loop keep running wherever you started them, with whatever permissions that process already has. What the sandbox changes is the destination of tool operations: the agent decides *what* to run, the sandbox decides *where* it runs. The isolation you get is the isolation of the environment you point it at, no more and no less. A `DockerSandbox` aimed at a privileged container with the host filesystem mounted is not a boundary. The same interface aimed at a locked-down container is.
 
 The same sandbox also vends the tools the agent uses to act on it. Attach a Docker sandbox and the agent gains a `sandbox_bash` tool and a `sandbox_file_editor` tool already pointed at that container. You do not wire them up yourself.
+
+## Two Ways to Run an Agent With a Sandbox
+
+There are two distinct patterns for combining an agent with a sandbox, and they answer different questions. OpenAI's [sandbox agents guide](https://developers.openai.com/api/docs/guides/agents/sandboxes) frames the same split as the boundary between the *harness* (the control plane that owns the agent loop, model calls, and tool routing) and *compute* (the execution plane where model-directed work runs).
+
+The first pattern is **the agent in a sandbox**. The runtime itself is the isolated environment: a container, a GitHub Action, a microVM with scoped credentials. The agent makes changes locally, and the worst it can do is bounded by that environment. This needs no SDK feature. Your deployment definition is the sandbox.
+
+The second pattern is **a sandbox for the agent**, and it is what this feature provides. The agent runtime stays where it is, in your trusted infrastructure, while command and file operations are routed into a separate execution environment. The control plane (model calls, conversation state, tool routing, approvals) stays put; only the execution plane moves. That separation lets you keep credentials, audit logs, and human review outside the environment where model-directed commands actually run.
+
+Reach for a Strands sandbox when you want that second pattern: the agent's reasoning runs in one place, and its commands and file edits run somewhere you have deliberately confined.
 
 ## Configuring a Sandbox
 
@@ -112,281 +124,43 @@ agent = Agent(sandbox=sandbox, tools=[locked_bash])
 </Tab>
 </Tabs>
 
-## Available Sandboxes
-
-The SDK ships two concrete sandboxes. Both run commands by spawning a process on the host that targets the isolated environment, so neither needs an in-process runtime for the container or remote machine.
-
-| Sandbox | Runs commands in | Import from |
-|---------|------------------|-------------|
-| Docker | A running Docker container, via `docker exec` | <Syntax py="strands.sandbox.docker" ts="@strands-agents/sdk/sandbox/docker" plain /> |
-| SSH | A remote host, via OpenSSH | <Syntax py="strands.sandbox.ssh" ts="@strands-agents/sdk/sandbox/ssh" plain /> |
-
-### Docker
-
-Use the Docker sandbox when you want the agent's work confined to a container you control. You start and manage the container; the sandbox runs commands in it with `docker exec`.
-
-<Tabs>
-<Tab label="Python">
-
-```python
-from strands import Agent
-from strands.sandbox.docker import DockerSandbox
-
-# working_dir and user are optional; omit them to use the container's defaults
-sandbox = DockerSandbox(
-    container="agent-workspace",
-    working_dir="/workspace",
-    user="1000:1000",
-)
-agent = Agent(sandbox=sandbox)
-```
-</Tab>
-<Tab label="TypeScript">
-
-```typescript
---8<-- "user-guide/concepts/sandbox/index_imports.ts:docker_imports"
-
---8<-- "user-guide/concepts/sandbox/index.ts:docker"
-```
-</Tab>
-</Tabs>
-
-### SSH
-
-Use the SSH sandbox to run the agent's work on a remote host. Each command spawns a fresh `ssh` process in batch mode, so authentication must be key-based: interactive password prompts are disabled.
-
-<Tabs>
-<Tab label="Python">
-
-```python
-from strands import Agent
-from strands.sandbox.ssh import SshSandbox
-
-sandbox = SshSandbox(
-    host="ubuntu@10.0.1.5",
-    working_dir="/home/ubuntu/workspace",
-    identity_file="~/.ssh/agent_key",
-)
-agent = Agent(sandbox=sandbox)
-```
-
-By default the SSH sandbox trusts a host key on first connect and rejects it if it later changes. It also rejects SSH options outside a vetted allowlist. Both guards can be loosened (`allow_unknown_hosts`, `allow_unsafe_ssh_options`) when you understand the tradeoff.
-</Tab>
-<Tab label="TypeScript">
-
-```typescript
---8<-- "user-guide/concepts/sandbox/index_imports.ts:ssh_imports"
-
---8<-- "user-guide/concepts/sandbox/index.ts:ssh"
-```
-
-By default the SSH sandbox trusts a host key on first connect and rejects it if it later changes. It also rejects SSH options outside a vetted allowlist. Both guards can be loosened (<Syntax ts="allowUnknownHosts" plain />, <Syntax ts="allowUnsafeSshOptions" plain />) when you understand the tradeoff.
-</Tab>
-</Tabs>
-
-## Working With a Sandbox Directly
-
-The sandbox is not only for the model. You can drive it from your own code through <Syntax py="agent.sandbox" ts="agent.sandbox" />, which is useful for setup, verification, and teardown around an agent run.
-
-<Tabs>
-<Tab label="Python">
-
-```python
-import asyncio
-
-from strands import Agent
-from strands.sandbox.docker import DockerSandbox
-
-agent = Agent(sandbox=DockerSandbox(container="agent-workspace", working_dir="/workspace"))
-
-async def main():
-    # Seed an input file, let the agent work, then read the result back
-    await agent.sandbox.write_text("/workspace/input.csv", "id,value\n1,42\n")
-
-    agent("Summarize /workspace/input.csv and write the summary to /workspace/out.txt")
-
-    result = await agent.sandbox.execute("cat /workspace/out.txt")
-    print(result.exit_code, result.stdout)
-
-asyncio.run(main())
-```
-
-The file helpers come in two forms. `read_file` and `write_file` move raw `bytes` for binary content; `read_text` and `write_text` wrap them with UTF-8 encoding for the common case. `list_files` returns `FileInfo` entries, and `remove_file` deletes one.
-</Tab>
-<Tab label="TypeScript">
-
-```typescript
---8<-- "user-guide/concepts/sandbox/index_imports.ts:direct_use_imports"
-
---8<-- "user-guide/concepts/sandbox/index.ts:direct_use"
-```
-
-The file helpers come in two forms. <Syntax ts="readFile" plain /> and <Syntax ts="writeFile" plain /> move raw bytes for binary content; <Syntax ts="readText" plain /> and <Syntax ts="writeText" plain /> wrap them with UTF-8 encoding for the common case. <Syntax ts="listFiles" plain /> returns `FileInfo` entries, and <Syntax ts="removeFile" plain /> deletes one.
-</Tab>
-</Tabs>
-
-### Streaming Output
-
-`execute` waits for the command to finish and returns the full result. When you want output as it arrives, for a long-running build or a live log, use the streaming form. It yields stdout and stderr chunks as they are produced, then a final result with the exit code:
-
-<Tabs>
-<Tab label="Python">
-
-```python
-import asyncio
-
-from strands.sandbox import ExecutionResult, StreamChunk
-
-async def main():
-    async for chunk in agent.sandbox.execute_streaming("npm run build"):
-        if isinstance(chunk, StreamChunk):
-            print(chunk.data, end="")
-        elif isinstance(chunk, ExecutionResult):
-            print(f"\nexit code: {chunk.exit_code}")
-
-asyncio.run(main())
-```
-</Tab>
-<Tab label="TypeScript">
-
-```typescript
---8<-- "user-guide/concepts/sandbox/index_imports.ts:streaming_imports"
-
---8<-- "user-guide/concepts/sandbox/index.ts:streaming"
-```
-</Tab>
-</Tabs>
-
 ## How It Works
 
 The agent process and the sandbox are separate. The agent runs the model, holds conversation state, and decides which tools to call. The sandbox is the environment those tool calls reach into. A sandbox-aware tool does not run the command itself: it hands the command to the sandbox and waits for the result.
 
 ```mermaid
 flowchart LR
-    subgraph runtime["Agent runtime (host process)"]
+    subgraph runtime["Agent runtime (your infrastructure)"]
         M[Model]
         L[Agent loop]
         T["sandbox_bash /\nsandbox_file_editor"]
         M --> L
         L --> T
     end
-    subgraph sb["Sandbox (isolated environment)"]
+    subgraph sb["Sandbox (execution environment you provision)"]
         E[Command / file operation]
     end
     T -->|execute, read_file, write_file| E
     E -->|stdout, stderr, exit code| T
 ```
 
-This separation is why a custom sandbox is small to write. The tools, the agent loop, and the model do not change when you swap environments. Only the transport between the tool and the execution environment changes, and that lives behind a handful of methods on the `Sandbox` interface.
-
-## Building a Custom Sandbox
-
-Write a custom sandbox when your execution environment is not a local Docker container or an SSH host: a remote code-execution API, a microVM, or a managed runtime. You have two starting points.
-
-Most backends run a POSIX shell, so start from `PosixShellSandbox`. It implements code execution and every file operation in terms of shell commands, which means you implement exactly one method: <Syntax py="execute_streaming" ts="executeStreaming" />. Build the command line for your backend, run it, and yield the output.
-
-<Tabs>
-<Tab label="Python">
-
-```python
-import asyncio
-from collections.abc import AsyncGenerator
-from typing import Any
-
-from strands.sandbox import ExecutionResult, PosixShellSandbox, StreamChunk
-
-class FirecrackerSandbox(PosixShellSandbox):
-    """Run commands in a Firecracker microVM addressed by id."""
-
-    def __init__(self, vm_id: str) -> None:
-        self.vm_id = vm_id
-
-    async def execute_streaming(
-        self,
-        command: str,
-        *,
-        timeout: float | None = None,
-        cwd: str | None = None,
-        env: dict[str, str] | None = None,
-        **kwargs: Any,
-    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
-        proc = await asyncio.create_subprocess_exec(
-            "fc-exec", self.vm_id, "sh", "-c", command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await proc.communicate()
-        if stdout:
-            yield StreamChunk(data=stdout.decode(), stream_type="stdout")
-        if stderr:
-            yield StreamChunk(data=stderr.decode(), stream_type="stderr")
-        yield ExecutionResult(
-            exit_code=proc.returncode or 0,
-            stdout=stdout.decode(),
-            stderr=stderr.decode(),
-        )
-```
-
-The inherited methods now route through your `execute_streaming`: `execute_code` base64-encodes the source and pipes it to an interpreter, and the file operations run `cat`, `mkdir`, `ls`, and `rm` for you.
-</Tab>
-<Tab label="TypeScript">
-
-```typescript
---8<-- "user-guide/concepts/sandbox/index_imports.ts:custom_posix_imports"
-
---8<-- "user-guide/concepts/sandbox/index.ts:custom_posix"
-```
-
-The inherited methods now route through your <Syntax ts="executeStreaming" plain />: <Syntax ts="executeCode" plain /> base64-encodes the source and pipes it to an interpreter, and the file operations run `cat`, `mkdir`, `ls`, and `rm` for you.
-</Tab>
-</Tabs>
-
-Extend the `Sandbox` base directly only when your backend is not shell-based, for example an HTTP code-execution API that returns structured results and generated files. Then you implement all six operations yourself: the two streaming methods plus <Syntax py="read_file" ts="readFile" />, <Syntax py="write_file" ts="writeFile" />, <Syntax py="remove_file" ts="removeFile" />, and <Syntax py="list_files" ts="listFiles" />.
-
-### Vending Tools From a Custom Sandbox
-
-To give your sandbox the same `sandbox_bash` and `sandbox_file_editor` tools the built-in sandboxes provide, override <Syntax py="get_tools" ts="getTools" /> and return tools bound to it. The factories take the sandbox instance, so the tools route through it:
-
-<Tabs>
-<Tab label="Python">
-
-```python
-from strands.types.tools import AgentTool
-from strands.vended_tools import make_bash, make_file_editor
-
-class FirecrackerSandbox(PosixShellSandbox):
-    # ... execute_streaming as above ...
-
-    def get_tools(self) -> list[AgentTool]:
-        return [
-            make_file_editor(sandbox=self, name="sandbox_file_editor"),
-            make_bash(sandbox=self, name="sandbox_bash"),
-        ]
-```
-</Tab>
-<Tab label="TypeScript">
-
-```typescript
---8<-- "user-guide/concepts/sandbox/index_imports.ts:custom_tools_imports"
-
---8<-- "user-guide/concepts/sandbox/index.ts:custom_tools"
-```
-</Tab>
-</Tabs>
+This is the harness-and-compute split made concrete. The model, the agent loop, and conversation state are the control plane and stay in your runtime. The command and file operations are the execution plane and run in the sandbox. Only the transport between a tool and the environment changes when you swap sandboxes, which is why a custom sandbox is small to write: it lives behind a handful of methods on the `Sandbox` interface.
 
 ## Security
 
-A sandbox is a boundary only when the environment behind it is isolated. The built-in Docker and SSH sandboxes confine the agent to a container or a remote host you control. The host fallback (`NotASandboxLocalEnvironment`) does not isolate anything: commands run with the full permissions of the agent process.
+A sandbox is a boundary only when the environment behind it is isolated. This is the part the name obscures, so it is worth stating plainly: the sandbox interface routes the agent's command and file operations into an environment, but it does not create the isolation. The guarantees you get are entirely the guarantees of the environment you provisioned and pointed it at.
+
+A Docker sandbox aimed at a container running as root, with the host Docker socket mounted, gives the agent a path to the host. The same interface aimed at a rootless container with dropped capabilities and no network is a real boundary. The interface is identical; the security is not. Scope the container or the remote account to the least privilege the task needs, and treat that configuration as the actual control.
 
 :::caution[The default is not a sandbox]
-Omitting a sandbox runs the agent's command and file tools directly on the host. Treat this as convenience for trusted, local development only. For untrusted input or unattended production runs, pass an explicit Docker or SSH sandbox and scope the container or remote account to the least privilege the task needs.
+Omitting a sandbox runs the agent's command and file tools directly on the host with the full permissions of the agent process. Treat this as convenience for trusted, local development only. For untrusted input or unattended production runs, pass an explicit Docker or SSH sandbox and confine the environment behind it.
 :::
 
-The shell-based sandboxes validate inputs that would otherwise let a command break out of its intended context: interpreter names and environment variable names are checked against strict patterns, and source code is transported base64-encoded rather than interpolated into a shell string. The SSH sandbox additionally pins host keys on first use and gates SSH options behind an allowlist. These are defense in depth, not a license to feed the sandbox untrusted commands without thought. See [Responsible AI](../../safety-security/responsible-ai.md) for the broader shared-responsibility model.
+The built-in sandboxes add defense in depth on top of whatever you configure, not in place of it. They validate inputs that would otherwise let a command break out of its intended context, and the SSH sandbox pins host keys and gates SSH options behind an allowlist. Those guards are detailed alongside each sandbox in [Available Sandboxes](./available-sandboxes.mdx). They reduce the blast radius of a mistake; they do not make an unconfined environment safe. See [Responsible AI](../../safety-security/responsible-ai.md) for the broader shared-responsibility model.
 
-## See also
+## Next Steps
 
+- [Available Sandboxes](./available-sandboxes.mdx): the built-in Docker and SSH sandboxes, and driving a sandbox from your own code
+- [Building a Custom Sandbox](./custom-sandbox.mdx): target a backend the built-ins do not cover, and vend its tools
 - [Vended Tools](../tools/vended-tools.mdx): the standalone bash and file editor tools the sandboxes bind
-- [Tools Overview](../tools/index.mdx): how tools extend agent capabilities
-- [Interrupts](../interrupts.mdx): require human approval before sensitive sandbox operations
 - [Responsible AI](../../safety-security/responsible-ai.md): the shared-responsibility model for tool execution

--- a/site/src/content/docs/user-guide/concepts/sandbox/index.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index.ts
@@ -1,0 +1,157 @@
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+import { SshSandbox } from '@strands-agents/sdk/sandbox/ssh'
+import { PosixShellSandbox } from '@strands-agents/sdk/sandbox'
+import type { ExecuteOptions, ExecutionResult, StreamChunk } from '@strands-agents/sdk/sandbox'
+import type { Tool } from '@strands-agents/sdk'
+import { makeBash } from '@strands-agents/sdk/vended-tools/bash'
+import { makeFileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
+import { spawn } from 'node:child_process'
+
+async function configuring() {
+  // --8<-- [start:configuring]
+  // Point at a running container; the agent's shell and file tools run inside it
+  const sandbox = new DockerSandbox({
+    container: 'agent-workspace',
+    workingDir: '/workspace',
+  })
+  const agent = new Agent({ sandbox })
+
+  await agent.invoke('Clone the repo at /workspace and run the test suite')
+  // --8<-- [end:configuring]
+}
+
+function hostDefault() {
+  // --8<-- [start:host_default]
+  // No sandbox: command and file tools run on the host with no isolation
+  const agent = new Agent()
+  console.log(agent.sandbox.constructor.name)
+  // Typical output:
+  // NotASandboxLocalEnvironment
+
+  // Opt out explicitly to keep that intent stable if the default changes
+  const explicitHost = new Agent({ sandbox: false })
+  void explicitHost
+  // --8<-- [end:host_default]
+}
+
+function overrideTool() {
+  // --8<-- [start:override_tool]
+  const sandbox = new DockerSandbox({ container: 'agent-workspace' })
+
+  // A read-only bash under the same name the sandbox uses
+  const lockedBash = makeBash(sandbox, {
+    name: 'sandbox_bash',
+    description: 'Run read-only shell commands. Do not modify files.',
+  })
+
+  // The agent keeps lockedBash; the sandbox's own sandbox_bash is skipped
+  const agent = new Agent({ sandbox, tools: [lockedBash] })
+  void agent
+  // --8<-- [end:override_tool]
+}
+
+function docker() {
+  // --8<-- [start:docker]
+  // workingDir and user are optional; omit them to use the container's defaults
+  const sandbox = new DockerSandbox({
+    container: 'agent-workspace',
+    workingDir: '/workspace',
+    user: '1000:1000',
+  })
+  const agent = new Agent({ sandbox })
+  void agent
+  // --8<-- [end:docker]
+}
+
+function ssh() {
+  // --8<-- [start:ssh]
+  const sandbox = new SshSandbox({
+    host: 'ubuntu@10.0.1.5',
+    workingDir: '/home/ubuntu/workspace',
+    identityFile: '~/.ssh/agent_key',
+  })
+  const agent = new Agent({ sandbox })
+  void agent
+  // --8<-- [end:ssh]
+}
+
+async function directUse() {
+  // --8<-- [start:direct_use]
+  const agent = new Agent({
+    sandbox: new DockerSandbox({ container: 'agent-workspace', workingDir: '/workspace' }),
+  })
+
+  // Seed an input file, let the agent work, then read the result back
+  await agent.sandbox.writeText('/workspace/input.csv', 'id,value\n1,42\n')
+
+  await agent.invoke('Summarize /workspace/input.csv and write the summary to /workspace/out.txt')
+
+  const result = await agent.sandbox.execute('cat /workspace/out.txt')
+  console.log(result.exitCode, result.stdout)
+  // --8<-- [end:direct_use]
+}
+
+async function streaming() {
+  // --8<-- [start:streaming]
+  const agent = new Agent({
+    sandbox: new DockerSandbox({ container: 'agent-workspace', workingDir: '/workspace' }),
+  })
+
+  for await (const chunk of agent.sandbox.executeStreaming('npm run build')) {
+    if (chunk.type === 'streamChunk') {
+      process.stdout.write(chunk.data)
+    } else {
+      console.log(`\nexit code: ${chunk.exitCode}`)
+    }
+  }
+  // --8<-- [end:streaming]
+}
+
+// --8<-- [start:custom_posix]
+class FirecrackerSandbox extends PosixShellSandbox {
+  constructor(private readonly vmId: string) {
+    super()
+  }
+
+  async *executeStreaming(
+    command: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    void options
+    const proc = spawn('fc-exec', [this.vmId, 'sh', '-c', command])
+
+    let stdout = ''
+    let stderr = ''
+    for await (const data of proc.stdout) {
+      const text = data.toString()
+      stdout += text
+      yield { type: 'streamChunk', data: text, streamType: 'stdout' }
+    }
+    for await (const data of proc.stderr) {
+      const text = data.toString()
+      stderr += text
+      yield { type: 'streamChunk', data: text, streamType: 'stderr' }
+    }
+    const exitCode: number = await new Promise((resolve) => proc.on('close', (code) => resolve(code ?? 0)))
+    yield { type: 'executionResult', exitCode, stdout, stderr, outputFiles: [] }
+  }
+}
+// --8<-- [end:custom_posix]
+
+class FirecrackerSandboxWithTools extends FirecrackerSandbox {
+  // --8<-- [start:custom_tools]
+  override getTools(): Tool[] {
+    return [makeFileEditor(this, { name: 'sandbox_file_editor' }), makeBash(this, { name: 'sandbox_bash' })]
+  }
+  // --8<-- [end:custom_tools]
+}
+
+void configuring
+void hostDefault
+void overrideTool
+void docker
+void ssh
+void directUse
+void streaming
+void FirecrackerSandboxWithTools

--- a/site/src/content/docs/user-guide/concepts/sandbox/index.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index.ts
@@ -1,12 +1,6 @@
 import { Agent } from '@strands-agents/sdk'
 import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
-import { SshSandbox } from '@strands-agents/sdk/sandbox/ssh'
-import { PosixShellSandbox } from '@strands-agents/sdk/sandbox'
-import type { ExecuteOptions, ExecutionResult, StreamChunk } from '@strands-agents/sdk/sandbox'
-import type { Tool } from '@strands-agents/sdk'
 import { makeBash } from '@strands-agents/sdk/vended-tools/bash'
-import { makeFileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
-import { spawn } from 'node:child_process'
 
 async function configuring() {
   // --8<-- [start:configuring]
@@ -51,107 +45,6 @@ function overrideTool() {
   // --8<-- [end:override_tool]
 }
 
-function docker() {
-  // --8<-- [start:docker]
-  // workingDir and user are optional; omit them to use the container's defaults
-  const sandbox = new DockerSandbox({
-    container: 'agent-workspace',
-    workingDir: '/workspace',
-    user: '1000:1000',
-  })
-  const agent = new Agent({ sandbox })
-  void agent
-  // --8<-- [end:docker]
-}
-
-function ssh() {
-  // --8<-- [start:ssh]
-  const sandbox = new SshSandbox({
-    host: 'ubuntu@10.0.1.5',
-    workingDir: '/home/ubuntu/workspace',
-    identityFile: '~/.ssh/agent_key',
-  })
-  const agent = new Agent({ sandbox })
-  void agent
-  // --8<-- [end:ssh]
-}
-
-async function directUse() {
-  // --8<-- [start:direct_use]
-  const agent = new Agent({
-    sandbox: new DockerSandbox({ container: 'agent-workspace', workingDir: '/workspace' }),
-  })
-
-  // Seed an input file, let the agent work, then read the result back
-  await agent.sandbox.writeText('/workspace/input.csv', 'id,value\n1,42\n')
-
-  await agent.invoke('Summarize /workspace/input.csv and write the summary to /workspace/out.txt')
-
-  const result = await agent.sandbox.execute('cat /workspace/out.txt')
-  console.log(result.exitCode, result.stdout)
-  // --8<-- [end:direct_use]
-}
-
-async function streaming() {
-  // --8<-- [start:streaming]
-  const agent = new Agent({
-    sandbox: new DockerSandbox({ container: 'agent-workspace', workingDir: '/workspace' }),
-  })
-
-  for await (const chunk of agent.sandbox.executeStreaming('npm run build')) {
-    if (chunk.type === 'streamChunk') {
-      process.stdout.write(chunk.data)
-    } else {
-      console.log(`\nexit code: ${chunk.exitCode}`)
-    }
-  }
-  // --8<-- [end:streaming]
-}
-
-// --8<-- [start:custom_posix]
-class FirecrackerSandbox extends PosixShellSandbox {
-  constructor(private readonly vmId: string) {
-    super()
-  }
-
-  async *executeStreaming(
-    command: string,
-    options?: ExecuteOptions
-  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
-    void options
-    const proc = spawn('fc-exec', [this.vmId, 'sh', '-c', command])
-
-    let stdout = ''
-    let stderr = ''
-    for await (const data of proc.stdout) {
-      const text = data.toString()
-      stdout += text
-      yield { type: 'streamChunk', data: text, streamType: 'stdout' }
-    }
-    for await (const data of proc.stderr) {
-      const text = data.toString()
-      stderr += text
-      yield { type: 'streamChunk', data: text, streamType: 'stderr' }
-    }
-    const exitCode: number = await new Promise((resolve) => proc.on('close', (code) => resolve(code ?? 0)))
-    yield { type: 'executionResult', exitCode, stdout, stderr, outputFiles: [] }
-  }
-}
-// --8<-- [end:custom_posix]
-
-class FirecrackerSandboxWithTools extends FirecrackerSandbox {
-  // --8<-- [start:custom_tools]
-  override getTools(): Tool[] {
-    return [makeFileEditor(this, { name: 'sandbox_file_editor' }), makeBash(this, { name: 'sandbox_bash' })]
-  }
-  // --8<-- [end:custom_tools]
-}
-
 void configuring
 void hostDefault
 void overrideTool
-void docker
-void ssh
-void directUse
-void streaming
-void FirecrackerSandboxWithTools

--- a/site/src/content/docs/user-guide/concepts/sandbox/index_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index_imports.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+// Imports for the Sandbox overview page snippets.
+
+// --8<-- [start:configuring_imports]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+// --8<-- [end:configuring_imports]
+
+// --8<-- [start:host_default_imports]
+import { Agent } from '@strands-agents/sdk'
+// --8<-- [end:host_default_imports]
+
+// --8<-- [start:override_tool_imports]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+import { makeBash } from '@strands-agents/sdk/vended-tools/bash'
+// --8<-- [end:override_tool_imports]
+
+// --8<-- [start:docker_imports]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+// --8<-- [end:docker_imports]
+
+// --8<-- [start:ssh_imports]
+import { Agent } from '@strands-agents/sdk'
+import { SshSandbox } from '@strands-agents/sdk/sandbox/ssh'
+// --8<-- [end:ssh_imports]
+
+// --8<-- [start:direct_use_imports]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+// --8<-- [end:direct_use_imports]
+
+// --8<-- [start:streaming_imports]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+// --8<-- [end:streaming_imports]
+
+// --8<-- [start:custom_posix_imports]
+import { spawn } from 'node:child_process'
+import { PosixShellSandbox } from '@strands-agents/sdk/sandbox'
+import type { ExecuteOptions, ExecutionResult, StreamChunk } from '@strands-agents/sdk/sandbox'
+// --8<-- [end:custom_posix_imports]
+
+// --8<-- [start:custom_tools_imports]
+import type { Tool } from '@strands-agents/sdk'
+import { makeBash } from '@strands-agents/sdk/vended-tools/bash'
+import { makeFileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
+// --8<-- [end:custom_tools_imports]

--- a/site/src/content/docs/user-guide/concepts/sandbox/index_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index_imports.ts
@@ -15,35 +15,3 @@ import { Agent } from '@strands-agents/sdk'
 import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
 import { makeBash } from '@strands-agents/sdk/vended-tools/bash'
 // --8<-- [end:override_tool_imports]
-
-// --8<-- [start:docker_imports]
-import { Agent } from '@strands-agents/sdk'
-import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
-// --8<-- [end:docker_imports]
-
-// --8<-- [start:ssh_imports]
-import { Agent } from '@strands-agents/sdk'
-import { SshSandbox } from '@strands-agents/sdk/sandbox/ssh'
-// --8<-- [end:ssh_imports]
-
-// --8<-- [start:direct_use_imports]
-import { Agent } from '@strands-agents/sdk'
-import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
-// --8<-- [end:direct_use_imports]
-
-// --8<-- [start:streaming_imports]
-import { Agent } from '@strands-agents/sdk'
-import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
-// --8<-- [end:streaming_imports]
-
-// --8<-- [start:custom_posix_imports]
-import { spawn } from 'node:child_process'
-import { PosixShellSandbox } from '@strands-agents/sdk/sandbox'
-import type { ExecuteOptions, ExecutionResult, StreamChunk } from '@strands-agents/sdk/sandbox'
-// --8<-- [end:custom_posix_imports]
-
-// --8<-- [start:custom_tools_imports]
-import type { Tool } from '@strands-agents/sdk'
-import { makeBash } from '@strands-agents/sdk/vended-tools/bash'
-import { makeFileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
-// --8<-- [end:custom_tools_imports]


### PR DESCRIPTION
## Description

Adds a **Sandbox** concept section to the docs, organized as a multi-page section like Tools and Model Providers. It documents the sandbox feature end to end: what a sandbox is and how to think about it, the built-in backends, driving a sandbox from your own code, and how to build a custom one.

**Framing.** A Strands sandbox is the *interface* an agent uses to reach an execution environment you provision. It does not sandbox the agent process; the isolation you get is whatever the environment behind it (a container, a remote host, your own backend) provides. The overview makes this explicit with a `Two Ways to Run an Agent With a Sandbox` section built on the harness/compute (control plane vs. execution plane) split, the same distinction OpenAI's [sandbox agents guide](https://developers.openai.com/api/docs/guides/agents/sandboxes) draws.

### Page structure

The section lands under Concepts in `navigation.yml`, between Plugins and Interventions, as a labeled **Sandbox** group with three pages:

- **Overview** (`index.mdx`): what a sandbox is, the agent-in-sandbox vs. sandbox-for-agent patterns, configuring a sandbox, the tools it vends and the same-name override rule, a mermaid diagram of the runtime/sandbox boundary, and a Security section grounding the guarantees in the environment you configure.
- **Available Sandboxes** (`available-sandboxes.mdx`): the built-in Docker and SSH sandboxes with their constructors and security defaults, driving a sandbox directly (`execute`, the file helpers), and streaming output.
- **Building a Custom Sandbox** (`custom-sandbox.mdx`): `PosixShellSandbox` (one method) vs. extending `Sandbox`, and vending tools via `get_tools` / `getTools`.

Python is inlined; TypeScript lives in sibling `.ts` snippet files (one pair per page) included via `--8<--`, per the repo's MDX conventions.

## Type of Change

Documentation update

## Testing

- **Full site build passes** (`npm run build`): 686 pages built, snippet includes resolve (no leftover `--8<--` markers in the rendered HTML), the mermaid diagram and language tabs render, frontmatter validates, and the broken-link checker reports no broken links.
- **TypeScript snippets typecheck.** Built the TypeScript SDK (`strands-ts`) and ran `tsc --noEmit` from `site/test-snippets`: 0 errors across all snippet files.
- **Code verified against SDK source** in both languages (`strands-py/src/strands/sandbox/`, `strands-ts/src/sandbox/`): `DockerSandbox`/`SshSandbox` constructors, `Agent(sandbox=...)` and the `sandbox: false` opt-out, `get_tools()` vending `sandbox_file_editor` + `sandbox_bash`, and the `Sandbox` / `PosixShellSandbox` method surface.
- **Voice and style gate.** Ran the docs-reviewer checks: no em-dashes, no emoji, no banned phrases, terminology matches the lock file, and code examples are self-contained and claim-accurate.
- **Prettier** formats the snippet `.ts` files cleanly.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR
- [x] My change is focused and reasonably small
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
