### PR TITLE
fix(agent): stop idempotency waiters from blocking thread-pool workers

### DIFF
--- a/strands-py/src/strands/agent/_concurrency.py
+++ b/strands-py/src/strands/agent/_concurrency.py
@@ -9,6 +9,7 @@ in ``agent.py`` and the synchronization primitives + bookkeeping here.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -20,67 +21,50 @@ if TYPE_CHECKING:
     from .agent_result import AgentResult
 
 
-def _resolve_future(future: asyncio.Future) -> None:
-    """Resolve a waiter future on its own loop. No-op if already done or cancelled."""
-    if not future.done():
-        future.set_result(None)
-
-
 @dataclass
 class _InflightInvocation:
     """Tracks an inflight invocation for idempotency deduplication.
 
-    Duplicate callers register an ``asyncio.Future`` via ``register_waiter`` and await
-    it, then read ``result`` or ``error``. The primary calls ``settle`` on completion,
-    which resolves every waiter's future on its own event loop via
-    ``call_soon_threadsafe``. No waiter ever blocks a thread-pool worker, so a storm of
-    duplicates cannot starve the executor the primary needs to make progress.
+    Duplicate callers register via ``register_waiter`` and await the returned awaitable,
+    then read ``result`` or ``error``. The primary calls ``settle`` on completion.
+
+    A single thread-safe ``concurrent.futures.Future`` is the broadcast signal; each
+    waiter turns it into a loop-local awaitable via ``asyncio.wrap_future``, which hooks
+    a done-callback that bridges back to the waiter's loop with ``call_soon_threadsafe``.
+    No waiter ever blocks a thread-pool worker, so a storm of duplicates cannot starve
+    the executor the primary needs to make progress. The wrapped future is ``shield``ed
+    so that cancelling one waiting duplicate cannot cancel the shared signal and strand
+    the others.
     """
 
     result: AgentResult | None = None
     error: BaseException | None = None
-    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
-    _settled: bool = False
-    _waiters: list[tuple[asyncio.AbstractEventLoop, asyncio.Future]] = field(default_factory=list, repr=False)
+    _done: concurrent.futures.Future = field(default_factory=concurrent.futures.Future, repr=False)
 
     @property
     def settled(self) -> bool:
         """Whether the primary has produced a result or error yet."""
-        with self._lock:
-            return self._settled
+        return self._done.done()
 
-    def register_waiter(self) -> asyncio.Future | None:
-        """Register the calling coroutine's loop to be notified on completion.
+    def register_waiter(self) -> asyncio.Future:
+        """Return a loop-local awaitable that resolves when the primary settles.
 
