### PR TITLE
fix(session): repair mid-iteration skip of orphaned toolUse

### DIFF
--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -271,39 +271,48 @@ class RepositorySessionManager(SessionManager):
                 )
                 messages.pop(0)
 
-        # Then check for orphaned toolUse messages
-        for index, message in enumerate(messages):
-            # Check all but the latest message in the messages array
-            # The latest message being orphaned is handled in the agent class
-            if index + 1 < len(messages):
-                if any("toolUse" in content for content in message["content"]):
-                    tool_use_ids = [
-                        content["toolUse"]["toolUseId"] for content in message["content"] if "toolUse" in content
-                    ]
+        # Then check for orphaned toolUse messages. Snapshot the eligible indices before
+        # iterating so that inserting a toolResult (which shifts later indices) does not
+        # cause the loop to skip a subsequent orphaned toolUse. The trailing message is
+        # excluded from the snapshot because that case is handled in the agent class when
+        # a new prompt arrives, so we do not synthesize a toolResult into persisted
+        # history for it here. Walking in reverse means each insert only shifts already-
+        # processed positions, so the original snapshot indices remain valid.
+        original_last_index = len(messages) - 1
+        tool_use_indices = [
+            index
+            for index, message in enumerate(messages)
+            if index < original_last_index and any("toolUse" in content for content in message["content"])
+        ]
+        for index in reversed(tool_use_indices):
+            message = messages[index]
+            tool_use_ids = [
+                content["toolUse"]["toolUseId"] for content in message["content"] if "toolUse" in content
+            ]
 
-                    # Check if there are more messages after the current toolUse message
-                    tool_result_ids = [
-                        content["toolResult"]["toolUseId"]
-                        for content in messages[index + 1]["content"]
-                        if "toolResult" in content
-                    ]
+            # Check the toolResult ids already present in the next message.
+            tool_result_ids = [
+                content["toolResult"]["toolUseId"]
+                for content in messages[index + 1]["content"]
+                if "toolResult" in content
+            ]
 
-                    missing_tool_use_ids = list(set(tool_use_ids) - set(tool_result_ids))
-                    # If there are missing tool use ids, that means the messages history is broken
-                    if missing_tool_use_ids:
-                        logger.warning(
-                            "Session message history has an orphaned toolUse with no toolResult. "
-                            "Adding toolResult content blocks to create valid conversation."
-                        )
-                        # Create the missing toolResult content blocks
-                        missing_content_blocks = generate_missing_tool_result_content(missing_tool_use_ids)
+            missing_tool_use_ids = list(set(tool_use_ids) - set(tool_result_ids))
+            if not missing_tool_use_ids:
+                continue
 
-                        if tool_result_ids:
-                            # If there were any toolResult ids, that means only some of the content blocks are missing
-                            messages[index + 1]["content"].extend(missing_content_blocks)
-                        else:
-                            # The message following the toolUse was not a toolResult, so lets insert it
-                            messages.insert(index + 1, {"role": "user", "content": missing_content_blocks})
+            logger.warning(
+                "Session message history has an orphaned toolUse with no toolResult. "
+                "Adding toolResult content blocks to create valid conversation."
+            )
+            missing_content_blocks = generate_missing_tool_result_content(missing_tool_use_ids)
+
+            if tool_result_ids:
+                # If there were any toolResult ids, that means only some of the content blocks are missing
+                messages[index + 1]["content"].extend(missing_content_blocks)
+            else:
+                # The message following the toolUse was not a toolResult, so lets insert it
+                messages.insert(index + 1, {"role": "user", "content": missing_content_blocks})
         return messages
 
     def sync_multi_agent(self, source: "MultiAgentBase", **kwargs: Any) -> None:

--- a/strands-py/tests/strands/session/test_repository_session_manager.py
+++ b/strands-py/tests/strands/session/test_repository_session_manager.py
@@ -1,5 +1,6 @@
 """Tests for AgentSessionManager."""
 
+import copy
 from unittest.mock import Mock
 
 import pytest
@@ -427,11 +428,83 @@ def test_fix_broken_tool_use_ignores_last_message(session_manager):
             ],
         },
     ]
+    original = copy.deepcopy(messages)
 
     fixed_messages = session_manager._fix_broken_tool_use(messages)
 
     # Should remain unchanged since toolUse is in last message
-    assert fixed_messages == messages
+    assert fixed_messages == original
+
+
+def test_fix_broken_tool_use_ignores_single_orphaned_tool_use(session_manager):
+    """Test that a conversation with only a single orphaned toolUse is left untouched."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"toolUse": {"toolUseId": "only-message-123", "name": "test_tool", "input": {"input": "test"}}}
+            ],
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    fixed_messages = session_manager._fix_broken_tool_use(messages)
+
+    assert fixed_messages == original
+
+
+def test_fix_broken_tool_use_consecutive_orphaned_tool_uses(session_manager):
+    """Consecutive non-trailing orphaned toolUse messages each receive a toolResult (issue #2028).
+
+    The trailing message is intentionally left for the agent class to handle at prompt-arrival
+    time, so this covers the mid-iteration skip caused by enumerate+insert against a live
+    ``len(messages)`` guard: with two orphans followed by a text message, the second orphan
+    used to end up as the new "last" index mid-loop and get skipped.
+    """
+    tru_messages = [
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": "first-123", "name": "test_tool", "input": {"input": "test1"}}}],
+        },
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": "second-456", "name": "test_tool", "input": {"input": "test2"}}}],
+        },
+        {"role": "user", "content": [{"text": "Next message"}]},
+    ]
+    exp_messages = [
+        tru_messages[0],
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "first-123",
+                        "status": "error",
+                        "content": [{"text": "Tool was interrupted."}],
+                    }
+                }
+            ],
+        },
+        tru_messages[1],
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "second-456",
+                        "status": "error",
+                        "content": [{"text": "Tool was interrupted."}],
+                    }
+                }
+            ],
+        },
+        tru_messages[2],
+    ]
+
+    tru_fixed = session_manager._fix_broken_tool_use(tru_messages)
+
+    assert tru_fixed == exp_messages
 
 
 def test_fix_broken_tool_use_does_not_change_valid_message(session_manager):


### PR DESCRIPTION
_fix_broken_tool_use walked messages with enumerate() and compared index + 1 against a live len(messages). When two orphaned toolUse messages sat next to each other, inserting a synthetic toolResult after the first one shifted the second orphan into the new last-message position mid-loop, and the guard skipped it.

The fix snapshots the eligible indices up front, excluding the originally-trailing message which agent.py handles at prompt-arrival time so we do not mutate persisted history that may never be resumed. Walking the snapshot in reverse keeps each insert from shifting an unprocessed position.

Closes #2028.
