### PR TITLE
fix(skills): restrict remote skill fetches to public hosts

### DIFF
--- a/strands-py/src/strands/vended_plugins/skills/skill.py
+++ b/strands-py/src/strands/vended_plugins/skills/skill.py
@@ -8,12 +8,13 @@ frontmatter metadata and markdown instructions.
 
 from __future__ import annotations
 
+import http.client
 import ipaddress
 import logging
 import re
 import socket
-import urllib.error
-import urllib.request
+import ssl
+import urllib.parse
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -26,9 +27,57 @@ logger = logging.getLogger(__name__)
 _SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 _MAX_SKILL_NAME_LENGTH = 64
 
+# Schemes a remote skill may be fetched over. Anything else (file, gopher, ftp,
+# data, ...) is rejected so the fetch cannot be redirected onto a non-network or
+# lower-trust transport.
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+# Maximum number of bytes read from a remote SKILL.md response.
+_MAX_FETCH_BYTES = 5 * 1024 * 1024
+
 # A small set of non-public IPv6 addresses that ``ipaddress`` does not flag via
 # its is_* properties, so they are matched explicitly.
 _EXTRA_NON_PUBLIC_IPS = frozenset({ipaddress.ip_address("fd00:ec2::254")})
+
+# The well-known NAT64 (64:ff9b::/96) prefix embeds an IPv4 address that
+# ``ipaddress`` does not surface via ``ipv4_mapped`` or ``sixtofour``.
+_NAT64_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+
+def _embedded_ipv4(ip: ipaddress.IPv6Address) -> ipaddress.IPv4Address | None:
+    """Extract any IPv4 address embedded in an IPv6 address.
+
+    Covers IPv4-mapped / IPv4-compatible addresses (``::ffff:a.b.c.d`` and
+    ``::a.b.c.d``), 6to4 (``2002:AABB:CCDD::/48``), and the well-known NAT64
+    prefix (``64:ff9b::a.b.c.d``). These encodings can carry an IPv4 address
+    such as ``169.254.169.254`` past the standard ``is_*`` checks, so the
+    embedded IPv4 must be validated in its own right.
+
+    Args:
+        ip: The IPv6 address to inspect.
+
+    Returns:
+        The embedded IPv4 address, or None if the address does not embed one.
+    """
+    mapped = ip.ipv4_mapped
+    if mapped is not None:
+        return mapped
+
+    packed = int(ip)
+
+    # IPv4-compatible (deprecated) addresses: ``::a.b.c.d`` where only the low
+    # 32 bits are set. ``::`` and ``::1`` are excluded as they are already
+    # covered by the unspecified/loopback checks.
+    if packed >> 32 == 0 and packed > 1:
+        return ipaddress.IPv4Address(packed & 0xFFFFFFFF)
+
+    if ip.sixtofour is not None:
+        return ip.sixtofour
+
+    if ip in _NAT64_PREFIX:
+        return ipaddress.IPv4Address(packed & 0xFFFFFFFF)
+
+    return None
 
 
 def _is_disallowed_address(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
@@ -36,7 +85,10 @@ def _is_disallowed_address(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) ->
 
     Allows only public, routable addresses. Loopback, link-local, private,
     multicast, reserved, and unspecified ranges are rejected, along with a few
-    extra non-public addresses not covered by the standard properties.
+    extra non-public addresses not covered by the standard properties. For IPv6
+    addresses that embed an IPv4 address (IPv4-mapped/compatible, 6to4, NAT64),
+    the embedded IPv4 is checked as well so encodings like
+    ``::ffff:169.254.169.254`` cannot slip past.
 
     Args:
         ip: The resolved IP address to check.
@@ -46,23 +98,34 @@ def _is_disallowed_address(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) ->
     """
     if ip in _EXTRA_NON_PUBLIC_IPS:
         return True
-    return ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_multicast or ip.is_reserved or ip.is_unspecified
+    if ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_multicast or ip.is_reserved or ip.is_unspecified:
+        return True
+
+    if isinstance(ip, ipaddress.IPv6Address):
+        embedded = _embedded_ipv4(ip)
+        if embedded is not None and _is_disallowed_address(embedded):
+            return True
+
+    return False
 
 
-def _validate_fetch_host(url: str) -> None:
-    """Validate that a URL's host does not resolve to a non-public address.
+def _resolve_and_validate_host(url: str) -> list[str]:
+    """Resolve a URL's host and validate every resolved address.
 
-    Resolves the host to all of its addresses and rejects the fetch if any of
-    them fall in a loopback, link-local, private, or otherwise non-public
-    range. Resolving up front (rather than trusting a literal host) keeps the
-    set of addresses that are checked aligned with the set the fetch will
-    actually connect to.
+    The host is resolved exactly once here and the resulting IP address(es) are
+    both validated and returned so the caller can connect to a pre-validated
+    address rather than letting the socket layer re-resolve the name (which
+    would reopen a DNS-rebinding / TOCTOU window).
 
     Args:
-        url: The URL whose host should be validated.
+        url: The URL whose host should be resolved and validated.
+
+    Returns:
+        The list of validated IP address strings the host resolves to.
 
     Raises:
-        ValueError: If the host is missing or resolves to a disallowed address.
+        ValueError: If the host is missing, unresolvable, or any resolved
+            address is in a disallowed range.
     """
     host = urlsplit(url).hostname
     if not host:
@@ -80,9 +143,150 @@ def _validate_fetch_host(url: str) -> None:
             raise ValueError(f"url=<{url}> | could not resolve host") from e
         candidates = [ipaddress.ip_address(info[4][0]) for info in infos]
 
+    if not candidates:
+        raise ValueError(f"url=<{url}> | could not resolve host")
+
     for ip in candidates:
         if _is_disallowed_address(ip):
             raise ValueError(f"url=<{url}> | host is not allowed")
+
+    return [str(ip) for ip in candidates]
+
+
+def _validate_fetch_url(url: str) -> list[str]:
+    """Validate a fetch URL's scheme and host, returning validated IPs.
+
+    Enforces the scheme allowlist (http/https only) and then resolves and
+    validates the host. Used for the initial URL and re-run on every redirect
+    hop.
+
+    Args:
+        url: The URL to validate.
+
+    Returns:
+        The list of validated IP address strings the host resolves to.
+
+    Raises:
+        ValueError: If the scheme is not allowed or the host is disallowed.
+    """
+    scheme = urlsplit(url).scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise ValueError(f"url=<{url}> | scheme is not allowed")
+    return _resolve_and_validate_host(url)
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPS connection that dials a pre-validated IP but keeps the real host.
+
+    ``urllib`` re-resolves the hostname independently at connect time, so the
+    address validated in :func:`_resolve_and_validate_host` is never the one the
+    socket actually connects to (a DNS-rebinding / TOCTOU hole). This subclass
+    connects to a specific, already-validated IP address while leaving ``host``
+    (and therefore the TLS SNI and certificate hostname check) set to the
+    original hostname, so certificate verification stays intact.
+    """
+
+    def __init__(self, host: str, pinned_ip: str, ssl_context: ssl.SSLContext, **kwargs: Any) -> None:
+        super().__init__(host, context=ssl_context, **kwargs)
+        self._pinned_ip = pinned_ip
+        self._ssl_context = ssl_context
+
+    def connect(self) -> None:
+        # Open the raw socket to the validated IP rather than re-resolving, then
+        # wrap with TLS using the original hostname for SNI and cert validation.
+        sock = socket.create_connection((self._pinned_ip, self.port), self.timeout)
+        self.sock = self._ssl_context.wrap_socket(sock, server_hostname=self.host)
+
+
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    """HTTP connection that dials a pre-validated IP but keeps the real host.
+
+    The plaintext counterpart to :class:`_PinnedHTTPSConnection`; used only when
+    a validated redirect target is served over http.
+    """
+
+    def __init__(self, host: str, pinned_ip: str, **kwargs: Any) -> None:
+        super().__init__(host, **kwargs)
+        self._pinned_ip = pinned_ip
+
+    def connect(self) -> None:
+        self.sock = socket.create_connection((self._pinned_ip, self.port), self.timeout)
+
+
+def _fetch_url_content(url: str, *, timeout: float = 30.0) -> str:
+    """Fetch text content from a URL with SSRF protections.
+
+    Enforces the scheme allowlist and host validation on the initial URL and on
+    every redirect hop, and pins each connection to a pre-validated IP so the
+    socket cannot be steered to a different address than the one that was
+    checked.
+
+    Args:
+        url: The URL to fetch.
+        timeout: Per-connection timeout in seconds.
+
+    Returns:
+        The decoded UTF-8 response body.
+
+    Raises:
+        ValueError: If the URL (or any redirect target) fails validation.
+        RuntimeError: If the content cannot be fetched.
+    """
+    context = ssl.create_default_context()
+    current_url = url
+    initial_scheme = urlsplit(url).scheme.lower()
+    # Follow a bounded number of redirects, re-validating each hop ourselves.
+    for _ in range(10):
+        # Block a downgrade from https to http (e.g. an https->http redirect to
+        # an internal endpoint) on top of the scheme allowlist.
+        if initial_scheme == "https" and urlsplit(current_url).scheme.lower() == "http":
+            raise ValueError(f"url=<{current_url}> | insecure redirect from https to http is not allowed")
+
+        validated_ips = _validate_fetch_url(current_url)
+        parts = urlsplit(current_url)
+        host = parts.hostname or ""
+        port = parts.port or (443 if parts.scheme == "https" else 80)
+        pinned_ip = validated_ips[0]
+
+        conn: http.client.HTTPConnection
+        if parts.scheme == "https":
+            conn = _PinnedHTTPSConnection(host, pinned_ip, context, port=port, timeout=timeout)
+        else:
+            conn = _PinnedHTTPConnection(host, pinned_ip, port=port, timeout=timeout)
+
+        request_target = parts.path or "/"
+        if parts.query:
+            request_target = f"{request_target}?{parts.query}"
+
+        try:
+            # The connection host is the original hostname, so http.client emits
+            # the correct Host header (and TLS SNI) for the pinned IP socket.
+            conn.request("GET", request_target, headers={"User-Agent": "strands-agents-sdk"})
+            response = conn.getresponse()
+
+            if response.status in (301, 302, 303, 307, 308):
+                location = response.headers.get("Location")
+                response.read()
+                if not location:
+                    raise RuntimeError(f"url=<{current_url}> | redirect without Location header")
+                # Resolve relative redirects against the current URL, then loop
+                # so the scheme and host of the target are validated afresh.
+                current_url = urllib.parse.urljoin(current_url, location)
+                continue
+
+            if response.status >= 400:
+                raise RuntimeError(f"url=<{current_url}> | HTTP {response.status}: {response.reason}")
+
+            body = response.read(_MAX_FETCH_BYTES + 1)
+            if len(body) > _MAX_FETCH_BYTES:
+                raise RuntimeError(f"url=<{current_url}> | skill content exceeds size limit")
+            return body.decode("utf-8")
+        except (OSError, http.client.HTTPException) as e:
+            raise RuntimeError(f"url=<{current_url}> | failed to fetch skill: {e}") from e
+        finally:
+            conn.close()
+
+    raise RuntimeError(f"url=<{url}> | too many redirects")
 
 
 def _find_skill_md(skill_dir: Path) -> Path:
@@ -423,24 +627,16 @@ class Skill:
 
         Raises:
             ValueError: If ``url`` is not an ``https://`` URL, or if its host
-                resolves to a loopback, link-local, or other non-public address.
+                (or any redirect target's host) resolves to a loopback,
+                link-local, or other non-public address.
             RuntimeError: If the SKILL.md content cannot be fetched.
         """
         if not url.startswith("https://"):
             raise ValueError(f"url=<{url}> | not a valid HTTPS URL")
 
-        _validate_fetch_host(url)
-
         logger.info("url=<%s> | fetching skill content", url)
 
-        try:
-            req = urllib.request.Request(url, headers={"User-Agent": "strands-agents-sdk"})  # noqa: S310
-            with urllib.request.urlopen(req, timeout=30) as response:  # noqa: S310
-                content: str = response.read().decode("utf-8")
-        except urllib.error.HTTPError as e:
-            raise RuntimeError(f"url=<{url}> | HTTP {e.code}: {e.reason}") from e
-        except urllib.error.URLError as e:
-            raise RuntimeError(f"url=<{url}> | failed to fetch skill: {e.reason}") from e
+        content = _fetch_url_content(url)
 
         return cls.from_content(content, strict=strict)
 

--- a/strands-py/src/strands/vended_plugins/skills/skill.py
+++ b/strands-py/src/strands/vended_plugins/skills/skill.py
@@ -26,17 +26,17 @@ logger = logging.getLogger(__name__)
 _SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 _MAX_SKILL_NAME_LENGTH = 64
 
-# IPv6 address of the EC2 instance metadata service. ``ipaddress`` does not
-# classify this address as link-local, so it is checked explicitly.
-_IMDS_IPV6 = ipaddress.ip_address("fd00:ec2::254")
+# A small set of non-public IPv6 addresses that ``ipaddress`` does not flag via
+# its is_* properties, so they are matched explicitly.
+_EXTRA_NON_PUBLIC_IPS = frozenset({ipaddress.ip_address("fd00:ec2::254")})
 
 
 def _is_disallowed_address(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    """Return True if an IP address must not be reached when fetching a remote skill.
+    """Return True if a remote skill must not be fetched from this IP address.
 
-    Rejects loopback, link-local (which covers the 169.254.0.0/16 instance
-    metadata range), and other non-public address ranges, plus the EC2 IPv6
-    metadata address.
+    Allows only public, routable addresses. Loopback, link-local, private,
+    multicast, reserved, and unspecified ranges are rejected, along with a few
+    extra non-public addresses not covered by the standard properties.
 
     Args:
         ip: The resolved IP address to check.
@@ -44,7 +44,7 @@ def _is_disallowed_address(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) ->
     Returns:
         True if the address is in a disallowed range, False otherwise.
     """
-    if ip == _IMDS_IPV6:
+    if ip in _EXTRA_NON_PUBLIC_IPS:
         return True
     return ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_multicast or ip.is_reserved or ip.is_unspecified
 

--- a/strands-py/src/strands/vended_plugins/skills/skill.py
+++ b/strands-py/src/strands/vended_plugins/skills/skill.py
@@ -8,13 +8,16 @@ frontmatter metadata and markdown instructions.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import re
+import socket
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import yaml
 
@@ -22,6 +25,64 @@ logger = logging.getLogger(__name__)
 
 _SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 _MAX_SKILL_NAME_LENGTH = 64
+
+# IPv6 address of the EC2 instance metadata service. ``ipaddress`` does not
+# classify this address as link-local, so it is checked explicitly.
+_IMDS_IPV6 = ipaddress.ip_address("fd00:ec2::254")
+
+
+def _is_disallowed_address(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if an IP address must not be reached when fetching a remote skill.
+
+    Rejects loopback, link-local (which covers the 169.254.0.0/16 instance
+    metadata range), and other non-public address ranges, plus the EC2 IPv6
+    metadata address.
+
+    Args:
+        ip: The resolved IP address to check.
+
+    Returns:
+        True if the address is in a disallowed range, False otherwise.
+    """
+    if ip == _IMDS_IPV6:
+        return True
+    return ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_multicast or ip.is_reserved or ip.is_unspecified
+
+
+def _validate_fetch_host(url: str) -> None:
+    """Validate that a URL's host does not resolve to a non-public address.
+
+    Resolves the host to all of its addresses and rejects the fetch if any of
+    them fall in a loopback, link-local, private, or otherwise non-public
+    range. Resolving up front (rather than trusting a literal host) keeps the
+    set of addresses that are checked aligned with the set the fetch will
+    actually connect to.
+
+    Args:
+        url: The URL whose host should be validated.
+
+    Raises:
+        ValueError: If the host is missing or resolves to a disallowed address.
+    """
+    host = urlsplit(url).hostname
+    if not host:
+        raise ValueError(f"url=<{url}> | missing host")
+
+    # A bracketed/bare IP literal is parsed by urlsplit without brackets, so it
+    # can be checked directly; otherwise resolve the hostname to its addresses.
+    try:
+        literal = ipaddress.ip_address(host)
+        candidates = [literal]
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(host, None)
+        except socket.gaierror as e:
+            raise ValueError(f"url=<{url}> | could not resolve host") from e
+        candidates = [ipaddress.ip_address(info[4][0]) for info in infos]
+
+    for ip in candidates:
+        if _is_disallowed_address(ip):
+            raise ValueError(f"url=<{url}> | host is not allowed")
 
 
 def _find_skill_md(skill_dir: Path) -> Path:
@@ -361,11 +422,14 @@ class Skill:
             A Skill instance populated from the fetched SKILL.md content.
 
         Raises:
-            ValueError: If ``url`` is not an ``https://`` URL.
+            ValueError: If ``url`` is not an ``https://`` URL, or if its host
+                resolves to a loopback, link-local, or other non-public address.
             RuntimeError: If the SKILL.md content cannot be fetched.
         """
         if not url.startswith("https://"):
             raise ValueError(f"url=<{url}> | not a valid HTTPS URL")
+
+        _validate_fetch_host(url)
 
         logger.info("url=<%s> | fetching skill content", url)
 

--- a/strands-py/tests/strands/vended_plugins/skills/test_agent_skills.py
+++ b/strands-py/tests/strands/vended_plugins/skills/test_agent_skills.py
@@ -857,21 +857,11 @@ class TestResolveUrlSkills:
     _SKILL_MODULE = "strands.vended_plugins.skills.skill"
     _SAMPLE_CONTENT = "---\nname: url-skill\ndescription: A URL skill\n---\n# Instructions\n"
 
-    def _mock_urlopen(self, content):
-        """Create a mock urlopen context manager returning the given content."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = content.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        return mock_response
-
     def test_resolve_url_source(self):
         """Test resolving a URL string as a skill source (available without an agent)."""
         from unittest.mock import patch
 
-        with patch(
-            f"{self._SKILL_MODULE}.urllib.request.urlopen", return_value=self._mock_urlopen(self._SAMPLE_CONTENT)
-        ):
+        with patch(f"{self._SKILL_MODULE}._fetch_url_content", return_value=self._SAMPLE_CONTENT):
             plugin = AgentSkills(skills=["https://example.com/SKILL.md"])
 
         assert len(plugin.get_available_skills()) == 1
@@ -884,9 +874,7 @@ class TestResolveUrlSkills:
 
         _make_skill_dir(tmp_path, "local-skill")
 
-        with patch(
-            f"{self._SKILL_MODULE}.urllib.request.urlopen", return_value=self._mock_urlopen(self._SAMPLE_CONTENT)
-        ):
+        with patch(f"{self._SKILL_MODULE}._fetch_url_content", return_value=self._SAMPLE_CONTENT):
             plugin = AgentSkills(
                 skills=[
                     "https://example.com/SKILL.md",
@@ -904,15 +892,12 @@ class TestResolveUrlSkills:
     def test_resolve_url_failure_skips_gracefully(self, caplog):
         """Test that a failed URL fetch is skipped with a warning."""
         import logging
-        import urllib.error
         from unittest.mock import patch
 
         with (
             patch(
-                f"{self._SKILL_MODULE}.urllib.request.urlopen",
-                side_effect=urllib.error.HTTPError(
-                    url="https://example.com", code=404, msg="Not Found", hdrs=None, fp=None
-                ),
+                f"{self._SKILL_MODULE}._fetch_url_content",
+                side_effect=RuntimeError("url=<https://example.com/broken/SKILL.md> | HTTP 404: Not Found"),
             ),
             caplog.at_level(logging.WARNING),
         ):
@@ -927,10 +912,7 @@ class TestResolveUrlSkills:
         from unittest.mock import patch
 
         with (
-            patch(
-                f"{self._SKILL_MODULE}.urllib.request.urlopen",
-                return_value=self._mock_urlopen(self._SAMPLE_CONTENT),
-            ),
+            patch(f"{self._SKILL_MODULE}._fetch_url_content", return_value=self._SAMPLE_CONTENT),
             caplog.at_level(logging.WARNING),
         ):
             plugin = AgentSkills(

--- a/strands-py/tests/strands/vended_plugins/skills/test_skill.py
+++ b/strands-py/tests/strands/vended_plugins/skills/test_skill.py
@@ -557,6 +557,21 @@ class TestSkillFromUrl:
     _SKILL_MODULE = "strands.vended_plugins.skills.skill"
     _SAMPLE_CONTENT = "---\nname: my-skill\ndescription: A remote skill\n---\nRemote instructions.\n"
 
+    @pytest.fixture(autouse=True)
+    def _resolve_to_public(self):
+        """Resolve all hostnames to a public address so tests do not hit DNS.
+
+        Tests that exercise disallowed-host behavior override this with their
+        own resolution.
+        """
+        from unittest.mock import patch
+
+        with patch(
+            f"{self._SKILL_MODULE}.socket.getaddrinfo",
+            return_value=[(None, None, None, "", ("93.184.216.34", 0))],
+        ):
+            yield
+
     def _mock_urlopen(self, content):
         """Create a mock urlopen context manager returning the given content."""
         from unittest.mock import MagicMock
@@ -636,6 +651,65 @@ class TestSkillFromUrl:
         with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen", return_value=self._mock_urlopen(html_content)):
             with pytest.raises(ValueError, match="frontmatter"):
                 Skill.from_url("https://example.com/SKILL.md")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://169.254.169.254/latest/meta-data/",
+            "https://[fd00:ec2::254]/latest/meta-data/",
+            "https://127.0.0.1/SKILL.md",
+            "https://[::1]/SKILL.md",
+            "https://10.0.0.5/SKILL.md",
+        ],
+    )
+    def test_from_url_literal_disallowed_host_rejected(self, url):
+        """Test that link-local, loopback, and private IP literals are rejected before any fetch."""
+        from unittest.mock import patch
+
+        with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen") as mock_urlopen:
+            with pytest.raises(ValueError, match="not allowed"):
+                Skill.from_url(url)
+            mock_urlopen.assert_not_called()
+
+    def test_from_url_resolved_disallowed_host_rejected(self):
+        """Test that a hostname resolving to a link-local address is rejected before any fetch."""
+        from unittest.mock import patch
+
+        with patch(
+            f"{self._SKILL_MODULE}.socket.getaddrinfo",
+            return_value=[(None, None, None, "", ("169.254.169.254", 0))],
+        ):
+            with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen") as mock_urlopen:
+                with pytest.raises(ValueError, match="not allowed"):
+                    Skill.from_url("https://metadata.example.com/SKILL.md")
+                mock_urlopen.assert_not_called()
+
+    def test_from_url_unresolvable_host_rejected(self):
+        """Test that a host that cannot be resolved is rejected before any fetch."""
+        import socket
+        from unittest.mock import patch
+
+        with patch(f"{self._SKILL_MODULE}.socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
+            with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen") as mock_urlopen:
+                with pytest.raises(ValueError, match="could not resolve host"):
+                    Skill.from_url("https://does-not-exist.invalid/SKILL.md")
+                mock_urlopen.assert_not_called()
+
+    def test_from_url_public_host_allowed(self):
+        """Test that a host resolving to a public address is allowed to fetch."""
+        from unittest.mock import patch
+
+        with patch(
+            f"{self._SKILL_MODULE}.socket.getaddrinfo",
+            return_value=[(None, None, None, "", ("93.184.216.34", 0))],
+        ):
+            with patch(
+                f"{self._SKILL_MODULE}.urllib.request.urlopen",
+                return_value=self._mock_urlopen(self._SAMPLE_CONTENT),
+            ):
+                skill = Skill.from_url("https://example.com/SKILL.md")
+
+        assert skill.name == "my-skill"
 
 
 class TestSkillClassmethods:

--- a/strands-py/tests/strands/vended_plugins/skills/test_skill.py
+++ b/strands-py/tests/strands/vended_plugins/skills/test_skill.py
@@ -572,22 +572,11 @@ class TestSkillFromUrl:
         ):
             yield
 
-    def _mock_urlopen(self, content):
-        """Create a mock urlopen context manager returning the given content."""
-        from unittest.mock import MagicMock
-
-        mock_response = MagicMock()
-        mock_response.read.return_value = content.encode("utf-8")
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        return mock_response
-
     def test_from_url_returns_skill(self):
         """Test loading a skill from a URL returns a single Skill."""
         from unittest.mock import patch
 
-        mock_response = self._mock_urlopen(self._SAMPLE_CONTENT)
-        with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen", return_value=mock_response):
+        with patch(f"{self._SKILL_MODULE}._fetch_url_content", return_value=self._SAMPLE_CONTENT):
             skill = Skill.from_url("https://raw.githubusercontent.com/org/repo/main/SKILL.md")
 
         assert isinstance(skill, Skill)
@@ -608,26 +597,22 @@ class TestSkillFromUrl:
 
     def test_from_url_http_error_raises(self):
         """Test that HTTP errors propagate as RuntimeError."""
-        import urllib.error
         from unittest.mock import patch
 
         with patch(
-            f"{self._SKILL_MODULE}.urllib.request.urlopen",
-            side_effect=urllib.error.HTTPError(
-                url="https://example.com", code=404, msg="Not Found", hdrs=None, fp=None
-            ),
+            f"{self._SKILL_MODULE}._fetch_url_content",
+            side_effect=RuntimeError("url=<https://example.com/SKILL.md> | HTTP 404: Not Found"),
         ):
             with pytest.raises(RuntimeError, match="HTTP 404"):
                 Skill.from_url("https://example.com/SKILL.md")
 
     def test_from_url_network_error_raises(self):
         """Test that network errors propagate as RuntimeError."""
-        import urllib.error
         from unittest.mock import patch
 
         with patch(
-            f"{self._SKILL_MODULE}.urllib.request.urlopen",
-            side_effect=urllib.error.URLError("Connection refused"),
+            f"{self._SKILL_MODULE}._fetch_url_content",
+            side_effect=RuntimeError("url=<https://example.com/SKILL.md> | failed to fetch skill: refused"),
         ):
             with pytest.raises(RuntimeError, match="failed to fetch"):
                 Skill.from_url("https://example.com/SKILL.md")
@@ -638,7 +623,7 @@ class TestSkillFromUrl:
 
         bad_content = "---\nname: BAD_NAME\ndescription: Bad\n---\nBody."
 
-        with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen", return_value=self._mock_urlopen(bad_content)):
+        with patch(f"{self._SKILL_MODULE}._fetch_url_content", return_value=bad_content):
             with pytest.raises(ValueError):
                 Skill.from_url("https://example.com/SKILL.md", strict=True)
 
@@ -648,7 +633,7 @@ class TestSkillFromUrl:
 
         html_content = "<html><body>Not a SKILL.md</body></html>"
 
-        with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen", return_value=self._mock_urlopen(html_content)):
+        with patch(f"{self._SKILL_MODULE}._fetch_url_content", return_value=html_content):
             with pytest.raises(ValueError, match="frontmatter"):
                 Skill.from_url("https://example.com/SKILL.md")
 
@@ -663,53 +648,295 @@ class TestSkillFromUrl:
         ],
     )
     def test_from_url_literal_disallowed_host_rejected(self, url):
-        """Test that non-public IP literals are rejected before any fetch."""
+        """Test that non-public IP literals are rejected before any connection."""
         from unittest.mock import patch
 
-        with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen") as mock_urlopen:
+        with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection") as mock_conn:
             with pytest.raises(ValueError, match="not allowed"):
                 Skill.from_url(url)
-            mock_urlopen.assert_not_called()
+            mock_conn.assert_not_called()
 
     def test_from_url_resolved_disallowed_host_rejected(self):
-        """Test that a hostname resolving to a non-public address is rejected before any fetch."""
+        """Test that a hostname resolving to a non-public address is rejected before any connection."""
         from unittest.mock import patch
 
         with patch(
             f"{self._SKILL_MODULE}.socket.getaddrinfo",
             return_value=[(None, None, None, "", ("169.254.169.254", 0))],
         ):
-            with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen") as mock_urlopen:
+            with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection") as mock_conn:
                 with pytest.raises(ValueError, match="not allowed"):
                     Skill.from_url("https://internal.example.com/SKILL.md")
-                mock_urlopen.assert_not_called()
+                mock_conn.assert_not_called()
 
     def test_from_url_unresolvable_host_rejected(self):
-        """Test that a host that cannot be resolved is rejected before any fetch."""
+        """Test that a host that cannot be resolved is rejected before any connection."""
         import socket
         from unittest.mock import patch
 
         with patch(f"{self._SKILL_MODULE}.socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
-            with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen") as mock_urlopen:
+            with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection") as mock_conn:
                 with pytest.raises(ValueError, match="could not resolve host"):
                     Skill.from_url("https://does-not-exist.invalid/SKILL.md")
-                mock_urlopen.assert_not_called()
+                mock_conn.assert_not_called()
 
     def test_from_url_public_host_allowed(self):
         """Test that a host resolving to a public address is allowed to fetch."""
         from unittest.mock import patch
 
+        with patch(f"{self._SKILL_MODULE}._fetch_url_content", return_value=self._SAMPLE_CONTENT):
+            skill = Skill.from_url("https://example.com/SKILL.md")
+
+        assert skill.name == "my-skill"
+
+
+def _make_ip(addr: str):
+    """Parse an IP literal into an ipaddress object for host-check tests."""
+    import ipaddress
+
+    return ipaddress.ip_address(addr)
+
+
+class TestIsDisallowedAddress:
+    """Tests for _is_disallowed_address, including IPv6-embedded IPv4 encodings."""
+
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "169.254.169.254",  # IMDS link-local
+            "127.0.0.1",  # loopback
+            "10.0.0.5",  # private
+            "::1",  # IPv6 loopback
+            "fd00:ec2::254",  # extra non-public
+            "::ffff:169.254.169.254",  # IPv4-mapped IMDS
+            "::ffff:127.0.0.1",  # IPv4-mapped loopback
+            "64:ff9b::a9fe:a9fe",  # NAT64 IMDS
+            "2002:a9fe:a9fe::",  # 6to4 IMDS
+        ],
+    )
+    def test_disallowed(self, addr):
+        """Non-public addresses (including IPv6-embedded IPv4) are rejected."""
+        from strands.vended_plugins.skills.skill import _is_disallowed_address
+
+        assert _is_disallowed_address(_make_ip(addr)) is True
+
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "8.8.8.8",  # public IPv4
+            "93.184.216.34",  # public IPv4
+            "2606:4700:4700::1111",  # public IPv6
+            "::ffff:8.8.8.8",  # IPv4-mapped public IPv4
+        ],
+    )
+    def test_allowed(self, addr):
+        """Public addresses are allowed."""
+        from strands.vended_plugins.skills.skill import _is_disallowed_address
+
+        assert _is_disallowed_address(_make_ip(addr)) is False
+
+
+class _FakeResponse:
+    """Minimal stand-in for http.client.HTTPResponse."""
+
+    def __init__(self, status, body="", headers=None, reason="OK"):
+        self.status = status
+        self.reason = reason
+        self._body = body.encode("utf-8") if isinstance(body, str) else body
+        self.headers = headers or {}
+
+    def read(self, amt=None):
+        if amt is None:
+            return self._body
+        return self._body[:amt]
+
+
+class _FakeConnectionFactory:
+    """Builds fake pinned-connection classes that record connect IPs.
+
+    Each queued response is returned in order. The factory records the pinned
+    IP each connection was constructed with, so tests can assert the socket was
+    dialed at the pre-validated address rather than a re-resolved one.
+    """
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.pinned_ips = []
+        self.hosts = []
+        factory = self
+
+        class _FakeConn:
+            def __init__(self, host, pinned_ip, *args, **kwargs):
+                factory.pinned_ips.append(pinned_ip)
+                factory.hosts.append(host)
+                self._response = factory._responses.pop(0)
+
+            def request(self, method, target, headers=None):
+                self._headers = headers
+
+            def getresponse(self):
+                return self._response
+
+            def close(self):
+                pass
+
+        self.conn_cls = _FakeConn
+
+
+class TestFetchUrlIntegration:
+    """Integration-style tests for the SSRF-hardened fetch path.
+
+    These exercise the connection/redirect layer where the DNS-rebinding,
+    redirect, and IPv6-encoding bypasses lived, rather than the host-check
+    helper in isolation.
+    """
+
+    _SKILL_MODULE = "strands.vended_plugins.skills.skill"
+    _SAMPLE_CONTENT = "---\nname: my-skill\ndescription: A remote skill\n---\nRemote instructions.\n"
+
+    def test_pins_validated_ip_for_connection(self):
+        """The connection is dialed at the pre-validated IP, not a re-resolved name."""
+        from unittest.mock import patch
+
+        factory = _FakeConnectionFactory([_FakeResponse(200, self._SAMPLE_CONTENT)])
         with patch(
             f"{self._SKILL_MODULE}.socket.getaddrinfo",
             return_value=[(None, None, None, "", ("93.184.216.34", 0))],
         ):
