### PR TITLE
feat: add local memory store

### DIFF
--- a/strands-py/src/strands/vended_memory_stores/__init__.py
+++ b/strands-py/src/strands/vended_memory_stores/__init__.py
@@ -9,6 +9,7 @@ from typing import Any
 
 __all__ = [
     "BedrockKnowledgeBaseStore",
+    "LocalMemoryStore",
 ]
 
 
@@ -21,4 +22,8 @@ def __getattr__(name: str) -> Any:
         from .bedrock_knowledge_base import BedrockKnowledgeBaseStore
 
         return BedrockKnowledgeBaseStore
+    if name == "LocalMemoryStore":
+        from .local import LocalMemoryStore
+
+        return LocalMemoryStore
     raise AttributeError(f"cannot import name '{name}' from '{__name__}' ({__file__})")

--- a/strands-py/src/strands/vended_memory_stores/local/__init__.py
+++ b/strands-py/src/strands/vended_memory_stores/local/__init__.py
@@ -1,0 +1,21 @@
+"""A :class:`~strands.memory.types.MemoryStore` that persists to a local JSON file.
+
+A zero-infrastructure store for prototyping and offline use: no cloud account or provisioned
+resources required. Persists to disk by default so an agent remembers across restarts.
+
+Example:
+    ```python
+    from strands.vended_memory_stores.local import LocalMemoryStore
+
+    store = LocalMemoryStore(name="notes")
+    ```
+"""
+
+from .store import LocalMemoryStore
+from .types import LocalMemoryAddResult, LocalMemoryStoreConfig
+
+__all__ = [
+    "LocalMemoryAddResult",
+    "LocalMemoryStore",
+    "LocalMemoryStoreConfig",
+]

--- a/strands-py/src/strands/vended_memory_stores/local/store.py
+++ b/strands-py/src/strands/vended_memory_stores/local/store.py
@@ -59,6 +59,15 @@ def _tokenize(text: str) -> set[str]:
     return {token for token in re.split(r"\W+", text.lower()) if token}
 
 
+def _token_overlap_score(query_tokens: set[str], content: str) -> int:
+    """Lexical relevance score for one record.
+
+    The number of distinct query tokens that appear in the content; a higher count means more of the
+    query's words are present. Returns 0 when there is no overlap.
+    """
+    return len(query_tokens & _tokenize(content))
+
+
 class LocalMemoryStore(MemoryStore):
     """A :class:`~strands.memory.types.MemoryStore` backed by an in-memory list and a local JSON file.
 
@@ -97,7 +106,8 @@ class LocalMemoryStore(MemoryStore):
             **store_config: See :class:`LocalMemoryStoreConfig`.
 
         Raises:
-            ValueError: If ``name`` is empty/whitespace, or ``max_search_results`` is less than 1.
+            ValueError: If ``name`` or ``path`` is empty/whitespace, or ``max_search_results`` is
+                less than 1.
         """
         self.name = store_config["name"]
         if not self.name.strip():
@@ -113,6 +123,8 @@ class LocalMemoryStore(MemoryStore):
 
         self._persist = store_config.get("persist", True)
         path = store_config.get("path")
+        if path is not None and not path.strip():
+            raise ValueError("LocalMemoryStore: path must not be empty.")
         if not self._persist:
             self._path: Path | None = None
         elif path is not None:
@@ -154,7 +166,7 @@ class LocalMemoryStore(MemoryStore):
 
         scored: list[tuple[dict[str, Any], int]] = []
         for record in records:
-            score = len(query_tokens & _tokenize(record["content"]))
+            score = _token_overlap_score(query_tokens, record["content"])
             if score > 0:
                 scored.append((record, score))
 
@@ -184,6 +196,8 @@ class LocalMemoryStore(MemoryStore):
 
         Raises:
             ValueError: If the store is not writable or ``content`` is empty/whitespace.
+            OSError: If persisting the entry to disk fails (e.g. the path is unreachable or not
+                writable), with the target path in the message.
         """
         if not self.writable:
             raise ValueError("LocalMemoryStore: store is not writable. Set writable=True in config to enable add().")
@@ -230,6 +244,8 @@ class LocalMemoryStore(MemoryStore):
             return self._records
         except json.JSONDecodeError as error:
             raise ValueError(f"LocalMemoryStore: invalid JSON in {self._path}: {error}") from error
+        except OSError as error:
+            raise OSError(f"LocalMemoryStore: failed to read {self._path}: {error}") from error
 
         if not isinstance(parsed_file, list):
             raise ValueError(f"LocalMemoryStore: invalid backing file {self._path}: expected a JSON array of records")
@@ -251,12 +267,19 @@ class LocalMemoryStore(MemoryStore):
         """Persist ``records`` with an atomic write (write to a ``.tmp`` file, then replace).
 
         A crash mid-write can never leave a partially written file. A no-op for ephemeral stores.
