### PR TITLE
docs: add TESTING.md for python

### DIFF
--- a/strands-py/docs/TESTING.md
+++ b/strands-py/docs/TESTING.md
@@ -56,7 +56,9 @@ exp_result = {"role": "assistant", "content": [{"text": "hi"}]}
 assert tru_result == exp_result
 ```
 
-**Assert whole objects, not field-by-field.** A single equality on the whole structure documents the expected shape and catches unexpected extra fields. Mask only genuinely volatile fields (timestamps, generated ids, metadata) with `unittest.mock.ANY`:
+The right granularity depends on **who controls the expected shape**:
+
+**When you control the shape, assert the whole object — not field-by-field.** A single equality on the whole structure documents the expected shape and catches unexpected extra fields. Mask only genuinely volatile fields (timestamps, generated ids, metadata) with `unittest.mock.ANY`:
 
 ```python
 tru_message = result.message
@@ -64,7 +66,7 @@ exp_message = {"role": "assistant", "content": [{"text": "abc"}], "metadata": un
 assert tru_message == exp_message
 ```
 
-**Do not assert a full `Message` dict when the test only cares about part of it.** If the test is about the text or role, assert just that (`assert result.message["role"] == "assistant"`). Asserting the entire `Message` shape couples the test to fields it doesn't care about, so an unrelated change to the `Message` type breaks it — this is a recurring source of breakage in `tests_integ/`.
+**When the shape is an externally-evolving type, assert only the fields the test is about.** This is the natural exception to the rule above: a type like `Message` grows fields the test doesn't care about, so asserting the entire dict couples the test to unrelated churn. If the test is about the text or role, assert just that (`assert result.message["role"] == "assistant"`) — pinning the whole `Message` shape is a recurring source of breakage in `tests_integ/`.
 
 ## Test Organization
 

--- a/strands-py/docs/TESTING.md
+++ b/strands-py/docs/TESTING.md
@@ -1,0 +1,78 @@
+# Testing Guidelines - Strands Python SDK
+
+> **IMPORTANT**: When writing tests, you **MUST** follow the guidelines in this document. They keep tests consistent, maintainable, and resilient to unrelated changes.
+
+This document is the authoritative testing reference for the Python SDK. For general development guidance, see [AGENTS.md](../AGENTS.md). It is the counterpart to the TypeScript SDK's [docs/TESTING.md](../../strands-ts/docs/TESTING.md); where a convention is shared, the two should stay aligned.
+
+## Test Layout
+
+- **Unit tests** mirror `src/strands/` exactly under `tests/strands/` — `tests/strands/agent/test_agent.py` tests `src/strands/agent/agent.py`. Do not put unit tests anywhere else.
+- **Integration tests** live in `tests_integ/`, organized by feature area, and run only in CI (they need real provider credentials). Whole-message-dict assertions in integ tests are especially brittle — see [Assertions](#assertions).
+- **Test files are prefixed `test_`**; test functions are prefixed `test_`.
+
+```bash
+hatch test                           # Run unit tests
+hatch test -c                        # Run with coverage
+hatch test tests/strands/agent/      # Run a specific directory
+hatch run test-integ                 # Run integration tests
+hatch test --all                     # All Python versions (3.10–3.14)
+```
+
+## Test Fixtures Quick Reference
+
+Reusable fixtures live in `tests/fixtures/`; shared async/AWS helpers are session-scoped fixtures in `tests/conftest.py`. **Reuse these — do not hand-roll a mock model, hook recorder, or tool.** If you find yourself writing one, check here first.
+
+| Fixture / helper | Location | When to use |
+| --- | --- | --- |
+| `MockedModelProvider` | `tests/fixtures/mocked_model_provider.py` | Drive the agent loop with a pre-defined sequence of responses (optionally with per-response `Usage` for metrics paths) instead of a real provider |
+| `MockHookProvider` | `tests/fixtures/mock_hook_provider.py` | Record hook invocations and assert which lifecycle events fired |
+| `MockMultiAgentHookProvider` | `tests/fixtures/mock_multiagent_hook_provider.py` | Same, for multi-agent lifecycle events |
+| `MockAgentTool` | `tests/fixtures/mock_agent_tool.py` | A stand-in `AgentTool` when a tool is incidental to the test |
+| `MockedSessionRepository` | `tests/fixtures/mock_session_repository.py` | In-memory `SessionRepository` for session/persistence tests |
+| `agenerator` | `tests/conftest.py` | Wrap a list as an async generator (feed a `MockedModelProvider.stream` or any `async for`) |
+| `alist` | `tests/conftest.py` | Collect an async iterable into a list (`events = await alist(agent.stream_async(...))`) |
+| `generate` | `tests/conftest.py` | Drive a sync generator to exhaustion, returning `(yielded_events, return_value)` |
+| `moto_env`, `moto_mock_aws` | `tests/conftest.py` | Mock AWS credentials/services with `moto` — never hit real AWS in a unit test |
+
+## Async Tests
+
+Pytest runs in **strict asyncio mode** (the default — `asyncio_mode` is not set). Every coroutine test **MUST** carry an explicit marker:
+
+```python
+@pytest.mark.asyncio
+async def test_streams_tool_use(agenerator):
+    ...
+```
+
+A coroutine test without the marker is silently skipped, not run. Consume agent/model streams with the `alist` fixture rather than re-implementing the `async for` collection loop.
+
+## Assertions
+
+**Name the assertion pair `tru_<noun>` / `exp_<noun>`.** This is the one sanctioned exception to the "name every variable for its content" rule — the matched prefixes make arrange/assert pairs scannable. Compute the actual value into `tru_<noun>`, define the expected value as `exp_<noun>`, then compare:
+
+```python
+tru_result = agent("hello")
+exp_result = {"role": "assistant", "content": [{"text": "hi"}]}
+assert tru_result == exp_result
+```
+
+**Assert whole objects, not field-by-field.** A single equality on the whole structure documents the expected shape and catches unexpected extra fields. Mask only genuinely volatile fields (timestamps, generated ids, metadata) with `unittest.mock.ANY`:
+
+```python
+tru_message = result.message
+exp_message = {"role": "assistant", "content": [{"text": "abc"}], "metadata": unittest.mock.ANY}
+assert tru_message == exp_message
+```
+
+**Do not assert a full `Message` dict when the test only cares about part of it.** If the test is about the text or role, assert just that (`assert result.message["role"] == "assistant"`). Asserting the entire `Message` shape couples the test to fields it doesn't care about, so an unrelated change to the `Message` type breaks it — this is a recurring source of breakage in `tests_integ/`.
+
+## Test Organization
+
+- **Default to flat, module-level `test_<behavior>` functions.** Most of the suite is flat.
+- **Use a `class Test<Subject>` only when tests share class-scoped setup or fixtures** — not merely to group related cases (a module already groups them).
+- **Parametrize repetitive cases** with `@pytest.mark.parametrize` instead of copy-pasting a test body across inputs.
+- **Keep tests focused and independent**; import packages at the top of the file.
+
+## Comments in Tests
+
+The evergreen-comment rule applies here too: a regression test should **link the issue and describe the behavior it now guarantees**, not narrate what the code used to do. Prefer `# guards against unbounded retry on a None tool name (#642)` over `# we used to hang on None here`.

--- a/strands-py/docs/TESTING.md
+++ b/strands-py/docs/TESTING.md
@@ -2,7 +2,7 @@
 
 > **IMPORTANT**: When writing tests, you **MUST** follow the guidelines in this document. They keep tests consistent, maintainable, and resilient to unrelated changes.
 
-This document is the authoritative testing reference for the Python SDK. For general development guidance, see [AGENTS.md](../AGENTS.md). It is the counterpart to the TypeScript SDK's [docs/TESTING.md](../../strands-ts/docs/TESTING.md); where a convention is shared, the two should stay aligned.
+This document is the authoritative testing reference for the Python SDK. For general development guidance, see [AGENTS.md](../AGENTS.md).
 
 ## Test Layout
 
@@ -70,8 +70,9 @@ assert tru_message == exp_message
 
 ## Test Organization
 
-- **Default to flat, module-level `test_<behavior>` functions.** Most of the suite is flat.
-- **Use a `class Test<Subject>` only when tests share class-scoped setup or fixtures** — not merely to group related cases (a module already groups them).
+- **Name tests `test_<method>_<description>`.** The test module already names the subject, so the class/subject should be omitted: `test__init__default_model_id`, `test_update_config_validation_warns_on_unknown_keys`. Add a subject prefix (`test_<subject>_<method>_<description>`) **only** when one module covers several subjects and the bare method name would be ambiguous.
+- **Default to flat, module-level functions.** Most of the suite is flat.
+- **Use a `class Test<Subject>` only when tests share class-scoped setup or fixtures** — not merely to group related cases (a module already groups them). Inside a class, the method name can drop the redundant subject since the class supplies it.
 - **Parametrize repetitive cases** with `@pytest.mark.parametrize` instead of copy-pasting a test body across inputs.
 - **Keep tests focused and independent**; import packages at the top of the file.
 

--- a/strands-ts/docs/TESTING.md
+++ b/strands-ts/docs/TESTING.md
@@ -45,10 +45,10 @@ src/subdir/
 
 ### Integration Test Location
 
-**Rule**: Integration tests are separate in `tests_integ/`
+**Rule**: Integration tests are separate in `test/integ/`
 
 ```
-tests_integ/
+test/integ/
 ├── api.test.ts                 # Tests public API
 └── environment.test.ts         # Tests environment compatibility
 ```


### PR DESCRIPTION
## Description

The TypeScript SDK has a thorough `docs/TESTING.md` that `strands-ts/AGENTS.md` hard-delegates to ("you MUST follow"). The Python SDK had no equivalent — its testing guidance was ~40 lines inside `AGENTS.md` and nothing in `docs/`. The practical cost is that real, reusable test infrastructure stays invisible: the shared fixtures (`MockedModelProvider`, `MockHookProvider`, `MockAgentTool`, `MockedSessionRepository`) and the `conftest.py` async/AWS helpers (`agenerator`, `alist`, `generate`, `moto_*`) aren't documented anywhere, so contributors hand-roll their own mocks instead of reusing them. A few sharp edges also went unwritten — strict-asyncio mode silently skips an unmarked coroutine test, and asserting a whole `Message` dict when a test only cares about role/text is a recurring source of brittle breakage in `tests_integ/`.

This adds `strands-py/docs/TESTING.md` as the authoritative Python testing reference, mirroring the TypeScript guide's depth and topic coverage so the two SDKs stay aligned. It documents the fixtures quick-reference (with "reuse these, don't hand-roll"), the `tru_`/`exp_` assertion-pair naming, whole-object assertions with `unittest.mock.ANY` for volatile fields, the strict-asyncio marker requirement, and the flat-vs-class test-organization preference — all reflecting conventions the suite already follows rather than inventing new ones.

It also corrects a contradiction in `strands-ts/docs/TESTING.md`, which referenced a `tests_integ/` directory that doesn't exist; the integration tests live in `test/integ/` (as the same file states a few lines later). An agent following the authoritative doc would otherwise create files in the wrong place.

The companion `AGENTS.md` restructure that links to this new file is a separate PR; this one is split out so the doc it points at lands first.

## Related Issues

None — maintenance change surfaced by a convention audit of both SDKs.

## Documentation PR

Not applicable — these are contributor-facing `docs/` files in the SDK packages, not user-facing documentation under `site/`.

## Type of Change

Documentation update

## Testing

Documentation-only. Verified that every fixture, helper, and path named in the new guide exists in the tree (`tests/fixtures/*`, the `conftest.py` session-scoped helpers, strict-asyncio being the default), and that the corrected `test/integ/` path matches the real TypeScript integration-test directory.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