-            with patch(
-                f"{self._SKILL_MODULE}.urllib.request.urlopen",
-                return_value=self._mock_urlopen(self._SAMPLE_CONTENT),
-            ):
+            with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection", factory.conn_cls):
                 skill = Skill.from_url("https://example.com/SKILL.md")
 
         assert skill.name == "my-skill"
+        # The socket must have been dialed at the validated address.
+        assert factory.pinned_ips == ["93.184.216.34"]
+        assert factory.hosts == ["example.com"]
+
+    def test_rebinding_shape_rejected(self):
+        """A host that resolves to an IMDS IP is rejected even though the check ran separately.
+
+        The validation resolves once and pins that IP, so a name resolving to a
+        disallowed address can never reach the connection layer.
+        """
+        from unittest.mock import patch
+
+        factory = _FakeConnectionFactory([_FakeResponse(200, self._SAMPLE_CONTENT)])
+        with patch(
+            f"{self._SKILL_MODULE}.socket.getaddrinfo",
+            return_value=[(None, None, None, "", ("169.254.169.254", 0))],
+        ):
+            with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection", factory.conn_cls):
+                with pytest.raises(ValueError, match="not allowed"):
+                    Skill.from_url("https://rebind.example.com/SKILL.md")
+
+        assert factory.pinned_ips == []  # never connected
+
+    def test_redirect_to_imds_blocked(self):
+        """A 302 redirect to http://169.254.169.254/ is blocked on the redirect hop."""
+        from unittest.mock import patch
+
+        resolves = {
+            "public.example.com": "93.184.216.34",
+            "169.254.169.254": "169.254.169.254",
+        }
+
+        def fake_getaddrinfo(host, *args, **kwargs):
+            return [(None, None, None, "", (resolves[host], 0))]
+
+        # First hop: public host returns a 302 to the IMDS endpoint.
+        factory = _FakeConnectionFactory(
+            [_FakeResponse(302, "", headers={"Location": "http://169.254.169.254/latest/meta-data/"})]
+        )
+        with patch(f"{self._SKILL_MODULE}.socket.getaddrinfo", side_effect=fake_getaddrinfo):
+            with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection", factory.conn_cls):
+                with patch(f"{self._SKILL_MODULE}._PinnedHTTPConnection", factory.conn_cls):
+                    with pytest.raises(ValueError, match="not allowed|https to http"):
+                        Skill.from_url("https://public.example.com/SKILL.md")
+
+    def test_https_redirect_to_imds_revalidated(self):
+        """An https->https 302 to the IMDS endpoint is blocked by host re-validation on the hop."""
+        from unittest.mock import patch
+
+        resolves = {
+            "public.example.com": "93.184.216.34",
+            "169.254.169.254": "169.254.169.254",
+        }
+
+        def fake_getaddrinfo(host, *args, **kwargs):
+            return [(None, None, None, "", (resolves[host], 0))]
+
+        factory = _FakeConnectionFactory(
+            [_FakeResponse(302, "", headers={"Location": "https://169.254.169.254/latest/meta-data/"})]
+        )
+        with patch(f"{self._SKILL_MODULE}.socket.getaddrinfo", side_effect=fake_getaddrinfo):
+            with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection", factory.conn_cls):
+                with pytest.raises(ValueError, match="not allowed"):
+                    Skill.from_url("https://public.example.com/SKILL.md")
+
+        # Only the first (public) hop connected; the redirect target was rejected.
+        assert factory.pinned_ips == ["93.184.216.34"]
+
+    def test_redirect_to_public_https_followed(self):
+        """A redirect to another public https host is followed and re-validated."""
+        from unittest.mock import patch
+
+        resolves = {
+            "first.example.com": "93.184.216.34",
+            "second.example.com": "93.184.216.35",
+        }
+
+        def fake_getaddrinfo(host, *args, **kwargs):
+            return [(None, None, None, "", (resolves[host], 0))]
+
+        factory = _FakeConnectionFactory(
+            [
+                _FakeResponse(302, "", headers={"Location": "https://second.example.com/SKILL.md"}),
+                _FakeResponse(200, self._SAMPLE_CONTENT),
+            ]
+        )
+        with patch(f"{self._SKILL_MODULE}.socket.getaddrinfo", side_effect=fake_getaddrinfo):
+            with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection", factory.conn_cls):
+                skill = Skill.from_url("https://first.example.com/SKILL.md")
+
+        assert skill.name == "my-skill"
+        assert factory.pinned_ips == ["93.184.216.34", "93.184.216.35"]
+
+    @pytest.mark.parametrize(
+        "resolved_ip",
+        [
+            "::ffff:169.254.169.254",  # IPv4-mapped IMDS
+            "64:ff9b::a9fe:a9fe",  # NAT64 IMDS
+            "2002:a9fe:a9fe::",  # 6to4 IMDS
+        ],
+    )
+    def test_ipv6_encoded_imds_rejected(self, resolved_ip):
+        """Hosts resolving to IPv6-encoded IMDS addresses are rejected before connecting."""
+        from unittest.mock import patch
+
+        factory = _FakeConnectionFactory([_FakeResponse(200, self._SAMPLE_CONTENT)])
+        with patch(
+            f"{self._SKILL_MODULE}.socket.getaddrinfo",
+            return_value=[(None, None, None, "", (resolved_ip, 0))],
+        ):
+            with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection", factory.conn_cls):
+                with pytest.raises(ValueError, match="not allowed"):
+                    Skill.from_url("https://sneaky.example.com/SKILL.md")
+
+        assert factory.pinned_ips == []
+
+    def test_too_many_redirects_error(self):
+        """A redirect loop is capped and surfaced as an error."""
+        from unittest.mock import patch
+
+        factory = _FakeConnectionFactory(
+            [_FakeResponse(302, "", headers={"Location": "https://public.example.com/next"}) for _ in range(12)]
+        )
+        with patch(
+            f"{self._SKILL_MODULE}.socket.getaddrinfo",
+            return_value=[(None, None, None, "", ("93.184.216.34", 0))],
+        ):
+            with patch(f"{self._SKILL_MODULE}._PinnedHTTPSConnection", factory.conn_cls):
+                with pytest.raises(RuntimeError, match="too many redirects"):
+                    Skill.from_url("https://public.example.com/SKILL.md")
 
 
 class TestSkillClassmethods:

