### PR TITLE
feat(memory): pass per-message sequence numbers to add_messages

### DIFF
--- a/strands-py/src/strands/memory/extraction/coordinator.py
+++ b/strands-py/src/strands/memory/extraction/coordinator.py
@@ -20,7 +20,7 @@ from ...models.model import Model
 from ...telemetry.tracer import get_tracer
 from ...types.content import ContentBlock, Message
 from ...types.exceptions import AggregateMemoryError
-from ..types import MemoryStore
+from ..types import AddMessagesContext, MemoryStore
 from .resolve_extraction_config import _ResolvedExtractionConfig
 from .types import Extractor, ExtractorContext, MemoryMessageFilter
 
@@ -209,7 +209,7 @@ class ExtractionCoordinator:
         # rolled back below on failure.
         self._marks[id(store)] = fresh[-1].seq
 
-        filtered = self._filter_messages([buffered.message for buffered in fresh], config.filter)
+        filtered = self._filter_messages(fresh, config.filter)
 
         span = get_tracer().start_memory_extract_span(
             store.name,
@@ -246,13 +246,15 @@ class ExtractionCoordinator:
         except Exception:  # noqa: BLE001 - telemetry must never break the agent loop.
             logger.debug("store=<%s> | memory extract span end failed", store.name, exc_info=True)
 
-    async def _write(self, store: MemoryStore, messages: list[Message], extractor: Extractor | None) -> int:
+    async def _write(self, store: MemoryStore, buffered: list[_Buffered], extractor: Extractor | None) -> int:
         """Save the messages to the store, one of two ways.
 
         - With an extractor: run it, then write each fact via ``add``
           concurrently. If any write fails the whole batch is re-raised and
           retried later, so stores should expect duplicate writes.
-        - Without an extractor: hand the raw messages to ``add_messages``.
+        - Without an extractor: hand the raw messages to ``add_messages``,
+          passing each message's sequence number so the store can build an
+          idempotency key that survives retries.
 
         Returns:
             The number of entries written (extracted facts, or raw messages).
@@ -260,6 +262,8 @@ class ExtractionCoordinator:
         Raises:
             AggregateMemoryError: If any concurrent ``add`` write fails.
         """
+        messages = [item.message for item in buffered]
+
         if extractor is not None:
             entries = await extractor.extract(messages, ExtractorContext(default_model=self._default_model))
             results = await asyncio.gather(
@@ -274,23 +278,26 @@ class ExtractionCoordinator:
                 )
             return len(entries)
 
-        await store.add_messages(messages)
+        await store.add_messages(messages, AddMessagesContext(sequence_numbers=[item.seq for item in buffered]))
         return len(messages)
 
-    def _filter_messages(self, messages: list[Message], message_filter: MemoryMessageFilter) -> list[Message]:
+    def _filter_messages(self, buffered: list[_Buffered], message_filter: MemoryMessageFilter) -> list[_Buffered]:
         """Remove excluded content blocks, dropping any message left empty.
 
-        Builds new message dicts rather than mutating the inputs.
+        Builds new message dicts rather than mutating the inputs, and carries each
+        surviving message's sequence number through so it stays aligned with the
+        filtered batch.
         """
         exclude = set(message_filter.exclude)
-        result: list[Message] = []
-        for message in messages:
+        result: list[_Buffered] = []
+        for item in buffered:
+            message = item.message
             content = [block for block in message["content"] if self._block_kind(block) not in exclude]
             if content:
                 new_message: Message = {"role": message["role"], "content": content}
                 if message.get("metadata") is not None:
                     new_message["metadata"] = message["metadata"]
-                result.append(new_message)
+                result.append(_Buffered(item.seq, new_message))
         return result
 
     def _block_kind(self, block: ContentBlock) -> str:

--- a/strands-py/src/strands/memory/types.py
+++ b/strands-py/src/strands/memory/types.py
@@ -49,9 +49,22 @@ class SearchOptions(TypedDict, total=False):
 class AddMessagesContext:
     """Context the manager supplies to :meth:`MemoryStore.add_messages`.
 
-    Intentionally empty for now so fields can be added later without a breaking
-    signature change.
+    An extension point: fields are added here without changing the
+    :meth:`MemoryStore.add_messages` signature.
+
+    Attributes:
+        sequence_numbers: Per-message identities aligned one-to-one with
+            ``messages`` (``sequence_numbers[i]`` identifies ``messages[i]``). A
+            retried batch reuses the same numbers, so a store can build an
+            idempotency key that survives retries -- unlike a content hash, which
+            collides when two messages share text (e.g. "ok"). Numbers increase
+            with order but may have gaps (a message filtered to empty is dropped
+            while its siblings keep their own numbers), and reset to 0 each agent
+            run, so a durable dedup token must combine one with a run-unique id.
+            ``None`` when the manager has no per-message numbers to supply.
     """
+
+    sequence_numbers: list[int] | None = None
 
 
 class MemorySearchOptions(SearchOptions, total=False):

--- a/strands-py/tests/strands/memory/test_extraction.py
+++ b/strands-py/tests/strands/memory/test_extraction.py
@@ -36,6 +36,7 @@ from strands.memory.extraction.types import (
     ExtractionTrigger,
     MemoryMessageFilter,
 )
+from strands.memory.types import AddMessagesContext
 from strands.types.content import Message
 
 # A stub model. The coordinator only passes ``default_model`` through to an
@@ -145,6 +146,17 @@ def _added_metadata(call: Any) -> Any:
 
 def _extractor_context(call: Any) -> Any:
     """Pull the ``ExtractorContext`` argument from a recorded ``extract`` call."""
+    if len(call.args) > 1:
+        return call.args[1]
+    return call.kwargs.get("context")
+
+
+def _add_messages_context(call: Any) -> Any:
+    """Pull the ``AddMessagesContext`` argument from a recorded ``add_messages`` call.
+
+    Tolerates ``add_messages(messages, context)`` (positional) and
+    ``add_messages(messages, context=...)`` (keyword).
+    """
     if len(call.args) > 1:
         return call.args[1]
     return call.kwargs.get("context")
@@ -606,3 +618,118 @@ async def test_background_save_does_not_block_scheduling_and_flush_awaits_it():
     release.set()
     await flushed
     assert completed["v"] is True
+
+
+# --------------------------------------------------------------------------- #
+# add_messages context (per-message seqs)
+#
+# Ported from the "addMessages context (per-message seqs)" describe block in
+# strands-ts/src/memory/extraction/__tests__/extraction.test.ts. These assert the
+# coordinator hands ``add_messages`` an ``AddMessagesContext`` carrying the
+# per-message sequence numbers aligned with the filtered batch, so a store can
+# build an idempotency key that survives retries.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_add_messages_passes_sequence_numbers_aligned_with_the_filtered_batch():
+    store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
+    coordinator = _coordinator(store)
+
+    coordinator.record(_user_msg("first"))
+    coordinator.record(_user_msg("second"))
+    await _drive(coordinator, store)
+
+    store.add_messages.assert_called_once()
+    batch = store.add_messages.call_args.args[0]
+    ctx = _add_messages_context(store.add_messages.call_args)
+    # Assert the whole context so an unexpected field added to the envelope later is caught.
+    assert ctx == AddMessagesContext(sequence_numbers=[0, 1])
+    assert len(ctx.sequence_numbers) == len(batch)
+
+
+@pytest.mark.asyncio
+async def test_add_messages_keeps_a_message_seq_when_an_earlier_message_is_filtered_to_empty():
+    store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
+    coordinator = _coordinator(store)
+
+    # seq 0 (kept), seq 1 (tool-only, filtered to empty and dropped), seq 2 (kept).
+    coordinator.record(_user_msg("a"))
+    coordinator.record(_tool_use_msg())
+    coordinator.record(_user_msg("b"))
+    await _drive(coordinator, store)
+
+    batch = store.add_messages.call_args.args[0]
+    ctx = _add_messages_context(store.add_messages.call_args)
+    assert len(batch) == 2
+    # The dropped message leaves a gap: 1 is missing, survivors keep their own seqs.
+    assert ctx == AddMessagesContext(sequence_numbers=[0, 2])
+
+
+@pytest.mark.asyncio
+async def test_add_messages_re_fires_the_same_seqs_for_a_batch_whose_save_failed():
+    store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
+    store.add_messages.side_effect = [RuntimeError("backend down"), None]
+    coordinator = _coordinator(store)
+
+    coordinator.record(_user_msg("first"))
+    coordinator.record(_user_msg("second"))
+    await _drive(coordinator, store)  # fails, mark rolled back
+    await _drive(coordinator, store)  # retries the same batch
+
+    assert store.add_messages.call_count == 2
+    first = _add_messages_context(store.add_messages.call_args_list[0])
+    second = _add_messages_context(store.add_messages.call_args_list[1])
+    assert first == AddMessagesContext(sequence_numbers=[0, 1])
+    # The retry carries the identical context in order, not a fresh renumbering.
+    assert second == first
+
+
+@pytest.mark.asyncio
+async def test_add_messages_anchors_the_seq_to_the_message_not_the_batch_position():
+    store = _make_store("s", ExtractionConfig(trigger=_trigger()), sink="add_messages")
+    coordinator = _coordinator(store)
+
+    # First turn (seq 0) saves cleanly; second turn (seq 1) fails then retries.
+    coordinator.record(_user_msg("turn one"))
+    await _drive(coordinator, store)
+    store.add_messages.side_effect = [RuntimeError("backend down"), None]
+    coordinator.record(_user_msg("turn two"))
+    await _drive(coordinator, store)  # fails, rolled back
+    await _drive(coordinator, store)  # retries turn two
+
+    assert store.add_messages.call_count == 3
+    retried = _add_messages_context(store.add_messages.call_args_list[2])
+    # Retried batch carries the message's original seq (1), not a renumbered 0.
+    assert retried == AddMessagesContext(sequence_numbers=[1])
+
+
+@pytest.mark.asyncio
+async def test_add_messages_gives_each_store_index_aligned_seqs_from_the_shared_buffer():
+    a = _make_store("a", ExtractionConfig(trigger=_trigger()), sink="add_messages")
+    b = _make_store("b", ExtractionConfig(trigger=_trigger()), sink="add_messages")
+    coordinator = _coordinator(a, b)
+
+    coordinator.record(_user_msg("first"))
+    coordinator.record(_user_msg("second"))
+    await _drive(coordinator, a)
+    await _drive(coordinator, b)
+
+    ctx_a = _add_messages_context(a.add_messages.call_args)
+    ctx_b = _add_messages_context(b.add_messages.call_args)
+    assert ctx_a == AddMessagesContext(sequence_numbers=[0, 1])
+    assert ctx_b == AddMessagesContext(sequence_numbers=[0, 1])
+
+
+@pytest.mark.asyncio
+async def test_extractor_route_does_not_receive_add_messages_context():
+    extractor = _make_extractor([ExtractionResult(content="fact")])
+    store = _make_store("s", ExtractionConfig(trigger=_trigger(), extractor=extractor), sink="both")
+    coordinator = _coordinator(store)
+
+    coordinator.record(_user_msg("something happened"))
+    await _drive(coordinator, store)
+
+    # Extractor route writes via add; add_messages is never called, so no context is built for it.
+    store.add_messages.assert_not_called()
+    extractor.extract.assert_called_once()


### PR DESCRIPTION
## Description

The extraction coordinator now threads each buffered message's sequence number through filtering and hands them to `add_messages` via a new `AddMessagesContext.sequence_numbers` field, aligned one-to-one with the filtered batch.

A store can use these per-message identities to build an idempotency key that survives the coordinator's retry-on-failure: when a save fails the mark is rolled back and the **same** batch re-fires with the **same** numbers, so a token derived from them dedups exactly. This is more robust than a content hash, which collides when two turns share text (e.g. "ok"). Numbers increase with order but may have gaps (a message filtered to empty is dropped while its siblings keep their own numbers) and reset to 0 each agent run, so a durable token combines one with a run-unique id.

This brings the Python coordinator to parity with the TypeScript implementation (`strands-ts` `AddMessagesContext.sequenceNumbers`, passed at `coordinator.ts` `_write`). The motivating consumer is an AgentCore Memory `MemoryStore` whose `add_messages` writes to `CreateEvent` and wants a deterministic `clientToken` for exact-once writes.

Implementation notes:
- `_filter_messages` now takes and returns `list[_Buffered]`, carrying each surviving message's `seq` through filtering so alignment with the filtered batch is structurally guaranteed (no parallel lists to keep in lockstep), mirroring the TS `_filterMessages`.
- `_write` derives `messages` from the buffered items and passes `AddMessagesContext(sequence_numbers=[...])` only on the no-extractor (`add_messages`) route; the extractor (`add`) route is unchanged.

## Related Issues

<!-- none -->

## Documentation PR

No documentation changes required; the `MemoryStore.add_messages` signature already accepts `context: AddMessagesContext | None = None`, and this only populates a previously-empty envelope.

## Type of Change

New feature

## Testing

Added six tests to `tests/strands/memory/test_extraction.py` (ported from the `addMessages context (per-message seqs)` block of the TS suite): sequence numbers aligned with the filtered batch; a gap left when an earlier message is filtered to empty; the same numbers re-firing on a retried batch; the seq anchored to the message rather than batch position; index-aligned numbers per store from the shared buffer; and the extractor route receiving no `add_messages` context.

Verified locally (worktree on `main`):
- `ruff check` + `ruff format --check` on changed files: clean
- `mypy ./src/strands/memory`: clean
- Full memory suite (`tests/strands/memory` + `tests/strands/vended_memory_stores`): 205 passed
- Full test suite (excluding modules that need uninstalled optional deps — models/a2a/cedar/otlp): 2929 passed

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
