### PR TITLE
fix(context-offloader): preserve body when search output exceeds max_chars

### DIFF
--- a/strands-py/src/strands/vended_plugins/context_offloader/search.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/search.py
@@ -139,7 +139,8 @@ def _search_by_pattern(
     safe_pattern = re.sub(r"[\n\r/\]]", " ", pattern)[:50]
     header = f"[{len(matched_set)} match{'es' if len(matched_set) > 1 else ''} for /{safe_pattern}/{scope_label}]"
     body = _format_lines(lines, sorted(visible), matched_set)
-    return _truncate(f"{header}\n\n{body}", max_chars, "output truncated, narrow your search")
+    truncated_body = _truncate(body, max_chars, "output truncated, narrow your search")
+    return f"{header}\n\n{truncated_body}"
 
 
 def _search_by_line_range(
@@ -149,4 +150,5 @@ def _search_by_line_range(
     indices = list(range(start, end + 1))
     header = f"[Lines {start + 1}-{end + 1} of {total_lines}]"
     body = _format_lines(lines, indices, set())
-    return _truncate(f"{header}\n\n{body}", max_chars, "output truncated, narrow your range")
+    truncated_body = _truncate(body, max_chars, "output truncated, narrow your range")
+    return f"{header}\n\n{truncated_body}"

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
@@ -161,6 +161,23 @@ class TestSearchContentTruncation:
         result = _search_content(text, line_range=(1, 2), context_lines=5, max_chars=10_000)
         assert "truncated" not in result
 
+    def test_single_long_line_pattern_result_keeps_body(self):
+        # A body with no internal newlines must still appear when truncated —
+        # the truncator can't mistake the header separator for a body line break.
+        long_json = '{"key":"' + "x" * 5_000 + '"}'
+        result = _search_content(long_json, pattern="key", context_lines=0, max_chars=500)
+        assert "[1 match for /key/]" in result
+        assert '> 1| {"key":"xxxx' in result
+        assert "output truncated, narrow your search" in result
+
+    def test_single_long_line_range_result_keeps_body(self):
+        # Same guarantee on the line-range path: a single long line survives truncation.
+        long_json = '{"key":"' + "x" * 5_000 + '"}'
+        result = _search_content(long_json, line_range=(1, 1), context_lines=0, max_chars=500)
+        assert "[Lines 1-1 of 1]" in result
+        assert '  1| {"key":"xxxx' in result
+        assert "output truncated, narrow your range" in result
+
 
 class TestSearchContentEdgeCases:
     def test_negative_context_lines_clamps_to_zero(self):


### PR DESCRIPTION
Truncation ran on the full `header\n\nbody` string, so a body with no internal newlines (e.g. a minified JSON blob) was cut at the header separator — the caller saw only the header and the truncation notice. Truncate the body alone and always emit the full header. Adds regression tests on both the pattern and line-range paths.

Fixes #3063

## Description

context_offloader's search returned only the header when the matching body was a
single long line (e.g. a minified JSON blob). _truncate ran on
f"{header}\n\n{body}", so output.rfind("\n", 0, max_chars) landed on the
header/body separator when the body had no internal newline before max_chars,
dropping the entire body and leaving the caller with just [1 match for /.../] and
the truncation notice.

The fix truncates the body alone and always emits the full header, so a
single-long-line body falls into _truncate's slice_end = max_chars branch and
returns a hard-cut prefix — the intended "as much content as fits" behavior.
Applied to both _search_by_pattern and _search_by_line_range.

## Related Issues
https://github.com/strands-agents/harness-sdk/issues/3063


## Documentation PR
N/A

## Type of Change
Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
