### PR TITLE
fix(ci): sha-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           allowed-skips: dependency-review, python, typescript, docs
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check PR title follows conventional commits
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/python-pr-and-push.yml
+++ b/.github/workflows/python-pr-and-push.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     - name: Check API breaking changes
       run: |
         if ! uvx griffe check --search strands-py/src --format github strands --against "main"; then

--- a/.github/workflows/python-pypi-publish-on-release.yml
+++ b/.github/workflows/python-pypi-publish-on-release.yml
@@ -84,4 +84,4 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -125,7 +125,7 @@ jobs:
         continue-on-error: false
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
   lint:


### PR DESCRIPTION
Pin all third-party actions to their current commit SHA to reduce supply chain risk.

| Action | Tag | SHA |
|--------|-----|-----|
| codecov/codecov-action | v7 | fb8b3582 |
| astral-sh/setup-uv | v7 | 37802adc |
| re-actors/alls-green | release/v1 | 05ac9388 |
| astral-sh/setup-uv | v3 | caf0cab7 |
| dorny/paths-filter | v4 | fbd0ab8f |
| amannn/action-semantic-pull-request | v6 | 48f25628 |
| pypa/gh-action-pypi-publish | release/v1 | cef22109 |
| amannn/action-semantic-pull-request | v5 | e32d7e60 |