### PR TITLE
docs: improve testing instructions

### DIFF
--- a/strands-py/docs/TESTING.md
+++ b/strands-py/docs/TESTING.md
@@ -70,6 +70,7 @@ assert tru_message == exp_message
 
 ## Test Organization
 
+- **Prefer adding assertions to an existing test over writing a new one.** When a test already sets up the same scenario, extend it with the new assertions rather than duplicating the arrange step in a new test function. Add a separate test only for a distinct behavior, execution path, or error condition.
 - **Name tests `test_<method>_<description>`.** The test module already names the subject, so the class/subject should be omitted: `test__init__default_model_id`, `test_update_config_validation_warns_on_unknown_keys`. Add a subject prefix (`test_<subject>_<method>_<description>`) **only** when one module covers several subjects and the bare method name would be ambiguous.
 - **Default to flat, module-level functions.** Most of the suite is flat.
 - **Use a `class Test<Subject>` only when tests share class-scoped setup or fixtures** — not merely to group related cases (a module already groups them). Inside a class, the method name can drop the redundant subject since the class supplies it.

--- a/strands-ts/docs/TESTING.md
+++ b/strands-ts/docs/TESTING.md
@@ -164,9 +164,9 @@ describe('calculateTotal', () => {
 
 ## Test Batching Strategy
 
-**Rule**: When test setup cost exceeds test logic cost, you MUST batch related assertions into a single test.
+**Rule**: When test setup cost exceeds test logic cost, you MUST batch related assertions into a single test. Prefer extending an existing test over adding a new one. If a test already arranges the scenario your new behavior needs, add the assertion(s) there rather than duplicating the setup. Reach for a new test only for the cases listed under "You SHOULD keep separate tests for" below.
 
-**You MUST batch when**:
+**You MUST batch (or extend an existing test) when**:
 
 - Setup complexity > test logic complexity
 - Multiple assertions verify the same object state


### PR DESCRIPTION
## Description

Agents adding coverage for a new behavior tend to write a brand-new unit test, duplicating the scenario setup, even when an existing test already arranges the same state and could simply carry one more assertion. This bloats the suite, multiplies expensive setup, and obscures intent.

Both SDK testing guides already lean this way — the TypeScript guide has a "Test Batching Strategy" section and the Python guide has assertion-granularity guidance — but neither states the rule plainly. This adds that guidance to both `TESTING.md` files, worded consistently and reusing each file's existing "when to keep a separate test" carve-out so the guides stay aligned.

In the TypeScript guide the rule is folded into the existing batching directive (reusing expensive setup is the same instinct) rather than added as a separate principle. In the Python guide it lands as the leading bullet of "Test Organization", since that file has no batching section to fold into.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

N/A — these are the SDK developer docs under `strands-py/docs/` and `strands-ts/docs/`, not the published site under `site/`.

## Type of Change

Documentation update

## Testing

Docs-only change. Re-read both edited sections in context to confirm the wording reads naturally and the TypeScript cross-reference ("listed under 'You SHOULD keep separate tests for' below") still points at the right list. No build or test run applies to these Markdown files.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
