### PR TITLE
feat(mcp/py): add continue_on_error to MCP client

### DIFF
--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -171,8 +171,11 @@ class MCPClient(ToolProvider):
         Raises:
             FileNotFoundError: If the config file does not exist.
             json.JSONDecodeError: If the config file contains invalid JSON.
-            ValueError: If the config shape is invalid, a server entry is not a mapping, or a server
-                config is invalid (and that server did not opt into ``continue_on_error``).
+            ValueError: If the overall config shape is invalid or a server entry is not a mapping.
+                These are malformed-config errors and always raise, regardless of
+                ``continue_on_error``. A failure building an individual server (e.g. a missing env
+                var) also raises unless that server set ``continue_on_error``, in which case it is
+                skipped.
         """
         servers = _load_servers_mapping(config)
 
@@ -221,7 +224,8 @@ class MCPClient(ToolProvider):
             prefix: Optional prefix for tool names.
             continue_on_error: When True, a connection failure during ``load_tools`` is logged and
                 yields no tools instead of raising, so one unavailable server does not prevent an
-                agent from using the others. Defaults to False.
+                agent from using the others. Only the connection (``start()``) is swallowed; an error
+                while listing tools after a successful connect still propagates. Defaults to False.
             elicitation_callback: Optional callback function to handle elicitation requests from the MCP server.
             progress_callback: Optional callback to receive progress notifications during tool execution.
                 Called with ``(progress, total, message)`` as the server reports progress. The ``total``
@@ -326,6 +330,21 @@ class MCPClient(ToolProvider):
             raise MCPClientInitializationError(f"the client initialization failed: {e}") from e
         return self
 
+    @property
+    def continue_on_error(self) -> bool:
+        """Whether a connection failure is swallowed instead of raised (see ``__init__``)."""
+        return self._continue_on_error
+
+    @property
+    def connection_failed(self) -> bool:
+        """Whether a ``continue_on_error`` connection attempt has failed and not yet been reset.
+
+        Sticky within a connection lifecycle: stays True until teardown (removing the last consumer,
+        or ``stop()``) resets the client. Always False when ``continue_on_error`` is not set, since a
+        failure raises instead.
+        """
+        return self._connection_failed
+
     # ToolProvider interface methods
     async def load_tools(self, **kwargs: Any) -> Sequence[AgentTool]:
         """Load and return tools from the MCP server.
@@ -338,7 +357,9 @@ class MCPClient(ToolProvider):
 
         Returns:
             List of AgentTool instances from the MCP server. Empty when the connection fails and
-            ``continue_on_error`` is set; the failure is not retried on subsequent calls.
+            ``continue_on_error`` is set; the failure is sticky within a connection lifecycle and is
+            not retried on subsequent calls. Teardown (removing the last consumer, or ``stop()``)
+            resets the client so a later consumer reconnects.
         """
         logger.debug(
             "started=<%s>, cached_tools=<%s> | loading tools",
@@ -418,7 +439,10 @@ class MCPClient(ToolProvider):
         self._consumers.discard(consumer_id)
         logger.debug("removed provider consumer, count=%d", len(self._consumers))
 
-        if not self._consumers and self._tool_provider_started:
+        # A swallowed continue_on_error failure leaves _tool_provider_started False but still needs
+        # teardown so the sticky _connection_failed flag resets and the client can reconnect for a
+        # later consumer, matching the reset-on-zero-consumers behavior of a successful client.
+        if not self._consumers and (self._tool_provider_started or self._connection_failed):
             logger.debug("no consumers remaining, cleaning up")
             try:
                 self.stop(None, None, None)  # Existing sync method - safe for finalizers

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -90,6 +90,11 @@ class MCPServerConfig(TypedDict, total=False):
     Provide either 'command' (stdio) or 'url' (streamable-http/sse), not both. When 'transport' is
     omitted it is auto-detected from the fields present. String values support '${VAR}' /
     '${env:VAR}' interpolation, and '~' in 'command' and 'cwd' is expanded to the home directory.
+
+    'disabled' skips the server entirely. 'continue_on_error' keeps the rest of the servers usable
+    when this one fails: a config-resolution failure (e.g. a missing env var) skips it during
+    load_servers instead of raising, and a connection failure yields no tools instead of raising
+    when the agent loads them.
     """
 
     command: str
@@ -100,6 +105,7 @@ class MCPServerConfig(TypedDict, total=False):
     headers: dict[str, str]
     transport: str
     disabled: bool
+    continue_on_error: bool
     prefix: str
     tool_filters: ToolFilters
     startup_timeout: int
@@ -146,7 +152,8 @@ class MCPClient(ToolProvider):
 
         Returns one client per enabled server. Accepts either a flat mapping of server name to
         config, or that mapping nested under an ``mcpServers`` key. Servers marked
-        ``"disabled": true`` are skipped.
+        ``"disabled": true`` are skipped. When a server sets ``"continue_on_error": true``, a
+        failure resolving its config (e.g. a missing env var) skips that server instead of raising.
 
         Transport is auto-detected from the fields present: ``command`` selects stdio and ``url``
         selects streamable-http. Set ``transport`` explicitly (``"stdio"``, ``"sse"``, or
@@ -164,8 +171,8 @@ class MCPClient(ToolProvider):
         Raises:
             FileNotFoundError: If the config file does not exist.
             json.JSONDecodeError: If the config file contains invalid JSON.
-            ValueError: If the config shape is invalid, a server entry is not a mapping, a server
-                config is invalid, or a referenced environment variable is not set.
+            ValueError: If the config shape is invalid, a server entry is not a mapping, or a server
+                config is invalid (and that server did not opt into ``continue_on_error``).
         """
         servers = _load_servers_mapping(config)
 
@@ -182,7 +189,12 @@ class MCPClient(ToolProvider):
             if server.get("disabled", False):
                 logger.debug("server_name=<%s> | skipping disabled MCP server", name)
                 continue
-            clients.append(_build_client_from_config(name, server))
+            try:
+                clients.append(_build_client_from_config(name, server))
+            except Exception as e:
+                if not server.get("continue_on_error", False):
+                    raise
+                logger.warning("server_name=<%s>, error=<%s> | MCP server config failed, skipping", name, e)
 
         logger.debug("loaded_servers=<%d> | created MCP clients from config", len(clients))
         return clients
@@ -194,6 +206,7 @@ class MCPClient(ToolProvider):
         startup_timeout: int = 30,
         tool_filters: ToolFilters | None = None,
         prefix: str | None = None,
+        continue_on_error: bool = False,
         elicitation_callback: ElicitationFnT | None = None,
         progress_callback: ProgressFnT | None = None,
         tasks_config: TasksConfig | None = None,
@@ -206,6 +219,9 @@ class MCPClient(ToolProvider):
                 Defaults to 30.
             tool_filters: Optional filters to apply to tools.
             prefix: Optional prefix for tool names.
+            continue_on_error: When True, a connection failure during ``load_tools`` is logged and
+                yields no tools instead of raising, so one unavailable server does not prevent an
+                agent from using the others. Defaults to False.
             elicitation_callback: Optional callback function to handle elicitation requests from the MCP server.
             progress_callback: Optional callback to receive progress notifications during tool execution.
                 Called with ``(progress, total, message)`` as the server reports progress. The ``total``
@@ -217,6 +233,9 @@ class MCPClient(ToolProvider):
         self._startup_timeout = startup_timeout
         self._tool_filters = tool_filters
         self._prefix = prefix
+        self._continue_on_error = continue_on_error
+        # True after a swallowed init failure, so load_tools stops retrying a failed server.
+        self._connection_failed = False
         self._elicitation_callback = elicitation_callback
         self._progress_callback = progress_callback
 
@@ -318,13 +337,18 @@ class MCPClient(ToolProvider):
             **kwargs: Additional arguments for future compatibility.
 
         Returns:
-            List of AgentTool instances from the MCP server.
+            List of AgentTool instances from the MCP server. Empty when the connection fails and
+            ``continue_on_error`` is set; the failure is not retried on subsequent calls.
         """
         logger.debug(
             "started=<%s>, cached_tools=<%s> | loading tools",
             self._tool_provider_started,
             self._loaded_tools is not None,
         )
+
+        # A previously swallowed init failure is not retried on subsequent calls.
+        if self._connection_failed:
+            return []
 
         if not self._tool_provider_started:
             try:
@@ -333,6 +357,10 @@ class MCPClient(ToolProvider):
                 self._tool_provider_started = True
                 logger.debug("MCP client started successfully")
             except Exception as e:
+                if self._continue_on_error:
+                    logger.warning("error=<%s> | MCP server failed to start, continuing with no tools", e)
+                    self._connection_failed = True
+                    return []
                 logger.error("error=<%s> | failed to start MCP client", e)
                 raise ToolProviderException(f"Failed to start MCP client: {e}") from e
 
@@ -471,6 +499,7 @@ class MCPClient(ToolProvider):
         self._session_id = uuid.uuid4()
         self._loaded_tools = None
         self._tool_provider_started = False
+        self._connection_failed = False
         self._consumers = set()
         self._server_task_capable = None
         self._tool_task_support_cache = {}
@@ -1388,6 +1417,7 @@ def _build_client_from_config(name: str, server: dict[str, Any]) -> MCPClient:
         startup_timeout=server.get("startup_timeout", 30),
         tool_filters=_parse_config_tool_filters(name, server.get("tool_filters")),
         prefix=server.get("prefix"),
+        continue_on_error=server.get("continue_on_error", False),
     )
 
 

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
@@ -301,3 +301,17 @@ def test_continue_on_error_passed_to_client(mock_client, transports):
     """The config flag is threaded through to the constructed client so its runtime honors it."""
     MCPClient.load_servers({"srv": {"command": "node", "continue_on_error": True}})
     assert mock_client[0][1]["continue_on_error"] is True
