### PR TITLE
feat(agent): add Agent.clone() to build fresh agents from a template

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -4,6 +4,7 @@ description: "Capture and restore agent state at any point in time. Use snapshot
 sourceLinks:
   - path: strands-py/src/strands/types/_snapshot.py
   - path: strands-ts/src/agent/snapshot.ts
+  - path: strands-ts/src/agent/agent.ts
 ---
 
 Snapshots capture agent state at a point in time so you can save and restore it later. You choose which fields to include — either by picking a preset (a preconfigured set of fields) or by specifying fields directly — and you can further refine with includes and excludes. Snapshots are plain JSON-serializable objects — persistence is up to you.
@@ -296,6 +297,45 @@ casual_snapshot = agent.take_snapshot(preset="session")
 ```
 </Tab>
 </Tabs>
+
+## Cloning Agents *(TypeScript only)*
+
+Snapshots copy an agent's **runtime state**. `Agent.clone()` is the complement: it copies an agent's **configuration** into a brand-new agent. Use it to serve many independent agents — per request, thread, or session — from one configured "template" agent.
+
+```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:clone_basic"
+```
+
+The clone is built by replaying the template's original `AgentConfig` through the constructor. It is **not** a copy of runtime state: conversation history, accumulated model state, and hook registrations added after construction are all absent from the clone (seed them explicitly via `options.overrides`).
+
+### What is shared vs. isolated
+
+The clone is constructed from the same config values the template was given, so any object you passed in the constructor is reused by reference — the template and every clone point at the same instance unless you override it:
+
+| Config | In each clone | How to isolate |
+| --- | --- | --- |
+| `model`, `tools` (incl. `McpClient`s) | The same instances you passed (a string `model` builds a fresh `BedrockModel` per clone) | `overrides.model` / `overrides.tools` |
+| `sessionManager` | The same instance you passed | `overrides.sessionManager` |
+| `memoryManager` | The same instance you passed (a fresh `MemoryManager` is constructed per clone) | `overrides.memoryManager` |
+| `plugins` (from the constructor) | The same instances you passed | `additionalPlugins` adds fresh instances; `overrides.plugins` replaces the list |
+| `appState`, `modelState` | A fresh store seeded from the config values | (already isolated) |
+| `messages` | A fresh array built from the config values | (already isolated) |
+
+Reusing instances is the right default for stateless wiring like `model` and `tools` — it's also what lets a clone resolve the template's [MCP tools](../tools/mcp-tools.mdx) on its own first run **without the template ever being initialized**, which makes `clone()` a good fit for servers that build a per-session agent from a shared template. When cloning for per-session isolation, two cases are worth handling explicitly:
+
+- **`sessionManager`** is bound to one session, so it's recommended to give each clone its own fresh instance via `overrides`:
+
+  ```typescript
+  --8<-- "user-guide/concepts/agents/snapshots.ts:clone_per_session"
+  ```
+
+- **Stateful plugins** hold per-agent state, so it's recommended to give each clone its own fresh instance via `additionalPlugins`:
+
+  ```typescript
+  --8<-- "user-guide/concepts/agents/snapshots.ts:clone_plugins"
+  ```
+
+`clone()` and snapshots compose: clone a template to get a freshly-wired agent for a new session, then `loadSnapshot()` into it (or attach a `SessionManager`) to resume that session's prior state.
 
 ## Relationship to Session Management
 

--- a/site/src/content/docs/user-guide/concepts/agents/snapshots.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/snapshots.ts
@@ -1,4 +1,15 @@
-import { Agent, type Snapshot } from '@strands-agents/sdk'
+import {
+  Agent,
+  McpClient,
+  SessionManager,
+  FileStorage,
+  type Snapshot,
+} from '@strands-agents/sdk'
+import type { Plugin } from '@strands-agents/sdk'
+
+declare const mcpClient: McpClient
+declare const statelessPlugin: Plugin
+declare const statefulPlugin: Plugin
 
 // Take snapshot example
 async function takeSnapshotExample() {
@@ -131,4 +142,60 @@ async function branchingExample() {
   await agent.invoke('Continue in a casual, conversational tone')
   const casualSnapshot = agent.takeSnapshot({ preset: 'session' })
   // --8<-- [end:branching]
+}
+
+// Basic clone
+function basicCloneExample() {
+  // --8<-- [start:clone_basic]
+  const template = new Agent({
+    model: 'global.anthropic.claude-sonnet-4-6',
+    systemPrompt: 'You are a helpful assistant',
+    tools: [mcpClient],
+  })
+
+  // Build a fresh agent wired up exactly like the template.
+  const clone = template.clone()
+  // --8<-- [end:clone_basic]
+  return clone
+}
+
+// Per-session isolation
+function clonePerSessionExample(sessionId: string) {
+  const template = new Agent({
+    model: 'global.anthropic.claude-sonnet-4-6',
+    tools: [mcpClient],
+  })
+  // --8<-- [start:clone_per_session]
+  // Each session gets its own SessionManager (otherwise all clones would
+  // share one session) and a disabled printer.
+  const perSession = template.clone({
+    overrides: {
+      sessionManager: new SessionManager({
+        sessionId,
+        storage: { snapshot: new FileStorage('./sessions') },
+      }),
+      printer: false,
+    },
+  })
+  // --8<-- [end:clone_per_session]
+  return perSession
+}
+
+// Stateful plugins: share vs isolate
+function clonePluginExample() {
+  // --8<-- [start:clone_plugins]
+  // A plugin in the template's constructor is shared across every clone —
+  // fine for stateless plugins.
+  const template = new Agent({
+    model: 'global.anthropic.claude-sonnet-4-6',
+    plugins: [statelessPlugin], // shared by all clones
+  })
+
+  // Give a clone its own plugin instance via additionalPlugins — use this for
+  // plugins that hold per-session mutable state.
+  const clone = template.clone({
+    additionalPlugins: [statefulPlugin],
+  })
+  // --8<-- [end:clone_plugins]
+  return clone
 }

--- a/strands-ts/src/agent/__tests__/agent.clone.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.clone.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Agent } from '../agent.js'
+import { McpClient } from '../../mcp.js'
+import { TestModelProvider } from '../../__fixtures__/model-test-helpers.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import { InitializedEvent } from '../../hooks/index.js'
+import type { Plugin } from '../../plugins/plugin.js'
+import type { LocalAgent } from '../../types/agent.js'
+import { Message } from '../../types/messages.js'
+
+/** A uniquely named plugin that flips `initialized` when it gets installed. */
+function makeNamedPlugin(name: string): Plugin & { initialized: boolean } {
+  const plugin = {
+    name,
+    initialized: false,
+    initAgent(agent: LocalAgent): void {
+      agent.addHook(InitializedEvent, () => {
+        plugin.initialized = true
+      })
+    },
+  }
+  return plugin
+}
+
+/**
+ * Build an object that passes `instanceof McpClient` whose `listTools` is a
+ * spy. `Agent.initialize()` only calls `listTools()` and assigns
+ * `onToolsChanged`, so that minimal surface is all the test needs.
+ */
+function makeFakeMcpClient(toolName: string): McpClient {
+  const tool = createMockTool(toolName, () => 'ok')
+  const client = Object.create(McpClient.prototype) as McpClient
+  Object.assign(client, { listTools: vi.fn(async () => [tool]) })
+  Object.defineProperty(client, 'onToolsChanged', {
+    configurable: true,
+    set: () => {},
+    get: () => undefined,
+  })
+  return client
+}
+
+describe('Agent.clone', () => {
+  it('replays the template config to build an independent fresh agent', () => {
+    const template = new Agent({
+      model: new TestModelProvider(),
+      tools: [],
+      name: 'tpl',
+      description: 'the template',
+      id: 'tpl-id',
+      systemPrompt: 'be helpful',
+      appState: { a: 1 },
+      modelState: { m: 2 },
+    })
+
+    const clone = template.clone()
+
+    expect(clone).toBeInstanceOf(Agent)
+    expect(clone).not.toBe(template)
+    // Single shape assertion so a field the clone drops (or carries with an
+    // unexpected value) fails the test — per TESTING.md "Object Assertion".
+    expect({
+      name: clone.name,
+      description: clone.description,
+      id: clone.id,
+      systemPrompt: clone.systemPrompt,
+      appState: clone.appState.getAll(),
+      modelState: clone.modelState.getAll(),
+    }).toEqual({
+      name: 'tpl',
+      description: 'the template',
+      id: 'tpl-id',
+      systemPrompt: 'be helpful',
+      appState: { a: 1 },
+      modelState: { m: 2 },
+    })
+    // Reference-identity check kept separate: the Model is intentionally
+    // shared with the template, not value-copied.
+    expect(clone.model).toBe(template.model)
+  })
+
+  it('does not carry runtime state (messages/appState mutations) into the clone', () => {
+    const template = new Agent({ model: new TestModelProvider(), tools: [], appState: { a: 1 } })
+
+    // Mutate the template's runtime state after construction.
+    template.messages.push(Message.fromMessageData({ role: 'user', content: [{ text: 'hi' }] }))
+    template.appState.set('a', 999)
+
+    const clone = template.clone()
+
+    // Clone reflects the original CONFIG, not the template's live state.
+    expect(clone.messages).toHaveLength(0)
+    expect(clone.appState.getAll()).toEqual({ a: 1 })
+    // Independent stores.
+    expect(clone.appState).not.toBe(template.appState)
+  })
+
+  it('seeds fresh state via overrides without mutating the template', () => {
+    const sm = { name: 'sm' } as never
+    const template = new Agent({ model: new TestModelProvider(), tools: [] })
+
+    const clone = template.clone({
+      overrides: {
+        printer: false,
+        appState: { seeded: true },
+        sessionManager: sm,
+      },
+    })
+
+    expect(clone.appState.getAll()).toEqual({ seeded: true })
+    expect(clone.sessionManager).toBe(sm)
+    expect(template.sessionManager).toBeUndefined()
+  })
+
+  it('appends additionalPlugins to the template plugins', async () => {
+    const basePlugin = makeNamedPlugin('base')
+    const extraPlugin = makeNamedPlugin('extra')
+    const template = new Agent({ model: new TestModelProvider(), tools: [], plugins: [basePlugin] })
+
+    const clone = template.clone({ additionalPlugins: [extraPlugin] })
+
+    // Both plugins should have been installed on the clone.
+    await clone.initialize()
+    expect(basePlugin.initialized).toBe(true)
+    expect(extraPlugin.initialized).toBe(true)
+  })
+
+  it('carries unconnected McpClient instances into the clone and resolves them lazily', async () => {
+    const client = makeFakeMcpClient('mcp_tool')
+    const localTool = createMockTool('local_tool', () => 'x')
+    const template = new Agent({
+      model: new TestModelProvider(),
+      tools: [localTool, client],
+      printer: false,
+    })
+
+    // The template was never initialized: its MCP tools are not resolved yet.
+    expect(client.listTools).not.toHaveBeenCalled()
+
+    const clone = template.clone({ overrides: { printer: false } })
+
+    // Cloning alone must not resolve MCP tools.
+    expect(client.listTools).not.toHaveBeenCalled()
+    // Before initialize the clone only knows the local tool.
+    expect(clone.tools.map((t) => t.name)).toEqual(['local_tool'])
+
+    // The clone resolves the SAME client on its own initialize() — no
+    // template.initialize() required.
+    await clone.initialize()
+    expect(client.listTools).toHaveBeenCalledTimes(1)
+    expect(clone.tools.map((t) => t.name).sort()).toEqual(['local_tool', 'mcp_tool'])
+  })
+
+  it('replaces plugins when overrides.plugins is supplied, then appends additionalPlugins', async () => {
+    const base = makeNamedPlugin('base')
+    const replacement = makeNamedPlugin('replacement')
+    const extra = makeNamedPlugin('extra')
+    const template = new Agent({ model: new TestModelProvider(), tools: [], plugins: [base] })
+
+    const clone = template.clone({
+      overrides: { plugins: [replacement] },
+      additionalPlugins: [extra],
+    })
+
+    await clone.initialize()
+    expect(base.initialized).toBe(false)
+    expect(replacement.initialized).toBe(true)
+    expect(extra.initialized).toBe(true)
+  })
+})

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -312,6 +312,30 @@ export type AgentConfig = {
 }
 
 /**
+ * Options for {@link Agent.clone}.
+ *
+ * A clone replays the template's original {@link AgentConfig} through the
+ * constructor. `overrides` are merged on top of that config (last-wins), and
+ * `additionalPlugins` are appended to the resulting plugin list (the template's,
+ * or `overrides.plugins` if that replaced it). Anything not overridden is taken
+ * from the template's config.
+ */
+export type AgentCloneOptions = {
+  /**
+   * Config fields to override on the clone. Merged over the template's original
+   * config, so e.g. `{ sessionManager }` swaps the session manager while leaving
+   * every other field as the template had it.
+   */
+  overrides?: Partial<AgentConfig>
+  /**
+   * Plugins to register on the clone in addition to the template's plugins.
+   * Use this for per-clone observability or policy plugins. Pass freshly built
+   * instances when a plugin holds mutable per-agent state.
+   */
+  additionalPlugins?: Plugin[]
+}
+
+/**
  * Resolve the contextManager facade into a concrete ConversationManager.
  *
  * When contextManager is undefined, falls back to the default SlidingWindowConversationManager.
@@ -484,10 +508,17 @@ export class Agent implements LocalAgent, InvokableAgent {
   private readonly _toolCaller: ToolCallerProxy
 
   /**
+   * The configuration this agent was constructed with, captured so {@link clone}
+   * can rebuild a fresh agent by replaying the constructor.
+   */
+  private readonly _config: AgentConfig
+
+  /**
    * Creates an instance of the Agent.
    * @param config - The configuration for the agent.
    */
   constructor(config?: AgentConfig) {
+    this._config = { ...config }
     // Initialize public fields
     this.messages = (config?.messages ?? []).map((msg) => (msg instanceof Message ? msg : Message.fromMessageData(msg)))
     this.appState = new StateStore(config?.appState)
@@ -1330,6 +1361,54 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   public loadSnapshot(snapshot: Snapshot): void {
     loadSnapshotInternal(this, snapshot)
+  }
+
+  /**
+   * Creates a fresh agent from this agent's original configuration.
+   *
+   * The clone is built by replaying the {@link AgentConfig} this agent was
+   * constructed with through the constructor — it is NOT a copy of this agent's
+   * current runtime state. Conversation history, accumulated model state, hook
+   * registrations made after construction, and in-flight invocation state are
+   * all absent from the clone. Override the initial `messages`/`appState`/
+   * `modelState` via `options.overrides` to seed the clone explicitly.
+   *
+   * The clone is constructed from the same config values, so any object passed
+   * in the original config — a `model`/`memoryManager` instance, `tools`,
+   * `sessionManager`, and any `plugins` not replaced — is reused by reference,
+   * shared with the template and across all clones unless overridden. (A
+   * `model` string or `memoryManager` config object is rebuilt fresh per clone,
+   * as in the constructor.) Sharing is intentional for stateless wiring like
+   * `model` and `tools` — it's what lets a clone resolve the template's MCP
+   * tools without re-connecting. But for per-session isolation, supply fresh
+   * instances: a `sessionManager` via `overrides` (otherwise every clone shares
+   * one session), and stateful plugins via `additionalPlugins`.
+   *
+   * @param options - Config overrides and additional plugins for the clone
+   * @returns A new, uninitialized {@link Agent}
+   *
+   * @example
+   * ```typescript
+   * const template = new Agent({ model, tools: [mcpClient] })
+   *
+   * // Per-thread clone with its own session and a disabled printer.
+   * const perThread = template.clone({
+   *   overrides: { sessionManager, printer: false },
+   * })
+   * ```
+   */
+  public clone(options?: AgentCloneOptions): Agent {
+    const { overrides, additionalPlugins } = options ?? {}
+    const config: AgentConfig = {
+      ...this._config,
+      ...overrides,
+    }
+    // `additionalPlugins` append to whichever plugin set survived the merge
+    // (the template's, or `overrides.plugins` if the caller replaced it).
+    if (additionalPlugins && additionalPlugins.length > 0) {
+      config.plugins = [...(config.plugins ?? []), ...additionalPlugins]
+    }
+    return new Agent(config)
   }
 
   /**

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -13,7 +13,7 @@ export { StateStore } from './state-store.js'
 
 // Agent types
 export { AgentResult } from './types/agent.js'
-export type { AgentConfig, ToolList, ToolExecutorStrategy } from './agent/agent.js'
+export type { AgentConfig, AgentCloneOptions, ToolList, ToolExecutorStrategy } from './agent/agent.js'
 export type { AgentAsToolOptions } from './agent/agent-as-tool.js'
 export type { ToolCaller, ToolCallerProxy, ToolHandle, DirectToolCallOptions } from './agent/tool-caller.js'
 export type { InvocationState, InvokeArgs, InvokeOptions, LocalAgent } from './types/agent.js'


### PR DESCRIPTION
## Description

Adds `Agent.clone(options?: AgentCloneOptions)` to the TypeScript SDK.

A clone is built by replaying the original `AgentConfig` through the constructor, merging `overrides` (last-wins) on top and appending `additionalPlugins`. The constructor now retains a shallow copy of its config so the replay carries the caller's original `tools` entries by reference.

**Motivation:** servers that serve many concurrent sessions from a single configured template `Agent` need an independent, fresh agent per session. Rebuilding such an agent from the template's *public* surface can't see unconnected `McpClient`s — those live in a private field and only resolve during `initialize()` — so the rebuilt agent silently misses MCP tools unless the template is initialized up front.

Concretely, the [CopilotKit + Strands quickstart](https://docs.showcase.copilotkit.ai/strands/quickstart) wraps a template `Agent` and serves it across conversation threads. Its code samples include a call to `agent.initialize()` on the template purely so per-thread agents pick up the template's MCP tools. With `clone()`, that step is no longer needed: because `clone()` replays the original config (which still holds the `McpClient` references), each clone resolves its MCP tools lazily on its own first `stream()` — the template never has to be initialized.

The clone replays **config, not live runtime state**: messages, accumulated model state, and post-construction hook registrations do not carry over. Seed those explicitly via `overrides`.

## Public API Changes

New method and options type on the public API:

```typescript
const template = new Agent({ model, tools: [mcpClient] });

// Per-thread clone with its own session and a disabled printer.
const perThread = template.clone({
  overrides: { sessionManager, printer: false },
  additionalPlugins: [myObservabilityPlugin],
});
```

`AgentCloneOptions` is exported from the package root.

## Use Cases

Multi-tenant / multi-session servers (AG-UI / CopilotKit adapters, A2A hosts) that hold one configured template `Agent` and need an independent, fresh agent per session — including full lazy MCP tool resolution — without mutating or pre-initializing the template.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

Added `strands-ts/src/agent/__tests__/agent.clone.test.ts` covering config replay, override merge precedence, plugin appending vs. replacement, runtime-state isolation, and lazy `McpClient` resolution on the clone (asserting the template stays uninitialized).

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
