### PR TITLE
fix(bedrock): treat guardContent qualifiers as optional

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -623,8 +623,10 @@ class BedrockModel(Model):
         if "guardContent" in content:
             guard = content["guardContent"]
             guard_text = guard["text"]
-            result = {"text": {"text": guard_text["text"], "qualifiers": guard_text["qualifiers"]}}
-            return {"guardContent": result}
+            text_block: dict[str, Any] = {"text": guard_text["text"]}
+            if "qualifiers" in guard_text:
+                text_block["qualifiers"] = guard_text["qualifiers"]
+            return {"guardContent": {"text": text_block}}
 
         # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ImageBlock.html
         if "image" in content:

--- a/strands-py/src/strands/types/content.py
+++ b/strands-py/src/strands/types/content.py
@@ -24,7 +24,7 @@ class GuardContentText(TypedDict):
         text: The input text details to be evaluated by the guardrail.
     """
 
-    qualifiers: list[Literal["grounding_source", "query", "guard_content"]]
+    qualifiers: NotRequired[list[Literal["grounding_source", "query", "guard_content"]]]
     text: str
 
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -1980,6 +1980,30 @@ def test_format_request_message_content_preserves_nonempty_tool_result_content(m
     assert tool_result["content"] == [{"text": "some result"}]
 
 
+def test_format_request_message_content_guard_content_without_qualifiers(model, model_id):
+    """Test that _format_request_message_content accepts guardContent text blocks without qualifiers.
+
+    The Bedrock GuardrailConverseTextBlock treats qualifiers as optional, so omitting it
+    should not raise a KeyError.
+
+    See: https://github.com/strands-agents/harness-sdk/issues/959
+    """
+    content = {"guardContent": {"text": {"text": "evaluate me"}}}
+
+    formatted = model._format_request_message_content(content)
+
+    assert formatted == {"guardContent": {"text": {"text": "evaluate me"}}}
+
+
+def test_format_request_message_content_guard_content_with_qualifiers(model, model_id):
+    """Test that _format_request_message_content forwards qualifiers when supplied."""
+    content = {"guardContent": {"text": {"text": "evaluate me", "qualifiers": ["guard_content"]}}}
+
+    formatted = model._format_request_message_content(content)
+
+    assert formatted == {"guardContent": {"text": {"text": "evaluate me", "qualifiers": ["guard_content"]}}}
+
+
 def test_format_request_removes_status_field_when_configured(model, model_id):
     model.update_config(include_tool_result_status=False)
 


### PR DESCRIPTION
The Bedrock guardrail content text block accepts qualifiers as an optional field, but the formatter unconditionally indexed into it and raised KeyError when callers passed a guardContent block without qualifiers. GuardContentText now marks qualifiers NotRequired to match the Bedrock API while keeping text required, and the formatter only forwards qualifiers when present.

Upstream #978 fixes the same crash by flipping the whole TypedDict to total=False, which also makes text optional. Keeping text required preserves the type contract.

Fixes #959.
