### PR TITLE
docs: populate sourceLinks code references across concept pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Before designing a feature or changing an API, read the relevant context in `tea
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `refactor:`, `docs:`, etc.
 - **CI**: The `ci.yml` merge gate detects which paths changed and runs only relevant checks.
 - **Skills**: Reusable, repo-specific workflows live under `.agents/skills/` — for PRs (`pr-create`, `pr-writer`, `pr-feedback`), docs (`docs-writer`, `docs-reviewer`, `docs-audit`, `docs-planner`), and code review (`strands-review`). See [`.agents/skills/README.md`](./.agents/skills/README.md) for what each does and when to use it.
+- **Doc `sourceLinks` track source files**: Doc pages under `site/` point at their backing implementation via `sourceLinks` frontmatter — repo-relative paths into `strands-py/` and `strands-ts/`. When you **rename or move a source file**, update any `sourceLinks` that reference its old path in the same change. The site build only fails on a malformed path or an unmapped file extension, **not** on a path that still resolves to the wrong (or now-nonexistent) file, so a stale reference rots silently. Find affected pages with `grep -rn "<old/path>" site/src/content/docs`.
 
 ### Testing
 

--- a/site/src/components/overrides/Head.astro
+++ b/site/src/components/overrides/Head.astro
@@ -9,6 +9,8 @@ import SiteScripts from '../SiteScripts.astro'
 import Analytics from '../Analytics.astro'
 import { baseSchemas } from '../../util/structured-data'
 import { relatedUserGuideFor } from '../../util/related-docs'
+import { resolveLanguage, sourceLinkUrl } from '../../util/source-links'
+import type { SourceLink } from '../../content.config'
 
 const { head } = Astro.locals.starlightRoute
 const route = Astro.locals.starlightRoute
@@ -72,6 +74,7 @@ const breadcrumbItems = pathSegments.map((segment, i) => {
 //   relatedLink:        https://schema.org/relatedLink
 //   isBasedOn:          https://schema.org/isBasedOn
 //   SoftwareSourceCode: https://schema.org/SoftwareSourceCode
+//   programmingLanguage: https://schema.org/programmingLanguage
 const entry = route.entry
 // Non-docs routes (blog authors/tags pages, etc.) flow through Starlight too
 // but their synthetic entry.data has no `tags` field — guard with ??.
@@ -93,10 +96,11 @@ if (tags.length > 0 || sourceLinks.length > 0) {
       : {}),
     ...(sourceLinks.length > 0
       ? {
-          "isBasedOn": sourceLinks.map((s: { repo: string, path: string }) => ({
+          "isBasedOn": sourceLinks.map((s: SourceLink) => ({
             "@type": "SoftwareSourceCode",
+            "programmingLanguage": resolveLanguage(s),
             "codeRepository": `https://github.com/strands-agents/${s.repo}`,
-            "url": `https://github.com/strands-agents/${s.repo}/blob/main/${s.path}`,
+            "url": sourceLinkUrl(s),
           })),
         }
       : {}),

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -16,8 +16,18 @@ const authorSchema = z.object({
 })
 
 export const sourceLinkSchema = z.object({
-  repo: z.enum(['sdk-python', 'sdk-typescript']),
+  // Repo-relative path to the implementation,
+  // e.g. 'strands-py/src/strands/agent/agent.py'.
   path: z.string(),
+  // SDK language this implementation is for. Optional — by default it is
+  // inferred from the file extension (see resolveLanguage in util/source-links).
+  // Set it explicitly only to override inference: a backing file whose
+  // extension doesn't map to a language, or a future language. Free-form string
+  // (not an enum) so a new language works without a schema change.
+  language: z.string().optional(),
+  // GitHub repo slug under the strands-agents org. Defaults to the monorepo;
+  // override only for code that lives in a different org repo.
+  repo: z.string().default('harness-sdk'),
 })
 export type SourceLink = z.infer<typeof sourceLinkSchema>
 

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -2,6 +2,10 @@
 title: Agent Loop
 tags: [event-loop, tool-execution, hooks]
 description: "How Strands agents reason, plan, and act. Understand the model-driven loop that orchestrates tool use, reflection, and goal completion."
+sourceLinks:
+  - path: strands-py/src/strands/agent/agent.py
+  - path: strands-py/src/strands/event_loop/event_loop.py
+  - path: strands-ts/src/agent/agent.ts
 ---
 
 A language model can answer questions. An agent can *do things*. The agent loop is what makes that difference possible.

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -1,6 +1,13 @@
 ---
 title: Conversation Management
 tags: [conversation-management, session-management, token-management]
+sourceLinks:
+  - path: strands-py/src/strands/agent/conversation_manager/conversation_manager.py
+  - path: strands-py/src/strands/agent/conversation_manager/sliding_window_conversation_manager.py
+  - path: strands-py/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
+  - path: strands-ts/src/conversation-manager/conversation-manager.ts
+  - path: strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+  - path: strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
 ---
 
 In the Strands Agents SDK, context refers to the information provided to the agent for understanding and reasoning. This includes:

--- a/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -2,6 +2,11 @@
 title: Hooks
 description: "Intercept and customize agent behavior at every step. Hooks let you add logging, validation, guardrails, and custom logic to the agent loop."
 tags: [hooks, event-loop, tool-execution]
+sourceLinks:
+  - path: strands-py/src/strands/hooks/events.py
+  - path: strands-py/src/strands/hooks/registry.py
+  - path: strands-ts/src/hooks/events.ts
+  - path: strands-ts/src/hooks/registry.ts
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -2,6 +2,9 @@
 title: Cedar Authorization
 description: "Control which tools an agent can invoke using Cedar policies. Enforce identity-aware access control, role-based permissions, and rate limits at the tool-call boundary."
 tags: [safety, interventions, tool-execution]
+sourceLinks:
+  - path: strands-py/src/strands/vended_interventions/cedar/cedar_authorization.py
+  - path: strands-ts/src/vended-interventions/cedar/cedar.ts
 sidebar:
   badge:
     text: New

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/human-in-the-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/human-in-the-loop.mdx
@@ -3,6 +3,9 @@ title: Human in the Loop
 tags: [interventions, tool-execution]
 description: "Gate agent tool execution behind human approval. Configurable modes for CLI, web, and custom UIs with optional session trust."
 languages: [python, typescript]
