### PR TITLE
docs: clarify summary_ratio replaces oldest messages (TS parity)

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -166,7 +166,7 @@ The [`SummarizingConversationManager`](@api/python/strands.agent.conversation_ma
 
 Configuration parameters:
 
-- **`summary_ratio`** (float, default: 0.3): Percentage of the oldest messages to summarize and replace when reducing context (clamped between 0.1 and 0.8)
+- **`summary_ratio`** (float, default: 0.3): Ratio of the oldest messages to summarize and replace when reducing context (clamped between 0.1 and 0.8)
 - **`preserve_recent_messages`** (int, default: 10): Minimum number of recent messages to always keep
 - **`summarization_agent`** (Agent, optional): Custom agent for generating summaries. If not provided, uses the main agent instance. Cannot be used together with `summarization_system_prompt`.
 - **`summarization_system_prompt`** (str, optional): Custom system prompt for summarization. If not provided, uses a default prompt that creates structured bullet-point summaries focusing on key topics, tools used, and technical information in third-person format. Cannot be used together with `summarization_agent`.
@@ -177,7 +177,7 @@ Configuration parameters:
 Configuration parameters:
 
 - **`model`** (Model, optional): Override model to use for generating summaries. When not provided, uses the agent's own model.
-- **`summaryRatio`** (number, default: 0.3): Ratio of messages to summarize when reducing context (clamped between 0.1 and 0.8)
+- **`summaryRatio`** (number, default: 0.3): Ratio of the oldest messages to summarize and replace when reducing context (clamped between 0.1 and 0.8)
 - **`preserveRecentMessages`** (number, default: 10): Minimum number of recent messages to always keep
 - **`summarizationSystemPrompt`** (string, optional): Custom system prompt for summarization. If not provided, uses a default prompt that creates structured bullet-point summaries focusing on key topics, tools used, and technical information in third-person format.
 - **`proactiveCompression`** (`boolean | { compressionThreshold: number }`, optional): Enable proactive context compression before the model call. Pass `true` for the default 0.7 threshold, or an object with a custom threshold. See [Proactive Context Compression](#proactive-context-compression).

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -89,7 +89,7 @@ async function summarizingCustom() {
 
   const conversationManager = new SummarizingConversationManager({
     model: summarizationModel, // Override the agent's model for summarization
-    summaryRatio: 0.3, // Summarize 30% of messages when context reduction is needed
+    summaryRatio: 0.3, // Summarize and replace the oldest 30% of messages
     preserveRecentMessages: 10, // Always keep 10 most recent messages
   })
 
@@ -175,5 +175,3 @@ async function pinFirstExample() {
   })
   // --8<-- [end:pin_first]
 }
-
-


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

TS equivalent of #2612 , also aligns both explanations to mention "ratio" instead of "percentage" (more accurate to actual parameter)

## Related Issues

<!-- Link to related issues using #issue-number format -->

#2612 (python docs update)

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Documentation update

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
