### PR TITLE
fix: bound tool schema normalization recursion depth

### DIFF
--- a/strands-py/src/strands/tools/registry.py
+++ b/strands-py/src/strands/tools/registry.py
@@ -214,7 +214,7 @@ class ToolRegistry:
                 self.validate_tool_spec(spec)
                 tool_config[tool_name] = spec
                 logger.debug("tool_name=<%s> | loaded tool config", tool_name)
-            except ValueError as e:
+            except (ValueError, RecursionError) as e:
                 logger.warning("tool_name=<%s> | spec validation failed | %s", tool_name, e)
 
         # Add any dynamic tools
@@ -228,7 +228,7 @@ class ToolRegistry:
                     self.validate_tool_spec(spec)
                     tool_config[tool_name] = spec
                     logger.debug("tool_name=<%s> | loaded dynamic tool config", tool_name)
-                except ValueError as e:
+                except (ValueError, RecursionError) as e:
                     logger.warning("tool_name=<%s> | dynamic tool spec validation failed | %s", tool_name, e)
 
         logger.debug("tool_count=<%s> | tools configured", len(tool_config))

--- a/strands-py/src/strands/tools/tools.py
+++ b/strands-py/src/strands/tools/tools.py
@@ -23,6 +23,14 @@ _COMPOSITION_KEYWORDS = ("anyOf", "oneOf", "allOf", "not")
 Properties with these should not get a default type: "string" added.
 """
 
+_MAX_SCHEMA_DEPTH = 64
+"""Maximum nesting depth permitted when normalizing a tool inputSchema.
+
+Bounds the mutual recursion between normalize_schema and _normalize_property so that a
+maliciously deep schema (e.g. from an untrusted MCP server) raises ValueError instead of
+exhausting the interpreter stack with RecursionError.
+"""
+
 
 class InvalidToolUseNameException(Exception):
     """Exception raised when a tool use has an invalid name."""
@@ -71,21 +79,25 @@ def validate_tool_use_name(tool: ToolUse) -> None:
         raise InvalidToolUseNameException(message)
 
 
-def _normalize_property(prop_name: str, prop_def: Any) -> dict[str, Any]:
+def _normalize_property(prop_name: str, prop_def: Any, *, _depth: int = 0) -> dict[str, Any]:
     """Normalize a single property definition.
 
     Args:
         prop_name: The name of the property.
         prop_def: The property definition to normalize.
+        _depth: Current nesting depth, used to bound recursion into nested object schemas.
 
     Returns:
         The normalized property definition.
+
+    Raises:
+        ValueError: If the schema nesting exceeds _MAX_SCHEMA_DEPTH.
     """
     if not isinstance(prop_def, dict):
         return {"type": "string", "description": f"Property {prop_name}"}
 
     if prop_def.get("type") == "object" and "properties" in prop_def:
-        return normalize_schema(prop_def)  # Recursive call
+        return normalize_schema(prop_def, _depth=_depth + 1)  # Recursive call
 
     # Copy existing property, ensuring defaults
     normalized_prop = prop_def.copy()
@@ -101,7 +113,7 @@ def _normalize_property(prop_name: str, prop_def: Any) -> dict[str, Any]:
     return normalized_prop
 
 
-def normalize_schema(schema: dict[str, Any]) -> dict[str, Any]:
+def normalize_schema(schema: dict[str, Any], *, _depth: int = 0) -> dict[str, Any]:
     """Normalize a JSON schema to match expectations.
 
     This function recursively processes nested objects to preserve the complete schema structure.
@@ -109,10 +121,17 @@ def normalize_schema(schema: dict[str, Any]) -> dict[str, Any]:
 
     Args:
         schema: The schema to normalize.
+        _depth: Current nesting depth, used to bound recursion into nested object schemas.
 
     Returns:
         The normalized schema.
+
+    Raises:
+        ValueError: If the schema nesting exceeds _MAX_SCHEMA_DEPTH.
     """
+    if _depth > _MAX_SCHEMA_DEPTH:
+        raise ValueError(f"tool inputSchema nesting exceeds {_MAX_SCHEMA_DEPTH} levels")
+
     # Start with a complete copy to preserve all existing properties
     normalized = schema.copy()
 
@@ -125,7 +144,7 @@ def normalize_schema(schema: dict[str, Any]) -> dict[str, Any]:
     if "properties" in normalized:
         properties = normalized["properties"]
         for prop_name, prop_def in properties.items():
-            normalized["properties"][prop_name] = _normalize_property(prop_name, prop_def)
+            normalized["properties"][prop_name] = _normalize_property(prop_name, prop_def, _depth=_depth)
 
     return normalized
 

--- a/strands-py/src/strands/tools/tools.py
+++ b/strands-py/src/strands/tools/tools.py
@@ -127,7 +127,7 @@ def normalize_schema(schema: dict[str, Any], *, _depth: int = 0) -> dict[str, An
         The normalized schema.
 
     Raises:
-        ValueError: If the schema nesting exceeds _MAX_SCHEMA_DEPTH.
+        ValueError: If the schema is nested too deeply.
     """
     if _depth > _MAX_SCHEMA_DEPTH:
         raise ValueError(f"tool inputSchema nesting exceeds {_MAX_SCHEMA_DEPTH} levels")
