### PR TITLE
fix(models/anthropic): suppress Pydantic serialization warnings during serialization

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -7,6 +7,7 @@ import base64
 import json
 import logging
 import mimetypes
+import warnings
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -475,18 +476,8 @@ class AnthropicModel(Model):
                 logger.debug("got response from model")
                 async for event in stream:
                     if event.type in AnthropicModel.EVENT_TYPES:
-                        if event.type == "message_stop":
-                            # Build dict directly to avoid Pydantic serialization warnings
-                            # when the message contains ParsedTextBlock objects (issue #1746)
-                            yield self.format_chunk(
-                                {
-                                    "type": "message_stop",
-                                    "message": {"stop_reason": event.message.stop_reason},
-                                }
-                            )
-                        elif event.type == "content_block_stop":
-                            yield self.format_chunk({"type": "content_block_stop", "index": event.index})
-                        else:
+                        with warnings.catch_warnings():
+                            warnings.filterwarnings("ignore", message=".*PydanticSerializationUnexpectedValue.*")
                             yield self.format_chunk(event.model_dump())
 
                 try:

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -478,7 +478,8 @@ class AnthropicModel(Model):
                     if event.type in AnthropicModel.EVENT_TYPES:
                         with warnings.catch_warnings():
                             warnings.filterwarnings("ignore", message=".*PydanticSerializationUnexpectedValue.*")
-                            yield self.format_chunk(event.model_dump())
+                            chunk = event.model_dump()
+                        yield self.format_chunk(chunk)
 
                 try:
                     message_snapshot = await stream.get_final_message()

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1154,6 +1154,83 @@ async def test_stream_content_block_stop_no_pydantic_warnings(anthropic_client, 
     assert {"contentBlockStop": {"contentBlockIndex": 0}} in events
 
 
+@pytest.mark.asyncio
+async def test_stream_all_events_no_pydantic_warnings(anthropic_client, model, alist):
+    """Verify no Pydantic serialization warnings for any event type during streaming.
+
+    Regression test for https://github.com/strands-agents/harness-sdk/issues/1865.
+    Covers message_start, content_block_start, content_block_delta, content_block_stop, and message_stop.
+    """
+
+    def make_model_dump_with_warning(return_value):
+        def model_dump_with_warning():
+            warnings.warn(
+                "PydanticSerializationUnexpectedValue(Expected `ParsedTextBlock[TypeVar]`)",
+                UserWarning,
+                stacklevel=2,
+            )
+            return return_value
+
+        return model_dump_with_warning
+
+    mock_message_start = unittest.mock.Mock()
+    mock_message_start.type = "message_start"
+    mock_message_start.model_dump = make_model_dump_with_warning({"type": "message_start"})
+
+    mock_content_block_start = unittest.mock.Mock()
+    mock_content_block_start.type = "content_block_start"
+    mock_content_block_start.model_dump = make_model_dump_with_warning(
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+    )
+
+    mock_content_block_delta = unittest.mock.Mock()
+    mock_content_block_delta.type = "content_block_delta"
+    mock_content_block_delta.model_dump = make_model_dump_with_warning(
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}
+    )
+
+    mock_content_block_stop = unittest.mock.Mock()
+    mock_content_block_stop.type = "content_block_stop"
+    mock_content_block_stop.model_dump = make_model_dump_with_warning(
+        {"type": "content_block_stop", "index": 0}
+    )
+
+    mock_message_stop = unittest.mock.Mock()
+    mock_message_stop.type = "message_stop"
+    mock_message_stop.model_dump = make_model_dump_with_warning(
+        {"type": "message_stop", "message": {"stop_reason": "end_turn"}}
+    )
+
+    final_message = unittest.mock.Mock()
+    final_message.usage = unittest.mock.Mock(model_dump=lambda: {"input_tokens": 10, "output_tokens": 5})
+
+    mock_context = generate_mock_stream_context(
+        [
+            mock_message_start,
+            mock_content_block_start,
+            mock_content_block_delta,
+            mock_content_block_stop,
+            mock_message_stop,
+        ],
+        final_message=final_message,
+    )
+    anthropic_client.messages.stream.return_value = mock_context
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        response = model.stream([{"role": "user", "content": [{"text": "hello"}]}], None, None)
+        events = await alist(response)
+
+    pydantic_warnings = [w for w in caught_warnings if "PydanticSerializationUnexpectedValue" in str(w.message)]
+    assert len(pydantic_warnings) == 0, f"Unexpected Pydantic warnings: {pydantic_warnings}"
+
+    assert {"messageStart": {"role": "assistant"}} in events
+    assert {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}} in events
+    assert {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Hello"}}} in events
+    assert {"contentBlockStop": {"contentBlockIndex": 0}} in events
+    assert {"messageStop": {"stopReason": "end_turn"}} in events
+
+
 class TestCountTokens:
     """Tests for AnthropicModel.count_tokens native token counting."""
 

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1219,16 +1219,20 @@ async def test_stream_all_events_no_pydantic_warnings(anthropic_client, model, a
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
         response = model.stream([{"role": "user", "content": [{"text": "hello"}]}], None, None)
-        events = await alist(response)
+        tru_events = await alist(response)
 
     pydantic_warnings = [w for w in caught_warnings if "PydanticSerializationUnexpectedValue" in str(w.message)]
     assert len(pydantic_warnings) == 0, f"Unexpected Pydantic warnings: {pydantic_warnings}"
 
-    assert {"messageStart": {"role": "assistant"}} in events
-    assert {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}} in events
-    assert {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Hello"}}} in events
-    assert {"contentBlockStop": {"contentBlockIndex": 0}} in events
-    assert {"messageStop": {"stopReason": "end_turn"}} in events
+    exp_events = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Hello"}}},
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15}, "metrics": {"latencyMs": 0}}},
+    ]
+    assert tru_events == exp_events
 
 
 class TestCountTokens:


### PR DESCRIPTION

## Description

When using the Anthropic SDK >= 0.84.0, every streaming response triggers multiple `PydanticSerializationUnexpectedValue` warnings on stderr because `model_dump()` encounters `ParsedTextBlock` objects that don't match the discriminated union schema.

The previous fix (from #1746) worked around this by manually building dicts for `message_stop` and `content_block_stop` events, but the same warnings still fire for `message_start`, `content_block_start`, and `content_block_delta`.

This PR replaces those per-event-type workarounds with a single `warnings.filterwarnings("ignore", message=".*PydanticSerializationUnexpectedValue.*")` scoped to the `model_dump()` call. The serialization still produces correct data — it just emits noise that we suppress.

## Related Issues

Fixes #1865

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Existing regression tests (`test_stream_message_stop_no_pydantic_warnings`, `test_stream_content_block_stop_no_pydantic_warnings`) already verify that Pydantic serialization warnings do not leak during streaming. Both pass with this change.

Added new regression test as well.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.