### PR TITLE
Add Latitude to tracing backends

### DIFF
--- a/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -293,6 +293,7 @@ Common visualization options include:
 3. **AWS X-Ray**: For AWS-based applications
 4. **Zipkin**: Lightweight distributed tracing
 5. **Opik**: For evaluating and optimizing multi-agent systems
+6. **Latitude**: Open-source LLM observability and evaluation with failure clustering and auto-generated evals from production
 
 ## Local Development Setup
 


### PR DESCRIPTION
Adds **Latitude** to the list of OpenTelemetry-compatible visualization and analysis backends on the tracing page.

[Latitude](https://latitude.so) is an open-source LLM observability and evaluation platform. Strands already exports OTLP traces (via `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS`), so Latitude works as a backend with no code changes. One-line addition matching the existing Langfuse / Opik entries.
