### PR TITLE
ci: restrict issue responder to collaborators and pin action version

### DIFF
--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -39,6 +39,7 @@ jobs:
           npm install @aws-sdk/client-bedrock-agentcore
           node - <<'JSEOF'
           const { BedrockAgentCoreClient, InvokeAgentRuntimeCommand } = require("@aws-sdk/client-bedrock-agentcore");
+          const crypto = require("crypto");
 
           const payload = JSON.stringify({
             source: "github",
@@ -53,26 +54,41 @@ jobs:
             }
           });
 
+          const client = new BedrockAgentCoreClient({ region: "us-east-1" });
+
+          const sessionId = `github-issue-${process.env.ISSUE_NUMBER}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+          // W3C trace context (version "00", 16-byte trace id, 8-byte span id, sampled flag).
+          // Passing traceParent propagates this trace id into the AgentCore runtime's OTel
+          // spans, so the same id ties the Actions run to the runtime logs/traces in CloudWatch.
+          const traceId = crypto.randomBytes(16).toString("hex");
+          const traceParent = `00-${traceId}-${crypto.randomBytes(8).toString("hex")}-01`;
+
           // Log only non-sensitive metadata. The issue title and body are
           // forwarded to AgentCore but not echoed to the public Actions log.
+          // runtimeSessionId and traceId are logged so the run can be correlated
+          // with the AgentCore runtime logs/traces in CloudWatch.
           console.log(
             `Invoking AgentCore for issue #${process.env.ISSUE_NUMBER} ` +
-            `by ${process.env.ISSUE_AUTHOR} in ${process.env.REPO}`
+            `by ${process.env.ISSUE_AUTHOR} in ${process.env.REPO} ` +
+            `(runtimeSessionId=${sessionId} traceId=${traceId})`
           );
 
-          const client = new BedrockAgentCoreClient({ region: "us-east-1" });
-          
-          const sessionId = `github-issue-${process.env.ISSUE_NUMBER}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-          
           const command = new InvokeAgentRuntimeCommand({
             agentRuntimeArn: process.env.GH_ISSUE_AGENTCORE_RUNTIME_ARN,
             runtimeSessionId: sessionId,
+            traceParent: traceParent,
             payload: Buffer.from(payload)
           });
 
           (async () => {
             const response = await client.send(command);
             const textResponse = await response.response.transformToString();
-            console.log("AgentCore invocation complete:", textResponse.length, "characters returned");
+            console.log(
+              `AgentCore invocation complete: runtimeSessionId=${sessionId} ` +
+              `traceId=${response.traceId ?? traceId} ` +
+              `requestId=${response.$metadata?.requestId ?? "unknown"} ` +
+              `(${textResponse.length} characters returned)`
+            );
           })();
           JSEOF

--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -11,6 +11,13 @@ permissions:
 jobs:
   respond-to-issue:
     runs-on: ubuntu-latest
+    # Only run for repository-affiliated authors. This is intentional: the job
+    # assumes an AWS role via OIDC and forwards issue text to a Bedrock AgentCore
+    # runtime, so an arbitrary account opening an issue must not be able to drive
+    # that invocation. Responding to external or first-time reporters is
+    # deliberately out of scope here; if that is wanted later, add a separate
+    # abuse control (e.g. rate limiting or a label gate) rather than relaxing
+    # this author_association gate.
     if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
 
     steps:
@@ -46,8 +53,12 @@ jobs:
             }
           });
 
-          console.log("Invoking AgentCore with payload:");
-          console.log(JSON.stringify(JSON.parse(payload), null, 2));
+          // Log only non-sensitive metadata. The issue title and body are
+          // forwarded to AgentCore but not echoed to the public Actions log.
+          console.log(
+            `Invoking AgentCore for issue #${process.env.ISSUE_NUMBER} ` +
+            `by ${process.env.ISSUE_AUTHOR} in ${process.env.REPO}`
+          );
 
           const client = new BedrockAgentCoreClient({ region: "us-east-1" });
           

