### PR TITLE
fix(ts-offloader): preserve body when search output exceeds max_chars

### DIFF
--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/search.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/search.test.ts
@@ -168,14 +168,28 @@ describe('searchContent', () => {
       const text = Array.from({ length: 500 }, (_, i) => `match line ${i + 1}`).join('\n')
       const result = searchContent(text, { pattern: 'match', context_lines: 0 }, 200)
       expect(result).toContain('output truncated, narrow your search')
-      expect(result.length).toBeLessThanOrEqual(250) // 200 + truncation message
+      expect(result.length).toBeLessThanOrEqual(280)
     })
 
     it('truncates line range results when output exceeds maxChars', () => {
       const text = Array.from({ length: 500 }, (_, i) => `line ${i + 1}`).join('\n')
       const result = searchContent(text, { line_range: { start: 1, end: 500 }, context_lines: 5 }, 200)
       expect(result).toContain('output truncated, narrow your range')
-      expect(result.length).toBeLessThanOrEqual(250)
+      expect(result.length).toBeLessThanOrEqual(280)
+    })
+
+    it('preserves body for single-long-line content in pattern search', () => {
+      const longJson = '{"key":"' + 'x'.repeat(5000) + '"}'
+      const result = searchContent(longJson, { pattern: 'key', context_lines: 0 }, 500)
+      expect(result).toContain('output truncated')
+      expect(result).toContain('{"key":"')
+    })
+
+    it('preserves body for single-long-line content in line range', () => {
+      const longJson = '{"key":"' + 'x'.repeat(5000) + '"}'
+      const result = searchContent(longJson, { line_range: { start: 1, end: 50 }, context_lines: 5 }, 500)
+      expect(result).toContain('output truncated')
+      expect(result).toContain('{"key":"')
     })
 
     it('does not truncate when output fits within maxChars', () => {

--- a/strands-ts/src/vended-plugins/context-offloader/search.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/search.ts
@@ -75,7 +75,8 @@ function searchByPattern(
     [...visible].sort((a, b) => a - b),
     matchedSet
   )
-  return truncate(`${header}\n\n${body}`, maxChars, 'output truncated, narrow your search')
+  const truncatedBody = truncate(body, maxChars, 'output truncated, narrow your search')
+  return `${header}\n\n${truncatedBody}`
 }
 
 /** Formats a contiguous range of lines with truncation. */
@@ -83,7 +84,8 @@ function searchByLineRange(lines: string[], start: number, end: number, totalLin
   const indices = Array.from({ length: end - start + 1 }, (_, i) => start + i)
   const header = `[Lines ${start + 1}-${end + 1} of ${totalLines}]`
   const body = formatLines(lines, indices, new Set())
-  return truncate(`${header}\n\n${body}`, maxChars, 'output truncated, narrow your range')
+  const truncatedBody = truncate(body, maxChars, 'output truncated, narrow your range')
+  return `${header}\n\n${truncatedBody}`
 }
 
 const TEXT_APPLICATION_TYPES = new Set([


### PR DESCRIPTION

## Description
<!-- Provide a detailed description of the changes in this PR -->

Port of #3064 to the TypeScript SDK. Truncate only the body and unconditionally prepend the header, so that single-line content (e.g. minified JSON) is hard-cut at max_chars rather than dropped entirely.



## Related Issues

Fixes #3063

## Documentation PR

N/A

## Type of Change

Bug fix


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [X] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