+
+        Raises:
+            OSError: If the backing directory cannot be created or the file cannot be written
+                (e.g. the path is unreachable or not writable), with the target path in the message.
         """
         if self._path is None:
             return
 
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = self._path.with_name(f"{self._path.name}.tmp")
-        with open(tmp_path, "w", encoding="utf-8", newline="\n") as file:
-            json.dump(records, file, indent=2, ensure_ascii=False)
-        tmp_path.replace(self._path)
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self._path.with_name(f"{self._path.name}.tmp")
+            with open(tmp_path, "w", encoding="utf-8", newline="\n") as file:
+                json.dump(records, file, indent=2, ensure_ascii=False)
+            tmp_path.replace(self._path)
+        except OSError as error:
+            raise OSError(f"LocalMemoryStore: failed to write {self._path}: {error}") from error

--- a/strands-py/src/strands/vended_memory_stores/local/store.py
+++ b/strands-py/src/strands/vended_memory_stores/local/store.py
@@ -1,0 +1,262 @@
+"""A :class:`~strands.memory.types.MemoryStore` that persists to a local JSON file.
+
+A zero-infrastructure store for prototyping and testing. It persists to disk by default so memories persist
+across sessions, and can be set to ephemeral for testing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from typing_extensions import Unpack
+
+from ...memory.types import MemoryEntry, MemoryStore, Metadata, SearchOptions
+from .types import LocalMemoryAddResult, LocalMemoryStoreConfig
+
+DEFAULT_MAX_SEARCH_RESULTS = 10
+
+# Synthetic metadata key holding the token-overlap relevance score on a search result.
+RELEVANCE_SCORE_KEY = "_relevanceScore"
+
+
+def _new_id() -> str:
+    """Return a fresh record identifier."""
+    return str(uuid.uuid4())
+
+
+def _now() -> str:
+    """Return the current UTC time as a millisecond-precision, ``Z``-suffixed ISO 8601 string.
+
+    This matches the format JavaScript's ``Date.prototype.toISOString()`` emits, so a record written
+    by either SDK carries the same timestamp shape.
+    """
+    now = datetime.now(timezone.utc)
+    return f"{now.strftime('%Y-%m-%dT%H:%M:%S')}.{now.microsecond // 1000:03d}Z"
+
+
+def _sanitize_name(name: str) -> str:
+    r"""Sanitize a store name into a safe single-path-segment filename.
+
+    Collapses parent-directory and separator sequences, then replaces any remaining unsafe
+    character, guarding the default-path branch against a name that would escape the memory
+    directory. Ensures cross-SDK compatibility.
+    """
+    sanitized = name.replace("..", "_").replace("/", "_").replace("\\", "_")
+    return re.sub(r"[^\w\-.]", "_", sanitized, flags=re.ASCII)
+
+
+def _tokenize(text: str) -> set[str]:
+    r"""Lowercase and split text into a set of word tokens, dropping empties.
+
+    Splits on any run of non-word characters. Ensures cross-SDK compatibility.
+    """
+    return {token for token in re.split(r"\W+", text.lower()) if token}
+
+
+class LocalMemoryStore(MemoryStore):
+    """A :class:`~strands.memory.types.MemoryStore` backed by an in-memory list and a local JSON file.
+
+    A zero-infrastructure store for prototyping and testing. It persists to disk by default so memories persist
+    accross sessions. Set ``persist=False`` for an ephemeral, single-session store.
+
+    Recall is lexical: results are ranked by how many query tokens overlap an entry's content, with
+    the most recent entry winning ties. This is keyword matching, not the semantic search a managed
+    vector store (e.g. :class:`~strands.vended_memory_stores.bedrock_knowledge_base.BedrockKnowledgeBaseStore`)
+    provides.
+
+    Each :meth:`add` rewrites the whole file, so this fits modest volumes (hundreds to low thousands
+    of entries), not production workloads — use a managed store like ``BedrockKnowledgeBaseStore`` for
+    that. Writes within a process are serialized; concurrent writers across processes are not.
+
+    The on-disk format is shared with the TypeScript SDK's ``LocalMemoryStore``: records use the same
+    camelCase keys (``id``, ``content``, ``metadata``, ``createdAt``) and the same timestamp shape, so
+    a backing file written by either SDK can be read by the other.
+
+    Example:
+        ```python
+        from strands.vended_memory_stores.local import LocalMemoryStore
+
+        # Persists to ~/.strands/memory/notes.json by default.
+        store = LocalMemoryStore(name="notes")
+
+        result = await store.add("User prefers dark mode")
+        results = await store.search("what theme does the user like?")
+        ```
+    """
+
+    def __init__(self, **store_config: Unpack[LocalMemoryStoreConfig]) -> None:
+        """Initialize the store.
+
+        Args:
+            **store_config: See :class:`LocalMemoryStoreConfig`.
+
+        Raises:
+            ValueError: If ``name`` is empty/whitespace, or ``max_search_results`` is less than 1.
+        """
+        self.name = store_config["name"]
+        if not self.name.strip():
+            raise ValueError("LocalMemoryStore: name must not be empty.")
+        self.description = store_config.get("description")
+        max_search_results = store_config.get("max_search_results")
+        if max_search_results is not None and max_search_results < 1:
+            raise ValueError("LocalMemoryStore: max_search_results must be at least 1.")
+        self.max_search_results = max_search_results
+        # A local store is writable by default: the point is a zero-setup store you can write to.
+        self.writable = store_config.get("writable", True)
+        self.extraction = store_config.get("extraction")
+
+        self._persist = store_config.get("persist", True)
+        path = store_config.get("path")
+        if not self._persist:
+            self._path: Path | None = None
+        elif path is not None:
+            self._path = Path(path)
+        else:
+            self._path = Path.home() / ".strands" / "memory" / f"{_sanitize_name(self.name)}.json"
+
+        # Records load lazily on first read/write so construction never touches the filesystem.
+        self._records: list[dict[str, Any]] | None = None
+        self._lock = threading.Lock()
+
+    async def search(self, query: str, options: SearchOptions | None = None) -> list[MemoryEntry]:
+        """Search stored entries for those whose content overlaps the query.
+
+        Results are ranked by query-token overlap, with the most recent entry winning ties.
+
+        Args:
+            query: The search query text.
+            options: Optional search configuration.
+
+        Returns:
+            Matching memory entries ordered by relevance. Each entry's ``metadata`` includes a
+            reserved synthetic ``_relevanceScore`` key (the token-overlap count). An empty or
+            token-less query returns no results.
+
+        Raises:
+            ValueError: If ``options.max_search_results`` is less than 1.
+        """
+        caller_max = options.get("max_search_results") if options is not None else None
+        if caller_max is not None and caller_max < 1:
+            raise ValueError("LocalMemoryStore: max_search_results must be at least 1.")
+        limit = caller_max or self.max_search_results or DEFAULT_MAX_SEARCH_RESULTS
+
+        query_tokens = _tokenize(query)
+        if not query_tokens:
+            return []
+
+        records = self._load()
+
+        scored: list[tuple[dict[str, Any], int]] = []
+        for record in records:
+            score = len(query_tokens & _tokenize(record["content"]))
+            if score > 0:
+                scored.append((record, score))
+
+        scored.sort(key=lambda item: (item[1], item[0]["createdAt"]), reverse=True)
+
+        entries: list[MemoryEntry] = []
+        for record, score in scored[:limit]:
+            metadata: Metadata = {**(record.get("metadata") or {}), RELEVANCE_SCORE_KEY: score}
+            entries.append(MemoryEntry(content=record["content"], metadata=metadata))
+        return entries
+
+    async def add(self, content: str, metadata: Metadata | None = None) -> LocalMemoryAddResult:
+        """Add ``content`` (with optional ``metadata``) to the store.
+
+        Identical content is deduplicated: a repeat write returns the existing record's id without
+        storing a second copy, so the at-least-once retries that extraction may perform never
+        accumulate duplicates.
+
+        Args:
+            content: The text content to store.
+            metadata: Optional metadata to attach to the entry. The key ``_relevanceScore`` is
+                reserved: :meth:`search` populates it on results, so a value stored under it here is
+                overwritten in search output.
+
+        Returns:
+            The id of the stored (or already-present) record.
+
+        Raises:
+            ValueError: If the store is not writable or ``content`` is empty/whitespace.
+        """
+        if not self.writable:
+            raise ValueError("LocalMemoryStore: store is not writable. Set writable=True in config to enable add().")
+        if not content.strip():
+            raise ValueError("LocalMemoryStore: content must not be empty.")
+
+        # The lock serializes the whole load-modify-flush cycle so concurrent adds don't each load
+        # the same snapshot and clobber one another (last-write-wins). Within a single event loop the
+        # synchronous critical section is already atomic; the lock additionally guards a store shared
+        # across OS threads.
+        with self._lock:
+            records = self._load()
+
+            normalized_content = content.strip()
+            for record in records:
+                if record["content"].strip() == normalized_content:
+                    return LocalMemoryAddResult(id=record["id"])
+
+            new_record: dict[str, Any] = {"id": _new_id(), "content": content, "createdAt": _now()}
+            if metadata is not None:
+                new_record["metadata"] = metadata
+
+            # Flush the candidate list first and only commit it to the in-memory cache once the write
+            # succeeds, so a failed flush never leaves a phantom record that later writes resurrect.
+            next_records = [*records, new_record]
+            self._flush(next_records)
+            self._records = next_records
+            return LocalMemoryAddResult(id=new_record["id"])
+
+    def _load(self) -> list[dict[str, Any]]:
+        """Load records from disk on first use; ephemeral stores (and a missing file) start empty."""
+        if self._records is not None:
+            return self._records
+
+        if self._path is None:
+            self._records = []
+            return self._records
+
+        try:
+            with open(self._path, encoding="utf-8") as file:
+                parsed_file = json.load(file)
+        except FileNotFoundError:
+            self._records = []
+            return self._records
+        except json.JSONDecodeError as error:
+            raise ValueError(f"LocalMemoryStore: invalid JSON in {self._path}: {error}") from error
+
+        if not isinstance(parsed_file, list):
+            raise ValueError(f"LocalMemoryStore: invalid backing file {self._path}: expected a JSON array of records")
+        for record in parsed_file:
+            if (
+                not isinstance(record, dict)
+                or not isinstance(record.get("id"), str)
+                or not isinstance(record.get("content"), str)
+                or not isinstance(record.get("createdAt"), str)
+            ):
+                raise ValueError(
+                    f"LocalMemoryStore: invalid backing file {self._path}: "
+                    "each record must have string 'id', 'content', and 'createdAt' fields"
+                )
+        self._records = parsed_file
+        return self._records
+
+    def _flush(self, records: list[dict[str, Any]]) -> None:
+        """Persist ``records`` with an atomic write (write to a ``.tmp`` file, then replace).
+
+        A crash mid-write can never leave a partially written file. A no-op for ephemeral stores.
+        """
+        if self._path is None:
+            return
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._path.with_name(f"{self._path.name}.tmp")
+        with open(tmp_path, "w", encoding="utf-8", newline="\n") as file:
+            json.dump(records, file, indent=2, ensure_ascii=False)
+        tmp_path.replace(self._path)

--- a/strands-py/src/strands/vended_memory_stores/local/types.py
+++ b/strands-py/src/strands/vended_memory_stores/local/types.py
@@ -1,0 +1,36 @@
+"""Configuration and result types for the local memory store."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...memory.types import MemoryStoreConfig
+
+
+class LocalMemoryStoreConfig(MemoryStoreConfig, total=False):
+    """Full configuration for a :class:`LocalMemoryStore`, passed as its constructor kwargs.
+
+    The store persists to disk by default so memories persist across sessions.
+    Set ``persist`` to ``False`` for an ephemeral, single-session store.
+
+    Attributes:
+        persist: Whether to persist entries to disk so they survive process restarts. ``True``
+            (default) flushes writes to ``path`` (or the default location); ``False`` keeps entries
+            in memory only, so they are lost when the process exits.
+        path: Full path to the JSON file backing this store. Defaults to
+            ``~/.strands/memory/<sanitized-store-name>.json``. Ignored when ``persist`` is ``False``.
+    """
+
+    persist: bool
+    path: str
+
+
+@dataclass
+class LocalMemoryAddResult:
+    """Result returned by :meth:`LocalMemoryStore.add`.
+
+    Attributes:
+        id: The generated id of the stored (or already-present, on dedup) record.
+    """
+
+    id: str

--- a/strands-py/tests/strands/vended_memory_stores/local/test_store.py
+++ b/strands-py/tests/strands/vended_memory_stores/local/test_store.py
@@ -1,0 +1,372 @@
+"""Tests for ``LocalMemoryStore``.
+
+Test scaffolding:
+- ``tmp_path`` backs every persistent store, so tests never touch the real ``~/.strands/memory``.
+- ``make_store`` builds a store rooted at a unique file under ``tmp_path``.
+- ``_FakeAgent`` / ``_invoke_all`` mirror the extraction wiring in the Bedrock store tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import re
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import strands.vended_memory_stores.local.store as store_module
+from strands.hooks.events import AfterInvocationEvent, MessageAddedEvent
+from strands.hooks.registry import HookOrder
+from strands.memory.extraction.triggers import InvocationTrigger
+from strands.memory.extraction.types import ExtractionConfig, ExtractionResult
+from strands.memory.memory_manager import MemoryManager
+from strands.vended_memory_stores.local import LocalMemoryStore
+
+
+@pytest.fixture
+def store_path(tmp_path: Path) -> str:
+    """A unique backing-file path under the test's temp dir."""
+    return str(tmp_path / "notes.json")
+
+
+@pytest.fixture
+def make_store(store_path: str):
+    """Factory building a persistent store at ``store_path`` with overridable config."""
+
+    def _make(**overrides: Any) -> LocalMemoryStore:
+        config: dict[str, Any] = {"name": "notes", "path": store_path}
+        config.update(overrides)
+        return LocalMemoryStore(**config)
+
+    return _make
+
+
+class TestPackageExport:
+    def test_lazy_export_from_parent_package(self):
+        # The store is documented as importable from the parent package via its lazy __getattr__.
+        from strands.vended_memory_stores import __getattr__
+
+        assert __getattr__("LocalMemoryStore") is LocalMemoryStore
+
+    def test_unknown_attribute_raises(self):
+        from strands.vended_memory_stores import __getattr__
+
+        with pytest.raises(AttributeError):
+            __getattr__("NoSuchStore")
+
+
+class TestConstructor:
+    def test_is_writable_by_default(self, make_store):
+        assert make_store().writable is True
+
+    def test_honors_explicit_writable_false(self, make_store):
+        assert make_store(writable=False).writable is False
+
+    def test_exposes_identity_fields(self, make_store):
+        store = make_store(description="my notes", max_search_results=7)
+        assert store.name == "notes"
+        assert store.description == "my notes"
+        assert store.max_search_results == 7
+
+    def test_raises_when_max_search_results_below_one(self, make_store):
+        with pytest.raises(ValueError, match="max_search_results must be at least 1"):
+            make_store(max_search_results=0)
+
+    def test_raises_when_name_is_empty(self, make_store):
+        with pytest.raises(ValueError, match="name must not be empty"):
+            make_store(name="   ")
+
+    def test_does_no_filesystem_io_on_construction(self, make_store, store_path):
+        make_store()
+        assert not Path(store_path).exists()
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_a_sanitized_path_under_the_home_memory_dir(self, tmp_path, monkeypatch):
+        # No explicit path: the store derives ~/.strands/memory/<sanitized-store-name>.json. Home is
+        # redirected to tmp_path so the test never touches the real home dir, and the unsafe name
+        # exercises sanitization.
+        monkeypatch.setattr(store_module.Path, "home", classmethod(lambda cls: tmp_path))
+        store = LocalMemoryStore(name="../weird/name")
+        await store.add("a fact worth keeping")
+        expected = tmp_path / ".strands" / "memory" / "__weird_name.json"
+        assert expected.is_file()
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_raises_when_not_writable(self, make_store):
+        store = make_store(writable=False)
+        with pytest.raises(ValueError, match="store is not writable"):
+            await store.add("fact")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_empty_content(self, make_store):
+        store = make_store()
+        with pytest.raises(ValueError, match="content must not be empty"):
+            await store.add("   ")
+
+    @pytest.mark.asyncio
+    async def test_returns_an_id(self, make_store):
+        result = await make_store().add("user prefers dark mode")
+        assert result.id
+
+    @pytest.mark.asyncio
+    async def test_uses_the_monkeypatchable_id_generator(self, make_store, monkeypatch):
+        # _new_id is a module-level seam; patching it pins the id the store mints.
+        monkeypatch.setattr(store_module, "_new_id", lambda: "fixed-id")
+        result = await make_store().add("user prefers dark mode")
+        assert result.id == "fixed-id"
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_identical_content(self, make_store):
+        store = make_store()
+        first = await store.add("user prefers dark mode")
+        second = await store.add("user prefers dark mode")
+        assert second.id == first.id
+        assert len(await store.search("dark mode preferences")) == 1
+
+    @pytest.mark.asyncio
+    async def test_persists_human_readable_json(self, make_store, store_path):
+        store = make_store()
+        await store.add("user prefers dark mode", {"source": "user"})
+        raw = Path(store_path).read_text(encoding="utf-8")
+        assert "\n  " in raw  # pretty-printed
+        parsed = json.loads(raw)
+        assert len(parsed) == 1
+        assert parsed[0]["content"] == "user prefers dark mode"
+        assert parsed[0]["metadata"] == {"source": "user"}
+        assert parsed[0]["id"]
+        assert parsed[0]["createdAt"]
+
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_raises_when_max_search_results_below_one(self, make_store):
+        store = make_store()
+        with pytest.raises(ValueError, match="max_search_results must be at least 1"):
+            await store.search("q", {"max_search_results": 0})
+
+    @pytest.mark.asyncio
+    async def test_returns_nothing_for_token_less_query(self, make_store):
+        store = make_store()
+        await store.add("user prefers dark mode")
+        assert await store.search("") == []
+        assert await store.search("   ...  ") == []
+
+    @pytest.mark.asyncio
+    async def test_ranks_higher_overlap_first_with_relevance_score(self, make_store):
+        store = make_store()
+        await store.add("the cat sat on the mat")
+        await store.add("the cat chased the dog in the park")
+
+        results = await store.search("cat dog park")
+        assert len(results) == 2
+        assert results[0].content == "the cat chased the dog in the park"
+        assert results[0].metadata["_relevanceScore"] == 3
+        assert results[1].metadata["_relevanceScore"] == 1
+
+    @pytest.mark.asyncio
+    async def test_excludes_records_with_no_token_overlap(self, make_store):
+        store = make_store()
+        await store.add("the cat sat on the mat")
+        await store.add("a completely unrelated note")
+
+        results = await store.search("cat")
+        assert len(results) == 1
+        assert results[0].content == "the cat sat on the mat"
+
+    @pytest.mark.asyncio
+    async def test_breaks_ties_by_recency(self, make_store, monkeypatch):
+        store = make_store()
+        timestamps = iter(["2026-01-01T00:00:00.000Z", "2026-01-02T00:00:00.000Z"])
+        monkeypatch.setattr(store_module, "_now", lambda: next(timestamps))
+        await store.add("coffee is great")
+        await store.add("coffee is bitter")
+
+        results = await store.search("coffee")
+        assert results[0].content == "coffee is bitter"
+        assert results[1].content == "coffee is great"
+
+    @pytest.mark.asyncio
+    async def test_caps_results_to_max_search_results(self, make_store):
+        store = make_store()
+        await store.add("alpha match")
+        await store.add("beta match")
+        await store.add("gamma match")
+        assert len(await store.search("match", {"max_search_results": 2})) == 2
+
+    @pytest.mark.asyncio
+    async def test_tokenizes_non_ascii_content_as_whole_words(self, make_store):
+        # Unicode-aware tokenization (matching the TS SDK): accented/non-Latin words stay intact, so
+        # a query for the same word matches rather than being shredded into ASCII fragments.
+        store = make_store()
+        await store.add("the café in 日本 is naïve")
+        assert len(await store.search("café")) == 1
+        assert len(await store.search("日本")) == 1
+
+
+class TestPersistence:
+    @pytest.mark.asyncio
+    async def test_survives_restart(self, make_store):
+        first = make_store()
+        await first.add("user lives in Berlin")
+
+        second = make_store()
+        results = await second.search("where does the user live")
+        assert len(results) == 1
+        assert results[0].content == "user lives in Berlin"
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_writes_no_file_and_forgets(self, make_store, store_path):
+        first = make_store(persist=False)
+        await first.add("ephemeral fact")
+        assert not Path(store_path).exists()
+
+        second = make_store(persist=False)
+        assert await second.search("ephemeral fact") == []
+
+    @pytest.mark.asyncio
+    async def test_starts_empty_when_file_missing(self, make_store):
+        assert await make_store().search("anything") == []
+
+    @pytest.mark.asyncio
+    async def test_raises_clear_error_on_corrupt_file(self, make_store, store_path):
+        Path(store_path).write_text("not json{", encoding="utf-8")
+        store = make_store()
+        with pytest.raises(ValueError, match="invalid JSON"):
+            await store.search("anything")
+
+    @pytest.mark.asyncio
+    async def test_raises_clear_error_on_wrong_shape_file(self, make_store, store_path):
+        # Valid JSON that is not an array of records (e.g. a hand-edited object) must fail fast with
+        # a clear message rather than crashing opaquely deeper in search/add.
+        Path(store_path).write_text("{}", encoding="utf-8")
+        store = make_store()
+        with pytest.raises(ValueError, match="expected a JSON array"):
+            await store.search("anything")
+
+    @pytest.mark.asyncio
+    async def test_raises_clear_error_on_malformed_record(self, make_store, store_path):
+        # A valid JSON array whose elements lack the required fields must also fail fast with a clear
+        # message rather than raising a bare KeyError deeper in search/add.
+        Path(store_path).write_text(json.dumps([{"foo": "bar"}]), encoding="utf-8")
+        store = make_store()
+        with pytest.raises(ValueError, match="each record must have string"):
+            await store.search("anything")
+
+    @pytest.mark.asyncio
+    async def test_keeps_all_entries_under_concurrent_writes(self, make_store, store_path):
+        store = make_store()
+        await asyncio.gather(*(store.add(f"fact number {index}") for index in range(10)))
+        assert len(json.loads(Path(store_path).read_text(encoding="utf-8"))) == 10
+
+
+class TestCrossSdkInterop:
+    """The on-disk format is shared with the TypeScript SDK; a file written by either loads in both."""
+
+    @pytest.mark.asyncio
+    async def test_loads_a_file_written_in_the_shared_camelcase_format(self, make_store, store_path):
+        # A record shaped exactly as the TypeScript SDK writes it: camelCase keys and a millisecond,
+        # Z-suffixed timestamp. The Python store must read it without translation.
+        ts_written = [
+            {
+                "id": "019ed65a-fd27-746c-aa3a-693a4a5434df",
+                "content": "the user prefers dark mode",
+                "metadata": {"source": "ts"},
+                "createdAt": "2026-01-02T00:00:00.000Z",
+            }
+        ]
+        Path(store_path).write_text(json.dumps(ts_written), encoding="utf-8")
+
+        store = make_store()
+        results = await store.search("dark mode preference")
+        assert len(results) == 1
+        assert results[0].content == "the user prefers dark mode"
+        assert results[0].metadata["source"] == "ts"
+        assert results[0].metadata["_relevanceScore"] == 2
+
+    @pytest.mark.asyncio
+    async def test_now_matches_javascript_toisostring_shape(self):
+        # Millisecond precision, 'Z' suffix — the same shape Date.prototype.toISOString() emits.
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", store_module._now())
+
+
+class TestPackageExports:
+    def test_lazily_exported_from_vended_memory_stores(self):
+        import strands.vended_memory_stores as vended_memory_stores
+
+        assert vended_memory_stores.LocalMemoryStore is LocalMemoryStore
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        import strands.vended_memory_stores as vended_memory_stores
+
+        with pytest.raises(AttributeError):
+            _ = vended_memory_stores.NotAStore
+
+
+class _FakeAgent:
+    """Minimal agent stand-in for ``init_agent`` wiring (mirrors the Bedrock store tests)."""
+
+    def __init__(self, model: Any = None) -> None:
+        self.model = model
+        self.hooks: list[tuple[Any, Any, float]] = []
+        self._middleware_registry = MagicMock()
+
+    def add_hook(self, callback: Any, event_type: Any = None, *, order: float = HookOrder.DEFAULT) -> None:
+        self.hooks.append((callback, event_type, order))
+
+
+async def _invoke_all(agent: _FakeAgent, event: Any) -> None:
+    """Fire every recorded hook registered for ``event``'s type."""
+    for callback, event_type, _order in list(agent.hooks):
+        if event_type is type(event):
+            result = callback(event)
+            if inspect.isawaitable(result):
+                await result
+
+
+class TestMemoryManagerIntegration:
+    @pytest.mark.asyncio
+    async def test_manager_stamps_store_name(self, make_store):
+        store = make_store()
+        await store.add("user prefers dark mode")
+
+        mm = MemoryManager(stores=[store])
+        results = await mm.search("dark mode")
+        assert len(results) == 1
+        assert results[0].store_name == "notes"
+
+    @pytest.mark.asyncio
+    async def test_manager_add_writes_to_store(self, make_store, store_path):
+        store = make_store()
+        mm = MemoryManager(stores=[store], add_tool_config=True)
+        await mm.add("user likes coffee")
+        assert len(json.loads(Path(store_path).read_text(encoding="utf-8"))) == 1
+
+    @pytest.mark.asyncio
+    async def test_ingests_extracted_facts_through_add(self, make_store, store_path):
+        extractor = MagicMock()
+
+        async def _extract(messages, context=None):
+            return [ExtractionResult(content="user prefers dark mode")]
+
+        extractor.extract.side_effect = _extract
+
+        store = make_store(extraction=ExtractionConfig(trigger=InvocationTrigger(), extractor=extractor))
+        mm = MemoryManager(stores=[store])
+        agent = _FakeAgent()
+        mm.init_agent(agent)
+
+        message = {"role": "user", "content": [{"text": "I like dark mode"}]}
+        await _invoke_all(agent, MessageAddedEvent(agent=agent, message=message))
+        await _invoke_all(agent, AfterInvocationEvent(agent=agent))
+        await mm.flush()
+
+        extractor.extract.assert_called_once()
+        parsed = json.loads(Path(store_path).read_text(encoding="utf-8"))
+        assert len(parsed) == 1
+        assert parsed[0]["content"] == "user prefers dark mode"

--- a/strands-py/tests/strands/vended_memory_stores/local/test_store.py
+++ b/strands-py/tests/strands/vended_memory_stores/local/test_store.py
@@ -80,6 +80,10 @@ class TestConstructor:
         with pytest.raises(ValueError, match="name must not be empty"):
             make_store(name="   ")
 
+    def test_raises_when_explicit_path_is_empty(self):
+        with pytest.raises(ValueError, match="path must not be empty"):
+            LocalMemoryStore(name="notes", path="   ")
+
     def test_does_no_filesystem_io_on_construction(self, make_store, store_path):
         make_store()
         assert not Path(store_path).exists()
@@ -263,6 +267,16 @@ class TestPersistence:
         store = make_store()
         await asyncio.gather(*(store.add(f"fact number {index}") for index in range(10)))
         assert len(json.loads(Path(store_path).read_text(encoding="utf-8"))) == 10
+
+    @pytest.mark.asyncio
+    async def test_raises_clear_error_when_path_is_unreachable(self, tmp_path):
+        # Point the store under an existing FILE, so the backing path can't be reached — surfacing a
+        # wrapped "failed to read/write" error naming the path rather than a bare OSError.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory", encoding="utf-8")
+        store = LocalMemoryStore(name="notes", path=str(blocker / "notes.json"))
+        with pytest.raises(OSError, match="failed to"):
+            await store.add("user prefers dark mode")
 
 
 class TestCrossSdkInterop:

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -77,6 +77,10 @@
       "types": "./dist/src/vended-memory-stores/bedrock-knowledge-base/index.d.ts",
       "default": "./dist/src/vended-memory-stores/bedrock-knowledge-base/index.js"
     },
