### PR TITLE
fix(event_loop): log exception type instead of full traceback on cycle failure

### DIFF
--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -391,7 +391,7 @@ async def event_loop_cycle(
             tracer.end_span_with_error(cycle_span, str(e), e)
             # Handle any other exceptions
             yield ForceStopEvent(reason=e)
-            logger.exception("cycle failed")
+            logger.error("exception=<%s> | event loop cycle failed", type(e).__name__)
             raise EventLoopException(e, invocation_state["request_state"]) from e
 
 
@@ -645,7 +645,7 @@ async def _handle_model_execution(
 
     except Exception as e:
         yield ForceStopEvent(reason=e)
-        logger.exception("cycle failed")
+        logger.error("exception=<%s> | event loop cycle failed", type(e).__name__)
         raise EventLoopException(e, invocation_state["request_state"]) from e
 
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -392,6 +392,7 @@ async def event_loop_cycle(
             # Handle any other exceptions
             yield ForceStopEvent(reason=e)
             logger.error("exception=<%s> | event loop cycle failed", type(e).__name__)
+            logger.debug("event loop cycle failed", exc_info=True)
             raise EventLoopException(e, invocation_state["request_state"]) from e
 
 
@@ -646,6 +647,7 @@ async def _handle_model_execution(
     except Exception as e:
         yield ForceStopEvent(reason=e)
         logger.error("exception=<%s> | event loop cycle failed", type(e).__name__)
+        logger.debug("event loop cycle failed", exc_info=True)
         raise EventLoopException(e, invocation_state["request_state"]) from e
 
 

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -526,6 +526,42 @@ async def test_cycle_exception(
     assert tru_stop_event == exp_stop_event
 
 
+@pytest.mark.asyncio
+async def test_cycle_exception_logs_exception_type_without_traceback(
+    agent,
+    model,
+    tool_stream,
+    agenerator,
+    caplog,
+):
+    """A failed cycle logs the exception type at ERROR without attaching a full traceback.
+
+    The ERROR-level cycle-failure record names the exception type and carries no exc_info, so the
+    handler's exception arguments and stack frames are not emitted into application logs.
+    """
+    model.stream.side_effect = [
+        agenerator(tool_stream),
+        agenerator(tool_stream),
+        agenerator(tool_stream),
+        ValueError("Invalid error presented"),
+    ]
+
+    with caplog.at_level("ERROR", logger="strands.event_loop.event_loop"):
+        with pytest.raises(EventLoopException):
+            stream = strands.event_loop.event_loop.event_loop_cycle(
+                agent=agent,
+                invocation_state={},
+            )
+            async for _event in stream:
+                pass
+
+    error_records = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert error_records
+    cycle_record = next(record for record in error_records if "event loop cycle failed" in record.getMessage())
+    assert "ValueError" in cycle_record.getMessage()
+    assert cycle_record.exc_info is None
+
+
 @patch("strands.event_loop.event_loop.get_tracer")
 @pytest.mark.asyncio
 async def test_event_loop_cycle_creates_spans(

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -546,7 +546,7 @@ async def test_cycle_exception_logs_exception_type_without_traceback(
         ValueError("Invalid error presented"),
     ]
 
-    with caplog.at_level("ERROR", logger="strands.event_loop.event_loop"):
+    with caplog.at_level("DEBUG", logger="strands.event_loop.event_loop"):
         with pytest.raises(EventLoopException):
             stream = strands.event_loop.event_loop.event_loop_cycle(
                 agent=agent,
@@ -555,11 +555,60 @@ async def test_cycle_exception_logs_exception_type_without_traceback(
             async for _event in stream:
                 pass
 
-    error_records = [record for record in caplog.records if record.levelname == "ERROR"]
+    cycle_records = [r for r in caplog.records if "event loop cycle failed" in r.getMessage()]
+
+    # The ERROR record names the exception type but carries no traceback (payload-free by default).
+    error_records = [record for record in cycle_records if record.levelname == "ERROR"]
     assert error_records
-    cycle_record = next(record for record in error_records if "event loop cycle failed" in record.getMessage())
+    cycle_record = error_records[0]
     assert "ValueError" in cycle_record.getMessage()
     assert cycle_record.exc_info is None
+
+    # The full traceback remains available opt-in at DEBUG.
+    debug_records = [record for record in cycle_records if record.levelname == "DEBUG"]
+    assert debug_records
+    assert debug_records[0].exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_post_stream_exception_logs_exception_type_without_traceback(
+    agent,
+    model,
+    agenerator,
+    alist,
+    caplog,
+):
+    """A failure while finalizing a completed stream logs the type at ERROR and the traceback at DEBUG.
+
+    This exercises the post-stream handler (the metrics/message-append block) rather than the
+    model-invocation handler, so both cycle-failure log sites share the same payload-free behavior.
+    """
+    model.stream.return_value = agenerator(
+        [
+            {"contentBlockDelta": {"delta": {"text": "test text"}}},
+            {"contentBlockStop": {}},
+        ]
+    )
+    agent.event_loop_metrics.update_metrics = MagicMock(side_effect=ValueError("Invalid error presented"))
+
+    with caplog.at_level("DEBUG", logger="strands.event_loop.event_loop"):
+        with pytest.raises(EventLoopException):
+            stream = strands.event_loop.event_loop.event_loop_cycle(
+                agent=agent,
+                invocation_state={},
+            )
+            await alist(stream)
+
+    cycle_records = [r for r in caplog.records if "event loop cycle failed" in r.getMessage()]
+
+    error_records = [record for record in cycle_records if record.levelname == "ERROR"]
+    assert error_records
+    assert "ValueError" in error_records[0].getMessage()
+    assert error_records[0].exc_info is None
+
+    debug_records = [record for record in cycle_records if record.levelname == "DEBUG"]
+    assert debug_records
+    assert debug_records[0].exc_info is not None
 
 
 @patch("strands.event_loop.event_loop.get_tracer")


### PR DESCRIPTION
## Description

The event loop logs a failed cycle in two places, `event_loop_cycle` and `_handle_model_execution`, with `logger.exception("cycle failed")`. `logger.exception` emits the full traceback at ERROR level. Those frames and the wrapped exception's arguments can include message content, model responses, and tool I/O, so the application log ends up carrying request payload detail that operators did not opt into.

This change replaces both calls with the structured-logging form already used for the model-retry path in the same file:

```python
logger.error("exception=<%s> | event loop cycle failed", type(e).__name__)
```

The failure is still surfaced fully: it is raised as `EventLoopException` (so callers see the original cause via `from e`) and recorded on the tracer span through `tracer.end_span_with_error`, which already receives the exception. The application logger now reports the exception type and a stable message, matching the existing `exception=<%s>` log call in `_handle_model_execution`.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Added `test_cycle_exception_logs_exception_type_without_traceback`, which drives a cycle to failure and asserts the ERROR-level cycle-failure record names the exception type and carries no `exc_info`. Ran the Python event loop unit tests and ruff locally.

- [ ] I ran `hatch run prepare` (hatch was unavailable in this environment; ran the event loop unit tests with pytest and ran `ruff check` / `ruff format --check` on the changed files instead)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly (no documentation change required for this fix)
- [x] I have added comments to my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