+sourceLinks:
+  - path: strands-py/src/strands/vended_interventions/hitl/hitl.py
+  - path: strands-ts/src/vended-interventions/hitl/hitl.ts
 sidebar:
   badge:
     text: New

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
@@ -3,6 +3,13 @@ title: Interventions
 description: "A composable control layer for authorization, guardrails, and steering with typed actions, ordered evaluation, and short-circuiting."
 tags: [interventions, hooks, event-loop, tool-execution]
 languages: [python, typescript]
+sourceLinks:
+  - path: strands-py/src/strands/interventions/handler.py
+  - path: strands-py/src/strands/interventions/actions.py
+  - path: strands-py/src/strands/interventions/registry.py
+  - path: strands-ts/src/interventions/handler.ts
+  - path: strands-ts/src/interventions/actions.ts
+  - path: strands-ts/src/interventions/registry.ts
 ---
 
 Interventions are a composable control layer for agents. They provide a typed action model for common control concerns — authorization, guardrails, steering, and content transformation — with ordered evaluation and short-circuiting. Unlike raw [hooks](../hooks.mdx) and [plugins](../../plugins/index.mdx) which mutate event objects directly, intervention handlers return typed decisions (`proceed`, `deny`, `guide`, `confirm`, `transform`) that the framework applies with well-defined semantics — enabling automatic short-circuiting, feedback accumulation, and conflict resolution.

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/steering.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/steering.mdx
@@ -2,6 +2,9 @@
 title: Steering
 description: "LLM-based contextual guidance for agents using the interventions framework — just-in-time feedback instead of front-loaded prompts."
 tags: [hooks, event-loop, tool-execution]
+sourceLinks:
+  - path: strands-py/src/strands/vended_plugins/steering/core/handler.py
+  - path: strands-ts/src/vended-interventions/steering/handlers/llm.ts
 ---
 
 Steering provides modular prompting for complex agent tasks through context-aware guidance that appears when relevant, rather than front-loading all instructions in monolithic prompts. Steering handlers observe agent activity and intervene at key moments — before a tool call or after a model response — with targeted feedback. They are built on the [interventions](./index.mdx) framework and use the same typed action model.

--- a/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
@@ -1,6 +1,9 @@
 ---
 title: Prompts
 tags: [safety, conversation-management, prompt-authoring]
+sourceLinks:
+  - path: strands-py/src/strands/agent/agent.py
+  - path: strands-ts/src/agent/agent.ts
 ---
 
 In the Strands Agents SDK, system prompts and user messages are the primary way to communicate with AI models. The SDK provides a flexible system for managing prompts, including both system prompts and user messages.

--- a/site/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
@@ -1,6 +1,10 @@
 ---
 title: Retry Strategies
 tags: [event-loop, error-handling]
+sourceLinks:
+  - path: strands-py/src/strands/event_loop/_retry.py
+  - path: strands-ts/src/retry/model-retry-strategy.ts
+  - path: strands-ts/src/retry/default-model-retry-strategy.ts
 ---
 
 Model providers occasionally encounter errors such as rate limits, service unavailability, or network timeouts. By default, the agent retries throttled responses automatically with exponential backoff. The <Syntax py="Agent.retry_strategy" ts="Agent.retryStrategy" /> parameter lets you customize this behavior.

--- a/site/src/content/docs/user-guide/concepts/agents/session-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/session-management.mdx
@@ -2,6 +2,13 @@
 title: Session Management
 description: "Persist agent conversations across sessions. Save and restore chat history, tool state, and context for long-running AI workflows."
 tags: [session-management, snapshots, state]
+sourceLinks:
+  - path: strands-py/src/strands/session/session_manager.py
+  - path: strands-py/src/strands/session/file_session_manager.py
+  - path: strands-py/src/strands/session/s3_session_manager.py
+  - path: strands-ts/src/session/session-manager.ts
+  - path: strands-ts/src/session/file-storage.ts
+  - path: strands-ts/src/session/s3-storage.ts
 ---
 
 Session management in Strands Agents provides a robust mechanism for persisting agent state and conversation history across multiple interactions. This enables agents to maintain context and continuity even when the application restarts or when deployed in distributed environments.

--- a/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -1,6 +1,9 @@
 ---
 title: Snapshots
 description: "Capture and restore agent state at any point in time. Use snapshots for checkpointing, undo/redo, branching conversations, and custom persistence."
+sourceLinks:
+  - path: strands-py/src/strands/types/_snapshot.py
+  - path: strands-ts/src/agent/snapshot.ts
 ---
 
 Snapshots capture agent state at a point in time so you can save and restore it later. You choose which fields to include — either by picking a preset (a preconfigured set of fields) or by specifying fields directly — and you can further refine with includes and excludes. Snapshots are plain JSON-serializable objects — persistence is up to you.

--- a/site/src/content/docs/user-guide/concepts/agents/state.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/state.mdx
@@ -3,6 +3,10 @@ title: State Management
 sidebar:
   label: "State"
 tags: [state, snapshots, session-management]
+sourceLinks:
+  - path: strands-py/src/strands/agent/state.py
+  - path: strands-py/src/strands/types/json_dict.py
+  - path: strands-ts/src/agent/agent.ts
 ---
 
 Strands Agents state is maintained in several forms:

--- a/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
@@ -2,6 +2,9 @@
 title: Structured Output
 description: "Get typed, validated responses from AI agents. Define Pydantic models and Strands returns structured data instead of raw text."
 tags: [structured-output]
+sourceLinks:
+  - path: strands-py/src/strands/agent/agent.py
+  - path: strands-ts/src/tools/structured-output-tool.ts
 ---
 
 ## Introduction

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -2,6 +2,9 @@
 title: BidiAgent
 experimental: true
 tags: [bidi-streaming]
+sourceLinks:
+  - path: strands-py/src/strands/experimental/bidi/agent/agent.py
+  - path: strands-py/src/strands/experimental/bidi/agent/loop.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
@@ -2,6 +2,9 @@
 title: Events
 experimental: true
 tags: [bidi-streaming]
