### PR TITLE
docs(cedar): document namespace option

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -119,6 +119,35 @@ Pass your tool definitions to catch policy typos at construction time. The handl
 
 Schema validation integrates with the [`cedar-for-agents`](https://github.com/cedar-policy/cedar-for-agents) ecosystem via `@cedar-policy/mcp-schema-generator-wasm` (TypeScript) and `cedar-policy-mcp-schema-generator` (Python).
 
+## Namespaced policies
+
+When using policy generators like [`cedar-agent-policy-builder`](https://github.com/cedar-policy/cedar-for-agents) that produce namespaced Cedar policies (e.g. `Agent::Action::"search"` instead of `Action::"search"`), set the `namespace` option to match:
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:namespace_imports"
+
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:namespace"
+```
+</Tab>
+</Tabs>
+
+When `namespace` is set:
+
+| Cedar concept | Unnamespaced (default) | Namespaced (`namespace: 'Agent'`) |
+|---|---|---|
+| **Action** | `Action::"search"` | `Agent::Action::"search"` |
+| **Resource** | `Resource::"agent"` | `Agent::Resource::"default"` |
+| **Default principal** | `User::"anonymous"` | `Agent::User::"anonymous"` |
+
+Schema generation also uses the configured namespace, so `tools` and `namespace` work together correctly.
+
+:::note
+The `namespace` option is currently available in the TypeScript SDK only. Python support is planned.
+:::
+
 ## Environment gating
 
 Block tools based on deployment context by forwarding environment metadata through <Syntax py="context_enricher" ts="contextEnricher" />:

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
@@ -159,6 +159,39 @@ async function schemaValidationExample() {
   // --8<-- [end:schema_validation]
 }
 
+async function namespaceExample() {
+  // --8<-- [start:namespace]
+  const searchTool = tool({
+    name: 'search',
+    description: 'Search for information',
+    inputSchema: z.object({ query: z.string() }),
+    callback: (input) => `Results for: ${input.query}`,
+  })
+
+  const cedar = new CedarAuthorization({
+    namespace: 'Agent',
+    policies: `
+      permit(principal, action == Agent::Action::"search", resource);
+    `,
+    tools: [searchTool],
+    entities: [{ uid: { type: 'Agent::Resource', id: 'default' }, attrs: {}, parents: [] }],
+    principalResolver: (state) => {
+      if (!state.user_id) return undefined
+      return { type: 'Agent::User', id: String(state.user_id) }
+    },
+  })
+
+  const agent = new Agent({
+    tools: [searchTool],
+    interventions: [cedar],
+  })
+
+  await agent.invoke('Search for reports', {
+    invocationState: { user_id: 'alice' },
+  })
+  // --8<-- [end:namespace]
+}
+
 async function envGatingExample() {
   // --8<-- [start:env_gating]
   const deployTool = tool({
@@ -234,6 +267,7 @@ void basicExample
 void roleBasedExample
 void rateLimitExample
 void schemaValidationExample
+void namespaceExample
 void envGatingExample
 void filePoliciesExample
 void hotReloadExample

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization_imports.ts
@@ -24,6 +24,12 @@ import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/ced
 import { z } from 'zod'
 // --8<-- [end:schema_validation_imports]
 
+// --8<-- [start:namespace_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+import { z } from 'zod'
+// --8<-- [end:namespace_imports]
+
 // --8<-- [start:env_gating_imports]
 import { Agent, tool } from '@strands-agents/sdk'
 import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'


### PR DESCRIPTION
## Summary

This PR documents the `namespace` config option added to `CedarAuthorization` in #2896.

## Changes

- Adds a "Namespaced policies" section to the Cedar Authorization docs page
- Includes a TypeScript code example showing `namespace` + `tools` + `principalResolver` together
- Documents the type mapping table (namespaced vs non-namespaced)
- Notes that Python support is planned as a follow-up

## Context

Requested by @lizradway  on #2896;the new public option needed user-facing documentation.