--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -11,10 +11,11 @@ permissions:
 jobs:
   respond-to-issue:
     runs-on: ubuntu-latest
-    
+    if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ secrets.STRANDS_AGENTCORE_ACTIONS_ROLE }}
           aws-region: us-east-1
@@ -61,6 +62,6 @@ jobs:
           (async () => {
             const response = await client.send(command);
             const textResponse = await response.response.transformToString();
-            console.log("Response:", textResponse);
+            console.log("AgentCore invocation complete:", textResponse.length, "characters returned");
           })();
           JSEOF

--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -82,13 +82,24 @@ jobs:
           });
 
           (async () => {
-            const response = await client.send(command);
-            const textResponse = await response.response.transformToString();
-            console.log(
-              `AgentCore invocation complete: runtimeSessionId=${sessionId} ` +
-              `traceId=${response.traceId ?? traceId} ` +
-              `requestId=${response.$metadata?.requestId ?? "unknown"} ` +
-              `(${textResponse.length} characters returned)`
-            );
+            try {
+              const response = await client.send(command);
+              const textResponse = await response.response.transformToString();
+              console.log(
+                `AgentCore invocation complete: runtimeSessionId=${sessionId} ` +
+                `traceId=${response.traceId ?? traceId} ` +
+                `requestId=${response.$metadata?.requestId ?? "unknown"} ` +
+                `(${textResponse.length} characters returned)`
+              );
+            } catch (err) {
+              // Log the same correlation IDs on failure: a failed invocation is exactly
+              // when the trace id is most useful for finding the runtime logs in CloudWatch.
+              console.error(
+                `AgentCore invocation failed: runtimeSessionId=${sessionId} ` +
+                `traceId=${err?.traceId ?? traceId} ` +
+                `requestId=${err?.$metadata?.requestId ?? "unknown"}: ${err}`
+              );
+              process.exitCode = 1;
+            }
           })();
           JSEOF


### PR DESCRIPTION
## Description

Hardens the issue responder workflow (`.github/workflows/issue-responder.yml`) and adds log correlation for debugging:

1. **Restrict who can trigger the workflow.** Adds a job-level condition so the responder only runs for issues opened by a repository `OWNER`, `MEMBER`, or `COLLABORATOR`:

   ```yaml
   if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
   ```

   Previously every newly opened issue from any account reached the AgentCore invocation. A comment in the workflow records that excluding external/first-time reporters is intentional, so the behavior is not later "fixed" as a regression.

2. **Pin the third-party action by commit SHA.** `aws-actions/configure-aws-credentials@v6` is now pinned to `254c19bd240aabef8777f48595e9d2d7b972184b` (v6.2.1) so the action content cannot change under a moving tag.

3. **Reduce what is written to the public Actions log.** The step previously logged the full AgentCore response body and the full inbound payload (issue title/body); it now logs only non-sensitive metadata. The issue title and body are still forwarded to AgentCore, just not echoed to the public log.

4. **Log identifiers for CloudWatch correlation.** The run now logs the `runtimeSessionId` and a trace id on invoke, and the server-returned `traceId` and `requestId` on completion, so a maintainer can take an id from the Actions log and find the matching AgentCore runtime logs/traces in CloudWatch. A W3C `traceParent` is generated and passed on the invoke so the trace id also propagates into the runtime's OTel spans. No deep link is constructed (that would require echoing the runtime id from the secret ARN into the public log).

   Behavior note: this adds one field (`traceParent`) to the `InvokeAgentRuntime` call. All logged values are non-sensitive (a random session name, a random trace id, and the AWS request id).

## Verification

- YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/issue-responder.yml'))"`
- `actionlint .github/workflows/issue-responder.yml` passes with no findings.
- `node --check` on the embedded invocation script passes.

This is a workflow-only change; there is no application code path and no unit-test surface, so no regression test file is added.

## Type of change

Other (CI / workflow hardening)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings