### PR TITLE
docs(site): add "New" badge to interventions section

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -114,6 +114,9 @@ sidebar:
               - docs/user-guide/concepts/plugins/context-injector
               - docs/user-guide/concepts/plugins/goal-loop
           - label: Interventions
+            badge:
+              text: New
+              variant: tip
             items:
               - label: "Overview"
                 slug: docs/user-guide/concepts/agents/interventions

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
@@ -10,6 +10,10 @@ sourceLinks:
   - path: strands-ts/src/interventions/handler.ts
   - path: strands-ts/src/interventions/actions.ts
   - path: strands-ts/src/interventions/registry.ts
+sidebar:
+  badge:
+    text: New
+    variant: tip
 ---
 
 Interventions are a composable control layer for agents. They provide a typed action model for common control concerns — authorization, guardrails, steering, and content transformation — with ordered evaluation and short-circuiting. Unlike raw [hooks](../hooks.mdx) and [plugins](../../plugins/index.mdx) which mutate event objects directly, intervention handlers return typed decisions (`proceed`, `deny`, `guide`, `confirm`, `transform`) that the framework applies with well-defined semantics — enabling automatic short-circuiting, feedback accumulation, and conflict resolution.

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/steering.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/steering.mdx
@@ -5,6 +5,10 @@ tags: [hooks, event-loop, tool-execution]
 sourceLinks:
   - path: strands-py/src/strands/vended_plugins/steering/core/handler.py
   - path: strands-ts/src/vended-interventions/steering/handlers/llm.ts
+sidebar:
+  badge:
+    text: New
+    variant: tip
 ---
 
 Steering provides modular prompting for complex agent tasks through context-aware guidance that appears when relevant, rather than front-loading all instructions in monolithic prompts. Steering handlers observe agent activity and intervene at key moments — before a tool call or after a model response — with targeted feedback. They are built on the [interventions](./index.mdx) framework and use the same typed action model.


### PR DESCRIPTION
adds "new" badge to interventions page to match other projects launched for harness launch