@@ -159,7 +159,7 @@ def normalize_tool_spec(tool_spec: ToolSpec) -> ToolSpec:
         The normalized tool specification.
 
     Raises:
-        ValueError: If the inputSchema nesting exceeds _MAX_SCHEMA_DEPTH.
+        ValueError: If the inputSchema is nested too deeply.
     """
     normalized = tool_spec.copy()
 

--- a/strands-py/src/strands/tools/tools.py
+++ b/strands-py/src/strands/tools/tools.py
@@ -157,6 +157,9 @@ def normalize_tool_spec(tool_spec: ToolSpec) -> ToolSpec:
 
     Returns:
         The normalized tool specification.
+
+    Raises:
+        ValueError: If the inputSchema nesting exceeds _MAX_SCHEMA_DEPTH.
     """
     normalized = tool_spec.copy()
 

--- a/strands-py/src/strands/vended_interventions/cedar/__init__.py
+++ b/strands-py/src/strands/vended_interventions/cedar/__init__.py
@@ -22,8 +22,7 @@ try:
     import cedarpy as _cedarpy  # noqa: F401
 except ImportError as _e:
     raise ImportError(
-        "The cedar intervention handler requires 'cedarpy'. "
-        "Install it with: pip install strands-agents[cedar]"
+        "The cedar intervention handler requires 'cedarpy'. Install it with: pip install strands-agents[cedar]"
     ) from _e
 
 from ._schema_generator import ToolDefinition

--- a/strands-py/tests/strands/tools/test_registry.py
+++ b/strands-py/tests/strands/tools/test_registry.py
@@ -2,6 +2,7 @@
 Tests for the SDK tool registry module.
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -692,3 +693,32 @@ def test_process_tools_with_multiple_agents():
 
     assert tool_names == ["researcher", "reviewer", "writer"]
     assert all(registry.registry[name].tool_type == "agent" for name in tool_names)
+
+
+def test_get_all_tools_config_skips_tool_with_too_deeply_nested_schema(caplog):
+    """A tool with a pathologically deep inputSchema is skipped without taking down the others."""
+    deep_schema = {"type": "object", "properties": {"value": {"type": "string"}}}
+    for _ in range(100):
+        deep_schema = {"type": "object", "properties": {"child": deep_schema}}
+
+    hostile_tool = PythonAgentTool(
+        tool_name="hostile_tool",
+        tool_spec={
+            "name": "hostile_tool",
+            "description": "tool with a deeply nested inputSchema",
+            "inputSchema": {"json": deep_schema},
+        },
+        tool_func=lambda: None,
+    )
+    valid_tool = strands.tool(lambda a: a, name="valid_tool")
+
+    tool_registry = ToolRegistry()
+    tool_registry.register_tool(hostile_tool)
+    tool_registry.register_tool(valid_tool)
+
+    with caplog.at_level(logging.WARNING):
+        tool_config = tool_registry.get_all_tools_config()
+
+    assert "hostile_tool" not in tool_config
+    assert "valid_tool" in tool_config
+    assert "hostile_tool" in caplog.text

--- a/strands-py/tests/strands/tools/test_tools.py
+++ b/strands-py/tests/strands/tools/test_tools.py
@@ -279,6 +279,34 @@ def test_normalize_schema_with_deeply_nested_objects():
     assert normalized == expected
 
 
