### PR TITLE
docs: document concurrent invocations and idempotency in the agent loop

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -309,7 +309,7 @@ Sometimes more than one request targets the same agent instance at once: a retri
   </Tab>
   <Tab label="TypeScript">
 
-  The TypeScript SDK also rejects overlapping invocations: invoking an agent that is already running throws `ConcurrentInvocationError`. It does not offer a configurable concurrency mode or idempotency-token deduplication of retries; both are available only in the Python SDK.
+  TypeScript rejects overlapping invocations: invoking an agent that is already running throws `ConcurrentInvocationError`. It does not offer a configurable concurrency mode or idempotency-token deduplication of retries; both are available only in the Python SDK.
   </Tab>
 </Tabs>
 

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -245,6 +245,69 @@ When multiple caps trip simultaneously, the reported stop reason
 follows priority order: turns, then total tokens, then output
 tokens.
 
+## Concurrent Invocations
+
+Sometimes more than one request targets the same agent instance at once: a retried API call, a double-submitted form, two web requests that happen to share an agent. An agent mutates its conversation history as each invocation runs, so by default it processes one invocation at a time and rejects overlap.
+
+:::note[Python SDK]
+Concurrency control is available in the Python SDK.
+:::
+
+Invoking an agent that is already running raises `ConcurrencyException`:
+
+```python
+from strands import Agent
+from strands.types.exceptions import ConcurrencyException
+
+agent = Agent()
+
+try:
+    result = agent("Summarize this report")
+except ConcurrencyException:
+    # Another invocation is already running on this agent instance
+    ...
+```
+
+For most applications this is the behavior you want. One agent instance maps to one conversation, and letting invocations overlap would interleave their messages and corrupt the history.
+
+### Deduplicating retried requests
+
+When a retry arrives for a request that is still running, returning the original's result beats both erroring and starting the work twice. Pass an idempotency token that identifies the logical request, for example `agent("Process order 1234", idempotency_token="order-1234")`.
+
+If a call with the same token is already in flight, this call waits for the original and returns the same `AgentResult`. Tokens are compared by equality, so any stable identifier works: an order ID, a request UUID, or the prompt string itself.
+
+A deduplicated call gets the final result only, not the original's streamed events. Its `callback_handler` still fires once with that result, so output consumers are not left empty-handed.
+
+If the original ends without producing a result, for instance when it is cancelled mid-flight, the waiting calls raise `IdempotencyAbortedError` so they can decide whether to retry:
+
+```python
+from strands import Agent
+from strands.types.exceptions import IdempotencyAbortedError
+
+agent = Agent()
+
+try:
+    result = agent("Process order 1234", idempotency_token="order-1234")
+except IdempotencyAbortedError:
+    # The original was aborted before producing a result
+    ...
+```
+
+The idempotency token works the same way on `invoke_async` and `stream_async`.
+
+### Allowing concurrent invocations
+
+To run multiple invocations on one agent at the same time, set the concurrency mode when you construct it:
+
+```python
+from strands import Agent
+from strands.types.agent import ConcurrentInvocationMode
+
+agent = Agent(concurrent_invocation_mode=ConcurrentInvocationMode.UNSAFE_REENTRANT)
+```
+
+This removes the single-invocation guard entirely: overlapping calls neither raise nor deduplicate, and an idempotency token is ignored. Nothing protects the conversation history from concurrent mutation, so interleaved invocations can corrupt it. Reach for this only when each invocation works on isolated state, or when you handle synchronization yourself. To run independent work in parallel, a separate agent per task is safer than sharing one.
+
 ## Common Problems
 
 ### Context Window Exhaustion

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -269,7 +269,7 @@ Sometimes more than one request targets the same agent instance at once: a retri
 
   For most applications this is the behavior you want. One agent instance maps to one conversation, and letting invocations overlap would interleave their messages and corrupt the history.
 
-  ### Deduplicating retried requests
+  #### Deduplicating retried requests
 
   When a retry arrives for a request that is still running, returning the original's result beats both erroring and starting the work twice. Pass an idempotency token that identifies the logical request, for example `agent("Process order 1234", idempotency_token="order-1234")`.
 
@@ -294,7 +294,7 @@ Sometimes more than one request targets the same agent instance at once: a retri
 
   The idempotency token works the same way on `invoke_async` and `stream_async`.
 
-  ### Allowing concurrent invocations
+  #### Allowing concurrent invocations
 
   To run multiple invocations on one agent at the same time, set the concurrency mode when you construct it:
 
@@ -309,7 +309,7 @@ Sometimes more than one request targets the same agent instance at once: a retri
   </Tab>
   <Tab label="TypeScript">
 
-  The TypeScript SDK also rejects overlapping invocations: invoking an agent that is already running throws `ConcurrentInvocationError`. The configurable concurrency mode and idempotency-token deduplication described here are available only in the Python SDK.
+  The TypeScript SDK also rejects overlapping invocations: invoking an agent that is already running throws `ConcurrentInvocationError`. It does not offer a configurable concurrency mode or idempotency-token deduplication of retries; both are available only in the Python SDK.
   </Tab>
 </Tabs>
 

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -247,66 +247,71 @@ tokens.
 
 ## Concurrent Invocations
 
-Sometimes more than one request targets the same agent instance at once: a retried API call, a double-submitted form, two web requests that happen to share an agent. An agent mutates its conversation history as each invocation runs, so by default it processes one invocation at a time and rejects overlap.
+Sometimes more than one request targets the same agent instance at once: a retried API call, a double-submitted form, two web requests that happen to share an agent.
 
