### PR TITLE
fix(otel): record tool_trace on interrupted tool calls

### DIFF
--- a/strands-py/src/strands/telemetry/metrics.py
+++ b/strands-py/src/strands/telemetry/metrics.py
@@ -298,7 +298,7 @@ class EventLoopMetrics:
         duration: float,
         tool_trace: Trace,
         success: bool,
-        message: Message,
+        message: Message | None = None,
     ) -> None:
         """Record metrics for a tool invocation.
 
@@ -307,7 +307,8 @@ class EventLoopMetrics:
             duration: How long the tool call took in seconds.
             tool_trace: The trace object for this tool call.
             success: Whether the tool call was successful.
-            message: The message associated with the tool call.
+            message: The message associated with the tool call, if any. Pass ``None``
+                when the call ended without producing a tool result (e.g. on interrupt).
         """
         tool_name = tool.get("name", "unknown_tool")
         tool_use_id = tool.get("toolUseId", "unknown")
@@ -319,7 +320,8 @@ class EventLoopMetrics:
             }
         )
         tool_trace.raw_name = f"{tool_name} - {tool_use_id}"
-        tool_trace.add_message(message)
+        if message is not None:
+            tool_trace.add_message(message)
 
         self.tool_metrics.setdefault(tool_name, ToolMetrics(tool)).add_call(
             tool,

--- a/strands-py/src/strands/tools/executors/_executor.py
+++ b/strands-py/src/strands/tools/executors/_executor.py
@@ -331,6 +331,10 @@ class ToolExecutor(abc.ABC):
                 yield event
 
             if isinstance(event, ToolInterruptEvent):
+                tool_duration = time.time() - tool_start_time
+                if ToolExecutor._is_agent(agent):
+                    agent.event_loop_metrics.add_tool_usage(tool_use, tool_duration, tool_trace, False)
+                cycle_trace.add_child(tool_trace)
                 tracer.end_tool_call_span(tool_call_span, tool_result=None)
                 return
 

--- a/strands-py/tests/strands/tools/executors/test_executor.py
+++ b/strands-py/tests/strands/tools/executors/test_executor.py
@@ -224,6 +224,26 @@ async def test_executor_stream_with_trace(
     assert isinstance(cycle_trace.add_child.call_args[0][0], Trace)
 
 
+@pytest.mark.asyncio
+async def test_executor_stream_with_trace_records_metrics_on_interrupt(
+    executor, agent, tool_results, cycle_trace, cycle_span, invocation_state, alist
+):
+    """Interrupted tool calls are recorded in metrics and cycle_trace with no message attached (issue #1063)."""
+    tool_use: ToolUse = {"name": "interrupt_tool", "toolUseId": "test_tool_id", "input": {}}
+    stream = executor._stream_with_trace(agent, tool_use, tool_results, cycle_trace, cycle_span, invocation_state)
+
+    await alist(stream)
+
+    agent.event_loop_metrics.add_tool_usage.assert_called_once()
+    call_args = agent.event_loop_metrics.add_tool_usage.call_args
+    tool_arg, _duration, trace_arg, success_arg, *rest = call_args.args
+    assert tool_arg == tool_use
+    assert success_arg is False
+    assert rest == [] and "message" not in call_args.kwargs
+    assert isinstance(trace_arg, Trace)
+    cycle_trace.add_child.assert_called_once_with(trace_arg)
+
+
 @pytest.mark.parametrize(
     ("cancel_tool", "cancel_message"),
     [(True, "tool cancelled by user"), ("user cancel message", "user cancel message")],


### PR DESCRIPTION
A tool call that yielded a ToolInterruptEvent left _stream_with_trace before the tool's metrics or cycle_trace were recorded, so the interrupted tool was absent from agent.event_loop_metrics, cycle_trace, and any downstream OTel sink. The interrupt branch now records the usage with success=False and adds the tool_trace to cycle_trace before ending the span.

Fixes #1063.
