### PR TITLE
docs(designs): add a reasoning bridge to the design doc template

### DIFF
--- a/team/designs/README.md
+++ b/team/designs/README.md
@@ -1,6 +1,6 @@
 # Design Documents
 
-This folder contains design documents for significant features and changes to Strands Agents. These documents capture the context, decision, and consequences of architectural choices.
+This folder contains design documents for significant features and changes to Strands Agents. These documents capture the problem, the proposal and the alternatives weighed against it, and the consequences of architectural choices.
 
 For lightweight architecture decision records, see [DECISIONS.md](../DECISIONS.md).
 
@@ -41,33 +41,63 @@ Skip the design process for bug fixes, small improvements, documentation updates
 
 **Issue**: Issue Link
 
-## Context
+## Problem
 
-What is the issue that we're seeing that is motivating this decision or change?
+In a few sentences, what is the issue motivating this change?
 
 - What task are you trying to accomplish?
 - What makes it difficult or impossible today?
 - Who experiences this problem?
 
-## Decision
+### Current State
 
-What is the change that we're proposing and/or doing?
+Now show *how* it's hard. Ground the reader in the existing system — how it works today and exactly where it falls short — before proposing to change it.
+
+- How is this handled now — the current API, flow, or workaround?
+- What concretely breaks, and where? Use examples, error messages, or numbers where you can.
+- What are the paper cuts — the small, recurring frictions that add up — not just the outright failures?
+- How often does this come up, and how costly is it when it does?
+
+## Goals and Non-Goals
+
+What are we optimizing for, and what is explicitly out of scope?
+
+- What does a good solution need to do?
+- What constraints does it operate under?
+- What is explicitly *not* being addressed here?
+
+## Proposal
+
+What are we proposing, and what else did we weigh? List the options on equal footing with their pros and cons, recommended one first, so the reader can see the choice was made by weighing tradeoffs rather than asserted.
+
+### Recommended: [name]
+
+What the change is:
 
 - Changes to the API (with code examples)
 - How it integrates with existing features
 - Expected behavior and usage patterns
 
+**Pros:** what this option gets right, including against the goals above.
+
+**Cons:** what it costs or gives up — every option, including this one, has some.
+
+### Alternative: [name]
+
+- What this option would look like
+- **Pros:** ...
+- **Cons:** ...
+- Why we didn't recommend it
+
+*If there's no genuine alternative — the design space is narrow or one approach clearly dominates — say so in a sentence rather than inventing a strawman. Still spell out the recommended option's own tradeoffs.*
+
 ## Developer Experience
 
-Show what the developer experience looks like:
+Show what the developer experience looks like for the recommended option:
 
 - Code examples showing typical usage
 - Configuration or setup required
 - Error messages and edge cases
-
-## Alternatives Considered
-
-What other approaches did you consider? Why did you choose this one?
 
 ## Consequences
 
@@ -79,6 +109,14 @@ Are you willing to implement this if approved?
 
 Yes / No / Maybe with guidance
 ```
+
+## Writing the document
+
+A few habits make these documents easier to review:
+
+- **Earn the code.** Don't show an API, snippet, or interface until the reader understands the problem it solves — work through Problem, Current State, and Goals first. Code shown before the reader knows what is even going on reads as a solution to an unstated problem, and reviewers end up reverse-engineering your intent from the syntax. By the time the first snippet appears in the Proposal, the reader should already know why it needs to exist.
+- **Lead with the rubric, not the verdict.** State the goals and constraints before the proposal, so the choice reads as reasoned rather than asserted.
+- **Weigh options honestly.** List alternatives on equal footing with real pros and cons, recommended one first, so the recommendation is earned by the tradeoffs rather than propped up by strawmen. If there's no genuine alternative, say so plainly instead of inventing one.
 
 ## Accepted Designs
 


### PR DESCRIPTION
## Description

Reworks the design document template in `team/designs/README.md` so the proposal lands as a conclusion the reader can evaluate, rather than an assertion they're given early on.

The previous template went straight from `## Context` to `## Decision`. After a short problem statement, the reader was given the answer with no intervening account of the goals or constraints that produced it. That ordering is borrowed from the ADR format, which suits a record of a decision already made; but this folder holds proposals under active review (see line 9 and the `Proposed` status), where the reasoning needs to set up the recommendation.

Changes:

- **Add a `### Current State` subsection to Context**, prompting authors for how the system works today and exactly where it breaks — concrete examples, error messages, frequency, and cost. This pushes the otherwise-generic Context toward the specifics that make a proposal feel necessary.
- **Insert `## Goals and Non-Goals`** between Context and the proposal, so the reader knows the rubric before the recommendation.
- **Rename `## Decision` → `## Proposal`** to match the fact that these documents are proposals under review, not records of settled decisions.
- **Keep `## Alternatives Considered` after the Proposal** (following Rust RFC / PEP / Oxide convention) and reword it to ask explicitly why the proposal was chosen over each alternative — alternatives read better as a justification of a proposal the reader has already seen than as a list they must hold in their head before the reveal.
- **Add a `## Writing the document` section** after the template with prose guidance on using it: *earn the code* (don't show an API or snippet until the reader understands the problem it solves), *lead with the rubric not the verdict*, and *justify by contrast*.
- Update the intro sentence to describe the new flow.

The resulting order is: Context (incl. Current State) → Goals and Non-Goals → Proposal → Developer Experience → Alternatives Considered → Consequences → Willingness to Implement.

## Related Issues

<!-- none -->

## Documentation PR

Not applicable — this changes contributor-facing process docs under `team/`, not the `site/` documentation.

## Type of Change

Documentation update

## Testing

Markdown-only change to a single template file under `team/`; no SDK code touched. Verified the rendered template reads top-to-bottom with the reasoning preceding the proposal, and confirmed no other files reference the removed/renamed headings as required structure.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
