### PR TITLE
fix(context-offloader): confine retrieved paths to the artifact directory

### DIFF
--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.node.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.node.ts
@@ -75,6 +75,24 @@ describe('FileStorage', () => {
     await expect(storage.retrieve('../../etc/passwd')).rejects.toThrow('Reference not found')
   })
 
+  it('confines retrieval to the artifact directory and rejects sibling prefixes', async () => {
+    const storage = new FileStorage(tmpDir)
+
+    // A sibling whose path shares the artifact directory prefix must not be retrievable.
+    const sibling = `${tmpDir}_secret.txt`
+    await fs.writeFile(sibling, 'top secret')
+    try {
+      await expect(storage.retrieve(sibling)).rejects.toThrow('Reference not found')
+    } finally {
+      await fs.rm(sibling, { force: true })
+    }
+
+    // A genuine file stored inside the artifact directory is still retrievable.
+    const ref = await storage.store('inside', new TextEncoder().encode('ok'), 'text/plain')
+    const result = await storage.retrieve(ref)
+    expect(new TextDecoder().decode(result.content)).toBe('ok')
+  })
+
   it('creates artifact directory if it does not exist', async () => {
     const nestedDir = path.join(tmpDir, 'nested', 'dir')
     const storage = new FileStorage(nestedDir)

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -324,7 +324,7 @@ export class FileStorage implements Storage {
 
     const filePath = path.resolve(this._artifactDir, reference)
     const resolvedDir = path.resolve(this._artifactDir)
-    if (!filePath.startsWith(resolvedDir)) {
+    if (filePath !== resolvedDir && !filePath.startsWith(resolvedDir + path.sep)) {
       throw new Error(`Reference not found: ${reference}`)
     }
 


### PR DESCRIPTION
## Description

`FileStorage.retrieve` in the context-offloader plugin confirms that a resolved reference stays within the configured artifact directory before reading it. The previous check compared the resolved path against the resolved directory with a bare `startsWith`, which also accepted sibling paths that happen to share the directory name as a prefix (for example a `contexts_secret.txt` file next to a `contexts/` directory).

This change adds a trailing path-separator boundary plus an exact-match allowance so retrieval is limited to the artifact directory and the files inside it.

This mirrors the path-confinement approach already applied to session storage in #2993.

## Changes

- `storage.ts`: tighten the `FileStorage.retrieve` containment check to require the resolved path equal the artifact directory or sit beneath it (separator boundary).
- `storage.test.node.ts`: add a regression test that a sibling path sharing the directory prefix is rejected while a genuine file inside the directory remains retrievable.

## Testing

- `npm run test` (unit-node) for context-offloader: 113 passed
- `npm run lint` on changed files: clean
- `npm run type-check`: clean
- `npm run build`: clean
- Confirmed the new test fails against the prior check and passes with this change.