### PR TITLE
fix(bidi): respect role from BidiTextInputEvent

### DIFF
--- a/strands-py/src/strands/experimental/bidi/agent/loop.py
+++ b/strands-py/src/strands/experimental/bidi/agent/loop.py
@@ -141,7 +141,7 @@ class _BidiAgentLoop:
             await self._send_gate.wait()
 
         if isinstance(event, BidiTextInputEvent):
-            message: Message = {"role": "user", "content": [{"text": event.text}]}
+            message: Message = {"role": event.role, "content": [{"text": event.text}]}
             await self._agent._append_messages(message)
 
         await self._agent.model.send(event)

--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
@@ -248,3 +248,12 @@ async def test_bidi_agent_loop_request_state_preserved_with_invocation_state(age
     # Verify request_state was added without removing custom_data
     assert "request_state" in loop._invocation_state
     assert loop._invocation_state.get("custom_data") == "preserved"
+
+
+@pytest.mark.asyncio
+async def test_bidi_agent_loop_send_respects_event_role(loop, agent):
+    agent.model.start = unittest.mock.AsyncMock()
+    agent.model.send = unittest.mock.AsyncMock()
+    await loop.start()
+    await loop.send(BidiTextInputEvent(text="injected context", role="assistant"))
+    assert agent.messages[-1] == {"role": "assistant", "content": [{"text": "injected context"}]}


### PR DESCRIPTION
The bidi agent loop hardcodes the appended message role to user when handling a BidiTextInputEvent, ignoring the event's role attribute entirely. Callers who construct an event with role="assistant" to inject context have that value silently overwritten. The fix swaps the literal for event.role at the single call site so the explicit role flows through.

Fixes #2089.