### PR TITLE
ci(docs): bump pino from 9 to 10

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -45,7 +45,7 @@
         "acorn": "^8.14.0",
         "astro": "^6.4.8",
         "js-yaml": "^4.2.0",
-        "pino": "^9.7.0",
+        "pino": "^10.3.1",
         "pino-pretty": "^13.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
@@ -8481,32 +8481,32 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
-      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
+        "pino-abstract-transport": "^3.0.0",
         "pino-std-serializers": "^7.0.0",
         "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
         "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
+        "thread-stream": "^4.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9894,13 +9894,16 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tiny-inflate": {
@@ -11291,6 +11294,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -60,7 +60,7 @@
     "acorn": "^8.14.0",
     "astro": "^6.4.8",
     "js-yaml": "^4.2.0",
-    "pino": "^9.7.0",
+    "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",


### PR DESCRIPTION
## Summary

Bumps `pino` from `^9.7.0` to `^10.3.1` in `site` devDependencies (`pino-pretty` stays on `^13`). This is what Dependabot #2690 proposed; opening it here so the change is scoped and the lockfile stays clean.

## Where pino is used

`pino` and `pino-pretty` are **only used in a documentation example** — `site/src/content/docs/user-guide/observability-evaluation/logs.ts` (embedded into `logs.mdx` via the snippet mechanism), which shows how to plug a Pino logger into the SDK's `configureLogging`. They are **not** used in any shipped/runtime code; both are `devDependencies`.

## Why bump instead of removing

The first instinct was to just remove pino since it's not used at runtime. We didn't, because:

1. **The doc example is type-checked.** `site/test-snippets/tsconfig.json` includes `../src/content/docs/**/*.ts`, and the `Typecheck snippets` step in `docs-ci.yml` runs it. `logs.ts` does `import pino from 'pino'`, so removing the dependency would either break that type-check or force excluding the file from coverage.
2. **Keeping it preserves QA on the sample.** With pino installed, the example stays under type-check coverage, so if a future SDK or pino change breaks the documented snippet, CI catches it. Excluding the file (or deleting the example) would silently drop that protection.
3. **It's a devDependency — no runtime/shipping cost.** Since there's no production footprint, keeping it current via the normal bump is the low-risk, high-signal option.

## Validation

- `pino` resolves to 10.3.1, `pino-pretty` to 13.1.3. Ran `npm run typecheck:snippets`: **no pino-related errors** and the `logs.ts` sample type-checks against pino 10 (its `import pino` + `transport: { target: 'pino-pretty' }` usage is unchanged; pino 10's only breaking change is dropping Node 18, which CI doesn't use). The remaining snippet errors are pre-existing `@strands-agents/sdk` resolution noise (the SDK is built first in CI) and are identical to the main baseline.
- Lockfile diff is scoped to the pino subtree (pino, pino-abstract-transport 2→3, thread-stream 3→4 + its nested real-require); unrelated pre-existing lockfile drift was left untouched.

## Closes #2690

Supersedes Dependabot's pino bump (its branch was deleted on close, so it can't be reopened).