+
+
+def test_mixed_config_non_opted_in_failure_aborts_whole_load(mock_client, transports):
+    """continue_on_error is per-server, not global: a failing server that did not opt in aborts the load.
+
+    A sibling opting in does not extend its tolerance to others.
+    """
+    with pytest.raises(ValueError):
+        MCPClient.load_servers(
+            {
+                "lenient": {"command": "node", "continue_on_error": True},
+                "strict": {"command": "node", "env": {"V": "${NONEXISTENT_VAR}"}},
+            }
+        )

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
@@ -139,12 +139,17 @@ def test_expands_tilde_in_command_and_cwd(mock_client, transports):
 def test_prefix_and_startup_timeout_passed(mock_client, transports):
     MCPClient.load_servers({"srv": {"command": "node", "prefix": "p", "startup_timeout": 5}})
     _, kwargs = mock_client[0]
-    assert kwargs == {"startup_timeout": 5, "tool_filters": None, "prefix": "p"}
+    assert kwargs == {"startup_timeout": 5, "tool_filters": None, "prefix": "p", "continue_on_error": False}
 
 
 def test_default_startup_timeout(mock_client, transports):
     MCPClient.load_servers({"srv": {"command": "node"}})
-    assert mock_client[0][1] == {"startup_timeout": 30, "tool_filters": None, "prefix": None}
+    assert mock_client[0][1] == {
+        "startup_timeout": 30,
+        "tool_filters": None,
+        "prefix": None,
+        "continue_on_error": False,
+    }
 
 
 def test_tool_filters_compiled_to_regex(mock_client, transports):
@@ -264,3 +269,35 @@ def test_non_str_non_dict_config(mock_client, transports):
 def test_skips_disabled_servers(mock_client, transports):
     clients = MCPClient.load_servers({"active": {"command": "node"}, "inactive": {"command": "node", "disabled": True}})
     assert len(clients) == 1