+    "./vended-memory-stores/local": {
+      "types": "./dist/src/vended-memory-stores/local/index.d.ts",
+      "default": "./dist/src/vended-memory-stores/local/index.js"
+    },
     "./telemetry": {
       "types": "./dist/src/telemetry/index.d.ts",
       "default": "./dist/src/telemetry/index.js"

--- a/strands-ts/src/vended-memory-stores/local/__tests__/local-memory-store.test.node.ts
+++ b/strands-ts/src/vended-memory-stores/local/__tests__/local-memory-store.test.node.ts
@@ -56,6 +56,10 @@ describe('LocalMemoryStore', () => {
       expect(() => new LocalMemoryStore({ name: '   ' })).toThrow('name must not be empty')
     })
 
+    it('throws when an explicit path is empty', () => {
+      expect(() => new LocalMemoryStore({ name: 'notes', path: '   ' })).toThrow('path must not be empty')
+    })
+
     it('does no filesystem I/O on construction', async () => {
       new LocalMemoryStore({ name: 'notes', path: filePath() })
       await expect(fs.access(filePath())).rejects.toThrow()
@@ -228,6 +232,15 @@ describe('LocalMemoryStore', () => {
       await fs.writeFile(filePath(), JSON.stringify([{ foo: 'bar' }]), 'utf8')
       const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
       await expect(store.search('anything')).rejects.toThrow('each record must have string')
+    })
+
+    it('throws a clear error when the path is unreachable', async () => {
+      // Point the store under an existing FILE, so the backing path can't be reached — surfacing a
+      // wrapped "failed to read/write" error naming the path rather than a bare OS error.
+      const blocker = join(dir, 'blocker')
+      await fs.writeFile(blocker, 'not a directory', 'utf8')
+      const store = new LocalMemoryStore({ name: 'notes', path: join(blocker, 'notes.json') })
+      await expect(store.add('user prefers dark mode')).rejects.toThrow('failed to')
     })
 
     it('keeps all entries when many writes happen concurrently', async () => {

--- a/strands-ts/src/vended-memory-stores/local/__tests__/local-memory-store.test.node.ts
+++ b/strands-ts/src/vended-memory-stores/local/__tests__/local-memory-store.test.node.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'node:fs'
+import * as os from 'node:os'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LocalMemoryStore } from '../store.js'
+import { MemoryManager } from '../../../memory/index.js'
+import { InvocationTrigger } from '../../../memory/extraction/triggers.js'
+import type { Extractor } from '../../../memory/extraction/types.js'
+import { Message, TextBlock } from '../../../types/messages.js'
+import { AfterInvocationEvent, MessageAddedEvent } from '../../../hooks/events.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+
+// Every test that persists points at a unique file under the OS temp dir, never the real
+// ~/.strands/memory, so tests don't touch a developer's actual memory.
+let dir: string
+let counter = 0
+
+beforeEach(async () => {
+  dir = join(tmpdir(), `strands-local-memory-${process.pid}-${counter++}`)
+  await fs.mkdir(dir, { recursive: true })
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+function filePath(name = 'notes'): string {
+  return join(dir, `${name}.json`)
+}
+
+describe('LocalMemoryStore', () => {
+  describe('constructor', () => {
+    it('is writable by default', () => {
+      expect(new LocalMemoryStore({ name: 'notes' }).writable).toBe(true)
+    })
+
+    it('honors an explicit writable: false', () => {
+      expect(new LocalMemoryStore({ name: 'notes', writable: false }).writable).toBe(false)
+    })
+
+    it('exposes name, description, and maxSearchResults', () => {
+      const store = new LocalMemoryStore({ name: 'notes', description: 'my notes', maxSearchResults: 7 })
+      expect(store.name).toBe('notes')
+      expect(store.description).toBe('my notes')
+      expect(store.maxSearchResults).toBe(7)
+    })
+
+    it('throws when maxSearchResults is less than 1', () => {
+      expect(() => new LocalMemoryStore({ name: 'notes', maxSearchResults: 0 })).toThrow(
+        'maxSearchResults must be at least 1'
+      )
+    })
+
+    it('throws when name is empty', () => {
+      expect(() => new LocalMemoryStore({ name: '   ' })).toThrow('name must not be empty')
+    })
+
+    it('does no filesystem I/O on construction', async () => {
+      new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await expect(fs.access(filePath())).rejects.toThrow()
+    })
+  })
+
+  describe('add', () => {
+    it('throws when the store is not writable', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', writable: false, path: filePath() })
+      await expect(store.add('fact')).rejects.toThrow('store is not writable')
+    })
+
+    it('throws on empty or whitespace content', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await expect(store.add('   ')).rejects.toThrow('content must not be empty')
+    })
+
+    it('returns an id for stored content', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      const { id } = await store.add('user prefers dark mode')
+      expect(id).toBeTruthy()
+    })
+
+    it('deduplicates identical content, returning the existing id', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      const first = await store.add('user prefers dark mode')
+      const second = await store.add('user prefers dark mode')
+      expect(second.id).toBe(first.id)
+      const results = await store.search('dark mode preferences')
+      expect(results).toHaveLength(1)
+    })
+
+    it('persists a human-readable JSON array to disk', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await store.add('user prefers dark mode', { source: 'user' })
+      const raw = await fs.readFile(filePath(), 'utf8')
+      expect(raw).toContain('\n  ') // pretty-printed
+      const parsed = JSON.parse(raw)
+      expect(parsed).toHaveLength(1)
+      expect(parsed[0]).toMatchObject({ content: 'user prefers dark mode', metadata: { source: 'user' } })
+      expect(parsed[0].id).toBeTruthy()
+      expect(parsed[0].createdAt).toBeTruthy()
+    })
+  })
+
+  describe('search', () => {
+    it('throws when maxSearchResults is less than 1', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await expect(store.search('q', { maxSearchResults: 0 })).rejects.toThrow('maxSearchResults must be at least 1')
+    })
+
+    it('returns no results for an empty or token-less query', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await store.add('user prefers dark mode')
+      expect(await store.search('')).toEqual([])
+      expect(await store.search('   ...  ')).toEqual([])
+    })
+
+    it('ranks higher token overlap first and exposes _relevanceScore', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await store.add('the cat sat on the mat')
+      await store.add('the cat chased the dog in the park')
+
+      const results = await store.search('cat dog park')
+      expect(results).toHaveLength(2)
+      expect(results[0]?.content).toBe('the cat chased the dog in the park')
+      expect(results[0]?.metadata?._relevanceScore).toBe(3)
+      expect(results[1]?.metadata?._relevanceScore).toBe(1)
+    })
+
+    it('excludes records with no token overlap', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await store.add('the cat sat on the mat')
+      await store.add('a completely unrelated note')
+
+      const results = await store.search('cat')
+      expect(results).toHaveLength(1)
+      expect(results[0]?.content).toBe('the cat sat on the mat')
+    })
+
+    it('breaks ties by recency (most recent first)', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      // Stamp deterministic, increasing timestamps so the tie-break is testable.
+      const isoSpy = vi
+        .spyOn(Date.prototype, 'toISOString')
+        .mockReturnValueOnce('2026-01-01T00:00:00.000Z')
+        .mockReturnValueOnce('2026-01-02T00:00:00.000Z')
+      await store.add('coffee is great')
+      await store.add('coffee is bitter')
+      isoSpy.mockRestore()
+
+      const results = await store.search('coffee')
+      expect(results[0]?.content).toBe('coffee is bitter')
+      expect(results[1]?.content).toBe('coffee is great')
+    })
+
+    it('caps results to maxSearchResults', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await store.add('alpha match')
+      await store.add('beta match')
+      await store.add('gamma match')
+      const results = await store.search('match', { maxSearchResults: 2 })
+      expect(results).toHaveLength(2)
+    })
+
+    it('tokenizes non-ASCII content as whole words (Unicode-aware, matching Python)', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await store.add('the café in 日本 is naïve')
+      expect(await store.search('café')).toHaveLength(1)
+      expect(await store.search('日本')).toHaveLength(1)
+    })
+  })
+
+  describe('persistence', () => {
+    it('recalls entries from a fresh instance pointed at the same file (survives restart)', async () => {
+      const first = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await first.add('user lives in Berlin')
+
+      const second = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      const results = await second.search('where does the user live')
+      expect(results).toHaveLength(1)
+      expect(results[0]?.content).toBe('user lives in Berlin')
+    })
+
+    it('is ephemeral when persist is false: no file, a fresh instance forgets', async () => {
+      const first = new LocalMemoryStore({ name: 'notes', persist: false, path: filePath() })
+      await first.add('ephemeral fact')
+      await expect(fs.access(filePath())).rejects.toThrow()
+
+      const second = new LocalMemoryStore({ name: 'notes', persist: false, path: filePath() })
+      expect(await second.search('ephemeral fact')).toEqual([])
+    })
+
+    it('starts empty when the backing file is missing', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      expect(await store.search('anything')).toEqual([])
+    })
+
+    it('defaults to a sanitized path under <home>/.strands/memory when no path is given', async () => {
+      // Redirect the home dir into the temp dir (HOME/USERPROFILE, which os.homedir reads) so the
+      // test never touches the real home dir; the unsafe name exercises sanitization.
+      const savedHome = process.env.HOME
+      const savedUserProfile = process.env.USERPROFILE
+      process.env.HOME = dir
+      process.env.USERPROFILE = dir
+      try {
+        const store = new LocalMemoryStore({ name: '../weird/name' })
+        await store.add('a fact worth keeping')
+        const expected = join(os.homedir(), '.strands', 'memory', '__weird_name.json')
+        await expect(fs.access(expected)).resolves.toBeUndefined()
+      } finally {
+        process.env.HOME = savedHome
+        process.env.USERPROFILE = savedUserProfile
+      }
+    })
+
+    it('throws a clear error on a corrupt backing file', async () => {
+      await fs.writeFile(filePath(), 'not json{', 'utf8')
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await expect(store.search('anything')).rejects.toThrow('invalid JSON')
+    })
+
+    it('throws a clear error on a valid-but-wrong-shape backing file', async () => {
+      await fs.writeFile(filePath(), '{}', 'utf8')
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await expect(store.search('anything')).rejects.toThrow('expected a JSON array')
+    })
+
+    it('throws a clear error on a malformed record', async () => {
+      await fs.writeFile(filePath(), JSON.stringify([{ foo: 'bar' }]), 'utf8')
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await expect(store.search('anything')).rejects.toThrow('each record must have string')
+    })
+
+    it('keeps all entries when many writes happen concurrently', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await Promise.all(Array.from({ length: 10 }, (_, index) => store.add(`fact number ${index}`)))
+      const raw = await fs.readFile(filePath(), 'utf8')
+      expect(JSON.parse(raw)).toHaveLength(10)
+    })
+
+    it('reflects a just-added record when a search races the first add (no stale cache)', async () => {
+      // On a cold store, search() and add() both trigger the lazy load; the memoized load must keep
+      // the added record visible to subsequent searches rather than overwriting it with a pre-write
+      // snapshot.
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await Promise.all([store.add('zebra giraffe'), store.search('apple')])
+      const results = await store.search('zebra')
+      expect(results).toHaveLength(1)
+      expect(results[0]?.content).toBe('zebra giraffe')
+    })
+  })
+
+  describe('cross-SDK interop', () => {
+    it('loads a file written in the shared camelCase format', async () => {
+      // A record shaped exactly as the Python SDK writes it: camelCase keys and a millisecond,
+      // Z-suffixed timestamp. The TS store must read it without translation.
+      const pyWritten = [
+        {
+          id: '019ed65a-fd27-746c-aa3a-693a4a5434df',
+          content: 'the user prefers dark mode',
+          metadata: { source: 'py' },
+          createdAt: '2026-01-02T00:00:00.000Z',
+        },
+      ]
+      await fs.writeFile(filePath(), JSON.stringify(pyWritten), 'utf8')
+
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      const results = await store.search('dark mode preference')
+      expect(results).toHaveLength(1)
+      expect(results[0]?.content).toBe('the user prefers dark mode')
+      expect(results[0]?.metadata?.source).toBe('py')
+      expect(results[0]?.metadata?._relevanceScore).toBe(2)
+    })
+
+    it('writes the shared camelCase format with a Z-suffixed millisecond timestamp', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await store.add('hello world')
+      const record = JSON.parse(await fs.readFile(filePath(), 'utf8'))[0]
+      expect(Object.keys(record).sort()).toEqual(['content', 'createdAt', 'id'])
+      expect(record.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+    })
+  })
+
+  describe('MemoryManager integration', () => {
+    it('stamps storeName on results returned through the manager', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      await store.add('user prefers dark mode')
+
+      const mm = new MemoryManager({ stores: [store] })
+      const results = await mm.search('dark mode')
+      expect(results).toHaveLength(1)
+      expect(results[0]?.storeName).toBe('notes')
+    })
+
+    it('writes through the manager add API', async () => {
+      const store = new LocalMemoryStore({ name: 'notes', path: filePath() })
+      const mm = new MemoryManager({ stores: [store], addToolConfig: true })
+      await mm.add('user likes coffee')
+      expect(JSON.parse(await fs.readFile(filePath(), 'utf8'))).toHaveLength(1)
+    })
+
+    it('ingests extracted facts through add when extraction fires (client-side extractor)', async () => {
+      const extractor: Extractor = {
+        extract: vi.fn().mockResolvedValue([{ content: 'user prefers dark mode' }]),
+      }
+      const store = new LocalMemoryStore({
+        name: 'notes',
+        path: filePath(),
+        extraction: { trigger: new InvocationTrigger(), extractor },
+      })
+
+      const mm = new MemoryManager({ stores: [store] })
+      const agent = createMockAgent()
+      mm.initAgent(agent)
+
+      const message = new Message({ role: 'user', content: [new TextBlock('I like dark mode')] })
+      const added = agent.trackedHooks.filter((hook) => hook.eventType === MessageAddedEvent)
+      for (const hook of added) await hook.callback(new MessageAddedEvent({ agent, message, invocationState: {} }))
+      const after = agent.trackedHooks.filter((hook) => hook.eventType === AfterInvocationEvent)
+      for (const hook of after) await hook.callback(new AfterInvocationEvent({ agent, invocationState: {} }))
+      await mm.flush()
+
+      expect(extractor.extract).toHaveBeenCalledTimes(1)
+      const parsed = JSON.parse(await fs.readFile(filePath(), 'utf8'))
+      expect(parsed).toHaveLength(1)
+      expect(parsed[0].content).toBe('user prefers dark mode')
+    })
+  })
+})