-        Returns:
-            A future to await, or None if the primary has already settled (the caller
-            then reads ``result``/``error`` directly). Returning None closes the race
-            where the primary settles between duplicate detection and registration.
+        Resolves immediately if the primary has already settled (the caller then reads
+        ``result``/``error``), so there is no register-after-settle race to handle.
         """
-        loop = asyncio.get_running_loop()
-        future = loop.create_future()
-        with self._lock:
-            if self._settled:
-                return None
-            self._waiters.append((loop, future))
-        return future
+        return asyncio.shield(asyncio.wrap_future(self._done))
 
     def settle(self, result: AgentResult | None, error: BaseException | None) -> None:
         """Record the outcome and wake every registered waiter. Idempotent."""
-        with self._lock:
-            if self._settled:
-                return
-            self.result = result
-            self.error = error
-            self._settled = True
-            waiters = self._waiters
-            self._waiters = []
-        for loop, future in waiters:
-            try:
-                loop.call_soon_threadsafe(_resolve_future, future)
-            except RuntimeError:
-                # Waiter's loop was already closed/torn down; nothing to wake.
-                pass
+        if self._done.done():
+            return
+        # Publish result/error before signalling so woken waiters observe them.
+        self.result = result
+        self.error = error
+        try:
+            self._done.set_result(None)
+        except concurrent.futures.InvalidStateError:
+            pass
 
 
 @dataclass

--- a/strands-py/src/strands/agent/_concurrency.py
+++ b/strands-py/src/strands/agent/_concurrency.py
@@ -55,16 +55,13 @@ class _InflightInvocation:
         return asyncio.shield(asyncio.wrap_future(self._done))
 
     def settle(self, result: AgentResult | None, error: BaseException | None) -> None:
-        """Record the outcome and wake every registered waiter. Idempotent."""
+        """Record the outcome and wake every registered waiter. Idempotent: first wins."""
         if self._done.done():
             return
         # Publish result/error before signalling so woken waiters observe them.
         self.result = result
         self.error = error
-        try:
-            self._done.set_result(None)
-        except concurrent.futures.InvalidStateError:
-            pass
+        self._done.set_result(None)
 
 
 @dataclass

--- a/strands-py/src/strands/agent/_concurrency.py
+++ b/strands-py/src/strands/agent/_concurrency.py
@@ -8,6 +8,7 @@ in ``agent.py`` and the synchronization primitives + bookkeeping here.
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -19,16 +20,67 @@ if TYPE_CHECKING:
     from .agent_result import AgentResult
 
 
+def _resolve_future(future: asyncio.Future) -> None:
+    """Resolve a waiter future on its own loop. No-op if already done or cancelled."""
+    if not future.done():
+        future.set_result(None)
+
+
 @dataclass
 class _InflightInvocation:
     """Tracks an inflight invocation for idempotency deduplication.
 
-    Duplicate callers wait on ``done`` and then read ``result`` or ``error``.
+    Duplicate callers register an ``asyncio.Future`` via ``register_waiter`` and await
+    it, then read ``result`` or ``error``. The primary calls ``settle`` on completion,
+    which resolves every waiter's future on its own event loop via
+    ``call_soon_threadsafe``. No waiter ever blocks a thread-pool worker, so a storm of
+    duplicates cannot starve the executor the primary needs to make progress.
     """
 
-    done: threading.Event = field(default_factory=threading.Event)
     result: AgentResult | None = None
     error: BaseException | None = None
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _settled: bool = False
+    _waiters: list[tuple[asyncio.AbstractEventLoop, asyncio.Future]] = field(default_factory=list, repr=False)
+
+    @property
+    def settled(self) -> bool:
+        """Whether the primary has produced a result or error yet."""
+        with self._lock:
+            return self._settled
+
+    def register_waiter(self) -> asyncio.Future | None:
+        """Register the calling coroutine's loop to be notified on completion.
+
+        Returns:
+            A future to await, or None if the primary has already settled (the caller
+            then reads ``result``/``error`` directly). Returning None closes the race
+            where the primary settles between duplicate detection and registration.
+        """
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        with self._lock:
+            if self._settled:
+                return None
+            self._waiters.append((loop, future))
+        return future
+
+    def settle(self, result: AgentResult | None, error: BaseException | None) -> None:
+        """Record the outcome and wake every registered waiter. Idempotent."""
+        with self._lock:
+            if self._settled:
+                return
+            self.result = result
+            self.error = error
+            self._settled = True
+            waiters = self._waiters
+            self._waiters = []
+        for loop, future in waiters:
+            try:
+                loop.call_soon_threadsafe(_resolve_future, future)
+            except RuntimeError:
+                # Waiter's loop was already closed/torn down; nothing to wake.
+                pass
 
 
 @dataclass
@@ -37,8 +89,8 @@ class _BeginResult:
 
     Exactly one of the following is the actionable signal for the caller:
 
-    - ``waiting_on`` is set: this call is a duplicate of an inflight token. Wait on
-      ``waiting_on.done`` and then yield the cached result or raise the cached error.
+    - ``waiting_on`` is set: this call is a duplicate of an inflight token. Await
+      ``waiting_on.register_waiter()`` and then yield the cached result or raise the cached error.
     - ``lock_acquired`` is False: a different invocation owns the lock. Raise
       ``ConcurrencyException``.
     - Otherwise: proceed with the invocation. Pass ``registered_token`` back to
@@ -54,8 +106,9 @@ class _ConcurrencyController:
     """Owns the invocation lock and the inflight idempotency-token registry.
 
     In THROW mode only one invocation can be inflight at a time, so a single
