### PR TITLE
Fix stream_async releasing unowned invocation locks

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1088,6 +1088,7 @@ class Agent(AgentBase):
         # Conditionally acquire lock based on concurrent_invocation_mode
         # Using threading.Lock instead of asyncio.Lock because run_async() creates
         # separate event loops in different threads
+        lock_acquired = False
         if self._concurrent_invocation_mode == ConcurrentInvocationMode.THROW:
             lock_acquired = self._invocation_lock.acquire(blocking=False)
             if not lock_acquired:
@@ -1153,7 +1154,7 @@ class Agent(AgentBase):
             # Clear cancel signal to allow agent reuse after cancellation
             self._cancel_signal.clear()
 
-            if self._invocation_lock.locked():
+            if lock_acquired:
                 self._invocation_lock.release()
 
     async def _run_loop(

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -2507,6 +2507,29 @@ async def test_agent_lock_released_on_exception():
         await agent.invoke_async("test")
 
 
+@pytest.mark.asyncio
+async def test_stream_async_does_not_release_unowned_lock_in_unsafe_reentrant_mode():
+    """stream_async should only release a lock it acquired itself."""
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "hello"}]}])
+    agent = Agent(model=model, concurrent_invocation_mode=ConcurrentInvocationMode.UNSAFE_REENTRANT)
+    agent._invocation_lock.acquire()
+
+    def raise_before_work(_prompt):
+        raise RuntimeError("stop before invocation work")
+
+    agent._interrupt_state.resume = raise_before_work
+
+    try:
+        with pytest.raises(RuntimeError, match="stop before invocation work"):
+            async for _ in agent.stream_async("test"):
+                pass
+
+        assert agent._invocation_lock.locked()
+    finally:
+        if agent._invocation_lock.locked():
+            agent._invocation_lock.release()
+
+
 def test_agent_direct_tool_call_during_invocation_raises_exception(tool_decorated):
     """Test that direct tool call during agent invocation raises ConcurrencyException."""
 


### PR DESCRIPTION
## Summary
- fixes #2918 by tracking whether `stream_async` acquired the invocation lock
- releases the invocation lock only when the current invocation acquired it
- adds a regression test for `UNSAFE_REENTRANT` mode with a lock owned by another invocation

## Verification
- `uv run --extra dev pytest tests/strands/agent/test_agent.py -k 'unowned_lock or lock_released_on_exception'`
- `uv run --extra dev pytest tests/strands/agent/test_agent.py`
- `uv run --extra dev ruff check src/strands/agent/agent.py tests/strands/agent/test_agent.py`
- `uv run --extra dev ruff format --check src/strands/agent/agent.py tests/strands/agent/test_agent.py`
- pre-commit hook: TypeScript build, tests, lint, format check, type checks passed (existing eslint warning only)