### PR TITLE
chore: add CODEOWNERS to scaffold PR assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @strands-agents/codeowners


### PR DESCRIPTION
Add CODEOWNERS to scaffold settings for PR assignment.
