### PR TITLE
feat(mcp/ts): load MCP servers from JSON

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { Agent, type ToolList } from '../agent.js'
-import { McpClient } from '../../mcp.js'
+import { McpClient } from '../../mcp/index.js'
 import { McpTool } from '../../tools/mcp-tool.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -25,7 +25,7 @@ import {
 } from '../types/messages.js'
 import { deepCopy } from '../types/json.js'
 import type { JSONValue } from '../types/json.js'
-import { McpClient } from '../mcp.js'
+import { McpClient } from '../mcp/index.js'
 import { isValidToolName, type Tool, type ToolContext } from '../tools/tool.js'
 import type { ToolChoice, ToolSpec } from '../tools/types.js'
 import { cloneSystemPrompt, systemPromptFromData } from '../types/messages.js'

--- a/strands-ts/src/index.node.ts
+++ b/strands-ts/src/index.node.ts
@@ -4,7 +4,10 @@
 // or bundlers will tree-shake the registrations.
 import { defaultSandbox } from './sandbox/default.js'
 import { NotASandboxLocalEnvironment } from './sandbox/not-a-sandbox-local-environment.js'
+import { mcpServerLoader } from './mcp/config.js'
+import { resolveServerConfigs } from './mcp/config.node.js'
 
 defaultSandbox.set(new NotASandboxLocalEnvironment())
+mcpServerLoader.set(resolveServerConfigs)
 
 export * from './index.js'

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -282,8 +282,9 @@ export {
   type McpCallToolOptions,
   type TasksConfig,
   type McpConnectionState,
+  type McpServerConfig,
   McpClient,
-} from './mcp.js'
+} from './mcp/index.js'
 export type { ElicitationCallback, ElicitationContext } from './types/elicitation.js'
 
 // Session management

--- a/strands-ts/src/mcp/__tests__/client.test.ts
+++ b/strands-ts/src/mcp/__tests__/client.test.ts
@@ -9,16 +9,16 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { ClientCredentialsProvider } from '@modelcontextprotocol/sdk/client/auth-extensions.js'
-import { McpClient } from '../mcp.js'
-import { McpTool } from '../tools/mcp-tool.js'
-import { JsonBlock, type TextBlock, type ToolResultBlock } from '../types/messages.js'
-import { ImageBlock } from '../types/media.js'
-import type { LocalAgent } from '../types/agent.js'
-import type { ToolContext } from '../tools/tool.js'
-import type { ElicitationCallback } from '../types/elicitation.js'
+import { McpClient } from '../client.js'
+import { McpTool } from '../../tools/mcp-tool.js'
+import { JsonBlock, type TextBlock, type ToolResultBlock } from '../../types/messages.js'
+import { ImageBlock } from '../../types/media.js'
+import type { LocalAgent } from '../../types/agent.js'
+import type { ToolContext } from '../../tools/tool.js'
+import type { ElicitationCallback } from '../../types/elicitation.js'
 import { context, propagation, trace, TraceFlags } from '@opentelemetry/api'
 import type { SpanContext } from '@opentelemetry/api'
-import { logger } from '../logging/index.js'
+import { logger } from '../../logging/index.js'
 import type { LoggingMessageNotificationParams } from '@modelcontextprotocol/sdk/types.js'
 
 /**
@@ -64,7 +64,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   }),
 }))
 
-vi.mock('../tools/tool.js', () => ({
+vi.mock('../../tools/tool.js', () => ({
   Tool: class {},
   createErrorResult: (err: unknown, toolUseId: string) => ({
     type: 'toolResultBlock',

--- a/strands-ts/src/mcp/__tests__/config.test.browser.ts
+++ b/strands-ts/src/mcp/__tests__/config.test.browser.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { McpClient } from '../client.js'
+
+// The unit-browser project has no setupFiles registering the MCP server loader,
+// mirroring a real browser where index.node.ts never loads.
+describe('McpClient.loadServers (browser)', () => {
+  it('throws because no Node loader is registered', async () => {
+    await expect(McpClient.loadServers({ server: { command: 'node' } })).rejects.toThrow(
+      'McpClient.loadServers is only available in Node.js'
+    )
+  })
+})

--- a/strands-ts/src/mcp/__tests__/config.test.node.ts
+++ b/strands-ts/src/mcp/__tests__/config.test.node.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import { McpClient } from '../client.js'
+import { mcpServerLoader } from '../config.js'
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}))
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/home/user'),
+}))
+
+vi.mock('node:path', () => ({
+  join: (...segments: string[]) => segments.join('/'),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn(function () {}),
+  getDefaultEnvironment: vi.fn(() => ({ PATH: '/usr/bin', HOME: '/home/user' })),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: vi.fn(function () {}),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: vi.fn(function () {}),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn(function (this: Record<string, unknown>) {
+    this.connect = vi.fn()
+    this.close = vi.fn()
+    this.listTools = vi.fn()
+    this.callTool = vi.fn()
+    this.setRequestHandler = vi.fn()
+    this.setNotificationHandler = vi.fn()
+    this.getServerCapabilities = vi.fn()
+    this.getServerVersion = vi.fn()
+    this.getInstructions = vi.fn()
+    this.experimental = { tasks: { callToolStream: vi.fn() } }
+  }),
+}))
+
+describe('McpClient.loadServers', () => {
+  // Register the Node loader after vi.mock hoisting so the resolver closes over the mocked
+  // transports. In production index.node.ts does this on import; this test bypasses that entry point.
+  beforeAll(async () => {
+    const { resolveServerConfigs } = await import('../config.node.js')
+    mcpServerLoader.set(resolveServerConfigs)
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('transport detection', () => {
+    it('creates StdioClientTransport when command is present', async () => {
+      const clients = await McpClient.loadServers({
+        'my-server': { command: 'node', args: ['server.js'] },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        args: ['server.js'],
+      })
+    })
+
+    it('creates McpClient with url when url is present', async () => {
+      const clients = await McpClient.loadServers({
+        'remote-server': { url: 'https://example.com/mcp' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(StdioClientTransport).not.toHaveBeenCalled()
+      expect(SSEClientTransport).not.toHaveBeenCalled()
+    })
+
+    it('creates SSEClientTransport when transport is "sse"', async () => {
+      const clients = await McpClient.loadServers({
+        'sse-server': { url: 'https://example.com/sse', transport: 'sse' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(SSEClientTransport).toHaveBeenCalledWith(new URL('https://example.com/sse'), undefined)
+    })
+
+    it('explicit transport overrides auto-detection', async () => {
+      const clients = await McpClient.loadServers({
+        server: { url: 'https://example.com/mcp', transport: 'sse' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(SSEClientTransport).toHaveBeenCalled()
+      expect(StreamableHTTPClientTransport).not.toHaveBeenCalled()
+    })
+
+    it('interpolates auth credentials for streamable-http', async () => {
+      vi.stubEnv('CLIENT_ID', 'my-id')
+      vi.stubEnv('CLIENT_SECRET', 'my-secret')
+
+      const clients = await McpClient.loadServers({
+        server: {
+          url: 'https://example.com/mcp',
+          auth: { clientId: '${CLIENT_ID}', clientSecret: '${CLIENT_SECRET}' },
+        },
+      })
+
+      expect(clients).toHaveLength(1)
+    })
+
+    it('throws when auth credential references missing env var', async () => {
+      vi.unstubAllEnvs()
+
+      await expect(
+        McpClient.loadServers({
+          server: {
+            url: 'https://example.com/mcp',
+            auth: { clientId: '${MISSING_ID}', clientSecret: 'literal' },
+          },
+        })
+      ).rejects.toThrow('Environment variable "MISSING_ID" is not set')
+    })
+  })
+
+  describe('env interpolation', () => {
+    it('interpolates ${VAR} in env values', async () => {
+      vi.stubEnv('MY_SECRET', 'secret123')
+
+      await McpClient.loadServers({
+        server: { command: 'node', env: { SECRET: '${MY_SECRET}' } },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        env: { PATH: '/usr/bin', HOME: '/home/user', SECRET: 'secret123' },
+      })
+    })
+
+    it('interpolates ${VAR} in headers', async () => {
+      vi.stubEnv('TOKEN', 'abc')
+
+      await McpClient.loadServers({
+        server: { url: 'https://example.com/sse', transport: 'sse', headers: { Authorization: 'Bearer ${TOKEN}' } },
+      })
+
+      expect(SSEClientTransport).toHaveBeenCalledWith(new URL('https://example.com/sse'), {
+        requestInit: { headers: { Authorization: 'Bearer abc' } },
+      })
+    })
+
+    it('interpolates ${VAR} in url', async () => {
+      vi.stubEnv('HOST', 'myhost.com')
+
+      const clients = await McpClient.loadServers({
+        server: { url: 'https://${HOST}/mcp', transport: 'sse' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(SSEClientTransport).toHaveBeenCalledWith(new URL('https://myhost.com/mcp'), undefined)
+    })
+
+    it('throws when env var is not set', async () => {
+      vi.unstubAllEnvs()
+
+      await expect(
+        McpClient.loadServers({
+          server: { command: 'node', env: { VAL: '${NONEXISTENT_VAR}' } },
+        })
+      ).rejects.toThrow('Environment variable "NONEXISTENT_VAR" is not set')
+    })
+
+    it('skips server with missing env var when continueOnError is true', async () => {
+      vi.unstubAllEnvs()
+
+      const clients = await McpClient.loadServers({
+        broken: { command: 'node', env: { VAL: '${NONEXISTENT_VAR}' }, continueOnError: true },
+        working: { command: 'node' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(clients[0]!.clientName).toBe('working')
+    })
+
+    it('throws on a non-object entry even when continueOnError is true', async () => {
+      // A malformed (non-object) entry is a structural config error, not a per-server
+      // resolution failure, so continueOnError does not suppress it.
+      await expect(
+        McpClient.loadServers({ bad: 'oops' as unknown as Record<string, never> }, { continueOnError: true })
+      ).rejects.toThrow('must be an object')
+    })
+
+    it('interpolates ${VAR} in cwd', async () => {
+      vi.stubEnv('PROJECT_DIR', '/home/user/projects')
+
+      await McpClient.loadServers({
+        server: { command: 'node', cwd: '${PROJECT_DIR}/my-server' },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        cwd: '/home/user/projects/my-server',
+      })
+    })
+
+    it('merges env with default environment', async () => {
+      await McpClient.loadServers({
+        server: { command: 'node', env: { CUSTOM: 'value' } },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        env: { PATH: '/usr/bin', HOME: '/home/user', CUSTOM: 'value' },
+      })
+    })
+  })
+
+  describe('file config loading', () => {
+    it('reads and parses a JSON file', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          'my-server': { command: 'node', args: ['server.js'] },
+        })
+      )
+
+      const clients = await McpClient.loadServers('/path/to/config.json')
+
+      expect(readFile).toHaveBeenCalledWith('/path/to/config.json', 'utf-8')
+      expect(clients).toHaveLength(1)
+    })
+
+    it('extracts mcpServers key when present', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          mcpServers: {
+            'server-a': { command: 'node' },
+            'server-b': { url: 'https://example.com' },
+          },
+        })
+      )
+
+      const clients = await McpClient.loadServers('/path/to/config.json')
+
+      expect(clients).toHaveLength(2)
+    })
+
+    it('uses whole object when mcpServers key is absent', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          'server-a': { command: 'node' },
+        })
+      )
+
+      const clients = await McpClient.loadServers('/path/to/config.json')
+
+      expect(clients).toHaveLength(1)
+    })
+
+    it('expands ~ to home directory', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          server: { command: 'node' },
+        })
+      )
+
+      await McpClient.loadServers('~/config/mcp.json')
+
+      expect(readFile).toHaveBeenCalledWith('/home/user/config/mcp.json', 'utf-8')
+    })
+  })
+
+  describe('defaults and per-server overrides', () => {
+    it('per-server continueOnError overrides defaults', async () => {
+      const clients = await McpClient.loadServers(
+        {
+          'strict-server': { command: 'node', continueOnError: false },
+          'lenient-server': { command: 'node', continueOnError: true },
+        },
+        { continueOnError: true }
+      )
+
+      expect(clients[0]!.continueOnError).toBe(false)
+      expect(clients[1]!.continueOnError).toBe(true)
+    })
+
+    it('applies default continueOnError when server does not override', async () => {
+      const clients = await McpClient.loadServers({ server: { command: 'node' } }, { continueOnError: true })
+
+      expect(clients[0]!.continueOnError).toBe(true)
+    })
+
+    it('uses server name as applicationName when not in defaults', async () => {
+      const clients = await McpClient.loadServers({
+        'my-named-server': { command: 'node' },
+      })
+
+      expect(clients[0]!.clientName).toBe('my-named-server')
+    })
+
+    it('uses defaults applicationName over server name', async () => {
+      const clients = await McpClient.loadServers({ server: { command: 'node' } }, { applicationName: 'my-app' })
+
+      expect(clients[0]!.clientName).toBe('my-app')
+    })
+  })
+
+  describe('error cases', () => {
+    it('throws when server has neither command nor url', async () => {
+      await expect(McpClient.loadServers({ bad: {} })).rejects.toThrow(
+        'Server config must include either "command" (stdio) or "url" (http)'
+      )
+    })
+
+    it('throws when stdio transport specified without command', async () => {
+      await expect(McpClient.loadServers({ bad: { transport: 'stdio' } })).rejects.toThrow(
+        'Stdio transport requires "command" field'
+      )
+    })
+
+    it('throws when streamable-http transport specified without url', async () => {
+      await expect(McpClient.loadServers({ bad: { transport: 'streamable-http' } })).rejects.toThrow(
+        'Streamable HTTP transport requires "url" field'
+      )
+    })
+
+    it('throws when sse transport specified without url', async () => {
+      await expect(McpClient.loadServers({ bad: { transport: 'sse' } })).rejects.toThrow(
+        'SSE transport requires "url" field'
+      )
+    })
+
+    it('throws on invalid file path', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockRejectedValue(new Error('ENOENT: no such file or directory'))
+
+      await expect(McpClient.loadServers('/nonexistent/path.json')).rejects.toThrow('ENOENT')
+    })
+
+    it('throws on malformed JSON', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue('not json{{{')
+
+      await expect(McpClient.loadServers('/path/to/bad.json')).rejects.toThrow()
+    })
+
+    it('throws when auth is used with sse transport', async () => {
+      await expect(
+        McpClient.loadServers({
+          server: {
+            url: 'https://example.com',
+            transport: 'sse',
+            auth: { clientId: 'id', clientSecret: 'secret' },
+          },
+        })
+      ).rejects.toThrow('SSE transport does not support auth')
+    })
+
+    it('throws on invalid config shape', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify([1, 2, 3]))
+
+      await expect(McpClient.loadServers('/path/to/bad.json')).rejects.toThrow('MCP config must be a JSON object')
+    })
+
+    it('throws when server has both command and url without explicit transport', async () => {
+      await expect(McpClient.loadServers({ bad: { command: 'node', url: 'https://example.com' } })).rejects.toThrow(
+        'Server config has both "command" and "url"'
+      )
+    })
+  })
+
+  describe('disabled', () => {
+    it('skips disabled servers', async () => {
+      const clients = await McpClient.loadServers({
+        active: { command: 'node' },
+        inactive: { command: 'node', disabled: true },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(clients[0]!.clientName).toBe('active')
+    })
+  })
+
+  describe('env interpolation syntax', () => {
+    it('supports ${env:VAR} namespaced syntax', async () => {
+      vi.stubEnv('MY_TOKEN', 'token123')
+
+      await McpClient.loadServers({
+        server: { command: 'node', env: { TOKEN: '${env:MY_TOKEN}' } },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        env: { PATH: '/usr/bin', HOME: '/home/user', TOKEN: 'token123' },
+      })
+    })
+
+    it('interpolates ${VAR} in command and args', async () => {
+      vi.stubEnv('MY_CMD', '/usr/local/bin/server')
+      vi.stubEnv('MY_ARG', '3000')
+
+      await McpClient.loadServers({
+        server: { command: '${MY_CMD}', args: ['--port=${MY_ARG}'] },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: '/usr/local/bin/server',
+        args: ['--port=3000'],
+      })
+    })
+  })
+})

--- a/strands-ts/src/mcp/__tests__/config.test.node.ts
+++ b/strands-ts/src/mcp/__tests__/config.test.node.ts
@@ -76,6 +76,7 @@ describe('McpClient.loadServers', () => {
       })
 
       expect(clients).toHaveLength(1)
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(new URL('https://example.com/mcp'), {})
       expect(StdioClientTransport).not.toHaveBeenCalled()
       expect(SSEClientTransport).not.toHaveBeenCalled()
     })
@@ -248,6 +249,11 @@ describe('McpClient.loadServers', () => {
       const clients = await McpClient.loadServers('/path/to/config.json')
 
       expect(clients).toHaveLength(2)
+      // Verify each entry wired to the right transport, not just that two clients were created:
+      // server-a (command) builds a stdio transport; server-b (url) takes the http path, not sse.
+      expect(StdioClientTransport).toHaveBeenCalledTimes(1)
+      expect(StdioClientTransport).toHaveBeenCalledWith({ command: 'node' })
+      expect(SSEClientTransport).not.toHaveBeenCalled()
     })
 
     it('uses whole object when mcpServers key is absent', async () => {

--- a/strands-ts/src/mcp/client.ts
+++ b/strands-ts/src/mcp/client.ts
@@ -12,10 +12,11 @@ import {
   type LoggingMessageNotificationParams,
 } from '@modelcontextprotocol/sdk/types.js'
 import { context, propagation, trace } from '@opentelemetry/api'
-import type { JSONSchema, JSONValue } from './types/json.js'
-import type { ElicitationCallback } from './types/elicitation.js'
-import { McpTool } from './tools/mcp-tool.js'
-import { logger } from './logging/index.js'
+import type { JSONSchema, JSONValue } from '../types/json.js'
+import type { ElicitationCallback } from '../types/elicitation.js'
+import { McpTool } from '../tools/mcp-tool.js'
+import { logger } from '../logging/index.js'
+import { type McpServerConfig, mcpServerLoader } from './config.js'
 
 /**
  * Widened transport type that accepts MCP transport implementations without requiring explicit casts.
@@ -125,6 +126,20 @@ export class McpClient {
 
   /** Default poll timeout for task completion in milliseconds (5 minutes). */
   public static readonly DEFAULT_POLL_TIMEOUT = 300000