+
+
+# continue_on_error Tests
+
+
+def test_continue_on_error_skips_server_with_failed_config(mock_client, transports):
+    """An early server whose config fails to resolve is skipped, leaving later servers loadable."""
+    clients = MCPClient.load_servers(
+        {
+            "broken": {"command": "node", "env": {"V": "${NONEXISTENT_VAR}"}, "continue_on_error": True},
+            "ok": {"url": "https://example.com/mcp"},
+        }
+    )
+    assert len(clients) == 1
+    # The one surviving client must be "ok" (http), not the broken stdio server that failed to build.
+    _open(mock_client[0][0])
+    transports["http"].assert_called_once_with(url="https://example.com/mcp", headers=None)
+    transports["stdio"].assert_not_called()
+
+
+def test_continue_on_error_logs_warning(mock_client, transports, caplog):
+    with caplog.at_level("WARNING", logger="strands.tools.mcp.mcp_client"):
+        MCPClient.load_servers(
+            {"broken": {"command": "node", "env": {"V": "${NONEXISTENT_VAR}"}, "continue_on_error": True}}
+        )
+    assert "MCP server config failed, skipping" in caplog.text
+
+
+def test_continue_on_error_passed_to_client(mock_client, transports):
+    """The config flag is threaded through to the constructed client so its runtime honors it."""
+    MCPClient.load_servers({"srv": {"command": "node", "continue_on_error": True}})
+    assert mock_client[0][1]["continue_on_error"] is True

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tool_provider.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tool_provider.py
@@ -70,6 +70,31 @@ def test_init_with_tool_filters_and_prefix(mock_transport):
     assert client._tool_provider_started is False
 
 
+def test_continue_on_error_and_connection_failed_accessors(mock_transport):
+    """The public accessors reflect the configured flag and the sticky failed state."""
+    default_client = MCPClient(mock_transport)
+    assert default_client.continue_on_error is False
+    assert default_client.connection_failed is False
+
+    lenient_client = MCPClient(mock_transport, continue_on_error=True)
+    assert lenient_client.continue_on_error is True
+    assert lenient_client.connection_failed is False
+
+    lenient_client._connection_failed = True
+    assert lenient_client.connection_failed is True
+
+
+@pytest.mark.asyncio
+async def test_connection_failed_accessor_reflects_swallowed_failure(mock_transport):
+    """connection_failed flips to True after load_tools swallows a start failure."""
+    client = MCPClient(mock_transport, continue_on_error=True)
+
+    with patch.object(client, "start", side_effect=Exception("Client start failed")):
+        await client.load_tools()
+
+    assert client.connection_failed is True
+
+
 @pytest.mark.asyncio
 async def test_load_tools_starts_client_when_not_started(mock_transport, mock_agent_tool):
     """Test that load_tools starts the client when not already started."""
