### PR TITLE
feat(offloader): add search/grep support to Python retrieval tool

### DIFF
--- a/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -245,17 +245,22 @@ agent = Agent(plugins=[
 
 The plugin includes a `retrieve_offloaded_content` tool that lets the agent fetch offloaded content by reference, returning it in its native format — text as a string, JSON as a JSON block, images as image blocks, and documents as document blocks. This tool is registered by default.
 
+The retrieval tool supports targeted retrieval through optional parameters, so the agent can search and filter offloaded content without loading it entirely back into context.
+
+**Parameters:**
+
 <Tabs>
 <Tab label="Python">
 
-The inline guidance in offloaded results tells the agent to use its available tools to selectively access the data it needs, and mentions `retrieve_offloaded_content` as a fallback.
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reference` | `str` | *(required)* Storage reference from the offloaded result |
+| `pattern` | `str` | Regex or keyword to grep for |
+| `line_range` | `dict` with `start` and `end` keys | 1-indexed inclusive line span to retrieve |
+| `context_lines` | `int` | Lines of context around pattern matches (default: 5) |
 
 </Tab>
 <Tab label="TypeScript">
-
-In the TypeScript SDK, the retrieval tool supports targeted retrieval through optional parameters, so the agent can search and filter offloaded content without loading it entirely back into context.
-
-**Parameters:**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -263,6 +268,9 @@ In the TypeScript SDK, the retrieval tool supports targeted retrieval through op
 | `pattern` | `string` | Regex or keyword to grep for |
 | `line_range` | `{ start: number; end: number }` | 1-indexed inclusive line span to retrieve |
 | `context_lines` | `number` | Lines of context around pattern matches (default: 5) |
+
+</Tab>
+</Tabs>
 
 **Retrieval modes:**
 
@@ -274,51 +282,18 @@ In the TypeScript SDK, the retrieval tool supports targeted retrieval through op
 
 Results include line numbers to enable follow-up queries. Large result sets are truncated with guidance to narrow the search. Binary content cannot be searched — pattern and line range parameters return an error for binary references.
 
-</Tab>
-</Tabs>
-
 ### Retrieval examples
 
-<Tabs>
-<Tab label="Python">
-
 **1. Tool result gets offloaded (replaces original result inline)**
 
 ```
 [Offloaded: 1 blocks, ~10,000 tokens]
 Tool result was offloaded to external storage due to size.
-Use the preview below to answer if possible.
-Use retrieve_offloaded_content to fetch the full content by reference.
-
-{"users":[{"id":1,"name":"Alice","role":"admin"},{"id":2,"name":"Bob","role":"user"},{"id":3,"name":"Charlie","rol
-
-[Stored references:]
-  mem_1_tool-123_0 (json, 42,000 bytes)
-```
-
-**2. Agent retrieves full content**
-
-Input: `{ reference: "mem_1_tool-123_0" }`
-
-The tool returns the full offloaded content in its native format.
-
-```
-{"users":[{"id":1,"name":"Alice","role":"admin"},{"id":2,"name":"Bob","role":"user"},{"id":3,"name":"Charlie","role":"user"}, ...]}
-```
-
-</Tab>
-<Tab label="TypeScript">
-
-**1. Tool result gets offloaded (replaces original result inline)**
-
-```
-[Offloaded: 1 blocks, ~10,000 tokens]
-Tool result was offloaded to external storage due to size.
-Use the preview below to answer if possible.
-Use retrieve_offloaded_content with a reference and either:
+Use the preview below if it answers your question.
+If you need more detail, use retrieve_offloaded_content with a reference and:
   - pattern: regex or keyword to find matching lines with context
   - line_range: { start, end } to read a specific span of lines
-Only retrieve the full content (omit pattern/line_range) as a last resort.
+Retrieve full content (omit pattern/line_range) as a last resort.
 
 {"users":[{"id":1,"name":"Alice","role":"admin"},{"id":2,"name":"Bob","role":"user"},{"id":3,"name":"Charlie","rol
 
@@ -345,8 +320,25 @@ Input: `{ reference: "mem_1_tool-123_0", pattern: "admin", context_lines: 2 }`
   51|   ]
 ```
 
-</Tab>
-</Tabs>
+**3. Agent retrieves a line range**
+
+Input: `{ reference: "mem_1_tool-123_0", line_range: { start: 45, end: 55 } }`
+
+```
+[Lines 45-55 of 120]
+
+  45|     { "id": 14, "name": "Carol", "role": "user" },
+  46|     { "id": 15, "name": "Dana", "role": "user" },
+  47|     { "id": 16, "name": "Eve", "role": "admin" },
+  48|     { "id": 17, "name": "Frank", "role": "user" },
+  49|     { "id": 18, "name": "Grace", "role": "user" },
+  50|     { "id": 19, "name": "Hank", "role": "member" },
+  51|     { "id": 20, "name": "Ivy", "role": "user" },
+  52|     { "id": 21, "name": "Jack", "role": "user" },
+  53|     { "id": 22, "name": "Kate", "role": "user" },
+  54|     { "id": 23, "name": "Leo", "role": "user" },
+  55|     { "id": 24, "name": "Mia", "role": "user" },
+```
 
 ### Using other tools for retrieval
 

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -35,19 +35,28 @@ from __future__ import annotations
 import json
 import logging
 import weakref
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 from ...hooks.events import AfterToolCallEvent, BeforeModelCallEvent
 from ...plugins import Plugin, hook
 from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
+from .search import is_searchable_content, search_content
 from .storage import FileStorage, InMemoryStorage, Storage
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
 
 logger = logging.getLogger(__name__)
+
+
+class LineRange(TypedDict):
+    """A span of lines to retrieve (1-indexed, inclusive)."""
+
+    start: int
+    end: int
+
 
 _DEFAULT_MAX_RESULT_TOKENS = 2_500
 """Default token threshold above which tool results are offloaded."""
@@ -185,15 +194,37 @@ class ContextOffloader(Plugin):
         self,
         reference: str,
         tool_context: ToolContext,
+        pattern: str | None = None,
+        line_range: LineRange | None = None,
+        context_lines: int | None = None,
     ) -> dict | str:
         """Retrieve offloaded content by reference.
 
-        Use this tool when you see a placeholder with a reference (ref: ...)
-        and need the full content. Only use this as a fallback if the data
-        cannot be accessed using your existing tools.
+        When a tool result was too large to keep in context, it was stored externally and replaced with a preview
+        and a reference. Use this tool with that reference to access the stored content.
+
+        Returns:
+          - With pattern: matching lines with line numbers and surrounding context
+          - With line_range: the specified span of lines with line numbers
+          - Without pattern/line_range: the full original content (use sparingly — re-injects all tokens)
+
+        Constraints:
+          - pattern/line_range/context_lines only work on text content. For binary content, omit them.
+          - Line numbers in results are 1-indexed and can be used in follow-up line_range calls.
+
+        Examples:
+          { reference: "ref_1", pattern: "error" } -> lines containing "error" with 5 lines context
+          { reference: "ref_1", pattern: "error|warning", context_lines: 3 } -> regex, 3 lines context
+          { reference: "ref_1", line_range: { start: 10, end: 25 } } -> lines 10-25
+          { reference: "ref_1", pattern: "TODO", line_range: { start: 1, end: 50 } } -> search within range
 
         Args:
-            reference: The reference string from the offload placeholder.
+            reference: The reference string from the offload placeholder (e.g. "mem_1_tool-123_0").
+            pattern: Regex or keyword to grep for. Returns only matching lines with context — not the full content.
+            line_range: Return only this span of lines. A dict with 'start' and 'end' keys (1-indexed).
+                Combine with pattern to search within the range.
+            context_lines: Lines before AND after each match (like grep -C). Default: 5.
+                Without pattern/line_range, returns first N lines.
             tool_context: Injected by the framework. Not user-facing.
         """
         storage = self._storage_for_agent(tool_context.agent)
@@ -202,6 +233,30 @@ class ContextOffloader(Plugin):
         except KeyError:
             return f"Error: reference not found: {reference}"
 
+        if pattern is None and line_range is None and context_lines is None:
+            return self._decode_full_content(content_bytes, content_type, reference)
+
+        if not is_searchable_content(content_type):
+            return (
+                f"Error: cannot search binary content ({content_type}). "
+                "Omit pattern/line_range/context_lines to retrieve the full content."
+            )
+
+        text = content_bytes.decode("utf-8")
+        ctx_lines = context_lines if context_lines is not None else 5
+        max_chars = self._max_result_tokens * _CHARS_PER_TOKEN
+
+        lr: tuple[int, int] | None = None
+        if line_range is not None:
+            lr = (int(line_range["start"]), int(line_range["end"]))
+        elif pattern is None:
+            lr = (1, max(1, ctx_lines))
+
+        return search_content(text, pattern=pattern, line_range=lr, context_lines=ctx_lines, max_chars=max_chars)
+
+    @staticmethod
+    def _decode_full_content(content_bytes: bytes, content_type: str, reference: str) -> dict | str:
+        """Decode stored content into its native format for full retrieval."""
         if content_type.startswith("text/"):
             return content_bytes.decode("utf-8")
 
@@ -306,11 +361,17 @@ class ContextOffloader(Plugin):
 
         guidance = (
             "Tool result was offloaded to external storage due to size.\n"
-            "Use the preview below to answer if possible.\n"
-            "Use your available tools to selectively access the data you need."
+            "Use the preview below if it answers your question.\n"
         )
         if self._include_retrieval_tool:
-            guidance += "\nYou can also use retrieve_offloaded_content with a reference to get the full content."
+            guidance += (
+                "If you need more detail, use retrieve_offloaded_content with a reference and:\n"
+                "  - pattern: regex or keyword to find matching lines with context\n"
+                "  - line_range: { start, end } to read a specific span of lines\n"
+                "Retrieve full content (omit pattern/line_range) as a last resort."
+            )
+        else:
+            guidance += "If you need more detail, use your available tools to access specific data."
 
         preview_text = (
             f"[Offloaded: {len(content)} blocks, ~{token_count:,} tokens]\n"

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -44,7 +44,7 @@ from ...plugins import Plugin, hook
 from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
-from .search import is_searchable_content, search_content
+from .search import _is_searchable_content, _search_content
 from .storage import FileStorage, InMemoryStorage, Storage
 
 if TYPE_CHECKING:
@@ -238,7 +238,7 @@ class ContextOffloader(Plugin):
         if pattern is None and line_range is None and context_lines is None:
             return self._decode_full_content(content_bytes, content_type, reference)
 
-        if not is_searchable_content(content_type):
+        if not _is_searchable_content(content_type):
             return (
                 f"Error: cannot search binary content ({content_type}). "
                 "Omit pattern/line_range/context_lines to retrieve the full content."
@@ -254,7 +254,7 @@ class ContextOffloader(Plugin):
         elif pattern is None:
             lr = (1, max(1, ctx_lines))
 
-        return search_content(text, pattern=pattern, line_range=lr, context_lines=ctx_lines, max_chars=max_chars)
+        return _search_content(text, pattern=pattern, line_range=lr, context_lines=ctx_lines, max_chars=max_chars)
 
     @staticmethod
     def _decode_full_content(content_bytes: bytes, content_type: str, reference: str) -> dict | str:

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -35,7 +35,9 @@ from __future__ import annotations
 import json
 import logging
 import weakref
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
+
+from typing_extensions import TypedDict
 
 from ...hooks.events import AfterToolCallEvent, BeforeModelCallEvent
 from ...plugins import Plugin, hook
@@ -213,10 +215,10 @@ class ContextOffloader(Plugin):
           - Line numbers in results are 1-indexed and can be used in follow-up line_range calls.
 
         Examples:
-          { reference: "ref_1", pattern: "error" } -> lines containing "error" with 5 lines context
-          { reference: "ref_1", pattern: "error|warning", context_lines: 3 } -> regex, 3 lines context
-          { reference: "ref_1", line_range: { start: 10, end: 25 } } -> lines 10-25
-          { reference: "ref_1", pattern: "TODO", line_range: { start: 1, end: 50 } } -> search within range
+          {"reference": "ref_1", "pattern": "error"} -> lines containing "error" with 5 lines context
+          {"reference": "ref_1", "pattern": "error|warning", "context_lines": 3} -> regex, 3 lines context
+          {"reference": "ref_1", "line_range": {"start": 10, "end": 25}} -> lines 10-25
+          {"reference": "ref_1", "pattern": "TODO", "line_range": {"start": 1, "end": 50}} -> search within range
 
         Args:
             reference: The reference string from the offload placeholder (e.g. "mem_1_tool-123_0").

--- a/strands-py/src/strands/vended_plugins/context_offloader/search.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/search.py
@@ -1,0 +1,151 @@
+"""Search and formatting utilities for offloaded content.
+
+Provides grep-like pattern matching and line-range random access over stored
+text content, with output capped to a character budget.
+"""
+
+from __future__ import annotations
+
+import re
+
+_MAX_PATTERN_LENGTH = 200
+
+_TEXT_APPLICATION_TYPES = frozenset(
+    {
+        "application/json",
+        "application/xml",
+        "application/javascript",
+        "application/typescript",
+        "application/yaml",
+        "application/x-yaml",
+        "application/toml",
+        "application/sql",
+        "application/graphql",
+        "application/xhtml+xml",
+    }
+)
+
+
+def is_searchable_content(content_type: str) -> bool:
+    """Return whether the given MIME content type can be searched as text."""
+    return content_type.startswith("text/") or content_type in _TEXT_APPLICATION_TYPES
+
+
+def search_content(
+    text: str,
+    *,
+    pattern: str | None = None,
+    line_range: tuple[int, int] | None = None,
+    context_lines: int = 5,
+    max_chars: int = 10_000,
+) -> str:
+    """Search offloaded text content by pattern or line range.
+
+    Args:
+        text: The full text content to search.
+        pattern: Regex or keyword to grep for.
+        line_range: Tuple of (start, end) 1-indexed inclusive line numbers.
+        context_lines: Lines before and after each match.
+        max_chars: Maximum output size in characters; results are truncated beyond this.
+
+    Returns:
+        Formatted search results with line numbers, or an error/empty message.
+    """
+    lines = text.split("\n")
+    total_lines = len(lines)
+
+    if total_lines == 0 or (total_lines == 1 and lines[0] == ""):
+        return "Content is empty (0 lines)."
+
+    scope_start = 0
+    scope_end = total_lines - 1
+
+    if line_range is not None:
+        start, end = line_range
+        if start > end:
+            return f"Error: line_range.start ({start}) must be <= line_range.end ({end})."
+        if start > total_lines:
+            return f"Error: line_range.start ({start}) is beyond content length ({total_lines} lines)."
+        scope_start = start - 1
+        scope_end = min(end - 1, total_lines - 1)
+
+    if pattern:
+        scope_label = f" in lines {line_range[0]}-{scope_end + 1}" if line_range else ""
+        return _search_by_pattern(lines, pattern, scope_start, scope_end, context_lines, max_chars, scope_label)
+
+    return _search_by_line_range(lines, scope_start, scope_end, total_lines, max_chars)
+
+
+def _truncate(output: str, max_chars: int, message: str) -> str:
+    """Cut output at the last newline before max_chars and append a truncation message."""
+    if len(output) <= max_chars:
+        return output
+
+    cut = output.rfind("\n", 0, max_chars)
+    slice_end = cut if cut > 0 else max_chars
+
+    return output[:slice_end] + f"\n\n[{message}]"
+
+
+def _format_lines(lines: list[str], indices: list[int], matched_set: set[int]) -> str:
+    """Format line indices with line numbers, > prefixes for matches, and --- separators."""
+    if not indices:
+        return ""
+    pad_width = len(str(indices[-1] + 1))
+    output: list[str] = []
+    for i, idx in enumerate(indices):
+        if i > 0 and idx > indices[i - 1] + 1:
+            output.append("---")
+        line_num = str(idx + 1).rjust(pad_width)
+        prefix = ">" if idx in matched_set else " "
+        output.append(f"{prefix} {line_num}| {lines[idx]}")
+    return "\n".join(output)
+
+
+def _search_by_pattern(
+    lines: list[str],
+    pattern: str,
+    scope_start: int,
+    scope_end: int,
+    context_lines: int,
+    max_chars: int,
+    scope_label: str,
+) -> str:
+    """Find lines matching a pattern, expand with context, and format with truncation."""
+    if len(pattern) > _MAX_PATTERN_LENGTH:
+        safe_input = re.escape(pattern[:_MAX_PATTERN_LENGTH])
+    else:
+        safe_input = pattern
+
+    try:
+        regex = re.compile(safe_input)
+    except re.error:
+        regex = re.compile(re.escape(safe_input))
+
+    matched_set: set[int] = set()
+    for i in range(scope_start, scope_end + 1):
+        if regex.search(lines[i]):
+            matched_set.add(i)
+
+    if not matched_set:
+        return f"No matches found for pattern '{pattern}'{scope_label} (searched {scope_end - scope_start + 1} lines)."
+
+    visible: set[int] = set()
+    for idx in matched_set:
+        for i in range(max(scope_start, idx - context_lines), min(scope_end, idx + context_lines) + 1):
+            visible.add(i)
+
+    safe_pattern = re.sub(r"[\n\r/\]]", " ", pattern)[:50]
+    header = f"[{len(matched_set)} match{'es' if len(matched_set) > 1 else ''} for /{safe_pattern}/{scope_label}]"
+    body = _format_lines(lines, sorted(visible), matched_set)
+    return _truncate(f"{header}\n\n{body}", max_chars, "output truncated, narrow your search")
+
+
+def _search_by_line_range(
+    lines: list[str], start: int, end: int, total_lines: int, max_chars: int
+) -> str:
+    """Format a contiguous range of lines with truncation."""
+    indices = list(range(start, end + 1))
+    header = f"[Lines {start + 1}-{end + 1} of {total_lines}]"
+    body = _format_lines(lines, indices, set())
+    return _truncate(f"{header}\n\n{body}", max_chars, "output truncated, narrow your range")

--- a/strands-py/src/strands/vended_plugins/context_offloader/search.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/search.py
@@ -26,12 +26,12 @@ _TEXT_APPLICATION_TYPES = frozenset(
 )
 
 
-def is_searchable_content(content_type: str) -> bool:
+def _is_searchable_content(content_type: str) -> bool:
     """Return whether the given MIME content type can be searched as text."""
     return content_type.startswith("text/") or content_type in _TEXT_APPLICATION_TYPES
 
 
-def search_content(
+def _search_content(
     text: str,
     *,
     pattern: str | None = None,

--- a/strands-py/src/strands/vended_plugins/context_offloader/search.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/search.py
@@ -62,12 +62,16 @@ def search_content(
 
     if line_range is not None:
         start, end = line_range
+        if start < 1:
+            return f"Error: line_range.start ({start}) must be >= 1."
         if start > end:
             return f"Error: line_range.start ({start}) must be <= line_range.end ({end})."
         if start > total_lines:
             return f"Error: line_range.start ({start}) is beyond content length ({total_lines} lines)."
         scope_start = start - 1
         scope_end = min(end - 1, total_lines - 1)
+
+    context_lines = max(0, context_lines)
 
     if pattern:
         scope_label = f" in lines {line_range[0]}-{scope_end + 1}" if line_range else ""
@@ -112,10 +116,7 @@ def _search_by_pattern(
     scope_label: str,
 ) -> str:
     """Find lines matching a pattern, expand with context, and format with truncation."""
-    if len(pattern) > _MAX_PATTERN_LENGTH:
-        safe_input = re.escape(pattern[:_MAX_PATTERN_LENGTH])
-    else:
-        safe_input = pattern
+    safe_input = pattern[:_MAX_PATTERN_LENGTH] if len(pattern) > _MAX_PATTERN_LENGTH else pattern
 
     try:
         regex = re.compile(safe_input)

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -529,6 +529,221 @@ class TestRetrievalTool:
         assert result["content"][0]["document"]["source"]["bytes"] == doc_bytes
 
 
+class TestRetrievalToolSearch:
+    """Tests for the search/grep functionality of the retrieval tool."""
+
+    @pytest.fixture
+    def storage(self):
+        return InMemoryStorage()
+
+    @pytest.fixture
+    def plugin(self, storage):
+        return ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10, include_retrieval_tool=True)
+
+    @pytest.fixture
+    def mock_agent(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def tool_context(self, mock_agent):
+        tool_use = ToolUse(toolUseId="retrieve_1", name="retrieve_offloaded_content", input={})
+        return ToolContext(tool_use=tool_use, agent=mock_agent, invocation_state={})
+
+    @pytest.mark.asyncio
+    async def test_finds_matching_lines_with_context(self, plugin, storage, tool_context):
+        content = "\n".join(f"line {i + 1}" for i in range(20))
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, pattern="line 10", context_lines=2, tool_context=tool_context
+        )
+
+        assert "1 match for /line 10/" in result
+        assert "> 10| line 10" in result
+        assert "   8| line 8" in result
+        assert "  12| line 12" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_line_range_without_pattern(self, plugin, storage, tool_context):
+        content = "\n".join(f"line {i + 1}" for i in range(50))
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, line_range={"start": 5, "end": 10}, tool_context=tool_context
+        )
+
+        assert "[Lines 5-10 of 50]" in result
+        assert "  5| line 5" in result
+        assert " 10| line 10" in result
+        assert "line 4" not in result
+        assert "line 11" not in result
+
+    @pytest.mark.asyncio
+    async def test_searches_within_line_range(self, plugin, storage, tool_context):
+        content = "\n".join(f"item {i + 1}" for i in range(30))
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref,
+            pattern="item 1",
+            line_range={"start": 10, "end": 20},
+            context_lines=0,
+            tool_context=tool_context,
+        )
+
+        assert "in lines 10-20" in result
+        assert "> 10| item 10" in result
+        assert "> 11| item 11" in result
+        assert "> 1|" not in result
+
+    @pytest.mark.asyncio
+    async def test_respects_custom_context_lines(self, plugin, storage, tool_context):
+        content = "\n".join(f"line {i + 1}" for i in range(20))
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, pattern="line 10", context_lines=0, tool_context=tool_context
+        )
+
+        assert "> 10| line 10" in result
+        assert "line 9" not in result
+        assert "line 11" not in result
+
+    @pytest.mark.asyncio
+    async def test_returns_error_for_binary_content(self, plugin, storage, tool_context):
+        ref = await storage.store("k1", b"\x89PNG", "image/png")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, pattern="test", tool_context=tool_context
+        )
+
+        assert "Error: cannot search binary content (image/png)" in result
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_literal_on_invalid_regex(self, plugin, storage, tool_context):
+        content = "foo (bar\nbaz\nfoo (bar again"
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, pattern="foo (bar", context_lines=0, tool_context=tool_context
+        )
+
+        assert "2 matches" in result
+        assert "> 1| foo (bar" in result
+        assert "> 3| foo (bar again" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_error_for_missing_reference(self, plugin, tool_context):
+        result = await plugin.retrieve_offloaded_content(
+            reference="nonexistent", pattern="test", tool_context=tool_context
+        )
+
+        assert "Error: reference not found" in result
+
+    @pytest.mark.asyncio
+    async def test_searches_json_content(self, plugin, storage, tool_context):
+        json_str = '{\n  "name": "test",\n  "items": [\n    1,\n    2,\n    3\n  ]\n}'
+        ref = await storage.store("k1", json_str.encode("utf-8"), "application/json")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, pattern="items", context_lines=1, tool_context=tool_context
+        )
+
+        assert "1 match for /items/" in result
+        assert "items" in result
+
+    @pytest.mark.asyncio
+    async def test_reports_no_matches(self, plugin, storage, tool_context):
+        content = "hello\nworld\n"
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, pattern="nonexistent", tool_context=tool_context
+        )
+
+        assert "No matches found for pattern 'nonexistent'" in result
+
+    @pytest.mark.asyncio
+    async def test_truncates_when_too_many_matches(self, storage, tool_context):
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=50,
+            preview_tokens=10,
+            include_retrieval_tool=True,
+        )
+        content = "\n".join(f"match line {i + 1}" for i in range(500))
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, pattern="match", context_lines=0, tool_context=tool_context
+        )
+
+        assert "output truncated, narrow your search" in result
+        assert len(result) < len(content)
+
+    @pytest.mark.asyncio
+    async def test_merges_overlapping_context(self, plugin, storage, tool_context):
+        content = "\n".join(f"line {i + 1}" for i in range(10))
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, pattern="line [45]", context_lines=2, tool_context=tool_context
+        )
+
+        assert "2 matches" in result
+        assert "---" not in result
+
+    @pytest.mark.asyncio
+    async def test_line_range_start_beyond_content(self, plugin, storage, tool_context):
+        content = "line 1\nline 2\nline 3"
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, line_range={"start": 100, "end": 200}, tool_context=tool_context
+        )
+
+        assert "beyond content length (3 lines)" in result
+
+    @pytest.mark.asyncio
+    async def test_clamps_line_range_end(self, plugin, storage, tool_context):
+        content = "line 1\nline 2\nline 3"
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, line_range={"start": 2, "end": 100}, tool_context=tool_context
+        )
+
+        assert "[Lines 2-3 of 3]" in result
+        assert "line 2" in result
+        assert "line 3" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_first_n_lines_with_only_context_lines(self, storage, tool_context):
+        plugin = ContextOffloader(
+            storage=storage, max_result_tokens=2500, preview_tokens=10, include_retrieval_tool=True
+        )
+        content = "\n".join(f"line {i + 1}" for i in range(20))
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(
+            reference=ref, context_lines=10, tool_context=tool_context
+        )
+
+        assert "[Lines 1-10 of 20]" in result
+        assert "line 1" in result
+        assert "line 10" in result
+        assert "line 11" not in result
+
+    @pytest.mark.asyncio
+    async def test_full_retrieval_without_search_params(self, plugin, storage, tool_context):
+        content = "hello world"
+        ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
+
+        result = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
+
+        assert result == "hello world"
+
+
 class TestInlineGuidance:
     @pytest.fixture
     def storage(self):
@@ -548,6 +763,8 @@ class TestInlineGuidance:
         await plugin._handle_tool_result(event)
         result_text = event.result["content"][0]["text"]
         assert "retrieve_offloaded_content" in result_text
+        assert "pattern" in result_text
+        assert "line_range" in result_text
 
     @pytest.mark.asyncio
     async def test_guidance_does_not_mention_retrieval_tool_when_disabled(self, storage, mock_agent):

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
@@ -1,29 +1,29 @@
 """Tests for the search module."""
 
-from strands.vended_plugins.context_offloader.search import is_searchable_content, search_content
+from strands.vended_plugins.context_offloader.search import _is_searchable_content, _search_content
 
 
 class TestIsSearchableContent:
     def test_text_types(self):
-        assert is_searchable_content("text/plain") is True
-        assert is_searchable_content("text/html") is True
+        assert _is_searchable_content("text/plain") is True
+        assert _is_searchable_content("text/html") is True
 
     def test_application_json(self):
-        assert is_searchable_content("application/json") is True
+        assert _is_searchable_content("application/json") is True
 
     def test_binary_types(self):
-        assert is_searchable_content("image/png") is False
-        assert is_searchable_content("video/mp4") is False
-        assert is_searchable_content("application/pdf") is False
+        assert _is_searchable_content("image/png") is False
+        assert _is_searchable_content("video/mp4") is False
+        assert _is_searchable_content("application/pdf") is False
 
 
 class TestSearchContentEmpty:
     def test_empty_string(self):
-        result = search_content("", pattern="x", context_lines=5, max_chars=10_000)
+        result = _search_content("", pattern="x", context_lines=5, max_chars=10_000)
         assert result == "Content is empty (0 lines)."
 
     def test_single_empty_line(self):
-        result = search_content("\n", line_range=(1, 1), context_lines=5, max_chars=10_000)
+        result = _search_content("\n", line_range=(1, 1), context_lines=5, max_chars=10_000)
         assert "Content is empty" not in result
 
 
@@ -31,23 +31,23 @@ class TestSearchContentLineRangeValidation:
     text = "line 1\nline 2\nline 3\nline 4\nline 5"
 
     def test_start_less_than_one(self):
-        result = search_content(self.text, line_range=(0, 3), context_lines=5, max_chars=10_000)
+        result = _search_content(self.text, line_range=(0, 3), context_lines=5, max_chars=10_000)
         assert "must be >= 1" in result
 
     def test_negative_start(self):
-        result = search_content(self.text, line_range=(-2, 3), context_lines=5, max_chars=10_000)
+        result = _search_content(self.text, line_range=(-2, 3), context_lines=5, max_chars=10_000)
         assert "must be >= 1" in result
 
     def test_start_greater_than_end(self):
-        result = search_content(self.text, line_range=(5, 2), context_lines=5, max_chars=10_000)
+        result = _search_content(self.text, line_range=(5, 2), context_lines=5, max_chars=10_000)
         assert "must be <= line_range.end" in result
 
     def test_start_beyond_total_lines(self):
-        result = search_content(self.text, line_range=(100, 200), context_lines=5, max_chars=10_000)
+        result = _search_content(self.text, line_range=(100, 200), context_lines=5, max_chars=10_000)
         assert "beyond content length (5 lines)" in result
 
     def test_clamps_end_to_total_lines(self):
-        result = search_content(self.text, line_range=(3, 999), context_lines=5, max_chars=10_000)
+        result = _search_content(self.text, line_range=(3, 999), context_lines=5, max_chars=10_000)
         assert "[Lines 3-5 of 5]" in result
         assert "line 3" in result
         assert "line 5" in result
@@ -57,7 +57,7 @@ class TestSearchContentPatternSearch:
     text = "\n".join(f"line {i + 1}" for i in range(20))
 
     def test_single_match_with_context(self):
-        result = search_content(self.text, pattern="line 10", context_lines=2, max_chars=10_000)
+        result = _search_content(self.text, pattern="line 10", context_lines=2, max_chars=10_000)
         assert "[1 match for /line 10/]" in result
         assert "> 10| line 10" in result
         assert "   8| line 8" in result
@@ -65,41 +65,41 @@ class TestSearchContentPatternSearch:
         assert "line 7" not in result
 
     def test_multiple_matches(self):
-        result = search_content(self.text, pattern="line [12]0", context_lines=0, max_chars=10_000)
+        result = _search_content(self.text, pattern="line [12]0", context_lines=0, max_chars=10_000)
         assert "2 matches" in result
         assert "> 10| line 10" in result
         assert "> 20| line 20" in result
 
     def test_no_matches(self):
-        result = search_content(self.text, pattern="nonexistent", context_lines=5, max_chars=10_000)
+        result = _search_content(self.text, pattern="nonexistent", context_lines=5, max_chars=10_000)
         assert "No matches found for pattern 'nonexistent'" in result
         assert "searched 20 lines" in result
 
     def test_zero_context_lines(self):
-        result = search_content(self.text, pattern="line 5", context_lines=0, max_chars=10_000)
+        result = _search_content(self.text, pattern="line 5", context_lines=0, max_chars=10_000)
         assert "> 5| line 5" in result
         assert "line 4" not in result
         assert "line 6" not in result
 
     def test_merges_overlapping_context(self):
-        result = search_content(self.text, pattern="line [67]", context_lines=2, max_chars=10_000)
+        result = _search_content(self.text, pattern="line [67]", context_lines=2, max_chars=10_000)
         assert "2 matches" in result
         assert "---" not in result
 
     def test_separates_non_overlapping_groups(self):
-        result = search_content(self.text, pattern="line (1|20)", context_lines=0, max_chars=10_000)
+        result = _search_content(self.text, pattern="line (1|20)", context_lines=0, max_chars=10_000)
         assert "---" in result
 
     def test_falls_back_to_literal_on_invalid_regex(self):
         text = "foo (bar\nbaz\nfoo (bar again"
-        result = search_content(text, pattern="foo (bar", context_lines=0, max_chars=10_000)
+        result = _search_content(text, pattern="foo (bar", context_lines=0, max_chars=10_000)
         assert "2 matches" in result
         assert "> 1| foo (bar" in result
         assert "> 3| foo (bar again" in result
 
     def test_sanitizes_pattern_in_header(self):
         text = "test line\nanother line"
-        result = search_content(text, pattern="test]\nline", context_lines=0, max_chars=10_000)
+        result = _search_content(text, pattern="test]\nline", context_lines=0, max_chars=10_000)
         header = result.split("\n")[0]
         assert "]/" not in header
 
@@ -108,7 +108,7 @@ class TestSearchContentPatternWithLineRange:
     text = "\n".join(f"item {i + 1}" for i in range(30))
 
     def test_searches_only_within_range(self):
-        result = search_content(
+        result = _search_content(
             self.text, pattern="item 1", line_range=(10, 20), context_lines=0, max_chars=10_000
         )
         assert "in lines 10-20" in result
@@ -117,7 +117,7 @@ class TestSearchContentPatternWithLineRange:
         assert "> 1|" not in result
 
     def test_no_matches_within_range(self):
-        result = search_content(
+        result = _search_content(
             self.text, pattern="item 5", line_range=(10, 20), context_lines=0, max_chars=10_000
         )
         assert "No matches found" in result
@@ -128,44 +128,44 @@ class TestSearchContentLineRangeNoPattern:
     text = "\n".join(f"line {i + 1}" for i in range(50))
 
     def test_returns_range_with_header(self):
-        result = search_content(self.text, line_range=(5, 10), context_lines=5, max_chars=10_000)
+        result = _search_content(self.text, line_range=(5, 10), context_lines=5, max_chars=10_000)
         assert "[Lines 5-10 of 50]" in result
         assert "  5| line 5" in result
         assert " 10| line 10" in result
 
     def test_does_not_show_lines_outside_range(self):
-        result = search_content(self.text, line_range=(5, 10), context_lines=5, max_chars=10_000)
+        result = _search_content(self.text, line_range=(5, 10), context_lines=5, max_chars=10_000)
         assert "line 4" not in result
         assert "line 11" not in result
 
     def test_no_separators_for_contiguous_lines(self):
-        result = search_content(self.text, line_range=(1, 10), context_lines=5, max_chars=10_000)
+        result = _search_content(self.text, line_range=(1, 10), context_lines=5, max_chars=10_000)
         assert "---" not in result
 
 
 class TestSearchContentTruncation:
     def test_truncates_pattern_results(self):
         text = "\n".join(f"match line {i + 1}" for i in range(500))
-        result = search_content(text, pattern="match", context_lines=0, max_chars=200)
+        result = _search_content(text, pattern="match", context_lines=0, max_chars=200)
         assert "output truncated, narrow your search" in result
         assert len(result) <= 250
 
     def test_truncates_line_range_results(self):
         text = "\n".join(f"line {i + 1}" for i in range(500))
-        result = search_content(text, line_range=(1, 500), context_lines=5, max_chars=200)
+        result = _search_content(text, line_range=(1, 500), context_lines=5, max_chars=200)
         assert "output truncated, narrow your range" in result
         assert len(result) <= 250
 
     def test_no_truncation_when_fits(self):
         text = "short\ncontent"
-        result = search_content(text, line_range=(1, 2), context_lines=5, max_chars=10_000)
+        result = _search_content(text, line_range=(1, 2), context_lines=5, max_chars=10_000)
         assert "truncated" not in result
 
 
 class TestSearchContentEdgeCases:
     def test_negative_context_lines_clamps_to_zero(self):
         text = "\n".join(f"line {i + 1}" for i in range(10))
-        result = search_content(text, pattern="line 5", context_lines=-3, max_chars=10_000)
+        result = _search_content(text, pattern="line 5", context_lines=-3, max_chars=10_000)
         assert "1 match" in result
         assert "> 5| line 5" in result
         assert "line 4" not in result
@@ -174,14 +174,14 @@ class TestSearchContentEdgeCases:
     def test_long_valid_regex_is_truncated_but_still_matches(self):
         text = "line 5\nother\nmore"
         long_pattern = "(line 5)" + "|x" * 120
-        result = search_content(text, pattern=long_pattern, context_lines=0, max_chars=10_000)
+        result = _search_content(text, pattern=long_pattern, context_lines=0, max_chars=10_000)
         assert "1 match" in result
         assert "> 1| line 5" in result
 
     def test_long_invalid_regex_falls_back_to_literal(self):
         text = "foo(bar\nother\nfoo(bar again"
         long_pattern = "foo(bar" + "z" * 200
-        result = search_content(text, pattern=long_pattern, context_lines=0, max_chars=10_000)
+        result = _search_content(text, pattern=long_pattern, context_lines=0, max_chars=10_000)
         assert "No matches" in result
 
     def test_empty_indices_format(self):

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
@@ -1,7 +1,5 @@
 """Tests for the search module."""
 
-import pytest
-
 from strands.vended_plugins.context_offloader.search import is_searchable_content, search_content
 
 
@@ -31,6 +29,14 @@ class TestSearchContentEmpty:
 
 class TestSearchContentLineRangeValidation:
     text = "line 1\nline 2\nline 3\nline 4\nline 5"
+
+    def test_start_less_than_one(self):
+        result = search_content(self.text, line_range=(0, 3), context_lines=5, max_chars=10_000)
+        assert "must be >= 1" in result
+
+    def test_negative_start(self):
+        result = search_content(self.text, line_range=(-2, 3), context_lines=5, max_chars=10_000)
+        assert "must be >= 1" in result
 
     def test_start_greater_than_end(self):
         result = search_content(self.text, line_range=(5, 2), context_lines=5, max_chars=10_000)
@@ -154,3 +160,31 @@ class TestSearchContentTruncation:
         text = "short\ncontent"
         result = search_content(text, line_range=(1, 2), context_lines=5, max_chars=10_000)
         assert "truncated" not in result
+
+
+class TestSearchContentEdgeCases:
+    def test_negative_context_lines_clamps_to_zero(self):
+        text = "\n".join(f"line {i + 1}" for i in range(10))
+        result = search_content(text, pattern="line 5", context_lines=-3, max_chars=10_000)
+        assert "1 match" in result
+        assert "> 5| line 5" in result
+        assert "line 4" not in result
+        assert "line 6" not in result
+
+    def test_long_valid_regex_is_truncated_but_still_matches(self):
+        text = "line 5\nother\nmore"
+        long_pattern = "(line 5)" + "|x" * 120
+        result = search_content(text, pattern=long_pattern, context_lines=0, max_chars=10_000)
+        assert "1 match" in result
+        assert "> 1| line 5" in result
+
+    def test_long_invalid_regex_falls_back_to_literal(self):
+        text = "foo(bar\nother\nfoo(bar again"
+        long_pattern = "foo(bar" + "z" * 200
+        result = search_content(text, pattern=long_pattern, context_lines=0, max_chars=10_000)
+        assert "No matches" in result
+
+    def test_empty_indices_format(self):
+        from strands.vended_plugins.context_offloader.search import _format_lines
+
+        assert _format_lines(["a", "b"], [], set()) == ""

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
@@ -1,0 +1,156 @@
+"""Tests for the search module."""
+
+import pytest
+
+from strands.vended_plugins.context_offloader.search import is_searchable_content, search_content
+
+
+class TestIsSearchableContent:
+    def test_text_types(self):
+        assert is_searchable_content("text/plain") is True
+        assert is_searchable_content("text/html") is True
+
+    def test_application_json(self):
+        assert is_searchable_content("application/json") is True
+
+    def test_binary_types(self):
+        assert is_searchable_content("image/png") is False
+        assert is_searchable_content("video/mp4") is False
+        assert is_searchable_content("application/pdf") is False
+
+
+class TestSearchContentEmpty:
+    def test_empty_string(self):
+        result = search_content("", pattern="x", context_lines=5, max_chars=10_000)
+        assert result == "Content is empty (0 lines)."
+
+    def test_single_empty_line(self):
+        result = search_content("\n", line_range=(1, 1), context_lines=5, max_chars=10_000)
+        assert "Content is empty" not in result
+
+
+class TestSearchContentLineRangeValidation:
+    text = "line 1\nline 2\nline 3\nline 4\nline 5"
+
+    def test_start_greater_than_end(self):
+        result = search_content(self.text, line_range=(5, 2), context_lines=5, max_chars=10_000)
+        assert "must be <= line_range.end" in result
+
+    def test_start_beyond_total_lines(self):
+        result = search_content(self.text, line_range=(100, 200), context_lines=5, max_chars=10_000)
+        assert "beyond content length (5 lines)" in result
+
+    def test_clamps_end_to_total_lines(self):
+        result = search_content(self.text, line_range=(3, 999), context_lines=5, max_chars=10_000)
+        assert "[Lines 3-5 of 5]" in result
+        assert "line 3" in result
+        assert "line 5" in result
+
+
+class TestSearchContentPatternSearch:
+    text = "\n".join(f"line {i + 1}" for i in range(20))
+
+    def test_single_match_with_context(self):
+        result = search_content(self.text, pattern="line 10", context_lines=2, max_chars=10_000)
+        assert "[1 match for /line 10/]" in result
+        assert "> 10| line 10" in result
+        assert "   8| line 8" in result
+        assert "  12| line 12" in result
+        assert "line 7" not in result
+
+    def test_multiple_matches(self):
+        result = search_content(self.text, pattern="line [12]0", context_lines=0, max_chars=10_000)
+        assert "2 matches" in result
+        assert "> 10| line 10" in result
+        assert "> 20| line 20" in result
+
+    def test_no_matches(self):
+        result = search_content(self.text, pattern="nonexistent", context_lines=5, max_chars=10_000)
+        assert "No matches found for pattern 'nonexistent'" in result
+        assert "searched 20 lines" in result
+
+    def test_zero_context_lines(self):
+        result = search_content(self.text, pattern="line 5", context_lines=0, max_chars=10_000)
+        assert "> 5| line 5" in result
+        assert "line 4" not in result
+        assert "line 6" not in result
+
+    def test_merges_overlapping_context(self):
+        result = search_content(self.text, pattern="line [67]", context_lines=2, max_chars=10_000)
+        assert "2 matches" in result
+        assert "---" not in result
+
+    def test_separates_non_overlapping_groups(self):
+        result = search_content(self.text, pattern="line (1|20)", context_lines=0, max_chars=10_000)
+        assert "---" in result
+
+    def test_falls_back_to_literal_on_invalid_regex(self):
+        text = "foo (bar\nbaz\nfoo (bar again"
+        result = search_content(text, pattern="foo (bar", context_lines=0, max_chars=10_000)
+        assert "2 matches" in result
+        assert "> 1| foo (bar" in result
+        assert "> 3| foo (bar again" in result
+
+    def test_sanitizes_pattern_in_header(self):
+        text = "test line\nanother line"
+        result = search_content(text, pattern="test]\nline", context_lines=0, max_chars=10_000)
+        header = result.split("\n")[0]
+        assert "]/" not in header
+
+
+class TestSearchContentPatternWithLineRange:
+    text = "\n".join(f"item {i + 1}" for i in range(30))
+
+    def test_searches_only_within_range(self):
+        result = search_content(
+            self.text, pattern="item 1", line_range=(10, 20), context_lines=0, max_chars=10_000
+        )
+        assert "in lines 10-20" in result
+        assert "> 10| item 10" in result
+        assert "> 11| item 11" in result
+        assert "> 1|" not in result
+
+    def test_no_matches_within_range(self):
+        result = search_content(
+            self.text, pattern="item 5", line_range=(10, 20), context_lines=0, max_chars=10_000
+        )
+        assert "No matches found" in result
+        assert "in lines 10-20" in result
+
+
+class TestSearchContentLineRangeNoPattern:
+    text = "\n".join(f"line {i + 1}" for i in range(50))
+
+    def test_returns_range_with_header(self):
+        result = search_content(self.text, line_range=(5, 10), context_lines=5, max_chars=10_000)
+        assert "[Lines 5-10 of 50]" in result
+        assert "  5| line 5" in result
+        assert " 10| line 10" in result
+
+    def test_does_not_show_lines_outside_range(self):
+        result = search_content(self.text, line_range=(5, 10), context_lines=5, max_chars=10_000)
+        assert "line 4" not in result
+        assert "line 11" not in result
+
+    def test_no_separators_for_contiguous_lines(self):
+        result = search_content(self.text, line_range=(1, 10), context_lines=5, max_chars=10_000)
+        assert "---" not in result
+
+
+class TestSearchContentTruncation:
+    def test_truncates_pattern_results(self):
+        text = "\n".join(f"match line {i + 1}" for i in range(500))
+        result = search_content(text, pattern="match", context_lines=0, max_chars=200)
+        assert "output truncated, narrow your search" in result
+        assert len(result) <= 250
+
+    def test_truncates_line_range_results(self):
+        text = "\n".join(f"line {i + 1}" for i in range(500))
+        result = search_content(text, line_range=(1, 500), context_lines=5, max_chars=200)
+        assert "output truncated, narrow your range" in result
+        assert len(result) <= 250
+
+    def test_no_truncation_when_fits(self):
+        text = "short\ncontent"
+        result = search_content(text, line_range=(1, 2), context_lines=5, max_chars=10_000)
+        assert "truncated" not in result


### PR DESCRIPTION
## Description

Port the TypeScript SDK's targeted retrieval functionality so the agent can search and filter offloaded content without loading it entirely back into context. Adds `pattern` (regex/keyword), `line_range`, and `context_lines` parameters to `retrieve_offloaded_content`.

### Changes

- **New module `search.py`**: `search_content()` and `is_searchable_content()` providing grep-like pattern matching, line-range random access, context expansion, overlapping-group merging, and output truncation.
- **Updated `retrieve_offloaded_content` tool**: Added optional `pattern`, `line_range` (typed as a `TypedDict` with `start`/`end` for proper JSON schema generation), and `context_lines` parameters. Omitting all three preserves existing full-retrieval behavior (backward compatible).
- **Updated inline guidance**: When the retrieval tool is enabled, the offload placeholder now advertises pattern/line_range usage and discourages full retrieval.

### Retrieval modes (matching TypeScript SDK)

| Mode | Parameters | Description |
|------|-----------|-------------|
| Pattern search | `pattern` | Grep for regex/keyword matches with configurable `context_lines` |
| Line range | `line_range` | Random access to specific 1-indexed line numbers |
| Combined | `pattern` + `line_range` | Search within a specific range |
| Head | `context_lines` only | Return first N lines |
| Full retrieval | (none) | Retrieve everything (discouraged for large content) |

## Related Issues

Ports strands-agents/harness-sdk#1060 (commit 0fb0d90) from TypeScript to Python.

## Documentation PR
Documentation updated in this PR

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [X] I ran `hatch run prepare`

### Test coverage added

- **`test_search.py`** (24 tests): Unit tests for `search_content` and `is_searchable_content` covering empty content, line range validation, pattern search with context, overlapping group merging, regex fallback, truncation.
- **`TestRetrievalToolSearch`** in `test_plugin.py` (17 tests): Integration tests exercising all retrieval modes through the tool, including binary content errors, missing references, JSON content search, and backward-compatible full retrieval.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
