### PR TITLE
fix(bidi): validate transcript message roles

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
+++ b/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
@@ -616,7 +616,7 @@ class BidiNovaSonicModel(BidiModel):
             return BidiTranscriptStreamEvent(
                 delta={"text": text_content},
                 text=text_content,
-                role=text_output["role"].lower(),
+                role=text_output["role"],
                 is_final=self._generation_stage == "FINAL",
                 current_transcript=text_content,
             )

--- a/strands-py/src/strands/experimental/bidi/models/openai_realtime.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai_realtime.py
@@ -229,18 +229,13 @@ class BidiOpenAIRealtimeModel(BidiModel):
 
         Args:
             text: The transcript text
-            role: The role (will be normalized to lowercase)
+            role: The raw provider role (normalized by the event constructor)
             is_final: Whether this is the final transcript
         """
-        # Normalize role to lowercase and ensure it's either "user" or "assistant"
-        normalized_role = role.lower() if isinstance(role, str) else "assistant"
-        if normalized_role not in ["user", "assistant"]:
-            normalized_role = "assistant"
-
         return BidiTranscriptStreamEvent(
             delta={"text": text},
             text=text,
-            role=cast(Role, normalized_role),
+            role=cast(Role, role),
             is_final=is_final,
             current_transcript=text if is_final else None,
         )
@@ -473,18 +468,14 @@ class BidiOpenAIRealtimeModel(BidiModel):
         # Assistant text output events - combine multiple similar events
         elif event_type in ["response.output_text.delta", "response.output_audio_transcript.delta"]:
             role = openai_event.get("role", "assistant")
-            return [
-                self._create_text_event(
-                    openai_event["delta"], role.lower() if isinstance(role, str) else "assistant", is_final=False
-                )
-            ]
+            return [self._create_text_event(openai_event["delta"], role, is_final=False)]
 
         elif event_type in ["response.output_audio_transcript.done"]:
-            role = openai_event.get("role", "assistant").lower()
+            role = openai_event.get("role", "assistant")
             return [self._create_text_event(openai_event["transcript"], role)]
 
         elif event_type in ["response.output_text.done"]:
-            role = openai_event.get("role", "assistant").lower()
+            role = openai_event.get("role", "assistant")
             return [self._create_text_event(openai_event["text"], role)]
 
         # User transcription events - combine multiple similar events
@@ -496,21 +487,13 @@ class BidiOpenAIRealtimeModel(BidiModel):
             text = openai_event.get(text_key, "")
             role = openai_event.get("role", "user")
             is_final = "completed" in event_type
-            return (
-                [self._create_text_event(text, role.lower() if isinstance(role, str) else "user", is_final=is_final)]
-                if text.strip()
-                else None
-            )
+            return [self._create_text_event(text, role, is_final=is_final)] if text.strip() else None
 
         elif event_type == "conversation.item.input_audio_transcription.segment":
             segment_data = openai_event.get("segment", {})
             text = segment_data.get("text", "")
             role = segment_data.get("role", "user")
-            return (
-                [self._create_text_event(text, role.lower() if isinstance(role, str) else "user")]
-                if text.strip()
-                else None
-            )
+            return [self._create_text_event(text, role)] if text.strip() else None
 
         elif event_type == "conversation.item.input_audio_transcription.failed":
             error_info = openai_event.get("error", {})

--- a/strands-py/src/strands/experimental/bidi/types/events.py
+++ b/strands-py/src/strands/experimental/bidi/types/events.py
@@ -47,6 +47,30 @@ Role = Literal["user", "assistant"]
 - "assistant": Messages from the assistant to the user.
 """
 
+_VALID_ROLES: tuple[str, ...] = ("user", "assistant")
+
+
+def normalize_role(role: Any, default: Role = "assistant") -> Role:
+    """Normalize a role value to a supported `Role`.
+
+    Provider outputs and transcript events may carry role values in arbitrary
+    casing or outside the supported set. This coerces the value to lowercase
+    and falls back to `default` when it is not one of the supported roles, so
+    that messages persisted to the conversation always carry a valid role.
+
+    Args:
+        role: The incoming role value (any type).
+        default: Role to use when the value is missing or unsupported.
+
+    Returns:
+        A role guaranteed to be one of the supported `Role` values.
+    """
+    normalized = role.lower() if isinstance(role, str) else default
+    if normalized not in _VALID_ROLES:
+        normalized = default
+    return cast(Role, normalized)
+
+
 StopReason = Literal["complete", "error", "interrupted", "tool_use"]
 """Reason for the model ending its response generation.
 
@@ -328,7 +352,7 @@ class BidiTranscriptStreamEvent(ModelStreamEvent):
                 "type": "bidi_transcript_stream",
                 "delta": delta,
                 "text": text,
-                "role": role,
+                "role": normalize_role(role),
                 "is_final": is_final,
                 "current_transcript": current_transcript,
             }

--- a/strands-py/src/strands/experimental/bidi/types/events.py
+++ b/strands-py/src/strands/experimental/bidi/types/events.py
@@ -50,13 +50,18 @@ Role = Literal["user", "assistant"]
 _VALID_ROLES: tuple[str, ...] = ("user", "assistant")
 
 
-def normalize_role(role: Any, default: Role = "assistant") -> Role:
+def normalize_role(role: Any, default: Role = "user") -> Role:
     """Normalize a role value to a supported `Role`.
 
     Provider outputs and transcript events may carry role values in arbitrary
