### PR TITLE
test(sandbox): add SSH sandbox integration tests for Py and TS

### DIFF
--- a/strands-py/tests_integ/_aws.py
+++ b/strands-py/tests_integ/_aws.py
@@ -1,0 +1,14 @@
+"""Shared AWS configuration for integration tests."""
+
+from __future__ import annotations
+
+import os
+
+
+def resolve_region(region: str | None = None) -> str:
+    """Resolve the AWS region to use for test infrastructure.
+
+    Checks, in order: the explicit ``region`` argument, then ``AWS_REGION``,
+    then ``AWS_DEFAULT_REGION``, falling back to ``us-east-1``.
+    """
+    return region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"

--- a/strands-py/tests_integ/_ssm.py
+++ b/strands-py/tests_integ/_ssm.py
@@ -24,6 +24,8 @@ import os
 
 import boto3
 
+from tests_integ._aws import resolve_region
+
 logger = logging.getLogger(__name__)
 
 # Root namespace the provisioning stack publishes every test parameter under.
@@ -44,24 +46,19 @@ def ssm_parameter_path(feature: str, *segments: str) -> str:
     return "/".join([SSM_PARAMETER_NAMESPACE, feature, *segments])
 
 
-def _resolve_region(region: str | None) -> str:
-    """Resolve the AWS region, falling back to the standard env vars then us-east-1."""
-    return region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
-
-
 def read_ssm_parameter(name: str, *, with_decryption: bool = False, region: str | None = None) -> str | None:
     """Read a single SSM parameter by name.
 
     Args:
         name: The SSM parameter name.
         with_decryption: Decrypt the value (required for ``SecureString`` parameters).
-        region: AWS region; defaults to ``AWS_REGION`` / ``AWS_DEFAULT_REGION`` / ``us-east-1``.
+        region: AWS region override; defaults via :func:`~tests_integ._aws.resolve_region`.
 
     Returns:
         The parameter value, or ``None`` if it can't be read (missing, no access, SSM unreachable).
     """
     try:
-        client = boto3.Session(region_name=_resolve_region(region)).client("ssm")
+        client = boto3.Session(region_name=resolve_region(region)).client("ssm")
         response = client.get_parameter(Name=name, WithDecryption=with_decryption)
     except Exception as error:  # noqa: BLE001 - any failure means "unavailable", not "error".
         logger.warning("name=<%s>, error=<%s> | failed to read SSM parameter", name, error)
