### PR TITLE
fix(models): raise ContextWindowOverflowException for ollama/llama/mistral/writer

### DIFF
--- a/strands-py/src/strands/models/llamaapi.py
+++ b/strands-py/src/strands/models/llamaapi.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
-from ..types.exceptions import ModelThrottledException
+from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent, Usage
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
@@ -30,6 +30,15 @@ T = TypeVar("T", bound=BaseModel)
 
 class LlamaAPIModel(Model):
     """Llama API model provider implementation."""
+
+    OVERFLOW_MESSAGES = {
+        "this model's maximum context length is",
+        "exceed context limit",
+        "model's maximum context limit",
+        "is longer than the model's context length",
+        "prompt is too long",
+        "too many tokens",
+    }
 
     class LlamaConfig(BaseModelConfig, total=False):
         """Configuration options for Llama API models.
@@ -355,6 +364,7 @@ class LlamaAPIModel(Model):
             Formatted message chunks from the model.
 
         Raises:
+            ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: When the model service is throttling requests from the client.
         """
         warn_on_tool_choice_not_supported(tool_choice)
@@ -368,6 +378,10 @@ class LlamaAPIModel(Model):
             response = self.client.chat.completions.create(**request)
         except llama_api_client.RateLimitError as e:
             raise ModelThrottledException(str(e)) from e
+        except llama_api_client.BadRequestError as e:
+            if any(message in str(e).lower() for message in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(e)) from e
+            raise
 
         logger.debug("got response from model")
         yield self.format_chunk({"chunk_type": "message_start"})

--- a/strands-py/src/strands/models/mistral.py
+++ b/strands-py/src/strands/models/mistral.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
-from ..types.exceptions import ModelThrottledException
+from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._defaults import resolve_config_metadata
@@ -36,6 +36,11 @@ class MistralModel(Model):
     - Tool/function calling
     - System prompts
     """
+
+    OVERFLOW_MESSAGES = {
+        "too large for model",
+        "maximum context length",
+    }
 
     class MistralConfig(BaseModelConfig, total=False):
         """Configuration parameters for Mistral models.
@@ -422,6 +427,7 @@ class MistralModel(Model):
             Formatted message chunks from the model.
 
         Raises:
+            ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: When the model service is throttling requests.
         """
         warn_on_tool_choice_not_supported(tool_choice)
@@ -501,6 +507,8 @@ class MistralModel(Model):
                                 yield self.format_chunk({"chunk_type": "metadata", "data": chunk.data.usage})
 
         except Exception as e:
+            if any(message in str(e).lower() for message in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(e)) from e
             if "rate" in str(e).lower() or "429" in str(e):
                 raise ModelThrottledException(str(e)) from e
             raise
@@ -523,6 +531,7 @@ class MistralModel(Model):
             An instance of the output model with the generated data.
 
         Raises:
+            ContextWindowOverflowException: If the input exceeds the model's context window.
             ValueError: If the response cannot be parsed into the output model.
         """
         tool_spec: ToolSpec = {
@@ -536,8 +545,13 @@ class MistralModel(Model):
         formatted_request["tool_choice"] = "any"
         formatted_request["parallel_tool_calls"] = False
 
-        async with Mistral(**self.client_args) as client:
-            response = await client.chat.complete_async(**formatted_request)
+        try:
+            async with Mistral(**self.client_args) as client:
+                response = await client.chat.complete_async(**formatted_request)
+        except Exception as e:
+            if any(message in str(e).lower() for message in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(e)) from e
+            raise
 
         if response.choices and response.choices[0].message.tool_calls:
             tool_call = response.choices[0].message.tool_calls[0]

--- a/strands-py/src/strands/models/ollama.py
+++ b/strands-py/src/strands/models/ollama.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
+from ..types.exceptions import ContextWindowOverflowException
 from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
@@ -33,6 +34,13 @@ class OllamaModel(Model):
     - Streaming responses
     - Tool/function calling
     """
+
+    OVERFLOW_MESSAGES = {
+        "the prompt is longer than the context length",
+        "the input length exceeds the context length",
+        "exceeds the available context",
+        "exceeded max context length",
+    }
 
     class OllamaConfig(BaseModelConfig, total=False):
         """Configuration parameters for Ollama models.
@@ -310,6 +318,9 @@ class OllamaModel(Model):
 
         Yields:
             Formatted message chunks from the model.
+
+        Raises:
+            ContextWindowOverflowException: If the input exceeds the model's context window.
         """
         warn_on_tool_choice_not_supported(tool_choice)
 
@@ -322,20 +333,29 @@ class OllamaModel(Model):
         event = None
 
         client = ollama.AsyncClient(self.host, **self.client_args)
-        response = await client.chat(**request)
 
-        logger.debug("got response from model")
-        yield self.format_chunk({"chunk_type": "message_start"})
-        yield self.format_chunk({"chunk_type": "content_start", "data_type": "text"})
+        # Ollama issues the request lazily, so overflow can surface at chat() or during iteration.
+        try:
+            response = await client.chat(**request)
 
-        async for event in response:
-            for tool_call in event.message.tool_calls or []:
-                yield self.format_chunk({"chunk_type": "content_start", "data_type": "tool", "data": tool_call})
-                yield self.format_chunk({"chunk_type": "content_delta", "data_type": "tool", "data": tool_call})
-                yield self.format_chunk({"chunk_type": "content_stop", "data_type": "tool", "data": tool_call})
-                tool_requested = True
+            logger.debug("got response from model")
+            yield self.format_chunk({"chunk_type": "message_start"})
+            yield self.format_chunk({"chunk_type": "content_start", "data_type": "text"})
 
-            yield self.format_chunk({"chunk_type": "content_delta", "data_type": "text", "data": event.message.content})
+            async for event in response:
+                for tool_call in event.message.tool_calls or []:
+                    yield self.format_chunk({"chunk_type": "content_start", "data_type": "tool", "data": tool_call})
+                    yield self.format_chunk({"chunk_type": "content_delta", "data_type": "tool", "data": tool_call})
+                    yield self.format_chunk({"chunk_type": "content_stop", "data_type": "tool", "data": tool_call})
+                    tool_requested = True
+
+                yield self.format_chunk(
+                    {"chunk_type": "content_delta", "data_type": "text", "data": event.message.content}
+                )
+        except ollama.ResponseError as error:
+            if any(message in str(error).lower() for message in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(error)) from error
+            raise
 
         stop_reason = "tool_use" if tool_requested else (event.done_reason if event else None)
 
@@ -360,13 +380,21 @@ class OllamaModel(Model):
 
         Yields:
             Model events with the last being the structured output.
+
+        Raises:
+            ContextWindowOverflowException: If the input exceeds the model's context window.
         """
         formatted_request = self.format_request(messages=prompt, system_prompt=system_prompt)
         formatted_request["format"] = output_model.model_json_schema()
         formatted_request["stream"] = False
 
         client = ollama.AsyncClient(self.host, **self.client_args)
-        response = await client.chat(**formatted_request)
+        try:
+            response = await client.chat(**formatted_request)
+        except ollama.ResponseError as error:
+            if any(message in str(error).lower() for message in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(error)) from error
+            raise
 
         try:
             content = response.message.content.strip()

--- a/strands-py/src/strands/models/writer.py
+++ b/strands-py/src/strands/models/writer.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages
-from ..types.exceptions import ModelThrottledException
+from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
@@ -28,6 +28,15 @@ T = TypeVar("T", bound=BaseModel)
 
 class WriterModel(Model):
     """Writer API model provider implementation."""
+
+    OVERFLOW_MESSAGES = {
+        "this model's maximum context length is",
+        "exceed context limit",
+        "model's maximum context limit",
+        "is longer than the model's context length",
+        "prompt is too long",
+        "too many tokens",
+    }
 
     class WriterConfig(BaseModelConfig, total=False):
         """Configuration options for Writer API.
@@ -384,6 +393,7 @@ class WriterModel(Model):
             Formatted message chunks from the model.
 
         Raises:
+            ContextWindowOverflowException: If the input exceeds the model's context window.
             ModelThrottledException: When the model service is throttling requests from the client.
         """
         warn_on_tool_choice_not_supported(tool_choice)
@@ -397,6 +407,10 @@ class WriterModel(Model):
             response = await self.client.chat.chat(**request)
         except writerai.RateLimitError as e:
             raise ModelThrottledException(str(e)) from e
+        except writerai.BadRequestError as e:
+            if any(message in str(e).lower() for message in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(e)) from e
+            raise
 
         yield self.format_chunk({"chunk_type": "message_start"})
         yield self.format_chunk({"chunk_type": "content_block_start", "data_type": "text"})
@@ -451,6 +465,9 @@ class WriterModel(Model):
             prompt: The prompt messages to use for the agent.
             system_prompt: System prompt to provide context to the model.
             **kwargs: Additional keyword arguments for future extensibility.
+
+        Raises:
+            ContextWindowOverflowException: If the input exceeds the model's context window.
         """
         formatted_request = self.format_request(messages=prompt, tool_specs=None, system_prompt=system_prompt)
         formatted_request["response_format"] = {
@@ -460,7 +477,12 @@ class WriterModel(Model):
         formatted_request["stream"] = False
         formatted_request.pop("stream_options", None)
 
-        response = await self.client.chat.chat(**formatted_request)
+        try:
+            response = await self.client.chat.chat(**formatted_request)
+        except writerai.BadRequestError as e:
+            if any(message in str(e).lower() for message in self.OVERFLOW_MESSAGES):
+                raise ContextWindowOverflowException(str(e)) from e
+            raise
 
         try:
             content = response.choices[0].message.content.strip()

--- a/strands-py/tests/strands/models/test_llamaapi.py
+++ b/strands-py/tests/strands/models/test_llamaapi.py
@@ -2,10 +2,12 @@
 import logging
 import unittest.mock
 
+import llama_api_client
 import pytest
 
 import strands
 from strands.models.llamaapi import LlamaAPIModel
+from strands.types.exceptions import ContextWindowOverflowException
 
 
 @pytest.fixture
@@ -547,3 +549,30 @@ def test_format_request_filters_location_source_document(model, caplog):
     assert len(user_content) == 1
     assert user_content[0]["type"] == "text"
     assert "Location sources are not supported by LlamaAPI" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "overflow_message",
+    [
+        "This model's maximum context length is 128000 tokens",
+        "prompt is too long",
+        "too many tokens in request",
+    ],
+)
+@pytest.mark.asyncio
+async def test_stream_context_overflow_error(overflow_message, model, messages, alist):
+    error = llama_api_client.BadRequestError(overflow_message, response=unittest.mock.Mock(), body=None)
+    with unittest.mock.patch.object(model.client.chat.completions, "create", side_effect=error):
+        with pytest.raises(ContextWindowOverflowException) as exc_info:
+            await alist(model.stream(messages))
+
+    assert overflow_message in str(exc_info.value)
+    assert exc_info.value.__cause__ == error
+
+
+@pytest.mark.asyncio
+async def test_stream_non_overflow_bad_request_propagates(model, messages, alist):
+    error = llama_api_client.BadRequestError("invalid 'model' parameter", response=unittest.mock.Mock(), body=None)
+    with unittest.mock.patch.object(model.client.chat.completions, "create", side_effect=error):
+        with pytest.raises(llama_api_client.BadRequestError, match="invalid 'model' parameter"):
+            await alist(model.stream(messages))

--- a/strands-py/tests/strands/models/test_mistral.py
+++ b/strands-py/tests/strands/models/test_mistral.py
@@ -6,7 +6,7 @@ import pytest
 
 import strands
 from strands.models.mistral import MistralModel
-from strands.types.exceptions import ModelThrottledException
+from strands.types.exceptions import ContextWindowOverflowException, ModelThrottledException
 
 
 @pytest.fixture
@@ -641,6 +641,47 @@ async def test_stream_other_error(mistral_client, model, alist):
     messages = [{"role": "user", "content": [{"text": "test"}]}]
     with pytest.raises(Exception, match="some other error"):
         await alist(model.stream(messages))
+
+
+@pytest.mark.asyncio
+async def test_stream_context_overflow_error(mistral_client, model, alist):
+    overflow_message = (
+        "Prompt contains 152960 tokens and 0 draft tokens, too large for model with 131072 maximum context length"
+    )
+    error = Exception(overflow_message)
+    mistral_client.chat.stream_async.side_effect = error
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(ContextWindowOverflowException) as exc_info:
+        await alist(model.stream(messages))
+
+    assert overflow_message in str(exc_info.value)
+    assert exc_info.value.__cause__ == error
+
+
+@pytest.mark.asyncio
+async def test_structured_output_context_overflow_error(mistral_client, model, test_output_model_cls, alist):
+    overflow_message = (
+        "Prompt contains 152960 tokens and 0 draft tokens, too large for model with 131072 maximum context length"
+    )
+    error = Exception(overflow_message)
+    mistral_client.chat.complete_async = unittest.mock.AsyncMock(side_effect=error)
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(ContextWindowOverflowException) as exc_info:
+        await alist(model.structured_output(test_output_model_cls, messages))
+
+    assert overflow_message in str(exc_info.value)
+    assert exc_info.value.__cause__ == error
+
+
+@pytest.mark.asyncio
+async def test_structured_output_other_error(mistral_client, model, test_output_model_cls, alist):
+    mistral_client.chat.complete_async = unittest.mock.AsyncMock(side_effect=Exception("some other error"))
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(Exception, match="some other error"):
+        await alist(model.structured_output(test_output_model_cls, messages))
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_ollama.py
+++ b/strands-py/tests/strands/models/test_ollama.py
@@ -3,12 +3,14 @@ import logging
 import re
 import unittest.mock
 
+import ollama
 import pydantic
 import pytest
 
 import strands
 from strands.models.ollama import OllamaModel
 from strands.types.content import Messages
+from strands.types.exceptions import ContextWindowOverflowException
 
 
 @pytest.fixture
@@ -741,3 +743,69 @@ def test_format_request_uses_tool_name_not_tool_use_id(model, model_id):
     # The function name in the request must come from "name", not "toolUseId"
     assert tool_call["function"]["name"] == "calculator"
     assert tool_call["function"]["name"] != "unique-id-abc-123"
+
+
+@pytest.mark.asyncio
+async def test_stream_context_overflow_error_on_request(ollama_client, model, alist):
+    error = ollama.ResponseError("request exceeds the available context size (2048 tokens), try increasing it")
+    ollama_client.chat = unittest.mock.AsyncMock(side_effect=error)
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(ContextWindowOverflowException) as exc_info:
+        await alist(model.stream(messages))
+
+    assert "exceeds the available context size" in str(exc_info.value)
+    assert exc_info.value.__cause__ == error
+
+
+@pytest.mark.asyncio
+async def test_stream_context_overflow_error_during_iteration(ollama_client, model, alist):
+    error = ollama.ResponseError("the prompt is longer than the context length currently available to the model")
+
+    async def overflowing_stream():
+        raise error
+        yield  # pragma: no cover - generator never yields
+
+    ollama_client.chat = unittest.mock.AsyncMock(return_value=overflowing_stream())
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(ContextWindowOverflowException) as exc_info:
+        await alist(model.stream(messages))
+
+    assert "the prompt is longer than the context length" in str(exc_info.value)
+    assert exc_info.value.__cause__ == error
+
+
+@pytest.mark.asyncio
+async def test_stream_non_overflow_response_error_propagates(ollama_client, model, alist):
+    error = ollama.ResponseError("model 'm1' not found")
+    ollama_client.chat = unittest.mock.AsyncMock(side_effect=error)
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(ollama.ResponseError, match="not found"):
+        await alist(model.stream(messages))
+
+
+@pytest.mark.asyncio
+async def test_structured_output_context_overflow_error(ollama_client, model, test_output_model_cls, alist):
+    error = ollama.ResponseError("request exceeds the available context size (2048 tokens), try increasing it")
+    ollama_client.chat = unittest.mock.AsyncMock(side_effect=error)
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(ContextWindowOverflowException) as exc_info:
+        await alist(model.structured_output(test_output_model_cls, messages))
+
+    assert "exceeds the available context size" in str(exc_info.value)
+    assert exc_info.value.__cause__ == error
+
+
+@pytest.mark.asyncio
+async def test_structured_output_non_overflow_response_error_propagates(
+    ollama_client, model, test_output_model_cls, alist
+):
+    error = ollama.ResponseError("model 'm1' not found")
+    ollama_client.chat = unittest.mock.AsyncMock(side_effect=error)
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(ollama.ResponseError, match="not found"):
+        await alist(model.structured_output(test_output_model_cls, messages))

--- a/strands-py/tests/strands/models/test_writer.py
+++ b/strands-py/tests/strands/models/test_writer.py
@@ -2,10 +2,13 @@ import logging
 import unittest.mock
 from typing import Any
 
+import pydantic
 import pytest
+import writerai
 
 import strands
 from strands.models.writer import WriterModel
+from strands.types.exceptions import ContextWindowOverflowException
 
 
 @pytest.fixture
@@ -49,6 +52,14 @@ def messages():
 @pytest.fixture
 def system_prompt():
     return "System prompt"
+
+
+@pytest.fixture
+def test_output_model_cls():
+    class TestOutputModel(pydantic.BaseModel):
+        name: str
+
+    return TestOutputModel
 
 
 def test__init__(writer_client_cls, model_id, stream_options, client_args):
@@ -566,3 +577,61 @@ def test_format_request_filters_location_source_document(model, caplog):
     assert len(user_content) == 1
     assert user_content[0]["type"] == "text"
     assert "Location sources are not supported by Writer" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "overflow_message",
+    [
+        "This model's maximum context length is 32768 tokens",
+        "prompt is too long",
+        "too many tokens in request",
+    ],
+)
+@pytest.mark.asyncio
+async def test_stream_context_overflow_error(overflow_message, writer_client, model, alist):
+    error = writerai.BadRequestError(overflow_message, response=unittest.mock.Mock(), body=None)
+    writer_client.chat.chat = unittest.mock.AsyncMock(side_effect=error)
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(ContextWindowOverflowException) as exc_info:
+        await alist(model.stream(messages))
+
+    assert overflow_message in str(exc_info.value)
+    assert exc_info.value.__cause__ == error
+
+
+@pytest.mark.asyncio
+async def test_stream_non_overflow_bad_request_propagates(writer_client, model, alist):
+    error = writerai.BadRequestError("invalid 'model' parameter", response=unittest.mock.Mock(), body=None)
+    writer_client.chat.chat = unittest.mock.AsyncMock(side_effect=error)
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(writerai.BadRequestError, match="invalid 'model' parameter"):
+        await alist(model.stream(messages))
+
+
+@pytest.mark.asyncio
+async def test_structured_output_context_overflow_error(writer_client, model, test_output_model_cls, alist):
+    error = writerai.BadRequestError(
+        "This model's maximum context length is 32768 tokens", response=unittest.mock.Mock(), body=None
+    )
+    writer_client.chat.chat = unittest.mock.AsyncMock(side_effect=error)
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(ContextWindowOverflowException) as exc_info:
+        await alist(model.structured_output(test_output_model_cls, messages))
+
+    assert "maximum context length" in str(exc_info.value)
+    assert exc_info.value.__cause__ == error
+
+
+@pytest.mark.asyncio
+async def test_structured_output_non_overflow_bad_request_propagates(
+    writer_client, model, test_output_model_cls, alist
+):
+    error = writerai.BadRequestError("invalid 'model' parameter", response=unittest.mock.Mock(), body=None)
+    writer_client.chat.chat = unittest.mock.AsyncMock(side_effect=error)
+
+    messages = [{"role": "user", "content": [{"text": "test"}]}]
+    with pytest.raises(writerai.BadRequestError, match="invalid 'model' parameter"):
+        await alist(model.structured_output(test_output_model_cls, messages))


### PR DESCRIPTION
## Description

Four model providers — Ollama, Mistral, LlamaAPI, and Writer — did not raise `ContextWindowOverflowException` when the context window was exceeded. The event loop relies on this exception to trigger automatic context reduction via `ConversationManager.reduce_context()`; without it, these providers surfaced the raw provider error and the recovery path never ran (i.e. `SlidingWindowConversationManager` was effectively dead code for them).

This PR maps each provider's context-overflow error to `ContextWindowOverflowException`, following the existing Anthropic/OpenAI/Bedrock pattern (a per-provider set of lowercased substrings matched against the error text). Detection is added to **both** `stream()` and `structured_output()`, since the original bug affects both call paths equally. (LlamaAPI's `structured_output()` is `NotImplementedError`, so only its `stream()` is covered.)

## Related Issues

<!-- Link to related issues using #issue-number format -->

Closes #2052 

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
