### PR TITLE
feat(issue-template): add Port Request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/port_request.yml
+++ b/.github/ISSUE_TEMPLATE/port_request.yml
@@ -1,0 +1,64 @@
+name: Port Request
+description: Kick off a port of completed work (feature or fix) from one SDK language into another via strandly
+title: "[PORT] "
+labels: ["port"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Kicks off a port from one SDK language to another. Once filled out, hand
+        this issue to the strandly port workflow:
+
+        ```
+        strandly port --issue <ISSUE_ID>
+        ```
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: Source SDK
+      description: The language the work is being ported FROM.
+      default: 0
+      options:
+        - strands-ts
+    validations:
+      required: true
+
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target SDK
+      description: The language the work is being ported INTO.
+      default: 0
+      options:
+        - strands-py
+    validations:
+      required: true
+
+  - type: textarea
+    id: related-files
+    attributes:
+      label: Related Files
+      description: |
+        Every source-SDK artifact for this change (source, tests, docs), one
+        repo-relative path per line and nothing else.
+
+        Example:
+        ```
+        strands-ts/src/models/anthropic.ts
+        strands-ts/src/models/__tests__/anthropic.test.ts
+        strands-ts/test/integ/models/anthropic.test.ts
+        site/src/content/docs/.../anthropic.mdx
+        ```
+      render: text
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: completeness
+    attributes:
+      label: Confirmation
+      options:
+        - label: The change is complete in the source SDK, and every related artifact is listed above (source, tests, and docs, if the change has any).
+          required: true


### PR DESCRIPTION
## Description

Adds a `[PORT]` issue template that kicks off porting completed work (a feature or fix) from one SDK language into another via the `strandly port` workflow.

A port issue is the entry point to that workflow: a maintainer fills out the template, then hands the issue to the porter with `strandly port --issue <ISSUE_ID>`. The template captures exactly what the port needs to reproduce the change in the target SDK:

- **Source SDK** and **Target SDK** dropdowns (currently `strands-ts` to `strands-py`).
- **Related Files**: every source-SDK artifact for the change (source, tests, docs), one repo-relative path per line, so the porter has the full surface to reproduce.
- A confirmation checkbox attesting the change is complete in the source SDK and every related artifact is listed.

## Why

Ports kicked off from free-form issues miss artifacts (an integ test, a docs page) that the source change actually touched, and the porter only discovers the gap partway through. Making the related-files list a required, structured field up front gives the workflow a complete and machine-readable starting point.

## Type of change

New feature (issue template)

## Testing

Validated the template renders as a GitHub issue form and parses as valid YAML. Exercised the resulting issue end to end through `strandly port --issue <ISSUE_ID>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)