### PR TITLE
fix: filter graph dependency reasoning blocks

### DIFF
--- a/strands-ts/src/multiagent/__tests__/graph.test.ts
+++ b/strands-ts/src/multiagent/__tests__/graph.test.ts
@@ -5,7 +5,7 @@ import { MockSnapshotStorage } from '../../__fixtures__/mock-storage-provider.js
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { createCancellableAgent } from '../../__fixtures__/agent-helpers.js'
 import { AfterNodeCallEvent, BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
-import { TextBlock, type ContentBlockData } from '../../types/messages.js'
+import { ReasoningBlock, TextBlock, type ContentBlockData } from '../../types/messages.js'
 import { Status, MultiAgentState } from '../state.js'
 import { AgentNode, MultiAgentNode } from '../nodes.js'
 import { Graph } from '../graph.js'
@@ -376,6 +376,31 @@ describe('Graph', () => {
       expect(streamSpy).toHaveBeenCalled()
       const input = streamSpy.mock.calls[0]![0] as TextBlock[]
       expect(input.map((b) => b.text)).toStrictEqual(['task-input', '[node: a]', 'from-a'])
+    })
+
+    it('does not pass dependency reasoning blocks to downstream nodes', async () => {
+      const agentA = new Agent({
+        model: new MockMessageModel().addTurn([
+          new ReasoningBlock({ text: 'private reasoning' }),
+          new TextBlock('from-a'),
+        ]),
+        printer: false,
+        id: 'a',
+      })
+      const agentB = makeAgent('b')
+      const streamSpy = vi.spyOn(agentB, 'stream')
+
+      const graph = new Graph({
+        nodes: [agentA, agentB],
+        edges: [['a', 'b']],
+      })
+
+      await graph.invoke('task-input')
+
+      expect(streamSpy).toHaveBeenCalled()
+      const input = streamSpy.mock.calls[0]![0] as TextBlock[]
+      expect(input.map((b) => b.text)).toStrictEqual(['task-input', '[node: a]', 'from-a'])
+      expect(input.map((b) => b.type)).toStrictEqual(['textBlock', 'textBlock', 'textBlock'])
     })
 
     it('converts ContentBlockData[] input to ContentBlock instances for downstream nodes', async () => {

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -742,7 +742,10 @@ export class Graph implements MultiAgent {
     for (const edge of this.edges.filter((e) => e.target.id === node.id)) {
       const ns = state.node(edge.source.id)!
       if (ns.content.length > 0) {
-        deps.push(new TextBlock(`[node: ${edge.source.id}]`), ...ns.content)
+        const content = ns.content.filter((block) => block.type !== 'reasoningBlock')
+        if (content.length > 0) {
+          deps.push(new TextBlock(`[node: ${edge.source.id}]`), ...content)
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Graph dependency resolution currently forwards every upstream content block into downstream node input. When the upstream node returns reasoning content, that reasoning block can become part of the downstream user message and providers such as Bedrock reject it.

This PR filters reasoning blocks out of dependency handoff content while preserving regular dependency text output and node markers.

## Related Issues

Resolves #2882

## Documentation PR

Not needed; this preserves the existing Graph handoff behavior for user-visible content and removes provider-incompatible reasoning content from the handoff.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`
- [x] `npm test -w strands-ts -- graph.test.ts`
- [x] `npm run build -w strands-ts`
- [x] `npm run type-check -w strands-ts`
- [x] `npm run format:check -w strands-ts`
- [x] `npx eslint src/multiagent/graph.ts src/multiagent/__tests__/graph.test.ts --max-warnings=0` from `strands-ts/`
- [x] Pre-commit ran `npm run test:coverage -w strands-ts` successfully: 128 files passed, 3498 tests passed, no type errors. The repo-wide lint step reported one pre-existing warning in `src/agent/__tests__/agent.context-manager.test.ts`, which this PR does not touch.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
