### PR TITLE
learn: reviewer learnings from PR #2954

### DIFF
--- a/.agents/learnings/check-symptom-vs-root-cause-on-bugfix.md
+++ b/.agents/learnings/check-symptom-vs-root-cause-on-bugfix.md
@@ -1,0 +1,10 @@
+# On a bugfix, distinguish symptom fix from documented root cause
+
+- **Source PR:** strands-agents/harness-sdk#2954
+- **Run:** learning-run-pr2954
+
+When a PR fixes a bug that links to an issue documenting a deeper root cause, check whether the change resolves that root cause or only the immediate symptom. If it is a narrower symptom fix, confirm a tracking issue exists for the remaining root cause and flag its absence rather than treating the bug as fully closed by the merge.
+
+Issue #2918 documented the root cause: `_ConcurrencyController.release_lock()` releases the invocation lock whenever it is held, with no check of *which* invocation owns it, and suggested centralizing acquire/release pairing in the controller. PR #2954 instead shipped a minimal fix to the one misbehaving caller (`stream_async`), leaving the owner-blind primitive in place. That is a legitimate, low-risk scoping choice — but a reviewer should confirm the residual root cause is tracked so it is not silently lost when the issue is closed.
+
+**Evidence:** PR #2954 closes #2918, but addresses only the `stream_async` symptom; the root-cause remediation proposed in #2918 (ownership tracking in `_ConcurrencyController`) remains unimplemented in `strands-py/src/strands/agent/_concurrency.py`.

--- a/.agents/learnings/release-lock-only-on-proven-ownership.md
+++ b/.agents/learnings/release-lock-only-on-proven-ownership.md
@@ -1,0 +1,12 @@
+# Release a lock only on proven ownership, not a mode/config proxy
+
+- **Source PR:** strands-agents/harness-sdk#2954
+- **Run:** learning-run-pr2954
+
+When reviewing a fix to a locking/concurrency bug, verify it enforces the real ownership / acquire-release pairing invariant rather than a proxy for it. A lock must be released only by the code path that *proved* it acquired the lock (mirror the acquire result), never based on a `mode`/config flag re-derived elsewhere.
+
+PR #2954 fixed a bug where `Agent.stream_async`'s `finally` could release the invocation lock owned by a concurrent direct tool call. The fix gated the release on `self._concurrency.mode == ConcurrentInvocationMode.THROW` — a proxy that re-derives the acquire decision `begin()` already made. The codebase already had the correct pattern next door: `tools/_caller.py` records the actual acquisition (`acquired_lock = ... try_acquire_lock()`) and releases only `if acquired_lock`. The linked issue #2918 asked for ownership/pairing to be tracked in `_ConcurrencyController`, which the merge did not do.
+
+Also watch for fields whose *name* implies ownership but whose *value* does not track it in every mode: `_BeginResult.lock_acquired` is `True` in `UNSAFE_REENTRANT` mode even though no lock was acquired, so gating release on `begin.lock_acquired` (the intuitive fix) would not have worked. Flag any `release()` conditioned on configuration instead of proven acquisition, and any `lock_acquired`/`owns_lock`-style flag that can be true without a real acquisition.
+
+**Evidence:** PR #2954 (commit e4ad16ea, `agent/agent.py:1217-1218`); root-cause issue #2918; reference pattern in `strands-py/src/strands/tools/_caller.py:97-142`; misleading field at `strands-py/src/strands/agent/_concurrency.py:124-128`; owner-blind primitive at `_concurrency.py:178-181`.


### PR DESCRIPTION
Adds two reviewer-learning corpus entries under `.agents/learnings/`, derived from the lifecycle of #2954 (fix: release invocation lock only in throw mode) and its root-cause issue #2918.

- `release-lock-only-on-proven-ownership.md` — release a lock only on proven acquisition, not on a `mode`/config proxy; beware ownership-named fields (`lock_acquired`) that aren't true in every mode.
- `check-symptom-vs-root-cause-on-bugfix.md` — when a bugfix closes an issue documenting a deeper root cause, verify the root cause is resolved or tracked, not just the symptom.

These pair with the matching constraints appended to the reviewer SOP in `strands-agents/devtools`.

Run: learning-run-pr2954