--- a/strands-ts/src/vended-memory-stores/local/index.ts
+++ b/strands-ts/src/vended-memory-stores/local/index.ts
@@ -1,0 +1,1 @@
+export { LocalMemoryStore, type LocalMemoryStoreConfig, type LocalMemoryAddResult } from './store.js'

--- a/strands-ts/src/vended-memory-stores/local/store.ts
+++ b/strands-ts/src/vended-memory-stores/local/store.ts
@@ -76,6 +76,19 @@ function tokenize(text: string): Set<string> {
 }
 
 /**
+ * Lexical relevance score for one record: the number of distinct query tokens that appear in the
+ * record's content. A higher count means more of the query's words are present. Returns 0 when there
+ * is no overlap.
+ */
+function tokenOverlapScore(queryTokens: Set<string>, content: string): number {
+  let score = 0
+  for (const token of tokenize(content)) {
+    if (queryTokens.has(token)) score++
+  }
+  return score
+}
+
+/**
  * A zero-infrastructure store {@link MemoryStore} that keeps entries in memory and by default
  * persists them to a local JSON file. Use for prototyping and testing.
  *
@@ -141,6 +154,9 @@ export class LocalMemoryStore implements MemoryStore {
     this.writable = writable ?? true
     if (extraction !== undefined) this.extraction = extraction
 
+    if (path !== undefined && !path.trim()) {
+      throw new Error('LocalMemoryStore: path must not be empty.')
+    }
     this._persist = persist ?? true
     this._explicitPath = path
   }
@@ -168,10 +184,7 @@ export class LocalMemoryStore implements MemoryStore {
 
     const scored: Array<{ record: LocalMemoryRecord; score: number }> = []
     for (const record of records) {
-      let score = 0
-      for (const token of tokenize(record.content)) {
-        if (queryTokens.has(token)) score++
-      }
+      const score = tokenOverlapScore(queryTokens, record.content)
       if (score > 0) scored.push({ record, score })
     }
 
@@ -278,7 +291,7 @@ export class LocalMemoryStore implements MemoryStore {
       rawContent = await readFile(filePath, 'utf8')
     } catch (error: unknown) {
       if ((error as { code?: string }).code === 'ENOENT') return []
-      throw error
+      throw new Error(`LocalMemoryStore: failed to read ${filePath}`, { cause: error })
     }
 
     let parsedFile: unknown
@@ -310,7 +323,8 @@ export class LocalMemoryStore implements MemoryStore {
   /**
    * Persists `records` to disk with an atomic write (write to a `.tmp` file, then rename) so a
    * crash mid-write can never leave a partially written file. A no-op for ephemeral stores. Callers
-   * serialize invocations via {@link _writeChain}.
+   * serialize invocations via {@link _writeChain}. Throws with the target path (and the OS error as
+   * `cause`) when the path is unreachable or not writable.
    */
   private async _flush(records: LocalMemoryRecord[]): Promise<void> {
     const filePath = await this._getPath()
@@ -318,9 +332,13 @@ export class LocalMemoryStore implements MemoryStore {
 
     const { mkdir, writeFile, rename } = await import('node:fs/promises')
     const { dirname } = await import('node:path')
-    await mkdir(dirname(filePath), { recursive: true })
-    const tmpPath = `${filePath}.tmp`
-    await writeFile(tmpPath, JSON.stringify(records, null, 2), 'utf8')
-    await rename(tmpPath, filePath)
+    try {
+      await mkdir(dirname(filePath), { recursive: true })
+      const tmpPath = `${filePath}.tmp`
+      await writeFile(tmpPath, JSON.stringify(records, null, 2), 'utf8')
+      await rename(tmpPath, filePath)
+    } catch (error: unknown) {
+      throw new Error(`LocalMemoryStore: failed to write ${filePath}`, { cause: error })
+    }
   }
 }