-    casing or outside the supported set. This coerces the value to lowercase
-    and falls back to `default` when it is not one of the supported roles, so
-    that messages persisted to the conversation always carry a valid role.
+    casing or outside the supported set. This trims surrounding whitespace,
+    coerces the value to lowercase, and falls back to `default` when it is not
+    one of the supported roles, so that messages persisted to the conversation
+    always carry a valid role.
+
+    The default is the lowest-trust role (`"user"`): unknown or spoofed role
+    values are never attributed to the assistant. Legitimate assistant output
+    passes an explicit `role="assistant"`, which the allowlist accepts verbatim.
 
     Args:
         role: The incoming role value (any type).
@@ -65,7 +70,7 @@ def normalize_role(role: Any, default: Role = "assistant") -> Role:
     Returns:
         A role guaranteed to be one of the supported `Role` values.
     """
-    normalized = role.lower() if isinstance(role, str) else default
+    normalized = role.strip().lower() if isinstance(role, str) else default
     if normalized not in _VALID_ROLES:
         normalized = default
     return cast(Role, normalized)
@@ -352,7 +357,7 @@ class BidiTranscriptStreamEvent(ModelStreamEvent):
                 "type": "bidi_transcript_stream",
                 "delta": delta,
                 "text": text,
-                "role": normalize_role(role),
+                "role": normalize_role(role, default="user"),
                 "is_final": is_final,
                 "current_transcript": current_transcript,
             }

--- a/strands-py/src/strands/experimental/bidi/types/events.py
+++ b/strands-py/src/strands/experimental/bidi/types/events.py
@@ -21,13 +21,16 @@ Audio format normalization:
 - Audio data stored as base64-encoded strings for JSON compatibility
 """
 
-from typing import TYPE_CHECKING, Any, Literal, cast
+import logging
+from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 
 from ....types._events import ModelStreamEvent, ToolUseStreamEvent, TypedEvent
 from ....types.streaming import ContentBlockDelta
 
 if TYPE_CHECKING:
     from ..models.model import BidiModelTimeoutError
+
+logger = logging.getLogger(__name__)
 
 AudioChannel = Literal[1, 2]
 """Number of audio channels.
@@ -47,10 +50,10 @@ Role = Literal["user", "assistant"]
 - "assistant": Messages from the assistant to the user.
 """
 
-_VALID_ROLES: tuple[str, ...] = ("user", "assistant")
+_VALID_ROLES: tuple[str, ...] = get_args(Role)
 
 
-def normalize_role(role: Any, default: Role = "user") -> Role:
+def _normalize_role(role: Any, default: Role = "user") -> Role:
     """Normalize a role value to a supported `Role`.
 
     Provider outputs and transcript events may carry role values in arbitrary
@@ -70,9 +73,10 @@ def normalize_role(role: Any, default: Role = "user") -> Role:
     Returns:
         A role guaranteed to be one of the supported `Role` values.
     """
-    normalized = role.strip().lower() if isinstance(role, str) else default
+    normalized = role.strip().lower() if isinstance(role, str) else None
     if normalized not in _VALID_ROLES:
-        normalized = default
+        logger.debug("role=<%s>, default=<%s> | coercing unsupported transcript role", role, default)
+        return default
     return cast(Role, normalized)
 
 
@@ -357,7 +361,7 @@ class BidiTranscriptStreamEvent(ModelStreamEvent):
                 "type": "bidi_transcript_stream",
                 "delta": delta,
                 "text": text,
-                "role": normalize_role(role, default="user"),
+                "role": _normalize_role(role, default="user"),
                 "is_final": is_final,
                 "current_transcript": current_transcript,
             }

--- a/strands-py/tests/strands/experimental/bidi/models/test_openai_realtime.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_openai_realtime.py
@@ -692,6 +692,14 @@ def test_helper_methods(model):
     assert model._create_voice_activity_event("speech_stopped") is None
 
 
