### PR TITLE
ci(deps): unify Dependabot grouping and cooldown across all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,59 +1,119 @@
+# Dependabot configuration.
+#
+# Shared conventions across every ecosystem below:
+#   - cooldown: hold new updates for a few days before opening a PR so we don't
+#     churn on same-day releases. Majors get a long (30-day) window so a human
+#     can vet breaking changes before the PR lands.
+#   - groups: batch low-risk updates (dev tooling, minor/patch bumps) into a
+#     single PR. Major production updates are intentionally left ungrouped so
+#     they arrive as individual, clearly-attributable PRs.
+#   - schedule: poll weekly. The cooldown already delays PRs by days, so daily
+#     polling just adds noise without surfacing updates any sooner.
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/strands-py"
+  # Python SDK (strands-py). Dev tooling and minor/patch bumps are batched;
+  # major bumps come individually and wait out the 30-day cooldown for review.
+  - package-ecosystem: 'pip'
+    directory: '/strands-py'
     schedule:
-      interval: "daily"
+      interval: 'weekly'
     open-pull-requests-limit: 100
     labels:
-      - "dependencies"
-      - "python"
+      - 'dependencies'
+      - 'python'
     commit-message:
-      prefix: "ci(python)"
-    versioning-strategy: increase-if-necessary
-    groups:
-      dev-dependencies:
-        patterns:
-          - "pytest"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 100
-    labels:
-      - "dependencies"
-      - "typescript"
-    commit-message:
-      prefix: "ci(typescript)"
+      prefix: 'ci(python)'
     cooldown:
       default-days: 5
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
     groups:
+      # All development dependencies in one PR.
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: 'development'
         applies-to: version-updates
+      # Production minor + patch bumps in one PR.
       production-minor:
-        dependency-type: "production"
+        dependency-type: 'production'
         applies-to: version-updates
         update-types:
-          - "minor"
-          - "patch"
-  - package-ecosystem: "npm"
-    directory: "/site"
+          - 'minor'
+          - 'patch'
+      # Major production updates aren't matched by any group, so they get individual
+      # PRs — gated by the 30-day semver-major cooldown above for manual review.
+  # TypeScript SDK at the repo root. Same batching strategy as the Python SDK.
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'weekly'
     open-pull-requests-limit: 100
     labels:
-      - "dependencies"
-      - "typescript"
+      - 'dependencies'
+      - 'typescript'
     commit-message:
-      prefix: "ci(docs)"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      prefix: 'ci(typescript)'
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      # All development dependencies in one PR.
+      development-dependencies:
+        dependency-type: 'development'
+        applies-to: version-updates
+      # Production minor + patch bumps in one PR.
+      production-minor:
+        dependency-type: 'production'
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Major production updates aren't matched by any group, so they get individual
+      # PRs — gated by the 30-day semver-major cooldown above for manual review.
+  # Documentation site (/site). Same batching strategy as the SDKs so docs
+  # tooling bumps don't each open a separate PR and majors get the review window.
+  - package-ecosystem: 'npm'
+    directory: '/site'
     schedule:
-      interval: "daily"
+      interval: 'weekly'
+    open-pull-requests-limit: 100
+    labels:
+      - 'dependencies'
+      - 'typescript'
+    commit-message:
+      prefix: 'ci(docs)'
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      # All development dependencies in one PR.
+      development-dependencies:
+        dependency-type: 'development'
+        applies-to: version-updates
+      # Production minor + patch bumps in one PR.
+      production-minor:
+        dependency-type: 'production'
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Major production updates aren't matched by any group, so they get individual
+      # PRs — gated by the 30-day semver-major cooldown above for manual review.
+  # GitHub Actions workflow pins. Low volume, so no grouping; the cooldown still
+  # holds majors back for review before the bump PR opens.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
     open-pull-requests-limit: 100
     commit-message:
       prefix: ci
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@
 #     they arrive as individual, clearly-attributable PRs.
 #   - schedule: poll weekly. The cooldown already delays PRs by days, so daily
 #     polling just adds noise without surfacing updates any sooner.
+#   - versioning-strategy: increase-if-necessary — bump the constraint floor at a
+#     major boundary instead of just widening the upper bound, so CI actually
+#     resolves and tests the new major rather than sitting on the old one.
 version: 2
 updates:
   # Python SDK (strands-py). Dev tooling and minor/patch bumps are batched;
@@ -23,6 +26,7 @@ updates:
       - 'python'
     commit-message:
       prefix: 'ci(python)'
+    versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 5
       semver-major-days: 30
@@ -53,6 +57,7 @@ updates:
       - 'typescript'
     commit-message:
       prefix: 'ci(typescript)'
+    versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 5
       semver-major-days: 30
@@ -84,6 +89,7 @@ updates:
       - 'typescript'
     commit-message:
       prefix: 'ci(docs)'
+    versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 5
       semver-major-days: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,10 @@
 #   - cooldown: hold new updates for a few days before opening a PR so we don't
 #     churn on same-day releases. Majors get a long (30-day) window so a human
 #     can vet breaking changes before the PR lands.
-#   - groups: batch low-risk updates (dev tooling, minor/patch bumps) into a
-#     single PR. Major production updates are intentionally left ungrouped so
-#     they arrive as individual, clearly-attributable PRs.
+#   - groups: batch low-risk updates into grouped PRs — dev tooling in one,
+#     production minor/patch bumps in another. Major production updates are
+#     intentionally left ungrouped so they arrive as individual,
+#     clearly-attributable PRs.
 #   - schedule: poll weekly. The cooldown already delays PRs by days, so daily
 #     polling just adds noise without surfacing updates any sooner.
 #   - versioning-strategy: increase-if-necessary — bump the constraint floor at a


### PR DESCRIPTION
## Description

The monorepo left us with individual dependabot updates with no cooldown, so Python major bumps opened as individual, immediately-mergeable PRs with no review window. These changes bring every ecosystem to one standard: group dev and minor/patch updates, hold majors behind a 30-day cooldown, and poll weekly instead of daily.

## Callout: versioning-strategy

Also sets `versioning-strategy: increase-if-necessary` (pip + npm, overlaps #2899) so majors raise the floor (`<2.0.0` → `>=2.4.0,<3.0.0`) and actually get tested, instead of `widen` leaving us on the old major. Tradeoff: floor-raising narrows the range we advertise to consumers — intentional.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

N/A — CI configuration only.

## Type of Change

Other: CI / dependency-management configuration

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
