### PR TITLE
docs: update sonnet 4 model ids to sonnet 4.6

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -84,7 +84,7 @@ async function summarizingCustom() {
   // --8<-- [start:summarizing_conversation_manager_custom]
   // Optionally use a different model for summarization
   const summarizationModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'global.anthropic.claude-sonnet-5',
   })
 
   const conversationManager = new SummarizingConversationManager({

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -84,7 +84,7 @@ async function summarizingCustom() {
   // --8<-- [start:summarizing_conversation_manager_custom]
   // Optionally use a different model for summarization
   const summarizationModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
   })
 
   const conversationManager = new SummarizingConversationManager({

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -108,7 +108,7 @@ session = boto3.Session(
 
 # Create a Bedrock model with the custom session
 bedrock_model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-5",
+    model_id="global.anthropic.claude-sonnet-4-6",
     boto_session=session
 )
 ```
@@ -185,7 +185,7 @@ You can specify which Bedrock model to use by passing in the model ID string dir
 from strands import Agent
 
 # Create an agent with a specific model by passing the model ID string
-agent = Agent(model="global.anthropic.claude-sonnet-5")
+agent = Agent(model="global.anthropic.claude-sonnet-4-6")
 
 response = agent("Tell me about Amazon Bedrock.")
 ```
@@ -304,8 +304,9 @@ boto_config = BotocoreConfig(
 
 # Create a configured Bedrock model
 bedrock_model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-5",
+    model_id="global.anthropic.claude-sonnet-4-6",
     region_name="us-east-1",  # Specify a different region than the default
+    temperature=0.3,
     stop_sequences=["###", "END"],
     boto_client_config=boto_config,
 )
@@ -350,7 +351,7 @@ in order to use these models. Both modes provide the same event structure and fu
 ```python
 # Streaming model (default)
 streaming_model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-5",
+    model_id="global.anthropic.claude-sonnet-4-6",
     streaming=True,  # This is the default
 )
 
@@ -384,7 +385,7 @@ from strands.models import BedrockModel
 
 # Create a Bedrock model that supports multimodal inputs
 bedrock_model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-5"
+    model_id="global.anthropic.claude-sonnet-4-6"
 )
 agent = Agent(model=bedrock_model)
 
@@ -483,7 +484,7 @@ from strands.models import BedrockModel
 
 # Using guardrails with BedrockModel
 bedrock_model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-5",
+    model_id="global.anthropic.claude-sonnet-4-6",
     guardrail_id="your-guardrail-id",
     guardrail_version="DRAFT",
     guardrail_trace="enabled",  # Options: "enabled", "disabled", "enabled_full"
@@ -600,7 +601,7 @@ from strands_tools import calculator, current_time
 
 # Using tool caching with BedrockModel
 bedrock_model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-5",
+    model_id="global.anthropic.claude-sonnet-4-6",
     cache_tools="default"
 )
 
@@ -854,10 +855,11 @@ from strands.models import BedrockModel
 
 # Create a Bedrock model with reasoning configuration
 bedrock_model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-5",
+    model_id="global.anthropic.claude-sonnet-4-6",
     additional_request_fields={
         "thinking": {
-            "type": "adaptive",
+            "type": "enabled",
+            "budget_tokens": 4096 # Minimum of 1,024
         }
     }
 )
@@ -953,7 +955,7 @@ You can enable native token counting with:
 
 ```python
 model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-5",
+    model_id="global.anthropic.claude-sonnet-4-6",
     use_native_token_count=True,
 )
 ```
@@ -968,7 +970,7 @@ You can enable native token counting with:
 
 ```typescript
 const model = new BedrockModel({
-  modelId: 'global.anthropic.claude-sonnet-5',
+  modelId: 'global.anthropic.claude-sonnet-4-6',
   useNativeTokenCount: true,
 })
 ```
@@ -988,13 +990,13 @@ This typically indicates that the model requires Cross-Region Inference, as docu
 Instead of: 
 
 ```
-anthropic.claude-sonnet-5
+anthropic.claude-sonnet-4-6
 ```
 
 Use: 
 
 ```
-us.anthropic.claude-sonnet-5
+us.anthropic.claude-sonnet-4-6
 ```
 
 
@@ -1003,7 +1005,7 @@ If you encounter the error:
 
 > ValidationException: An error occurred (ValidationException) when calling the ConverseStream operation: The provided model identifier is invalid
 
-This is very likely due to calling Bedrock with an inference model id, such as: `us.anthropic.claude-sonnet-5` from a region that does not [support inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html). If so, pass in a valid model id, as follows:
+This is very likely due to calling Bedrock with an inference model id, such as: `us.anthropic.claude-sonnet-4-6` from a region that does not [support inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html). If so, pass in a valid model id, as follows:
 
 <Tabs>
 <Tab label="Python">
@@ -1032,7 +1034,7 @@ Strands uses a default Claude 4 Sonnet inference model from the region of your c
 
 If you're using an ARN-based application inference profile as your `model_id` (e.g., `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123`), `CacheConfig(strategy="auto")` will not automatically enable prompt caching.
 
-The `strategy="auto"` detection checks the model ID string for `"claude"` or `"anthropic"` substrings. Cross-region inference profile IDs like `us.anthropic.claude-sonnet-5` contain `"anthropic"` and are detected correctly, but application inference profiles use opaque resource IDs (`application-inference-profile/abc123`) that carry no model name information, so detection returns `None`, caching is skipped, and Strands logs a warning: `model_id=<your-arn> | cache_config is enabled but this model does not support automatic caching`.
+The `strategy="auto"` detection checks the model ID string for `"claude"` or `"anthropic"` substrings. Cross-region inference profile IDs like `us.anthropic.claude-sonnet-4-6` contain `"anthropic"` and are detected correctly, but application inference profiles use opaque resource IDs (`application-inference-profile/abc123`) that carry no model name information, so detection returns `None`, caching is skipped, and Strands logs a warning: `model_id=<your-arn> | cache_config is enabled but this model does not support automatic caching`.
 
 Use `strategy="anthropic"` explicitly to fix this:
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -968,7 +968,7 @@ You can enable native token counting with:
 
 ```typescript
 const model = new BedrockModel({
-  modelId: ‘global.anthropic.claude-sonnet-5’,
+  modelId: 'global.anthropic.claude-sonnet-5',
   useNativeTokenCount: true,
 })
 ```

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -108,7 +108,7 @@ session = boto3.Session(
 
 # Create a Bedrock model with the custom session
 bedrock_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+    model_id="global.anthropic.claude-sonnet-5",
     boto_session=session
 )
 ```
@@ -185,7 +185,7 @@ You can specify which Bedrock model to use by passing in the model ID string dir
 from strands import Agent
 
 # Create an agent with a specific model by passing the model ID string
-agent = Agent(model="anthropic.claude-sonnet-4-20250514-v1:0")
+agent = Agent(model="global.anthropic.claude-sonnet-5")
 
 response = agent("Tell me about Amazon Bedrock.")
 ```
@@ -304,10 +304,8 @@ boto_config = BotocoreConfig(
 
 # Create a configured Bedrock model
 bedrock_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+    model_id="global.anthropic.claude-sonnet-5",
     region_name="us-east-1",  # Specify a different region than the default
-    temperature=0.3,
-    top_p=0.8,
     stop_sequences=["###", "END"],
     boto_client_config=boto_config,
 )
@@ -352,7 +350,7 @@ in order to use these models. Both modes provide the same event structure and fu
 ```python
 # Streaming model (default)
 streaming_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+    model_id="global.anthropic.claude-sonnet-5",
     streaming=True,  # This is the default
 )
 
@@ -386,7 +384,7 @@ from strands.models import BedrockModel
 
 # Create a Bedrock model that supports multimodal inputs
 bedrock_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0"
+    model_id="global.anthropic.claude-sonnet-5"
 )
 agent = Agent(model=bedrock_model)
 
