### PR TITLE
fix(agent): release invocation lock only in throw mode

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1214,7 +1214,8 @@ class Agent(AgentBase):
             self._cancel_signal.clear()
 
             self._concurrency.complete(begin.registered_token, result=result)
-            self._concurrency.release_lock()
+            if self._concurrency.mode == ConcurrentInvocationMode.THROW:
+                self._concurrency.release_lock()
 
     async def _run_loop(
         self,


### PR DESCRIPTION
In UNSAFE_REENTRANT mode begin() never acquires the invocation lock, but stream_async's finally was calling release_lock() unconditionally and could release a lock owned by a concurrent direct tool call from _caller.py. Gating the release on ConcurrentInvocationMode.THROW makes the UNSAFE_REENTRANT path a no-op while leaving THROW behavior unchanged.

Fixes #2918.