### PR TITLE
fix(graph): drop reasoning blocks before downstream node input

### DIFF
--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -741,8 +741,9 @@ export class Graph implements MultiAgent {
     const deps: ContentBlock[] = []
     for (const edge of this.edges.filter((e) => e.target.id === node.id)) {
       const ns = state.node(edge.source.id)!
-      if (ns.content.length > 0) {
-        deps.push(new TextBlock(`[node: ${edge.source.id}]`), ...ns.content)
+      const forwarded = ns.content.filter((b) => b.type !== 'reasoningBlock')
+      if (forwarded.length > 0) {
+        deps.push(new TextBlock(`[node: ${edge.source.id}]`), ...forwarded)
       }
     }
 


### PR DESCRIPTION
Graph nodes forward the previous node's full message into the next node's input, including reasoning blocks that downstream nodes cannot consume. The fix filters reasoning content out of the forwarded message before invoking the next executor, leaving every other content block intact.

Fixes #2882.