### PR TITLE
ci: gate dependency vulns on PR-introduced changes only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,25 @@ jobs:
               - '.github/workflows/docs-*'
               - '.github/workflows/ci.yml'
 
+  dependency-review:
+    name: Dependency Review
+    # Repo-level security gate covering every ecosystem in the monorepo
+    # (npm + Python) via GitHub's dependency graph. Diffs the PR against its
+    # base and fails only on vulnerabilities the PR introduces (adds or bumps
+    # to a vulnerable version); pre-existing advisories do not block.
+    # PR-only: it needs a base ref to diff, so it is skipped on dispatch.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
   python:
     name: Python
     needs: detect-changes
@@ -78,11 +97,11 @@ jobs:
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [detect-changes, python, typescript, docs]
+    needs: [detect-changes, dependency-review, python, typescript, docs]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
       - uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: python, typescript, docs
+          allowed-skips: dependency-review, python, typescript, docs
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/typescript-security-audit.yml
+++ b/.github/workflows/typescript-security-audit.yml
@@ -29,5 +29,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run security audit
+      # Informational: full-tree audit for visibility into pre-existing
+      # advisories. Does not block merge so unrelated PRs are not held hostage
+      # by transitive vulns; drive these down via Dependabot. PR-introduced
+      # vulns are gated by the repo-level Dependency Review job in ci.yml.
+      - name: Run security audit (informational)
+        continue-on-error: true
         run: npm audit --audit-level=high


### PR DESCRIPTION
## Problem

The merge gate fails on PRs that touch nothing dependency-related.

The TypeScript lane runs `npm audit --audit-level=high`, which audits the **entire lockfile** on every run. It cannot distinguish a vuln a PR introduced from advisories already in the tree (currently 13: 1 low, 11 moderate, 1 high — `hono`, `protobufjs`, etc.). So any PR fails the audit, the `typescript` reusable workflow concludes `failure`, and `CI Gate` blocks the merge — even when the change is unrelated.

Because the gate is enforced by a ruleset with no human bypass actor, a maintainer can't simply override a red check stemming from a pre-existing, unrelated advisory.

Separately, Python had **no** dependency/security scanning at all.

## Change

Add a single **repo-level** `Dependency Review` job to `ci.yml` using [`actions/dependency-review-action@v4`](https://github.com/actions/dependency-review-action):

- It diffs each PR against its base ref and fails (`fail-on-severity: high`) **only on vulnerabilities the PR introduces** — adds, or bumps to a vulnerable version. Pre-existing advisories are ignored; an introduced one fails loudly with an annotation on the offending package.
- It reads GitHub's dependency graph, so it covers **every ecosystem in the monorepo (npm + Python)** in one job — closing the gap where Python had no scanning.
- Wired into `CI Gate`. It's PR-only (needs a base ref to diff), so it's listed in `allowed-skips`: skipped on `workflow_dispatch` counts as passing, a real vuln fails the gate.

The full-tree `npm audit` in `typescript-security-audit.yml` is demoted to a non-blocking informational step (`continue-on-error: true`), keeping whole-tree visibility without holding unrelated PRs hostage.

## Why repo-level rather than per-lane

dependency-review is ecosystem-agnostic, so one job at the top of `ci.yml` gates npm and Python together — cleaner than duplicating it into each language workflow, and it gives Python coverage it didn't have. Trade-off: it runs on every PR regardless of which paths changed, rather than following the monorepo's per-lane path filtering. That's acceptable for a fast dependency-graph diff and avoids a required check that never reports.

## Why not just soften `npm audit`

`npm audit ... || true` would stop blocking but lose the signal — a PR that genuinely introduces a high-severity vuln would pass silently. dependency-review keeps that failure precise: **related → fails, unrelated → doesn't.**

## Prerequisite (confirmed)

`dependency-review-action` fails closed if the repo's dependency graph is unavailable. Verified enabled on `strands-agents/harness-sdk` (SBOM endpoint returns SPDX-2.3; Dependabot security updates are active, which requires the graph), so the gate will not fail closed.

## Follow-ups (not this PR)

- Drive the 13 existing advisories down via Dependabot.