### PR TITLE
fix: consume orphaned task exception on stream cancellation

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -64,6 +64,12 @@ def _clear_skip_count_tokens_cache() -> None:
     _SKIP_COUNT_TOKENS_MODELS.clear()
 
 
+def _suppress_task_exception(task: "asyncio.Task[None]") -> None:
+    """Consume exception from orphaned stream task to silence 'never retrieved' warning."""
+    if not task.cancelled():
+        task.exception()
+
+
 T = TypeVar("T", bound=BaseModel)
 
 DEFAULT_READ_TIMEOUT = 120
@@ -927,14 +933,17 @@ class BedrockModel(Model):
         thread = asyncio.to_thread(self._stream, callback, messages, tool_specs, system_prompt_content, tool_choice)
         task = asyncio.create_task(thread)
 
-        while True:
-            event = await queue.get()
-            if event is None:
-                break
+        try:
+            while True:
+                event = await queue.get()
+                if event is None:
+                    break
 
-            yield event
-
-        await task
+                yield event
+            await task
+        except BaseException:
+            task.add_done_callback(_suppress_task_exception)
+            raise
 
     def _stream(
         self,

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import os
 import sys
+import time
 import traceback
 import unittest.mock
 from unittest.mock import ANY
@@ -819,13 +820,16 @@ async def test_stream_with_invalid_content_throws(bedrock_client, model, alist):
 @pytest.mark.asyncio
 async def test_stream_cancellation_consumes_orphaned_task_exception(bedrock_client, model, messages):
     """Orphaned background task exception is consumed when stream generator is cancelled."""
-    import time
 
     def slow_converse_stream(**kwargs):
         time.sleep(0.1)
         raise RuntimeError("simulated boto3 timeout")
 
     bedrock_client.converse_stream.side_effect = slow_converse_stream
+
+    loop = asyncio.get_running_loop()
+    captured: list[dict] = []
+    loop.set_exception_handler(lambda _loop, ctx: captured.append(ctx))
 
     gen = model.stream(messages)
     with pytest.raises(asyncio.TimeoutError):
@@ -836,9 +840,7 @@ async def test_stream_cancellation_consumes_orphaned_task_exception(bedrock_clie
     # Allow the background thread to finish and the done-callback to fire
     await asyncio.sleep(0.2)
 
-    # If the fix is missing, asyncio would emit "Task exception was never retrieved"
-    # which pytest captures as a warning/error. Reaching here without that warning means
-    # the done-callback consumed the exception correctly.
+    assert not captured, f"orphaned task exception was not consumed: {captured}"
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import logging
 import os
@@ -813,6 +814,31 @@ async def test_stream_with_invalid_content_throws(bedrock_client, model, alist):
 
     with pytest.raises(TypeError):
         await alist(model.stream(messages))
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation_consumes_orphaned_task_exception(bedrock_client, model, messages):
+    """Orphaned background task exception is consumed when stream generator is cancelled."""
+    import time
+
+    def slow_converse_stream(**kwargs):
+        time.sleep(0.1)
+        raise RuntimeError("simulated boto3 timeout")
+
+    bedrock_client.converse_stream.side_effect = slow_converse_stream
+
+    gen = model.stream(messages)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(gen.__anext__(), timeout=0.01)
+
+    await gen.aclose()
+
+    # Allow the background thread to finish and the done-callback to fire
+    await asyncio.sleep(0.2)
+
+    # If the fix is missing, asyncio would emit "Task exception was never retrieved"
+    # which pytest captures as a warning/error. Reaching here without that warning means
+    # the done-callback consumed the exception correctly.
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Co-author: AnnasMazhar

## Description
<!-- Provide a detailed description of the changes in this PR -->

----------

This PR is re-opened from a previously opened PR by @AnnasMazhar. This PR builds on and adds the tests missing in their [PR](https://github.com/strands-agents/harness-sdk/pull/2269).

----------

When a consumer cancels, breaks from, or times out on BedrockModel.stream, the internal asyncio.Task wrapping asyncio.to_thread is never awaited. If boto3 eventually raises (e.g., ReadTimeoutError after read_timeout), asyncio emits "Task exception was never retrieved" — polluting application logs across three common usage patterns: asyncio.wait_for, async for ... break, and client disconnects in streaming HTTP handlers.

The happy path already awaits the task. The unhappy path (any BaseException interrupting the yield loop) leaves it orphaned.

## Related Issues

<!-- Link to related issues using #issue-number format -->
#2266 

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
