### PR TITLE
fix(litellm): generate toolUseId when missing from provider

### DIFF
--- a/strands-py/src/strands/models/litellm.py
+++ b/strands-py/src/strands/models/litellm.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import uuid
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -519,7 +520,11 @@ class LiteLLMModel(OpenAIModel):
             Formatted tool call chunks.
         """
         for tool_deltas in tool_calls.values():
-            yield self.format_chunk({"chunk_type": "content_start", "data_type": "tool", "data": tool_deltas[0]})
+            first_delta = tool_deltas[0]
+            if not first_delta.id:
+                first_delta.id = f"call_{uuid.uuid4()}"
+
+            yield self.format_chunk({"chunk_type": "content_start", "data_type": "tool", "data": first_delta})
 
             for tool_delta in tool_deltas:
                 yield self.format_chunk({"chunk_type": "content_delta", "data_type": "tool", "data": tool_delta})

--- a/strands-py/tests/strands/models/test_litellm.py
+++ b/strands-py/tests/strands/models/test_litellm.py
@@ -1019,3 +1019,26 @@ def test_thought_signature_round_trip():
     tool_call = LiteLLMModel.format_request_message_tool_call(internal_tool_use)
     assert "__thought__" in tool_call["id"]
     assert signature in tool_call["id"]
+
+
+@pytest.mark.asyncio
+async def test_stream_generates_tool_call_id_when_null(litellm_acompletion, model, agenerator, alist):
+    mock_tool_call = unittest.mock.Mock(index=0)
+    mock_tool_call.id = None
+    mock_tool_call.function.name = "test_tool"
+    mock_tool_call.function.arguments = '{"arg": "value"}'
+
+    mock_delta_1 = unittest.mock.Mock(content=None, tool_calls=[mock_tool_call], reasoning_content=None)
+    mock_delta_2 = unittest.mock.Mock(content=None, tool_calls=None, reasoning_content=None)
+
+    mock_event_1 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason=None, delta=mock_delta_1)])
+    mock_event_2 = unittest.mock.Mock(choices=[unittest.mock.Mock(finish_reason="tool_calls", delta=mock_delta_2)])
+
+    litellm_acompletion.side_effect = unittest.mock.AsyncMock(return_value=agenerator([mock_event_1, mock_event_2]))
+
+    response = model.stream([{"role": "user", "content": [{"text": "test"}]}])
+    events = await alist(response)
+
+    start = next(e for e in events if "contentBlockStart" in e and "toolUse" in e["contentBlockStart"]["start"])
+    tool_id = start["contentBlockStart"]["start"]["toolUse"]["toolUseId"]
+    assert tool_id and tool_id.startswith("call_")


### PR DESCRIPTION
Supersedes #1262 with a clean rebase on current main.

LiteLLM returns null for the tool call id field on some providers, leaving toolUseId as None in the resulting event stream. The fix assigns a fresh call_<uuid4> when the first tool delta arrives without an id, before the content_start chunk, so downstream consumers see a stable identifier. Behavior is unchanged whenever a provider supplies an id.

Refs #1262, fixes #1259.