### PR TITLE
fix(bedrock): deliver streaming chunks individually instead of in batches

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -920,12 +920,10 @@ class BedrockModel(Model):
         """
 
         def callback(event: StreamEvent | None = None) -> None:
-            loop.call_soon_threadsafe(queue.put_nowait, event)
-            if event is None:
-                return
+            asyncio.run_coroutine_threadsafe(queue.put(event), loop).result()
 
         loop = asyncio.get_event_loop()
-        queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
+        queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue(maxsize=1)
 
         # Handle backward compatibility: if system_prompt is provided but system_prompt_content is None
         if system_prompt and system_prompt_content is None:

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -934,6 +934,38 @@ async def test_stream(bedrock_client, model, messages, tool_spec, model_id, addi
 
 
 @pytest.mark.asyncio
+async def test_stream_delivers_chunks_individually(bedrock_client, model, messages):
+    """Test that stream delivers chunks one at a time, not in batches.
+
+    Regression test for https://github.com/strands-agents/sdk-python/issues/1523.
+    When the Bedrock stream produces chunks in a burst (no delay between them),
+    the consumer should still receive them individually rather than all at once.
+    """
+    chunks = [f"chunk_{i}" for i in range(10)]
+    bedrock_client.converse_stream.return_value = {"stream": chunks}
+
+    queue_depths = []
+    original_get = asyncio.Queue.get
+
+    async def tracking_get(self):
+        result = await original_get(self)
+        queue_depths.append(self.qsize())
+        return result
+
+    with unittest.mock.patch.object(asyncio.Queue, "get", tracking_get):
+        received = []
+        async for event in model.stream(messages):
+            received.append(event)
+
+    assert received == chunks
+    # After each get(), the queue should be empty (depth 0) — chunks delivered one at a time
+    assert all(d == 0 for d in queue_depths), (
+        f"Chunks were batched! Queue depths after each get(): {queue_depths}. "
+        f"Expected all zeros for individual delivery."
+    )
+
+
+@pytest.mark.asyncio
 async def test_stream_with_system_prompt_content(bedrock_client, model, messages, alist):
     """Test stream method with system_prompt_content parameter."""
     bedrock_client.converse_stream.return_value = {"stream": ["e1", "e2"]}


### PR DESCRIPTION
Supersedes #1759 with a clean rebase on current main after the monorepo restructure.

When Bedrock delivers a burst of chunks in a single TCP segment, call_soon_threadsafe schedules every put_nowait on the same event-loop tick, so the queue accumulates all chunks before any consumer await runs and the stream feels batched. Switching the producer callback to run_coroutine_threadsafe with a maxsize=1 queue forces real backpressure between the boto3 worker thread and the asyncio consumer, so each chunk is delivered before the next is enqueued. The pattern matches what mcp_client.py already does and the regression test asserts queue depth stays at zero after every consumer get.

Refs #1759, fixes #1523. Original commit by @shivaber, carried forward to the strands-py/ layout.