+sourceLinks:
+  - path: strands-py/src/strands/experimental/bidi/types/events.py
+  - path: strands-py/src/strands/experimental/bidi/types/io.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
@@ -4,6 +4,8 @@ sidebar:
   label: "Hooks"
 experimental: true
 tags: [bidi-streaming, hooks]
+sourceLinks:
+  - path: strands-py/src/strands/experimental/hooks/events.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/interruption.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/interruption.mdx
@@ -2,6 +2,9 @@
 title: Interruptions
 experimental: true
 tags: [bidi-streaming]
+sourceLinks:
+  - path: strands-py/src/strands/experimental/bidi/types/events.py
+  - path: strands-py/src/strands/experimental/bidi/io/audio.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/io.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/io.mdx
@@ -4,6 +4,9 @@ experimental: true
 sidebar:
   label: "IO"
 tags: [bidi-streaming]
+sourceLinks:
+  - path: strands-py/src/strands/experimental/bidi/io/text.py
+  - path: strands-py/src/strands/experimental/bidi/io/audio.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
@@ -2,6 +2,8 @@
 title: Gemini Live
 experimental: true
 tags: [bidi-streaming]
+sourceLinks:
+  - path: strands-py/src/strands/experimental/bidi/models/gemini_live.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
@@ -2,6 +2,8 @@
 title: Nova Sonic
 experimental: true
 tags: [bidi-streaming, aws, bedrock]
+sourceLinks:
+  - path: strands-py/src/strands/experimental/bidi/models/nova_sonic.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
@@ -2,6 +2,8 @@
 title: OpenAI Realtime
 experimental: true
 tags: [bidi-streaming]
+sourceLinks:
+  - path: strands-py/src/strands/experimental/bidi/models/openai_realtime.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/session-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/session-management.mdx
@@ -4,6 +4,9 @@ sidebar:
   label: "Session Management"
 experimental: true
 tags: [bidi-streaming, session-management, snapshots]
+sourceLinks:
+  - path: strands-py/src/strands/session/file_session_manager.py
+  - path: strands-py/src/strands/session/s3_session_manager.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/context-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/context-management.mdx
@@ -2,6 +2,11 @@
 title: Context Management
 description: "Manage your agent's context window as conversations grow and tool results accumulate."
 tags: [conversation-management, token-management]
+sourceLinks:
+  - path: strands-py/src/strands/_context_manager/modes/agentic/agentic_context.py
+  - path: strands-py/src/strands/agent/conversation_manager/conversation_manager.py
+  - path: strands-ts/src/context-manager/modes/agentic/agentic-context.ts
+  - path: strands-ts/src/conversation-manager/conversation-manager.ts
 sidebar:
   badge:
     text: New

--- a/site/src/content/docs/user-guide/concepts/experimental/agent-config.mdx
+++ b/site/src/content/docs/user-guide/concepts/experimental/agent-config.mdx
@@ -2,6 +2,8 @@
 title: Agent Configuration
 tags: [tool-authoring, bedrock, prompt-authoring]
 experimental: true
+sourceLinks:
+  - path: strands-py/src/strands/experimental/agent_config.py
 sidebar:
   label: "AgentConfig"
   badge:

--- a/site/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/site/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -2,6 +2,11 @@
 title: Interrupts
 tags: [event-loop, hooks, tool-execution, error-handling]
 description: "Pause AI agents mid-execution for human approval, input, or review. Build human-in-the-loop workflows with interrupt and resume patterns."
+sourceLinks:
+  - path: strands-py/src/strands/interrupt.py
+  - path: strands-py/src/strands/types/interrupt.py
+  - path: strands-ts/src/interrupt.ts
+  - path: strands-ts/src/types/interrupt.ts
 ---
 
 The interrupt system enables human-in-the-loop workflows by allowing users to pause agent execution and request human input before continuing. When an interrupt is raised, the agent stops its loop and returns control to the user. The user in turn provides a response to the agent. The agent then continues its execution starting from the point of interruption. Users can raise interrupts from either hook callbacks or tool definitions. The general flow looks as follows:

--- a/site/src/content/docs/user-guide/concepts/memory/bedrock-knowledge-base.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/bedrock-knowledge-base.mdx
@@ -2,6 +2,9 @@
 title: Bedrock Knowledge Base Store
 description: "Back agent memory with Amazon Bedrock Knowledge Bases: semantic search over a managed vector store and document ingestion for CUSTOM and S3 data sources."
 tags: [memory, bedrock, aws]
+sourceLinks:
+  - path: strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
+  - path: strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
 sidebar:
   label: "Bedrock Knowledge Base"
   badge:

--- a/site/src/content/docs/user-guide/concepts/memory/overview.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/overview.mdx
@@ -2,6 +2,11 @@
 title: Memory
 description: "Give agents long-term memory across sessions: store facts to configurable backends, recall them via tools or injection, and extract them automatically."
 tags: [memory]
+sourceLinks:
+  - path: strands-py/src/strands/memory/memory_manager.py
+  - path: strands-py/src/strands/memory/types.py
+  - path: strands-ts/src/memory/memory-manager.ts
+  - path: strands-ts/src/memory/types.ts
 sidebar:
   badge:
     text: New

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -2,6 +2,9 @@
 title: Amazon Bedrock
 integrationType: model-provider
 tags: [bedrock, aws, vision, safety, caching]
+sourceLinks:
+  - path: strands-py/src/strands/models/bedrock.py
+  - path: strands-ts/src/models/bedrock.ts
 ---
 
 Amazon Bedrock is a fully managed service that offers a choice of high-performing foundation models from leading AI companies through a unified API. Strands provides native support for Amazon Bedrock, allowing you to use these powerful models in your agents with minimal configuration.