--- a/strands-ts/src/vended-memory-stores/local/store.ts
+++ b/strands-ts/src/vended-memory-stores/local/store.ts
@@ -1,0 +1,326 @@
+import { v7 as uuidv7 } from 'uuid'
+
+import type { MemoryEntry, MemoryStore, MemoryStoreConfig, SearchOptions } from '../../memory/types.js'
+import type { ExtractionConfig } from '../../memory/extraction/types.js'
+import type { JSONValue } from '../../types/json.js'
+
+const DEFAULT_MAX_SEARCH_RESULTS = 10
+
+/**
+ * Metadata key holding the token-overlap relevance score on a search result.
+ */
+const RELEVANCE_SCORE_KEY = '_relevanceScore'
+
+/**
+ * A stored memory, as it is persisted on disk.
+ */
+interface LocalMemoryRecord {
+  id: string
+  content: string
+  metadata?: Record<string, JSONValue>
+  createdAt: string
+}
+
+/**
+ * Configuration for {@link LocalMemoryStore}.
+ *
+ * The store persists to disk by default so the memory records persist across restarts. Set
+ * {@link persist} to `false` for an ephemeral, single session store (useful for e.g. testing).
+ */
+export interface LocalMemoryStoreConfig extends MemoryStoreConfig {
+  /**
+   * Whether to persist entries to disk so they survive across sessions.
+   * - `true` (default): writes are flushed to {@link path} (or the default location).
+   * - `false`: entries live only in memory and are lost when the process exits.
+   *
+   * @defaultValue true
+   */
+  persist?: boolean
+  /**
+   * Full path to the JSON file backing this store. Defaults to
+   * `~/.strands/memory/<sanitized-store-name>.json`. Ignored when {@link persist} is `false`.
+   */
+  path?: string
+}
+
+/** Result returned by {@link LocalMemoryStore.add}. */
+export interface LocalMemoryAddResult {
+  /** The id of the stored record. */
+  id: string
+}
+
+/**
+ * Sanitizes a store name into a safe single-path-segment filename.
+ * Guards the default-path branch against a name that would escape the memory directory.
+ * Ensures cross-SDK consistent sanitization.
+ */
+function sanitizeName(name: string): string {
+  return name
+    .replace(/\.\./g, '_')
+    .replace(/[/\\]/g, '_')
+    .replace(/[^\w\-.]/g, '_')
+}
+
+/**
+ * Lowercases and splits text into a set of word tokens, dropping empties. Splits on any run of
+ * characters that are not Unicode letters, numbers, or underscore. Ensures cross-SDK consistent
+ * tokenization.
+ */
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^\p{L}\p{N}_]+/u)
+      .filter(Boolean)
+  )
+}
+
+/**
+ * A zero-infrastructure store {@link MemoryStore} that keeps entries in memory and by default
+ * persists them to a local JSON file. Use for prototyping and testing.
+ *
+ * Recall is lexical: results are ranked by how many query tokens overlap an entry's content, with
+ * the most recent entry winning ties. This is keyword matching, not the semantic search a managed
+ * vector store (e.g. {@link BedrockKnowledgeBaseStore}) provides.
+ *
+ * Each {@link add} rewrites the whole file, so this fits modest volumes, not fit for high volume
+ * production workloads. Use a managed store like {@link BedrockKnowledgeBaseStore} for that.
+ *
+ * The on-disk format is shared with the Python SDK's `LocalMemoryStore`: records use the same
+ * camelCase keys (`id`, `content`, `metadata`, `createdAt`) and the same timestamp shape, so a
+ * backing file written by either SDK can be read by the other.
+ *
+ * @example
+ * ```typescript
+ * import { LocalMemoryStore } from '@strands-agents/sdk/vended-memory-stores/local'
+ *
+ * // Persists to ~/.strands/memory/notes.json by default.
+ * const store = new LocalMemoryStore({ name: 'notes' })
+ *
+ * const { id } = await store.add('User prefers dark mode')
+ * const results = await store.search('what theme does the user like?')
+ * ```
+ */
+export class LocalMemoryStore implements MemoryStore {
+  readonly name: string
+  readonly description?: string
+  readonly maxSearchResults?: number
+  readonly writable: boolean
+  readonly extraction?: boolean | ExtractionConfig
+
+  private readonly _persist: boolean
+  /** Explicit `path` override from config, if any; the default path is resolved lazily in {@link _getPath}. */
+  private readonly _explicitPath: string | undefined
+  private _resolvedPath: string | undefined
+  /** The loaded records once {@link _load} resolves; the working in-memory copy thereafter. */
+  private _records: LocalMemoryRecord[] | undefined
+  /**
+   * Memoizes the first (async) load so concurrent `search`/`add` callers share a single file read
+   * instead of each racing their own — without it, a search interleaved with a first-use add could
+   * overwrite the cache with a pre-write snapshot and drop the just-added record.
+   */
+  private _loadPromise: Promise<LocalMemoryRecord[]> | undefined
+  /** Serializes writes so concurrent `add`s never interleave the load-modify-flush cycle. */
+  private _writeChain: Promise<unknown> = Promise.resolve()
+
+  constructor(options: LocalMemoryStoreConfig) {
+    const { name, description, maxSearchResults, writable, extraction, persist, path } = options
+
+    if (!name.trim()) {
+      throw new Error('LocalMemoryStore: name must not be empty.')
+    }
+    this.name = name
+    if (description !== undefined) this.description = description
+    if (maxSearchResults !== undefined) {
+      if (maxSearchResults < 1) {
+        throw new Error('LocalMemoryStore: maxSearchResults must be at least 1.')
+      }
+      this.maxSearchResults = maxSearchResults
+    }
+    // A local store is writable by default.
+    this.writable = writable ?? true
+    if (extraction !== undefined) this.extraction = extraction
+
+    this._persist = persist ?? true
+    this._explicitPath = path
+  }
+
+  /**
+   * Searches stored entries for those whose content overlaps the query, ranked by token overlap with
+   * the most recent entry winning ties.
+   *
+   * @param query - The search query text
+   * @param options - Optional search configuration
+   * @returns Matching memory entries ordered by relevance. Each entry's `metadata` includes a
+   *   `_relevanceScore` key (the token-overlap count). An empty or token-less query returns
+   *   no results.
+   */
+  async search(query: string, options?: SearchOptions): Promise<MemoryEntry[]> {
+    if (options?.maxSearchResults !== undefined && options.maxSearchResults < 1) {
+      throw new Error('LocalMemoryStore: maxSearchResults must be at least 1.')
+    }
+    const limit = options?.maxSearchResults || this.maxSearchResults || DEFAULT_MAX_SEARCH_RESULTS
+
+    const queryTokens = tokenize(query)
+    if (queryTokens.size === 0) return []
+
+    const records = await this._load()
+
+    const scored: Array<{ record: LocalMemoryRecord; score: number }> = []
+    for (const record of records) {
+      let score = 0
+      for (const token of tokenize(record.content)) {
+        if (queryTokens.has(token)) score++
+      }
+      if (score > 0) scored.push({ record, score })
+    }
+
+    scored.sort(
+      (left, right) => right.score - left.score || right.record.createdAt.localeCompare(left.record.createdAt)
+    )
+
+    return scored.slice(0, limit).map(({ record, score }) => ({
+      content: record.content,
+      metadata: { ...record.metadata, [RELEVANCE_SCORE_KEY]: score },
+    }))
+  }
+
+  /**
+   * Adds `content` (with optional `metadata`) to the store. Identical content is deduplicated: a
+   * repeat write returns the existing record's id without storing a second copy, so the at-least-once
+   * retries that extraction may perform never accumulate duplicates.
+   *
+   * @param content - The text content to store
+   * @param metadata - Optional metadata to attach to the entry. The key `_relevanceScore` is
+   *   reserved: {@link search} populates it on results, so a value stored under it here is
+   *   overwritten in search output.
+   * @returns The id of the stored (or already-present) record
+   */
+  async add(content: string, metadata?: Record<string, JSONValue>): Promise<LocalMemoryAddResult> {
+    if (!this.writable) {
+      throw new Error('LocalMemoryStore: store is not writable. Set writable: true in config to enable add().')
+    }
+    if (!content.trim()) {
+      throw new Error('LocalMemoryStore: content must not be empty.')
+    }
+
+    // Serialize the whole load-modify-flush cycle behind any in-flight write so concurrent `add`s
+    // don't each load the same snapshot and clobber one another (last-write-wins).
+    const run = this._writeChain.then(async () => {
+      const records = await this._load()
+
+      const normalizedContent = content.trim()
+      const existing = records.find((record) => record.content.trim() === normalizedContent)
+      if (existing) return { id: existing.id }
+
+      const record: LocalMemoryRecord = { id: uuidv7(), content, createdAt: new Date().toISOString() }
+      if (metadata !== undefined) record.metadata = metadata
+
+      // Flush the candidate list first and only commit it to the in-memory cache once the write
+      // succeeds, so a failed flush never leaves a phantom record that later writes resurrect.
+      const next = [...records, record]
+      await this._flush(next)
+      this._records = next
+      return { id: record.id }
+    })
+    // Keep the chain alive even if this write rejects, so a failed write doesn't wedge later ones.
+    this._writeChain = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  /**
+   * Resolves (and caches) the backing-file path: the explicit `path` from config, else
+   * `~/.strands/memory/<sanitized-store-name>.json`. Returns `undefined` for ephemeral stores. The
+   * `node:os`/`node:path` imports are dynamic so the module stays safe to bundle for the browser.
+   */
+  private async _getPath(): Promise<string | undefined> {
+    if (!this._persist) return undefined
+    if (this._resolvedPath !== undefined) return this._resolvedPath
+    if (this._explicitPath !== undefined) {
+      this._resolvedPath = this._explicitPath
+      return this._resolvedPath
+    }
+    const os = await import('node:os')
+    const path = await import('node:path')
+    this._resolvedPath = path.join(os.homedir(), '.strands', 'memory', `${sanitizeName(this.name)}.json`)
+    return this._resolvedPath
+  }
+
+  /**
+   * Loads records from disk on first use; ephemeral stores (and a missing file) start empty. The
+   * first call's promise is memoized in {@link _loadPromise} so concurrent callers await one shared
+   * read rather than each loading independently and racing to assign the cache.
+   */
+  private async _load(): Promise<LocalMemoryRecord[]> {
+    if (this._records !== undefined) return this._records
+    if (this._loadPromise !== undefined) return this._loadPromise
+
+    this._loadPromise = this._readFromDisk()
+    try {
+      this._records = await this._loadPromise
+    } finally {
+      this._loadPromise = undefined
+    }
+    return this._records
+  }
+
+  /** Reads and parses the backing file (or returns an empty list when ephemeral / missing). */
+  private async _readFromDisk(): Promise<LocalMemoryRecord[]> {
+    const filePath = await this._getPath()
+    if (filePath === undefined) return []
+
+    const { readFile } = await import('node:fs/promises')
+    let rawContent: string
+    try {
+      rawContent = await readFile(filePath, 'utf8')
+    } catch (error: unknown) {
+      if ((error as { code?: string }).code === 'ENOENT') return []
+      throw error
+    }
+
+    let parsedFile: unknown
+    try {
+      parsedFile = JSON.parse(rawContent)
+    } catch (error: unknown) {
+      throw new Error(`LocalMemoryStore: invalid JSON in ${filePath}`, { cause: error })
+    }
+    if (!Array.isArray(parsedFile)) {
+      throw new Error(`LocalMemoryStore: invalid backing file ${filePath}: expected a JSON array of records`)
+    }
+    for (const record of parsedFile) {
+      if (
+        record === null ||
+        typeof record !== 'object' ||
+        typeof record.id !== 'string' ||
+        typeof record.content !== 'string' ||
+        typeof record.createdAt !== 'string'
+      ) {
+        throw new Error(
+          `LocalMemoryStore: invalid backing file ${filePath}: ` +
+            "each record must have string 'id', 'content', and 'createdAt' fields"
+        )
+      }
+    }
+    return parsedFile as LocalMemoryRecord[]
+  }
+
+  /**
+   * Persists `records` to disk with an atomic write (write to a `.tmp` file, then rename) so a
+   * crash mid-write can never leave a partially written file. A no-op for ephemeral stores. Callers
+   * serialize invocations via {@link _writeChain}.
+   */
+  private async _flush(records: LocalMemoryRecord[]): Promise<void> {
+    const filePath = await this._getPath()
+    if (filePath === undefined) return
+
+    const { mkdir, writeFile, rename } = await import('node:fs/promises')
+    const { dirname } = await import('node:path')
+    await mkdir(dirname(filePath), { recursive: true })
+    const tmpPath = `${filePath}.tmp`
+    await writeFile(tmpPath, JSON.stringify(records, null, 2), 'utf8')
+    await rename(tmpPath, filePath)
+  }
+}


### PR DESCRIPTION
## Description

The memory feature ships only one concrete `MemoryStore`: `BedrockKnowledgeBaseStore`, which requires an AWS account, a provisioned Knowledge Base, and a data source. That gates the *first* experience of memory behind cloud setup — a developer can't try `MemoryManager`, `search_memory`/`add_memory`, context injection, or extraction without standing up infrastructure first.

This adds `LocalMemoryStore`, a zero-infrastructure `MemoryStore` shipped in both SDKs. It **persists to disk by default** (`~/.strands/memory/<name>.json`), so an agent remembers across restarts with no setup, and can be made ephemeral for tests and throwaway runs. `MemoryManager` is backend-agnostic — it talks to stores only through the `MemoryStore` interface — so this is purely additive: drop the store into `stores: [...]` and everything (tools, injection, client-side extraction) works unchanged.

A few design decisions worth calling out for review:

- **One class, not two.** An ephemeral in-memory store and a persistent file store share identical recall logic; the only difference is whether `add` also flushes to disk. Rather than two classes, persistence is a single internal seam (`persist` flag → load-on-init + atomic flush). One construct to learn, one copy of the search code.
- **Persistent by default.** Memory's value proposition *is* remembering across sessions, so the default that demonstrates the feature (survives a restart) is the right one; ephemeral is the opt-out.
- **Lexical recall, not semantic.** v1 ranks by query-token overlap with a recency tiebreak — keyword matching with zero new dependencies. This differs from Bedrock's embedding-based search (a query word matches only the same word, not a synonym), and the docstrings say so explicitly.
- **Subpath export, mirroring `BedrockKnowledgeBaseStore`.** Not added to the top-level barrel.

The store reads the whole file into memory and rewrites it atomically on each `add`, so it suits prototyping and personal memory (hundreds to low thousands of entries), not a production corpus — documented on the class. Writes within a process are serialized so concurrent `add`s can't clobber one another; cross-process writers are not coordinated.

## Public API Changes

A new `LocalMemoryStore`, exported from a subpath in each SDK alongside the existing Bedrock store.

TypeScript (`@strands-agents/sdk/vended-memory-stores/local`):

```typescript
import { Agent, MemoryManager } from '@strands-agents/sdk'
import { LocalMemoryStore } from '@strands-agents/sdk/vended-memory-stores/local'

// Persists to ~/.strands/memory/notes.json by default. Survives restarts.
const agent = new Agent({
  model,
  memoryManager: new MemoryManager({
    stores: [new LocalMemoryStore({ name: 'notes' })],
    addToolConfig: true,
  }),
})

// Ephemeral (tests / throwaway runs): nothing is written to disk.
new LocalMemoryStore({ name: 'notes', persist: false })
// Explicit location:
new LocalMemoryStore({ name: 'notes', path: './my-notes.json' })
```

Python (`strands.vended_memory_stores.local`):

```python
from strands import Agent
from strands.memory.memory_manager import MemoryManager
from strands.vended_memory_stores.local import LocalMemoryStore

agent = Agent(
    model=model,
    memory_manager=MemoryManager(
        stores=[LocalMemoryStore(name="notes")],
        add_tool_config=True,
    ),
)

LocalMemoryStore(name="notes", persist=False)         # ephemeral
LocalMemoryStore(name="notes", path="./my-notes.json")  # explicit path
```

`LocalMemoryStore` defaults `writable=true` (the point is a store you can write to) and implements `search` + `add`. With an `extraction` config it uses the manager's client-side path (model extractor → `add` per fact); it does not implement `addMessages`. Constructor config: `name` (required), `description`, `maxSearchResults`/`max_search_results`, `writable`, `extraction`, `persist` (default `true`), `path`.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

`team/designs/0011-memory-manager.md` still sketches this store under the name `InMemoryMemoryStore`, imported from the top-level barrel. The shipped store is `LocalMemoryStore` (persists by default, so "InMemory" would mislead) exported via subpath (matching `BedrockKnowledgeBaseStore`). The design doc and any how-to/example docs should be reconciled in a follow-up; no `site/` docs are included here.

## Type of Change

New feature

## Testing

Unit suites added in both SDKs covering: persistence round-trip across a fresh instance ("survives restart"), ephemeral mode (no file written, a new instance forgets), lexical ranking + recency tiebreak, empty/token-less query, empty/non-writable `add` errors, content dedup, `maxSearchResults` cap + `<1` validation, and corrupt/missing-file handling. Each SDK also has MemoryManager integration tests asserting the manager stamps `storeName`, the `add` API writes through, and a client-side extraction run persists the extracted fact.

Beyond the automated suites, I exercised the store end-to-end in both SDKs across **two separate processes**: one writes a fact, a second (fresh process) recalls it from the on-disk JSON — confirming the across-restart behavior, not just in-process mocks. I also confirmed the new subpath export specifier resolves and the TS browser bundle still builds (the store's `node:*` imports are dynamic).

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