-    inflight slot suffices. Uses ``threading`` primitives (not asyncio) because
-    ``Agent.run_async()`` may spawn separate event loops on separate threads.
+    inflight slot suffices. The lock and registry use ``threading`` primitives
+    because ``Agent.run_async()`` may spawn separate event loops on separate threads;
+    waiter notification bridges back to each waiter's loop via ``call_soon_threadsafe``.
     """
 
     def __init__(self, mode: ConcurrentInvocationMode) -> None:
@@ -124,12 +177,11 @@ class _ConcurrencyController:
             return
 
         if error is not None:
-            inflight.error = error
+            inflight.settle(None, error)
         elif result is not None:
-            inflight.result = result
+            inflight.settle(result, None)
         else:
-            inflight.error = IdempotencyAbortedError("Primary invocation was aborted before producing a result.")
-        inflight.done.set()
+            inflight.settle(None, IdempotencyAbortedError("Primary invocation was aborted before producing a result."))
 
     def try_acquire_lock(self) -> bool:
         """Non-blockingly acquire the invocation lock.

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -9,7 +9,6 @@ The Agent interface supports two complementary interaction patterns:
 2. Method-style for direct tool access: `agent.tool.tool_name(param1="value")`
 """
 
-import asyncio
 import copy
 import logging
 import threading
@@ -1132,7 +1131,9 @@ class Agent(AgentBase):
 
         if begin.waiting_on is not None:
             logger.debug("idempotency_token=<%s> | duplicate request detected, waiting for original", idempotency_token)
-            await asyncio.to_thread(begin.waiting_on.done.wait)
+            wait_future = begin.waiting_on.register_waiter()
+            if wait_future is not None:
+                await wait_future
             if begin.waiting_on.error is not None:
                 raise begin.waiting_on.error
             if begin.waiting_on.result is not None:

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1131,9 +1131,7 @@ class Agent(AgentBase):
 
         if begin.waiting_on is not None:
             logger.debug("idempotency_token=<%s> | duplicate request detected, waiting for original", idempotency_token)
-            wait_future = begin.waiting_on.register_waiter()
-            if wait_future is not None:
-                await wait_future
+            await begin.waiting_on.register_waiter()
             if begin.waiting_on.error is not None:
                 raise begin.waiting_on.error
             if begin.waiting_on.result is not None:

--- a/strands-py/tests/strands/agent/test_concurrency.py
+++ b/strands-py/tests/strands/agent/test_concurrency.py
@@ -106,6 +106,23 @@ def test_complete_with_neither_result_nor_error_sets_aborted(controller):
     assert isinstance(dup.waiting_on.error, IdempotencyAbortedError)
 
 
+def test_settle_is_idempotent_first_outcome_wins():
+    """settle() called twice keeps the first outcome and stays settled.
+
+    The controller serializes settle() via the inflight lock, so this guards the
+    idempotency contract directly at the _InflightInvocation level.
+    """
+    inflight = _InflightInvocation()
+    first_result = MagicMock()
+
+    inflight.settle(first_result, None)
+    inflight.settle(None, RuntimeError("second"))  # must be ignored
+
+    assert inflight.settled is True
+    assert inflight.result is first_result
+    assert inflight.error is None
+
+
 def test_complete_is_idempotent_on_double_call(controller):
     """except + finally both call complete(); second must no-op."""
     first = controller.begin("abc")

--- a/strands-py/tests/strands/agent/test_concurrency.py
+++ b/strands-py/tests/strands/agent/test_concurrency.py
@@ -263,7 +263,6 @@ async def test_register_waiter_resolves_when_primary_settles_from_another_thread
     dup = controller.begin("abc")
 
     wait_future = dup.waiting_on.register_waiter()
-    assert wait_future is not None
     assert not wait_future.done()
 
     mock_result = MagicMock()
@@ -274,25 +273,29 @@ async def test_register_waiter_resolves_when_primary_settles_from_another_thread
 
 
 @pytest.mark.asyncio
-async def test_register_waiter_returns_none_when_already_settled(controller):
-    """If the primary settles before the waiter registers, register_waiter returns None."""
+async def test_register_waiter_resolves_immediately_when_already_settled(controller):
+    """If the primary settles before the waiter registers, the awaitable resolves at once."""
     first = controller.begin("abc")
     dup = controller.begin("abc")
     controller.complete(first.registered_token, result=MagicMock())
 
     assert dup.waiting_on.settled is True
-    assert dup.waiting_on.register_waiter() is None
+    await asyncio.wait_for(dup.waiting_on.register_waiter(), timeout=5)
 
 
 @pytest.mark.asyncio
-async def test_register_waiter_cancellation_is_safe(controller):
-    """Cancelling a waiting coroutine must not break a later settle."""
+async def test_cancelling_one_waiter_does_not_strand_others(controller):
+    """Cancelling one waiting duplicate must not cancel the shared signal for the rest."""
     first = controller.begin("abc")
     dup = controller.begin("abc")
 
-    wait_future = dup.waiting_on.register_waiter()
-    wait_future.cancel()
+    cancelled = dup.waiting_on.register_waiter()
+    survivor = dup.waiting_on.register_waiter()
+    cancelled.cancel()
+    await asyncio.sleep(0)
 
-    # Settle must tolerate the already-cancelled waiter future without raising.
-    controller.complete(first.registered_token, result=MagicMock())
-    assert dup.waiting_on.settled is True
+    mock_result = MagicMock()
+    threading.Thread(target=lambda: controller.complete(first.registered_token, result=mock_result)).start()
+
+    await asyncio.wait_for(survivor, timeout=5)
+    assert dup.waiting_on.result is mock_result

--- a/strands-py/tests/strands/agent/test_concurrency.py
+++ b/strands-py/tests/strands/agent/test_concurrency.py
@@ -1,5 +1,6 @@
 """Unit tests for _ConcurrencyController (idempotency + invocation locking)."""
 
+import asyncio
 import threading
 from unittest.mock import MagicMock
 
@@ -78,7 +79,7 @@ def test_complete_with_result_signals_waiters(controller):
     mock_result = MagicMock()
     controller.complete(first.registered_token, result=mock_result)
 
-    assert dup.waiting_on.done.is_set()
+    assert dup.waiting_on.settled
     assert dup.waiting_on.result is mock_result
     assert dup.waiting_on.error is None
 
@@ -90,7 +91,7 @@ def test_complete_with_error_signals_waiters(controller):
     err = RuntimeError("boom")
     controller.complete(first.registered_token, error=err)
 
-    assert dup.waiting_on.done.is_set()
+    assert dup.waiting_on.settled
     assert dup.waiting_on.error is err
     assert dup.waiting_on.result is None
 
@@ -101,7 +102,7 @@ def test_complete_with_neither_result_nor_error_sets_aborted(controller):
 
     controller.complete(first.registered_token)
 
-    assert dup.waiting_on.done.is_set()
+    assert dup.waiting_on.settled
     assert isinstance(dup.waiting_on.error, IdempotencyAbortedError)
 
 
@@ -189,9 +190,9 @@ def test_multiple_duplicates_all_wake_up(controller):
     mock_result = MagicMock()
     controller.complete(first.registered_token, result=mock_result)
 
-    assert dup1.waiting_on.done.is_set()
-    assert dup2.waiting_on.done.is_set()
-    assert dup3.waiting_on.done.is_set()
+    assert dup1.waiting_on.settled
+    assert dup2.waiting_on.settled
+    assert dup3.waiting_on.settled
     # All three see the same _InflightInvocation instance.
     assert dup1.waiting_on is dup2.waiting_on is dup3.waiting_on
     assert dup1.waiting_on.result is mock_result
@@ -253,3 +254,45 @@ def test_concurrent_begin_only_one_primary_others_duplicates(controller):
     assert primaries[0].lock_acquired is True
     assert all(d.lock_acquired is False for d in duplicates)
     assert all(d.registered_token is None for d in duplicates)
+
+
+@pytest.mark.asyncio
+async def test_register_waiter_resolves_when_primary_settles_from_another_thread(controller):
+    """A waiter awaits a future (no thread parked) that resolves on cross-thread completion."""
+    first = controller.begin("abc")
+    dup = controller.begin("abc")
+
+    wait_future = dup.waiting_on.register_waiter()
+    assert wait_future is not None
+    assert not wait_future.done()
+
+    mock_result = MagicMock()
+    threading.Thread(target=lambda: controller.complete(first.registered_token, result=mock_result)).start()
+
+    await asyncio.wait_for(wait_future, timeout=5)
+    assert dup.waiting_on.result is mock_result
+
+
+@pytest.mark.asyncio
+async def test_register_waiter_returns_none_when_already_settled(controller):
+    """If the primary settles before the waiter registers, register_waiter returns None."""
+    first = controller.begin("abc")
+    dup = controller.begin("abc")
+    controller.complete(first.registered_token, result=MagicMock())
+
+    assert dup.waiting_on.settled is True
+    assert dup.waiting_on.register_waiter() is None
+
+
+@pytest.mark.asyncio
+async def test_register_waiter_cancellation_is_safe(controller):
+    """Cancelling a waiting coroutine must not break a later settle."""
+    first = controller.begin("abc")
+    dup = controller.begin("abc")
+
+    wait_future = dup.waiting_on.register_waiter()
+    wait_future.cancel()
+
+    # Settle must tolerate the already-cancelled waiter future without raising.
+    controller.complete(first.registered_token, result=MagicMock())
+    assert dup.waiting_on.settled is True


### PR DESCRIPTION
## Description
  
  Duplicate agent invocations that share an `idempotency_token` (THROW mode) wait for the in-flight primary to finish and then receive its result. That wait was implemented as `asyncio.to_thread(event.wait)`, which parks a worker from the event loop's default thread pool for the *entire* duration of the primary - one parked worker per waiting duplicate, doing no work.

This makes a retry storm dangerous when enough number of retries get triggered

  - **Thread/resource pressure** - every waiting duplicate ties up a thread until the primary completes.
  - **Deadlock** - when duplicates fill the default pool (`min(32, cpu+4)` workers), the primary can no longer obtain a worker for its own `asyncio.to_thread` model call (e.g. `BedrockModel`). The primary then never completes, so it never wakes the waiters, and the event loop wedges permanently with no timeout. On an 8-core host this triggers at  ~12 concurrent same-token calls on a shared loop.

The fix removes the parked thread entirely: a waiting duplicate now registers an `asyncio.Future` and awaits it. On completion the primary resolves each waiter's future on its own loop via `call_soon_threadsafe`. No waiter holds a thread, so duplicates can no longer starve the executor the primary depends on.

  ## Related Issues

  ## Documentation PR

  Not required — no public API or documented behavior change.
  
  ## Type of Change

  Bug fix

  ## Public API Changes

  None. From the caller's perspective behavior is unchanged: a duplicate still blocks until the primary finishes and then yields the same result (and still fires `callback_handler` with it). The change is purely how the wait is implemented internally.

  ## Testing
  
Existing idempotency unit and integration tests pass unchanged; added async unit tests covering cross-thread future resolution, the register-after-settle race, and waiter cancellation. Separately verified in a resource-capped container that previously-hanging configurations now complete and that waiting duplicates park zero threads.

  - [x] I ran `hatch run prepare`

  ## Checklist
  - [x] I have read the CONTRIBUTING document
  - [x] I have reviewed and understand every line of code in this PR
  - [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
  - [x] I have added any necessary tests that prove my fix is effective
  - [ ] I have updated the documentation accordingly
  - [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published

  ----