+@pytest.mark.parametrize("raw_role,expected", [("USER", "user"), ("Assistant", "assistant"), ("system", "user")])
+def test_create_text_event_normalizes_role(model, raw_role, expected):
+    """The raw provider role passes through; the event constructor is the single normalization point."""
+    text_event = model._create_text_event("Hello", raw_role)
+
+    assert text_event.role == expected
+
+
 @pytest.mark.asyncio
 async def test_send_event_helper(mock_websockets_connect, model):
     """Test _send_event helper method."""

--- a/strands-py/tests/strands/experimental/bidi/types/test_events.py
+++ b/strands-py/tests/strands/experimental/bidi/types/test_events.py
@@ -180,17 +180,31 @@ def test_normalize_role_accepts_supported_roles(raw_role, expected):
 
 @pytest.mark.parametrize(
     "raw_role",
-    ["system", "SYSTEM", "tool", "", "unknown", None, 123],
+    ["system", "admin", "SYSTEM", "tool", "", "unknown", None, 123],
 )
-def test_normalize_role_falls_back_for_unsupported_roles(raw_role):
-    """normalize_role coerces out-of-range values to the default role."""
-    assert normalize_role(raw_role) == "assistant"
-    assert normalize_role(raw_role, default="user") == "user"
+def test_normalize_role_falls_back_to_lowest_trust_role(raw_role):
+    """normalize_role coerces out-of-range values to the lowest-trust default ("user")."""
+    assert normalize_role(raw_role) == "user"
+    assert normalize_role(raw_role, default="assistant") == "assistant"
 
 
-@pytest.mark.parametrize("raw_role", ["system", "SYSTEM", "tool", "developer", "unknown"])
-def test_transcript_stream_event_rejects_out_of_range_role(raw_role):
-    """An out-of-range transcript role is normalized and never persisted verbatim."""
+@pytest.mark.parametrize(
+    "raw_role,expected",
+    [
+        (" user ", "user"),
+        (" User ", "user"),
+        ("\tassistant\n", "assistant"),
+        ("  USER", "user"),
+    ],
+)
+def test_normalize_role_strips_whitespace(raw_role, expected):
+    """normalize_role trims surrounding whitespace before the allowlist check."""
+    assert normalize_role(raw_role) == expected
+
+
+@pytest.mark.parametrize("raw_role", ["system", "admin", "SYSTEM", "tool", "developer", "unknown", ""])
+def test_transcript_stream_event_coerces_out_of_range_role_to_user(raw_role):
+    """An out-of-range transcript role is coerced to the lowest-trust role ("user")."""
     event = BidiTranscriptStreamEvent(
         delta={"text": "hi"},
         text="hi",
@@ -199,9 +213,23 @@ def test_transcript_stream_event_rejects_out_of_range_role(raw_role):
         current_transcript="hi",
     )
 
-    assert event.role in ("user", "assistant")
-    assert event["role"] in ("user", "assistant")
+    # Attacker-controlled content is never attributed to the assistant.
+    assert event.role == "user"
+    assert event["role"] == "user"
     assert event.role != raw_role.lower()
+
+
+def test_transcript_stream_event_strips_whitespace_role():
+    """A legitimately-spaced role is trimmed rather than mislabeled as the default."""
+    event = BidiTranscriptStreamEvent(
+        delta={"text": "hi"},
+        text="hi",
+        role=" user ",
+        is_final=True,
+        current_transcript="hi",
+    )
+
+    assert event.role == "user"
 
 
 def test_transcript_stream_event_normalizes_role_casing():

--- a/strands-py/tests/strands/experimental/bidi/types/test_events.py
+++ b/strands-py/tests/strands/experimental/bidi/types/test_events.py
@@ -21,7 +21,7 @@ from strands.experimental.bidi.types.events import (
     BidiTextInputEvent,
     BidiTranscriptStreamEvent,
     BidiUsageEvent,
-    normalize_role,
+    _normalize_role,
 )
 
 
@@ -175,7 +175,7 @@ def test_transcript_stream_event_extends_model_stream_event():
 )
 def test_normalize_role_accepts_supported_roles(raw_role, expected):
     """normalize_role lowercases and preserves supported roles."""
-    assert normalize_role(raw_role) == expected
+    assert _normalize_role(raw_role) == expected
 
 
 @pytest.mark.parametrize(
@@ -184,8 +184,8 @@ def test_normalize_role_accepts_supported_roles(raw_role, expected):
 )
 def test_normalize_role_falls_back_to_lowest_trust_role(raw_role):
     """normalize_role coerces out-of-range values to the lowest-trust default ("user")."""
