### PR TITLE
ci: opt back into fork-PR checkout under pull_request_target

### DIFF
--- a/.github/workflows/docs-deploy-preview.yml
+++ b/.github/workflows/docs-deploy-preview.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           ref: ${{ env.PR_HEAD_SHA }}
           persist-credentials: false
-          allow-unsafe-pr-checkout: true
+          allow-unsafe-pr-checkout: true  # opt back into fork-PR checkout, blocked by default in checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/docs-deploy-preview.yml
+++ b/.github/workflows/docs-deploy-preview.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           ref: ${{ env.PR_HEAD_SHA }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          allow-unsafe-pr-checkout: true
+          allow-unsafe-pr-checkout: true  # opt back into fork-PR checkout, blocked by default in checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }} # Pull the commit from the forked repo
           persist-credentials: false  # Don't persist credentials for subsequent actions
+          allow-unsafe-pr-checkout: true  # opt back into fork-PR checkout, blocked by default in checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Description

The `actions/checkout@v7` upgrade added a guard that **refuses to check out fork PR code in a `pull_request_target` workflow** unless `allow-unsafe-pr-checkout: true` is set on the step. This broke the integration-test and docs-preview jobs (the Python integration test is the one that surfaced first, e.g. run 27845026966):

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. [...] To opt in, [...] set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

This PR sets that flag on the three checkout steps that fetch the fork PR head under `pull_request_target`:

- `python-integration-test.yml`
- `typescript-integration-test.yml`
- `docs-deploy-preview.yml`

## Why opting in is safe here

The guard exists to prevent "pwn requests" — checking out untrusted fork code and executing it with the base repo's token/secrets. These jobs already apply exactly the mitigations the guard is meant to enforce, so setting the flag restores the prior (already-reviewed) behavior rather than opening a new hole:

- **Authorization check** — an `authorization-check` job (`strands-agents/devtools/authorization-check`) gates on the PR author's role (`maintain/triage/write/admin`) before anything else runs.
- **Maintainer approval before code runs** — the checkout job runs in a protected approval `environment` (`needs.authorization-check.outputs.approval-env`), so a maintainer must approve the run before any fork code executes.
- **No token in the fork checkout** — every affected step sets `persist-credentials: false`, so the base-repo `GITHUB_TOKEN` is never written into the fork's working tree. AWS creds are minted via OIDC only after the gate.

Workflows that were **not** changed: `issue-labeler.yml` checks out the base repo (`sparse-checkout: .github/labelers`), not the fork head; `ci.yml` and the `*-pr-and-push.yml` workflows use the plain `pull_request`/`push` events, not `pull_request_target`.

## Type of change

CI/build configuration fix.
