### PR TITLE
fix(openai): route gpt-5 mantle traffic through /openai/v1 base path

### DIFF
--- a/strands-py/src/strands/models/_openai_bedrock.py
+++ b/strands-py/src/strands/models/_openai_bedrock.py
@@ -20,8 +20,23 @@ from typing import Any, TypedDict
 import boto3
 from botocore.credentials import CredentialProvider
 
-_MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
+_MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws{path}"
 _MANTLE_DOCS_URL = "https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html"
+
+
+# Mantle-routed model id prefixes served from /openai/v1 instead of /v1.
+_OPENAI_PATH_MODEL_PREFIXES: tuple[str, ...] = ("openai.gpt-5.",)
+
+
+def _resolve_mantle_base_path(model_id: str) -> str:
+    """Resolve the Mantle base path for ``model_id``.
+
+    Model ids matching :data:`_OPENAI_PATH_MODEL_PREFIXES` are served from
+    ``/openai/v1``; other Mantle-routed models (e.g. ``openai.gpt-oss-*``) use ``/v1``.
+    """
+    if model_id.startswith(_OPENAI_PATH_MODEL_PREFIXES):
+        return "/openai/v1"
+    return "/v1"
 
 
 class BedrockMantleConfig(TypedDict, total=False):
@@ -79,13 +94,16 @@ def _resolve_region(config: BedrockMantleConfig) -> str:
 
 
 def resolve_bedrock_client_args(
-    config: BedrockMantleConfig, client_args: dict[str, Any] | None = None
+    config: BedrockMantleConfig, client_args: dict[str, Any] | None = None, model_id: str = ""
 ) -> dict[str, Any]:
     """Resolve a ``BedrockMantleConfig`` (plus optional ``client_args``) into OpenAI client kwargs.
 
     Mints a fresh bearer token on every call. Callers are expected to validate that
     ``client_args`` does not contain ``base_url`` or ``api_key`` before calling this
     function (typically at ``__init__`` time for fail-fast behavior).
+
+    The ``model_id`` selects the Mantle base path: ``openai.gpt-5.*`` is served from
+    ``/openai/v1`` while other models use ``/v1``.
 
     Raises:
         ValueError: If no region can be resolved.
@@ -121,6 +139,6 @@ def resolve_bedrock_client_args(
         ) from e
 
     resolved: dict[str, Any] = dict(client_args or {})
-    resolved["base_url"] = _MANTLE_BASE_URL_TEMPLATE.format(region=region)
+    resolved["base_url"] = _MANTLE_BASE_URL_TEMPLATE.format(region=region, path=_resolve_mantle_base_path(model_id))
     resolved["api_key"] = token
     return resolved

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -133,7 +133,9 @@ class OpenAIModel(Model):
         Delegates to :func:`resolve_bedrock_client_args` when ``bedrock_mantle_config`` is set.
         """
         if self._bedrock_mantle_config is not None:
-            return resolve_bedrock_client_args(self._bedrock_mantle_config, self.client_args)
+            return resolve_bedrock_client_args(
+                self._bedrock_mantle_config, self.client_args, model_id=str(self.config.get("model_id", ""))
+            )
         return self.client_args
 
     @override

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -187,7 +187,9 @@ class OpenAIResponsesModel(Model):
         Delegates to :func:`resolve_bedrock_client_args` when ``bedrock_mantle_config`` is set.
         """
         if self._bedrock_mantle_config is not None:
-            return resolve_bedrock_client_args(self._bedrock_mantle_config, self.client_args)
+            return resolve_bedrock_client_args(
+                self._bedrock_mantle_config, self.client_args, model_id=str(self.config.get("model_id", ""))
+            )
         return self.client_args
 
     @property

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1922,6 +1922,15 @@ class TestOpenAIModelBedrockMantleConfig:
         # Optional kwargs aren't forwarded so provide_token's own defaults apply.
         mock_provide_token.assert_called_once_with(region="us-east-1")
 
+    def test_bedrock_mantle_config_uses_openai_path_for_gpt5(self, openai_client, mock_provide_token):
+        """gpt-5.* models are routed through the /openai/v1 Mantle path."""
+        _ = openai_client
+        _ = mock_provide_token
+        model = OpenAIModel(model_id="openai.gpt-5.4", bedrock_mantle_config={"region": "us-east-1"})
+
+        resolved = model._resolve_client_args()
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
+
     def test_bedrock_mantle_config_forwards_credentials_provider_and_expiry(self, openai_client, mock_provide_token):
         """Optional credentials_provider and expiry are forwarded to provide_token."""
         _ = openai_client

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1618,6 +1618,14 @@ class TestOpenAIResponsesModelBedrockMantleConfig:
         assert resolved["api_key"] == "bedrock-api-key-deadbeef&Version=1"
         mock_provide_token.assert_called_once_with(region="us-east-1")
 
+    def test_bedrock_mantle_config_uses_openai_path_for_gpt5(self, openai_client, mock_provide_token):
+        """gpt-5.* models are routed through the /openai/v1 Mantle path."""
+        _ = openai_client
+        _ = mock_provide_token
+        model = OpenAIResponsesModel(model_id="openai.gpt-5.4", bedrock_mantle_config={"region": "us-east-1"})
+        resolved = model._resolve_client_args()
+        assert resolved["base_url"] == "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
+
     def test_bedrock_mantle_config_forwards_credentials_provider_and_expiry(self, openai_client, mock_provide_token):
         _ = openai_client
         from datetime import timedelta


### PR DESCRIPTION
The Bedrock Mantle base URL was hard-coded to /v1, but openai.gpt-5.* models are served from /openai/v1 per their model cards and fail at request time with a misleading "does not support /v1/responses" error otherwise. The base path is now selected from the model id, so openai.gpt-5.* routes to /openai/v1 while openai.gpt-oss-* and anything else keep using /v1. The prefix list is a tuple so new families can be added by appending one entry.

Upstream #2922 takes the same shape but does not wire the callers in openai.py and openai_responses.py, ships without tests, and adds an unrequested base_url override field on BedrockMantleConfig. This change keeps the scope to the bug and covers both call sites.

Fixes #2629.
