### PR TITLE
docs(shell-sdk): improve voice consistency and address Bind default feedback

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -341,7 +341,7 @@ github:
           href: https://github.com/strands-agents/harness-sdk/tree/main/strands-ts
           icon: TS
     - title: Strands
-      links: 
+      links:
         - label: Evals
           href: https://github.com/strands-agents/evals
           icon: EV

--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -332,7 +332,7 @@ sidebar:
 
 github:
   sections:
-    - title: SDKs
+    - title: Strands Harness
       links:
         - label: Python SDK
           href: https://github.com/strands-agents/harness-sdk/tree/main/strands-py
@@ -340,9 +340,14 @@ github:
         - label: TypeScript SDK
           href: https://github.com/strands-agents/harness-sdk/tree/main/strands-ts
           icon: TS
-        - label: Evals SDK
+    - title: Strands
+      links: 
+        - label: Evals
           href: https://github.com/strands-agents/evals
           icon: EV
+        - label: Shell
+          href: https://github.com/strands-agents/shell
+          icon: SH
     - title: Organizations
       links:
         - label: strands-agents

--- a/site/src/content/docs/user-guide/shell-sdk/commands.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/commands.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: "Commands"
 ---
 
-Strands Shell reimplements a curated subset of POSIX and coreutils in Rust, targeting the operations agents reach for most rather than a complete toolset. This page is the reference for what is supported and where behavior diverges from GNU or BSD: missing flags, unsupported features, and known gaps.
+Strands Shell reimplements a curated subset of POSIX and coreutils in Rust, targeting the operations agents reach for most rather than a complete toolset. This page is the reference for what's supported and where behavior diverges from GNU or BSD: missing flags, unsupported features, and known gaps.
 
 The shell is Bourne-compatible, with pipes, loops, functions, and subshells. The commands group into text processing, file contents, file management, path and system utilities, networking, JSON, search, and scripting.
 
