### PR TITLE
feat(mcp): load MCP clients from mcpServers JSON config

### DIFF
--- a/strands-py/src/strands/experimental/__init__.py
+++ b/strands-py/src/strands/experimental/__init__.py
@@ -5,5 +5,6 @@ This module implements experimental features that are subject to change in futur
 
 from . import checkpoint, steering, tools
 from .agent_config import config_to_agent
+from .mcp_config import load_mcp_clients_from_config
 
-__all__ = ["checkpoint", "config_to_agent", "tools", "steering"]
+__all__ = ["checkpoint", "config_to_agent", "load_mcp_clients_from_config", "tools", "steering"]

--- a/strands-py/src/strands/experimental/agent_config.py
+++ b/strands-py/src/strands/experimental/agent_config.py
@@ -9,6 +9,12 @@ programmatic approach after creating the agent:
     agent = config_to_agent("config.json")
     # Add tools that need code-based instantiation
     agent.tool_registry.process_tools([ToolWithConfigArg(HttpsConnection("localhost"))])
+
+MCP servers can be declared with the ``mcp_servers`` field using the same per-server
+configuration accepted by :func:`strands.experimental.mcp_config.load_mcp_clients_from_config`
+(``command``/``url``, ``prefix``, ``tool_filters``, ``${env:VAR}`` interpolation, ``disabled``, etc.).
+Each enabled server is created as an ``MCPClient`` and appended to the agent's tools; the agent
+manages their lifecycle automatically.
 """
 
 import json
@@ -42,6 +48,15 @@ AGENT_CONFIG_SCHEMA = {
             "type": "array",
             "items": {"type": "string"},
             "default": [],
+        },
+        "mcp_servers": {
+            "description": "Mapping of MCP server name to its configuration. Each enabled server "
+            "is loaded as an MCPClient and added to the agent's tools. Uses the same per-server "
+            "schema as load_mcp_clients_from_config (command/url, prefix, tool_filters, env, "
+            "headers, disabled, ${env:VAR} interpolation).",
+            "type": "object",
+            "additionalProperties": {"type": "object"},
+            "default": {},
         },
     },
     "additionalProperties": False,
@@ -128,6 +143,20 @@ def config_to_agent(config: str | dict[str, Any], **kwargs: dict[str, Any]) -> A
     for config_key, agent_param in config_mapping.items():
         if config_key in config_dict and config_dict[config_key] is not None:
             agent_kwargs[agent_param] = config_dict[config_key]
+
+    # Build MCP clients from the ``mcp_servers`` field and append them to the tools list.
+    # MCPClient is a ToolProvider, so the agent connects/lists/tears down each server
+    # automatically. Done before kwargs.update so explicit ``tools=`` kwargs still win.
+    mcp_servers = config_dict.get("mcp_servers")
+    if mcp_servers:
+        # Reuse the standalone loader (validation, ${env:VAR} interpolation, transport
+        # detection, tool_filters, disabled-skip) by wrapping in the mcpServers envelope.
+        from .mcp_config import load_mcp_clients_from_config
+
+        mcp_clients = load_mcp_clients_from_config({"mcpServers": mcp_servers})
+        if mcp_clients:
+            existing_tools = agent_kwargs.get("tools") or []
+            agent_kwargs["tools"] = [*existing_tools, *mcp_clients]
 
     # Override with any additional kwargs provided
     agent_kwargs.update(kwargs)

--- a/strands-py/src/strands/experimental/mcp_config.py
+++ b/strands-py/src/strands/experimental/mcp_config.py
@@ -328,8 +328,8 @@ def load_mcp_clients_from_config(config: str | dict[str, Any]) -> list[MCPClient
     Raises:
         FileNotFoundError: If the config file does not exist.
         json.JSONDecodeError: If the config file contains invalid JSON.
-        ValueError: If the config format is invalid, a server config is invalid, or a
-            referenced environment variable is not set.
+        ValueError: If the config format is invalid, a server config is not a dictionary or is
+            invalid, or a referenced environment variable is not set.
 
     Examples:
         Load from a dictionary:
@@ -361,6 +361,8 @@ def load_mcp_clients_from_config(config: str | dict[str, Any]) -> list[MCPClient
     servers = config_dict["mcpServers"]
     clients: list[MCPClient] = []
     for server_name, server_config in servers.items():
+        if not isinstance(server_config, dict):
+            raise ValueError(f"server '{server_name}' configuration must be a dictionary")
         if server_config.get("disabled", False):
             logger.debug("server_name=<%s> | skipping disabled MCP server", server_name)
             continue

--- a/strands-py/src/strands/experimental/mcp_config.py
+++ b/strands-py/src/strands/experimental/mcp_config.py
@@ -1,0 +1,371 @@
+"""MCP server configuration parsing and MCPClient factory.
+
+This module handles parsing MCP server configurations from dictionaries or JSON files
+and creating MCPClient instances with the appropriate transport callables. It accepts the
+ecosystem-standard ``mcpServers`` wrapper format used by Claude Desktop, Cursor, and VS Code,
+so an existing config can be loaded directly.
+
+Supported transport types:
+
+- stdio: Local subprocess via stdin/stdout (auto-detected when 'command' is present)
+- sse: Server-Sent Events over HTTP (auto-detected when 'url' is present without explicit transport)
+- streamable-http: Streamable HTTP transport
+
+Two ergonomic features keep secrets out of committed config files and make paths portable:
+
+- ``${env:VAR}`` interpolation in string values is replaced with the value of the ``VAR``
+  environment variable, so tokens and other secrets can stay in the environment.
+- ``~`` in the ``command`` and ``cwd`` paths is expanded to the user's home directory.
+
+Example::
+
+    {
+        "mcpServers": {
+            "aws_docs": {
+                "command": "~/bin/uvx",
+                "args": ["awslabs.aws-documentation-mcp-server@latest"],
+                "prefix": "aws"
+            },
+            "remote": {
+                "url": "https://example.com/sse",
+                "headers": {"Authorization": "Bearer ${env:MCP_TOKEN}"}
+            },
+            "legacy": {
+                "command": "old-server",
+                "disabled": true
+            }
+        }
+    }
+"""
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+from jsonschema import ValidationError
+from mcp import StdioServerParameters
+from mcp.client.sse import sse_client
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+
+from ..tools.mcp.mcp_client import MCPClient, ToolFilters
+
+logger = logging.getLogger(__name__)
+
+# Matches ${env:VAR_NAME} where VAR_NAME is a valid environment variable identifier.
+_ENV_VAR_PATTERN = re.compile(r"\$\{env:([A-Za-z_][A-Za-z0-9_]*)\}")
+
+MCP_SERVER_CONFIG_SCHEMA: dict[str, Any] = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MCP Server Configuration",
+    "description": "Configuration for a single MCP server.",
+    "type": "object",
+    "properties": {
+        "transport": {
+            "description": "Transport type. Auto-detected from 'command' (stdio) or 'url' (sse) if omitted.",
+            "type": "string",
+            "enum": ["stdio", "sse", "streamable-http"],
+        },
+        "command": {"description": "Command to run for stdio transport.", "type": "string"},
+        "args": {
+            "description": "Arguments for the stdio command.",
+            "type": "array",
+            "items": {"type": "string"},
+            "default": [],
+        },
+        "env": {
+            "description": "Environment variables for the stdio command.",
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+        "cwd": {"description": "Working directory for the stdio command.", "type": "string"},
+        "url": {"description": "URL for sse or streamable-http transport.", "type": "string"},
+        "headers": {
+            "description": "HTTP headers for sse or streamable-http transport.",
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+        "prefix": {"description": "Prefix to apply to tool names from this server.", "type": "string"},
+        "disabled": {
+            "description": "When true, the server is skipped and no client is created for it.",
+            "type": "boolean",
+            "default": False,
+        },
+        "startup_timeout": {
+            "description": "Timeout in seconds for server initialization. Defaults to 30.",
+            "type": "integer",
+            "default": 30,
+        },
+        "tool_filters": {
+            "description": "Filters for controlling which tools are loaded.",
+            "type": "object",
+            "properties": {
+                "allowed": {
+                    "description": "List of regex patterns for tools to include.",
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "rejected": {
+                    "description": "List of regex patterns for tools to exclude.",
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+            "additionalProperties": False,
+        },
+    },
+    "additionalProperties": False,
+}
+
+_SERVER_VALIDATOR = jsonschema.Draft7Validator(MCP_SERVER_CONFIG_SCHEMA)
+
+
+def _interpolate_env_vars(value: Any) -> Any:
+    """Recursively replace ``${env:VAR}`` references in string values with environment variables.
+
+    Strings, and the strings nested inside lists and dictionaries, are interpolated. Other
+    value types are returned unchanged.
+
+    Args:
+        value: A configuration value (string, list, dict, or scalar) to interpolate.
+
+    Returns:
+        The value with all ``${env:VAR}`` references replaced by their environment values.
+
+    Raises:
+        ValueError: If a referenced environment variable is not set.
+    """
+    if isinstance(value, str):
+
+        def _replace(match: re.Match[str]) -> str:
+            var_name = match.group(1)
+            if var_name not in os.environ:
+                raise ValueError(f"environment variable '{var_name}' referenced by '${{env:{var_name}}}' is not set")
+            return os.environ[var_name]
+
+        return _ENV_VAR_PATTERN.sub(_replace, value)
+    if isinstance(value, list):
+        return [_interpolate_env_vars(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _interpolate_env_vars(item) for key, item in value.items()}
+    return value
+
+
+def _parse_tool_filters(config: dict[str, Any] | None) -> ToolFilters | None:
+    """Parse a tool filter configuration into a ToolFilters instance.
+
+    All filter strings are compiled as regex patterns and matched using ``re.match``
+    (prefix match from start of string). Use ``"^echo$"`` for exact matching.
+    ``"echo"`` will match any tool name starting with "echo" (e.g. "echo_extra").
+
+    Args:
+        config: Tool filter configuration dict with 'allowed' and/or 'rejected' lists,
+            or None.
+
+    Returns:
+        A ToolFilters instance, or None if config is None or empty.
+
+    Raises:
+        ValueError: If a filter string is not a valid regex pattern.
+    """
+    if not config:
+        return None
+
+    result: ToolFilters = {}
+
+    if "allowed" in config:
+        allowed: list[Any] = []
+        for pattern_str in config["allowed"]:
+            try:
+                allowed.append(re.compile(pattern_str))
+            except re.error as e:
+                raise ValueError(f"invalid regex pattern in tool_filters.allowed: '{pattern_str}': {e}") from e
+        result["allowed"] = allowed
+
+    if "rejected" in config:
+        rejected: list[Any] = []
+        for pattern_str in config["rejected"]:
+            try:
+                rejected.append(re.compile(pattern_str))
+            except re.error as e:
+                raise ValueError(f"invalid regex pattern in tool_filters.rejected: '{pattern_str}': {e}") from e
+        result["rejected"] = rejected
+
+    return result if result else None
+
+
+def _create_mcp_client_from_config(server_name: str, config: dict[str, Any]) -> MCPClient:
+    """Create an MCPClient instance from a server configuration dictionary.
+
+    Before validation, ``${env:VAR}`` references in string values are replaced with the
+    corresponding environment variables, and ``~`` in the ``command`` and ``cwd`` paths is
+    expanded to the user's home directory.
+
+    Transport type is auto-detected based on the presence of 'command' (stdio) or 'url' (sse),
+    unless explicitly specified via the 'transport' field.
+
+    Args:
+        server_name: Name of the server (used in error messages).
+        config: Server configuration dictionary.
+
+    Returns:
+        A configured MCPClient instance.
+
+    Raises:
+        ValueError: If the configuration is invalid, missing required fields, or references
+            an environment variable that is not set.
+    """
+    # Resolve ${env:VAR} references before validation so secrets can live in the environment.
+    config = _interpolate_env_vars(config)
+
+    # Validate against schema
+    try:
+        _SERVER_VALIDATOR.validate(config)
+    except ValidationError as e:
+        error_path = " -> ".join(str(p) for p in e.absolute_path) if e.absolute_path else "root"
+        raise ValueError(f"server '{server_name}' configuration validation error at {error_path}: {e.message}") from e
+
+    # Determine transport type
+    transport = config.get("transport")
+    command = config.get("command")
+    url = config.get("url")
+
+    if transport is None:
+        if command:
+            transport = "stdio"
+        elif url:
+            transport = "sse"
+        else:
+            raise ValueError(
+                f"server '{server_name}' must specify either 'command' (for stdio) or 'url' (for sse/http)"
+            )
+
+    # Extract common MCPClient parameters
+    prefix = config.get("prefix")
+    startup_timeout = config.get("startup_timeout", 30)
+    tool_filters = _parse_tool_filters(config.get("tool_filters"))
+
+    # Build transport callable based on type
+    if transport == "stdio":
+        if not command:
+            raise ValueError(f"server '{server_name}': 'command' is required for stdio transport")
+        # Expand ~ in filesystem paths so configs are portable across machines.
+        command = os.path.expanduser(command)
+        cwd = config.get("cwd")
+        if cwd is not None:
+            cwd = os.path.expanduser(cwd)
+        args = config.get("args", [])
+        env = config.get("env")
+
+        def _stdio_transport() -> Any:
+            params = StdioServerParameters(command=command, args=args, env=env, cwd=cwd)
+            return stdio_client(params)
+
+        transport_callable = _stdio_transport
+    elif transport == "sse":
+        if not url:
+            raise ValueError(f"server '{server_name}': 'url' is required for sse transport")
+        headers = config.get("headers")
+
+        def _sse_transport() -> Any:
+            return sse_client(url=url, headers=headers)
+
+        transport_callable = _sse_transport
+    elif transport == "streamable-http":
+        if not url:
+            raise ValueError(f"server '{server_name}': 'url' is required for streamable-http transport")
+        headers = config.get("headers")
+
+        def _streamable_http_transport() -> Any:
+            return streamablehttp_client(url=url, headers=headers)
+
+        transport_callable = _streamable_http_transport
+    else:
+        raise ValueError(f"server '{server_name}': unsupported transport type '{transport}'")
+
+    logger.debug(
+        "server_name=<%s>, transport=<%s> | creating MCP client from config",
+        server_name,
+        transport,
+    )
+
+    return MCPClient(
+        transport_callable,
+        startup_timeout=startup_timeout,
+        tool_filters=tool_filters,
+        prefix=prefix,
+    )
+
+
+def load_mcp_clients_from_config(config: str | dict[str, Any]) -> list[MCPClient]:
+    """Load MCP client instances from a configuration file or dictionary.
+
+    Expects the standard ``mcpServers`` wrapper format used by Claude Desktop, Cursor,
+    VS Code, etc::
+
+        {
+            "mcpServers": {
+                "server_name": { "command": "...", ... }
+            }
+        }
+
+    String values support ``${env:VAR}`` interpolation (replaced with the value of the ``VAR``
+    environment variable), and ``~`` in the ``command`` and ``cwd`` paths is expanded to the
+    user's home directory. Servers marked ``"disabled": true`` are skipped.
+
+    Args:
+        config: Either a file path (with optional file:// prefix) to a JSON config file,
+            or a dictionary with a ``mcpServers`` key mapping server names to configs.
+
+    Returns:
+        A list of MCPClient instances, one per enabled server. Pass it directly to an agent
+        with ``Agent(tools=clients)``.
+
+    Raises:
+        FileNotFoundError: If the config file does not exist.
+        json.JSONDecodeError: If the config file contains invalid JSON.
+        ValueError: If the config format is invalid, a server config is invalid, or a
+            referenced environment variable is not set.
+
+    Examples:
+        Load from a dictionary:
+        >>> clients = load_mcp_clients_from_config({"mcpServers": {"echo": {"command": "echo"}}})
+
+        Load from a file and build an agent:
+        >>> clients = load_mcp_clients_from_config("mcp.json")
+        >>> agent = Agent(tools=clients)
+    """
+    if isinstance(config, str):
+        file_path = config
+        if file_path.startswith("file://"):
+            file_path = file_path[7:]
+
+        config_path = Path(file_path)
+        if not config_path.exists():
+            raise FileNotFoundError(f"MCP configuration file not found: {file_path}")
+
+        with open(config_path) as f:
+            config_dict: dict[str, Any] = json.load(f)
+    elif isinstance(config, dict):
+        config_dict = config
+    else:
+        raise ValueError("Config must be a file path string or dictionary")
+
+    if "mcpServers" not in config_dict or not isinstance(config_dict["mcpServers"], dict):
+        raise ValueError("Config must contain an 'mcpServers' key with a dictionary of server configurations")
+
+    servers = config_dict["mcpServers"]
+    clients: list[MCPClient] = []
+    for server_name, server_config in servers.items():
+        if server_config.get("disabled", False):
+            logger.debug("server_name=<%s> | skipping disabled MCP server", server_name)
+            continue
+        clients.append(_create_mcp_client_from_config(server_name, server_config))
+
+    logger.debug("loaded_servers=<%d> | MCP clients created from config", len(clients))
+
+    return clients

--- a/strands-py/src/strands/experimental/mcp_config.py
+++ b/strands-py/src/strands/experimental/mcp_config.py
@@ -162,6 +162,12 @@ def _parse_tool_filters(config: dict[str, Any] | None) -> ToolFilters | None:
     (prefix match from start of string). Use ``"^echo$"`` for exact matching.
     ``"echo"`` will match any tool name starting with "echo" (e.g. "echo_extra").
 
+    Note:
+        Filters are matched against the **server-side (unprefixed)** tool name. The
+        ``prefix`` is applied *after* filtering, so a server tool ``echo`` exposed with
+        ``prefix="cfg"`` (final name ``cfg_echo``) is selected by the pattern ``"^echo$"``,
+        not ``"^cfg_echo$"``.
+
     Args:
         config: Tool filter configuration dict with 'allowed' and/or 'rejected' lists,
             or None.
@@ -316,6 +322,9 @@ def load_mcp_clients_from_config(config: str | dict[str, Any]) -> list[MCPClient
     String values support ``${env:VAR}`` interpolation (replaced with the value of the ``VAR``
     environment variable), and ``~`` in the ``command`` and ``cwd`` paths is expanded to the
     user's home directory. Servers marked ``"disabled": true`` are skipped.
+
+    ``tool_filters`` patterns match the server-side (unprefixed) tool name; ``prefix`` is
+    applied afterwards.
 
     Args:
         config: Either a file path (with optional file:// prefix) to a JSON config file,

--- a/strands-py/tests/strands/experimental/test_agent_config.py
+++ b/strands-py/tests/strands/experimental/test_agent_config.py
@@ -170,3 +170,133 @@ def test_config_to_agent_with_tool():
     config = {"model": "test-model", "tools": ["tests.fixtures.say_tool:say"]}
     agent = config_to_agent(config)
     assert "say" in agent.tool_names
+
+
+def test_config_to_agent_with_mcp_servers_adds_clients(monkeypatch):
+    """mcp_servers entries are loaded as MCPClient instances and added to the agent's tools."""
+    captured = {}
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    # Patch the Agent imported lazily inside config_to_agent.
+    monkeypatch.setattr("strands.agent.Agent", _FakeAgent)
+
+    config = {
+        "model": "test-model",
+        "mcp_servers": {
+            "echo": {"command": "python", "args": ["echo_server.py"], "prefix": "echo"},
+            "remote": {"url": "https://example.com/sse"},
+        },
+    }
+
+    config_to_agent(config)
+
+    from strands.tools.mcp import MCPClient
+
+    tools = captured.get("tools", [])
+    assert len(tools) == 2
+    assert all(isinstance(t, MCPClient) for t in tools)
+
+
+def test_config_to_agent_mcp_servers_appended_after_regular_tools(monkeypatch):
+    """MCP clients are appended after declaratively loaded tools, preserving order."""
+    captured = {}
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("strands.agent.Agent", _FakeAgent)
+
+    config = {
+        "model": "test-model",
+        "tools": ["tests.fixtures.say_tool:say"],
+        "mcp_servers": {"echo": {"command": "python", "args": ["echo_server.py"]}},
+    }
+
+    config_to_agent(config)
+
+    from strands.tools.mcp import MCPClient
+
+    tools = captured.get("tools", [])
+    assert len(tools) == 2
+    # Regular tool first, MCP client appended last.
+    assert isinstance(tools[-1], MCPClient)
+
+
+def test_config_to_agent_mcp_servers_skips_disabled(monkeypatch):
+    """Servers marked disabled produce no client."""
+    captured = {}
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("strands.agent.Agent", _FakeAgent)
+
+    config = {
+        "model": "test-model",
+        "mcp_servers": {
+            "echo": {"command": "python", "args": ["echo_server.py"]},
+            "legacy": {"command": "old-server", "disabled": True},
+        },
+    }
+
+    config_to_agent(config)
+
+    from strands.tools.mcp import MCPClient
+
+    tools = captured.get("tools", [])
+    assert len(tools) == 1
+    assert isinstance(tools[0], MCPClient)
+
+
+def test_config_to_agent_mcp_servers_env_interpolation(monkeypatch):
+    """${env:VAR} references in mcp_servers config are resolved via the shared loader."""
+    captured = {}
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("strands.agent.Agent", _FakeAgent)
+    monkeypatch.setenv("MCP_TEST_TOKEN", "secret-value")
+
+    config = {
+        "model": "test-model",
+        "mcp_servers": {
+            "remote": {
+                "url": "https://example.com/sse",
+                "headers": {"Authorization": "Bearer ${env:MCP_TEST_TOKEN}"},
+            }
+        },
+    }
+
+    # Should not raise; missing env var would raise ValueError.
+    config_to_agent(config)
+    from strands.tools.mcp import MCPClient
+
+    assert len(captured.get("tools", [])) == 1
+    assert isinstance(captured["tools"][0], MCPClient)
+
+
+def test_config_to_agent_mcp_servers_invalid_server_config(monkeypatch):
+    """An invalid per-server config surfaces a clear error with the server name."""
+    monkeypatch.setattr("strands.agent.Agent", lambda **kwargs: None)
+
+    config = {
+        "model": "test-model",
+        "mcp_servers": {"broken": {"unknown_field": "x"}},
+    }
+
+    with pytest.raises(ValueError, match="broken"):
+        config_to_agent(config)
+
+
+def test_config_to_agent_mcp_servers_wrong_type():
+    """mcp_servers must be an object/dict, not a list."""
+    config = {"model": "test-model", "mcp_servers": ["not", "a", "dict"]}
+    with pytest.raises(ValueError, match="Configuration validation error"):
+        config_to_agent(config)

--- a/strands-py/tests/strands/experimental/test_mcp_config.py
+++ b/strands-py/tests/strands/experimental/test_mcp_config.py
@@ -394,3 +394,8 @@ class TestLoadMcpClientsFromConfig:
         config = {"mcpServers": {"bad_server": {"transport": "invalid"}}}
         with pytest.raises(ValueError, match="bad_server"):
             load_mcp_clients_from_config(config)
+
+    def test_non_dict_server_config_raises_clear_error(self):
+        config = {"mcpServers": {"bad": "not-a-dict"}}
+        with pytest.raises(ValueError, match="server 'bad' configuration must be a dictionary"):
+            load_mcp_clients_from_config(config)

--- a/strands-py/tests/strands/experimental/test_mcp_config.py
+++ b/strands-py/tests/strands/experimental/test_mcp_config.py
@@ -1,0 +1,396 @@
+"""Tests for MCP config parsing and MCPClient factory."""
+
+import json
+import os
+import re
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands.experimental.mcp_config import (
+    _create_mcp_client_from_config,
+    _interpolate_env_vars,
+    _parse_tool_filters,
+    load_mcp_clients_from_config,
+)
+
+
+class TestInterpolateEnvVars:
+    """Tests for _interpolate_env_vars function."""
+
+    def test_returns_non_string_scalars_unchanged(self):
+        assert _interpolate_env_vars(30) == 30
+        assert _interpolate_env_vars(True) is True
+        assert _interpolate_env_vars(None) is None
+
+    def test_string_without_reference_unchanged(self):
+        assert _interpolate_env_vars("plain value") == "plain value"
+
+    def test_replaces_single_reference(self, monkeypatch):
+        monkeypatch.setenv("MY_TOKEN", "secret123")
+        assert _interpolate_env_vars("Bearer ${env:MY_TOKEN}") == "Bearer secret123"
+
+    def test_replaces_multiple_references(self, monkeypatch):
+        monkeypatch.setenv("HOST", "localhost")
+        monkeypatch.setenv("PORT", "8000")
+        assert _interpolate_env_vars("http://${env:HOST}:${env:PORT}/sse") == "http://localhost:8000/sse"
+
+    def test_interpolates_inside_list(self, monkeypatch):
+        monkeypatch.setenv("ARG", "value")
+        assert _interpolate_env_vars(["--flag", "${env:ARG}"]) == ["--flag", "value"]
+
+    def test_interpolates_inside_dict(self, monkeypatch):
+        monkeypatch.setenv("TOKEN", "abc")
+        result = _interpolate_env_vars({"headers": {"Authorization": "Bearer ${env:TOKEN}"}})
+        assert result == {"headers": {"Authorization": "Bearer abc"}}
+
+    def test_missing_env_var_raises_error(self, monkeypatch):
+        monkeypatch.delenv("DOES_NOT_EXIST", raising=False)
+        with pytest.raises(ValueError, match="environment variable 'DOES_NOT_EXIST'.*is not set"):
+            _interpolate_env_vars("${env:DOES_NOT_EXIST}")
+
+
+class TestParseToolFilters:
+    """Tests for _parse_tool_filters function."""
+
+    def test_returns_none_for_none_input(self):
+        assert _parse_tool_filters(None) is None
+
+    def test_returns_none_for_empty_dict(self):
+        assert _parse_tool_filters({}) is None
+
+    def test_compiles_allowed_patterns(self):
+        config = {"allowed": ["echo", "search"]}
+        result = _parse_tool_filters(config)
+        assert result is not None
+        assert len(result["allowed"]) == 2
+        assert isinstance(result["allowed"][0], re.Pattern)
+        assert result["allowed"][0].match("echo")
+
+    def test_compiles_rejected_patterns(self):
+        config = {"rejected": ["dangerous_tool"]}
+        result = _parse_tool_filters(config)
+        assert result is not None
+        assert isinstance(result["rejected"][0], re.Pattern)
+        assert result["rejected"][0].match("dangerous_tool")
+
+    def test_compiles_regex_patterns(self):
+        config = {"allowed": ["search_.*", "get_\\w+"]}
+        result = _parse_tool_filters(config)
+        assert result is not None
+        assert result["allowed"][0].match("search_docs")
+        assert result["allowed"][1].match("get_data")
+
+    def test_mixed_allowed_and_rejected(self):
+        config = {"allowed": ["search_.*"], "rejected": ["dangerous_tool"]}
+        result = _parse_tool_filters(config)
+        assert result is not None
+        assert "allowed" in result
+        assert "rejected" in result
+
+    def test_invalid_regex_raises_error(self):
+        config = {"allowed": ["[invalid"]}
+        with pytest.raises(ValueError, match="invalid regex pattern"):
+            _parse_tool_filters(config)
+
+    def test_invalid_rejected_regex_raises_error(self):
+        config = {"rejected": ["(unclosed"]}
+        with pytest.raises(ValueError, match="invalid regex pattern in tool_filters.rejected"):
+            _parse_tool_filters(config)
+
+
+class TestCreateMcpClientFromConfig:
+    """Tests for _create_mcp_client_from_config function."""
+
+    @patch("strands.experimental.mcp_config.stdio_client")
+    @patch("strands.experimental.mcp_config.StdioServerParameters")
+    def test_stdio_transport_from_command(self, mock_params_cls, mock_stdio_client):
+        config = {"command": "uvx", "args": ["some-server@latest"]}
+        mock_params_cls.return_value = MagicMock()
+        client = _create_mcp_client_from_config("test_server", config)
+        assert client is not None
+
+    @patch("strands.experimental.mcp_config.sse_client")
+    def test_sse_transport_explicit(self, mock_sse_client):
+        config = {"transport": "sse", "url": "http://localhost:8000/sse"}
+        client = _create_mcp_client_from_config("test_server", config)
+        assert client is not None
+
+    @patch("strands.experimental.mcp_config.streamablehttp_client")
+    def test_streamable_http_transport_explicit(self, mock_http_client):
+        config = {"transport": "streamable-http", "url": "http://localhost:8000/mcp"}
+        client = _create_mcp_client_from_config("test_server", config)
+        assert client is not None
+
+    @patch("strands.experimental.mcp_config.sse_client")
+    def test_url_without_transport_defaults_to_sse(self, mock_sse_client):
+        config = {"url": "http://localhost:8000/sse"}
+        client = _create_mcp_client_from_config("test_server", config)
+        assert client is not None
+
+    def test_prefix_passed_to_mcp_client(self):
+        config = {"command": "echo", "prefix": "myprefix"}
+        with (
+            patch("strands.experimental.mcp_config.stdio_client"),
+            patch("strands.experimental.mcp_config.StdioServerParameters"),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            _create_mcp_client_from_config("test_server", config)
+            assert mock_mcp_client.call_args[1]["prefix"] == "myprefix"
+
+    def test_startup_timeout_passed_to_mcp_client(self):
+        config = {"command": "echo", "startup_timeout": 60}
+        with (
+            patch("strands.experimental.mcp_config.stdio_client"),
+            patch("strands.experimental.mcp_config.StdioServerParameters"),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            _create_mcp_client_from_config("test_server", config)
+            assert mock_mcp_client.call_args[1]["startup_timeout"] == 60
+
+    def test_tool_filters_passed_to_mcp_client(self):
+        config = {"command": "echo", "tool_filters": {"allowed": ["echo"], "rejected": ["dangerous_.*"]}}
+        with (
+            patch("strands.experimental.mcp_config.stdio_client"),
+            patch("strands.experimental.mcp_config.StdioServerParameters"),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            _create_mcp_client_from_config("test_server", config)
+            tool_filters = mock_mcp_client.call_args[1]["tool_filters"]
+            assert "allowed" in tool_filters
+            assert "rejected" in tool_filters
+
+    def test_stdio_params_include_args_env(self, monkeypatch):
+        config = {"command": "echo", "args": ["hi"], "env": {"KEY": "val"}}
+        captured = {}
+
+        def fake_params(command, args, env, cwd):
+            captured.update(command=command, args=args, env=env, cwd=cwd)
+            return MagicMock()
+
+        with (
+            patch("strands.experimental.mcp_config.StdioServerParameters", side_effect=fake_params),
+            patch("strands.experimental.mcp_config.stdio_client"),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            _create_mcp_client_from_config("test_server", config)
+            mock_mcp_client.call_args[0][0]()
+        assert captured == {"command": "echo", "args": ["hi"], "env": {"KEY": "val"}, "cwd": None}
+
+    def test_env_interpolation_in_headers(self, monkeypatch):
+        monkeypatch.setenv("MCP_TOKEN", "secret-xyz")
+        config = {
+            "transport": "sse",
+            "url": "http://localhost:8000/sse",
+            "headers": {"Authorization": "${env:MCP_TOKEN}"},
+        }
+        captured = {}
+
+        def fake_sse(url, headers):
+            captured["url"] = url
+            captured["headers"] = headers
+            return MagicMock()
+
+        with (
+            patch("strands.experimental.mcp_config.sse_client", side_effect=fake_sse),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            _create_mcp_client_from_config("test_server", config)
+            # Invoke the transport callable to observe interpolated values
+            mock_mcp_client.call_args[0][0]()
+        assert captured["headers"]["Authorization"] == "secret-xyz"
+
+    def test_env_interpolation_missing_var_raises(self, monkeypatch):
+        monkeypatch.delenv("ABSENT_TOKEN", raising=False)
+        config = {"transport": "sse", "url": "http://x/sse", "headers": {"Authorization": "${env:ABSENT_TOKEN}"}}
+        with pytest.raises(ValueError, match="ABSENT_TOKEN.*is not set"):
+            _create_mcp_client_from_config("test_server", config)
+
+    def test_tilde_expansion_in_command(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/home/testuser")
+        config = {"command": "~/bin/server"}
+        captured = {}
+
+        def fake_params(command, args, env, cwd):
+            captured["command"] = command
+            captured["cwd"] = cwd
+            return MagicMock()
+
+        with (
+            patch("strands.experimental.mcp_config.StdioServerParameters", side_effect=fake_params),
+            patch("strands.experimental.mcp_config.stdio_client"),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            _create_mcp_client_from_config("test_server", config)
+            mock_mcp_client.call_args[0][0]()
+        assert captured["command"] == "/home/testuser/bin/server"
+
+    def test_tilde_expansion_in_cwd(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/home/testuser")
+        config = {"command": "server", "cwd": "~/workdir"}
+        captured = {}
+
+        def fake_params(command, args, env, cwd):
+            captured["cwd"] = cwd
+            return MagicMock()
+
+        with (
+            patch("strands.experimental.mcp_config.StdioServerParameters", side_effect=fake_params),
+            patch("strands.experimental.mcp_config.stdio_client"),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            _create_mcp_client_from_config("test_server", config)
+            mock_mcp_client.call_args[0][0]()
+        assert captured["cwd"] == "/home/testuser/workdir"
+
+    def test_missing_command_and_url_raises_error(self):
+        config = {"prefix": "test"}
+        with pytest.raises(ValueError, match="must specify either 'command'.*or 'url'"):
+            _create_mcp_client_from_config("test_server", config)
+
+    def test_missing_url_for_sse_raises_error(self):
+        config = {"transport": "sse"}
+        with pytest.raises(ValueError, match="'url' is required"):
+            _create_mcp_client_from_config("test_server", config)
+
+    def test_missing_url_for_streamable_http_raises_error(self):
+        config = {"transport": "streamable-http"}
+        with pytest.raises(ValueError, match="'url' is required"):
+            _create_mcp_client_from_config("test_server", config)
+
+    @patch("strands.experimental.mcp_config.streamablehttp_client")
+    def test_streamable_http_transport_callable_invoked(self, mock_http_client):
+        config = {"transport": "streamable-http", "url": "http://localhost:8000/mcp", "headers": {"X-Key": "v"}}
+        with patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client:
+            _create_mcp_client_from_config("test_server", config)
+            mock_mcp_client.call_args[0][0]()
+        mock_http_client.assert_called_once_with(url="http://localhost:8000/mcp", headers={"X-Key": "v"})
+
+    def test_invalid_transport_raises_error(self):
+        config = {"transport": "websocket", "url": "ws://localhost:8000"}
+        with pytest.raises(ValueError, match="configuration validation error"):
+            _create_mcp_client_from_config("test_server", config)
+
+    def test_invalid_startup_timeout_type_raises_error(self):
+        config = {"command": "echo", "startup_timeout": "30"}
+        with pytest.raises(ValueError, match="configuration validation error"):
+            _create_mcp_client_from_config("test_server", config)
+
+
+class TestLoadMcpClientsFromConfig:
+    """Tests for load_mcp_clients_from_config function."""
+
+    def test_load_from_dict(self):
+        config = {
+            "mcpServers": {
+                "server1": {"command": "echo", "args": []},
+                "server2": {"command": "cat", "args": []},
+            }
+        }
+        with (
+            patch("strands.experimental.mcp_config.stdio_client"),
+            patch("strands.experimental.mcp_config.StdioServerParameters"),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            mock_mcp_client.return_value = MagicMock()
+            clients = load_mcp_clients_from_config(config)
+            assert len(clients) == 2
+
+    def test_load_from_json_file(self):
+        config_data = {"mcpServers": {"my_server": {"command": "echo", "args": ["hello"]}}}
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+                json.dump(config_data, f)
+                temp_path = f.name
+            with (
+                patch("strands.experimental.mcp_config.stdio_client"),
+                patch("strands.experimental.mcp_config.StdioServerParameters"),
+                patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+            ):
+                mock_mcp_client.return_value = MagicMock()
+                clients = load_mcp_clients_from_config(temp_path)
+                assert len(clients) == 1
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def test_load_from_file_uri(self):
+        config_data = {"mcpServers": {"my_server": {"command": "echo"}}}
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+                json.dump(config_data, f)
+                temp_path = f.name
+            with (
+                patch("strands.experimental.mcp_config.stdio_client"),
+                patch("strands.experimental.mcp_config.StdioServerParameters"),
+                patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+            ):
+                mock_mcp_client.return_value = MagicMock()
+                clients = load_mcp_clients_from_config(f"file://{temp_path}")
+                assert len(clients) == 1
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def test_disabled_server_is_skipped(self):
+        config = {
+            "mcpServers": {
+                "active": {"command": "echo"},
+                "inactive": {"command": "cat", "disabled": True},
+            }
+        }
+        with (
+            patch("strands.experimental.mcp_config.stdio_client"),
+            patch("strands.experimental.mcp_config.StdioServerParameters"),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            mock_mcp_client.return_value = MagicMock()
+            clients = load_mcp_clients_from_config(config)
+            assert len(clients) == 1
+
+    def test_disabled_false_is_loaded(self):
+        config = {"mcpServers": {"active": {"command": "echo", "disabled": False}}}
+        with (
+            patch("strands.experimental.mcp_config.stdio_client"),
+            patch("strands.experimental.mcp_config.StdioServerParameters"),
+            patch("strands.experimental.mcp_config.MCPClient") as mock_mcp_client,
+        ):
+            mock_mcp_client.return_value = MagicMock()
+            clients = load_mcp_clients_from_config(config)
+            assert len(clients) == 1
+
+    def test_file_not_found_raises_error(self):
+        with pytest.raises(FileNotFoundError):
+            load_mcp_clients_from_config("/nonexistent/path/config.json")
+
+    def test_invalid_json_raises_error(self):
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+                f.write("not json")
+                temp_path = f.name
+            with pytest.raises(json.JSONDecodeError):
+                load_mcp_clients_from_config(temp_path)
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def test_invalid_config_type_raises_error(self):
+        with pytest.raises(ValueError, match="must be a file path string or dictionary"):
+            load_mcp_clients_from_config(123)  # type: ignore[arg-type]
+
+    def test_empty_mcp_servers_returns_empty(self):
+        clients = load_mcp_clients_from_config({"mcpServers": {}})
+        assert clients == []
+
+    def test_missing_mcp_servers_key_raises_error(self):
+        with pytest.raises(ValueError, match="mcpServers"):
+            load_mcp_clients_from_config({"server1": {"command": "echo"}})
+
+    def test_server_creation_error_includes_server_name(self):
+        config = {"mcpServers": {"bad_server": {"transport": "invalid"}}}
+        with pytest.raises(ValueError, match="bad_server"):
+            load_mcp_clients_from_config(config)

--- a/strands-py/tests_integ/mcp/test_mcp_config.py
+++ b/strands-py/tests_integ/mcp/test_mcp_config.py
@@ -21,7 +21,7 @@ def test_load_stdio_server_from_config():
                 "command": "python",
                 "args": _ECHO_SERVER_ARGS,
                 "prefix": "cfg",
-                "tool_filters": {"allowed": ["cfg_echo$"]},
+                "tool_filters": {"allowed": ["^echo$"]},
             }
         }
     }
@@ -46,7 +46,7 @@ def test_load_stdio_server_from_json_file():
                 "command": "python",
                 "args": _ECHO_SERVER_ARGS,
                 "prefix": "file",
-                "tool_filters": {"allowed": ["file_echo$"]},
+                "tool_filters": {"allowed": ["^echo$"]},
             }
         }
     }
@@ -81,7 +81,7 @@ def test_env_interpolation_and_disabled_skip(monkeypatch):
                 "command": "python",
                 "args": _ECHO_SERVER_ARGS,
                 "prefix": "${env:ECHO_PREFIX}",
-                "tool_filters": {"allowed": ["dyn_echo$"]},
+                "tool_filters": {"allowed": ["^echo$"]},
             },
             "disabled_echo": {
                 "command": "python",
@@ -99,5 +99,30 @@ def test_env_interpolation_and_disabled_skip(monkeypatch):
 
     result = agent.tool.dyn_echo(to_echo="Dynamic Prefix")
     assert "Dynamic Prefix" in str(result)
+
+    agent.cleanup()
+
+
+def test_config_to_agent_with_mcp_servers():
+    """End-to-end: config_to_agent loads an MCP server declared via mcp_servers."""
+    from strands.experimental import config_to_agent
+
+    config = {
+        "model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "mcp_servers": {
+            "echo": {
+                "command": "python",
+                "args": _ECHO_SERVER_ARGS,
+                "prefix": "agent",
+                "tool_filters": {"allowed": ["^echo$"]},
+            }
+        },
+    }
+
+    agent = config_to_agent(config)
+    assert "agent_echo" in agent.tool_names
+
+    result = agent.tool.agent_echo(to_echo="Agent Config Test")
+    assert "Agent Config Test" in str(result)
 
     agent.cleanup()

--- a/strands-py/tests_integ/mcp/test_mcp_config.py
+++ b/strands-py/tests_integ/mcp/test_mcp_config.py
@@ -1,0 +1,103 @@
+"""Integration tests for loading MCP servers from config.
+
+These tests use the local stdio ``echo_server.py`` and are network-free.
+"""
+
+import json
+import os
+import tempfile
+
+from strands import Agent
+from strands.experimental.mcp_config import load_mcp_clients_from_config
+
+_ECHO_SERVER_ARGS = ["tests_integ/mcp/echo_server.py"]
+
+
+def test_load_stdio_server_from_config():
+    """Load a stdio MCP server from a config dict and use it with an agent."""
+    config = {
+        "mcpServers": {
+            "echo": {
+                "command": "python",
+                "args": _ECHO_SERVER_ARGS,
+                "prefix": "cfg",
+                "tool_filters": {"allowed": ["cfg_echo$"]},
+            }
+        }
+    }
+
+    clients = load_mcp_clients_from_config(config)
+    assert len(clients) == 1
+
+    agent = Agent(tools=clients)
+    assert "cfg_echo" in agent.tool_names
+
+    result = agent.tool.cfg_echo(to_echo="Config Test")
+    assert "Config Test" in str(result)
+
+    agent.cleanup()
+
+
+def test_load_stdio_server_from_json_file():
+    """Load a stdio MCP server from a JSON config file."""
+    config_data = {
+        "mcpServers": {
+            "echo": {
+                "command": "python",
+                "args": _ECHO_SERVER_ARGS,
+                "prefix": "file",
+                "tool_filters": {"allowed": ["file_echo$"]},
+            }
+        }
+    }
+    temp_path = ""
+
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config_data, f)
+            temp_path = f.name
+
+        clients = load_mcp_clients_from_config(temp_path)
+        assert len(clients) == 1
+
+        agent = Agent(tools=clients)
+        assert "file_echo" in agent.tool_names
+
+        result = agent.tool.file_echo(to_echo="File Config Test")
+        assert "File Config Test" in str(result)
+
+        agent.cleanup()
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+
+def test_env_interpolation_and_disabled_skip(monkeypatch):
+    """Resolve ``${env:VAR}`` in the prefix and skip a disabled server."""
+    monkeypatch.setenv("ECHO_PREFIX", "dyn")
+    config = {
+        "mcpServers": {
+            "echo": {
+                "command": "python",
+                "args": _ECHO_SERVER_ARGS,
+                "prefix": "${env:ECHO_PREFIX}",
+                "tool_filters": {"allowed": ["dyn_echo$"]},
+            },
+            "disabled_echo": {
+                "command": "python",
+                "args": _ECHO_SERVER_ARGS,
+                "disabled": True,
+            },
+        }
+    }
+
+    clients = load_mcp_clients_from_config(config)
+    assert len(clients) == 1
+
+    agent = Agent(tools=clients)
+    assert "dyn_echo" in agent.tool_names
+
+    result = agent.tool.dyn_echo(to_echo="Dynamic Prefix")
+    assert "Dynamic Prefix" in str(result)
+
+    agent.cleanup()


### PR DESCRIPTION
## Motivation

Setting up MCP servers today means hand-writing a transport callable and an `MCPClient` for each one. That's fine for a single server, but verbose for several — and there's already an ecosystem-standard way to declare them: the `mcpServers` JSON block used by Claude Desktop, Cursor, and VS Code. This PR lets users load that same config directly, so a config someone already has can be dropped in and passed straight to an agent.

Resolves #482.

## Public API change

A new `load_mcp_clients_from_config()` in `strands.experimental`:

```python
from strands import Agent
from strands.experimental import load_mcp_clients_from_config

clients = load_mcp_clients_from_config("mcp.json")   # path or already-parsed dict
agent = Agent(tools=clients)                          # MCPClient is a ToolProvider — lifecycle is auto-managed
```

It accepts the standard wrapper format and resolves secrets/paths at load time:

```json
{
  "mcpServers": {
    "aws_docs": {
      "command": "~/bin/uvx",
      "args": ["awslabs.aws-documentation-mcp-server@latest"],
      "prefix": "aws",
      "tool_filters": {"allowed": ["search_.*"], "rejected": ["^delete_.*"]}
    },
    "remote": {
      "url": "https://example.com/sse",
      "headers": {"Authorization": "Bearer ${env:MCP_TOKEN}"}
    },
    "legacy": {"command": "old-server", "disabled": true}
  }
}
```

- **Transport auto-detection**: `command` → stdio, `url` → sse; `"transport": "streamable-http"` (or `"stdio"`/`"sse"`) to be explicit.
- **`${env:VAR}` interpolation** in any string value, so tokens stay in the environment and the file stays committable. A missing variable raises a clear `ValueError` rather than silently sending an empty header.
- **`~` expansion** in `command` and `cwd` so configs are portable across machines.
- **`disabled: true`** skips a server; **`prefix`** and **`tool_filters`** (`allowed`/`rejected`, compiled as regex) map to the existing `MCPClient` options.
- Per-server configs are validated against a JSON schema with the server name in the error message.

## API design + alternatives considered

- **Module-level function returning `list[MCPClient]`** (chosen) over a `MCPClient.from_config` classmethod: one config produces *many* clients, so a list-returning loader reads more naturally and drops straight into `Agent(tools=...)`. It also mirrors the existing `config_to_agent` in the same `experimental` package.
- **`strands.experimental`** placement: this is config sugar over the stable `MCPClient` primitive and matches issue #482's decision to keep it experimental and JSON-only.
- **No new lifecycle code**: `MCPClient` is already a `ToolProvider`, so the agent connects/lists/tears down automatically — the loader is pure config→client wiring.

## Relationship to the earlier (closed) PR

This builds directly on the maintainer-approved work in #2108 (closed by @zastrowm because it was backed out of the harness migration, with a note that it would be restored). I kept the reviewed core — schema validation, transport auto-detection, regex `tool_filters`, the `mcpServers` wrapper, returning `list[MCPClient]` — and added the three things that PR explicitly deferred and that real configs need: `${env:VAR}` interpolation, `~` expansion, and the `disabled` flag. Happy to defer to @gautamsirdeshmukh if a restoration is already in flight — flagging to avoid duplicate effort.

> Note on scope: the linked task framed this as "TypeScript SDK parity," but I verified `strands-ts/src/mcp.ts` has **no** `mcpServers`/config loader today, so I've framed this around the established Claude Desktop/Cursor/VS Code convention instead of TS parity.

## Testing

- **Unit** (`tests/strands/experimental/test_mcp_config.py`, 44 tests, network- and AWS-free): env interpolation (nested lists/dicts, missing-var error), tool-filter regex compilation (incl. invalid-pattern errors), transport detection/validation for all three types, `~` expansion in `command`/`cwd`, `disabled` skip, file/`file://`/dict loading, and error paths. Coverage of the new module is 98%.
- **Integration** (`tests_integ/mcp/test_mcp_config.py`): loads the local stdio `echo_server.py` from a dict and from a JSON file, plus an env-interpolation + disabled-skip case, and calls a tool end-to-end via an `Agent`.
- **Manually exercised** the full path against a local stdio server: a disabled server is skipped, `prefix: "${env:...}"` resolves (tool surfaced as `dynamic-prefix_echo`), and a `rejected` filter drops `secret_tool`.

## Gate

`ruff format --check`, `ruff check`, and `mypy ./src` (215 files) all pass; full `tests/strands/experimental/` suite is green (135 tests). The integration tests need provisioned credentials (session-scoped `conftest`), so they're left for CI to run against pre-provisioned infra per `AGENTS.md`.

cc @mkmeral