### PR TITLE
feat: map labels to native issue type and language field

### DIFF
--- a/.github/labelers/language.yml
+++ b/.github/labelers/language.yml
@@ -10,8 +10,14 @@ instructions: |
   If the issue is language-agnostic or unclear, do not assign a label.
   Issues about general agent behavior, documentation content, or feature requests without language-specific file paths or package managers should not receive a language label.
 
+# On issue events, each label also sets the native "Language" issue field via `option:`.
+field:
+  name: Language
+
 labels:
   python:
     description: "Issue relates to the Python SDK (strands-py/, .py files, pip, pyproject.toml)"
+    option: Python
   typescript:
     description: "Issue relates to the TypeScript SDK (strands-ts/, .ts files, npm, package.json)"
+    option: TypeScript

--- a/.github/labelers/type.yml
+++ b/.github/labelers/type.yml
@@ -9,12 +9,12 @@ instructions: |
   - "feat" -> enhancement
   - "fix" -> bug
   - "chore", "ci", "build", "refactor", "perf", "style", "test" -> chore
-  - "docs" -> follow the documentation rules below
+  - "docs" -> documentation
   The prefix wins even when the description sounds user-facing: a "perf:" or "refactor:" title is a chore. When no conventional-commit prefix is present, fall back to the body: maintenance with no user-facing impact (dependency bumps, CI config, internal refactors) is a chore, while anything that adds or changes user-facing functionality is an enhancement.
   If the title starts with [BUG] it is a bug. If the title starts with [FEATURE] it is an enhancement.
-  Documentation improvements or corrections are bugs. Requests for new docs or content additions are enhancements. Documentation questions are questions.
-  Proposals or discussions about API shape, architecture, or UX before any implementation are design.
-  Requests for or drafts of blog posts, announcements, or long-form articles are blog.
+  Documentation changes, corrections, or additions are documentation. Documentation questions are questions.
+  Proposals or discussions about API shape, architecture, or UX before any implementation are design; this takes precedence over enhancement even when the proposal describes new functionality.
+  Requests for or drafts of blog posts, announcements, or long-form articles are blog; this takes precedence over documentation and enhancement for prose content meant for the site.
 
 labels:
   bug:

--- a/.github/labelers/type.yml
+++ b/.github/labelers/type.yml
@@ -1,6 +1,7 @@
 # .github/labelers/type.yml
 # Classifies issues by type (bug, feature, etc.)
 # Use max_labels: 1 in the workflow since these are mutually exclusive.
+# On issue events, each label also maps to a native issue type via `type:`.
 
 instructions: |
   Choose exactly one type. You are given only the title and body — there is no diff or file list, so judge from those.
@@ -12,13 +13,28 @@ instructions: |
   The prefix wins even when the description sounds user-facing: a "perf:" or "refactor:" title is a chore. When no conventional-commit prefix is present, fall back to the body: maintenance with no user-facing impact (dependency bumps, CI config, internal refactors) is a chore, while anything that adds or changes user-facing functionality is an enhancement.
   If the title starts with [BUG] it is a bug. If the title starts with [FEATURE] it is an enhancement.
   Documentation improvements or corrections are bugs. Requests for new docs or content additions are enhancements. Documentation questions are questions.
+  Proposals or discussions about API shape, architecture, or UX before any implementation are design.
+  Requests for or drafts of blog posts, announcements, or long-form articles are blog.
 
 labels:
   bug:
     description: "Something is broken or not working as documented"
+    type: Bug
   enhancement:
     description: "New feature request or improvement to existing functionality"
+    type: Feature
   question:
     description: "User asking for help, clarification, or how to do something"
+    type: Task
   chore:
     description: "Maintenance tasks, dependency updates, CI changes, refactoring with no user-facing impact"
+    type: Chore
+  documentation:
+    description: "Documentation changes, improvements, additions, content updates"
+    type: Documentation
+  design:
+    description: "Proposal or discussion about API shape, architecture, or UX before implementation"
+    type: Design
+  blog:
+    description: "Blog post or long-form article for the site (announcements, tutorials, deep-dives)"
+    type: Blog


### PR DESCRIPTION
## What

On issue events, the `issue-labeler` action now also sets the org's native **issue type** (from `type.yml`) and the **Language** issue field (from `language.yml`), in addition to the labels it already applies. Pull requests are unaffected.

This depends on the action change in strands-agents/devtools#72.

## Changes

- **`type.yml`**: each label now declares a `type:` mapping to a native issue type (bug→Bug, enhancement→Feature, question→Task, chore→Chore). Adds three new labels with mappings: `documentation`→Documentation, `design`→Design, and `blog`→Blog, plus classifier guidance for them. The `docs:` prefix and documentation issues now route to the new `documentation` label (previously folded into bug/enhancement/question), and `design`/`blog` are given precedence over `enhancement`/`documentation` so they are reachable under `max_labels: 1`.
- **`language.yml`**: adds a top-level `field: {name: Language}` block and `option:` keys (python→Python, typescript→TypeScript) so the native Language field is set.

## Notes

- **Additive and non-fatal.** Labeling behavior is otherwise unchanged. The action's native type/field step is best-effort: if a type/field/option name can't be resolved or a write fails, it logs a warning and the run still succeeds.
- **Prerequisites confirmed.** The `bug`, `enhancement`, `question`, `chore`, `documentation`, `design`, and `blog` repo labels all exist on harness-sdk, and the org-level issue types (Task, Bug, Feature, Design, Chore, Documentation, Blog) and the `Language` field options (Python, TypeScript) are provisioned by exact name.
- Names map to org-level issue types and fields by name at runtime, so no IDs are hardcoded here.
