### PR TITLE
fix(test): raise timeout on multimodal swarm/graph integ tests to reduce flakiness

### DIFF
--- a/strands-py/tests_integ/test_multiagent_graph.py
+++ b/strands-py/tests_integ/test_multiagent_graph.py
@@ -175,6 +175,7 @@ async def test_graph_execution_with_string(math_agent, summary_agent, validation
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(180)
 async def test_graph_execution_with_image(image_analysis_agent, summary_agent, yellow_img, hook_provider):
     """Test graph execution with multi-modal image input."""
     builder = GraphBuilder()

--- a/strands-py/tests_integ/test_multiagent_swarm.py
+++ b/strands-py/tests_integ/test_multiagent_swarm.py
@@ -149,6 +149,7 @@ def test_swarm_execution_with_string(researcher_agent, analyst_agent, writer_age
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(180)
 async def test_swarm_execution_with_image(researcher_agent, analyst_agent, writer_agent, yellow_img):
     """Test swarm execution with image input."""
     # Create the swarm


### PR DESCRIPTION
## Problem

`tests_integ/test_multiagent_swarm.py::test_swarm_execution_with_image` intermittently fails CI with:

```
FAILED tests_integ/test_multiagent_swarm.py::test_swarm_execution_with_image - Failed: Timeout (>90.0s) from pytest-timeout.
```

(followed by the usual `ConnectionReset` / `Event loop is closed` teardown noise from the hard SIGALRM kill).

`test_multiagent_graph.py::test_graph_execution_with_image` shares the same workload profile and is exposed to the same flake.

## Root cause

Both tests run a multi-agent **multimodal vision** workload (image analysis plus handoffs/tool calls against live Bedrock) but have no per-test timeout override, so they fall back to the global `timeout = 90` in `pyproject.toml`. That is strictly heavier than the string-only sibling `test_swarm_execution_with_string`, which already overrides to `@pytest.mark.timeout(120)`. The image variants routinely run close to the 90s line and flake.

The swarm/graph budgets (`execution_timeout=900s`, `node_timeout=300s`) are far larger, so pytest-timeout fires first and kills the run mid-request rather than the run completing or timing out cleanly.

## Fix

Add `@pytest.mark.timeout(180)` to both multimodal image tests, giving the heavier vision path adequate headroom while staying well under the swarm/graph timeouts. No production code changes.