### PR TITLE
ci: tighten dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       - "python"
     commit-message:
       prefix: "ci(python)"
+    versioning-strategy: increase-if-necessary
     groups:
       dev-dependencies:
         patterns:


### PR DESCRIPTION
pip currently uses widen, so major bumps just extend the upper bound and uv keeps resolving the old major. increase-if-necessary shifts the floor at majors so CI actually tests the new major.