--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -2,6 +2,9 @@
 title: Anthropic
 tags: [structured-output, caching]
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/anthropic.py
+  - path: strands-ts/src/models/anthropic.ts
 ---
 
 [Anthropic](https://docs.anthropic.com/en/home) is an AI safety and research company focused on building reliable, interpretable, and steerable AI systems. Included in their offerings is the Claude AI family of models, which are known for their conversational abilities, careful reasoning, and capacity to follow complex instructions. The Strands Agents SDK implements an Anthropic provider, allowing users to run agents against Claude models directly.

--- a/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
@@ -4,6 +4,9 @@ tags: [tool-execution]
 sidebar:
   label: "Custom Providers"
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/model.py
+  - path: strands-ts/src/models/model.ts
 ---
 
 Strands Agents SDK provides an extensible interface for implementing custom model providers, allowing organizations to integrate their own LLM services while keeping implementation details private to their codebase.

--- a/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -4,6 +4,9 @@ tags: [vision]
 integrationType: model-provider
 redirectFrom:
   - docs/user-guide/concepts/model-providers/gemini
+sourceLinks:
+  - path: strands-py/src/strands/models/gemini.py
+  - path: strands-ts/src/models/google/model.ts
 ---
 
 [Google Gemini](https://ai.google.dev/api) is Google's family of multimodal large language models designed for advanced reasoning, code generation, and creative tasks. The Strands Agents SDK implements a Google/Gemini provider, allowing you to run agents against the Gemini models available through Google's AI API.

--- a/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
@@ -3,6 +3,8 @@ title: LiteLLM
 tags: [structured-output]
 languages: Python
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/litellm.py
 ---
 
 [LiteLLM](https://docs.litellm.ai/docs/) is a unified interface for various LLM providers that allows you to interact with models from Amazon, Anthropic, OpenAI, and many others through a single API. The Strands Agents SDK implements a LiteLLM provider, allowing you to run agents against any model LiteLLM supports.

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
@@ -5,6 +5,8 @@ languages: Python
 sidebar:
   label: "LlamaAPI"
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/llamaapi.py
 ---
 
 [Llama API](https://llama.developer.meta.com?utm_source=partner-strandsagent&utm_medium=website) is a Meta-hosted API service that helps you integrate Llama models into your applications quickly and efficiently.

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
@@ -3,6 +3,8 @@ title: llama.cpp
 tags: [local-models]
 languages: Python
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/llamacpp.py
 ---
 
 [llama.cpp](https://github.com/ggml-org/llama.cpp) is a high-performance C++ inference engine for running large language models locally. The Strands Agents SDK implements a llama.cpp provider, allowing you to run agents against any llama.cpp server with quantized models.

--- a/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
@@ -4,6 +4,8 @@ languages: Python
 sidebar:
   label: "MistralAI"
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/mistral.py
 ---
 
 [Mistral AI](https://mistral.ai/)  is a research lab building the best open source models in the world.

--- a/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -3,6 +3,8 @@ title: Ollama
 tags: [local-models]
 languages: Python
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/ollama.py
 ---
 
 Ollama is a framework for running open-source large language models locally. Strands provides native support for Ollama, allowing you to use locally-hosted models in your agents.

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
@@ -2,6 +2,9 @@
 title: OpenAI Responses API
 tags: [mcp, state]
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/openai_responses.py
+  - path: strands-ts/src/models/openai/responses-adapter.ts
 ---
 
 The [Responses API](https://platform.openai.com/docs/api-reference/responses) is OpenAI's interface for generating model responses and building agents. It is a superset of the [Chat Completions](./openai) API, with additional support for [built-in tools](#built-in-tools), server-side conversation state management, and multi-modal inputs.

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -2,6 +2,9 @@
 title: OpenAI
 tags: [vision, structured-output]
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/openai.py
+  - path: strands-ts/src/models/openai/model.ts
 ---
 
 [OpenAI](https://platform.openai.com/docs/overview) is an AI research and deployment company that provides a suite of powerful language models. The Strands Agents SDK implements an OpenAI provider, allowing you to run agents against any OpenAI or OpenAI-compatible model.

--- a/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
@@ -4,6 +4,8 @@ languages: Python
 sidebar:
   label: "SageMaker"
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/sagemaker.py
 ---
 
 [Amazon SageMaker](https://aws.amazon.com/sagemaker/) is a fully managed machine learning service that provides infrastructure and tools for building, training, and deploying ML models at scale. The Strands Agents SDK implements a SageMaker provider, allowing you to run agents against models deployed on SageMaker inference endpoints, including both pre-trained models from SageMaker JumpStart and custom fine-tuned models. The provider is designed to work with models that support OpenAI-compatible chat completion APIs.

--- a/site/src/content/docs/user-guide/concepts/model-providers/vercel.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/vercel.mdx
@@ -3,6 +3,8 @@ title: Vercel
 tags: [vision]
 languages: TypeScript
 integrationType: model-provider
+sourceLinks:
+  - path: strands-ts/src/models/vercel.ts
 ---
 
 The [Vercel AI SDK](https://sdk.vercel.ai/) is a TypeScript toolkit for building AI-powered applications. It defines a [Language Model Specification](https://github.com/vercel/ai/tree/main/packages/provider/src/language-model/v3) that standardizes how applications interact with LLMs across providers. The Strands Agents SDK includes a `VercelModel` adapter that wraps any Language Model Specification v3 (`LanguageModelV3`) provider for use as a Strands model provider.

--- a/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
@@ -3,6 +3,8 @@ title: Writer
 tags: [vision, structured-output]
 languages: Python
 integrationType: model-provider
+sourceLinks:
+  - path: strands-py/src/strands/models/writer.py
 ---
 
 [Writer](https://writer.com/) is an enterprise generative AI platform offering specialized Palmyra models for finance, healthcare, creative, and general-purpose use cases. The models excel at tool calling, structured outputs, and domain-specific tasks, with Palmyra X5 supporting a 1M token context window.

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -3,6 +3,13 @@ title: Agent-to-Agent (A2A) Protocol
 sidebar:
   label: "Agent2Agent (A2A)"
 tags: [multi-agent]
+sourceLinks:
+  - path: strands-py/src/strands/agent/a2a_agent.py
+  - path: strands-py/src/strands/multiagent/a2a/server.py
+  - path: strands-py/src/strands/multiagent/a2a/executor.py
+  - path: strands-ts/src/a2a/a2a-agent.ts
+  - path: strands-ts/src/a2a/server.ts
+  - path: strands-ts/src/a2a/executor.ts
 ---
 
 Strands Agents supports the [Agent-to-Agent (A2A) protocol](https://a2aproject.github.io/A2A/latest/), enabling seamless communication between AI agents across different platforms and implementations.

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -3,6 +3,9 @@ title: Agents as Tools with Strands Agents SDK
 sidebar:
   label: "Agents as Tools"
 tags: [multi-agent, tool-authoring, tool-execution]
+sourceLinks:
+  - path: strands-py/src/strands/agent/_agent_as_tool.py
+  - path: strands-ts/src/agent/agent-as-tool.ts
 ---
 
 ## The Concept: Agents as Tools

--- a/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
@@ -3,6 +3,10 @@ title: Graph Multi-Agent Pattern
 sidebar:
   label: "Graph"
 tags: [multi-agent]
+sourceLinks:
+  - path: strands-py/src/strands/multiagent/base.py
+  - path: strands-py/src/strands/multiagent/graph.py
+  - path: strands-ts/src/multiagent/graph.ts
 ---
 
 A Graph is a deterministic directed graph based agent orchestration system where agents, custom nodes, or other multi-agent systems (like [Swarm](./swarm.md) or nested Graphs) are nodes in a graph. Nodes are executed according to edge dependencies, with output from one node passed as input to connected nodes. The Graph pattern supports both acyclic (DAG) and cyclic topologies, enabling feedback loops and iterative refinement workflows.

--- a/site/src/content/docs/user-guide/concepts/multi-agent/multi-agent-patterns.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/multi-agent-patterns.mdx
@@ -2,6 +2,12 @@
 title: Multi-agent Patterns
 description: "Coordinate multiple AI agents with handoffs, swarms, graphs, and workflow patterns. Built-in primitives for complex multi-agent orchestration."
 tags: [multi-agent]
+sourceLinks:
+  - path: strands-py/src/strands/multiagent/base.py
+  - path: strands-py/src/strands/multiagent/graph.py
+  - path: strands-py/src/strands/multiagent/swarm.py
+  - path: strands-ts/src/multiagent/graph.ts
+  - path: strands-ts/src/multiagent/swarm.ts
 ---
 
 In Strands, building a system with multiple agents or complex tool chains can be approached in several ways. The three primary patterns you'll encounter are Graph, Swarm, and Workflow. While they all aim to solve complex problems, they have differences in their structures, execution workflows, and use cases.

--- a/site/src/content/docs/user-guide/concepts/multi-agent/swarm.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/swarm.mdx
@@ -3,6 +3,10 @@ title: Swarm Multi-Agent Pattern
 sidebar:
   label: "Swarm"
 tags: [multi-agent]
+sourceLinks:
+  - path: strands-py/src/strands/multiagent/base.py
+  - path: strands-py/src/strands/multiagent/swarm.py
+  - path: strands-ts/src/multiagent/swarm.ts
 ---
 
 A Swarm is a collaborative agent orchestration system where multiple agents work together as a team to solve complex tasks. Unlike traditional sequential or hierarchical multi-agent systems, a Swarm enables autonomous coordination between agents with shared context and working memory.

--- a/site/src/content/docs/user-guide/concepts/plugins/context-injector.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-injector.mdx
@@ -2,6 +2,9 @@
 title: Context Injector
 description: "Fold real-time text into the model input before each call with the ContextInjector plugin: a clock, environment facts, or a lookup, not stored in history."
 tags: [token-management]
+sourceLinks:
+  - path: strands-py/src/strands/vended_plugins/context_injector/plugin.py
+  - path: strands-ts/src/vended-plugins/context-injector/plugin.ts
 sidebar:
   badge:
     text: New

--- a/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -1,6 +1,11 @@
 ---
 title: Context Offloader
 tags: [conversation-management, hooks, token-management]
+sourceLinks:
+  - path: strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+  - path: strands-py/src/strands/vended_plugins/context_offloader/storage.py
+  - path: strands-ts/src/vended-plugins/context-offloader/plugin.ts
+  - path: strands-ts/src/vended-plugins/context-offloader/storage.ts
 sidebar:
   badge:
     text: New

--- a/site/src/content/docs/user-guide/concepts/plugins/goal-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/goal-loop.mdx
@@ -2,6 +2,11 @@
 title: GoalLoop
 description: "Iterative refinement plugin that validates agent responses against a goal, looping with feedback until satisfied."
 tags: [hooks, event-loop, prompt-authoring]
+sourceLinks:
+  - path: strands-py/src/strands/vended_plugins/goal/plugin.py
+  - path: strands-py/src/strands/vended_plugins/goal/judge.py
+  - path: strands-ts/src/vended-plugins/goal/plugin.ts
+  - path: strands-ts/src/vended-plugins/goal/judge.ts
 sidebar:
   badge:
     text: New

--- a/site/src/content/docs/user-guide/concepts/plugins/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/index.mdx
@@ -2,6 +2,9 @@
 title: Plugins
 tags: [hooks, event-loop]
 description: "Extend agent behavior with plugins. Add steering, guardrails, and custom capabilities that hook into the agent lifecycle."
+sourceLinks:
+  - path: strands-py/src/strands/plugins/plugin.py
+  - path: strands-ts/src/plugins/plugin.ts
 ---
 
 Plugins allow you to change the typical behavior of an agent. They enable you to introduce concepts like [Skills](https://agentskills.io/specification), [steering](./steering), or other behavioral modifications into the agentic loop. Plugins work by taking advantage of the low-level primitives exposed by the Agent class—`model`, <Syntax py="system_prompt" ts="systemPrompt" />, `messages`, `tools`, and `hooks`—and executing logic to improve an agent's behavior.

--- a/site/src/content/docs/user-guide/concepts/plugins/skills.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/skills.mdx
@@ -1,6 +1,11 @@
 ---
 title: Skills
 tags: [token-management, prompt-authoring]
+sourceLinks:
+  - path: strands-py/src/strands/vended_plugins/skills/agent_skills.py
+  - path: strands-py/src/strands/vended_plugins/skills/skill.py
+  - path: strands-ts/src/vended-plugins/skills/agent-skills.ts
+  - path: strands-ts/src/vended-plugins/skills/skill.ts
 sidebar:
   badge:
     text: New

--- a/site/src/content/docs/user-guide/concepts/plugins/steering.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/steering.mdx
@@ -2,6 +2,10 @@
 title: Steering
 tags: [hooks, conversation-management, prompt-authoring]
 languages: [python]
+sourceLinks:
+  - path: strands-py/src/strands/vended_plugins/steering/core/handler.py
+  - path: strands-py/src/strands/vended_plugins/steering/handlers/llm/llm_handler.py
+  - path: strands-py/src/strands/vended_plugins/steering/context_providers/ledger_provider.py
 ---
 
 

--- a/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
@@ -3,6 +3,11 @@ title: Async Iterators for Streaming
 sidebar:
   label: "Async Iterators"
 tags: [streaming]
+sourceLinks:
+  - path: strands-py/src/strands/agent/agent.py
+  - path: strands-py/src/strands/event_loop/streaming.py
+  - path: strands-ts/src/agent/agent.ts
+  - path: strands-ts/src/models/streaming.ts
 ---
 
 Async iterators provide asynchronous streaming of agent events, allowing you to process events as they occur in real-time. This approach is ideal for asynchronous frameworks where you need fine-grained control over async execution flow.

--- a/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
@@ -1,6 +1,8 @@
 ---
 title: Callback Handlers
 tags: [streaming]
+sourceLinks:
+  - path: strands-py/src/strands/handlers/callback_handler.py
 ---
 
 :::note[Not supported in TypeScript]

--- a/site/src/content/docs/user-guide/concepts/tools/custom-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/custom-tools.mdx
@@ -2,6 +2,12 @@
 title: Creating Custom Tools
 description: "Turn any Python function into an AI agent tool. Define inputs with docstrings, and the agent calls your function autonomously."
 tags: [tool-authoring]
+sourceLinks:
+  - path: strands-py/src/strands/tools/decorator.py
+  - path: strands-py/src/strands/tools/tools.py
+  - path: strands-py/src/strands/tools/loader.py
+  - path: strands-ts/src/tools/function-tool.ts
+  - path: strands-ts/src/tools/tool-factory.ts
 ---
 
 There are multiple approaches to defining custom tools in Strands, with differences between Python and TypeScript implementations.

--- a/site/src/content/docs/user-guide/concepts/tools/executors.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/executors.mdx
@@ -3,6 +3,10 @@ title: Tool Executors
 sidebar:
   label: "Executors"
 tags: [tool-execution, event-loop]
+sourceLinks:
+  - path: strands-py/src/strands/tools/executors/concurrent.py
+  - path: strands-py/src/strands/tools/executors/sequential.py
+  - path: strands-ts/src/agent/agent.ts
 ---
 
 Tool executors control whether tools from a single assistant turn run concurrently or sequentially. Both SDKs default to concurrent execution.

--- a/site/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -4,6 +4,11 @@ description: "Give AI agents the ability to take real-world actions. Strands sup
 sidebar:
   label: "Overview"
 tags: [tool-authoring, mcp]
+sourceLinks:
+  - path: strands-py/src/strands/tools/decorator.py
+  - path: strands-py/src/strands/tools/registry.py
+  - path: strands-ts/src/tools/tool.ts
+  - path: strands-ts/src/tools/tool-factory.ts
 ---
 
 Tools are the primary mechanism for extending agent capabilities, enabling them to perform actions beyond simple text generation. Tools allow agents to interact with external systems, access data, and manipulate their environment.

--- a/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
@@ -4,6 +4,10 @@ description: "Connect AI agents to any MCP server for tool access. Strands agent
 sidebar:
   label: "Model Context Protocol (MCP)"
 tags: [tool-authoring, mcp]
+sourceLinks:
+  - path: strands-py/src/strands/tools/mcp/mcp_client.py
+  - path: strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+  - path: strands-ts/src/tools/mcp-tool.ts
 ---
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open protocol that standardizes how applications provide context to Large Language Models. Strands Agents integrates with MCP to extend agent capabilities through external tools and services.

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -5,6 +5,11 @@ sidebar:
   label: "Vended Tools"
 languages: [typescript]
 tags: [tool-authoring]
+sourceLinks:
+  - path: strands-ts/src/vended-tools/file-editor/file-editor.ts
+  - path: strands-ts/src/vended-tools/bash/bash.ts
+  - path: strands-ts/src/vended-tools/http-request/http-request.ts
+  - path: strands-ts/src/vended-tools/notebook/notebook.ts
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 

--- a/site/src/util/render-to-markdown.ts
+++ b/site/src/util/render-to-markdown.ts
@@ -7,6 +7,7 @@ import { htmlToMarkdown } from './html-to-markdown'
 import { pathWithBase } from './links'
 import { relatedUserGuideFor } from './related-docs'
 import type { SourceLink } from '../content.config'
+import { resolveLanguage, languageLabel, sourceLinkUrl } from './source-links'
 
 /**
  * Render the "Related pages" block for headless consumers. Appended only to
@@ -30,17 +31,33 @@ async function renderRelatedPages(
 /**
  * Render the "Implementation" block for headless consumers. Appended only to
  * the markdown surfaces (/<slug>/index.md, /llms-full.txt) — never the HTML
- * page. Link text and URL both embed repo+path so parsers can extract either.
+ * page. Links are grouped under a per-language heading ("Python", "TypeScript",
+ * …) so agents and crawlers get an unambiguous "here is the link for language
+ * X" mapping. The language is inferred from each path's extension (or its
+ * explicit `language` override). Link text and URL both embed repo+path so
+ * parsers can extract either.
  */
-function renderImplementation(entry: CollectionEntry<'docs'> | CollectionEntry<'blog'>): string {
+export function renderImplementation(entry: CollectionEntry<'docs'> | CollectionEntry<'blog'>): string {
   if (entry.collection !== 'docs') return ''
   const links: SourceLink[] | undefined = entry.data.sourceLinks
   if (!links || links.length === 0) return ''
-  const items = links.map(({ repo, path }) => {
-    const url = `https://github.com/strands-agents/${repo}/blob/main/${path}`
-    return `- [${repo}/${path}](${url})`
+
+  // Group links by language, preserving first-seen order of both languages and
+  // the links within each language.
+  const byLanguage = new Map<string, SourceLink[]>()
+  for (const link of links) {
+    const language = resolveLanguage(link)
+    const group = byLanguage.get(language) ?? []
+    group.push(link)
+    byLanguage.set(language, group)
+  }
+
+  const sections = [...byLanguage.entries()].map(([language, group]) => {
+    const items = group.map((link) => `- [${link.repo}/${link.path}](${sourceLinkUrl(link)})`)
+    return `### ${languageLabel(language)}\n\n${items.join('\n')}`
   })
-  return `\n\n## Implementation\n\n${items.join('\n')}\n`
+
+  return `\n\n## Implementation\n\n${sections.join('\n\n')}\n`
 }
 
 /**

--- a/site/src/util/source-links.ts
+++ b/site/src/util/source-links.ts
@@ -1,0 +1,58 @@
+import type { SourceLink } from '../content.config'
+
+/**
+ * Maps a source file extension to its SDK language. The language a `sourceLink`
+ * points at is normally derivable from the path itself (a `.py` file is Python,
+ * a `.ts` file is TypeScript), so we infer it rather than making every doc page
+ * repeat it. A page can still set `language` explicitly to override this — see
+ * `resolveLanguage`.
+ *
+ * Keyed by lowercase canonical language code. `LANGUAGE_LABELS` maps the same
+ * codes to their display form.
+ */
+const EXTENSION_TO_LANGUAGE: Record<string, string> = {
+  py: 'python',
+  ts: 'typescript',
+  tsx: 'typescript',
+}
+
+/** Display labels for known SDK language codes. */
+const LANGUAGE_LABELS: Record<string, string> = {
+  python: 'Python',
+  typescript: 'TypeScript',
+}
+
+/** Lowercase file extension of a path, or '' if it has none. */
+function extensionOf(path: string): string {
+  const base = path.slice(path.lastIndexOf('/') + 1)
+  const dot = base.lastIndexOf('.')
+  return dot === -1 ? '' : base.slice(dot + 1).toLowerCase()
+}
+
+/**
+ * Resolve the language code for a source link: the explicit `language` if set,
+ * otherwise inferred from the file extension.
+ *
+ * Throws if neither is available — a path with an unmapped extension and no
+ * explicit `language` is an authoring error, surfaced at build time rather than
+ * silently rendering an unlabeled link.
+ */
+export function resolveLanguage(link: SourceLink): string {
+  if (link.language) return link.language
+  const inferred = EXTENSION_TO_LANGUAGE[extensionOf(link.path)]
+  if (inferred) return inferred
+  throw new Error(
+    `sourceLink "${link.path}" has an unrecognized file extension; ` +
+      `add it to EXTENSION_TO_LANGUAGE or set "language" explicitly on the link.`,
+  )
+}
+
+/** Human-readable label for a language code (capitalized fallback if unknown). */
+export function languageLabel(language: string): string {
+  return LANGUAGE_LABELS[language.toLowerCase()] ?? language.charAt(0).toUpperCase() + language.slice(1)
+}
+
+/** Full GitHub blob URL for a source link. */
+export function sourceLinkUrl(link: SourceLink): string {
+  return `https://github.com/strands-agents/${link.repo}/blob/main/${link.path}`
+}

--- a/site/test/render-to-markdown.test.ts
+++ b/site/test/render-to-markdown.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import type { CollectionEntry } from 'astro:content'
+import { renderImplementation } from '../src/util/render-to-markdown'
+import type { SourceLink } from '../src/content.config'
+
+function docWithSourceLinks(sourceLinks?: SourceLink[]): CollectionEntry<'docs'> {
+  return {
+    id: 'docs/user-guide/example',
+    collection: 'docs',
+    data: { title: 'Example', tags: [], sourceLinks },
+  } as unknown as CollectionEntry<'docs'>
+}
+
+describe('renderImplementation', () => {
+  it('returns empty string when there are no source links', () => {
+    expect(renderImplementation(docWithSourceLinks(undefined))).toBe('')
+    expect(renderImplementation(docWithSourceLinks([]))).toBe('')
+  })
+
+  it('infers language from the file extension and groups under per-language headings', () => {
+    const md = renderImplementation(
+      docWithSourceLinks([
+        { path: 'strands-py/src/strands/agent/agent.py', repo: 'harness-sdk' },
+        { path: 'strands-ts/src/agent/agent.ts', repo: 'harness-sdk' },
+      ]),
+    )
+
+    expect(md).toContain('## Implementation')
+    expect(md).toContain('### Python')
+    expect(md).toContain('### TypeScript')
+    expect(md).toContain(
+      '- [harness-sdk/strands-py/src/strands/agent/agent.py]' +
+        '(https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/agent/agent.py)',
+    )
+    expect(md).toContain(
+      '- [harness-sdk/strands-ts/src/agent/agent.ts]' +
+        '(https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/agent/agent.ts)',
+    )
+  })
+
+  it('collects multiple links for the same language under one heading', () => {
+    const md = renderImplementation(
+      docWithSourceLinks([
+        { path: 'strands-py/src/strands/models/bedrock.py', repo: 'harness-sdk' },
+        { path: 'strands-py/src/strands/models/model.py', repo: 'harness-sdk' },
+      ]),
+    )
+
+    expect(md.match(/### Python/g)).toHaveLength(1)
+    expect(md).toContain('bedrock.py')
+    expect(md).toContain('model.py')
+  })
+
+  it('preserves first-seen language order', () => {
+    const md = renderImplementation(
+      docWithSourceLinks([
+        { path: 'strands-ts/src/agent/agent.ts', repo: 'harness-sdk' },
+        { path: 'strands-py/src/strands/agent/agent.py', repo: 'harness-sdk' },
+      ]),
+    )
+
+    expect(md.indexOf('### TypeScript')).toBeLessThan(md.indexOf('### Python'))
+  })
+
+  it('respects an explicit language override over the extension', () => {
+    const md = renderImplementation(
+      docWithSourceLinks([{ path: 'configs/agent.toml', language: 'python', repo: 'harness-sdk' }]),
+    )
+
+    expect(md).toContain('### Python')
+    expect(md).toContain('configs/agent.toml')
+  })
+
+  it('honors a custom repo override in the generated URL', () => {
+    const md = renderImplementation(
+      docWithSourceLinks([{ path: 'src/tool.py', repo: 'tools' }]),
+    )
+
+    expect(md).toContain('https://github.com/strands-agents/tools/blob/main/src/tool.py')
+  })
+})

--- a/site/test/source-links.test.ts
+++ b/site/test/source-links.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { resolveLanguage, languageLabel, sourceLinkUrl } from '../src/util/source-links'
+
+describe('resolveLanguage', () => {
+  it('infers python from a .py extension', () => {
+    expect(resolveLanguage({ path: 'strands-py/src/strands/agent/agent.py', repo: 'harness-sdk' })).toBe('python')
+  })
+
+  it('infers typescript from .ts and .tsx extensions', () => {
+    expect(resolveLanguage({ path: 'strands-ts/src/agent/agent.ts', repo: 'harness-sdk' })).toBe('typescript')
+    expect(resolveLanguage({ path: 'strands-ts/src/component.tsx', repo: 'harness-sdk' })).toBe('typescript')
+  })
+
+  it('prefers an explicit language over the inferred extension', () => {
+    expect(resolveLanguage({ path: 'configs/agent.toml', language: 'python', repo: 'harness-sdk' })).toBe('python')
+    // Even when the extension is known, the override wins.
+    expect(resolveLanguage({ path: 'snippet.ts', language: 'python', repo: 'harness-sdk' })).toBe('python')
+  })
+
+  it('throws for an unmapped extension with no explicit language', () => {
+    expect(() => resolveLanguage({ path: 'configs/agent.toml', repo: 'harness-sdk' })).toThrow(/unrecognized file extension/)
+  })
+
+  it('throws for a path with no extension and no explicit language', () => {
+    expect(() => resolveLanguage({ path: 'Makefile', repo: 'harness-sdk' })).toThrow(/unrecognized file extension/)
+  })
+})
+
+describe('languageLabel', () => {
+  it('maps known codes to their display label', () => {
+    expect(languageLabel('python')).toBe('Python')
+    expect(languageLabel('typescript')).toBe('TypeScript')
+  })
+
+  it('capitalizes unknown codes as a fallback', () => {
+    expect(languageLabel('rust')).toBe('Rust')
+  })
+})
+
+describe('sourceLinkUrl', () => {
+  it('builds a GitHub blob URL from repo and path', () => {
+    expect(sourceLinkUrl({ path: 'strands-py/src/strands/agent/agent.py', repo: 'harness-sdk' })).toBe(
+      'https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/agent/agent.py',
+    )
+  })
+
+  it('respects a custom repo override', () => {
+    expect(sourceLinkUrl({ path: 'src/tool.py', repo: 'tools' })).toBe(
+      'https://github.com/strands-agents/tools/blob/main/src/tool.py',
+    )
+  })
+})


### PR DESCRIPTION
## Why

The `sourceLinks` frontmatter mechanic existed in the schema but was unused on every page, and its shape predated the monorepo consolidation ([design 0009](../team/designs/0009-mono-repository.md)) — it hardcoded `repo: 'sdk-python' | 'sdk-typescript'` and built URLs against the old separate repos. This PR reworks the mechanic for the monorepo and populates it across the user-guide concept pages, so headless consumers (agents, crawlers) get an explicit per-language "here is the source for Python / here is the source for TypeScript" mapping for each documented feature.

These sections render **only** on the headless surfaces (`/<slug>/index.md`, `llms-full.txt`) and as JSON-LD — never on the visible HTML page. They're an agent/crawler affordance, not human-facing chrome.

## Mechanic changes

- **`content.config.ts`** — `language` is now **optional**, inferred from the file extension (`.py`→python, `.ts`→typescript); set it explicitly only to override (non-code file, future language). `repo` **defaults to the `harness-sdk` monorepo**, with an optional override for code living in another org repo.
- **`util/source-links.ts`** (new) — shared `resolveLanguage` / `languageLabel` / `sourceLinkUrl`. `resolveLanguage` **throws at build time** on an unmapped extension with no explicit language, so an authoring mistake fails the build loudly instead of rendering an unlabeled link.
- **`render-to-markdown.ts`** — the headless "Implementation" block now groups links under per-language headings (`### Python`, `### TypeScript`, …).
- **`Head.astro`** — each JSON-LD `SoftwareSourceCode` node carries `programmingLanguage`.

### Authoring shape

```yaml
sourceLinks:
  - path: strands-py/src/strands/models/bedrock.py
  - path: strands-ts/src/models/bedrock.ts
```

### Rendered (headless `index.md`)

```markdown
## Implementation

### Python

- [harness-sdk/strands-py/src/strands/models/bedrock.py](https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/bedrock.py)

### TypeScript

- [harness-sdk/strands-ts/src/models/bedrock.ts](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/models/bedrock.ts)
```

## Population

59 concept pages across model-providers, agents, multi-agent, tools, plugins, bidirectional-streaming, streaming, memory, and interventions. Per-language nuance is honored — e.g. Python-only providers link only Python; the steering page maps Python→plugin handler and TypeScript→intervention handler.

**Intentionally skipped** (no single backing implementation): navigational overviews (model-providers index, streaming index, bidi quickstart) and external-package pages (amazon-nova, community-tools-package, multi-agent/workflow).

## Verification

- **All 131 referenced paths verified to exist** and to *implement what their page documents* (symbol-level check, not just existence) — every multi-file page checked per-file. Caught and fixed two issues along the way: vended-tools links pointed at re-export barrels (repointed to the real tool files), and `state.py` is a thin alias (added `types/json_dict.py`, the actual implementation).
- `astro sync` + `npm run typecheck` clean.
- **334 tests pass** (added `source-links.test.ts` covering inference, override-wins, and the throw-on-unknown-extension safety net).
- **Full `npm run build` clean — no broken links.**
- Spot-checked rendered output on representative bilingual, Python-only, TS-only, and cross-language-split pages across all three surfaces.

## Notes

- This touches `site/` plus a one-bullet directive in the top-level `AGENTS.md`: when a source file is renamed/moved, update any `sourceLinks` that reference its old path in the same change (the build only catches malformed paths and unmapped extensions, not a path that resolves to the wrong/nonexistent file).
- **Maintenance churn is low.** A quick analysis of the last 12 months: ~1,200 commits touched SDK source, only 7 of them renamed/moved a file (~0.6%), and exactly 1 of those hit a file referenced by `sourceLinks`. So the expected ongoing tax is roughly one one-line path update every month or two, found via `grep -rn "<old/path>" site/src/content/docs`. A CI check that asserts every `sourceLinks` path exists is an option if stale links ever ship, but isn't worth the gate weight for a ~once-a-year event today.