### PR TITLE
fix(bidi): validate the AWS region before building the Nova Sonic endpoint URL

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
+++ b/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
@@ -101,7 +101,7 @@ _MAX_HISTORY_MESSAGE_BYTES = 50 * 1024  # 50KB per message
 _MAX_HISTORY_TOTAL_BYTES = 200 * 1024  # 200KB total history
 
 # Matches AWS region identifiers such as us-east-1, ap-southeast-1, and us-gov-east-1.
-_VALID_REGION = re.compile(r"^[a-z]{2}(-[a-z]+)+-\d+$")
+_VALID_REGION = re.compile(r"[a-z]{2}(-[a-z]+)+-\d+")
 
 
 class BidiNovaSonicModel(BidiModel):
@@ -200,7 +200,7 @@ class BidiNovaSonicModel(BidiModel):
 
         # Validate the region before it is interpolated into the service endpoint URL
         region = resolved["region"]
-        if not isinstance(region, str) or not _VALID_REGION.match(region):
+        if not isinstance(region, str) or not _VALID_REGION.fullmatch(region):
             raise ValueError(f"invalid AWS region: {region!r}")
 
         return resolved

--- a/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
+++ b/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
@@ -24,6 +24,7 @@ import asyncio
 import base64
 import json
 import logging
+import re
 import uuid
 from typing import Any, AsyncGenerator, cast
 
@@ -99,6 +100,9 @@ NOVA_TOOL_CONFIG = {"mediaType": "application/json"}
 _MAX_HISTORY_MESSAGE_BYTES = 50 * 1024  # 50KB per message
 _MAX_HISTORY_TOTAL_BYTES = 200 * 1024  # 200KB total history
 
+# Matches AWS region identifiers such as us-east-1, ap-southeast-1, and us-gov-east-1.
+_VALID_REGION = re.compile(r"^[a-z]{2}(-[a-z]+)+-\d+$")
+
 
 class BidiNovaSonicModel(BidiModel):
     """Nova Sonic implementation for bidirectional streaming.
@@ -137,6 +141,7 @@ class BidiNovaSonicModel(BidiModel):
         Raises:
             ValueError: If turn_detection is used with v1 model.
             ValueError: If endpointingSensitivity is not HIGH, MEDIUM, or LOW.
+            ValueError: If the resolved AWS region is not a valid region identifier.
         """
         # Store model ID
         self.model_id = model_id
@@ -192,6 +197,11 @@ class BidiNovaSonicModel(BidiModel):
         # Resolve region from session or use default
         if "region" not in resolved:
             resolved["region"] = resolved["boto_session"].region_name or "us-east-1"
+
+        # Validate the region before it is interpolated into the service endpoint URL
+        region = resolved["region"]
+        if not isinstance(region, str) or not _VALID_REGION.match(region):
+            raise ValueError(f"invalid AWS region: {region!r}")
 
         return resolved
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_nova_sonic.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_nova_sonic.py
@@ -97,18 +97,20 @@ async def test_model_initialization(model_id, boto_session):
 
 
 @pytest.mark.asyncio
-async def test_valid_region_accepted(model_id):
+@pytest.mark.parametrize("region", ["us-east-1", "ap-southeast-1", "us-gov-east-1"])
+async def test_valid_region_accepted(model_id, region):
     """A well-formed region resolves successfully and is used for the model."""
-    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": "us-east-1"})
+    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": region})
 
-    assert model.region == "us-east-1"
+    assert model.region == region
 
 
 @pytest.mark.asyncio
-async def test_invalid_region_rejected(model_id):
+@pytest.mark.parametrize("region", ["x@attacker.com:443/#", "us-east-1\n"])
+async def test_invalid_region_rejected(model_id, region):
     """A malformed region is rejected before it can reach the endpoint URL."""
     with pytest.raises(ValueError, match="invalid AWS region"):
-        BidiNovaSonicModel(model_id=model_id, client_config={"region": "x@attacker.com:443/#"})
+        BidiNovaSonicModel(model_id=model_id, client_config={"region": region})
 
 
 # Audio Configuration Tests

--- a/strands-py/tests/strands/experimental/bidi/models/test_nova_sonic.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_nova_sonic.py
@@ -96,6 +96,21 @@ async def test_model_initialization(model_id, boto_session):
     assert model._connection_id is None
 
 
+@pytest.mark.asyncio
+async def test_valid_region_accepted(model_id):
+    """A well-formed region resolves successfully and is used for the model."""
+    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": "us-east-1"})
+
+    assert model.region == "us-east-1"
+
+
+@pytest.mark.asyncio
+async def test_invalid_region_rejected(model_id):
+    """A malformed region is rejected before it can reach the endpoint URL."""
+    with pytest.raises(ValueError, match="invalid AWS region"):
+        BidiNovaSonicModel(model_id=model_id, client_config={"region": "x@attacker.com:443/#"})
+
+
 # Audio Configuration Tests
 
 


### PR DESCRIPTION
## Description

The Nova Sonic bidi provider builds its Bedrock runtime endpoint by interpolating the resolved AWS region directly into a URL:

```python
endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com"
```

`self.region` comes from `_resolve_client_config`, which takes it from the developer-supplied `client_config["region"]`, then the boto session's `region_name`, then falls back to `"us-east-1"` with no validation. A malformed region value therefore flows unchecked into the endpoint URL.

This change validates the resolved region in `_resolve_client_config` against the standard AWS region format (`^[a-z]{2}(-[a-z]+)+-\d+$`, which covers forms like `us-east-1`, `ap-southeast-1`, and `us-gov-east-1`) and raises `ValueError` on a mismatch, before the value is ever interpolated into the endpoint.

I kept the change small and local: the region is still validated where it is resolved, and the existing endpoint construction is unchanged. A more thorough alternative would be to let the underlying client resolve the endpoint from `region_name` (the way `models/bedrock.py` does) and pass an explicit `endpoint_uri` only as a separately validated override. That is a larger change with more behavioral surface for the bidi client, so I went with the focused validation here and am noting the alternative for maintainers.

## Related Issues

N/A

## Testing

Added two regression tests in `test_nova_sonic.py`:
- a valid region (`us-east-1`) resolves and is used by the model
- a malformed region (`x@attacker.com:443/#`) raises `ValueError`

```
pytest tests/strands/experimental/bidi/models/test_nova_sonic.py
33 passed
```

`ruff format --check` and `mypy` pass for the changed source file (the pre-existing import-organization warnings come from the module-level `sys.version_info` guard and are unrelated to this change).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective
- [x] I have made corresponding changes to the documentation (docstring `Raises:` updated)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