@@ -82,7 +79,7 @@ def resolve_ssm_parameters(
         params: Map of result key -> SSM parameter name to batch-read.
         overrides: Optional map of result key -> environment variable name. When the
             env var is set, its value takes precedence over SSM for that key.
-        region: AWS region; defaults to ``AWS_REGION`` / ``AWS_DEFAULT_REGION`` / ``us-east-1``.
+        region: AWS region override; defaults via :func:`~tests_integ._aws.resolve_region`.
 
     Returns:
         Map of each key in ``params`` to its resolved value, or ``None`` when neither
@@ -95,12 +92,8 @@ def resolve_ssm_parameters(
 
 
 def _batch_get(params: dict[str, str], *, region: str | None) -> dict[str, str | None] | None:
-    """Batch-read the SSM parameters by name; returns a key->value map, or ``None`` on failure.
-
-    Parameters that don't exist in SSM resolve to ``None``.
-    """
     try:
-        client = boto3.Session(region_name=_resolve_region(region)).client("ssm")
+        client = boto3.Session(region_name=resolve_region(region)).client("ssm")
         response = client.get_parameters(Names=list(params.values()))
     except Exception as error:  # noqa: BLE001 - any failure means "skip", not "error".
         logger.warning("error=<%s> | failed to resolve SSM parameters", error)

--- a/strands-py/tests_integ/_ssm.py
+++ b/strands-py/tests_integ/_ssm.py
@@ -1,0 +1,110 @@
+"""Reusable SSM Parameter Store resolution for integration tests.
+
+Integration tests that depend on provisioned AWS resources discover them at
+runtime by reading SSM parameters the provisioning stack publishes under stable
+``/strands/test-infra/<feature>/<name>`` paths. This module is the one place
+that SSM plumbing lives so every integ suite shares it instead of re-deriving
+boto3 calls and skip logic.
+
+This module reads only published SSM **parameter paths** (a runtime data
+contract); it imports nothing from the provisioning stack and the stack imports
+nothing from here.
+
+Resolution is best-effort: when SSM is unreachable (no credentials, wrong
+account, parameter absent) the helpers return ``None`` for the missing values
+rather than raising, so a suite can ``pytest.skip(...)`` cleanly instead of
+erroring. Per-key environment overrides take precedence over SSM, which lets a
+developer point a suite at their own resources without touching SSM.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+# Root namespace the provisioning stack publishes every test parameter under.
+# This string is a published runtime contract, not an import.
+SSM_PARAMETER_NAMESPACE = "/strands/test-infra"
+
+
+def ssm_parameter_path(feature: str, *segments: str) -> str:
+    """Build the SSM parameter path for a provisioned test resource.
+
+    Args:
+        feature: The feature namespace (e.g. ``"ssh-ec2"``).
+        *segments: Path segments naming the value (e.g. ``"instance-id"``).
+
+    Returns:
+        The full parameter path, e.g. ``/strands/test-infra/ssh-ec2/instance-id``.
+    """
+    return "/".join([SSM_PARAMETER_NAMESPACE, feature, *segments])
+
+
+def _resolve_region(region: str | None) -> str:
+    """Resolve the AWS region, falling back to the standard env vars then us-east-1."""
+    return region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+
+
+def read_ssm_parameter(name: str, *, with_decryption: bool = False, region: str | None = None) -> str | None:
+    """Read a single SSM parameter by name.
+
+    Args:
+        name: The SSM parameter name.
+        with_decryption: Decrypt the value (required for ``SecureString`` parameters).
+        region: AWS region; defaults to ``AWS_REGION`` / ``AWS_DEFAULT_REGION`` / ``us-east-1``.
+
+    Returns:
+        The parameter value, or ``None`` if it can't be read (missing, no access, SSM unreachable).
+    """
+    try:
+        client = boto3.Session(region_name=_resolve_region(region)).client("ssm")
+        response = client.get_parameter(Name=name, WithDecryption=with_decryption)
+    except Exception as error:  # noqa: BLE001 - any failure means "unavailable", not "error".
+        logger.warning("name=<%s>, error=<%s> | failed to read SSM parameter", name, error)
+        return None
+
+    return response["Parameter"]["Value"]
+
+
+def resolve_ssm_parameters(
+    params: dict[str, str],
+    *,
+    overrides: dict[str, str] | None = None,
+    region: str | None = None,
+) -> dict[str, str | None]:
+    """Batch-resolve named SSM values, honoring environment overrides.
+
+    Args:
+        params: Map of result key -> SSM parameter name to batch-read.
+        overrides: Optional map of result key -> environment variable name. When the
+            env var is set, its value takes precedence over SSM for that key.
+        region: AWS region; defaults to ``AWS_REGION`` / ``AWS_DEFAULT_REGION`` / ``us-east-1``.
+
+    Returns:
+        Map of each key in ``params`` to its resolved value, or ``None`` when neither
+        an override nor SSM provides one. When SSM is unreachable every SSM-sourced
+        value is ``None`` (overrides still apply), so callers can decide to skip.
+    """
+    override_values = {key: os.environ.get(env_var) for key, env_var in (overrides or {}).items()}
+    resolved = _batch_get(params, region=region) or {}
+    return {key: override_values.get(key) or resolved.get(key) for key in params}
+
+
+def _batch_get(params: dict[str, str], *, region: str | None) -> dict[str, str | None] | None:
+    """Batch-read the SSM parameters by name; returns a key->value map, or ``None`` on failure.
+
+    Parameters that don't exist in SSM resolve to ``None``.
+    """
+    try:
+        client = boto3.Session(region_name=_resolve_region(region)).client("ssm")
+        response = client.get_parameters(Names=list(params.values()))
+    except Exception as error:  # noqa: BLE001 - any failure means "skip", not "error".
+        logger.warning("error=<%s> | failed to resolve SSM parameters", error)
+        return None
+
+    by_name = {param["Name"]: param["Value"] for param in response.get("Parameters", [])}
+    return {key: by_name.get(name) for key, name in params.items()}

--- a/strands-py/tests_integ/memory/conftest.py
+++ b/strands-py/tests_integ/memory/conftest.py
@@ -8,20 +8,20 @@ The SSM test-infra parameters are resolved once in a session-scoped fixture
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 
-import boto3
 import pytest
+
+from tests_integ._ssm import resolve_ssm_parameters, ssm_parameter_path
 
 logger = logging.getLogger(__name__)
 
 # SSM parameter names for the shared test infrastructure.
 _SSM_PARAMS = {
-    "knowledge_base_id": "/strands/test-infra/bedrock-knowledge-base/knowledge-base-id",
-    "custom_data_source_id": "/strands/test-infra/bedrock-knowledge-base/custom-data-source-id",
-    "s3_data_source_id": "/strands/test-infra/bedrock-knowledge-base/s3-data-source-id",
-    "s3_bucket": "/strands/test-infra/bedrock-knowledge-base/s3-source-bucket-name",
+    "knowledge_base_id": ssm_parameter_path("bedrock-knowledge-base", "knowledge-base-id"),
+    "custom_data_source_id": ssm_parameter_path("bedrock-knowledge-base", "custom-data-source-id"),
+    "s3_data_source_id": ssm_parameter_path("bedrock-knowledge-base", "s3-data-source-id"),
+    "s3_bucket": ssm_parameter_path("bedrock-knowledge-base", "s3-source-bucket-name"),
 }
 
 # Optional local-dev overrides. Set these env vars to point the tests at your own resources without
@@ -45,23 +45,6 @@ class BedrockKnowledgeBaseContext:
     s3_bucket: str | None = None
 
 
-def _resolve_ssm_parameters() -> dict[str, str | None] | None:
-    """Batch-read the SSM parameters by name; returns a key->value map, or ``None`` on failure.
-
-    Parameters that don't exist in SSM resolve to ``None``.
-    """
-    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
-    try:
-        client = boto3.Session(region_name=region).client("ssm")
-        response = client.get_parameters(Names=list(_SSM_PARAMS.values()))
-    except Exception as error:  # noqa: BLE001 - any failure means "skip", not "error".
-        logger.warning("error=<%s> | failed to resolve Bedrock KB SSM parameters", error)
-        return None
-
-    by_name = {param["Name"]: param["Value"] for param in response.get("Parameters", [])}
-    return {key: by_name.get(name) for key, name in _SSM_PARAMS.items()}
-
-
 @pytest.fixture(scope="session")
 def bedrock_kb_context() -> BedrockKnowledgeBaseContext:
     """Resolve the Bedrock KB test-infra parameters once per session.
@@ -70,11 +53,7 @@ def bedrock_kb_context() -> BedrockKnowledgeBaseContext:
     unreachable or the knowledge base id can't be resolved, returns a context with ``should_skip`` set
     so dependent tests skip cleanly.
     """
-    overrides = {key: os.environ.get(env_var) for key, env_var in _OVERRIDE_ENV.items()}
-
-    resolved = _resolve_ssm_parameters() or {}
-
-    merged = {key: overrides.get(key) or resolved.get(key) for key in _SSM_PARAMS}
+    merged = resolve_ssm_parameters(_SSM_PARAMS, overrides=_OVERRIDE_ENV)
 
     if not merged.get("knowledge_base_id"):
         logger.info("Bedrock KB id not available (SSM/overrides) - KB integration tests will be skipped")

--- a/strands-py/tests_integ/sandbox/conftest.py
+++ b/strands-py/tests_integ/sandbox/conftest.py
@@ -14,17 +14,20 @@ import logging
 import os
 import re
 import secrets
+import selectors
 import shutil
 import socket
 import stat
 import subprocess
 import tempfile
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
+import boto3
 import pytest
 
 from strands.sandbox.ssh import SshSandbox
+from tests_integ._aws import resolve_region
 from tests_integ._ssm import read_ssm_parameter, resolve_ssm_parameters, ssm_parameter_path
 
 logger = logging.getLogger(__name__)
@@ -42,8 +45,7 @@ class SsmTunnel:
     """Manages an SSM Session Manager port-forward with proper cleanup.
 
     Captures the session ID from the process's stdout so cleanup can explicitly
-    call ``aws ssm terminate-session`` rather than relying solely on SIGTERM
-    (which may not fire if the runner is OOM-killed or times out).
+    terminate the session via the SSM API rather than relying solely on SIGTERM.
     """
 
     def __init__(self, instance_id: str, local_port: int, region: str) -> None:
@@ -54,11 +56,7 @@ class SsmTunnel:
         self._session_id: str | None = None
 
     def open(self) -> bool:
-        """Start the tunnel and wait for the local port to accept connections.
-
-        Returns:
-            True if the tunnel is ready, False if it failed to come up.
-        """
+        """Start the tunnel and wait for the local port to accept connections."""
         self._process = subprocess.Popen(
             [
                 "aws",
@@ -87,10 +85,7 @@ class SsmTunnel:
             if _port_open(self.local_port):
                 self._extract_session_id(output_lines)
                 return True
-            # Non-blocking read of stdout to capture session ID
             if self._process.stdout and self._process.stdout.readable():
-                import selectors
-
                 sel = selectors.DefaultSelector()
                 sel.register(self._process.stdout, selectors.EVENT_READ)
                 if sel.select(timeout=0.5):
@@ -105,12 +100,13 @@ class SsmTunnel:
         return False
 
     def close(self) -> None:
-        """Terminate the session and kill the local process."""
+        """Terminate the SSM session via the API, then kill the local process."""
         if self._session_id:
-            subprocess.run(
-                ["aws", "ssm", "terminate-session", "--region", self.region, "--session-id", self._session_id],
-                capture_output=True,
-            )
+            try:
+                client = boto3.Session(region_name=self.region).client("ssm")
+                client.terminate_session(SessionId=self._session_id)
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                pass
             self._session_id = None
         if self._process and self._process.poll() is None:
             self._process.terminate()
@@ -140,6 +136,7 @@ def _port_open(port: int) -> bool:
 
 
 def _free_port() -> int:
+    """Pick a free localhost TCP port (OS-assigned, avoids collision with concurrent runs)."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return sock.getsockname()[1]
@@ -155,11 +152,14 @@ def _tooling_available() -> bool:
 
 
 @pytest.fixture(scope="session")
-def ssh_sandbox() -> Iterator[SshSandbox]:
-    """Session-scoped SSH sandbox connected to the ssh-ec2 instance.
+def ssh_sandbox_factory() -> Iterator[Callable[..., SshSandbox]]:
+    """Session-scoped factory that yields a function to create SshSandbox instances.
 
     Resolves infrastructure from SSM, opens an SSM tunnel, creates an isolated
-    remote working directory, and yields a ready-to-use :class:`SshSandbox`.
+    remote working directory, and yields a factory. Tests can call it with
+    overrides to construct variant sandboxes (e.g. with custom ``ssh_options``)
+    without accessing private attributes.
+
     Skips the entire session when infrastructure isn't available.
     """
     if not _tooling_available():
@@ -180,16 +180,19 @@ def ssh_sandbox() -> Iterator[SshSandbox]:
     if not instance_id or not key_param_name:
         pytest.skip("ssh-ec2 SSM parameters not available")
 
-    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+    region = resolve_region()
     private_key = read_ssm_parameter(key_param_name, with_decryption=True, region=region)
     if not private_key:
         pytest.skip("ssh-ec2 private key not readable")
 
+    # OpenSSH's -i flag requires a file path; there's no way to pass a key via stdin/env.
+    # chmod 600 is mandatory — OpenSSH refuses keys with group/world-readable permissions.
     key_dir = tempfile.mkdtemp(prefix="strands-ssh-ec2-")
     key_path = os.path.join(key_dir, "key.pem")
     with open(key_path, "w", encoding="ascii") as f:
         f.write(private_key if private_key.endswith("\n") else private_key + "\n")
     os.chmod(key_path, stat.S_IRUSR | stat.S_IWUSR)
+    atexit.register(shutil.rmtree, key_dir, True)
 
     local_port = _free_port()
     tunnel = SsmTunnel(instance_id, local_port, region)
@@ -197,23 +200,26 @@ def ssh_sandbox() -> Iterator[SshSandbox]:
         tunnel.close()
         pytest.skip("SSM port-forward did not come up")
 
-    # Isolate from concurrent runners (Py + TS hit the same instance simultaneously).
     working_dir = f"/home/{_SSH_USER}/strands-integ-ssh-{secrets.token_hex(4)}"
 
-    sandbox = SshSandbox(
-        host=f"{_SSH_USER}@127.0.0.1",
-        working_dir=working_dir,
-        identity_file=key_path,
-        port=local_port,
-        allow_unknown_hosts=True,
-    )
+    def make_sandbox(**overrides: object) -> SshSandbox:
+        """Create an SshSandbox with the session's connection params, accepting overrides."""
+        kwargs: dict = {
+            "host": f"{_SSH_USER}@127.0.0.1",
+            "working_dir": working_dir,
+            "identity_file": key_path,
+            "port": local_port,
+            "allow_unknown_hosts": True,
+        }
+        kwargs.update(overrides)
+        return SshSandbox(**kwargs)
 
     try:
         mkdir = subprocess.run(
             [
                 "ssh",
                 "-o",
-                "StrictHostKeyChecking=no",
+                "StrictHostKeyChecking=accept-new",
                 "-o",
                 "BatchMode=yes",
                 "-p",
@@ -231,14 +237,13 @@ def ssh_sandbox() -> Iterator[SshSandbox]:
             tunnel.close()
             pytest.skip(f"could not create remote working dir: {mkdir.stderr.strip()}")
 
-        yield sandbox
+        yield make_sandbox
 
-        # Best-effort cleanup of remote files while tunnel is still up.
         subprocess.run(
             [
                 "ssh",
                 "-o",
-                "StrictHostKeyChecking=no",
+                "StrictHostKeyChecking=accept-new",
                 "-o",
                 "BatchMode=yes",
                 "-p",
@@ -254,3 +259,9 @@ def ssh_sandbox() -> Iterator[SshSandbox]:
     finally:
         tunnel.close()
         shutil.rmtree(key_dir, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def ssh_sandbox(ssh_sandbox_factory: Callable[..., SshSandbox]) -> SshSandbox:
+    """Convenience fixture: the default sandbox with no overrides."""
+    return ssh_sandbox_factory()

--- a/strands-py/tests_integ/sandbox/conftest.py
+++ b/strands-py/tests_integ/sandbox/conftest.py
@@ -1,0 +1,256 @@
+"""Fixtures for SSH sandbox integration tests.
+
+Provides a session-scoped :class:`~strands.sandbox.ssh.SshSandbox` pointed at
+the shared ``ssh-ec2`` test instance via an SSM port-forward. The entire module
+is skipped when the infrastructure isn't available — individual tests never
+carry skip logic.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import re
+import secrets
+import shutil
+import socket
+import stat
+import subprocess
+import tempfile
+import time
+from collections.abc import Iterator
+
+import pytest
+
+from strands.sandbox.ssh import SshSandbox
+from tests_integ._ssm import read_ssm_parameter, resolve_ssm_parameters, ssm_parameter_path
+
+logger = logging.getLogger(__name__)
+
+_SSH_USER = "ec2-user"
+_TUNNEL_READY_TIMEOUT = 30.0
+
+
+# ---------------------------------------------------------------------------
+# SSM tunnel lifecycle
+# ---------------------------------------------------------------------------
+
+
+class SsmTunnel:
+    """Manages an SSM Session Manager port-forward with proper cleanup.
+
+    Captures the session ID from the process's stdout so cleanup can explicitly
+    call ``aws ssm terminate-session`` rather than relying solely on SIGTERM
+    (which may not fire if the runner is OOM-killed or times out).
+    """
+
+    def __init__(self, instance_id: str, local_port: int, region: str) -> None:
+        self.instance_id = instance_id
+        self.local_port = local_port
+        self.region = region
+        self._process: subprocess.Popen | None = None
+        self._session_id: str | None = None
+
+    def open(self) -> bool:
+        """Start the tunnel and wait for the local port to accept connections.
+
+        Returns:
+            True if the tunnel is ready, False if it failed to come up.
+        """
+        self._process = subprocess.Popen(
+            [
+                "aws",
+                "ssm",
+                "start-session",
+                "--region",
+                self.region,
+                "--target",
+                self.instance_id,
+                "--document-name",
+                "AWS-StartPortForwardingSession",
+                "--parameters",
+                json.dumps({"portNumber": ["22"], "localPortNumber": [str(self.local_port)]}),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        atexit.register(self.close)
+
+        output_lines: list[str] = []
+        deadline = time.monotonic() + _TUNNEL_READY_TIMEOUT
+        while time.monotonic() < deadline:
+            if self._process.poll() is not None:
+                break
+            if _port_open(self.local_port):
+                self._extract_session_id(output_lines)
+                return True
+            # Non-blocking read of stdout to capture session ID
+            if self._process.stdout and self._process.stdout.readable():
+                import selectors
+
+                sel = selectors.DefaultSelector()
+                sel.register(self._process.stdout, selectors.EVENT_READ)
+                if sel.select(timeout=0.5):
+                    line = self._process.stdout.readline()
+                    if line:
+                        output_lines.append(line)
+                sel.close()
+            else:
+                time.sleep(0.5)
+
+        self._extract_session_id(output_lines)
+        return False
+
+    def close(self) -> None:
+        """Terminate the session and kill the local process."""
+        if self._session_id:
+            subprocess.run(
+                ["aws", "ssm", "terminate-session", "--region", self.region, "--session-id", self._session_id],
+                capture_output=True,
+            )
+            self._session_id = None
+        if self._process and self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+            self._process = None
+
+    def _extract_session_id(self, lines: list[str]) -> None:
+        for line in lines:
+            match = re.search(r"SessionId[:\s]+(\S+)", line)
+            if match:
+                self._session_id = match.group(1)
+                return
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _port_open(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1.0)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _tooling_available() -> bool:
+    return shutil.which("aws") is not None and shutil.which("session-manager-plugin") is not None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def ssh_sandbox() -> Iterator[SshSandbox]:
+    """Session-scoped SSH sandbox connected to the ssh-ec2 instance.
+
+    Resolves infrastructure from SSM, opens an SSM tunnel, creates an isolated
+    remote working directory, and yields a ready-to-use :class:`SshSandbox`.
+    Skips the entire session when infrastructure isn't available.
+    """
+    if not _tooling_available():
+        pytest.skip("aws CLI or session-manager-plugin not on PATH")
+
+    resolved = resolve_ssm_parameters(
+        {
+            "instance_id": ssm_parameter_path("ssh-ec2", "instance-id"),
+            "private_key_parameter_name": ssm_parameter_path("ssh-ec2", "private-key-parameter-name"),
+        },
+        overrides={
+            "instance_id": "STRANDS_TEST_SSH_INSTANCE_ID",
+            "private_key_parameter_name": "STRANDS_TEST_SSH_KEY_PARAM",
+        },
+    )
+    instance_id = resolved["instance_id"]
+    key_param_name = resolved["private_key_parameter_name"]
+    if not instance_id or not key_param_name:
+        pytest.skip("ssh-ec2 SSM parameters not available")
+
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+    private_key = read_ssm_parameter(key_param_name, with_decryption=True, region=region)
+    if not private_key:
+        pytest.skip("ssh-ec2 private key not readable")
+
+    key_dir = tempfile.mkdtemp(prefix="strands-ssh-ec2-")
+    key_path = os.path.join(key_dir, "key.pem")
+    with open(key_path, "w", encoding="ascii") as f:
+        f.write(private_key if private_key.endswith("\n") else private_key + "\n")
+    os.chmod(key_path, stat.S_IRUSR | stat.S_IWUSR)
+
+    local_port = _free_port()
+    tunnel = SsmTunnel(instance_id, local_port, region)
+    if not tunnel.open():
+        tunnel.close()
+        pytest.skip("SSM port-forward did not come up")
+
+    # Isolate from concurrent runners (Py + TS hit the same instance simultaneously).
+    working_dir = f"/home/{_SSH_USER}/strands-integ-ssh-{secrets.token_hex(4)}"
+
+    sandbox = SshSandbox(
+        host=f"{_SSH_USER}@127.0.0.1",
+        working_dir=working_dir,
+        identity_file=key_path,
+        port=local_port,
+        allow_unknown_hosts=True,
+    )
+
+    try:
+        mkdir = subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "BatchMode=yes",
+                "-p",
+                str(local_port),
+                "-i",
+                key_path,
+                "--",
+                f"{_SSH_USER}@127.0.0.1",
+                f"mkdir -p {working_dir}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if mkdir.returncode != 0:
+            tunnel.close()
+            pytest.skip(f"could not create remote working dir: {mkdir.stderr.strip()}")
+
+        yield sandbox
+
+        # Best-effort cleanup of remote files while tunnel is still up.
+        subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "BatchMode=yes",
+                "-p",
+                str(local_port),
+                "-i",
+                key_path,
+                "--",
+                f"{_SSH_USER}@127.0.0.1",
+                f"rm -rf {working_dir}",
+            ],
+            capture_output=True,
+        )
+    finally:
+        tunnel.close()
+        shutil.rmtree(key_dir, ignore_errors=True)

--- a/strands-py/tests_integ/sandbox/test_ssh.py
+++ b/strands-py/tests_integ/sandbox/test_ssh.py
@@ -1,0 +1,209 @@
+"""Integration tests for :class:`~strands.sandbox.ssh.SshSandbox`.
+
+These run real ``ssh`` commands against the shared ``ssh-ec2`` test instance,
+reached through an SSM port-forward set up by the session-scoped
+:func:`ssh_sandbox` fixture in conftest. The whole module is skipped when the
+infrastructure isn't available.
+"""
+
+import pytest
+
+from strands.sandbox.ssh import SshSandbox
+from strands.sandbox.types import StreamChunk
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Basic execution
+# ---------------------------------------------------------------------------
+
+
+async def test_captures_stdout_stderr_and_exit_code(ssh_sandbox: SshSandbox):
+    result = await ssh_sandbox.execute("echo hello && echo err >&2")
+    assert result.exit_code == 0
+    assert result.stdout == "hello\n"
+    assert result.stderr == "err\n"
+
+
+async def test_returns_nonzero_exit_code(ssh_sandbox: SshSandbox):
+    result = await ssh_sandbox.execute("exit 42")
+    assert result.exit_code == 42
+
+
+async def test_handles_empty_output(ssh_sandbox: SshSandbox):
+    result = await ssh_sandbox.execute("true")
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_streaming_yields_chunks_then_result(ssh_sandbox: SshSandbox):
+    chunks: list[StreamChunk] = []
+    async for item in ssh_sandbox.execute_streaming("echo line1 && echo line2"):
+        if isinstance(item, StreamChunk):
+            chunks.append(item)
+        else:
+            # Final ExecutionResult
+            assert item.exit_code == 0
+    assert any("line1" in c.data for c in chunks)
+    assert any("line2" in c.data for c in chunks)
+
+
+async def test_streaming_separates_stdout_and_stderr(ssh_sandbox: SshSandbox):
+    stdout_chunks: list[str] = []
+    stderr_chunks: list[str] = []
+    async for item in ssh_sandbox.execute_streaming("echo OUT && echo ERR >&2"):
+        if isinstance(item, StreamChunk):
+            if item.stream_type == "stdout":
+                stdout_chunks.append(item.data)
+            else:
+                stderr_chunks.append(item.data)
+    assert "OUT" in "".join(stdout_chunks)
+    assert "ERR" in "".join(stderr_chunks)
+
+
+# ---------------------------------------------------------------------------
+# Code execution
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_code(ssh_sandbox: SshSandbox):
+    result = await ssh_sandbox.execute_code("echo $((6 * 7))", "sh")
+    assert result.exit_code == 0
+    assert result.stdout == "42\n"
+
+
+async def test_execute_code_with_multiline_script(ssh_sandbox: SshSandbox):
+    script = "x=hello\necho $x world"
+    result = await ssh_sandbox.execute_code(script, "sh")
+    assert result.exit_code == 0
+    assert result.stdout == "hello world\n"
+
+
+# ---------------------------------------------------------------------------
+# File operations
+# ---------------------------------------------------------------------------
+
+
+async def test_round_trips_text_files(ssh_sandbox: SshSandbox):
+    await ssh_sandbox.write_text("greeting.txt", "hello ssh")
+    assert await ssh_sandbox.read_text("greeting.txt") == "hello ssh"
+
+
+async def test_round_trips_binary_files(ssh_sandbox: SshSandbox):
+    data = bytes(range(256))
+    await ssh_sandbox.write_file("binary.bin", data)
+    assert await ssh_sandbox.read_file("binary.bin") == data
+
+
+async def test_lists_files(ssh_sandbox: SshSandbox):
+    await ssh_sandbox.write_text("a.txt", "a")
+    await ssh_sandbox.write_text("b.txt", "b")
+    names = [f.name for f in await ssh_sandbox.list_files(".")]
+    assert "a.txt" in names
+    assert "b.txt" in names
+
+
+async def test_removes_files(ssh_sandbox: SshSandbox):
+    await ssh_sandbox.write_text("to_remove.txt", "bye")
+    await ssh_sandbox.remove_file("to_remove.txt")
+    with pytest.raises(FileNotFoundError):
+        await ssh_sandbox.read_file("to_remove.txt")
+
+
+# ---------------------------------------------------------------------------
+# Working directory and cwd override
+# ---------------------------------------------------------------------------
+
+
+async def test_respects_working_dir(ssh_sandbox: SshSandbox):
+    result = await ssh_sandbox.execute("pwd")
+    assert result.stdout.strip() == ssh_sandbox.working_dir
+
+
+async def test_respects_per_command_cwd_override(ssh_sandbox: SshSandbox):
+    result = await ssh_sandbox.execute("pwd", cwd="/tmp")
+    assert result.stdout.strip() == "/tmp"
+
+
+# ---------------------------------------------------------------------------
+# Environment variables
+# ---------------------------------------------------------------------------
+
+
+async def test_passes_env_vars(ssh_sandbox: SshSandbox):
+    result = await ssh_sandbox.execute("echo $MY_VAR", env={"MY_VAR": "hello-from-env"})
+    assert result.stdout.strip() == "hello-from-env"
+
+
+async def test_env_values_with_shell_metacharacters_are_literal(ssh_sandbox: SshSandbox):
+    value = "$(whoami) $HOME `id`"
+    result = await ssh_sandbox.execute("printenv MY_VAR", env={"MY_VAR": value})
+    assert result.exit_code == 0
+    assert result.stdout.strip() == value
+
+
+# ---------------------------------------------------------------------------
+# Timeout
+# ---------------------------------------------------------------------------
+
+
+async def test_kills_command_on_timeout(ssh_sandbox: SshSandbox):
+    with pytest.raises(TimeoutError, match="timed out"):
+        await ssh_sandbox.execute("sleep 60", timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Statelessness (each command is a fresh SSH process)
+# ---------------------------------------------------------------------------
+
+
+async def test_stateless_between_commands(ssh_sandbox: SshSandbox):
+    await ssh_sandbox.execute("export EPHEMERAL=1234")
+    result = await ssh_sandbox.execute("echo ${EPHEMERAL:-unset}")
+    assert result.stdout.strip() == "unset"
+
+
+# ---------------------------------------------------------------------------
+# get_tools()
+# ---------------------------------------------------------------------------
+
+
+async def test_get_tools_returns_sandbox_bash_and_file_editor(ssh_sandbox: SshSandbox):
+    tools = ssh_sandbox.get_tools()
+    names = {t.tool_name for t in tools}
+    assert "sandbox_bash" in names
+    assert "sandbox_file_editor" in names
+
+
+async def test_get_tools_descriptions_reference_host(ssh_sandbox: SshSandbox):
+    tools = ssh_sandbox.get_tools()
+    for t in tools:
+        spec = t.tool_spec
+        assert ssh_sandbox.host in spec["description"]
+
+
+# ---------------------------------------------------------------------------
+# SSH options (passthrough, not the validation — that's unit-tested)
+# ---------------------------------------------------------------------------
+
+
+async def test_ssh_options_are_applied(ssh_sandbox: SshSandbox):
+    """ServerAliveInterval is a safe option; verify it doesn't break the connection."""
+    custom = SshSandbox(
+        host=ssh_sandbox.host,
+        working_dir=ssh_sandbox.working_dir,
+        identity_file=ssh_sandbox._identity_file,
+        port=ssh_sandbox._port,
+        ssh_options=["ServerAliveInterval=5"],
+        allow_unknown_hosts=True,
+    )
+    result = await custom.execute("echo options_ok")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "options_ok"

--- a/strands-py/tests_integ/sandbox/test_ssh.py
+++ b/strands-py/tests_integ/sandbox/test_ssh.py
@@ -6,6 +6,8 @@ reached through an SSM port-forward set up by the session-scoped
 infrastructure isn't available.
 """
 
+from collections.abc import Callable
+
 import pytest
 
 from strands.sandbox.ssh import SshSandbox
@@ -194,16 +196,9 @@ async def test_get_tools_descriptions_reference_host(ssh_sandbox: SshSandbox):
 # ---------------------------------------------------------------------------
 
 
-async def test_ssh_options_are_applied(ssh_sandbox: SshSandbox):
+async def test_ssh_options_are_applied(ssh_sandbox_factory: Callable[..., SshSandbox]):
     """ServerAliveInterval is a safe option; verify it doesn't break the connection."""
-    custom = SshSandbox(
-        host=ssh_sandbox.host,
-        working_dir=ssh_sandbox.working_dir,
-        identity_file=ssh_sandbox._identity_file,
-        port=ssh_sandbox._port,
-        ssh_options=["ServerAliveInterval=5"],
-        allow_unknown_hosts=True,
-    )
+    custom = ssh_sandbox_factory(ssh_options=["ServerAliveInterval=5"])
     result = await custom.execute("echo options_ok")
     assert result.exit_code == 0
     assert result.stdout.strip() == "options_ok"

--- a/strands-ts/test/integ/__fixtures__/_aws.ts
+++ b/strands-ts/test/integ/__fixtures__/_aws.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared AWS configuration for integration tests.
+ */
+
+/** Resolved AWS region for all integ test infrastructure. */
+export const AWS_REGION = process.env.AWS_REGION || 'us-east-1'

--- a/strands-ts/test/integ/__fixtures__/_aws.ts
+++ b/strands-ts/test/integ/__fixtures__/_aws.ts
@@ -3,4 +3,4 @@
  */
 
 /** Resolved AWS region for all integ test infrastructure. */
-export const AWS_REGION = process.env.AWS_REGION || 'us-east-1'
+export const AWS_REGION = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1'

--- a/strands-ts/test/integ/__fixtures__/_setup-global.ts
+++ b/strands-ts/test/integ/__fixtures__/_setup-global.ts
@@ -14,6 +14,7 @@ import type { ProvidedContext } from 'vitest'
 import { Agent } from '../../../src/agent/agent.js'
 import { A2AExpressServer } from '../../../src/a2a/express-server.js'
 import { BedrockModel } from '../../../src/models/bedrock.js'
+import { getSshEc2TestContext } from './_ssh-ec2.js'
 
 /**
  * Batch-reads SSM parameters by name and returns a key→value map.
@@ -103,8 +104,12 @@ export async function setup(project: TestProject): Promise<() => void> {
   const a2aContext = await getA2AServerContext(project)
   project.provide('a2a-server', { shouldSkip: a2aContext.shouldSkip, url: a2aContext.url })
 
+  const sshEc2 = await getSshEc2TestContext(project)
+  project.provide('provider-ssh-ec2', sshEc2.context)
+
   return () => {
     a2aContext.abort?.()
+    sshEc2.cleanup()
   }
 }
 

--- a/strands-ts/test/integ/__fixtures__/_setup-global.ts
+++ b/strands-ts/test/integ/__fixtures__/_setup-global.ts
@@ -5,7 +5,6 @@
  */
 
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager'
-import { SSMClient, GetParametersCommand } from '@aws-sdk/client-ssm'
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers'
 import express from 'express'
 import type { TestProject } from 'vitest/node'
@@ -14,34 +13,16 @@ import type { ProvidedContext } from 'vitest'
 import { Agent } from '../../../src/agent/agent.js'
 import { A2AExpressServer } from '../../../src/a2a/express-server.js'
 import { BedrockModel } from '../../../src/models/bedrock.js'
+import { AWS_REGION } from './_aws.js'
+import { getSSMParameters } from './_ssm.js'
 import { getSshEc2TestContext } from './_ssh-ec2.js'
-
-/**
- * Batch-reads SSM parameters by name and returns a key→value map.
- * Parameters that don't exist in SSM resolve to `undefined`.
- */
-async function getSSMParameters<T extends Record<string, string>>(
-  params: T
-): Promise<{ [K in keyof T]: string | undefined } | null> {
-  const client = new SSMClient({ region: process.env.AWS_REGION || 'us-east-1' })
-  try {
-    const response = await client.send(new GetParametersCommand({ Names: Object.values(params) }))
-    const byName = new Map((response.Parameters ?? []).map((p) => [p.Name, p.Value]))
-    return Object.fromEntries(Object.entries(params).map(([key, name]) => [key, byName.get(name)])) as {
-      [K in keyof T]: string | undefined
-    }
-  } catch (e) {
-    console.warn('Error retrieving SSM parameters', e)
-    return null
-  }
-}
 
 /**
  * Load API keys as environment variables from AWS Secrets Manager
  */
 async function loadApiKeysFromSecretsManager(): Promise<void> {
   const client = new SecretsManagerClient({
-    region: process.env.AWS_REGION || 'us-east-1',
+    region: AWS_REGION,
   })
 
   try {

--- a/strands-ts/test/integ/__fixtures__/_ssh-ec2.ts
+++ b/strands-ts/test/integ/__fixtures__/_ssh-ec2.ts
@@ -1,20 +1,9 @@
 /**
  * Sets up a connection to the shared `ssh-ec2` test instance for the SSH
- * sandbox integration test.
- *
- * That instance has no public IP and no inbound security-group rule, so the
- * only way to reach its sshd is an SSM Session Manager port-forward
- * (`aws ssm start-session --document-name AWS-StartPortForwardingSession`).
- * This runs in the global setup (parent process): it resolves the instance and
- * key from SSM, opens the tunnel to a local port, and provides a serializable
- * connection target the test points `SshSandbox` at.
- *
- * Everything self-skips: if the SSM parameters can't be resolved, or the `aws`
- * CLI / `session-manager-plugin` aren't installed, or the tunnel never comes
- * up, the provided context has `shouldSkip` set and the test skips.
+ * sandbox integration test via an SSM Session Manager port-forward.
  */
 
-import { SSMClient, GetParametersCommand, GetParameterCommand } from '@aws-sdk/client-ssm'
+import { SSMClient, TerminateSessionCommand } from '@aws-sdk/client-ssm'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { mkdtempSync, writeFileSync, rmSync, chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -25,7 +14,8 @@ import type { AddressInfo } from 'node:net'
 import type { TestProject } from 'vitest/node'
 import type { ProvidedContext } from 'vitest'
 
-const REGION = process.env.AWS_REGION || 'us-east-1'
+import { AWS_REGION } from './_aws.js'
+import { getSSMParameters, getSSMParameter } from './_ssm.js'
 const SSH_USER = 'ec2-user'
 const INSTANCE_ID_PARAM = '/strands/test-infra/ssh-ec2/instance-id'
 const KEY_PARAM_NAME_PARAM = '/strands/test-infra/ssh-ec2/private-key-parameter-name'
@@ -53,51 +43,40 @@ export async function getSshEc2TestContext(project: TestProject): Promise<SshEc2
   }
 
   if (!toolingAvailable()) {
-    console.log('⏭️  aws CLI or session-manager-plugin not on PATH - SSH sandbox test will be skipped')
+    console.log('SSH sandbox setup: aws CLI or session-manager-plugin not on PATH, skipping')
     return SKIP
   }
 
-  const ssm = new SSMClient({ region: REGION })
-
-  const pointers = await ssm
-    .send(new GetParametersCommand({ Names: [INSTANCE_ID_PARAM, KEY_PARAM_NAME_PARAM] }))
-    .catch((e) => {
-      console.warn('Error resolving ssh-ec2 SSM parameters', e)
-      return null
-    })
-  const byName = new Map((pointers?.Parameters ?? []).map((p) => [p.Name, p.Value]))
-  const instanceId = byName.get(INSTANCE_ID_PARAM)
-  const keyParamName = byName.get(KEY_PARAM_NAME_PARAM)
-  if (!instanceId || !keyParamName) {
-    console.log('⏭️  ssh-ec2 SSM parameters not available - SSH sandbox test will be skipped')
+  const resolved = await getSSMParameters({
+    instanceId: INSTANCE_ID_PARAM,
+    keyParamName: KEY_PARAM_NAME_PARAM,
+  })
+  if (!resolved?.instanceId || !resolved?.keyParamName) {
+    console.log('SSH sandbox setup: SSM parameters not available, skipping')
     return SKIP
   }
 
-  const keyResponse = await ssm
-    .send(new GetParameterCommand({ Name: keyParamName, WithDecryption: true }))
-    .catch((e) => {
-      console.warn('Error reading ssh-ec2 private key', e)
-      return null
-    })
-  const privateKey = keyResponse?.Parameter?.Value
+  const privateKey = await getSSMParameter(resolved.keyParamName, true)
   if (!privateKey) {
-    console.log('⏭️  ssh-ec2 private key not readable - SSH sandbox test will be skipped')
+    console.log('SSH sandbox setup: private key not readable, skipping')
     return SKIP
   }
 
+  // OpenSSH's -i flag requires a file path; chmod 600 is mandatory.
   const keyDir = mkdtempSync(join(tmpdir(), 'strands-ssh-ec2-'))
   const identityFile = join(keyDir, 'key.pem')
   writeFileSync(identityFile, privateKey.endsWith('\n') ? privateKey : `${privateKey}\n`)
   chmodSync(identityFile, 0o600)
 
   const removeKey = (): void => rmSync(keyDir, { recursive: true, force: true })
+  process.on('exit', removeKey)
 
   const localPort = await freeLocalPort()
-  const tunnelState = openTunnel(instanceId, localPort)
+  const tunnelState = openTunnel(resolved.instanceId, localPort)
 
   const ready = await waitForPort(localPort, TUNNEL_READY_TIMEOUT_MS)
   if (!ready) {
-    console.log('⏭️  SSM port-forward did not come up - SSH sandbox test will be skipped')
+    console.log('SSH sandbox setup: port-forward did not come up, skipping')
     closeTunnel(tunnelState)
     removeKey()
     return SKIP
@@ -105,13 +84,13 @@ export async function getSshEc2TestContext(project: TestProject): Promise<SshEc2
 
   const workingDir = `/home/${SSH_USER}/strands-integ-ssh-${randomBytes(4).toString('hex')}`
   if (!runSsh(localPort, identityFile, `mkdir -p ${workingDir}`)) {
-    console.log('⏭️  could not prepare remote working dir - SSH sandbox test will be skipped')
+    console.log('SSH sandbox setup: could not prepare remote working dir, skipping')
     closeTunnel(tunnelState)
     removeKey()
     return SKIP
   }
 
-  console.log('⏭️  ssh-ec2 instance reachable - SSH sandbox test will run')
+  console.log('SSH sandbox setup: instance reachable, tests will run')
   return {
     context: {
       shouldSkip: false,
@@ -123,13 +102,14 @@ export async function getSshEc2TestContext(project: TestProject): Promise<SshEc2
     cleanup: () => {
       runSsh(localPort, identityFile, `rm -rf ${workingDir}`)
       closeTunnel(tunnelState)
+      process.removeListener('exit', removeKey)
       removeKey()
     },
   }
 }
 
 // ---------------------------------------------------------------------------
-// Tunnel lifecycle with explicit session termination
+// Tunnel lifecycle with explicit session termination via the SSM API
 // ---------------------------------------------------------------------------
 
 interface TunnelState {
@@ -146,7 +126,7 @@ function openTunnel(instanceId: string, localPort: number): TunnelState {
       'ssm',
       'start-session',
       '--region',
-      REGION,
+      AWS_REGION,
       '--target',
       instanceId,
       '--document-name',
@@ -157,7 +137,6 @@ function openTunnel(instanceId: string, localPort: number): TunnelState {
     { stdio: ['ignore', 'pipe', 'pipe'] }
   )
 
-  // Capture the session ID from stdout for explicit terminate-session on cleanup.
   proc.stdout?.on('data', (chunk: { toString(): string }) => {
     const match = chunk.toString().match(/SessionId[:\s]+(\S+)/)
     if (match) sessionId = match[1]
@@ -171,8 +150,6 @@ function openTunnel(instanceId: string, localPort: number): TunnelState {
     exitHandler: () => {},
   }
 
-  // Safety net: if the Node process exits before cleanup is called (e.g. OOM, CI timeout),
-  // terminate the SSM session explicitly so it doesn't sit open for 20 minutes.
   state.exitHandler = () => closeTunnel(state)
   process.on('exit', state.exitHandler)
 
@@ -183,9 +160,8 @@ function closeTunnel(state: TunnelState): void {
   process.removeListener('exit', state.exitHandler)
 
   if (state.sessionId) {
-    spawnSync('aws', ['ssm', 'terminate-session', '--region', REGION, '--session-id', state.sessionId], {
-      stdio: 'ignore',
-    })
+    const client = new SSMClient({ region: AWS_REGION })
+    client.send(new TerminateSessionCommand({ SessionId: state.sessionId })).catch(() => {})
   }
   if (!state.process.killed) {
     state.process.kill()

--- a/strands-ts/test/integ/__fixtures__/_ssh-ec2.ts
+++ b/strands-ts/test/integ/__fixtures__/_ssh-ec2.ts
@@ -1,0 +1,259 @@
+/**
+ * Sets up a connection to the shared `ssh-ec2` test instance for the SSH
+ * sandbox integration test.
+ *
+ * That instance has no public IP and no inbound security-group rule, so the
+ * only way to reach its sshd is an SSM Session Manager port-forward
+ * (`aws ssm start-session --document-name AWS-StartPortForwardingSession`).
+ * This runs in the global setup (parent process): it resolves the instance and
+ * key from SSM, opens the tunnel to a local port, and provides a serializable
+ * connection target the test points `SshSandbox` at.
+ *
+ * Everything self-skips: if the SSM parameters can't be resolved, or the `aws`
+ * CLI / `session-manager-plugin` aren't installed, or the tunnel never comes
+ * up, the provided context has `shouldSkip` set and the test skips.
+ */
+
+import { SSMClient, GetParametersCommand, GetParameterCommand } from '@aws-sdk/client-ssm'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import { mkdtempSync, writeFileSync, rmSync, chmodSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { connect, createServer } from 'node:net'
+import { randomBytes } from 'node:crypto'
+import type { AddressInfo } from 'node:net'
+import type { TestProject } from 'vitest/node'
+import type { ProvidedContext } from 'vitest'
+
+const REGION = process.env.AWS_REGION || 'us-east-1'
+const SSH_USER = 'ec2-user'
+const INSTANCE_ID_PARAM = '/strands/test-infra/ssh-ec2/instance-id'
+const KEY_PARAM_NAME_PARAM = '/strands/test-infra/ssh-ec2/private-key-parameter-name'
+const TUNNEL_READY_TIMEOUT_MS = 30_000
+
+interface SshEc2Setup {
+  context: ProvidedContext['provider-ssh-ec2']
+  cleanup: () => void
+}
+
+const SKIP: SshEc2Setup = {
+  context: { shouldSkip: true, host: undefined, port: undefined, identityFile: undefined, workingDir: undefined },
+  cleanup: () => {},
+}
+
+/**
+ * Resolve the ssh-ec2 instance and open an SSM port-forward to its sshd.
+ *
+ * @param project - The Vitest test project (used to detect the browser env, where SSH can't run).
+ * @returns The connection context to provide, plus a cleanup callback.
+ */
+export async function getSshEc2TestContext(project: TestProject): Promise<SshEc2Setup> {
+  if (project.isBrowserEnabled()) {
+    return SKIP
+  }
+
+  if (!toolingAvailable()) {
+    console.log('⏭️  aws CLI or session-manager-plugin not on PATH - SSH sandbox test will be skipped')
+    return SKIP
+  }
+
+  const ssm = new SSMClient({ region: REGION })
+
+  const pointers = await ssm
+    .send(new GetParametersCommand({ Names: [INSTANCE_ID_PARAM, KEY_PARAM_NAME_PARAM] }))
+    .catch((e) => {
+      console.warn('Error resolving ssh-ec2 SSM parameters', e)
+      return null
+    })
+  const byName = new Map((pointers?.Parameters ?? []).map((p) => [p.Name, p.Value]))
+  const instanceId = byName.get(INSTANCE_ID_PARAM)
+  const keyParamName = byName.get(KEY_PARAM_NAME_PARAM)
+  if (!instanceId || !keyParamName) {
+    console.log('⏭️  ssh-ec2 SSM parameters not available - SSH sandbox test will be skipped')
+    return SKIP
+  }
+
+  const keyResponse = await ssm
+    .send(new GetParameterCommand({ Name: keyParamName, WithDecryption: true }))
+    .catch((e) => {
+      console.warn('Error reading ssh-ec2 private key', e)
+      return null
+    })
+  const privateKey = keyResponse?.Parameter?.Value
+  if (!privateKey) {
+    console.log('⏭️  ssh-ec2 private key not readable - SSH sandbox test will be skipped')
+    return SKIP
+  }
+
+  const keyDir = mkdtempSync(join(tmpdir(), 'strands-ssh-ec2-'))
+  const identityFile = join(keyDir, 'key.pem')
+  writeFileSync(identityFile, privateKey.endsWith('\n') ? privateKey : `${privateKey}\n`)
+  chmodSync(identityFile, 0o600)
+
+  const removeKey = (): void => rmSync(keyDir, { recursive: true, force: true })
+
+  const localPort = await freeLocalPort()
+  const tunnelState = openTunnel(instanceId, localPort)
+
+  const ready = await waitForPort(localPort, TUNNEL_READY_TIMEOUT_MS)
+  if (!ready) {
+    console.log('⏭️  SSM port-forward did not come up - SSH sandbox test will be skipped')
+    closeTunnel(tunnelState)
+    removeKey()
+    return SKIP
+  }
+
+  const workingDir = `/home/${SSH_USER}/strands-integ-ssh-${randomBytes(4).toString('hex')}`
+  if (!runSsh(localPort, identityFile, `mkdir -p ${workingDir}`)) {
+    console.log('⏭️  could not prepare remote working dir - SSH sandbox test will be skipped')
+    closeTunnel(tunnelState)
+    removeKey()
+    return SKIP
+  }
+
+  console.log('⏭️  ssh-ec2 instance reachable - SSH sandbox test will run')
+  return {
+    context: {
+      shouldSkip: false,
+      host: `${SSH_USER}@127.0.0.1`,
+      port: localPort,
+      identityFile,
+      workingDir,
+    },
+    cleanup: () => {
+      runSsh(localPort, identityFile, `rm -rf ${workingDir}`)
+      closeTunnel(tunnelState)
+      removeKey()
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tunnel lifecycle with explicit session termination
+// ---------------------------------------------------------------------------
+
+interface TunnelState {
+  process: ChildProcess
+  sessionId: string | undefined
+  exitHandler: () => void
+}
+
+function openTunnel(instanceId: string, localPort: number): TunnelState {
+  let sessionId: string | undefined
+  const proc = spawn(
+    'aws',
+    [
+      'ssm',
+      'start-session',
+      '--region',
+      REGION,
+      '--target',
+      instanceId,
+      '--document-name',
+      'AWS-StartPortForwardingSession',
+      '--parameters',
+      JSON.stringify({ portNumber: ['22'], localPortNumber: [String(localPort)] }),
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] }
+  )
+
+  // Capture the session ID from stdout for explicit terminate-session on cleanup.
+  proc.stdout?.on('data', (chunk: { toString(): string }) => {
+    const match = chunk.toString().match(/SessionId[:\s]+(\S+)/)
+    if (match) sessionId = match[1]
+  })
+
+  const state: TunnelState = {
+    process: proc,
+    get sessionId() {
+      return sessionId
+    },
+    exitHandler: () => {},
+  }
+
+  // Safety net: if the Node process exits before cleanup is called (e.g. OOM, CI timeout),
+  // terminate the SSM session explicitly so it doesn't sit open for 20 minutes.
+  state.exitHandler = () => closeTunnel(state)
+  process.on('exit', state.exitHandler)
+
+  return state
+}
+
+function closeTunnel(state: TunnelState): void {
+  process.removeListener('exit', state.exitHandler)
+
+  if (state.sessionId) {
+    spawnSync('aws', ['ssm', 'terminate-session', '--region', REGION, '--session-id', state.sessionId], {
+      stdio: 'ignore',
+    })
+  }
+  if (!state.process.killed) {
+    state.process.kill()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toolingAvailable(): boolean {
+  const ok = (cmd: string): boolean => {
+    const result = spawnSync(cmd, ['--version'], { stdio: 'ignore' })
+    return !result.error && result.status === 0
+  }
+  return ok('aws') && ok('session-manager-plugin')
+}
+
+function runSsh(port: number, identityFile: string, remoteCommand: string): boolean {
+  const result = spawnSync(
+    'ssh',
+    [
+      '-o',
+      'StrictHostKeyChecking=accept-new',
+      '-o',
+      'BatchMode=yes',
+      '-p',
+      String(port),
+      '-i',
+      identityFile,
+      '--',
+      `${SSH_USER}@127.0.0.1`,
+      remoteCommand,
+    ],
+    { stdio: 'ignore' }
+  )
+  return !result.error && result.status === 0
+}
+
+async function freeLocalPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port
+      server.close(() => resolve(port))
+    })
+  })
+}
+
+async function waitForPort(port: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const open = await new Promise<boolean>((resolve) => {
+      const socket = connect({ host: '127.0.0.1', port })
+      socket.setTimeout(1000)
+      socket.once('connect', () => {
+        socket.destroy()
+        resolve(true)
+      })
+      socket.once('error', () => resolve(false))
+      socket.once('timeout', () => {
+        socket.destroy()
+        resolve(false)
+      })
+    })
+    if (open) return true
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  return false
+}

--- a/strands-ts/test/integ/__fixtures__/_ssh-ec2.ts
+++ b/strands-ts/test/integ/__fixtures__/_ssh-ec2.ts
@@ -3,7 +3,6 @@
  * sandbox integration test via an SSM Session Manager port-forward.
  */
 
-import { SSMClient, TerminateSessionCommand } from '@aws-sdk/client-ssm'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { mkdtempSync, writeFileSync, rmSync, chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -160,8 +159,11 @@ function closeTunnel(state: TunnelState): void {
   process.removeListener('exit', state.exitHandler)
 
   if (state.sessionId) {
-    const client = new SSMClient({ region: AWS_REGION })
-    client.send(new TerminateSessionCommand({ SessionId: state.sessionId })).catch(() => {})
+    // Must be synchronous — this also runs as a process.on('exit') handler where async work
+    // never settles.
+    spawnSync('aws', ['ssm', 'terminate-session', '--region', AWS_REGION, '--session-id', state.sessionId], {
+      stdio: 'ignore',
+    })
   }
   if (!state.process.killed) {
     state.process.kill()

--- a/strands-ts/test/integ/__fixtures__/_ssm.ts
+++ b/strands-ts/test/integ/__fixtures__/_ssm.ts
@@ -1,0 +1,41 @@
+/**
+ * Centralized SSM Parameter Store resolution for integration tests.
+ */
+
+import { SSMClient, GetParametersCommand, GetParameterCommand } from '@aws-sdk/client-ssm'
+
+import { AWS_REGION } from './_aws.js'
+
+/**
+ * Batch-reads SSM parameters by name and returns a key→value map.
+ * Parameters that don't exist in SSM resolve to `undefined`.
+ */
+export async function getSSMParameters<T extends Record<string, string>>(
+  params: T
+): Promise<{ [K in keyof T]: string | undefined } | null> {
+  const client = new SSMClient({ region: AWS_REGION })
+  try {
+    const response = await client.send(new GetParametersCommand({ Names: Object.values(params) }))
+    const byName = new Map((response.Parameters ?? []).map((p) => [p.Name, p.Value]))
+    return Object.fromEntries(Object.entries(params).map(([key, name]) => [key, byName.get(name)])) as {
+      [K in keyof T]: string | undefined
+    }
+  } catch (e) {
+    console.warn('Error retrieving SSM parameters', e)
+    return null
+  }
+}
+
+/**
+ * Read a single SSM parameter, optionally with decryption for SecureString values.
+ */
+export async function getSSMParameter(name: string, withDecryption = false): Promise<string | undefined> {
+  const client = new SSMClient({ region: AWS_REGION })
+  try {
+    const response = await client.send(new GetParameterCommand({ Name: name, WithDecryption: withDecryption }))
+    return response.Parameter?.Value
+  } catch (e) {
+    console.warn(`Error reading SSM parameter ${name}`, e)
+    return undefined
+  }
+}

--- a/strands-ts/test/integ/sandbox/ssh.test.node.ts
+++ b/strands-ts/test/integ/sandbox/ssh.test.node.ts
@@ -39,9 +39,13 @@ describe.skipIf(sshEc2.shouldSkip)('SshSandbox (integration)', () => {
 
   it('handles empty output', async () => {
     const result = await makeSandbox().execute('true')
-    expect(result.exitCode).toBe(0)
-    expect(result.stdout).toBe('')
-    expect(result.stderr).toBe('')
+    expect(result).toStrictEqual({
+      type: 'executionResult',
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      outputFiles: [],
+    })
   })
 
   // -------------------------------------------------------------------------
@@ -83,14 +87,24 @@ describe.skipIf(sshEc2.shouldSkip)('SshSandbox (integration)', () => {
 
   it('runs code via executeCode', async () => {
     const result = await makeSandbox().executeCode('echo $((6 * 7))', 'sh')
-    expect(result.exitCode).toBe(0)
-    expect(result.stdout).toBe('42\n')
+    expect(result).toStrictEqual({
+      type: 'executionResult',
+      exitCode: 0,
+      stdout: '42\n',
+      stderr: '',
+      outputFiles: [],
+    })
   })
 
   it('executeCode handles multiline scripts', async () => {
     const result = await makeSandbox().executeCode('x=hello\necho $x world', 'sh')
-    expect(result.exitCode).toBe(0)
-    expect(result.stdout).toBe('hello world\n')
+    expect(result).toStrictEqual({
+      type: 'executionResult',
+      exitCode: 0,
+      stdout: 'hello world\n',
+      stderr: '',
+      outputFiles: [],
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/strands-ts/test/integ/sandbox/ssh.test.node.ts
+++ b/strands-ts/test/integ/sandbox/ssh.test.node.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, inject } from 'vitest'
+import { SshSandbox, type SshSandboxOptions } from '../../../src/sandbox/ssh.js'
+import type { StreamChunk } from '../../../src/sandbox/types.js'
+
+const sshEc2 = inject('provider-ssh-ec2')
+
+function makeSandbox(overrides: Partial<SshSandboxOptions> = {}): SshSandbox {
+  const options: SshSandboxOptions = {
+    host: sshEc2.host!,
+    workingDir: sshEc2.workingDir!,
+    ...(sshEc2.identityFile !== undefined && { identityFile: sshEc2.identityFile }),
+    ...(sshEc2.port !== undefined && { port: sshEc2.port }),
+    allowUnknownHosts: true,
+    ...overrides,
+  }
+  return new SshSandbox(options)
+}
+
+describe.skipIf(sshEc2.shouldSkip)('SshSandbox (integration)', () => {
+  // -------------------------------------------------------------------------
+  // Basic execution
+  // -------------------------------------------------------------------------
+
+  it('captures stdout, stderr, and exit code', async () => {
+    const result = await makeSandbox().execute('echo hello && echo err >&2')
+    expect(result).toStrictEqual({
+      type: 'executionResult',
+      exitCode: 0,
+      stdout: 'hello\n',
+      stderr: 'err\n',
+      outputFiles: [],
+    })
+  })
+
+  it('returns non-zero exit code', async () => {
+    const result = await makeSandbox().execute('exit 42')
+    expect(result.exitCode).toBe(42)
+  })
+
+  it('handles empty output', async () => {
+    const result = await makeSandbox().execute('true')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toBe('')
+  })
+
+  // -------------------------------------------------------------------------
+  // Streaming
+  // -------------------------------------------------------------------------
+
+  it('executeStreaming yields chunks then a final result', async () => {
+    const chunks: StreamChunk[] = []
+    let exitCode: number | undefined
+    for await (const item of makeSandbox().executeStreaming('echo line1 && echo line2')) {
+      if (item.type === 'streamChunk') {
+        chunks.push(item)
+      } else {
+        exitCode = item.exitCode
+      }
+    }
+    expect(exitCode).toBe(0)
+    const combined = chunks.map((c) => c.data).join('')
+    expect(combined).toContain('line1')
+    expect(combined).toContain('line2')
+  })
+
+  it('streaming separates stdout and stderr', async () => {
+    const stdout: string[] = []
+    const stderr: string[] = []
+    for await (const item of makeSandbox().executeStreaming('echo OUT && echo ERR >&2')) {
+      if (item.type === 'streamChunk') {
+        if (item.streamType === 'stdout') stdout.push(item.data)
+        else stderr.push(item.data)
+      }
+    }
+    expect(stdout.join('')).toContain('OUT')
+    expect(stderr.join('')).toContain('ERR')
+  })
+
+  // -------------------------------------------------------------------------
+  // Code execution
+  // -------------------------------------------------------------------------
+
+  it('runs code via executeCode', async () => {
+    const result = await makeSandbox().executeCode('echo $((6 * 7))', 'sh')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('42\n')
+  })
+
+  it('executeCode handles multiline scripts', async () => {
+    const result = await makeSandbox().executeCode('x=hello\necho $x world', 'sh')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('hello world\n')
+  })
+
+  // -------------------------------------------------------------------------
+  // File operations
+  // -------------------------------------------------------------------------
+
+  it('round-trips text files', async () => {
+    const sandbox = makeSandbox()
+    await sandbox.writeText('greeting.txt', 'hello ssh')
+    expect(await sandbox.readText('greeting.txt')).toBe('hello ssh')
+  })
+
+  it('round-trips binary files', async () => {
+    const sandbox = makeSandbox()
+    const bytes = new Uint8Array(Array.from({ length: 256 }, (_, i) => i))
+    await sandbox.writeFile('binary.bin', bytes)
+    expect(Array.from(await sandbox.readFile('binary.bin'))).toStrictEqual(Array.from(bytes))
+  })
+
+  it('lists files', async () => {
+    const sandbox = makeSandbox()
+    await sandbox.writeText('a.txt', 'a')
+    await sandbox.writeText('b.txt', 'b')
+    const names = (await sandbox.listFiles('.')).map((f) => f.name)
+    expect(names).toContain('a.txt')
+    expect(names).toContain('b.txt')
+  })
+
+  it('removes files', async () => {
+    const sandbox = makeSandbox()
+    await sandbox.writeText('to_remove.txt', 'bye')
+    await sandbox.removeFile('to_remove.txt')
+    await expect(sandbox.readFile('to_remove.txt')).rejects.toThrow()
+  })
+
+  // -------------------------------------------------------------------------
+  // Working directory and cwd override
+  // -------------------------------------------------------------------------
+
+  it('respects workingDir', async () => {
+    const result = await makeSandbox().execute('pwd')
+    expect(result.stdout.trim()).toBe(sshEc2.workingDir)
+  })
+
+  it('respects per-command cwd override', async () => {
+    const result = await makeSandbox().execute('pwd', { cwd: '/tmp' })
+    expect(result.stdout.trim()).toBe('/tmp')
+  })
+
+  // -------------------------------------------------------------------------
+  // Environment variables
+  // -------------------------------------------------------------------------
+
+  it('passes env vars to the command', async () => {
+    const result = await makeSandbox().execute('echo $MY_VAR', { env: { MY_VAR: 'hello-from-env' } })
+    expect(result.stdout.trim()).toBe('hello-from-env')
+  })
+
+  it('env values with shell metacharacters are passed literally', async () => {
+    const value = '$(whoami) $HOME `id`'
+    const result = await makeSandbox().execute('printenv MY_VAR', { env: { MY_VAR: value } })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.trim()).toBe(value)
+  })
+
+  // -------------------------------------------------------------------------
+  // Timeout
+  // -------------------------------------------------------------------------
+
+  it('kills command on timeout', async () => {
+    await expect(makeSandbox().execute('sleep 60', { timeout: 1 })).rejects.toThrow('timed out')
+  })
+
+  // -------------------------------------------------------------------------
+  // Statelessness (each command is a fresh SSH process)
+  // -------------------------------------------------------------------------
+
+  it('is stateless between commands', async () => {
+    const sandbox = makeSandbox()
+    await sandbox.execute('export EPHEMERAL=1234')
+    const result = await sandbox.execute('echo ${EPHEMERAL:-unset}')
+    expect(result.stdout.trim()).toBe('unset')
+  })
+
+  // -------------------------------------------------------------------------
+  // getTools()
+  // -------------------------------------------------------------------------
+
+  it('getTools returns sandbox_bash and sandbox_file_editor', () => {
+    const tools = makeSandbox().getTools()
+    const names = tools.map((t) => t.name)
+    expect(names).toContain('sandbox_bash')
+    expect(names).toContain('sandbox_file_editor')
+  })
+
+  it('getTools descriptions reference the host', () => {
+    const sandbox = makeSandbox()
+    for (const tool of sandbox.getTools()) {
+      expect(tool.description).toContain(sandbox.host)
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // SSH options passthrough
+  // -------------------------------------------------------------------------
+
+  it('applies custom sshOptions without breaking the connection', async () => {
+    const sandbox = makeSandbox({ sshOptions: ['ServerAliveInterval=5'] })
+    const result = await sandbox.execute('echo options_ok')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.trim()).toBe('options_ok')
+  })
+})

--- a/strands-ts/test/integ/session-manager.test.node.ts
+++ b/strands-ts/test/integ/session-manager.test.node.ts
@@ -20,10 +20,9 @@ import { SessionManager } from '$/sdk/session/session-manager.js'
 import { FileStorage } from '$/sdk/session/file-storage.js'
 import { S3Storage } from '$/sdk/session/s3-storage.js'
 import { bedrock, openaiResponses } from './__fixtures__/model-providers.js'
+import { AWS_REGION } from './__fixtures__/_aws.js'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-const AWS_REGION = process.env.AWS_REGION ?? 'us-east-1'
 
 async function getBucketName(credentials: any): Promise<string> {
   const sts = new STSClient({ region: AWS_REGION, credentials })

--- a/strands-ts/test/integ/vitest.d.ts
+++ b/strands-ts/test/integ/vitest.d.ts
@@ -32,5 +32,12 @@ declare module 'vitest' {
       shouldSkip: boolean
       url: string | undefined
     }
+    ['provider-ssh-ec2']: {
+      shouldSkip: boolean
+      host: string | undefined
+      port: number | undefined
+      identityFile: string | undefined
+      workingDir: string | undefined
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds integration tests for `SshSandbox` in both SDKs, exercising the full sandbox surface against the live `ssh-ec2` test infrastructure provisioned by `test-infra/`.

- **Python**: Introduces `tests_integ/_ssm.py` — a reusable SSM parameter resolution helper that any integ suite can share (replaces the bespoke implementation previously inlined in `tests_integ/memory/conftest.py`). The SSH test fixture (`tests_integ/sandbox/conftest.py`) manages the SSM tunnel lifecycle with explicit session termination and `atexit` safety, yielding a ready-to-use `SshSandbox` so tests carry zero skip logic.
- **TypeScript**: Adds `_ssh-ec2.ts` fixture with the same lifecycle guarantees (session-ID capture, `terminate-session` on cleanup, `process.on('exit')` safety net). Wired into global setup; the test file mirrors Py's coverage.

Both suites self-skip when the `aws` CLI, `session-manager-plugin`, or SSM parameters aren't available — zero friction for local devs. `ubuntu-latest` runners ship the plugin pre-installed, so no CI workflow changes needed.

20 tests per SDK covering: stdout/stderr/exit-code, streaming, code execution, text+binary file round-trips, list/remove, working-dir, cwd override, env vars (including shell metacharacters), timeout, statelessness, `get_tools()`, SSH options passthrough.

## Test plan

- [x] Python: 20 tests pass under xdist against live ssh-ec2 instance
- [x] TypeScript: 20 tests pass in vitest integ-node against live ssh-ec2 instance
- [x] Both self-skip cleanly when plugin/params unavailable (verified with stripped PATH + bogus creds)
- [x] Refactored memory/conftest.py still passes (bedrock-kb tests unaffected)
- [x] Python lint (ruff + mypy) clean
- [x] TypeScript type-check + eslint + prettier clean