### PR TITLE
fix: fixed memory test failure

### DIFF
--- a/strands-ts/src/vended-memory-stores/local/__tests__/local-memory-store.test.node.ts
+++ b/strands-ts/src/vended-memory-stores/local/__tests__/local-memory-store.test.node.ts
@@ -323,7 +323,7 @@ describe('LocalMemoryStore', () => {
 
       const mm = new MemoryManager({ stores: [store] })
       const agent = createMockAgent()
-      mm.initAgent(agent)
+      await mm.initAgent(agent)
 
       const message = new Message({ role: 'user', content: [new TextBlock('I like dark mode')] })
       const added = agent.trackedHooks.filter((hook) => hook.eventType === MessageAddedEvent)


### PR DESCRIPTION
## Description

The unit test `LocalMemoryStore > MemoryManager integration > ingests extracted facts through add when extraction fires (client-side extractor)` was failing deterministically with:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

Root cause is a missing `await` in the test, not a defect in the memory subsystem. `MemoryManager.initAgent` is `async` and registers its lifecycle hooks (`MessageAddedEvent`, `AfterInvocationEvent`) only *after* its first `await this._initStores()`, so those registrations are scheduled as a microtask and have not run yet when the method returns its pending promise. The test called it fire-and-forget:

```ts
mm.initAgent(agent)   // not awaited — hooks not registered yet
const added = agent.trackedHooks.filter((hook) => hook.eventType === MessageAddedEvent)  // empty
```

With `trackedHooks` still empty, no message was buffered and the extraction trigger never fired, so the extractor was invoked 0 times. Awaiting `initAgent` lets the hook registrations complete before the test inspects `trackedHooks`. This was the only un-awaited `initAgent` call in the SDK — every other call site (~40, including the sibling Bedrock-KB store test and all of `extraction.test.ts`) already awaits it.

## Related Issues

N/A

## Documentation PR

N/A — test-only change.

## Type of Change

Bug fix

## Testing

`npm test -- local-memory-store.test.node.ts` — the full file passes (34/34) deterministically across repeated runs; it failed reliably before the change.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