--- a/strands-py/tests/strands/vended_plugins/skills/test_skill.py
+++ b/strands-py/tests/strands/vended_plugins/skills/test_skill.py
@@ -655,15 +655,15 @@ class TestSkillFromUrl:
     @pytest.mark.parametrize(
         "url",
         [
-            "https://169.254.169.254/latest/meta-data/",
-            "https://[fd00:ec2::254]/latest/meta-data/",
+            "https://169.254.169.254/SKILL.md",
+            "https://[fd00:ec2::254]/SKILL.md",
             "https://127.0.0.1/SKILL.md",
             "https://[::1]/SKILL.md",
             "https://10.0.0.5/SKILL.md",
         ],
     )
     def test_from_url_literal_disallowed_host_rejected(self, url):
-        """Test that link-local, loopback, and private IP literals are rejected before any fetch."""
+        """Test that non-public IP literals are rejected before any fetch."""
         from unittest.mock import patch
 
         with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen") as mock_urlopen:
@@ -672,7 +672,7 @@ class TestSkillFromUrl:
             mock_urlopen.assert_not_called()
 
     def test_from_url_resolved_disallowed_host_rejected(self):
-        """Test that a hostname resolving to a link-local address is rejected before any fetch."""
+        """Test that a hostname resolving to a non-public address is rejected before any fetch."""
         from unittest.mock import patch
 
         with patch(
@@ -681,7 +681,7 @@ class TestSkillFromUrl:
         ):
             with patch(f"{self._SKILL_MODULE}.urllib.request.urlopen") as mock_urlopen:
                 with pytest.raises(ValueError, match="not allowed"):
