### PR TITLE
fix(site): pin @astrojs/markdown-satteri and satteri as direct deps

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -38,6 +38,7 @@
         "vite": "^7.3.5"
       },
       "devDependencies": {
+        "@astrojs/markdown-satteri": "^0.2.2",
         "@astrojs/starlight": "^0.40.0",
         "@types/js-yaml": "^4.0.9",
         "@types/mdast": "^4.0.4",
@@ -49,6 +50,7 @@
         "pino-pretty": "^13.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "satteri": "^0.8.1",
         "sitemapper": "^4.1.4",
         "tsx": "^4.21.0",
         "typedoc": "^0.28.14",
@@ -63,7 +65,7 @@
       "version": "0.0.1-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.1037.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.1066.0",
         "@types/json-schema": "^7.0.15",
         "uuid": "^14.0.0",
         "yaml": "^2.8.3"
@@ -83,6 +85,8 @@
         "@aws-sdk/client-sts": "^3.996.0",
         "@aws-sdk/credential-providers": "^3.943.0",
         "@aws/bedrock-token-generator": "^1.1.0",
+        "@cedar-policy/cedar-wasm": "^4.11.0",
+        "@cedar-policy/mcp-schema-generator-wasm": "^0.6.0",
         "@eslint/js": "^9.39.4",
         "@google/genai": "^1.40.0",
         "@opentelemetry/api": "^1.9.0",
@@ -121,6 +125,8 @@
         "@aws-sdk/client-bedrock-agent-runtime": "^3.943.0",
         "@aws-sdk/client-s3": "^3.943.0",
         "@aws/bedrock-token-generator": "^1.1.0",
+        "@cedar-policy/cedar-wasm": "^4.0.0",
+        "@cedar-policy/mcp-schema-generator-wasm": "^0.6.0",
         "@google/genai": "^1.40.0",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@opentelemetry/api": "^1.9.0",
@@ -155,6 +161,12 @@
           "optional": true
         },
         "@aws/bedrock-token-generator": {
+          "optional": true
+        },
+        "@cedar-policy/cedar-wasm": {
+          "optional": true
+        },
+        "@cedar-policy/mcp-schema-generator-wasm": {
           "optional": true
         },
         "@google/genai": {
@@ -273,8 +285,6 @@
       "integrity": "sha512-F3jxs0QstnLL5Fa/Uq6idPZ2IsT8AKo/S+AvnIOvFX+8rst5j2MJBPllgzD1O5JbFqyiXs6Wx59o8h2O9U41pw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@astrojs/internal-helpers": "0.10.0",
         "github-slugger": "^2.0.0",
@@ -985,8 +995,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@bruits/satteri-darwin-x64": {
       "version": "0.8.1",
@@ -999,8 +1008,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@bruits/satteri-linux-x64-gnu": {
       "version": "0.8.1",
@@ -1013,8 +1021,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@bruits/satteri-wasm32-wasi": {
       "version": "0.8.1",
@@ -1025,7 +1032,6 @@
       ],
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.1",
         "@emnapi/runtime": "1.9.1",
@@ -1042,7 +1048,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1058,8 +1063,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
@@ -1118,7 +1122,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
@@ -1141,7 +1144,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2242,7 +2244,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.2"
       },
@@ -3233,7 +3234,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -9389,8 +9389,6 @@
       "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.8.1.tgz",
       "integrity": "sha512-B3dPc3RsWN+CIrwJHk6KnPQjdN7cg9mnSgfs7AUEXITlIYRnSMleOZQPgpmm759pGZ/vpnsXciNfJKXKME2rrg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.5",
         "@types/hast": "^3.0.4",
@@ -9905,6 +9903,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
@@ -11294,13 +11299,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/thread-stream/node_modules/real-require": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
-      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
-      "dev": true,
-      "license": "MIT"
     }
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -53,6 +53,7 @@
     "vite": "^7.3.5"
   },
   "devDependencies": {
+    "@astrojs/markdown-satteri": "^0.2.2",
     "@astrojs/starlight": "^0.40.0",
     "@types/js-yaml": "^4.0.9",
     "@types/mdast": "^4.0.4",
@@ -64,6 +65,7 @@
     "pino-pretty": "^13.0.0",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
+    "satteri": "^0.8.1",
     "sitemapper": "^4.1.4",
     "tsx": "^4.21.0",
     "typedoc": "^0.28.14",


### PR DESCRIPTION
```
[vite]: Rollup failed to resolve import "satteri" from "node_modules/@astrojs/mdx/dist/satteri/index.js"
```

* pinning them as direct deps locks them into the lockfile so any future regeneration keeps them.
* `npm ci && npm run build` succeeds with no broken links.
* once this lands, I can rebase all of the open `site/` dependabot PRs (#2887, #2744, #2688, #2888, #2684)