### PR TITLE
fix(model): drop blank text content blocks before send

### DIFF
--- a/strands-ts/src/models/__tests__/model.test.ts
+++ b/strands-ts/src/models/__tests__/model.test.ts
@@ -633,6 +633,42 @@ describe('Model', () => {
       })
     })
 
+    describe('when a content block emits no text deltas alongside reasoning and tool use', () => {
+      it('drops the resulting empty TextBlock from the aggregated message but still yields it', async () => {
+        const provider = new TestModelProvider(async function* () {
+          yield { type: 'modelMessageStartEvent', role: 'assistant' }
+          yield { type: 'modelContentBlockStartEvent' }
+          yield {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'reasoningContentDelta', text: 'Thinking', signature: 'sig1' },
+          }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelContentBlockStartEvent' }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield {
+            type: 'modelContentBlockStartEvent',
+            start: { type: 'toolUseStart', toolUseId: 'tool1', name: 'get_weather' },
+          }
+          yield {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'toolUseInputDelta', input: '{"city": "Paris"}' },
+          }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelMessageStopEvent', stopReason: 'toolUse' }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        const { items, result } = await collectGenerator(provider.streamAggregated(messages))
+
+        expect(items).toContainEqual({ type: 'textBlock', text: '' })
+        expect(result.message.content).toEqual([
+          { type: 'reasoningBlock', text: 'Thinking', signature: 'sig1' },
+          { type: 'toolUseBlock', toolUseId: 'tool1', name: 'get_weather', input: { city: 'Paris' } },
+        ])
+      })
+    })
+
     describe('when multiple metadata events are emitted', () => {
       it('yields all metadata events but keeps only the last one in return value', async () => {
         const provider = new TestModelProvider(async function* () {

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -436,9 +436,12 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
           case 'modelMessageStopEvent':
             // Store message and stop reason
             if (messageRole) {
+              const filtered = contentBlocks.filter(
+                (block) => !(block instanceof TextBlock && block.text.trim() === '')
+              )
               stoppedMessage = new Message({
                 role: messageRole,
-                content: [...contentBlocks],
+                content: filtered,
               })
               finalStopReason = event.stopReason!
             }


### PR DESCRIPTION
Bedrock models such as openai.gpt-oss-20b-1:0 emit an empty text content block alongside reasoning and tool use. The aggregator stored that as a TextBlock(''), so on the next turn Bedrock rejected the request with ValidationException for blank text at messages.1.content.0. Empty TextBlock instances are now filtered at message-construction time, while the streamed events themselves are unchanged for consumers reading the raw stream.

Originally proposed by @manikanta5827 on the archived sdk-typescript repo as #380; this carries the fix forward to the monorepo path with a regression test.

Fixes #2522.
