### PR TITLE
fix(pre-push): prevent false-positive test failures when output is piped

### DIFF
--- a/.agents/skills/pre-push/SKILL.md
+++ b/.agents/skills/pre-push/SKILL.md
@@ -15,13 +15,13 @@ The repo's CI (`.github/workflows/ci.yml`) detects which of three areas changed 
 
 ### 1. Run the bundled script
 
-From the repo root:
-
 ```bash
-bash .agents/skills/pre-push/run-checks.sh
+bash .agents/skills/pre-push/run-checks.sh 2>&1
 ```
 
-That path is relative to the repo root, but the script itself runs from anywhere in the repo — it locates the root with `git rev-parse --show-toplevel` before doing anything, so the area detection and checks are unaffected by your working directory. From a subdirectory, just point at the script absolutely:
+Non-zero exit means something failed. On failure, the script prints a summary at the end with every failed step and the last 20 lines of its error output — everything you need to start fixing is in the tail of the output. Ignore noise earlier in the output.
+
+The script runs from anywhere in the repo (it locates the root via `git rev-parse --show-toplevel`). From a subdirectory:
 
 ```bash
 bash "$(git rev-parse --show-toplevel)/.agents/skills/pre-push/run-checks.sh"
@@ -44,7 +44,7 @@ Useful flags:
 
 ### 2. Triage what phase 2 reports
 
-If phase 2 comes back green, you're done — report it and stop. If it's red, work the failures before calling the branch push-ready, splitting by whether the fix requires judgment:
+If the script exits 0, you're done — report it and stop. If it exits non-zero, work the `FAILED:` items before calling the branch push-ready, splitting by whether the fix requires judgment:
 
 - **Mechanical / unambiguous** — a missing type annotation, an unused import the linter flagged but didn't strip, a lockfile that needs committing. Just fix these and re-run the script.
 - **Anything ambiguous** — loop back to the developer with the failing output before changing anything. The clearest case is a **test failure**: it means either the change broke real behavior (fix the code) or the behavior change is intended and the test is stale (fix the test). Don't guess, and never rewrite a test just to make it pass — that silences the very check that caught the regression. Surface it and let the developer decide.
@@ -57,6 +57,13 @@ How that split applies to the specific things phase 2 reports:
 - **Missing tool** (`hatch`/`npm` not found) — the script says how to install. Report it; don't silently work around it.
 
 After fixing anything, re-run the script to confirm green.
+
+## Output format
+
+- **Starting a check:** `  > label`
+- **Inline failure:** `  FAILED: label` (printed inline as each check fails)
+- **End summary (on failure only):** after `============`, each failed step is listed as `--- FAILED: label ---` followed by the last 20 lines of its output. This summary has everything needed to diagnose and fix.
+- **Exit code:** non-zero if any check failed
 
 ## Rules
 

--- a/.agents/skills/pre-push/run-checks.sh
+++ b/.agents/skills/pre-push/run-checks.sh
@@ -205,16 +205,26 @@ fi
 
 # --- runner helpers ---------------------------------------------------------
 FAILED_AREAS=()
+FAILED_STEPS=()
+FAILED_SNIPPETS=()
+# Output is buffered through a temp file so child processes never block on pipe
+# backpressure (see commit message). This means no streaming/color in interactive
+# use — acceptable since the only consumer is agents.
 run_step() {  # run_step "label" cmd args...
   local label="$1"; shift
   echo
   echo "  > ${label}"
-  if "$@"; then
-    return 0
-  else
+  local _outfile rc=0
+  _outfile="$(mktemp "${TMPDIR:-/tmp}/run-checks.XXXXXX")" || { "$@"; return; }
+  trap 'rm -f "${_outfile:-}"' RETURN
+  "$@" > "$_outfile" 2>&1 || rc=$?
+  cat "$_outfile"
+  if [[ $rc -ne 0 ]]; then
     echo "  FAILED: ${label}" >&2
-    return 1
+    FAILED_STEPS+=("${label}")
+    FAILED_SNIPPETS+=("$(tail -20 "$_outfile")")
   fi
+  [[ $rc -eq 0 ]]
 }
 
 # A fixer that errors is reported but does not fail the area; the checks that
@@ -425,5 +435,11 @@ if [[ ${#FAILED_AREAS[@]} -eq 0 ]]; then
   exit 0
 else
   echo "Failures in: ${FAILED_AREAS[*]}"
+  echo
+  for i in "${!FAILED_STEPS[@]}"; do
+    echo "--- FAILED: ${FAILED_STEPS[$i]} ---"
+    echo "${FAILED_SNIPPETS[$i]}"
+    echo
+  done
   exit 1
 fi


### PR DESCRIPTION
## Description

Two bugs in the pre-push skill that caused agents to run the script twice instead of once:

**Bug 1: False-positive test failures when output is piped.** The `run_step()` function ran child commands with stdout connected directly to the script's stdout. When an agent captures output via a pipe, the OS pipe buffer (64KB on macOS) fills up, vitest's main thread blocks in `write()`, and marginal tests time out — producing a spurious non-zero exit code. The fix routes child output through a temp file unconditionally so the child process never blocks on pipe backpressure.

**Bug 2: Agents couldn't extract actionable failure info from a single run.** The script printed `Failures in: typescript` at the end but not *which steps* failed or *why*. Agents had to re-run individual commands to see the actual errors. Now the script prints a summary block at the end with each failed step and the last 20 lines of its error output — everything needed to start fixing in one tool result.

SKILL.md is updated to tell agents: run once with `2>&1`, read the summary at the end.

## Related Issues

None.

## Documentation PR

N/A — this change is entirely within `.agents/skills/`.

## Type of Change

Bug fix

## Testing

- Confirmed `bash .agents/skills/pre-push/run-checks.sh typescript 2>&1 | cat > /dev/null` exits 0 (previously exited 1 due to pipe-induced test timeouts)
- Confirmed a subagent using the skill identifies all failures with file/line/error in a single command with no second invocation
- Confirmed passing runs still exit 0 and print "All local checks passed."

- [ ] I ran `hatch run prepare`

N/A — no Python changes.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.