@@ -124,6 +149,28 @@ async def test_load_tools_returns_empty_when_continue_on_error_and_start_fails(m
         tools = await client.load_tools()
 
     assert tools == []
+
+
+@pytest.mark.asyncio
+async def test_continue_on_error_isolates_connection_failure_from_sibling_clients(mock_transport, mock_agent_tool):
+    """A client whose connection fails yields no tools while a sibling client still loads its own.
+
+    Covers the "other servers stay usable" guarantee at connection time (not just config resolution):
+    one server's failed start() does not affect a separate, healthy client.
+    """
+    failing = MCPClient(mock_transport, continue_on_error=True)
+    healthy = MCPClient(mock_transport)
+
+    with (
+        patch.object(failing, "start", side_effect=Exception("connection refused")),
+        patch.object(healthy, "start"),
+        patch.object(healthy, "list_tools_sync", return_value=PaginatedList([mock_agent_tool])),
+    ):
+        assert await failing.load_tools() == []
+        healthy_tools = await healthy.load_tools()
+
+    assert len(healthy_tools) == 1
+    assert healthy_tools[0] is mock_agent_tool
 
 
 @pytest.mark.asyncio
@@ -374,6 +421,52 @@ def test_remove_consumer_cleanup_failure(mock_transport):
 
         with pytest.raises(ToolProviderException, match="Failed to cleanup MCP client: Cleanup failed"):
             client.remove_consumer("consumer1")
+
+
+def test_remove_consumer_with_cleanup_after_continue_on_error_failure(mock_transport):
+    """A swallowed start failure still triggers cleanup on the last consumer so the sticky flag resets."""
+    client = MCPClient(mock_transport, continue_on_error=True)
+    client._consumers.add("consumer1")
+    client._connection_failed = True  # swallowed failure leaves _tool_provider_started False
+
+    with patch.object(client, "stop") as mock_stop:
+        client.remove_consumer("consumer1")
+
+        # stop() runs despite _tool_provider_started being False, because a failed client needs teardown too
+        mock_stop.assert_called_once_with(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_load_tools_reconnects_for_new_consumer_after_continue_on_error_failure(mock_transport):
+    """A failed client that loses all consumers resets and reconnects for the next consumer.
+
+    Guarantees the failure is sticky only within a connection lifecycle, not for the object's life:
+    successful and failed clients both reset on zero consumers so a recovered server is usable again.
+    """
+    client = MCPClient(mock_transport, continue_on_error=True)
+
+    with patch.object(client, "start") as mock_start, patch.object(client, "list_tools_sync") as mock_list_tools:
+        # First consumer: server is down, failure is swallowed
+        mock_start.side_effect = Exception("Client start failed")
+        client.add_consumer("consumer1")
+        assert await client.load_tools() == []
+        assert client._connection_failed is True
+
+        # Last consumer leaves: real stop() resets _connection_failed (and other reuse state)
+        client.remove_consumer("consumer1")
+        assert client._connection_failed is False
+        assert client._tool_provider_started is False
+
+        # New consumer: server has recovered, start() now succeeds and tools load
+        tool = create_mock_tool(tool_name="recovered_tool")
+        mock_start.side_effect = None
+        mock_list_tools.return_value = PaginatedList([tool])
+        client.add_consumer("consumer2")
+        tools = await client.load_tools()
+
+        assert len(tools) == 1
+        assert tools[0].tool_name == "recovered_tool"
+        assert mock_start.call_count == 2
 
 
 def test_mcp_client_reuse_across_multiple_agents(mock_transport):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tool_provider.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tool_provider.py
@@ -114,6 +114,46 @@ async def test_load_tools_raises_exception_on_client_start_failure(mock_transpor
 
 
 @pytest.mark.asyncio
+async def test_load_tools_returns_empty_when_continue_on_error_and_start_fails(mock_transport):
+    """With continue_on_error, a start failure yields no tools instead of raising."""
+    client = MCPClient(mock_transport, continue_on_error=True)
+
+    with patch.object(client, "start") as mock_start:
+        mock_start.side_effect = Exception("Client start failed")
+
+        tools = await client.load_tools()
+
+    assert tools == []
+
+
+@pytest.mark.asyncio
+async def test_load_tools_logs_warning_when_continue_on_error_swallows_failure(mock_transport, caplog):
+    client = MCPClient(mock_transport, continue_on_error=True)
+
+    with patch.object(client, "start") as mock_start:
+        mock_start.side_effect = Exception("Client start failed")
+        with caplog.at_level("WARNING", logger="strands.tools.mcp.mcp_client"):
+            await client.load_tools()
+
+    assert "MCP server failed to start" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_load_tools_does_not_retry_start_after_continue_on_error_failure(mock_transport):
+    """A swallowed failure is not retried: a second load_tools call doesn't re-run start()."""
+    client = MCPClient(mock_transport, continue_on_error=True)
+
+    with patch.object(client, "start") as mock_start:
+        mock_start.side_effect = Exception("Client start failed")
+
+        await client.load_tools()  # first call swallows the failure
+        tools = await client.load_tools()  # second must short-circuit, not retry start()
+
+        assert tools == []
+        mock_start.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_load_tools_caches_tools(mock_transport, mock_agent_tool):
     """Test that load_tools caches tools and doesn't reload them."""
     client = MCPClient(mock_transport)


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

`MCPClient.load_servers` in the Python SDK currently has no way to tolerate a single bad MCP server - if a server fails to connect, `load_tools` raises, preventing any subsequents servers from initializing and more importantly breaking the overall agent init.

The TypeScript SDK already includes a `continueOnError` param on the client allowing users to denote servers which should not break the agent init if their own connection process fails. This PR adds the Python equivalent.

## Related Issues

<!-- Link to related issues using #issue-number format -->

- https://github.com/strands-agents/harness-sdk/pull/3053
- https://github.com/strands-agents/harness-sdk/pull/2947 (contains `continueOnError`)

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