+
+  /**
+   * Parses an MCP servers config (file path or object) and returns McpClient instances.
+   *
+   * @param config - A file path to a JSON config, or a flat server map object.
+   * @param defaults - Options applied to all clients unless overridden per-server.
+   * @returns An array of McpClient instances ready to be passed to an Agent.
+   */
+  public static async loadServers(
+    config: string | Record<string, McpServerConfig>,
+    defaults?: McpClientOptions
+  ): Promise<McpClient[]> {
+    return (await mcpServerLoader.get()(config, defaults)).map((c) => new McpClient(c))
+  }
 
   private _clientName: string
   private _clientVersion: string

--- a/strands-ts/src/mcp/config.node.ts
+++ b/strands-ts/src/mcp/config.node.ts
@@ -1,0 +1,165 @@
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import type { McpClientConfig, McpClientOptions, McpTransport } from './client.js'
+import type { McpServerConfig } from './config.js'
+import { logger } from '../logging/index.js'
+
+/**
+ * Resolves an MCP servers config into an array of client configurations ready for instantiation.
+ *
+ * Registered into the `mcpServerLoader` slot by the Node entry point so that `McpClient.loadServers`
+ * can reach it without the browser bundle graph importing any of this module's Node-only dependencies.
+ *
+ * @param config - A file path to a JSON config, or a flat server map object.
+ * @param defaults - Options applied to all clients unless overridden per-server.
+ * @returns Resolved McpClientConfig array (one per enabled, successfully-resolved server).
+ *
+ * @internal
+ */
+export async function resolveServerConfigs(
+  config: string | Record<string, McpServerConfig>,
+  defaults?: McpClientOptions
+): Promise<McpClientConfig[]> {
+  const servers = await loadServersObject(config)
+  const results: McpClientConfig[] = []
+
+  for (const [name, server] of Object.entries(servers)) {
+    // A non-object entry is a malformed-config error and always throws, unlike per-server failures.
+    if (!server || typeof server !== 'object' || Array.isArray(server)) {
+      throw new Error(`Server "${name}" must be an object, got ${Array.isArray(server) ? 'array' : typeof server}`)
+    }
+
+    if (server.disabled) continue
+
+    const continueOnError = server.continueOnError ?? defaults?.continueOnError ?? false
+
+    try {
+      if (server.command && server.url && !server.transport) {
+        throw new Error('Server config has both "command" and "url" — set "transport" explicitly or remove one')
+      }
+
+      const type = server.transport ?? (server.command ? 'stdio' : server.url ? 'streamable-http' : undefined)
+      if (!type) throw new Error('Server config must include either "command" (stdio) or "url" (http)')
+
+      let clientConfig: McpClientConfig
+      switch (type) {
+        case 'stdio':
+          clientConfig = buildStdioConfig(server)
+          break
+        case 'streamable-http':
+          clientConfig = buildHttpConfig(server)
+          break
+        case 'sse':
+          clientConfig = buildSseConfig(server)
+          break
+        default: {
+          const _exhaustive: never = type
+          throw new Error(`Unsupported transport type: ${_exhaustive}`)
+        }
+      }
+
+      results.push({ ...baseOptions(name, server, defaults), ...clientConfig })
+    } catch (error) {
+      if (!continueOnError) throw error
+      logger.warn(`server=<${name}>, error=<${error}> | MCP server config failed, skipping (continueOnError)`)
+    }
+  }
+
+  return results
+}
+
+function buildStdioConfig(server: McpServerConfig): McpClientConfig {
+  if (!server.command) throw new Error('Stdio transport requires "command" field')
+
+  const opts: ConstructorParameters<typeof StdioClientTransport>[0] = {
+    command: interpolateEnv(server.command),
+  }
+  if (server.args) opts.args = server.args.map(interpolateEnv)
+  if (server.env) opts.env = { ...getDefaultEnvironment(), ...interpolateRecord(server.env) }
+  if (server.cwd) opts.cwd = interpolateEnv(server.cwd)
+
+  return { transport: new StdioClientTransport(opts) as McpTransport }
+}
+
+function buildHttpConfig(server: McpServerConfig): McpClientConfig {
+  if (!server.url) throw new Error('Streamable HTTP transport requires "url" field')
+
+  const config: McpClientConfig = { url: interpolateEnv(server.url) }
+  if (server.headers) config.headers = interpolateRecord(server.headers)
+  if (server.auth) {
+    config.auth = {
+      clientId: interpolateEnv(server.auth.clientId),
+      clientSecret: interpolateEnv(server.auth.clientSecret),
+      ...(server.auth.scopes && { scopes: server.auth.scopes.map(interpolateEnv) }),
+    }
+  }
+  return config
+}
+
+function buildSseConfig(server: McpServerConfig): McpClientConfig {
+  if (!server.url) throw new Error('SSE transport requires "url" field')
+  if (server.auth)
+    throw new Error('SSE transport does not support auth — use streamable-http or provide a pre-configured transport')
+
+  const headers = server.headers ? interpolateRecord(server.headers) : undefined
+
+  return {
+    transport: new SSEClientTransport(
+      new URL(interpolateEnv(server.url)),
+      headers ? { requestInit: { headers } } : undefined
+    ) as McpTransport,
+  }
+}
+
+function baseOptions(name: string, server: McpServerConfig, defaults?: McpClientOptions): McpClientOptions {
+  // applicationName is the shared app identity sent in the MCP handshake; honor an explicit
+  // default for all clients, falling back to the server's config key when none is given.
+  const opts: McpClientOptions = { ...defaults, applicationName: defaults?.applicationName ?? name }
+  if (server.continueOnError != null) opts.continueOnError = server.continueOnError
+  if (server.tasksConfig != null) opts.tasksConfig = server.tasksConfig
+  return opts
+}
+
+/**
+ * Replaces `$\{VAR\}` and `$\{env:VAR\}` placeholders with their process.env values.
+ * Throws if a referenced variable is not set.
+ *
+ * @example
+ * ```typescript
+ * interpolateEnv('Bearer $\{TOKEN\}')       // → 'Bearer ghp_abc123'
+ * interpolateEnv('$\{env:HOME\}/config')    // → '/home/user/config'
+ * ```
+ */
+function interpolateEnv(value: string): string {
+  return value.replace(/\$\{(?:env:)?([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, key: string) => {
+    const resolved = process.env[key]
+    if (resolved === undefined) throw new Error(`Environment variable "${key}" is not set`)
+    return resolved
+  })
+}
+
+/** Applies {@link interpolateEnv} to every value in a string record. */
+function interpolateRecord(record: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(record).map(([k, v]) => [k, interpolateEnv(v)]))
+}
+
+async function loadServersObject(
+  config: string | Record<string, McpServerConfig>
+): Promise<Record<string, McpServerConfig>> {
+  if (typeof config !== 'string') return config
+
+  const filePath = config.startsWith('~/') ? join(homedir(), config.slice(2)) : config
+  const parsed = JSON.parse(await readFile(filePath, 'utf-8'))
+  const servers = parsed.mcpServers ?? parsed
+
+  if (!servers || typeof servers !== 'object' || Array.isArray(servers)) {
+    throw new Error(
+      'MCP config must be a JSON object mapping server names to configs, e.g. { "my-server": { "command": "node" } }'
+    )
+  }
+
+  return servers
+}

--- a/strands-ts/src/mcp/config.ts
+++ b/strands-ts/src/mcp/config.ts
@@ -1,0 +1,60 @@
+import type { McpClientConfig, McpClientCredentials, McpClientOptions, TasksConfig } from './client.js'
+import { createDefaultSlot } from '../default-slot.js'
+
+/**
+ * Configuration for a single MCP server entry in a config file or object.
+ *
+ * Provide either `command` (stdio transport) or `url` (streamable-http/SSE), not both.
+ * When `transport` is omitted, it is auto-detected from the fields present.
+ */
+export interface McpServerConfig {
+  /** Command to spawn (stdio transport, supports `${VAR}` or `${env:VAR}` interpolation). */
+  command?: string
+  /** Arguments passed to the command (supports `${VAR}` or `${env:VAR}` interpolation). */
+  args?: string[]
+  /** Environment variables passed to the child process (supports `${VAR}` or `${env:VAR}` interpolation). */
+  env?: Record<string, string>
+  /** Working directory for the spawned process (supports `${VAR}` or `${env:VAR}` interpolation). */
+  cwd?: string
+  /** Server endpoint URL (streamable-http or SSE transport, supports `${VAR}` or `${env:VAR}` interpolation). */
+  url?: string
+  /** HTTP headers sent with every request (supports `${VAR}` or `${env:VAR}` interpolation). */
+  headers?: Record<string, string>
+  /** Explicit transport type. When omitted, auto-detected: `command` → stdio, `url` → streamable-http. */
+  transport?: 'stdio' | 'sse' | 'streamable-http'
+  /** Client credentials for OAuth machine-to-machine auth (streamable-http only). */
+  auth?: McpClientCredentials
+  /** When true, this server is skipped during loadServers. */
+  disabled?: boolean
+  /** When true, config or connection failures skip this server instead of throwing. */
+  continueOnError?: boolean
+  /** Task-augmented tool execution configuration (experimental). */
+  tasksConfig?: TasksConfig
+}
+
+/**
+ * Translates each declarative MCP server entry into the parameters that instantiate an McpClient.
+ *
+ * Implemented by the Node-only module `config.node.ts` and registered into {@link mcpServerLoader}
+ * when running in a Node environment. Keeping it behind a slot keeps the Node-only filesystem and
+ * stdio/SSE transport imports out of the browser bundle graph.
+ *
+ * @internal
+ */
+export type McpServerLoader = (
+  config: string | Record<string, McpServerConfig>,
+  defaults?: McpClientOptions
+) => Promise<McpClientConfig[]>
+
+/**
+ * Registry slot holding the Node-only MCP server loader.
+ *
+ * The Node entry point (`index.node.ts`) fills this slot on import. In environments where it is
+ * never filled (e.g. the browser), reading the slot throws a clear, actionable error instead of
+ * failing at bundle time with an unresolved `node:fs` import.
+ *
+ * @internal
+ */
+export const mcpServerLoader = createDefaultSlot<McpServerLoader>(
+  'McpClient.loadServers is only available in Node.js. Construct McpClient instances directly, or import from "@strands-agents/sdk" in a Node entry point.'
+)

--- a/strands-ts/src/mcp/index.ts
+++ b/strands-ts/src/mcp/index.ts
@@ -1,0 +1,11 @@
+export {
+  type McpClientOptions,
+  type McpClientConfig,
+  type McpClientCredentials,
+  type McpTransport,
+  type McpCallToolOptions,
+  type TasksConfig,
+  type McpConnectionState,
+  McpClient,
+} from './client.js'
+export type { McpServerConfig } from './config.js'

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -6,7 +6,7 @@ import type { JSONSchema, JSONValue } from '../types/json.js'
 import { JsonBlock, TextBlock, ToolResultBlock, type ToolResultContent } from '../types/messages.js'
 import { ImageBlock, decodeBase64 } from '../types/media.js'
 import { toMediaFormat, IMAGE_FORMATS, type ImageFormat } from '../mime.js'
-import type { McpClient } from '../mcp.js'
+import type { McpClient } from '../mcp/index.js'
 import { logger } from '../logging/logger.js'
 
 export interface McpToolConfig {

--- a/strands-ts/test/integ/__fixtures__/register-node-defaults.ts
+++ b/strands-ts/test/integ/__fixtures__/register-node-defaults.ts
@@ -1,5 +1,8 @@
 import { defaultSandbox } from '$/sdk/sandbox/default.js'
 import { NotASandboxLocalEnvironment } from '$/sdk/sandbox/not-a-sandbox-local-environment.js'
+import { mcpServerLoader } from '$/sdk/mcp/config.js'
+import { resolveServerConfigs } from '$/sdk/mcp/config.node.js'
 
-// Integration tests don't load index.node.ts; register the node default sandbox.
+// Integration tests don't load index.node.ts; register the node defaults.
 defaultSandbox.set(new NotASandboxLocalEnvironment())
+mcpServerLoader.set(resolveServerConfigs)


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Adds `McpClient.loadServers()` — a static factory that turns an `mcpServers` JSON config (a file path or an in-memory map) into ready-to-use `McpClient[]`, so users can declare multiple MCP servers declaratively instead of hand-wiring a transport per client.

**Before:**
```ts
import { Agent, McpClient } from '@strands-agents/sdk'
import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'

const awsDocs = new McpClient({ transport: new StdioClientTransport(
    { command: 'uvx', args: ['awslabs.aws-documentation-mcp-server@latest'] }) 
})

const github = new McpClient({ transport: new StreamableHTTPClientTransport(
    new URL('https://api.githubcopilot.com/mcp/'), { requestInit: { 
        headers: { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } } 
    }) 
})

const agent = new Agent({
  tools: [awsDocs, github],
})
```


**After:**
```ts
import { Agent, McpClient } from '@strands-agents/sdk'

const agent = new Agent({
  tools: await McpClient.loadServers({
    'aws-docs': { 
        command: 'uvx', 
        args: ['awslabs.aws-documentation-mcp-server@latest'] },
    'github': { 
        url: 'https://api.githubcopilot.com/mcp/', 
        headers: { Authorization: 'Bearer ${GITHUB_TOKEN}' } },
  }),
})
```

Or directly from a JSON file:

```ts
const agent = new Agent({
    tools: await McpClient.loadServers('~/mcp-config.json')
})
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

- Python PR: https://github.com/strands-agents/harness-sdk/pull/3053

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

Not yet

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
