### PR TITLE
docs: stop in-tab headings from creating broken TOC links

### DIFF
--- a/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
@@ -46,7 +46,7 @@ graph TD
 <Tabs>
 <Tab label="Python">
 
-### 1. GraphNode
+**1. GraphNode**
 
 A [`GraphNode`](@api/python/strands.multiagent.graph#GraphNode) represents a node in the graph with:
 
@@ -57,7 +57,7 @@ A [`GraphNode`](@api/python/strands.multiagent.graph#GraphNode) represents a nod
 - **result**: The NodeResult after execution
 - **execution_time**: Time taken to execute the node in milliseconds
 
-### 2. GraphEdge
+**2. GraphEdge**
 
 A [`GraphEdge`](@api/python/strands.multiagent.graph#GraphEdge) represents a connection between nodes with:
 
@@ -65,7 +65,7 @@ A [`GraphEdge`](@api/python/strands.multiagent.graph#GraphEdge) represents a con
 - **to_node**: Target node
 - **condition**: Optional function that determines if the edge should be traversed
 
-### 3. GraphBuilder
+**3. GraphBuilder**
 
 The [`GraphBuilder`](@api/python/strands.multiagent.graph#GraphBuilder) provides a simple interface for constructing graphs:
 
@@ -81,21 +81,21 @@ The [`GraphBuilder`](@api/python/strands.multiagent.graph#GraphBuilder) provides
 </Tab>
 <Tab label="TypeScript">
 
-### Nodes
+**Nodes**
 
 Nodes wrap agents or other orchestrators for execution within the graph. The SDK provides two built-in node types:
 
 - **AgentNode**: Wraps an `AgentBase` instance. Created automatically when you pass an agent to the `nodes` array. Uses the agent's `id` as the node identifier.
 - **MultiAgentNode**: Wraps a `MultiAgentBase` instance (e.g. another `Graph` or `Swarm`). Created automatically when you pass an orchestrator to the `nodes` array. Uses the orchestrator's `id` as the node identifier.
 
-### Edges
+**Edges**
 
 Edges define directed connections between nodes. They can be specified as simple tuples or with an optional handler for conditional traversal:
 
 - **`[source, target]`**: Tuple of node IDs for unconditional edges
 - **`{ source, target, handler }`**: Object with an optional `EdgeHandler` function for conditional traversal
 
-### Graph Constructor
+**Graph Constructor**
 
 The `Graph` constructor accepts:
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/multi-agent-patterns.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/multi-agent-patterns.mdx
@@ -89,7 +89,7 @@ Some Examples:
 
 Both Graph and Swarm patterns support passing shared state to all agents through the `invocation_state` parameter. This enables sharing context and configuration across agents without exposing it to the LLM.
 
-### How Shared State Works
+**How Shared State Works**
 
 The `invocation_state` is automatically propagated to:
 
@@ -97,7 +97,7 @@ The `invocation_state` is automatically propagated to:
 - Tools via `ToolContext` when using `@tool(context=True)` - see [Python Tools](../tools/custom-tools.md#accessing-state-in-tools)
 - Tool-related hooks (BeforeToolCallEvent, AfterToolCallEvent) - see [Hooks](../agents/hooks.md#accessing-invocation-state-in-hooks)
 
-### Example Usage
+**Example Usage**
 
 ```python
 # Same invocation_state works for both patterns
@@ -121,7 +121,7 @@ result = swarm(
 )
 ```
 
-### Accessing Shared State in Tools
+**Accessing Shared State in Tools**
 
 ```python
 from strands import tool, ToolContext
@@ -137,7 +137,7 @@ def query_data(query: str, tool_context: ToolContext) -> str:
 
 Both Graph and Swarm support passing per-invocation state to all nodes through the `invocationState` option. This is a mutable `Record<string, unknown>` shared by reference — one node's hooks/tools can read state written by a previous node.
 
-### How Invocation State Works
+**How Invocation State Works**
 
 Pass `invocationState` as the second argument to `invoke()` or `stream()`:
 
@@ -151,13 +151,13 @@ The `invocationState` is automatically forwarded to:
 - Tools via `context.invocationState` in the tool callback
 - All hook events on both the orchestrator and individual agents
 
-### Accessing Invocation State in Tools
+**Accessing Invocation State in Tools**
 
 ```typescript
 --8<-- "user-guide/concepts/multi-agent/multi-agent-patterns.ts:invocation_state_tool"
 ```
 
-### MultiAgentState
+**MultiAgentState**
 
 In addition to `invocationState`, the orchestrator's `MultiAgentState` is shared across all nodes and provides access to execution progress, node results, and custom application state:
 

--- a/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
@@ -106,7 +106,7 @@ result = agent("What is 125 * 37?")
 
 When running this code with logging enabled, you'll see logs from different components of the SDK as the agent processes the request, calls the calculator tool, and generates a response.
 
-### Tool Registry and Execution
+**Tool Registry and Execution**
 
 Logs related to tool discovery, registration, and execution:
 
@@ -135,7 +135,7 @@ DEBUG | strands.tools.registry | tool_name=<calculator> | reloading tool
 DEBUG | strands.tools.registry | tool_name=<calculator> | successfully reloaded tool
 ```
 
-### Event Loop
+**Event Loop**
 
 Logs related to the event loop processing:
 
@@ -144,7 +144,7 @@ ERROR | strands.event_loop.error_handler | an exception occurred in event_loop_c
 DEBUG | strands.event_loop.error_handler | message_index=<5> | found message with tool results at index
 ```
 
-### Model Interactions
+**Model Interactions**
 
 Logs related to interactions with foundation models:
 
@@ -188,7 +188,7 @@ Future versions will include more detailed logging for tool operations and event
 <Tabs>
 <Tab label="Python">
 
-### Filtering Specific Modules
+**Filtering Specific Modules**
 
 You can configure logging for specific modules within the SDK:
 
@@ -202,7 +202,7 @@ logging.getLogger("strands.tools.registry").setLevel(logging.DEBUG)
 logging.getLogger("strands.models").setLevel(logging.WARNING)
 ```
 
-### Custom Handlers
+**Custom Handlers**
 
 You can add custom handlers to process logs in different ways:
 
@@ -230,7 +230,7 @@ logging.getLogger("strands").addHandler(file_handler)
 </Tab>
 <Tab label="TypeScript">
 
-### Custom Logger Implementation
+**Custom Logger Implementation**
 
 You can implement your own logger to integrate with your application's logging system:
 

--- a/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
@@ -78,7 +78,7 @@ Key metrics include:
 - **Accumulated metrics**: Latency measurements in milliseconds for all model requests
 - **Execution traces**: Detailed trace information for performance analysis
 
-### Agent Invocations
+**Agent Invocations**
 
 The `agent_invocations` property is a list of [`AgentInvocation`](@api/python/strands.telemetry.metrics#AgentInvocation) objects that track metrics for each agent invocation (request). Each `AgentInvocation` contains:
 
@@ -128,7 +128,7 @@ Key metrics include:
 - **Accumulated usage**: Aggregated token counts (input, output, total, and cache metrics) across all agent invocations
 - **Accumulated metrics**: Latency measurements in milliseconds for all model requests
 
-### Agent Invocations
+**Agent Invocations**
 
 The `agentInvocations` property is a list of `InvocationMetricsData` objects that track metrics for each agent invocation (request). Each invocation contains:
 


### PR DESCRIPTION
## Description

The right-hand table of contents is generated from a page's markdown headings, but several pages place `###` headings inside `<Tab>` components. Only the active tab is visible, so each of those headings becomes a TOC entry whose anchor target is hidden whenever its tab isn't selected — clicking it scrolls nowhere. This is the same problem that was fixed for the swarm page in strands-agents/docs#750.

This converts the in-tab `###` headings to bold text, matching how sub-sections inside tabs are already written elsewhere in the docs (the swarm page, the model-provider pages, the community plugin pages). Bold preserves the visual emphasis while keeping the headings out of the TOC, so the table of contents only lists destinations you can actually reach.

Two notes on scope, after building the site and inspecting each page's generated TOC:

- `plugins/index.mdx` and `mcp-tools.mdx` only have `####` (h4) headings inside tabs. Those sit below Starlight's default `maxHeadingLevel` of 3 and never appear in the TOC, so they aren't broken and are left as-is.
- `multi-agent-patterns.mdx` has the affected headings in both the Python and TypeScript tabs (six, not the three originally noted).

The net change is 20 in-tab `###` headings across `logs`, `metrics`, `graph`, and `multi-agent-patterns`.

## Related Issues

Resolves #2600

## Documentation PR

Documentation-only change under `site/`.

## Type of Change

Documentation update

## Testing

Built the docs site (`cd site && npm run build`) and compared each affected page's generated `<starlight-toc>` before and after: the 20 in-tab headings are listed in the TOC on `main` and are gone after this change, while every heading outside a tab is unchanged. (`hatch run prepare` targets the Python SDK and does not apply to a docs-only change.)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