@@ -485,7 +483,7 @@ from strands.models import BedrockModel
 
 # Using guardrails with BedrockModel
 bedrock_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+    model_id="global.anthropic.claude-sonnet-5",
     guardrail_id="your-guardrail-id",
     guardrail_version="DRAFT",
     guardrail_trace="enabled",  # Options: "enabled", "disabled", "enabled_full"
@@ -602,7 +600,7 @@ from strands_tools import calculator, current_time
 
 # Using tool caching with BedrockModel
 bedrock_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+    model_id="global.anthropic.claude-sonnet-5",
     cache_tools="default"
 )
 
@@ -856,11 +854,10 @@ from strands.models import BedrockModel
 
 # Create a Bedrock model with reasoning configuration
 bedrock_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+    model_id="global.anthropic.claude-sonnet-5",
     additional_request_fields={
         "thinking": {
-            "type": "enabled",
-            "budget_tokens": 4096 # Minimum of 1,024
+            "type": "adaptive",
         }
     }
 )
@@ -956,7 +953,7 @@ You can enable native token counting with:
 
 ```python
 model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+    model_id="global.anthropic.claude-sonnet-5",
     use_native_token_count=True,
 )
 ```
@@ -971,7 +968,7 @@ You can enable native token counting with:
 
 ```typescript
 const model = new BedrockModel({
-  modelId: ‘anthropic.claude-sonnet-4-20250514-v1:0’,
+  modelId: ‘global.anthropic.claude-sonnet-5’,
   useNativeTokenCount: true,
 })
 ```
