### PR TITLE
docs(porting): add TypeScript-to-Python porting guide

### DIFF
--- a/strands-py/docs/PORTING.md
+++ b/strands-py/docs/PORTING.md
@@ -1,0 +1,66 @@
+# Porting from TypeScript
+
+## Overview
+
+This guide collects the rules for porting a feature from the TypeScript SDK (`strands-ts`) into the Python SDK (`strands-py`). TypeScript is canonical: a port reproduces the TypeScript behavior, expressed idiomatically in Python.
+
+The rules below are construct-to-construct mappings; general language idiom a competent porter already applies is left out. Concessions forced by a Python limitation are collected under [Workarounds](#workarounds).
+
+## A TypeScript `interface` maps to one of three Python forms, by role
+
+A single TypeScript `interface` covers roles that Python expresses with distinct constructs, so the Python form depends on what the interface is *for*:
+
+1. **Behavioral contract (has method members)** maps to a `Protocol` (implemented implicitly).
+   - `interface Extractor { extract() }` to `class Extractor(Protocol)`
+2. **Any data shape (fields, constructed and passed around)** maps to a `@dataclass`. `readonly` fields map to `@dataclass(frozen=True)`.
+   - `interface ExtractionResult` to `@dataclass class ExtractionResult`
+3. **Pure constructor config (destructured once to build an object, never kept as a unit)** maps to explicit `__init__` parameters, no type at all; the fields become attributes. A required field (especially a required callback) is a positional parameter; optional fields go after a bare `*,` as keyword-only.
+   - `interface ContextInjectorConfig` to `__init__(self, render_content, *, name=None, trigger=None)`
+
+## A tagged object-literal union member maps to a frozen dataclass
+
+A union member that is a TypeScript object literal with a string tag becomes a frozen dataclass whose tag is a non-init defaulted field:
+
+```python
+# type Deny = { type: 'deny'; reason: string }   ->
+@dataclass(frozen=True)
+class Deny:
+    type: str = field(default="deny", init=False)
+    reason: str = ""
+```
+
+`readonly` maps to `frozen=True`; the literal `type:` tag maps to `field(default="...", init=False)` (present at runtime, not a constructor argument). A factory function (`function deny(reason): Deny`) collapses into the constructor (`deny("x")` becomes `Deny(reason="x")`). The union alias maps directly (`type X = A | B` to `X = A | B`). Downstream dispatch on the tag (`switch (action.type)`) becomes `isinstance` checks (`isinstance(action, Deny)`).
+
+## A `tool({...})` object-literal maps to a `@tool`-decorated function
+
+Each field of the tool object lands in a specific place:
+
+| TypeScript `tool({...})` field | Python `@tool` function |
+|---|---|
+| `name: 'summarize_context'` | the function name (`def summarize_context`) |
+| `description: '...'` | the function docstring |
+| `inputSchema: z.object({ keepRecent: z.number().int().optional() })` | typed parameters (`keep_recent: int \| None = None`) |
+| per-field `.describe('...')` | the matching `Args:` docstring entry |
+| `callback: (input, context) => {...}` | the function body |
+| `context` (2nd callback arg) | `@tool(context=True)` plus a `tool_context: ToolContext` param |
+
+The declarative schema and its descriptions collapse into the function signature plus its Google-style docstring.
+
+## External wire keys stay verbatim
+
+A key that belongs to an external API or protocol (not our own surface) is copied character-for-character, not re-cased: `max_tokens`, `input_tokens`, `tool_use`, `stop_reason` are the third-party spelling. This extends to docstrings and comments that *name* those keys.
+
+## Workarounds
+
+Concessions forced by a Python (or current-codebase) limitation, where the port is constrained by what already exists rather than chosen freely. Unlike the rules above, these would not be how you'd do it porting Python from scratch.
+
+### The Python surface is async; bridge a sync-only client with a worker thread
+
+The exposed method is always an async generator (`async def stream(...) -> AsyncGenerator[...]`). How the underlying client is driven depends on what it offers:
+
+- **Async client available** (for example Anthropic's `AsyncAnthropic`): use it directly with `async with` / `async for`. When a TypeScript API exposes both sync and async forms, the Python port takes the async form.
+- **Sync-only client** (boto3 has no async client): keep the async-generator surface but run the blocking call in `asyncio.to_thread`, feeding events back through an `asyncio.Queue` plus a callback, with a sentinel (`None`) to close. The blocking work must never run on the event loop thread.
+
+### Shared types are looked up by their existing target name, never renamed
+
+Exceptions, content-block types, and stream-event types live in a central types module on each side. When the source references one, use the target's existing name for it; do not transform the identifier. There is no suffix rule: `ProviderTokenCountError` keeps that exact name in both languages, while `ContextWindowOverflowError` is `ContextWindowOverflowException` in Python, because that is how each is already spelled. Resolve each against what is actually there rather than applying a uniform `Error` to `Exception` rename.

--- a/strands-py/docs/README.md
+++ b/strands-py/docs/README.md
@@ -5,6 +5,7 @@ This folder contains documentation for contributors and developers working on th
 ## Contents
 
 - [STYLE_GUIDE.md](./STYLE_GUIDE.md) - Code style conventions and formatting guidelines
+- [PORTING.md](./PORTING.md) - Rules for porting features from the TypeScript SDK to Python
 - [HOOKS.md](./HOOKS.md) - Hooks system rules and usage guide
 - [PR.md](../../team/PR.md) - Pull request description guidelines
 - [MCP_CLIENT_ARCHITECTURE.md](./MCP_CLIENT_ARCHITECTURE.md) - MCP client threading architecture and design decisions


### PR DESCRIPTION
## Description

Adds `strands-py/docs/PORTING.md`, a developer guide for porting a feature from the TypeScript SDK (`strands-ts`) into the Python SDK (`strands-py`). It collects the construct-to-construct mappings we want a port to follow:

- A TypeScript `interface` maps to one of three Python forms by role: `Protocol` (behavioral contract), `@dataclass` (data shape), or plain `__init__` kwargs (pure constructor config).
- A tagged object-literal union member maps to a frozen dataclass.
- A `tool({...})` object-literal maps to a `@tool`-decorated function.
- External wire keys (third-party API/protocol keys) are copied verbatim, not re-cased.

It also calls out two **workarounds** forced by Python rather than chosen freely: bridging a sync-only client (boto3) behind the async surface with a worker thread, and looking up shared types by their existing target-module name instead of mechanically renaming.

The guide is indexed from `strands-py/docs/README.md`.

## Why

Ports were being done from memory and drifting: the same TypeScript construct came out as different Python shapes depending on who did the work. Writing the mappings down once gives porters a consistent reference and reviewers a thing to point at. The guide deliberately omits obvious language idiom and anything still under design discussion, so it states only the mappings we're confident in.

## Type of change

Documentation

## Testing

Docs-only change. The rules were derived from and checked against real ports in the SDK (for example the `ContextInjector` plugin and the model providers); each example in the guide reflects code that exists in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)