### PR TITLE
fix(typescript): allow interface return types from tool callbacks

### DIFF
--- a/strands-ts/src/tools/__tests__/zod-tool.test-d.ts
+++ b/strands-ts/src/tools/__tests__/zod-tool.test-d.ts
@@ -103,7 +103,7 @@ describe('zod-tool type tests', () => {
       expectTypeOf(asyncComplexTool.invoke).returns.resolves.toEqualTypeOf<{
         id: string
         timestamp: number
-        metadata: { processed: true }
+        metadata: { processed: boolean }
       }>()
     })
   })
@@ -152,7 +152,7 @@ describe('zod-tool type tests', () => {
 
       expectTypeOf(generatorObjectTool.invoke).returns.resolves.toEqualTypeOf<{
         processed: number
-        success: true
+        success: boolean
       }>()
     })
   })
@@ -294,6 +294,28 @@ describe('zod-tool type tests', () => {
       })
 
       expectTypeOf(customTool.invoke).returns.resolves.toEqualTypeOf<CustomResult>()
+    })
+
+    it('should accept interface return types without index signatures', () => {
+      interface Product {
+        id: string
+        name: string
+        price: number
+      }
+
+      const catalogTool = tool({
+        name: 'catalogTool',
+        inputSchema: z.object({ category: z.string() }),
+        callback: (): { products: Product[]; totalProducts: number } => ({
+          products: [],
+          totalProducts: 0,
+        }),
+      })
+
+      expectTypeOf(catalogTool.invoke).returns.resolves.toEqualTypeOf<{
+        products: Product[]
+        totalProducts: number
+      }>()
     })
   })
 })

--- a/strands-ts/src/tools/tool-factory.ts
+++ b/strands-ts/src/tools/tool-factory.ts
@@ -23,7 +23,7 @@ function isZodType(value: unknown): value is z.ZodType {
  * @param config - Tool configuration with Zod schema
  * @returns An InvokableTool with typed input and output
  */
-export function tool<TInput extends z.ZodType, TReturn extends JSONValue = JSONValue>(
+export function tool<TInput extends z.ZodType, TReturn = JSONValue>(
   config: ZodToolConfig<TInput, TReturn>
 ): InvokableTool<z.infer<TInput>, TReturn>
 

--- a/strands-ts/src/tools/zod-tool.ts
+++ b/strands-ts/src/tools/zod-tool.ts
@@ -17,7 +17,7 @@ type ZodInferred<TInput> = TInput extends z.ZodType ? z.infer<TInput> : never
  * @typeParam TInput - Zod schema type for input validation
  * @typeParam TReturn - Return type of the callback function
  */
-export interface ZodToolConfig<TInput extends z.ZodType | undefined, TReturn extends JSONValue = JSONValue> {
+export interface ZodToolConfig<TInput extends z.ZodType | undefined, TReturn = JSONValue> {
   /** The name of the tool */
   name: string
 
@@ -33,6 +33,8 @@ export interface ZodToolConfig<TInput extends z.ZodType | undefined, TReturn ext
   /**
    * Callback function that implements the tool's functionality.
    *
+   * The return value must be JSON-serializable.
+   *
    * @param input - Validated input matching the Zod schema
    * @param context - Optional execution context
    * @returns The result (can be a value, Promise, or AsyncGenerator)
@@ -47,7 +49,7 @@ export interface ZodToolConfig<TInput extends z.ZodType | undefined, TReturn ext
  * Zod-based tool implementation.
  * Extends Tool abstract class and implements InvokableTool interface.
  */
-export class ZodTool<TInput extends z.ZodType | undefined, TReturn extends JSONValue = JSONValue>
+export class ZodTool<TInput extends z.ZodType | undefined, TReturn = JSONValue>
   extends Tool
   implements InvokableTool<ZodInferred<TInput>, TReturn>
 {


### PR DESCRIPTION
Tools that return an interface fail to compile because TReturn extends JSONValue rejects interfaces, which lack an implicit string index signature in TypeScript. Removing the constraint while keeping JSONValue as the default fixes it without changing inference for existing callers.

Closes #2517.
