### PR TITLE
fix(telemetry): drop misleading gen_ai.agent.name from multiagent spans

### DIFF
--- a/strands-py/src/strands/telemetry/tracer.py
+++ b/strands-py/src/strands/telemetry/tracer.py
@@ -748,11 +748,6 @@ class Tracer:
         """Start a new span for swarm invocation."""
         operation = f"invoke_{instance}"
         attributes: dict[str, AttributeValue] = self._get_common_attributes(operation)
-        attributes.update(
-            {
-                "gen_ai.agent.name": instance,
-            }
-        )
 
         if custom_trace_attributes:
             attributes.update(custom_trace_attributes)

--- a/strands-py/tests/strands/telemetry/test_tracer.py
+++ b/strands-py/tests/strands/telemetry/test_tracer.py
@@ -497,7 +497,6 @@ def test_start_swarm_call_span_with_string_task(mock_tracer):
             {
                 "gen_ai.operation.name": "invoke_swarm",
                 "gen_ai.system": "strands-agents",
-                "gen_ai.agent.name": "swarm",
                 "workflow_id": "wf-789",
                 "priority": "high",
             }
@@ -526,7 +525,6 @@ def test_start_swarm_span_with_contentblock_task(mock_tracer):
             {
                 "gen_ai.operation.name": "invoke_swarm",
                 "gen_ai.system": "strands-agents",
-                "gen_ai.agent.name": "swarm",
             }
         )
         mock_span.add_event.assert_any_call(
@@ -584,7 +582,6 @@ def test_start_swarm_span_with_contentblock_task_latest_conventions(mock_tracer,
             {
                 "gen_ai.operation.name": "invoke_swarm",
                 "gen_ai.provider.name": "strands-agents",
-                "gen_ai.agent.name": "swarm",
             }
         )
         mock_span.add_event.assert_any_call(


### PR DESCRIPTION
The Swarm and Graph multiagent spans set gen_ai.agent.name to the orchestrator type, which the OTel GenAI semantic conventions reserve for an actual agent identity. The operation type is already conveyed by gen_ai.operation.name via the common attributes, so the attribute adds no information and confuses trace inspection. This drops it from start_multiagent_span and tightens the affected tracer tests so the attribute cannot quietly return.

Fixes #1105.