+def _build_nested_schema(depth):
+    """Build a schema nested `depth` levels deep via chained object properties."""
+    schema = {"type": "object", "properties": {"value": {"type": "string"}}}
+    for _ in range(depth):
+        schema = {"type": "object", "properties": {"child": schema}}
+    return schema
+
+
+def test_normalize_schema_raises_value_error_when_too_deeply_nested():
+    """A pathologically deep schema raises ValueError rather than RecursionError."""
+    schema = _build_nested_schema(100)
+
+    with pytest.raises(ValueError, match="nesting exceeds"):
+        normalize_schema(schema)
+
+
+def test_normalize_tool_spec_raises_value_error_when_too_deeply_nested():
+    """normalize_tool_spec surfaces the depth bound as ValueError, not RecursionError."""
+    tool_spec = {
+        "name": "deep_tool",
+        "description": "tool with a hostile inputSchema",
+        "inputSchema": {"json": _build_nested_schema(100)},
+    }
+
+    with pytest.raises(ValueError, match="nesting exceeds"):
+        normalize_tool_spec(tool_spec)
+
+
 def test_normalize_schema_with_const_constraint():
     """Test that const constraints are preserved."""
     schema = {

--- a/strands-py/tests/strands/vended_interventions/cedar/test_cedar_authorization.py
+++ b/strands-py/tests/strands/vended_interventions/cedar/test_cedar_authorization.py
@@ -562,7 +562,6 @@ class TestReload:
         assert cedar.before_tool_call(_make_event("delete")).type == "proceed"
 
 
-
 class TestEntities:
     def test_inline_entities(self):
         entities = [

--- a/strands-py/tests/strands/vended_interventions/cedar/test_cedar_integration.py
+++ b/strands-py/tests/strands/vended_interventions/cedar/test_cedar_integration.py
@@ -44,9 +44,7 @@ class TestPermitDeny:
             ]
         )
 
-        cedar = CedarAuthorization(
-            policies='permit(principal, action == Action::"search", resource);'
-        )
+        cedar = CedarAuthorization(policies='permit(principal, action == Action::"search", resource);')
         agent = Agent(model=model, tools=[search], interventions=[cedar])
         result = agent("Search for test")
 
@@ -69,9 +67,7 @@ class TestPermitDeny:
             ]
         )
 
-        cedar = CedarAuthorization(
-            policies='permit(principal, action == Action::"search", resource);'
-        )
+        cedar = CedarAuthorization(policies='permit(principal, action == Action::"search", resource);')
         agent = Agent(model=model, tools=[delete_record], interventions=[cedar])
         result = agent("Delete record 42")
 

--- a/strands-py/tests/strands/vended_interventions/cedar/test_schema_generator.py
+++ b/strands-py/tests/strands/vended_interventions/cedar/test_schema_generator.py
@@ -11,9 +11,7 @@ try:
 except ImportError:
     HAS_SCHEMA_GENERATOR = False
 
-pytestmark = pytest.mark.skipif(
-    not HAS_SCHEMA_GENERATOR, reason="cedar-policy-mcp-schema-generator not installed"
-)
+pytestmark = pytest.mark.skipif(not HAS_SCHEMA_GENERATOR, reason="cedar-policy-mcp-schema-generator not installed")
 
 
 class TestSchemaGeneration:


### PR DESCRIPTION
## Description

`normalize_schema` and `_normalize_property` in `tools/tools.py` are mutually recursive over a tool's `inputSchema` and carry no depth limit, while the `ToolRegistry` guards that wrap them catch only `ValueError`. A sufficiently deeply nested `inputSchema` therefore raises `RecursionError`, which is not a `ValueError` subclass, so it escapes `get_all_tool_specs()`. Because the event loop rebuilds tool specs on every cycle, the failure recurs on each agent invocation rather than being isolated to the offending tool.

This is most relevant for tool specs that originate from an external peer (for example, an MCP server's `inputSchema`), where the schema shape is not under the SDK's control.

This change:

- Adds a `_MAX_SCHEMA_DEPTH` bound (64) to `normalize_schema` / `_normalize_property`. Over-deep schemas now raise `ValueError`, which the registry already logs-and-skips, so a single malformed tool no longer takes down the whole `get_all_tool_specs()` call.
- Broadens the two registry normalization guards from `except ValueError` to `except (ValueError, RecursionError)` as defense-in-depth, so any future unbounded-recursion regression degrades to "skip tool + warn" instead of propagating out of the agent.

64 is well above any realistic hand-authored schema (typically 2–5 object levels deep) and an order of magnitude below CPython's default stack limit, so it rejects pathological input without risking false positives on legitimate tools.

The diff also includes a separate `chore:` commit applying `ruff format` to four `vended_interventions/cedar/` files. These were surfaced by `hatch run prepare` and are unrelated formatting only (no behavior change); happy to split them into their own PR if preferred.

## Note for maintainers

Longer term, it may be worth removing schema normalization altogether rather than hardening it. Model providers already reject invalid schemas with their own errors, so the normalization layer is largely defensive duplication. If the providers are the real source of truth for schema validity, this recursion (and this class of bug) goes away entirely. Raising as a discussion point, not part of this change.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Type of Change

Bug fix

## Testing

Added two regression tests in `tests/strands/tools/test_tools.py` that build a 100-level nested schema and assert `normalize_schema` and `normalize_tool_spec` raise `ValueError` (not `RecursionError`). Existing tests covering legitimately nested schemas still pass, confirming valid schemas continue to normalize correctly.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
