### PR TITLE
ci: skip SDK test matrices on markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,15 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
+          # `**/!(*.md)` excludes docs-only changes from the SDK test matrices; keep it an
+          # extglob, not a `!**/*.md` negation (paths-filter OR-s patterns, so a bare negation fires on everything).
           filters: |
             python:
-              - 'strands-py/**'
+              - 'strands-py/**/!(*.md)'
               - '.github/workflows/python-*'
               - '.github/workflows/ci.yml'
             typescript:
-              - 'strands-ts/**'
+              - 'strands-ts/**/!(*.md)'
               - 'strandly/**'
               - 'package.json'
               - 'package-lock.json'


### PR DESCRIPTION


## Description

Don't run the entire integ test suite on markdown changes only. See e.g. https://github.com/strands-agents/harness-sdk/pull/2959

Verified all test suites run as expected when .md changes are combined with source code changes.

## Related Issues

Motivated by the CI behavior observed on #2959.

## Documentation PR

Not applicable.

## Type of Change

Other (please describe): CI configuration — refine merge-gate path filtering.

## Testing

Cannot run the merge gate locally, but I traced the edited filters against the real `paths-filter` matching algorithm (per-pattern `picomatch({dot:true})`, OR-ed under the `some` quantifier) for representative change-sets:

- `strands-py/AGENTS.md` only → python does **not** fire (intended)
- `strands-py/src/strands/agent/agent.py` → python **fires** (intended)
- `strands-py/AGENTS.md` + `…/agent.py` together → python **fires** — the critical mixed case: any non-`.md` file in the changeset still triggers the suite
- `strands-ts/AGENTS.md` only → typescript does **not** fire (intended)
- `site/**` → docs **fires**, SDK suites do not (unchanged)

Note: because every filter lists `.github/workflows/ci.yml`, this PR itself will (correctly) trigger all three suites.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.