@@ -991,13 +988,13 @@ This typically indicates that the model requires Cross-Region Inference, as docu
 Instead of: 
 
 ```
-anthropic.claude-sonnet-4-20250514-v1:0
+anthropic.claude-sonnet-5
 ```
 
 Use: 
 
 ```
-us.anthropic.claude-sonnet-4-20250514-v1:0
+us.anthropic.claude-sonnet-5
 ```
 
 
@@ -1006,7 +1003,7 @@ If you encounter the error:
 
 > ValidationException: An error occurred (ValidationException) when calling the ConverseStream operation: The provided model identifier is invalid
 
-This is very likely due to calling Bedrock with an inference model id, such as: `us.anthropic.claude-sonnet-4-20250514-v1:0` from a region that does not [support inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html). If so, pass in a valid model id, as follows:
+This is very likely due to calling Bedrock with an inference model id, such as: `us.anthropic.claude-sonnet-5` from a region that does not [support inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html). If so, pass in a valid model id, as follows:
 
 <Tabs>
 <Tab label="Python">
@@ -1035,7 +1032,7 @@ Strands uses a default Claude 4 Sonnet inference model from the region of your c
 
 If you're using an ARN-based application inference profile as your `model_id` (e.g., `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123`), `CacheConfig(strategy="auto")` will not automatically enable prompt caching.
 
