### PR TITLE
feat(mcp/py): load MCP servers from JSON

### DIFF
--- a/strands-py/src/strands/tools/mcp/__init__.py
+++ b/strands-py/src/strands/tools/mcp/__init__.py
@@ -7,8 +7,8 @@ servers.
 """
 
 from .mcp_agent_tool import MCPAgentTool
-from .mcp_client import MCPClient, ToolFilters
+from .mcp_client import MCPClient, MCPServerConfig, ToolFilters
 from .mcp_tasks import TasksConfig
 from .mcp_types import MCPTransport
 
-__all__ = ["MCPAgentTool", "MCPClient", "MCPTransport", "TasksConfig", "ToolFilters"]
+__all__ = ["MCPAgentTool", "MCPClient", "MCPServerConfig", "MCPTransport", "TasksConfig", "ToolFilters"]

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -12,6 +12,8 @@ import base64
 import contextvars
 import json
 import logging
+import os
+import re
 import sys
 import threading
 import uuid
@@ -19,13 +21,16 @@ from asyncio import AbstractEventLoop
 from collections.abc import Callable, Coroutine, Sequence
 from concurrent import futures
 from datetime import timedelta
+from pathlib import Path
 from re import Pattern
 from types import TracebackType
 from typing import Any, TypeVar, cast
 
 import anyio
-from mcp import ClientSession, ListToolsResult
+from mcp import ClientSession, ListToolsResult, StdioServerParameters, stdio_client
 from mcp.client.session import ElicitationFnT
+from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.exceptions import McpError
 from mcp.shared.session import ProgressFnT
 from mcp.types import (
@@ -113,6 +118,48 @@ class MCPClient(ToolProvider):
     while maintaining communication with the MCP service. When structured content is available
     from MCP tools, it will be returned as the last item in the content array of the ToolResult.
     """
+
+    @classmethod
+    def load_servers(cls, config: "str | dict[str, Any]") -> "list[MCPClient]":
+        """Create MCPClient instances from an ``mcpServers`` JSON config (file path or mapping).
+
+        Returns one client per enabled server. Accepts either a flat mapping of server name to
+        config, or that mapping nested under an ``mcpServers`` key. Servers marked
+        ``"disabled": true`` are skipped.
+
+        Transport is auto-detected from the fields present: ``command`` selects stdio and ``url``
+        selects streamable-http. Set ``transport`` explicitly (``"stdio"``, ``"sse"``, or
+        ``"streamable-http"``) to override. String values support ``${VAR}`` / ``${env:VAR}``
+        interpolation against the process environment, and ``~`` in ``command`` and ``cwd`` is
+        expanded to the user's home directory.
+
+        Args:
+            config: A file path (with optional ``file://`` prefix) to a JSON config, or a
+                dictionary mapping server names to configs (optionally under an ``mcpServers`` key).
+
+        Returns:
+            One MCPClient per enabled server, ready to pass to ``Agent(tools=...)``.
+
+        Raises:
+            FileNotFoundError: If the config file does not exist.
+            json.JSONDecodeError: If the config file contains invalid JSON.
+            ValueError: If the config shape is invalid, a server entry is not a mapping, a server
+                config is invalid, or a referenced environment variable is not set.
+        """
+        servers = _load_servers_mapping(config)
+
+        clients: list[MCPClient] = []
+        for name, server in servers.items():
+            # A non-dict entry is a malformed-config error and always raises, unlike per-server failures.
+            if not isinstance(server, dict):
+                raise ValueError(f"server '{name}' configuration must be a dictionary, got {type(server).__name__}")
+            if server.get("disabled", False):
+                logger.debug("server_name=<%s> | skipping disabled MCP server", name)
+                continue
+            clients.append(_build_client_from_config(name, server))
+
+        logger.debug("loaded_servers=<%d> | created MCP clients from config", len(clients))
+        return clients
 
     def __init__(
         self,
@@ -1259,3 +1306,145 @@ class MCPClient(ToolProvider):
             final_status.status,
         )
         return self._create_task_error_result(f"Unexpected task status: {final_status.status}")
