### PR TITLE
ci(python): add timeouts and apt retries to test-lint workflow

### DIFF
--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -87,8 +87,10 @@ jobs:
               && sudo apt-get -o Acquire::Retries=3 install -y portaudio19-dev libasound2-dev; then
               exit 0
             fi
-            echo "apt-get attempt $attempt failed; retrying in 15s..."
-            sleep 15
+            if [ "$attempt" -lt 3 ]; then
+              echo "apt-get attempt $attempt failed; retrying in 15s..."
+              sleep 15
+            fi
           done
           echo "apt-get failed after 3 attempts" >&2
           exit 1
@@ -97,7 +99,17 @@ jobs:
         working-directory: .
         timeout-minutes: 5
         run: |
-          brew install portaudio
+          for attempt in 1 2 3; do
+            if brew install portaudio; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "brew install attempt $attempt failed; retrying in 15s..."
+              sleep 15
+            fi
+          done
+          echo "brew install failed after 3 attempts" >&2
+          exit 1
       - name: Install system audio dependencies (Windows)
         if: matrix.os-name == 'windows'
         working-directory: .
@@ -151,8 +163,10 @@ jobs:
               && sudo apt-get -o Acquire::Retries=3 install -y portaudio19-dev libasound2-dev; then
               exit 0
             fi
-            echo "apt-get attempt $attempt failed; retrying in 15s..."
-            sleep 15
+            if [ "$attempt" -lt 3 ]; then
+              echo "apt-get attempt $attempt failed; retrying in 15s..."
+              sleep 15
+            fi
           done
           echo "apt-get failed after 3 attempts" >&2
           exit 1

--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -56,6 +56,10 @@ jobs:
           python-version: "3.14"
       fail-fast: true
     runs-on: ${{ matrix.os }}
+    # Successful unit-test legs run in ~3-4 min (slowest observed ~16 min);
+    # 25 min caps a hung step (e.g. apt) instead of letting it run to the
+    # 6-hour default.
+    timeout-minutes: 25
     env:
       LOG_LEVEL: DEBUG
     defaults:
@@ -74,12 +78,24 @@ jobs:
       - name: Install system audio dependencies (Linux)
         if: matrix.os-name == 'linux'
         working-directory: .
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update
-          sudo apt-get install -y portaudio19-dev libasound2-dev
+          for attempt in 1 2 3; do
+            if sudo apt-get -o Acquire::Retries=3 update \
+              && sudo apt-get -o Acquire::Retries=3 install -y portaudio19-dev libasound2-dev; then
+              exit 0
+            fi
+            echo "apt-get attempt $attempt failed; retrying in 15s..."
+            sleep 15
+          done
+          echo "apt-get failed after 3 attempts" >&2
+          exit 1
       - name: Install system audio dependencies (macOS)
         if: matrix.os-name == 'macOS'
         working-directory: .
+        timeout-minutes: 5
         run: |
           brew install portaudio
       - name: Install system audio dependencies (Windows)
@@ -103,6 +119,9 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    # Lint typically runs in ~2 min; 20 min caps a hung step instead of
+    # letting it run to the 6-hour default.
+    timeout-minutes: 20
     permissions:
       contents: read
     defaults:
@@ -123,9 +142,20 @@ jobs:
 
       - name: Install system audio dependencies (Linux)
         working-directory: .
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update
-          sudo apt-get install -y portaudio19-dev libasound2-dev
+          for attempt in 1 2 3; do
+            if sudo apt-get -o Acquire::Retries=3 update \
+              && sudo apt-get -o Acquire::Retries=3 install -y portaudio19-dev libasound2-dev; then
+              exit 0
+            fi
+            echo "apt-get attempt $attempt failed; retrying in 15s..."
+            sleep 15
+          done
+          echo "apt-get failed after 3 attempts" >&2
+          exit 1
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

The Python test/lint jobs in `python-test-lint.yml` have no job-level timeout. When a setup step stalls, the job runs until GitHub's 6-hour default before it's killed. This has happened more than once on the Linux **"Install system audio dependencies"** step, where `sudo apt-get update`/`install` hangs (frozen on apt with no timeout or retry) — a single matrix leg sat for 4+ hours while every other leg finished in minutes.

## Changes

- **Job-level `timeout-minutes`** — 25 for the unit-test matrix, 20 for lint. Sized from observed run data: legs normally finish in ~2-4 min, slowest observed ~16 min, so these leave generous headroom (>50% over the max) while capping a hung job at minutes instead of ~6 hours.
- **Resilient apt step** — wrap the `apt-get` commands in a 3-attempt retry loop with a 5-minute step timeout, set `DEBIAN_FRONTEND=noninteractive`, and pass `-o Acquire::Retries=3`. Transient mirror/network blips now recover automatically; a genuinely broken repo still fails loudly after 3 attempts.
- **macOS** — add a 5-minute step timeout to the `brew install portaudio` step (same hang class).

## Behavior

On the happy path the outcome is unchanged: both packages install and the step succeeds. The retry/timeout only changes what happens on a stall or transient failure — fast, bounded failure (and self-healing) instead of an open-ended hang.

## Validation

- YAML parses; the retry loop was checked under `bash -eo pipefail` (the runner's default shell): failed attempts fall through and retry, success exits 0, and it exits 1 after 3 failures. The `if cmd1 && cmd2` guard is exempt from `set -e`, so the loop is not aborted early.