-The `strategy="auto"` detection checks the model ID string for `"claude"` or `"anthropic"` substrings. Cross-region inference profile IDs like `us.anthropic.claude-sonnet-4-20250514-v1:0` contain `"anthropic"` and are detected correctly, but application inference profiles use opaque resource IDs (`application-inference-profile/abc123`) that carry no model name information, so detection returns `None`, caching is skipped, and Strands logs a warning: `model_id=<your-arn> | cache_config is enabled but this model does not support automatic caching`.
+The `strategy="auto"` detection checks the model ID string for `"claude"` or `"anthropic"` substrings. Cross-region inference profile IDs like `us.anthropic.claude-sonnet-5` contain `"anthropic"` and are detected correctly, but application inference profiles use opaque resource IDs (`application-inference-profile/abc123`) that carry no model name information, so detection returns `None`, caching is skipped, and Strands logs a warning: `model_id=<your-arn> | cache_config is enabled but this model does not support automatic caching`.
 
 Use `strategy="anthropic"` explicitly to fix this:
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -657,7 +657,7 @@ def web_search(query: str) -> str:
     """
 
 model = BedrockModel(
-    model_id="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    model_id="global.anthropic.claude-sonnet-4-6",
     cache_config=CacheConfig(strategy="auto")
 )
 agent = Agent(model=model, tools=[web_search])
@@ -779,14 +779,13 @@ You can update the model configuration during runtime:
 ```python
 # Create the model with initial configuration
 bedrock_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+    model_id="global.anthropic.claude-sonnet-4-6",
     temperature=0.7
 )
 
 # Update configuration later
 bedrock_model.update_config(
     temperature=0.3,
-    top_p=0.2,
 )
 ```
 </Tab>

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -26,7 +26,7 @@ async function basicUsageDefault() {
 async function basicUsageModelId() {
   // --8<-- [start:basic_model_id]
   // Create an agent using the model
-  const agent = new Agent({ model: 'anthropic.claude-sonnet-4-20250514-v1:0' })
+  const agent = new Agent({ model: 'global.anthropic.claude-sonnet-5' })
 
   const response = await agent.invoke('Tell me about Amazon Bedrock.')
   // --8<-- [end:basic_model_id]
@@ -54,10 +54,8 @@ async function configurationExample() {
   // --8<-- [start:configuration]
   // Create a configured Bedrock model
   const bedrockModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'global.anthropic.claude-sonnet-5',
     region: 'us-east-1', // Specify a different region than the default
-    temperature: 0.3,
-    topP: 0.8,
     stopSequences: ['###', 'END'],
     clientConfig: {
       retryMode: 'standard',
@@ -78,7 +76,7 @@ async function streamingExample() {
   // --8<-- [start:streaming]
   // Streaming model (default)
   const streamingModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'global.anthropic.claude-sonnet-5',
     stream: true, // This is the default
   })
 
@@ -138,11 +136,10 @@ async function reasoningSupport() {
   // --8<-- [start:reasoning]
   // Create a Bedrock model with reasoning configuration
   const bedrockModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'global.anthropic.claude-sonnet-5',
     additionalRequestFields: {
       thinking: {
-        type: 'enabled',
-        budget_tokens: 4096, // Minimum of 1,024
+        type: 'adaptive',
       },
     },
   })
@@ -165,7 +162,7 @@ async function customCredentials() {
   // https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html
 
   const bedrockModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'global.anthropic.claude-sonnet-5',
     region: 'us-west-2',
     clientConfig: {
       credentials: {
@@ -182,7 +179,7 @@ async function customCredentials() {
 async function multimodalSupport() {
   // --8<-- [start:multimodal_full]
   const bedrockModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'global.anthropic.claude-sonnet-5',
   })
 
   const agent = new Agent({ model: bedrockModel })
@@ -264,7 +261,7 @@ async function systemPromptCachingFull() {
 async function toolCachingFull() {
   // --8<-- [start:tool_caching_full]
   const bedrockModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'global.anthropic.claude-sonnet-5',
     cacheConfig: { strategy: 'auto' },
   })
 
@@ -406,7 +403,7 @@ async function guardrailsExample() {
   // --8<-- [start:guardrails]
   // Using guardrails with BedrockModel
   const bedrockModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'global.anthropic.claude-sonnet-5',
     guardrailConfig: {
       guardrailIdentifier: 'your-guardrail-id',
       guardrailVersion: 'DRAFT',

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -26,7 +26,7 @@ async function basicUsageDefault() {
 async function basicUsageModelId() {
   // --8<-- [start:basic_model_id]
   // Create an agent using the model
-  const agent = new Agent({ model: 'global.anthropic.claude-sonnet-5' })
+  const agent = new Agent({ model: 'global.anthropic.claude-sonnet-4-6' })
 
   const response = await agent.invoke('Tell me about Amazon Bedrock.')
   // --8<-- [end:basic_model_id]
@@ -54,9 +54,10 @@ async function configurationExample() {
   // --8<-- [start:configuration]
   // Create a configured Bedrock model
   const bedrockModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
     region: 'us-east-1', // Specify a different region than the default
     stopSequences: ['###', 'END'],
+    temperature: 0.3,
     clientConfig: {
       retryMode: 'standard',
       maxAttempts: 3,
@@ -76,7 +77,7 @@ async function streamingExample() {
   // --8<-- [start:streaming]
   // Streaming model (default)
   const streamingModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
     stream: true, // This is the default
   })
 
@@ -136,10 +137,11 @@ async function reasoningSupport() {
   // --8<-- [start:reasoning]
   // Create a Bedrock model with reasoning configuration
   const bedrockModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
     additionalRequestFields: {
       thinking: {
-        type: 'adaptive',
+        type: 'enabled',
+        budget_tokens: 4096, // Minimum of 1,024
       },
     },
   })
@@ -162,7 +164,7 @@ async function customCredentials() {
   // https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html
 
   const bedrockModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
     region: 'us-west-2',
     clientConfig: {
       credentials: {
@@ -179,7 +181,7 @@ async function customCredentials() {
 async function multimodalSupport() {
   // --8<-- [start:multimodal_full]
   const bedrockModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
   })
 
   const agent = new Agent({ model: bedrockModel })
@@ -261,7 +263,7 @@ async function systemPromptCachingFull() {
 async function toolCachingFull() {
   // --8<-- [start:tool_caching_full]
   const bedrockModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
     cacheConfig: { strategy: 'auto' },
   })
 
@@ -299,7 +301,7 @@ async function toolCachingFull() {
 async function automaticCacheStrategy() {
   // --8<-- [start:automatic_cache_strategy]
   const bedrockModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
     cacheConfig: { strategy: 'auto' },
   })
 
@@ -403,7 +405,7 @@ async function guardrailsExample() {
   // --8<-- [start:guardrails]
   // Using guardrails with BedrockModel
   const bedrockModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
     guardrailConfig: {
       guardrailIdentifier: 'your-guardrail-id',
       guardrailVersion: 'DRAFT',
@@ -428,7 +430,7 @@ async function guardrailsExample() {
 async function requestTimeoutExample() {
   // --8<-- [start:request_timeout]
   const bedrockModel = new BedrockModel({
-    modelId: 'global.anthropic.claude-sonnet-5',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
     clientConfig: {
       requestHandler: { requestTimeout: 60_000 },
     },

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -299,7 +299,7 @@ async function toolCachingFull() {
 async function automaticCacheStrategy() {
   // --8<-- [start:automatic_cache_strategy]
   const bedrockModel = new BedrockModel({
-    modelId: 'us.anthropic.claude-sonnet-4-6',
+    modelId: 'global.anthropic.claude-sonnet-5',
     cacheConfig: { strategy: 'auto' },
   })
 
@@ -428,7 +428,7 @@ async function guardrailsExample() {
 async function requestTimeoutExample() {
   // --8<-- [start:request_timeout]
   const bedrockModel = new BedrockModel({
-    modelId: 'us.anthropic.claude-sonnet-4-6',
+    modelId: 'global.anthropic.claude-sonnet-5',
     clientConfig: {
       requestHandler: { requestTimeout: 60_000 },
     },

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -56,8 +56,8 @@ async function configurationExample() {
   const bedrockModel = new BedrockModel({
     modelId: 'global.anthropic.claude-sonnet-4-6',
     region: 'us-east-1', // Specify a different region than the default
-    stopSequences: ['###', 'END'],
     temperature: 0.3,
+    stopSequences: ['###', 'END'],
     clientConfig: {
       retryMode: 'standard',
       maxAttempts: 3,

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -94,14 +94,13 @@ async function updateConfiguration() {
   // --8<-- [start:update_config]
   // Create the model with initial configuration
   const bedrockModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'global.anthropic.claude-sonnet-4-6',
     temperature: 0.7,
   })
 
   // Update configuration later
   bedrockModel.updateConfig({
     temperature: 0.3,
-    topP: 0.2,
   })
   // --8<-- [end:update_config]
 }
@@ -126,7 +125,7 @@ async function toolBasedConfigUpdate() {
   })
 
   const agent = new Agent({
-    model: new BedrockModel({ modelId: 'anthropic.claude-sonnet-4-20250514-v1:0' }),
+    model: new BedrockModel({ modelId: 'global.anthropic.claude-sonnet-4-6' }),
     tools: [updateTemperature],
   })
   // --8<-- [end:tool_update_config]

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
@@ -20,7 +20,7 @@ from strands_evals.evaluators import OutputEvaluator
 
 @eval_task()
 def my_task():
-    return Agent(model="global.anthropic.claude-sonnet-5", callback_handler=None)
+    return Agent(model="global.anthropic.claude-sonnet-4-6", callback_handler=None)
 
 cases = [Case(name="greeting", input="Hello!")]
 evaluator = OutputEvaluator(rubric="Score 1.0 if friendly. Score 0.0 otherwise.")

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
@@ -20,7 +20,7 @@ from strands_evals.evaluators import OutputEvaluator
 
 @eval_task()
 def my_task():
-    return Agent(model="us.anthropic.claude-sonnet-4-20250514-v1:0", callback_handler=None)
+    return Agent(model="global.anthropic.claude-sonnet-5", callback_handler=None)
 
 cases = [Case(name="greeting", input="Hello!")]
 evaluator = OutputEvaluator(rubric="Score 1.0 if friendly. Score 0.0 otherwise.")

--- a/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -140,7 +140,7 @@ from strands import Agent
 # Option 1: Skip StrandsTelemetry if global tracer provider and/or meter provider are already configured
 # (your existing OpenTelemetry setup will be used automatically)
 agent = Agent(
-    model="global.anthropic.claude-sonnet-5",
+    model="global.anthropic.claude-sonnet-4-6",
     system_prompt="You are a helpful AI assistant"
 )
 
@@ -165,7 +165,7 @@ strands_telemetry.setup_otlp_exporter().setup_console_exporter()  # Chaining sup
 
 # Create agent (tracing will be enabled automatically)
 agent = Agent(
-    model="global.anthropic.claude-sonnet-5",
+    model="global.anthropic.claude-sonnet-4-6",
     system_prompt="You are a helpful AI assistant"
 )
 
@@ -256,7 +256,7 @@ Strands traces include rich attributes that provide context for each operation:
 | `gen_ai.agent.name` | Name of the agent |
 | `gen_ai.user.message` | Formatted prompt sent to the model |
 | `gen_ai.assistant.message` | Formatted assistant prompt sent to the model |
-| `gen_ai.request.model` | Model ID (e.g., "global.anthropic.claude-sonnet-5") |
+| `gen_ai.request.model` | Model ID (e.g., "global.anthropic.claude-sonnet-4-6") |
 | `gen_ai.event.start_time` | When model invocation began |
 | `gen_ai.event.end_time` | When model invocation completed |
 | `gen_ai.choice` | Response from the model (may include tool calls) |
@@ -500,7 +500,7 @@ strands_telemetry.setup_console_exporter()   # Print traces to console
 
 # Create agent
 agent = Agent(
-    model="global.anthropic.claude-sonnet-5",
+    model="global.anthropic.claude-sonnet-4-6",
     system_prompt="You are a helpful AI assistant"
 )
 

--- a/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -140,7 +140,7 @@ from strands import Agent
 # Option 1: Skip StrandsTelemetry if global tracer provider and/or meter provider are already configured
 # (your existing OpenTelemetry setup will be used automatically)
 agent = Agent(
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+    model="global.anthropic.claude-sonnet-5",
     system_prompt="You are a helpful AI assistant"
 )
 
@@ -165,7 +165,7 @@ strands_telemetry.setup_otlp_exporter().setup_console_exporter()  # Chaining sup
 
 # Create agent (tracing will be enabled automatically)
 agent = Agent(
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+    model="global.anthropic.claude-sonnet-5",
     system_prompt="You are a helpful AI assistant"
 )
 
@@ -256,7 +256,7 @@ Strands traces include rich attributes that provide context for each operation:
 | `gen_ai.agent.name` | Name of the agent |
 | `gen_ai.user.message` | Formatted prompt sent to the model |
 | `gen_ai.assistant.message` | Formatted assistant prompt sent to the model |
-| `gen_ai.request.model` | Model ID (e.g., "us.anthropic.claude-sonnet-4-20250514-v1:0") |
+| `gen_ai.request.model` | Model ID (e.g., "global.anthropic.claude-sonnet-5") |
 | `gen_ai.event.start_time` | When model invocation began |
 | `gen_ai.event.end_time` | When model invocation completed |
 | `gen_ai.choice` | Response from the model (may include tool calls) |
@@ -500,7 +500,7 @@ strands_telemetry.setup_console_exporter()   # Print traces to console
 
 # Create agent
 agent = Agent(
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+    model="global.anthropic.claude-sonnet-5",
     system_prompt="You are a helpful AI assistant"
 )
 

--- a/site/src/content/docs/user-guide/quickstart/python.mdx
+++ b/site/src/content/docs/user-guide/quickstart/python.mdx
@@ -433,6 +433,7 @@ from strands.models import BedrockModel
 bedrock_model = BedrockModel(
     model_id="global.anthropic.claude-sonnet-4-6",
     region_name="us-west-2",
+    temperature=0.3,
 )
 
 agent = Agent(model=bedrock_model)

--- a/site/src/content/docs/user-guide/quickstart/python.mdx
+++ b/site/src/content/docs/user-guide/quickstart/python.mdx
@@ -417,7 +417,7 @@ The simplest way to specify a model is to pass the model ID string directly:
 from strands import Agent
 
 # Create an agent with a specific model by passing the model ID string
-agent = Agent(model="global.anthropic.claude-sonnet-5")
+agent = Agent(model="global.anthropic.claude-sonnet-4-6")
 ```
 
 ### Amazon Bedrock (Default)
@@ -431,7 +431,7 @@ from strands.models import BedrockModel
 
 # Create a BedrockModel
 bedrock_model = BedrockModel(
-    model_id="global.anthropic.claude-sonnet-5",
+    model_id="global.anthropic.claude-sonnet-4-6",
     region_name="us-west-2",
 )
 

--- a/site/src/content/docs/user-guide/quickstart/python.mdx
+++ b/site/src/content/docs/user-guide/quickstart/python.mdx
@@ -417,7 +417,7 @@ The simplest way to specify a model is to pass the model ID string directly:
 from strands import Agent
 
 # Create an agent with a specific model by passing the model ID string
-agent = Agent(model="anthropic.claude-sonnet-4-20250514-v1:0")
+agent = Agent(model="global.anthropic.claude-sonnet-5")
 ```
 
 ### Amazon Bedrock (Default)
@@ -431,9 +431,8 @@ from strands.models import BedrockModel
 
 # Create a BedrockModel
 bedrock_model = BedrockModel(
-    model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+    model_id="global.anthropic.claude-sonnet-5",
     region_name="us-west-2",
-    temperature=0.3,
 )
 
 agent = Agent(model=bedrock_model)

--- a/site/src/content/docs/user-guide/quickstart/typescript.ts
+++ b/site/src/content/docs/user-guide/quickstart/typescript.ts
@@ -81,6 +81,7 @@ import { BedrockModel } from '@strands-agents/sdk'
 const bedrockModel = new BedrockModel({
   modelId: 'global.anthropic.claude-opus-4-6-v1',
   region: 'us-west-2',
+  temperature: 0.3,
 })
 
 const bedrockAgent = new Agent({ model: bedrockModel })

--- a/site/src/content/docs/user-guide/quickstart/typescript.ts
+++ b/site/src/content/docs/user-guide/quickstart/typescript.ts
@@ -70,7 +70,7 @@ console.log(myAgent['model'].getConfig().modelId)
 // --8<-- [start:model-string]
 // Create an agent with a specific model by passing the model ID string
 const specificAgent = new Agent({
-  model: 'global.anthropic.claude-sonnet-5',
+  model: 'global.anthropic.claude-opus-4-6-v1',
 })
 // --8<-- [end:model-string]
 
@@ -79,7 +79,7 @@ import { BedrockModel } from '@strands-agents/sdk'
 
 // Create a BedrockModel with custom configuration
 const bedrockModel = new BedrockModel({
-  modelId: 'global.anthropic.claude-sonnet-5',
+  modelId: 'global.anthropic.claude-opus-4-6-v1',
   region: 'us-west-2',
 })
 

--- a/site/src/content/docs/user-guide/quickstart/typescript.ts
+++ b/site/src/content/docs/user-guide/quickstart/typescript.ts
@@ -70,7 +70,7 @@ console.log(myAgent['model'].getConfig().modelId)
 // --8<-- [start:model-string]
 // Create an agent with a specific model by passing the model ID string
 const specificAgent = new Agent({
-  model: 'global.anthropic.claude-opus-4-6-v1',
+  model: 'global.anthropic.claude-sonnet-5',
 })
 // --8<-- [end:model-string]
 
@@ -79,9 +79,8 @@ import { BedrockModel } from '@strands-agents/sdk'
 
 // Create a BedrockModel with custom configuration
 const bedrockModel = new BedrockModel({
-  modelId: 'global.anthropic.claude-opus-4-6-v1',
+  modelId: 'global.anthropic.claude-sonnet-5',
   region: 'us-west-2',
-  temperature: 0.3,
 })
 
 const bedrockAgent = new Agent({ model: bedrockModel })


### PR DESCRIPTION
## Description
Agents constructed with the model ID `anthropic.claude-sonnet-4-20250514-v1:0` produce ValidationExceptions when invoked. This breaks the demo code provided in the site docs. This PR updates the Sonnet 4 model IDs in the docs to Sonnet 4.6.

Note that for Sonnet 4.6, setting temperature and top_p simultaneously results in a ValidationException when invoked. The top_p parameter was removed in the offending doc demos.

## Related Issues

## Documentation PR

## Type of Change
Documentation update

## Testing

- Verified global.anthropic.claude-sonnet-4-6 invokes successfully via Bedrock Converse API
- Ran site build successfully

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
