### PR TITLE
fix(google): disambiguate Gemini tool-result part displayNames

### DIFF
--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -966,6 +966,57 @@ describe('GoogleModel', () => {
       ])
     })
 
+    it('disambiguates displayName for multiple same-format images in one tool result', () => {
+      const toolUseBlock = new ToolUseBlock({ toolUseId: 'test-id', name: 'two_images', input: {} })
+      const toolResultBlock = new ToolResultBlock({
+        toolUseId: 'test-id',
+        status: 'success',
+        content: [
+          new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47]) } }),
+          new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x48]) } }),
+        ],
+      })
+      const messages = [
+        new Message({ role: 'assistant', content: [toolUseBlock] }),
+        new Message({ role: 'user', content: [toolResultBlock] }),
+      ]
+
+      const contents = formatMessages(messages)
+
+      const resultPart = contents[1]!.parts![0]! as {
+        functionResponse: { parts?: Array<{ inlineData: { displayName: string } }> }
+      }
+      const displayNames = resultPart.functionResponse.parts!.map((p) => p.inlineData.displayName)
+      // Gemini rejects duplicate part names within one function_response.parts.
+      expect(new Set(displayNames).size).toBe(displayNames.length)
+      expect(displayNames).toEqual(['image.png', 'image-1.png'])
+    })
+
+    it('disambiguates displayName for documents sharing a name in one tool result', () => {
+      const toolUseBlock = new ToolUseBlock({ toolUseId: 'test-id', name: 'two_docs', input: {} })
+      const toolResultBlock = new ToolResultBlock({
+        toolUseId: 'test-id',
+        status: 'success',
+        content: [
+          new DocumentBlock({ name: 'report.pdf', format: 'pdf', source: { bytes: new Uint8Array([0x25, 0x50]) } }),
+          new DocumentBlock({ name: 'report.pdf', format: 'pdf', source: { bytes: new Uint8Array([0x25, 0x51]) } }),
+        ],
+      })
+      const messages = [
+        new Message({ role: 'assistant', content: [toolUseBlock] }),
+        new Message({ role: 'user', content: [toolResultBlock] }),
+      ]
+
+      const contents = formatMessages(messages)
+
+      const resultPart = contents[1]!.parts![0]! as {
+        functionResponse: { parts?: Array<{ inlineData: { displayName: string } }> }
+      }
+      const displayNames = resultPart.functionResponse.parts!.map((p) => p.inlineData.displayName)
+      expect(new Set(displayNames).size).toBe(displayNames.length)
+      expect(displayNames).toEqual(['report.pdf', 'report-1.pdf'])
+    })
+
     it('formats document block with bytes source in tool result as inlineData', () => {
       const docBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46])
       const toolUseBlock = new ToolUseBlock({ toolUseId: 'test-id', name: 'read_doc', input: {} })