-:::note[Python SDK]
-Concurrency control is available in the Python SDK.
-:::
+<Tabs>
+  <Tab label="Python">
 
-Invoking an agent that is already running raises `ConcurrencyException`:
+  An agent mutates its conversation history as each invocation runs, so by default it processes one invocation at a time and rejects overlap. Invoking an agent that is already running raises `ConcurrencyException`:
 
-```python
-from strands import Agent
-from strands.types.exceptions import ConcurrencyException
+  ```python
+  from strands import Agent
+  from strands.types.exceptions import ConcurrencyException
 
-agent = Agent()
+  agent = Agent()
 
-try:
-    result = agent("Summarize this report")
-except ConcurrencyException:
-    # Another invocation is already running on this agent instance
-    ...
-```
+  try:
+      result = agent("Summarize this report")
+  except ConcurrencyException:
+      # Another invocation is already running on this agent instance
+      ...
+  ```
 
-For most applications this is the behavior you want. One agent instance maps to one conversation, and letting invocations overlap would interleave their messages and corrupt the history.
+  For most applications this is the behavior you want. One agent instance maps to one conversation, and letting invocations overlap would interleave their messages and corrupt the history.
 
-### Deduplicating retried requests
+  ### Deduplicating retried requests
 
-When a retry arrives for a request that is still running, returning the original's result beats both erroring and starting the work twice. Pass an idempotency token that identifies the logical request, for example `agent("Process order 1234", idempotency_token="order-1234")`.
+  When a retry arrives for a request that is still running, returning the original's result beats both erroring and starting the work twice. Pass an idempotency token that identifies the logical request, for example `agent("Process order 1234", idempotency_token="order-1234")`.
 
-If a call with the same token is already in flight, this call waits for the original and returns the same `AgentResult`. Tokens are compared by equality, so any stable identifier works: an order ID, a request UUID, or the prompt string itself.
+  If a call with the same token is already in flight, this call waits for the original and returns the same `AgentResult`. Tokens are compared by equality, so any stable identifier works: an order ID, a request UUID, or the prompt string itself.
 
-A deduplicated call gets the final result only, not the original's streamed events. Its `callback_handler` still fires once with that result, so output consumers are not left empty-handed.
+  A deduplicated call gets the final result only, not the original's streamed events. Its `callback_handler` still fires once with that result, so output consumers are not left empty-handed.
 
-If the original ends without producing a result, for instance when it is cancelled mid-flight, the waiting calls raise `IdempotencyAbortedError` so they can decide whether to retry:
+  If the original ends without producing a result, for instance when it is cancelled mid-flight, the waiting calls raise `IdempotencyAbortedError` so they can decide whether to retry:
 
-```python
-from strands import Agent
-from strands.types.exceptions import IdempotencyAbortedError
+  ```python
+  from strands import Agent
+  from strands.types.exceptions import IdempotencyAbortedError
 
-agent = Agent()
+  agent = Agent()
 
-try:
-    result = agent("Process order 1234", idempotency_token="order-1234")
-except IdempotencyAbortedError:
-    # The original was aborted before producing a result
-    ...
-```
+  try:
+      result = agent("Process order 1234", idempotency_token="order-1234")
+  except IdempotencyAbortedError:
+      # The original was aborted before producing a result
+      ...
+  ```
 
-The idempotency token works the same way on `invoke_async` and `stream_async`.
+  The idempotency token works the same way on `invoke_async` and `stream_async`.
 
-### Allowing concurrent invocations
+  ### Allowing concurrent invocations
 
-To run multiple invocations on one agent at the same time, set the concurrency mode when you construct it:
+  To run multiple invocations on one agent at the same time, set the concurrency mode when you construct it:
 
-```python
-from strands import Agent
-from strands.types.agent import ConcurrentInvocationMode
+  ```python
+  from strands import Agent
+  from strands.types.agent import ConcurrentInvocationMode
 
-agent = Agent(concurrent_invocation_mode=ConcurrentInvocationMode.UNSAFE_REENTRANT)
-```
+  agent = Agent(concurrent_invocation_mode=ConcurrentInvocationMode.UNSAFE_REENTRANT)
+  ```
 
-This removes the single-invocation guard entirely: overlapping calls neither raise nor deduplicate, and an idempotency token is ignored. Nothing protects the conversation history from concurrent mutation, so interleaved invocations can corrupt it. Reach for this only when each invocation works on isolated state, or when you handle synchronization yourself. To run independent work in parallel, a separate agent per task is safer than sharing one.
+  This removes the single-invocation guard entirely: overlapping calls neither raise nor deduplicate, and an idempotency token is ignored. Nothing protects the conversation history from concurrent mutation, so interleaved invocations can corrupt it. Reach for this only when each invocation works on isolated state, or when you handle synchronization yourself. To run independent work in parallel, a separate agent per task is safer than sharing one.
+  </Tab>
+  <Tab label="TypeScript">
+
+  The TypeScript SDK also rejects overlapping invocations: invoking an agent that is already running throws `ConcurrentInvocationError`. The configurable concurrency mode and idempotency-token deduplication described here are available only in the Python SDK.
+  </Tab>
+</Tabs>
 
 ## Common Problems
 


### PR DESCRIPTION
## Description
Documentation Update for idempotency semantics in Agent Loop

## Related Issues

#1365 

##Related PRs
#1937  #2932 

## Type of Change
Documentation update