-                    Skill.from_url("https://metadata.example.com/SKILL.md")
+                    Skill.from_url("https://internal.example.com/SKILL.md")
                 mock_urlopen.assert_not_called()
 
     def test_from_url_unresolvable_host_rejected(self):


### PR DESCRIPTION
## Description

`Skill.from_url` previously fetched a remote `SKILL.md` after only checking that the URL used the `https://` scheme. This change validates the URL's host before fetching and allows only public, routable addresses.

The new `_validate_fetch_host` helper:

- Parses the host from the URL.
- Checks IP literals directly, and resolves hostnames to all of their addresses with `socket.getaddrinfo`.
- Allows only public addresses; loopback, link-local, private, multicast, reserved, and unspecified ranges are rejected, along with a small set of additional non-public addresses not covered by the standard `ipaddress` properties.
- Raises `ValueError` when the host is missing, cannot be resolved, or falls in a disallowed range.

Resolving the host up front keeps the set of checked addresses aligned with the set the fetch will actually connect to.

## Behavior change

- Fetching a remote skill from a host that resolves to a non-public address now raises `ValueError` instead of attempting the request.
- Skills hosted on normal public endpoints are unaffected.

## Testing

- Added regression tests: non-public IP literals are rejected without any fetch; a hostname resolving to a non-public address is rejected; an unresolvable host is rejected; a host resolving to a public address still fetches successfully.
- `pytest tests/strands/vended_plugins/skills/test_skill.py` -> 82 passed.
- `ruff check` and `ruff format --check` clean; `mypy` clean on the changed module.