--- a/strands-ts/src/models/google/adapters.ts
+++ b/strands-ts/src/models/google/adapters.ts
@@ -266,6 +266,25 @@ function formatToolResultBlock(block: ToolResultBlock, toolUseIdToName: Map<stri
   const parts: Part[] = []
   const output: Array<{ text?: string; json?: unknown }> = []
 
+  // Gemini enforces unique displayNames within one function_response.parts. Disambiguate
+  // collisions (e.g. two same-format images, or two documents sharing a name) by suffixing.
+  const usedDisplayNames = new Set<string>()
+  const uniqueDisplayName = (name: string): string => {
+    if (!usedDisplayNames.has(name)) {
+      usedDisplayNames.add(name)
+      return name
+    }
+    const dot = name.lastIndexOf('.')
+    const [base, ext] = dot > 0 ? [name.slice(0, dot), name.slice(dot)] : [name, '']
+    let i = 1
+    let candidate = `${base}-${i}${ext}`
+    while (usedDisplayNames.has(candidate)) {
+      candidate = `${base}-${++i}${ext}`
+    }
+    usedDisplayNames.add(candidate)
+    return candidate
+  }
+
   for (const c of block.content) {
     switch (c.type) {
       case 'textBlock':
@@ -281,7 +300,7 @@ function formatToolResultBlock(block: ToolResultBlock, toolUseIdToName: Map<stri
             inlineData: {
               data: encodeBase64(c.source.bytes),
               mimeType,
-              displayName: `image.${c.format}`,
+              displayName: uniqueDisplayName(`image.${c.format}`),
             },
           })
         } else {
@@ -296,7 +315,7 @@ function formatToolResultBlock(block: ToolResultBlock, toolUseIdToName: Map<stri
             inlineData: {
               data: encodeBase64(c.source.bytes),
               mimeType,
-              displayName: c.name,
+              displayName: uniqueDisplayName(c.name),
             },
           })
         } else if (c.source.type === 'documentSourceText') {
@@ -304,7 +323,7 @@ function formatToolResultBlock(block: ToolResultBlock, toolUseIdToName: Map<stri
             inlineData: {
               data: encodeBase64(new TextEncoder().encode(c.source.text)),
               mimeType,
-              displayName: c.name,
+              displayName: uniqueDisplayName(c.name),
             },
           })
         } else {


### PR DESCRIPTION
Thanks to the maintainers for Strands, and to @Jarvvski for the exceptionally clear bug report (#2748) — exact error, root-cause pointer, and a locally-verified fix made this straightforward.

## Problem

Any Gemini tool result carrying two or more images of the same format makes the *next* request fail deterministically:

```
{
  "error": {
    "code": 400,
    "message": "Duplicate parts `image.png` in a function_response.parts is not allowed.",
    "status": "INVALID_ARGUMENT"
  }
}
```

Since most multi-image use cases emit a single format (e.g. rendered PDF pages as PNGs), this breaks the common case. The 400 is non-retryable, so the agent run fails outright.

## Cause

`formatToolResultBlock` in `strands-ts/src/models/google/adapters.ts` hardcodes the same `displayName` for every part:

- `imageBlock` branch: `displayName: \`image.${c.format}\`` — identical for every image of a given format.
- `documentBlock` branch (latent, also noted in the issue): `displayName: c.name` — collides when two documents share a name.

Gemini enforces unique part names within one `function_response.parts`, so any tool result with >= 2 colliding names is unsendable.

## Change

Added a small per-result de-duplication helper inside `formatToolResultBlock` that returns the base name on first use and suffixes subsequent collisions (`image.png` -> `image-1.png`, `report.pdf` -> `report-1.pdf`), applied to both the image and document branches. Scope is limited to this one function — no new abstraction, no other paths touched.

## Before / After

| Item | Before | After |
|------|--------|-------|
| 2x PNG in one tool result | ❌ `400` Duplicate parts `image.png` | ✅ `image.png`, `image-1.png` (accepted) |
| 2x docs sharing a name | ❌ Duplicate parts `report.pdf` | ✅ `report.pdf`, `report-1.pdf` |
| Single image (existing behavior) | `image.png` | `image.png` (unchanged ✅) |
| Single document (existing behavior) | `report.pdf` | `report.pdf` (unchanged ✅) |
| `response.output` ordering / contents | unchanged | unchanged ✅ |
| Public API / function signature | unchanged | unchanged ✅ |

## Tests (red/green)

Added two regression tests in `strands-ts/src/models/__tests__/google.test.ts` following the existing `formatMessages` tool-result pattern. They assert all `displayName`s within one `function_response.parts` are unique.

With the source fix **reverted** (tests kept) — tests fail, proving they catch the bug:

```
 × disambiguates displayName for multiple same-format images in one tool result
 × disambiguates displayName for documents sharing a name in one tool result
AssertionError: expected 1 to be 2 // Object.is equality
   expect(displayNames).toEqual(['image.png', 'image-1.png'])
 Test Files  1 failed (1)
      Tests  2 failed | 77 passed (79)
```

With the fix applied — green, and the full package suite passes with no regressions:

```
 ✓ |unit-node| src/models/__tests__/google.test.ts (79 tests)
 Test Files  128 passed (128)
      Tests  3499 passed (3499)
Type Errors  no errors
```

Also ran locally in `strands-ts/`: `build` (tsc) clean, `prettier --check` clean, `eslint` clean. The repo pre-commit hook (build + test:coverage + lint + conventional-commit) passed on commit.

Fixes #2748

---

*This contribution was prepared with the help of an AI agent (Claude Code). I have reviewed every line of the change, the reasoning, and the test results before submitting, and I can explain and maintain it.*