+
+
+# Matches ${VAR} and ${env:VAR} where VAR is a valid environment variable identifier.
+_ENV_VAR_PATTERN = re.compile(r"\$\{(?:env:)?([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _load_servers_mapping(config: str | dict[str, Any]) -> dict[str, Any]:
+    """Resolve the load_servers input into a mapping of server name to server config.
+
+    Reads and parses the file when config is a path, then unwraps the optional ``mcpServers`` key
+    so both wrapped and flat shapes are accepted.
+    """
+    if isinstance(config, str):
+        file_path = config[len("file://") :] if config.startswith("file://") else config
+        path = Path(file_path).expanduser()
+        if not path.exists():
+            raise FileNotFoundError(f"MCP configuration file not found: {file_path}")
+        config_dict = json.loads(path.read_text())
+    elif isinstance(config, dict):
+        config_dict = config
+    else:
+        raise ValueError("config must be a file path string or a dictionary")
+
+    servers = config_dict.get("mcpServers", config_dict) if isinstance(config_dict, dict) else None
+    if not isinstance(servers, dict):
+        raise ValueError(
+            'MCP config must be a JSON object mapping server names to configs, e.g. {"my-server": {"command": "node"}}'
+        )
+    return servers
+
+
+def _build_client_from_config(name: str, server: dict[str, Any]) -> MCPClient:
+    """Build a single MCPClient from one server entry.
+
+    Interpolates ``${VAR}`` references first so secrets can live in the environment, then detects
+    the transport and constructs the matching transport callable.
+    """
+    server = cast(dict[str, Any], _interpolate_env_vars(server))
+
+    if server.get("command") and server.get("url") and not server.get("transport"):
+        raise ValueError(f"server '{name}' has both 'command' and 'url' — set 'transport' explicitly or remove one")
+
+    transport = server.get("transport")
+    if transport is None:
+        transport = "stdio" if server.get("command") else "streamable-http" if server.get("url") else None
+    if transport is None:
+        raise ValueError(f"server '{name}' must include either 'command' (stdio) or 'url' (http)")
+
+    transport_callable = _config_transport_callable(name, transport, server)
+
+    logger.debug("server_name=<%s>, transport=<%s> | creating MCP client from config", name, transport)
+    return MCPClient(
+        transport_callable,
+        startup_timeout=server.get("startup_timeout", 30),
+        tool_filters=_parse_config_tool_filters(name, server.get("tool_filters")),
+        prefix=server.get("prefix"),
+    )
+
+
+def _config_transport_callable(name: str, transport: str, server: dict[str, Any]) -> Callable[[], MCPTransport]:
+    """Return a zero-arg callable that opens the transport for the given server entry."""
+    match transport:
+        case "stdio":
+            command = server.get("command")
+            if not command:
+                raise ValueError(f"server '{name}': stdio transport requires 'command'")
+            params = StdioServerParameters(
+                command=os.path.expanduser(command),
+                args=server.get("args", []),
+                env=server.get("env"),
+                cwd=os.path.expanduser(server["cwd"]) if server.get("cwd") else None,
+            )
+            return lambda: stdio_client(params)
+
+        case "streamable-http":
+            url = server.get("url")
+            if not url:
+                raise ValueError(f"server '{name}': streamable-http transport requires 'url'")
+            headers = server.get("headers")
+            return lambda: streamablehttp_client(url=cast(str, url), headers=headers)
+
+        case "sse":
+            url = server.get("url")
+            if not url:
+                raise ValueError(f"server '{name}': sse transport requires 'url'")
+            headers = server.get("headers")
+            return lambda: sse_client(url=cast(str, url), headers=headers)
+
+        case _:
+            raise ValueError(f"server '{name}': unsupported transport type '{transport}'")
+
+
+def _parse_config_tool_filters(name: str, config: dict[str, Any] | None) -> ToolFilters | None:
+    """Compile a tool-filter config into a ToolFilters mapping of regex patterns.
+
+    Patterns match the server-side (unprefixed) tool name; any ``prefix`` is applied afterwards.
+    """
+    if not config:
+        return None
+
+    result: ToolFilters = {}
+    if config.get("allowed") is not None:
+        result["allowed"] = _compile_filter_patterns(name, "allowed", config["allowed"])
+    if config.get("rejected") is not None:
+        result["rejected"] = _compile_filter_patterns(name, "rejected", config["rejected"])
+
+    return result or None
+
+
+def _compile_filter_patterns(name: str, key: str, patterns: list[str]) -> list[_ToolMatcher]:
+    """Compile a list of regex strings into patterns, raising a clear error on an invalid one."""
+    compiled: list[_ToolMatcher] = []
+    for pattern in patterns:
+        try:
+            compiled.append(re.compile(pattern))
+        except re.error as e:
+            raise ValueError(f"server '{name}': invalid regex in tool_filters.{key}: '{pattern}': {e}") from e
+    return compiled
+
+
+def _interpolate_env_vars(value: Any) -> Any:
+    """Recursively replace ``${VAR}`` / ``${env:VAR}`` references in strings with env values.
+
+    Strings nested inside lists and dicts are interpolated; other types pass through unchanged.
+
+    Raises:
+        ValueError: If a referenced environment variable is not set.
+    """
+    if isinstance(value, str):
+
+        def _replace(match: re.Match[str]) -> str:
+            var = match.group(1)
+            if var not in os.environ:
+                raise ValueError(f"environment variable '{var}' is not set")
+            return os.environ[var]
+
+        return _ENV_VAR_PATTERN.sub(_replace, value)
+    if isinstance(value, list):
+        return [_interpolate_env_vars(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _interpolate_env_vars(item) for key, item in value.items()}
+    return value

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -84,6 +84,27 @@ class ToolFilters(TypedDict, total=False):
     rejected: list[_ToolMatcher]
 
 
+class MCPServerConfig(TypedDict, total=False):
+    """Schema for a single MCP server entry in a load_servers config.
+
+    Provide either 'command' (stdio) or 'url' (streamable-http/sse), not both. When 'transport' is
+    omitted it is auto-detected from the fields present. String values support '${VAR}' /
+    '${env:VAR}' interpolation, and '~' in 'command' and 'cwd' is expanded to the home directory.
+    """
+
+    command: str
+    args: list[str]
+    env: dict[str, str]
+    cwd: str
+    url: str
+    headers: dict[str, str]
+    transport: str
+    disabled: bool
+    prefix: str
+    tool_filters: ToolFilters
+    startup_timeout: int
+
+
 MIME_TO_FORMAT: dict[str, ImageFormat] = {
     "image/jpeg": "jpeg",
     "image/jpg": "jpeg",
@@ -153,6 +174,11 @@ class MCPClient(ToolProvider):
             # A non-dict entry is a malformed-config error and always raises, unlike per-server failures.
             if not isinstance(server, dict):
                 raise ValueError(f"server '{name}' configuration must be a dictionary, got {type(server).__name__}")
+            unknown_keys = sorted(server.keys() - MCPServerConfig.__annotations__.keys())
+            if unknown_keys:
+                logger.warning(
+                    "server_name=<%s>, unknown_keys=<%s> | ignoring unrecognized MCP config keys", name, unknown_keys
+                )
             if server.get("disabled", False):
                 logger.debug("server_name=<%s> | skipping disabled MCP server", name)
                 continue

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
@@ -123,9 +123,10 @@ def test_malformed_placeholder_not_interpolated(mock_client, transports):
 # Path Expansion Tests
 
 
-def test_expands_tilde_in_command_and_cwd(mock_client, transports, monkeypatch):
-    monkeypatch.setenv("HOME", "/home/user")
-    MCPClient.load_servers({"srv": {"command": "~/bin/server", "cwd": "~/project"}})
+def test_expands_tilde_in_command_and_cwd(mock_client, transports):
+    # Patch expanduser to a fixed home so the assertion holds regardless of platform.
+    with patch("os.path.expanduser", lambda p: p.replace("~", "/home/user")):
+        MCPClient.load_servers({"srv": {"command": "~/bin/server", "cwd": "~/project"}})
     _open(mock_client[0][0])
     transports["params"].assert_called_once_with(
         command="/home/user/bin/server", args=[], env=None, cwd="/home/user/project"
@@ -138,13 +139,12 @@ def test_expands_tilde_in_command_and_cwd(mock_client, transports, monkeypatch):
 def test_prefix_and_startup_timeout_passed(mock_client, transports):
     MCPClient.load_servers({"srv": {"command": "node", "prefix": "p", "startup_timeout": 5}})
     _, kwargs = mock_client[0]
-    assert kwargs["prefix"] == "p"
-    assert kwargs["startup_timeout"] == 5
+    assert kwargs == {"startup_timeout": 5, "tool_filters": None, "prefix": "p"}
 
 
 def test_default_startup_timeout(mock_client, transports):
     MCPClient.load_servers({"srv": {"command": "node"}})
-    assert mock_client[0][1]["startup_timeout"] == 30
+    assert mock_client[0][1] == {"startup_timeout": 30, "tool_filters": None, "prefix": None}
 
 
 def test_tool_filters_compiled_to_regex(mock_client, transports):
@@ -159,6 +159,12 @@ def test_tool_filters_compiled_to_regex(mock_client, transports):
 def test_invalid_regex_raises(mock_client, transports):
     with pytest.raises(ValueError, match="invalid regex in tool_filters.allowed"):
         MCPClient.load_servers({"srv": {"command": "node", "tool_filters": {"allowed": ["([unclosed"]}}})
+
+
+def test_unknown_config_key_warns(mock_client, transports, caplog):
+    with caplog.at_level("WARNING", logger="strands.tools.mcp.mcp_client"):
+        MCPClient.load_servers({"srv": {"command": "node", "startup_timout": 5}})
+    assert "startup_timout" in caplog.text
 
 
 # File Loading Tests
@@ -176,6 +182,11 @@ def test_extracts_mcp_servers_key(mock_client, transports, tmp_path):
     cfg.write_text(json.dumps({"mcpServers": {"a": {"command": "node"}, "b": {"url": "https://x.com"}}}))
     clients = MCPClient.load_servers(str(cfg))
     assert len(clients) == 2
+    # Verify each entry wired to the right transport, not just that two clients were created.
+    _open(mock_client[0][0])
+    _open(mock_client[1][0])
+    transports["stdio"].assert_called_once()
+    transports["http"].assert_called_once_with(url="https://x.com", headers=None)
 
 
 def test_flat_object_without_wrapper(mock_client, transports, tmp_path):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_config.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_config.py
@@ -1,0 +1,255 @@
+"""Unit tests for MCPClient.load_servers (mcpServers JSON config loading)."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from strands.tools.mcp.mcp_client import MCPClient
+
+
+@pytest.fixture
+def mock_client():
+    """Patch MCPClient.__init__ so load_servers builds instances without opening connections.
+
+    Records the (transport_callable, kwargs) each client was constructed with.
+    """
+    calls = []
+
+    def fake_init(self, transport_callable, **kwargs):
+        calls.append((transport_callable, kwargs))
+
+    with patch.object(MCPClient, "__init__", fake_init):
+        yield calls
+
+
+@pytest.fixture
+def transports():
+    """Patch the three transport constructors as imported into mcp_client."""
+    with (
+        patch("strands.tools.mcp.mcp_client.stdio_client") as stdio,
+        patch("strands.tools.mcp.mcp_client.streamablehttp_client") as http,
+        patch("strands.tools.mcp.mcp_client.sse_client") as sse,
+        patch("strands.tools.mcp.mcp_client.StdioServerParameters") as params,
+    ):
+        yield {"stdio": stdio, "http": http, "sse": sse, "params": params}
+
+
+def _open(callable_):
+    """Invoke a returned transport callable so its underlying constructor is exercised."""
+    return callable_()
+
+
+# Transport Detection Tests
+
+
+def test_command_detects_stdio(mock_client, transports):
+    clients = MCPClient.load_servers({"srv": {"command": "node", "args": ["server.js"]}})
+    assert len(clients) == 1
+    _open(mock_client[0][0])
+    transports["params"].assert_called_once_with(command="node", args=["server.js"], env=None, cwd=None)
+    transports["stdio"].assert_called_once()
+
+
+def test_url_detects_streamable_http(mock_client, transports):
+    clients = MCPClient.load_servers({"srv": {"url": "https://example.com/mcp"}})
+    assert len(clients) == 1
+    _open(mock_client[0][0])
+    transports["http"].assert_called_once_with(url="https://example.com/mcp", headers=None)
+    transports["sse"].assert_not_called()
+
+
+def test_explicit_sse(mock_client, transports):
+    clients = MCPClient.load_servers({"srv": {"url": "https://example.com/sse", "transport": "sse"}})
+    assert len(clients) == 1
+    _open(mock_client[0][0])
+    transports["sse"].assert_called_once_with(url="https://example.com/sse", headers=None)
+    transports["http"].assert_not_called()
+
+
+def test_explicit_transport_overrides_detection(mock_client, transports):
+    MCPClient.load_servers({"srv": {"url": "https://example.com/mcp", "transport": "sse"}})
+    _open(mock_client[0][0])
+    transports["sse"].assert_called_once()
+    transports["http"].assert_not_called()
+
+
+# Environment Variable Interpolation Tests
+
+
+def test_interpolates_bare_var_in_env(mock_client, transports, monkeypatch):
+    monkeypatch.setenv("MY_SECRET", "secret123")
+    MCPClient.load_servers({"srv": {"command": "node", "env": {"SECRET": "${MY_SECRET}"}}})
+    _open(mock_client[0][0])
+    transports["params"].assert_called_once_with(command="node", args=[], env={"SECRET": "secret123"}, cwd=None)
+
+
+def test_interpolates_namespaced_env_syntax(mock_client, transports, monkeypatch):
+    monkeypatch.setenv("MY_TOKEN", "token123")
+    MCPClient.load_servers({"srv": {"command": "node", "env": {"TOKEN": "${env:MY_TOKEN}"}}})
+    _open(mock_client[0][0])
+    transports["params"].assert_called_once_with(command="node", args=[], env={"TOKEN": "token123"}, cwd=None)
+
+
+def test_interpolates_in_headers(mock_client, transports, monkeypatch):
+    monkeypatch.setenv("TOKEN", "abc")
+    MCPClient.load_servers({"srv": {"url": "https://example.com/mcp", "headers": {"Authorization": "Bearer ${TOKEN}"}}})
+    _open(mock_client[0][0])
+    transports["http"].assert_called_once_with(url="https://example.com/mcp", headers={"Authorization": "Bearer abc"})
+
+
+def test_interpolates_in_command_and_args(mock_client, transports, monkeypatch):
+    monkeypatch.setenv("MY_CMD", "/usr/local/bin/server")
+    monkeypatch.setenv("MY_ARG", "3000")
+    MCPClient.load_servers({"srv": {"command": "${MY_CMD}", "args": ["--port=${MY_ARG}"]}})
+    _open(mock_client[0][0])
+    transports["params"].assert_called_once_with(
+        command="/usr/local/bin/server", args=["--port=3000"], env=None, cwd=None
+    )
+
+
+def test_missing_env_var_raises(mock_client, transports):
+    with pytest.raises(ValueError, match="environment variable 'NONEXISTENT_VAR' is not set"):
+        MCPClient.load_servers({"srv": {"command": "node", "env": {"V": "${NONEXISTENT_VAR}"}}})
+
+
+def test_malformed_placeholder_not_interpolated(mock_client, transports):
+    # `${ }` is not a valid identifier; the strict pattern leaves it untouched rather than erroring.
+    MCPClient.load_servers({"srv": {"command": "node", "args": ["${ }"]}})
+    _open(mock_client[0][0])
+    transports["params"].assert_called_once_with(command="node", args=["${ }"], env=None, cwd=None)
+
+
+# Path Expansion Tests
+
+
+def test_expands_tilde_in_command_and_cwd(mock_client, transports, monkeypatch):
+    monkeypatch.setenv("HOME", "/home/user")
+    MCPClient.load_servers({"srv": {"command": "~/bin/server", "cwd": "~/project"}})
+    _open(mock_client[0][0])
+    transports["params"].assert_called_once_with(
+        command="/home/user/bin/server", args=[], env=None, cwd="/home/user/project"
+    )
+
+
+# Per-Server Option Tests
+
+
+def test_prefix_and_startup_timeout_passed(mock_client, transports):
+    MCPClient.load_servers({"srv": {"command": "node", "prefix": "p", "startup_timeout": 5}})
+    _, kwargs = mock_client[0]
+    assert kwargs["prefix"] == "p"
+    assert kwargs["startup_timeout"] == 5
+
+
+def test_default_startup_timeout(mock_client, transports):
+    MCPClient.load_servers({"srv": {"command": "node"}})
+    assert mock_client[0][1]["startup_timeout"] == 30
+
+
+def test_tool_filters_compiled_to_regex(mock_client, transports):
+    MCPClient.load_servers(
+        {"srv": {"command": "node", "tool_filters": {"allowed": ["search_.*"], "rejected": ["^delete_"]}}}
+    )
+    filters = mock_client[0][1]["tool_filters"]
+    assert [p.pattern for p in filters["allowed"]] == ["search_.*"]
+    assert [p.pattern for p in filters["rejected"]] == ["^delete_"]
+
+
+def test_invalid_regex_raises(mock_client, transports):
+    with pytest.raises(ValueError, match="invalid regex in tool_filters.allowed"):
+        MCPClient.load_servers({"srv": {"command": "node", "tool_filters": {"allowed": ["([unclosed"]}}})
+
+
+# File Loading Tests
+
+
+def test_loads_from_file(mock_client, transports, tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"srv": {"command": "node"}}))
+    clients = MCPClient.load_servers(str(cfg))
+    assert len(clients) == 1
+
+
+def test_extracts_mcp_servers_key(mock_client, transports, tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"mcpServers": {"a": {"command": "node"}, "b": {"url": "https://x.com"}}}))
+    clients = MCPClient.load_servers(str(cfg))
+    assert len(clients) == 2
+
+
+def test_flat_object_without_wrapper(mock_client, transports, tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"a": {"command": "node"}}))
+    assert len(MCPClient.load_servers(str(cfg))) == 1
+
+
+def test_file_uri_prefix_stripped(mock_client, transports, tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"srv": {"command": "node"}}))
+    assert len(MCPClient.load_servers(f"file://{cfg}")) == 1
+
+
+def test_missing_file_raises(mock_client, transports):
+    with pytest.raises(FileNotFoundError, match="MCP configuration file not found"):
+        MCPClient.load_servers("/nonexistent/path.json")
+
+
+def test_malformed_json_raises(mock_client, transports, tmp_path):
+    cfg = tmp_path / "bad.json"
+    cfg.write_text("not json{{{")
+    with pytest.raises(json.JSONDecodeError):
+        MCPClient.load_servers(str(cfg))
+
+
+# Error Case Tests
+
+
+def test_neither_command_nor_url(mock_client, transports):
+    with pytest.raises(ValueError, match="must include either 'command'"):
+        MCPClient.load_servers({"bad": {}})
+
+
+def test_both_command_and_url_without_transport(mock_client, transports):
+    with pytest.raises(ValueError, match="has both 'command' and 'url'"):
+        MCPClient.load_servers({"bad": {"command": "node", "url": "https://x.com"}})
+
+
+def test_stdio_without_command(mock_client, transports):
+    with pytest.raises(ValueError, match="stdio transport requires 'command'"):
+        MCPClient.load_servers({"bad": {"transport": "stdio", "url": "https://x.com"}})
+
+
+def test_streamable_http_without_url(mock_client, transports):
+    with pytest.raises(ValueError, match="streamable-http transport requires 'url'"):
+        MCPClient.load_servers({"bad": {"transport": "streamable-http", "command": "node"}})
+
+
+def test_sse_without_url(mock_client, transports):
+    with pytest.raises(ValueError, match="sse transport requires 'url'"):
+        MCPClient.load_servers({"bad": {"transport": "sse", "command": "node"}})
+
+
+def test_non_dict_server_entry(mock_client, transports):
+    with pytest.raises(ValueError, match="server 'bad' configuration must be a dictionary"):
+        MCPClient.load_servers({"bad": "oops"})
+
+
+def test_invalid_config_shape(mock_client, transports, tmp_path):
+    cfg = tmp_path / "bad.json"
+    cfg.write_text(json.dumps([1, 2, 3]))
+    with pytest.raises(ValueError, match="MCP config must be a JSON object"):
+        MCPClient.load_servers(str(cfg))
+
+
+def test_non_str_non_dict_config(mock_client, transports):
+    with pytest.raises(ValueError, match="config must be a file path string or a dictionary"):
+        MCPClient.load_servers(123)  # type: ignore[arg-type]
+
+
+# Disabled Server Tests
+
+
+def test_skips_disabled_servers(mock_client, transports):
+    clients = MCPClient.load_servers({"active": {"command": "node"}, "inactive": {"command": "node", "disabled": True}})
+    assert len(clients) == 1


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Adds `MCPClient.load_servers()` — a static factory that turns an `mcpServers` JSON config (a file path or an in-memory map) into ready-to-use `list[MCPClient]`, so users can declare multiple MCP servers declaratively instead of hand-wiring a transport per client.

**Before:**
```py
from strands import Agent
from strands.tools.mcp import MCPClient
from mcp import StdioServerParameters, stdio_client
from mcp.client.streamable_http import streamablehttp_client

aws_docs = MCPClient(lambda: stdio_client(
    StdioServerParameters(command="uvx", args=["awslabs.aws-documentation-mcp-server@latest"])
))

github = MCPClient(lambda: streamablehttp_client(
    url="https://api.githubcopilot.com/mcp/",
    headers={"Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"}
))

agent = Agent(tools=[aws_docs, github])
```


**After:**
```py
from strands import Agent
from strands.tools.mcp import MCPClient

agent = Agent(tools=MCPClient.load_servers({
    "aws-docs": {
        "command": "uvx",
        "args": ["awslabs.aws-documentation-mcp-server@latest"]
    },
    "github": {
        "url": "https://api.githubcopilot.com/mcp/",
        "headers": {
            "Authorization": "Bearer ${GITHUB_TOKEN}"}
     }
}))
```

Or directly from a JSON file:

```py
agent = Agent(tools=MCPClient.load_servers("~/mcp-config.json"))
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

- TypeScript PR: https://github.com/strands-agents/harness-sdk/pull/2947

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

Not yet

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