-    assert normalize_role(raw_role) == "user"
-    assert normalize_role(raw_role, default="assistant") == "assistant"
+    assert _normalize_role(raw_role) == "user"
+    assert _normalize_role(raw_role, default="assistant") == "assistant"
 
 
 @pytest.mark.parametrize(
@@ -199,7 +199,7 @@ def test_normalize_role_falls_back_to_lowest_trust_role(raw_role):
 )
 def test_normalize_role_strips_whitespace(raw_role, expected):
     """normalize_role trims surrounding whitespace before the allowlist check."""
-    assert normalize_role(raw_role) == expected
+    assert _normalize_role(raw_role) == expected
 
 
 @pytest.mark.parametrize("raw_role", ["system", "admin", "SYSTEM", "tool", "developer", "unknown", ""])
@@ -216,7 +216,6 @@ def test_transcript_stream_event_coerces_out_of_range_role_to_user(raw_role):
     # Attacker-controlled content is never attributed to the assistant.
     assert event.role == "user"
     assert event["role"] == "user"
-    assert event.role != raw_role.lower()
 
 
 def test_transcript_stream_event_strips_whitespace_role():

--- a/strands-py/tests/strands/experimental/bidi/types/test_events.py
+++ b/strands-py/tests/strands/experimental/bidi/types/test_events.py
@@ -21,6 +21,7 @@ from strands.experimental.bidi.types.events import (
     BidiTextInputEvent,
     BidiTranscriptStreamEvent,
     BidiUsageEvent,
+    normalize_role,
 )
 
 
@@ -161,3 +162,56 @@ def test_transcript_stream_event_extends_model_stream_event():
     )
 
     assert isinstance(event, ModelStreamEvent)
+
+
+@pytest.mark.parametrize(
+    "raw_role,expected",
+    [
+        ("user", "user"),
+        ("assistant", "assistant"),
+        ("USER", "user"),
+        ("Assistant", "assistant"),
+    ],
+)
+def test_normalize_role_accepts_supported_roles(raw_role, expected):
+    """normalize_role lowercases and preserves supported roles."""
+    assert normalize_role(raw_role) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_role",
+    ["system", "SYSTEM", "tool", "", "unknown", None, 123],
+)
+def test_normalize_role_falls_back_for_unsupported_roles(raw_role):
+    """normalize_role coerces out-of-range values to the default role."""
+    assert normalize_role(raw_role) == "assistant"
+    assert normalize_role(raw_role, default="user") == "user"
+
+
+@pytest.mark.parametrize("raw_role", ["system", "SYSTEM", "tool", "developer", "unknown"])
+def test_transcript_stream_event_rejects_out_of_range_role(raw_role):
+    """An out-of-range transcript role is normalized and never persisted verbatim."""
+    event = BidiTranscriptStreamEvent(
+        delta={"text": "hi"},
+        text="hi",
+        role=raw_role,
+        is_final=True,
+        current_transcript="hi",
+    )
+
+    assert event.role in ("user", "assistant")
+    assert event["role"] in ("user", "assistant")
+    assert event.role != raw_role.lower()
+
+
+def test_transcript_stream_event_normalizes_role_casing():
+    """A supported role in mixed casing is normalized to lowercase."""
+    event = BidiTranscriptStreamEvent(
+        delta={"text": "hi"},
+        text="hi",
+        role="USER",
+        is_final=True,
+        current_transcript="hi",
+    )
+
+    assert event.role == "user"


### PR DESCRIPTION
## What

Normalize the message role carried by `BidiTranscriptStreamEvent` so that transcript events appended to the conversation always use a supported role.

The role field is declared as `Literal["user", "assistant"]`, but that type hint is not enforced at runtime. Provider integrations translate their own transcript payloads into this event, and some passed the raw role through while one coerced unknown values to `assistant` locally. A role outside the supported set, or in mixed casing, could be stored verbatim on `agent.messages`, leaving conversation history inconsistent across providers.

## Change

- Add an internal `_normalize_role` helper in `bidi/types/events.py` that trims whitespace, lowercases the incoming value, and falls back to a default when it is not one of the supported roles. The default is the lowest-trust role (`"user"`), so an unknown or spoofed role value is never attributed to the assistant. Coercion is logged at debug so provider bugs surface instead of being masked.
- Apply it inside the `BidiTranscriptStreamEvent` constructor, making it the single normalization point: the provider-local coercion in `openai_realtime` (which defaulted to `assistant`) and the `.lower()` in `nova_sonic` are removed, and providers now pass the raw role through.

## Tests

- Cases in `tests/.../types/test_events.py` covering `_normalize_role` directly and the event constructor: mixed-casing supported roles are lowercased, and out-of-range values (such as `system`) are coerced to `user` and never persisted verbatim.
- A provider-level test in `tests/.../models/test_openai_realtime.py` asserting the raw role reaches the constructor and is normalized there.
- Ran the bidi test suite (143 passed) plus `ruff check`, `ruff format --check`, and `mypy` on the changed files.
