### PR TITLE
fix: forward structured output request params for OpenAI Chat Completions

### DIFF
--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -849,10 +849,12 @@ class OpenAIModel(Model):
         # https://github.com/encode/httpx/discussions/2959.
         async with self._get_client() as client:
             try:
+                request = self.format_request(prompt, system_prompt=system_prompt)
+                # parse() is non-streaming; stream=True would raise, so drop the streaming-only fields.
+                request.pop("stream", None)
+                request.pop("stream_options", None)
                 response: ParsedChatCompletion = await client.beta.chat.completions.parse(
-                    model=self.get_config()["model_id"],
-                    messages=self.format_request(prompt, system_prompt=system_prompt)["messages"],
-                    response_format=output_model,
+                    **request, response_format=output_model
                 )
             except openai.BadRequestError as e:
                 # Check if this is a context length exceeded error

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1258,6 +1258,38 @@ async def test_structured_output(openai_client, model, test_output_model_cls, al
     assert tru_result == exp_result
 
 
+@pytest.mark.asyncio
+async def test_structured_output_forwards_request_params(openai_client, model_id, test_output_model_cls, alist):
+    messages = [{"role": "user", "content": [{"text": "Generate a person"}]}]
+    model = OpenAIModel(model_id=model_id, params={"max_tokens": 100, "temperature": 0.5})
+
+    mock_parsed_instance = test_output_model_cls(name="John", age=30)
+    mock_choice = unittest.mock.Mock()
+    mock_choice.message.parsed = mock_parsed_instance
+    mock_response = unittest.mock.Mock(choices=[mock_choice])
+    openai_client.beta.chat.completions.parse = unittest.mock.AsyncMock(return_value=mock_response)
+
+    stream = model.structured_output(test_output_model_cls, messages, system_prompt="Be precise.")
+    events = await alist(stream)
+
+    tru_result = events[-1]
+    exp_result = {"output": test_output_model_cls(name="John", age=30)}
+    assert tru_result == exp_result
+
+    # Config params are forwarded; the streaming-only fields (stream, stream_options) are dropped.
+    openai_client.beta.chat.completions.parse.assert_called_once_with(
+        messages=[
+            {"role": "system", "content": "Be precise."},
+            {"role": "user", "content": [{"text": "Generate a person", "type": "text"}]},
+        ],
+        model=model_id,
+        tools=[],
+        max_tokens=100,
+        temperature=0.5,
+        response_format=test_output_model_cls,
+    )
+
+
 def test_config_validation_warns_on_unknown_keys(openai_client, captured_warnings):
     """Test that unknown config keys emit a warning."""
     OpenAIModel({"api_key": "test"}, model_id="test-model", invalid_param="test")


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Equivalent to https://github.com/strands-agents/harness-sdk/pull/2551 (fix for normal OpenAI provider)

#2551 

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
