### PR TITLE
fix(test): retry flaky guardrail output-intervention test

### DIFF
--- a/strands-py/tests_integ/test_bedrock_guardrails.py
+++ b/strands-py/tests_integ/test_bedrock_guardrails.py
@@ -130,6 +130,7 @@ def test_guardrail_input_intervention(boto_session, bedrock_guardrail, guardrail
     assert agent.messages[0]["content"][0]["text"] == "Redacted."
 
 
+@retry_on_flaky("LLM may mention CACTUS unprompted, triggering guardrail on response2", retry_on=[AssertionError])
 @pytest.mark.parametrize("processing_mode", ["sync", "async"])
 def test_guardrail_output_intervention(boto_session, bedrock_guardrail, processing_mode):
     bedrock_model = BedrockModel(


### PR DESCRIPTION
## Description

`tests_integ/test_bedrock_guardrails.py::test_guardrail_output_intervention[sync]` flakes intermittently in CI:

```
assert response2.stop_reason != "guardrail_intervened"
AssertionError: assert 'guardrail_intervened' != 'guardrail_intervened'
```

The agent's system prompt is *"When asked to say the word, say CACTUS."* The test sends a benign second prompt (`agent("Hello!")`) and asserts the output guardrail does **not** fire. But the model occasionally volunteers "CACTUS" unprompted in that second reply, which trips the output guardrail and fails the assertion.

This is the same non-determinism the sibling test `test_guardrail_output_intervention_redact_output` already guards against — it carries `@retry_on_flaky("LLM may mention CACTUS unprompted, triggering guardrail on response2")`. `test_guardrail_output_intervention` simply wasn't decorated.

### Fix

Apply the same `retry_on_flaky` helper (already used across this file and `test_cedar_authorization.py`), scoped to `AssertionError` so genuine failures still propagate immediately rather than being masked.

## Related Issues

Surfaced by a flaky CI run on the integration suite.

## Type of Change

Other: test robustness fix

## Testing

`ruff check` and `ruff format --check` pass. This is a one-line decorator addition reusing an existing, established helper; CI exercises the test against the live Bedrock guardrail.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR
- [x] My change is focused and reasonably small
- [x] My changes generate no new warnings