### PR TITLE
fix(ci): guard upload-metrics on integration-test job result

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -140,10 +140,14 @@ jobs:
   upload-metrics:
     runs-on: ubuntu-latest
     needs: check-access-and-checkout
-    # Publishes to the team's CloudWatch via STRANDS_INTEG_TEST_ROLE, which a
-    # fork cannot assume — skip on forks so fork runs don't hit a guaranteed
-    # failure. Not a gate: purely observability.
-    if: always() && github.event.repository.fork != true
+    # Publishes to the team's CloudWatch via STRANDS_INTEG_TEST_ROLE. Only run
+    # when the integration-test job actually executed; on fork PRs the auth
+    # environment gate skips the test job and no test-results artifact is
+    # produced, so this job would otherwise fail on artifact download. The
+    # previous github.event.repository.fork guard did not catch this case
+    # because pull_request_target always evaluates that field against the base
+    # repo, which is never a fork.
+    if: needs.check-access-and-checkout.result == 'success' || needs.check-access-and-checkout.result == 'failure'
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Under `pull_request_target`, `github.event.repository` always resolves to the base repo, which is never a fork, so the previous check never skipped fork-PR runs. When the auth environment gate skips the integration-test job on a fork PR, no `test-results` artifact is uploaded, and `upload-metrics` fails on artifact download.

Gating on the integration-test job's own result covers this cleanly and also handles any future case where the tests are skipped for another reason. Not a gate change: `upload-metrics` remains observability-only.