@@ -15,20 +15,20 @@ These notes apply across commands:
 
 - Regex uses the Rust `regex` crate. Backreferences and lookaround are unavailable, so `grep -P` is unsupported and GNU BRE escapes are not translated.
 - `jq` is backed by [`jaq`](https://github.com/01mf02/jaq), a jq subset.
-- Unsupported flags are rejected, not ignored. Idioms such as `cp -p`, `set -o pipefail`, or `ln -sf` produce an error rather than silently doing the wrong thing.
-- Multiple file arguments are not uniformly supported. `cut` and `uniq` read only the first file; `head` and `tail` return a hard error; `cat`, `sort`, and `wc` handle multiple files correctly.
+- Unsupported flags are rejected, not ignored. Idioms like `cp -p`, `set -o pipefail`, or `ln -sf` produce an error rather than succeeding with incorrect behavior.
+- Multiple file arguments aren't uniformly supported. `cut` and `uniq` read only the first file; `head` and `tail` return a hard error; `cat`, `sort`, and `wc` handle multiple files correctly.
 - Malformed numeric input passes silently. `test`, `[`, and arithmetic `$(( ))` treat non-numeric or empty operands as `0` without an error.
-- Stdin under `strands-shell -c` is not connected to commands (`bad fd 0`). Use an in-shell pipe instead.
+- Stdin under `strands-shell -c` isn't connected to commands (`bad fd 0`). Use an in-shell pipe instead.
 
 ## Text processing
 
 | Command | Notable gaps |
 |---|---|
 | `grep` | No `-P`, backreferences, lookaround, or `-f`. `-o` on empty-matching patterns emits blank lines. |
-| `sed` | No branching (`b`, `t`, `:label`) or multiline (`N`, `D`, `P`); no `-f`. `s///N` replaces the wrong match; range `c` emits per line. |
-| `tr` | Missing `[:punct:]`, `[:cntrl:]`, and `[c*n]` repeats. `-c` two-set translate uses the wrong replacement character. |
+| `sed` | No branching (`b`, `t`, `:label`) or multiline (`N`, `D`, `P`); no `-f`. `s///N` replaces the incorrect match; range `c` emits per line. |
+| `tr` | Missing `[:punct:]`, `[:cntrl:]`, and `[c*n]` repeats. `-c` two-set translate uses the incorrect replacement character. |
 | `cut` | No `-b` or `--complement`. Reads only the first file when given several. |
-| `sort` | No `-c`, `-o`, `-V`, or `-h` (`-h` prints help instead). Keyed-tie order is non-deterministic. Loads all input into memory. |
+| `sort` | No `-c`, `-o`, `-V`, or `-h` (`-h` incorrectly prints help). Keyed-tie order is non-deterministic. Loads all input into memory. |
 | `uniq` | No `-w` or `-D`. Reads only the first file when given several. |
 | `wc` | No `-m` (char count) or `-L`. Counts are correct; column padding differs from coreutils. |
 
@@ -64,8 +64,8 @@ These notes apply across commands:
 | `readlink` | Plain read only; no `-f`, `-e`, or `-m` canonicalization. |
 | `mktemp` | No `-u` or `-t`. |
 | `date` | `%s` is not expanded; unknown specifiers pass through literally; no `-d` or `-r`. UTC only. |
-| `env` | Print-only. `env VAR=v cmd`, `-i`, and `-u` are unsupported; use the shell-prefix form instead. |
-| `echo` | Expands escapes by default; `-e` and `-E` are printed literally (escape expansion cannot be disabled). |
+| `env` | Print-only. `env VAR=v cmd`, `-i`, and `-u` aren't supported; use the shell-prefix form instead. |
+| `echo` | Expands escapes by default; `-e` and `-E` are printed literally (escape expansion can't be disabled). |
 | `pwd` | Full support, including `-L` and `-P`. |
 | `sleep` | No unit suffixes (`0.1s`). Respects the shell timeout. |
 | `true`, `false` | Full support. |
@@ -76,7 +76,7 @@ These notes apply across commands:
 |---|---|
 | `curl` | GET, POST, JSON, headers, auth, redirects, and `-w` are supported. No `--max-time`, `--connect-timeout`, or `--retry` (risk of an indefinite hang); no `-I`, `-F`, `-A`, `-G`, or cookie jar. SSRF and credential controls are enforced. |
 
-The SSRF guard and credential injection on `curl` are security features, covered in the [security model](security.md). They are not optional and cannot be disabled per command.
+The SSRF guard and credential injection on `curl` are security features, covered in the [security model](security.md). They aren't optional and can't be disabled per command.
 
 ## JSON
 
@@ -89,7 +89,7 @@ The SSRF guard and credential injection on `curl` are security features, covered
 | Command | Notable gaps |
 |---|---|
 | `find` | `-name`, `-type`, `-maxdepth`, `-exec`, and `-print0` are supported. No `-delete`, `-size`, `-mtime`, `-prune`, or `-regex`. Children are sorted alphabetically, not in readdir order. |
-| `xargs` | Space-separated `-n`, `-I`, `-0`, and `-d` are supported; attached forms (`-n1`, `-I{}`) and `-t`, `-r`, `-L`, `-P` are not. Implicitly behaves as `-r`. |
+| `xargs` | Space-separated `-n`, `-I`, `-0`, and `-d` are supported; attached forms (`-n1`, `-I{}`) and `-t`, `-r`, `-L`, `-P` aren't. Implicitly behaves as `-r`. |
 
 ## Scripting
 
@@ -114,8 +114,7 @@ Reach for `lua` when shell syntax gets awkward: multi-step transforms, structure
 | `type` | No `-t` or `-a`. |
 | `cd` | No `CDPATH`; `-P` and `-L` are not parsed. |
 | `getopts`, `export`, `unset`, `shift`, `umask`, `hash`, `wait`, `:` | Full support. |
-
-Arithmetic `$(( ))` handles precedence, bitwise operators, the ternary, hex, and octal correctly. Malformed input returns a wrong result with exit 0 (`$((2 3))` yields `2`, `$((1/0))` yields `0`). Post-increment `x++` and `x--` return the value without updating the variable.
+| `$(( ))` arithmetic | Precedence, bitwise, ternary, hex, and octal work correctly. Malformed input returns an incorrect result with exit 0 (`$((2 3))` yields `2`, `$((1/0))` yields `0`). Post-increment `x++`/`x--` returns the value without updating the variable. |
 
 ## Shell language
 

--- a/site/src/content/docs/user-guide/shell-sdk/commands.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/commands.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: "Commands"
 ---
 
-Strands Shell reimplements a curated subset of POSIX and coreutils in Rust, targeting the operations agents reach for most rather than a complete toolset. This page is the reference for what's supported and where behavior diverges from GNU or BSD: missing flags, unsupported features, and known gaps.
+Strands Shell reimplements a curated subset of POSIX and coreutils in Rust, targeting the operations agents reach for most rather than a complete toolset. This page is the reference for what is supported and where behavior diverges from GNU or BSD: missing flags, unsupported features, and known gaps.
 
 The shell is Bourne-compatible, with pipes, loops, functions, and subshells. The commands group into text processing, file contents, file management, path and system utilities, networking, JSON, search, and scripting.
 
@@ -16,9 +16,9 @@ These notes apply across commands:
 - Regex uses the Rust `regex` crate. Backreferences and lookaround are unavailable, so `grep -P` is unsupported and GNU BRE escapes are not translated.
 - `jq` is backed by [`jaq`](https://github.com/01mf02/jaq), a jq subset.
 - Unsupported flags are rejected, not ignored. Idioms like `cp -p`, `set -o pipefail`, or `ln -sf` produce an error rather than succeeding with incorrect behavior.
-- Multiple file arguments aren't uniformly supported. `cut` and `uniq` read only the first file; `head` and `tail` return a hard error; `cat`, `sort`, and `wc` handle multiple files correctly.
+- Multiple file arguments are not uniformly supported. `cut` and `uniq` read only the first file; `head` and `tail` return a hard error; `cat`, `sort`, and `wc` handle multiple files correctly.
 - Malformed numeric input passes silently. `test`, `[`, and arithmetic `$(( ))` treat non-numeric or empty operands as `0` without an error.
-- Stdin under `strands-shell -c` isn't connected to commands (`bad fd 0`). Use an in-shell pipe instead.
+- Stdin under `strands-shell -c` is not connected to commands (`bad fd 0`). Use an in-shell pipe instead.
 
 ## Text processing
 
@@ -64,8 +64,8 @@ These notes apply across commands:
 | `readlink` | Plain read only; no `-f`, `-e`, or `-m` canonicalization. |
 | `mktemp` | No `-u` or `-t`. |
 | `date` | `%s` is not expanded; unknown specifiers pass through literally; no `-d` or `-r`. UTC only. |
-| `env` | Print-only. `env VAR=v cmd`, `-i`, and `-u` aren't supported; use the shell-prefix form instead. |
-| `echo` | Expands escapes by default; `-e` and `-E` are printed literally (escape expansion can't be disabled). |
+| `env` | Print-only. `env VAR=v cmd`, `-i`, and `-u` are not supported; use the shell-prefix form instead. |
+| `echo` | Expands escapes by default; `-e` and `-E` are printed literally (escape expansion cannot be disabled). |
 | `pwd` | Full support, including `-L` and `-P`. |
 | `sleep` | No unit suffixes (`0.1s`). Respects the shell timeout. |
 | `true`, `false` | Full support. |
@@ -76,7 +76,7 @@ These notes apply across commands:
 |---|---|
 | `curl` | GET, POST, JSON, headers, auth, redirects, and `-w` are supported. No `--max-time`, `--connect-timeout`, or `--retry` (risk of an indefinite hang); no `-I`, `-F`, `-A`, `-G`, or cookie jar. SSRF and credential controls are enforced. |
 
-The SSRF guard and credential injection on `curl` are security features, covered in the [security model](security.md). They aren't optional and can't be disabled per command.
+The SSRF guard and credential injection on `curl` are security features, covered in the [security model](security.md). They are not optional and cannot be disabled per command.
 
 ## JSON
 
@@ -89,7 +89,7 @@ The SSRF guard and credential injection on `curl` are security features, covered
 | Command | Notable gaps |
 |---|---|
 | `find` | `-name`, `-type`, `-maxdepth`, `-exec`, and `-print0` are supported. No `-delete`, `-size`, `-mtime`, `-prune`, or `-regex`. Children are sorted alphabetically, not in readdir order. |
-| `xargs` | Space-separated `-n`, `-I`, `-0`, and `-d` are supported; attached forms (`-n1`, `-I{}`) and `-t`, `-r`, `-L`, `-P` aren't. Implicitly behaves as `-r`. |
+| `xargs` | Space-separated `-n`, `-I`, `-0`, and `-d` are supported; attached forms (`-n1`, `-I{}`) and `-t`, `-r`, `-L`, `-P` are not. Implicitly behaves as `-r`. |
 
 ## Scripting
 

--- a/site/src/content/docs/user-guide/shell-sdk/configuration.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/configuration.mdx
@@ -13,11 +13,11 @@ The examples below use the Python API. The Node.js API takes the same options as
 
 ## Binds
 
-A bind maps a host directory into the shell's virtual filesystem. The agent sees the destination path; everything outside a bound path does not exist.
+A bind maps a host directory into the shell's virtual filesystem. The agent sees the destination path; everything outside a bound path doesn't exist.
 
 Each bind has a mode that decides how host and sandbox relate:
 
-- `copy` snapshots the host directory into the VFS at construction time. The agent's reads and writes stay inside the sandbox and never touch your host files. Use this for source code.
+- `copy` snapshots the host directory into the VFS at construction time. The agent's reads and writes stay inside the sandbox and don't touch your host files. Use this for source code.
 - `direct` passes reads and writes through to the host in real time. The agent can modify your live files, and host-side changes after construction are visible to the agent. Use this only for designated output directories.
 
 ```python
@@ -31,6 +31,10 @@ shell = strands_shell.Shell(
 )
 ```
 
+:::note
+The TOML parser defaults `mode` to `copy` when omitted, but the Python and Node.js constructors default to `direct`. Always pass `mode` explicitly when constructing a `Bind` in code to avoid accidentally granting live host access.
+:::
+
 Add `readonly=True` to reject writes through a mount even in `direct` mode, which lets you expose a live host directory for reading without risking modification.
 
 ```python
@@ -38,12 +42,12 @@ strands_shell.Bind("/host/reference", "/ref", mode="direct", readonly=True)
 ```
 
 :::caution
-A `direct` bind is live. The agent can read and modify host files in real time, including deleting them. Never `direct`-bind a directory that holds secrets, credentials, or configuration you do not want the agent to change. When in doubt, use `copy`.
+A `direct` bind is live. The agent can read and modify host files in real time, including deleting them. Avoid `direct`-binding a directory that holds secrets, credentials, or configuration you don't want the agent to change. When in doubt, use `copy`.
 :::
 
 ## Credentials
 
-A credential rule attaches a secret to a URL prefix. When a command makes a request to a matching URL, the Kernel injects the secret as a bearer token at request time. The agent never holds the value: it does not appear in the environment, in command output, or in the Lua scripting context.
+A credential rule attaches a secret to a URL prefix. When a command makes a request to a matching URL, the Kernel injects the secret as a bearer token at request time. The agent doesn't hold the value: it doesn't appear in the environment, in command output, or in the Lua scripting context.
 
 Provide the secret one of two ways, and exactly one: an inline `token`, or an `env_var` resolved against the process environment when the shell is constructed.
 
@@ -59,7 +63,7 @@ shell = strands_shell.Shell(
 result = shell.run("curl https://api.example.com/v1/status")
 ```
 
-The Kernel matches on URL prefix with a path-boundary check, and it injects only on the original request. It never re-injects on a redirect, even a redirect back to the same host, which closes the credential-exfiltration path where an agent follows a redirect to a logging endpoint.
+The Kernel matches on URL prefix with a path-boundary check, and it injects only on the original request. It doesn't re-inject on a redirect, even a redirect back to the same host, which closes the credential-exfiltration path where an agent follows a redirect to a logging endpoint.
 
 ## Network access
 
@@ -74,7 +78,7 @@ shell = strands_shell.Shell(
 ```
 
 :::caution
-Do not allowlist a bare scheme like `https://`. A prefix that broad permits every host and disables the SSRF guard entirely. List the specific endpoints the agent needs.
+Don't allowlist a bare scheme like `https://`. A prefix that broad permits every host and disables the SSRF guard entirely. List the specific endpoints the agent needs.
 :::
 
 ## Behavioral settings
@@ -94,7 +98,7 @@ shell = strands_shell.Shell(
 
 ## Resource limits
 
-Resource caps go in a single `Limits` bundle, separate from behavioral settings, so protective caps stay visually distinct from runtime behavior. Override only the caps you care about; the rest keep their defaults.
+Resource caps go in a single `Limits` bundle, separate from behavioral settings so protective caps stay visually distinct from runtime behavior. Override only the caps you care about; the rest keep their defaults.
 
 ```python
 shell = strands_shell.Shell(
@@ -116,7 +120,7 @@ shell = strands_shell.Shell(
 | `max_inodes` | 10,000 | Total files and directories in the VFS |
 | `max_depth` | 64 | Directory nesting depth |
 
-These caps are best-effort. They stop a runaway agent from exhausting memory or hanging; they are not a defense against an adversary actively trying to break out. For hard guarantees, see the [security model](security.md).
+These caps are best-effort. They stop a runaway agent from exhausting memory or hanging; they aren't a defense against an adversary actively trying to break out. For hard guarantees, see the [security model](security.md).
 
 ## TOML configuration
 
@@ -160,7 +164,7 @@ shell = strands_shell.Shell(config_file="sandbox.toml")
 A few rules the parser enforces:
 
 - Unknown keys are rejected, so a typo like `timeout_seconds` fails loudly instead of being silently ignored.
-- `bind` mode defaults to `copy` when omitted, which is the safe choice.
+- In TOML, `bind` mode defaults to `copy` when omitted. Note that this differs from the Python and Node.js constructors, which default to `direct`. Always specify `mode` explicitly in code.
 - A `cred` entry needs a `kind` (`bearer` or `query`) and exactly one of `api_key` or `api_key_env`. A `query` credential also needs a `param` naming the query parameter.
 - `timeout` is in whole seconds and defaults to 30 when the key is absent. A value of `0` is rejected, because it would expire every command immediately.
 

--- a/site/src/content/docs/user-guide/shell-sdk/configuration.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/configuration.mdx
@@ -31,7 +31,7 @@ shell = strands_shell.Shell(
 )
 ```
 
-:::note
+:::caution
 The TOML parser defaults `mode` to `copy` when omitted, but the Python and Node.js constructors default to `direct`. Always pass `mode` explicitly when constructing a `Bind` in code to avoid accidentally granting live host access.
 :::
 

--- a/site/src/content/docs/user-guide/shell-sdk/index.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/index.mdx
@@ -53,13 +53,13 @@ Strands Shell is written in Rust and compiles from one source to native bindings
 
 ## What you control
 
-A fresh shell starts empty without access to files, network, or credentials. You grant access explicitly through three mechanisms: 
+A fresh shell starts empty without access to files, network, or credentials. You grant access explicitly through three mechanisms:
 
 - **Binds** map a host directory into the shell's filesystem. A `copy` bind snapshots the directory at construction time, isolating the agent from your live files. A `direct` bind passes reads and writes through to the host in real time. Prefer `copy` for source code and reserve `direct` for output directories.
 
- - **Credentials** attach a secret to a URL prefix. When a command makes a request to a matching URL, the Kernel injects the credential at request time. The agent doesn't hold the secret, and the Kernel doesn't re-inject on a redirect, even back to the same host.
+- **Credentials** attach a secret to a URL prefix. When a command makes a request to a matching URL, the Kernel injects the credential at request time. The agent doesn't hold the secret, and the Kernel doesn't re-inject on a redirect, even back to the same host.
 
- - **Allowed URLs** widen the network policy. By default the SSRF guard blocks private ranges (RFC1918, link-local, loopback, and cloud metadata endpoints) while letting public URLs through. Add a prefix to the allowlist to permit a specific internal host.
+- **Allowed URLs** widen the network policy. By default the SSRF guard blocks private ranges (RFC1918, link-local, loopback, and cloud metadata endpoints) while letting public URLs through. Add a prefix to the allowlist to permit a specific internal host.
 
 The [Configuration](configuration.md) guide covers each of these in depth, including the TOML format that lets you declare the whole policy in a file.
 

--- a/site/src/content/docs/user-guide/shell-sdk/index.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/index.mdx
@@ -5,22 +5,22 @@ sidebar:
   label: "Overview"
 ---
 
-Agents run shell commands in tight loops: install dependencies, run tests, grep for errors, iterate. Those loops need to be fast, and they need to be contained. An agent that can run `curl` can also read your cloud credentials, reach your internal network, and overwrite files you never meant to expose.
+Agents run shell commands in tight loops: install dependencies, run tests, grep for errors, iterate. Those loops need to be fast, and they need to be contained. An agent that can run `curl` can also read your cloud credentials, reach your internal network, and overwrite files you didn't intend to expose.
 
-Strands Shell is a Bourne-compatible shell that runs inside your own process. It ships `grep`, `sed`, `jq`, `curl`, `find`, and dozens of other commands without ever calling `fork`, `exec`, or a raw syscall. You declare what the agent can reach (files, URLs, credentials) up front, and everything else does not exist as far as the agent is concerned.
+Strands Shell is a Bourne-compatible shell that runs inside your own process. It ships `grep`, `sed`, `jq`, `curl`, `find`, and dozens of other commands without calling `fork`, `exec`, or a raw syscall. You declare what the agent can reach (files, URLs, credentials) up front, and everything else doesn't exist as far as the agent is concerned. The source is on [GitHub](https://github.com/strands-agents/shell).
 
 ## Why a virtual shell
 
-Most agent setups reach for a container or a cloud sandbox to isolate command execution. Both work, and both cost you something on every command: a Docker container adds a cold start and a daemon to manage, a cloud sandbox adds a network round trip and a platform to depend on. When an agent runs hundreds of commands per task, that overhead compounds.
+Most agent setups use a container or a cloud sandbox to isolate command execution. Both work, and both cost something on every command: a Docker container adds a cold start and a daemon to manage; a cloud sandbox adds a network round trip and a platform dependency. When an agent runs hundreds of commands per task, that overhead compounds.
 
-Strands Shell takes a different position. The isolation boundary is an in-process virtual filesystem and a mediation layer, not an operating-system primitive. There is no container to start and no VM to provision, so constructing a shell and running a command costs under a millisecond.
+Strands Shell takes a different approach. The isolation boundary is an in-process virtual filesystem and a mediation layer, not an operating-system primitive. Because there's no container to start and no VM to provision, constructing a shell and running a command costs under a millisecond.
 
 | | Docker | Cloud sandbox | Strands Shell |
 |---|---|---|---|
 | Cold start | ~200ms | ~1s (network) | under 1ms |
 | Isolation | Container namespace | MicroVM | In-process VFS |
 | Network | iptables or sidecar | Platform policy | URL allowlist plus SSRF guard |
-| Secrets | Environment variables the agent can read | Platform-specific | Injected per request, agent never sees them |
+| Secrets | Environment variables the agent can read | Platform-specific | Injected per request, agent doesn't see them |
 | Setup | Docker daemon | API key plus network | `pip install strands-shell` |
 | Platforms | Linux | Cloud only | macOS, Linux, WASM |
 
@@ -47,36 +47,34 @@ flowchart TB
     end
 ```
 
-The engine parses and runs shell syntax: pipelines, loops, functions, subshells. When a command needs to touch the outside world, it asks the Kernel, and the Kernel decides. The filesystem is an in-memory VFS with explicit bind mounts. Network access goes through an SSRF guard that blocks private address ranges by default. Credentials are injected per request and stripped before the agent can read them.
+The engine parses and runs shell syntax and when a command needs to touch the outside world, it asks the Kernel, and the Kernel decides. The filesystem is an in-memory VFS with explicit bind mounts, network access goes through an SSRF guard that blocks private address ranges by default, and credentials are injected per request and stripped before the agent can read them.
 
-State persists across `run` calls. Environment variables, the working directory, and shell functions set in one command are visible in the next, so an agent can `cd` into a directory and keep working there across turns.
-
-Strands Shell is written in Rust and compiles from one source to native bindings for Python (via PyO3) and Node.js (via napi-rs), plus a WASM target. The three language surfaces are intentionally parallel: the same config shape, the same command set, the same mediation guarantees.
+Strands Shell is written in Rust and compiles from one source to native bindings for Python (via PyO3) and Node.js (via napi-rs), plus a WASM target. All three surfaces expose the same functionality.
 
 ## What you control
 
-A fresh shell is an empty sandbox: no files, no network, no credentials. You grant access explicitly through three mechanisms.
+A fresh shell starts empty without access to files, network, or credentials. You grant access explicitly through three mechanisms: 
 
-**Binds** map a host directory into the shell's filesystem. A `copy` bind snapshots the directory at construction time, isolating the agent from your live files. A `direct` bind passes reads and writes through to the host in real time. Prefer `copy` for source code and reserve `direct` for output directories.
+- **Binds** map a host directory into the shell's filesystem. A `copy` bind snapshots the directory at construction time, isolating the agent from your live files. A `direct` bind passes reads and writes through to the host in real time. Prefer `copy` for source code and reserve `direct` for output directories.
 
-**Credentials** attach a secret to a URL prefix. When a command makes a request to a matching URL, the Kernel injects the credential at request time. The agent never holds the secret, and the Kernel never re-injects it on a redirect, even back to the same host.
+ - **Credentials** attach a secret to a URL prefix. When a command makes a request to a matching URL, the Kernel injects the credential at request time. The agent doesn't hold the secret, and the Kernel doesn't re-inject on a redirect, even back to the same host.
 
-**Allowed URLs** widen the network policy. By default the SSRF guard blocks private ranges (RFC1918, link-local, loopback, and cloud metadata endpoints) while letting public URLs through. Add a prefix to the allowlist to permit a specific internal host.
+ - **Allowed URLs** widen the network policy. By default the SSRF guard blocks private ranges (RFC1918, link-local, loopback, and cloud metadata endpoints) while letting public URLs through. Add a prefix to the allowlist to permit a specific internal host.
 
 The [Configuration](configuration.md) guide covers each of these in depth, including the TOML format that lets you declare the whole policy in a file.
 
 ## What Strands Shell is not
 
-Strands Shell is a mediation layer, not a hardened sandbox. The Kernel enforces what the agent *should* reach through deny-by-default policy, and it runs in the same process as your code. It does not protect against memory-safety exploits in the shell engine itself, timing side channels, or an attacker who already controls the host process.
+Strands Shell is a mediation layer, not a hardened sandbox. The Kernel enforces what the agent *should* reach through deny-by-default policy, and it runs in the same process as your code. It doesn't protect against memory-safety exploits in the shell engine itself, timing side channels, or an attacker who already controls the host process.
 
 The distinction matters for your threat model:
 
-- For "my agent should not touch anything I have not explicitly allowed," the Kernel handles it. This is the common case: a coding agent, a research agent, a CI assistant.
+- For "my agent shouldn't touch anything I haven't explicitly allowed," the Kernel handles it. This is the common case: a coding agent, a research agent, a CI assistant.
 - For "an untrusted tenant is running arbitrary adversarial code," you need OS-level isolation. Run each Strands Shell instance inside a container or microVM, and let the Kernel handle the in-process mediation on top.
 
-Resource limits (timeouts, output caps, file-descriptor and inode limits) are best-effort. They stop a runaway agent from filling memory or hanging forever; they do not stop someone actively trying to break out. For hard guarantees, use OS-level cgroups.
+Resource limits (timeouts, output caps, file-descriptor and inode limits) are best-effort. They stop a runaway agent from filling memory or hanging forever but they don't stop someone actively trying to break out. For hard guarantees, use OS-level cgroups.
 
-A Strands Shell instance is single-owner. If you serve multiple agents, create one shell per session. Construction is cheap (no containers, no VMs, just an in-memory VFS), so spinning one up per request is the intended pattern, not a workaround.
+A Strands Shell instance is single-owner. If you serve multiple agents, create one shell per session. Construction is cheap (no containers, no VMs, just an in-memory VFS), so spinning one up per request is the intended pattern.
 
 ## Next steps
 

--- a/site/src/content/docs/user-guide/shell-sdk/mcp-server.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/mcp-server.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: "MCP Server"
 ---
 
-The built-in MCP server exposes a sandboxed shell over JSON-RPC on stdio, so any framework that speaks the [Model Context Protocol](https://modelcontextprotocol.io/) can use it without a line of binding code. This is the integration path when you are not embedding the Python or Node.js API directly.
+The built-in MCP server exposes a sandboxed shell over JSON-RPC on stdio, so any framework that speaks the [Model Context Protocol](https://modelcontextprotocol.io/) can use it without a line of binding code. This is the integration path when you aren't embedding the Python or Node.js API directly.
 
 ## Start the server
 
@@ -15,7 +15,7 @@ Run the server with the `--mcp` flag. With no config, it starts a bare in-memory
 uvx strands-shell --mcp
 ```
 
-To grant access, pass a [TOML config file](configuration.md#toml-configuration) before the flag. The server applies the same binds, credentials, allowlist, and limits you would set in code.
+To grant access, pass a [TOML config file](configuration.md#toml-configuration) before the flag. The server applies the same binds, credentials, allowlist, and limits you'd set in code.
 
 ```bash
 uvx strands-shell --config sandbox.toml --mcp
@@ -95,11 +95,11 @@ local result = tools.search({ query = "deny by default" })
 print(result)
 ```
 
-Nested MCP servers are a native-target feature. They are not available under the WASM build, which has no MCP server or client and no `--config` flag.
+Nested MCP servers are a native-target feature. They aren't available under the WASM build, which has no MCP server or client and no `--config` flag.
 
 ## When to use the MCP server
 
-Reach for the MCP server when your agent already speaks MCP and you want isolation without writing binding code: the agent gets a shell plus file tools, all mediated by the Kernel, configured from one TOML file. When you are writing the agent host yourself in Python or Node.js, embed the [Python](quickstart.md#python) or [Node.js](quickstart.md#nodejs) API directly instead, which gives you the typed `Output`, file operations, and per-session control without a subprocess.
+Reach for the MCP server when your agent already speaks MCP and you want isolation without writing binding code: the agent gets a shell plus file tools, all mediated by the Kernel, configured from one TOML file. When you're writing the agent host yourself in Python or Node.js, embed the [Python](quickstart.md#python) or [Node.js](quickstart.md#nodejs) API directly instead, which gives you the typed `Output`, file operations, and per-session control without a subprocess.
 
 ## Next steps
 

--- a/site/src/content/docs/user-guide/shell-sdk/quickstart.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/quickstart.mdx
@@ -6,7 +6,7 @@ sidebar:
 tags: [quickstart]
 ---
 
-This guide gets you from zero to a running sandboxed command. You will install Strands Shell, create a shell with a single bound directory, and run a command against it. By the end you will have a working sandbox you can hand to an agent.
+This guide gets you from zero to a running sandboxed command. You'll install Strands Shell, create a shell with a single bound directory, and run a command against it. By the end you'll have a working sandbox you can hand to an agent.
 
 Strands Shell offers three surfaces. Pick the one that matches how you build:
 
@@ -16,7 +16,7 @@ Strands Shell offers three surfaces. Pick the one that matches how you build:
 
 ## MCP server
 
-The fastest way to give an existing agent a sandboxed shell is the built-in MCP server. It needs no code: point your MCP client at the `strands-shell` command and the agent gets four tools (`shell`, `read_file`, `write_file`, `list_dir`).
+The fastest way to give an existing agent a sandboxed shell is the built-in MCP server. It doesn't need any code, just point your MCP client at the `strands-shell` command and the agent gets four tools (`shell`, `read_file`, `write_file`, `list_dir`).
 
 Add this to your MCP client configuration:
 
@@ -31,7 +31,7 @@ Add this to your MCP client configuration:
 }
 ```
 
-This starts a bare in-memory sandbox: no host files, no network, no credentials. To grant access, write a [TOML config file](configuration.md#toml-configuration) and pass it before the `--mcp` flag:
+This starts a bare in-memory sandbox without access to files, network, or credentials. To grant access, write a [TOML config file](configuration.md#toml-configuration) and pass it before the `--mcp` flag:
 
 ```json
 {
@@ -48,13 +48,13 @@ The [MCP Server](mcp-server.md) page documents the four tools, their parameters,
 
 ## Python
 
-Install the shell. You need Python 3.10 or later.
+Install the shell, using Python 3.10 or later:
 
 ```bash
 pip install strands-shell
 ```
 
-Create a shell, bind a directory into it, and run a command. The bind is the grant: `/my/project` on your host becomes `/workspace` inside the sandbox, and nothing else on your filesystem is visible.
+Create a shell, bind a directory into it, and run a command. Only bound directories are visible inside the sandbox, so `/my/project` on your host appears as `/workspace` and the agent can't see anything else.
 
 ```python
 import strands_shell
@@ -67,7 +67,7 @@ result = shell.run("grep -rn TODO /workspace")
 print(result.stdout)
 ```
 
-`run` returns an `Output` with three fields: `stdout`, `stderr`, and `status` (the exit code). It does not raise when a command fails, so check `status` to branch on success.
+`run` returns an `Output` with three fields: `stdout`, `stderr`, and `status` (the exit code). It doesn't raise when a command fails, so check `status` to branch on success.
 
 ```python
 result = shell.run("test -f /workspace/pyproject.toml")
@@ -104,13 +104,13 @@ for entry in entries:
 
 ## Node.js
 
-Install the shell. You need Node.js 18 or later.
+Install the shell using Node.js 18 or later.
 
 ```bash
 npm install @strands-agents/shell
 ```
 
-Create a shell with `Shell.create`, which returns a promise. Bind a directory, then run a command.
+Create a shell with `Shell.create`, which returns a promise. Then bind a directory, then run a command.
 
 ```javascript
 import { Shell } from '@strands-agents/shell'
@@ -152,10 +152,10 @@ for (const entry of entries) {
 
 ## What you built
 
-You created a sandbox with exactly one directory visible to it and ran a command that could not reach anything else: not your home directory, not your credentials, not the network. That is the whole model. You add capability by adding binds, credentials, and allowed URLs, and the agent gets nothing you did not grant.
+You created a sandbox with exactly one directory visible to it and ran a command that couldn't reach anything else: not your home directory, not your credentials, not the network. That's the whole model. You add capability by adding binds, credentials, and allowed URLs, and the agent gets nothing you didn't grant.
 
 ## Next steps
 
 - [Configuration](configuration.md): the difference between `copy` and `direct` binds, credential injection, the network allowlist, and the TOML format.
 - [Commands](commands.md): which commands and flags are supported, and where they diverge from GNU coreutils.
-- [Security Model](security.md): what the sandbox guarantees, what it does not, and when to add OS-level isolation.
+- [Security Model](security.md): what the sandbox guarantees, what it doesn't, and when to add OS-level isolation.

--- a/site/src/content/docs/user-guide/shell-sdk/security.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/security.mdx
@@ -5,32 +5,32 @@ sidebar:
   label: "Security Model"
 ---
 
-Strands Shell exists to answer one question: what should this agent be allowed to touch? The answer is enforced by the Kernel, a single mediation boundary that every filesystem, network, and credential operation flows through. This page explains where that boundary sits, what it guarantees, and the threat models it does and does not cover.
+Strands Shell exists to answer one question: what should this agent be allowed to touch? The answer is enforced by the Kernel, a single mediation boundary that every filesystem, network, and credential operation flows through. This page explains where that boundary sits, what it guarantees, and the threat models it does and doesn't cover.
 
 The framing that matters most: **Strands Shell is a mediation layer, not a hardened sandbox.** It enforces what an agent *should* reach through deny-by-default policy. It runs in the same process as your code, not in a VM. Getting this distinction right is the difference between an appropriate deployment and a false sense of safety.
 
 ## The Kernel boundary
 
-All effects flow through the Kernel. There is no path around it: the shell makes no `fork`, no `exec`, and no raw syscalls, because the engine runs entirely in userspace. A command that wants to read a file, reach a URL, or use a credential asks the Kernel, and the Kernel applies policy.
+All effects flow through the Kernel. There's no path around it: the shell makes no `fork`, no `exec`, and no raw syscalls, because the engine runs entirely in userspace. A command that wants to read a file, reach a URL, or use a credential asks the Kernel, and the Kernel applies policy.
 
 The default Kernel is backed by an in-memory virtual filesystem and enforces four guarantees:
 
 1. **Filesystem isolation.** The VFS exposes only explicitly bound paths. No path can escape its declared mounts, and `..` components, symlinks, and bind-path tricks are checked against the mount boundary.
 2. **Network SSRF guard.** A two-layer check filters network access: a URL-level parse plus IP filtering at DNS-resolution time. It blocks RFC1918, link-local, loopback, IMDS, IPv4-mapped IPv6, 6to4, and Teredo addresses by default.
 3. **Credential injection.** Secrets are matched per URL prefix with a path-boundary check and injected only on the original request, then stripped on redirects.
-4. **No syscalls.** There is no `fork`, `exec`, or raw syscall path for a command to reach the host environment.
+4. **No syscalls.** There's no `fork`, `exec`, or raw syscall path for a command to reach the host environment.
 
 A custom Kernel (for embedding the shell in another runtime) carries its own security properties. The guarantees above describe the bundled implementation.
 
 ## Deny by default
 
-Out of the box a shell is empty: no files, no network, no credentials. You add capability explicitly, and the safe choice is the default at every turn. The principle is least privilege, and the practices that follow from it:
+Out of the box a shell is empty: no files, no network, no credentials. You add capability explicitly. The TOML config defaults bind mode to `copy` (the safe choice), but the Python and Node.js constructors default to `direct`; always pass `mode` explicitly in code. The principle is least privilege, and the practices that follow from it:
 
 - **Prefer `copy` over `direct` binds for source code.** A `copy` bind snapshots files into the VFS, isolating the agent from your live filesystem. Reserve `direct` for output directories where the agent must persist results.
-- **Scope binds narrowly.** Bind `/my/project/src`, not `/my/project` or `/`. The agent does not need your `.git`, your `.env`, or your `node_modules`.
-- **Allowlist URLs explicitly.** Never allowlist a bare `https://`; that disables the SSRF guard. List the specific endpoints the agent needs.
+- **Scope binds narrowly.** Bind `/my/project/src`, not `/my/project` or `/`. The agent doesn't need your `.git`, your `.env`, or your `node_modules`.
+- **Allowlist URLs explicitly.** Don't allowlist a bare `https://`; that disables the SSRF guard. List the specific endpoints the agent needs.
 - **Keep a timeout set.** The config-driven API defaults to a 30-second per-command timeout, which bounds runaway commands. Raise it for long-running work rather than removing it.
-- **Set `max_output`.** Cap the output an agent can generate so a single command cannot fill memory. 1 MiB is a reasonable default.
+- **Set `max_output`.** Cap the output an agent can generate so a single command can't fill memory. 1 MiB is a reasonable default.
 
 The [configuration guide](configuration.md) shows how to apply each of these.
 
@@ -38,24 +38,24 @@ The [configuration guide](configuration.md) shows how to apply each of these.
 
 The credential design solves a specific problem: an agent that can make HTTP requests should be able to *use* a secret without being able to *read* it. A secret in an environment variable fails this, because any command can print the environment.
 
-Strands Shell injects credentials at request time, keyed to a URL prefix. The value never enters the agent's reach: it is absent from the environment, from command output, from error messages, and from the Lua scripting context. The Kernel injects only on the original request and never re-injects on a redirect, even one that points back to the same host. That closes the exfiltration path where an agent follows a crafted redirect to a logging endpoint and reads the forwarded header.
+Strands Shell injects credentials at request time, keyed to a URL prefix. The value doesn't enter the agent's reach: it's absent from the environment, from command output, from error messages, and from the Lua scripting context. The Kernel injects only on the original request and doesn't re-inject on a redirect, even one that points back to the same host. That closes the exfiltration path where an agent follows a crafted redirect to a logging endpoint and reads the forwarded header.
 
 ## What is out of scope
 
-Some properties are explicitly not part of the security boundary. Treating them as guarantees is a mistake:
+Some properties are explicitly not part of the security boundary. Treating them as guarantees would be a mistake:
 
-- **Resource exhaustion within configured limits.** Limits are best-effort. They catch runaway agents; they do not stop deliberate attempts to exhaust CPU or memory. Use OS-level cgroups for hard caps.
-- **Speculative execution and side channels.** The same-process architecture does not defend against timing attacks. Use VM isolation for that threat model.
+- **Resource exhaustion within configured limits.** Limits are best-effort. They catch runaway agents; they don't stop deliberate attempts to exhaust CPU or memory. Use OS-level cgroups for hard caps.
+- **Speculative execution and side channels.** The same-process architecture doesn't defend against timing attacks. Use VM isolation for that threat model.
 - **Multi-tenancy within one process.** A shell instance is single-owner. Sharing one instance across mutually distrusting agents is a documented non-goal.
-- **Memory-safety exploits in the engine itself.** The Kernel mediates policy; it is not a defense against an attacker who compromises the host process.
+- **Memory-safety exploits in the engine itself.** The Kernel mediates policy; it's not a defense against an attacker who compromises the host process.
 - **Reading files the agent was granted.** A bind is a grant. An agent reading a directory you bound is the system working as designed.
 
 ## Choosing the right isolation
 
 Match the tool to the threat model:
 
-- **"My agent should not touch anything I have not allowed."** The Kernel handles this directly. This covers the common cases: a coding agent on a repository, a research agent with a scoped API key, a CI assistant. No container required.
-- **"An untrusted tenant is running arbitrary adversarial code."** Add OS-level isolation. Run each shell instance inside a container or microVM, and let the Kernel handle in-process mediation on top. Construction is cheap, so one shell per session is the intended pattern, not a workaround.
+- **"My agent shouldn't touch anything I haven't allowed."** The Kernel handles this directly. This covers the common cases: a coding agent on a repository, a research agent with a scoped API key, a CI assistant. No container required.
+- **"An untrusted tenant is running arbitrary adversarial code."** Add OS-level isolation. Run each shell instance inside a container or microVM, and let the Kernel handle in-process mediation on top. Construction is cheap, so one shell per session is the intended pattern.
 
 The two layers compose. The Kernel gives you fine-grained, fast, deny-by-default mediation; the container gives you a hard kernel boundary. For adversarial workloads, use both.
 
@@ -63,4 +63,4 @@ The two layers compose. The Kernel gives you fine-grained, fast, deny-by-default
 
 A bypass of filesystem mediation, the SSRF guard, or credential injection is a security issue, not a normal bug. Reaching a path outside a bound mount, defeating the metadata-service block, exfiltrating an injected credential, or causing one MCP session to read another session's state all qualify.
 
-Do not open a public GitHub issue. Report through the [AWS Vulnerability Disclosure Program on HackerOne](https://hackerone.com/aws_vdp) or by email to `aws-security@amazon.com`. The repository's [SECURITY.md](https://github.com/strands-agents/shell/blob/main/SECURITY.md) has the full policy and the complete in-scope and out-of-scope lists.
+Don't open a public GitHub issue. Report through the [AWS Vulnerability Disclosure Program on HackerOne](https://hackerone.com/aws_vdp) or by email to [aws-security@amazon.com](mailto:aws-security@amazon.com). The repository's [SECURITY.md](https://github.com/strands-agents/shell/blob/main/SECURITY.md) has the full policy and the complete in-scope and out-of-scope lists.

--- a/site/src/content/docs/user-guide/shell-sdk/security.mdx
+++ b/site/src/content/docs/user-guide/shell-sdk/security.mdx
@@ -63,4 +63,4 @@ The two layers compose. The Kernel gives you fine-grained, fast, deny-by-default
 
 A bypass of filesystem mediation, the SSRF guard, or credential injection is a security issue, not a normal bug. Reaching a path outside a bound mount, defeating the metadata-service block, exfiltrating an injected credential, or causing one MCP session to read another session's state all qualify.
 
-Don't open a public GitHub issue. Report through the [AWS Vulnerability Disclosure Program on HackerOne](https://hackerone.com/aws_vdp) or by email to [aws-security@amazon.com](mailto:aws-security@amazon.com). The repository's [SECURITY.md](https://github.com/strands-agents/shell/blob/main/SECURITY.md) has the full policy and the complete in-scope and out-of-scope lists.
+Don't open a public GitHub issue. Report through the [AWS Vulnerability Disclosure Program on HackerOne](https://hackerone.com/aws_vdp) or by email to `aws-security@amazon.com`. The repository's [SECURITY.md](https://github.com/strands-agents/shell/blob/main/SECURITY.md) has the full policy and the complete in-scope and out-of-scope lists.


### PR DESCRIPTION
## Description

Follow-up to #2849. Addresses the [review comment](https://github.com/strands-agents/harness-sdk/pull/2849#discussion_r3425546326) about `Bind` constructor defaults being incorrectly framed as safe, and brings the shell docs voice in line with the rest of the site (contractions, softer tone, less repetition).

Also adds the Shell SDK repo to the GitHub nav dropdown and aligns commands.mdx vocabulary with upstream `COMMANDS.md`.

## Related Issues

Follow-up to #2849

## Documentation PR

This PR is itself a documentation update.

## Type of Change

Documentation update

## Testing

Docs-only changes (MDX content and navigation YAML).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.