### PR TITLE
feat(checkpoint): port durable-execution checkpoints to TypeScript

### DIFF
--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -48,6 +48,10 @@
       "types": "./dist/src/multiagent/index.d.ts",
       "default": "./dist/src/multiagent/index.js"
     },
+    "./experimental": {
+      "types": "./dist/src/experimental/index.d.ts",
+      "default": "./dist/src/experimental/index.js"
+    },
     "./vended-tools/notebook": {
       "types": "./dist/src/vended-tools/notebook/index.d.ts",
       "default": "./dist/src/vended-tools/notebook/index.js"

--- a/strands-ts/src/agent/__tests__/agent.checkpoint.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.checkpoint.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import { Checkpoint } from '../../experimental/checkpoint.js'
+import { CheckpointError } from '../../errors.js'
+import type { InvokeArgs } from '../../types/agent.js'
+import { AfterModelCallEvent, AfterToolsEvent, BeforeToolCallEvent } from '../../hooks/events.js'
+
+/** A model that always returns a single tool-use turn (reused across calls). */
+function toolUseModel(): MockMessageModel {
+  return new MockMessageModel().addTurn({ type: 'toolUseBlock', name: 'noop', toolUseId: 'tool-1', input: {} })
+}
+
+describe('Agent checkpointing', () => {
+  describe('constructor flag', () => {
+    it('does not checkpoint by default (checkpointing defaults to false)', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'done' })
+      const agent = new Agent({ model, printer: false })
+
+      const result = await agent.invoke('hi')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.checkpoint).toBeUndefined()
+    })
+
+    it('pauses at a cycle boundary when checkpointing is true', async () => {
+      const agent = new Agent({
+        model: toolUseModel(),
+        tools: [createMockTool('noop', () => 'ok')],
+        checkpointing: true,
+        printer: false,
+      })
+
+      const result = await agent.invoke('hi')
+
+      expect(result.stopReason).toBe('checkpoint')
+      expect(result.checkpoint).toBeDefined()
+    })
+  })
+
+  describe('resume validation', () => {
+    it('throws when a checkpointResume block is passed but checkpointing is false', async () => {
+      const agent = new Agent({ model: toolUseModel(), printer: false })
+      const args = { checkpointResume: { checkpoint: {} } } as unknown as InvokeArgs
+
+      await expect(agent.invoke(args)).rejects.toThrow(/checkpointing: true/)
+    })
+
+    it('throws when the checkpointResume block is missing its checkpoint key', async () => {
+      const agent = new Agent({ model: toolUseModel(), checkpointing: true, printer: false })
+      const args = { checkpointResume: {} } as unknown as InvokeArgs
+
+      await expect(agent.invoke(args)).rejects.toThrow(/checkpoint/)
+    })
+
+    it('throws CheckpointError when the checkpoint schema version is incompatible', async () => {
+      const agent = new Agent({ model: toolUseModel(), checkpointing: true, printer: false })
+      const args = { checkpointResume: { checkpoint: { position: 'after_model', schemaVersion: '0.1' } } } as InvokeArgs
+
+      await expect(agent.invoke(args)).rejects.toThrow(CheckpointError)
+    })
+  })
+
+  describe('cycle boundaries', () => {
+    it('emits an after_model checkpoint (cycle 0) before running tools', async () => {
+      let toolRan = false
+      const agent = new Agent({
+        model: toolUseModel(),
+        tools: [createMockTool('noop', () => ((toolRan = true), 'ok'))],
+        checkpointing: true,
+        printer: false,
+      })
+
+      const result = await agent.invoke('hi')
+
+      expect(result.stopReason).toBe('checkpoint')
+      expect(result.checkpoint?.position).toBe('after_model')
+      expect(result.checkpoint?.cycleIndex).toBe(0)
+      expect(toolRan).toBe(false)
+      // Deferred-append invariant: the assistant tool_use message is NOT appended
+      // at after_model, so the conversation stays reinvokable (no dangling tool_use).
+      const dangling = agent.messages.filter((m) => m.content.some((b) => b.type === 'toolUseBlock'))
+      expect(dangling).toHaveLength(0)
+    })
+
+    it('resuming from after_model runs tools then emits an after_tools checkpoint (cycle 0)', async () => {
+      let toolRan = false
+      const agent = new Agent({
+        model: toolUseModel(),
+        tools: [createMockTool('noop', () => ((toolRan = true), 'ok'))],
+        checkpointing: true,
+        printer: false,
+      })
+
+      const resume = {
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_model', cycleIndex: 0 }).toJSON() },
+      }
+      const result = await agent.invoke(resume)
+
+      expect(result.stopReason).toBe('checkpoint')
+      expect(result.checkpoint?.position).toBe('after_tools')
+      expect(result.checkpoint?.cycleIndex).toBe(0)
+      expect(toolRan).toBe(true)
+    })
+
+    it('resuming from after_tools increments the cycle index for the next after_model checkpoint', async () => {
+      const agent = new Agent({
+        model: toolUseModel(),
+        tools: [createMockTool('noop', () => 'ok')],
+        checkpointing: true,
+        printer: false,
+      })
+
+      const resume = {
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_tools', cycleIndex: 2 }).toJSON() },
+      }
+      const result = await agent.invoke(resume)
+
+      expect(result.stopReason).toBe('checkpoint')
+      expect(result.checkpoint?.position).toBe('after_model')
+      expect(result.checkpoint?.cycleIndex).toBe(3)
+    })
+
+    it('does not checkpoint a plain end-turn cycle (no tool use)', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'done' })
+      const agent = new Agent({ model, checkpointing: true, printer: false })
+
+      const result = await agent.invoke('hi')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.checkpoint).toBeUndefined()
+    })
+
+    it('starts a fresh invocation at cycle 0 (no cycle-index leak between invocations)', async () => {
+      const agent = new Agent({
+        model: toolUseModel(),
+        tools: [createMockTool('noop', () => 'ok')],
+        checkpointing: true,
+        printer: false,
+      })
+
+      // Prior invocation advances an internal position via resume.
+      await agent.invoke({
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_tools', cycleIndex: 5 }).toJSON() },
+      })
+
+      // A fresh, non-resume invocation must start over at cycle 0.
+      const fresh = await agent.invoke('hi')
+      expect(fresh.checkpoint?.position).toBe('after_model')
+      expect(fresh.checkpoint?.cycleIndex).toBe(0)
+    })
+  })
+
+  describe('cancel precedence', () => {
+    it('cancel beats the after_model checkpoint', async () => {
+      // Cancel arrives *during* the model call (via an AfterModelCallEvent hook),
+      // after the top-of-loop cancellation check has already passed. This forces
+      // control through the after_model boundary, where the cancel path must win
+      // over the checkpoint emission. (A pre-aborted signal would instead throw at
+      // the top of the loop and never reach the boundary.)
+      const controller = new AbortController()
+      const agent = new Agent({
+        model: toolUseModel(),
+        tools: [createMockTool('noop', () => 'ok')],
+        checkpointing: true,
+        printer: false,
+      })
+      agent.addHook(AfterModelCallEvent, () => controller.abort())
+
+      const result = await agent.invoke('hi', { cancelSignal: controller.signal })
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(result.checkpoint).toBeUndefined()
+    })
+
+    it('cancel beats the after_tools checkpoint', async () => {
+      const controller = new AbortController()
+      const agent = new Agent({
+        model: toolUseModel(),
+        // Tool aborts mid-execution; the after_tools checkpoint must yield to cancel.
+        tools: [createMockTool('noop', () => (controller.abort(), 'ok'))],
+        checkpointing: true,
+        printer: false,
+      })
+
+      // Resume from after_model so tools execute this invocation.
+      const resume = {
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_model', cycleIndex: 0 }).toJSON() },
+      }
+      const result = await agent.invoke(resume, { cancelSignal: controller.signal })
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(result.checkpoint).toBeUndefined()
+    })
+  })
+
+  describe('interrupt precedence', () => {
+    it('interrupt beats the after_tools checkpoint', async () => {
+      const agent = new Agent({
+        model: toolUseModel(),
+        tools: [createMockTool('noop', () => 'ok')],
+        checkpointing: true,
+        printer: false,
+      })
+      // A hook interrupts before the tool runs. Resume from after_model so the
+      // cycle reaches tool execution; the interrupt must win over the after_tools
+      // checkpoint that would otherwise fire.
+      agent.addHook(BeforeToolCallEvent, (event) => {
+        event.interrupt({ name: 'confirm', reason: 'ok?' })
+      })
+
+      const resume = {
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_model', cycleIndex: 0 }).toJSON() },
+      }
+      const result = await agent.invoke(resume)
+
+      expect(result.stopReason).toBe('interrupt')
+      expect(result.checkpoint).toBeUndefined()
+    })
+  })
+
+  describe('after_tools suppression', () => {
+    it('a hook-requested endTurn wins over the after_tools checkpoint', async () => {
+      const agent = new Agent({
+        model: toolUseModel(),
+        tools: [createMockTool('noop', () => 'ok')],
+        checkpointing: true,
+        printer: false,
+      })
+      agent.addHook(AfterToolsEvent, (event) => {
+        event.endTurn = true
+      })
+
+      // Resume from after_model so tools run and the after_tools boundary is reached.
+      const resume = {
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_model', cycleIndex: 0 }).toJSON() },
+      }
+      const result = await agent.invoke(resume)
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.checkpoint).toBeUndefined()
+    })
+  })
+})

--- a/strands-ts/src/agent/__tests__/agent.checkpoint.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.checkpoint.test.ts
@@ -40,18 +40,18 @@ describe('Agent checkpointing', () => {
   })
 
   describe('resume validation', () => {
-    it('throws when a checkpointResume block is passed but checkpointing is false', async () => {
+    it('throws CheckpointError when a checkpointResume block is passed but checkpointing is false', async () => {
       const agent = new Agent({ model: toolUseModel(), printer: false })
       const args = { checkpointResume: { checkpoint: {} } } as unknown as InvokeArgs
 
-      await expect(agent.invoke(args)).rejects.toThrow(/checkpointing: true/)
+      await expect(agent.invoke(args)).rejects.toThrow(CheckpointError)
     })
 
-    it('throws when the checkpointResume block is missing its checkpoint key', async () => {
+    it('throws CheckpointError when the checkpointResume block is missing its checkpoint key', async () => {
       const agent = new Agent({ model: toolUseModel(), checkpointing: true, printer: false })
       const args = { checkpointResume: {} } as unknown as InvokeArgs
 
-      await expect(agent.invoke(args)).rejects.toThrow(/checkpoint/)
+      await expect(agent.invoke(args)).rejects.toThrow(CheckpointError)
     })
 
     it('throws CheckpointError when the checkpoint schema version is incompatible', async () => {

--- a/strands-ts/src/agent/__tests__/agent.checkpoint.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.checkpoint.test.ts
@@ -56,14 +56,14 @@ describe('Agent checkpointing', () => {
 
     it('throws CheckpointError when the checkpoint schema version is incompatible', async () => {
       const agent = new Agent({ model: toolUseModel(), checkpointing: true, printer: false })
-      const args = { checkpointResume: { checkpoint: { position: 'after_model', schemaVersion: '0.1' } } } as InvokeArgs
+      const args = { checkpointResume: { checkpoint: { position: 'afterModel', schemaVersion: '0.1' } } } as InvokeArgs
 
       await expect(agent.invoke(args)).rejects.toThrow(CheckpointError)
     })
   })
 
   describe('cycle boundaries', () => {
-    it('emits an after_model checkpoint (cycle 0) before running tools', async () => {
+    it('emits an afterModel checkpoint (cycle 0) before running tools', async () => {
       let toolRan = false
       const agent = new Agent({
         model: toolUseModel(),
@@ -75,16 +75,16 @@ describe('Agent checkpointing', () => {
       const result = await agent.invoke('hi')
 
       expect(result.stopReason).toBe('checkpoint')
-      expect(result.checkpoint?.position).toBe('after_model')
+      expect(result.checkpoint?.position).toBe('afterModel')
       expect(result.checkpoint?.cycleIndex).toBe(0)
       expect(toolRan).toBe(false)
       // Deferred-append invariant: the assistant tool_use message is NOT appended
-      // at after_model, so the conversation stays reinvokable (no dangling tool_use).
+      // at afterModel, so the conversation stays reinvokable (no dangling tool_use).
       const dangling = agent.messages.filter((m) => m.content.some((b) => b.type === 'toolUseBlock'))
       expect(dangling).toHaveLength(0)
     })
 
-    it('resuming from after_model runs tools then emits an after_tools checkpoint (cycle 0)', async () => {
+    it('resuming from afterModel runs tools then emits an afterTools checkpoint (cycle 0)', async () => {
       let toolRan = false
       const agent = new Agent({
         model: toolUseModel(),
@@ -94,17 +94,17 @@ describe('Agent checkpointing', () => {
       })
 
       const resume = {
-        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_model', cycleIndex: 0 }).toJSON() },
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'afterModel', cycleIndex: 0 }).toJSON() },
       }
       const result = await agent.invoke(resume)
 
       expect(result.stopReason).toBe('checkpoint')
-      expect(result.checkpoint?.position).toBe('after_tools')
+      expect(result.checkpoint?.position).toBe('afterTools')
       expect(result.checkpoint?.cycleIndex).toBe(0)
       expect(toolRan).toBe(true)
     })
 
-    it('resuming from after_tools increments the cycle index for the next after_model checkpoint', async () => {
+    it('resuming from afterTools increments the cycle index for the next afterModel checkpoint', async () => {
       const agent = new Agent({
         model: toolUseModel(),
         tools: [createMockTool('noop', () => 'ok')],
@@ -113,12 +113,12 @@ describe('Agent checkpointing', () => {
       })
 
       const resume = {
-        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_tools', cycleIndex: 2 }).toJSON() },
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'afterTools', cycleIndex: 2 }).toJSON() },
       }
       const result = await agent.invoke(resume)
 
       expect(result.stopReason).toBe('checkpoint')
-      expect(result.checkpoint?.position).toBe('after_model')
+      expect(result.checkpoint?.position).toBe('afterModel')
       expect(result.checkpoint?.cycleIndex).toBe(3)
     })
 
@@ -142,21 +142,21 @@ describe('Agent checkpointing', () => {
 
       // Prior invocation advances an internal position via resume.
       await agent.invoke({
-        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_tools', cycleIndex: 5 }).toJSON() },
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'afterTools', cycleIndex: 5 }).toJSON() },
       })
 
       // A fresh, non-resume invocation must start over at cycle 0.
       const fresh = await agent.invoke('hi')
-      expect(fresh.checkpoint?.position).toBe('after_model')
+      expect(fresh.checkpoint?.position).toBe('afterModel')
       expect(fresh.checkpoint?.cycleIndex).toBe(0)
     })
   })
 
   describe('cancel precedence', () => {
-    it('cancel beats the after_model checkpoint', async () => {
+    it('cancel beats the afterModel checkpoint', async () => {
       // Cancel arrives *during* the model call (via an AfterModelCallEvent hook),
       // after the top-of-loop cancellation check has already passed. This forces
-      // control through the after_model boundary, where the cancel path must win
+      // control through the afterModel boundary, where the cancel path must win
       // over the checkpoint emission. (A pre-aborted signal would instead throw at
       // the top of the loop and never reach the boundary.)
       const controller = new AbortController()
@@ -174,19 +174,19 @@ describe('Agent checkpointing', () => {
       expect(result.checkpoint).toBeUndefined()
     })
 
-    it('cancel beats the after_tools checkpoint', async () => {
+    it('cancel beats the afterTools checkpoint', async () => {
       const controller = new AbortController()
       const agent = new Agent({
         model: toolUseModel(),
-        // Tool aborts mid-execution; the after_tools checkpoint must yield to cancel.
+        // Tool aborts mid-execution; the afterTools checkpoint must yield to cancel.
         tools: [createMockTool('noop', () => (controller.abort(), 'ok'))],
         checkpointing: true,
         printer: false,
       })
 
-      // Resume from after_model so tools execute this invocation.
+      // Resume from afterModel so tools execute this invocation.
       const resume = {
-        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_model', cycleIndex: 0 }).toJSON() },
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'afterModel', cycleIndex: 0 }).toJSON() },
       }
       const result = await agent.invoke(resume, { cancelSignal: controller.signal })
 
@@ -196,22 +196,22 @@ describe('Agent checkpointing', () => {
   })
 
   describe('interrupt precedence', () => {
-    it('interrupt beats the after_tools checkpoint', async () => {
+    it('interrupt beats the afterTools checkpoint', async () => {
       const agent = new Agent({
         model: toolUseModel(),
         tools: [createMockTool('noop', () => 'ok')],
         checkpointing: true,
         printer: false,
       })
-      // A hook interrupts before the tool runs. Resume from after_model so the
-      // cycle reaches tool execution; the interrupt must win over the after_tools
+      // A hook interrupts before the tool runs. Resume from afterModel so the
+      // cycle reaches tool execution; the interrupt must win over the afterTools
       // checkpoint that would otherwise fire.
       agent.addHook(BeforeToolCallEvent, (event) => {
         event.interrupt({ name: 'confirm', reason: 'ok?' })
       })
 
       const resume = {
-        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_model', cycleIndex: 0 }).toJSON() },
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'afterModel', cycleIndex: 0 }).toJSON() },
       }
       const result = await agent.invoke(resume)
 
@@ -220,8 +220,8 @@ describe('Agent checkpointing', () => {
     })
   })
 
-  describe('after_tools suppression', () => {
-    it('a hook-requested endTurn wins over the after_tools checkpoint', async () => {
+  describe('afterTools suppression', () => {
+    it('a hook-requested endTurn wins over the afterTools checkpoint', async () => {
       const agent = new Agent({
         model: toolUseModel(),
         tools: [createMockTool('noop', () => 'ok')],
@@ -232,9 +232,9 @@ describe('Agent checkpointing', () => {
         event.endTurn = true
       })
 
-      // Resume from after_model so tools run and the after_tools boundary is reached.
+      // Resume from afterModel so tools run and the afterTools boundary is reached.
       const resume = {
-        checkpointResume: { checkpoint: new Checkpoint({ position: 'after_model', cycleIndex: 0 }).toJSON() },
+        checkpointResume: { checkpoint: new Checkpoint({ position: 'afterModel', cycleIndex: 0 }).toJSON() },
       }
       const result = await agent.invoke(resume)
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -297,8 +297,8 @@ export type AgentConfig = {
    */
   toolExecutor?: ToolExecutorStrategy
   /**
-   * When `true`, the agent loop pauses at cycle boundaries (`after_model`,
-   * `after_tools`) and returns `stopReason: 'checkpoint'` with a populated
+   * When `true`, the agent loop pauses at cycle boundaries (`afterModel`,
+   * `afterTools`) and returns `stopReason: 'checkpoint'` with a populated
    * `checkpoint` field. Resume by passing the checkpoint back as
    * `{ checkpointResume: { checkpoint: ... } }`.
    *
@@ -1393,10 +1393,10 @@ export class Agent implements LocalAgent, InvokableAgent {
     let cycleIndex = 0
     let resumePosition: CheckpointPosition | undefined
     if (resumeCheckpoint) {
-      // after_tools means the cycle finished; the next after_model checkpoint
+      // afterTools means the cycle finished; the next afterModel checkpoint
       // belongs to the following cycle.
       cycleIndex =
-        resumeCheckpoint.position === 'after_tools' ? resumeCheckpoint.cycleIndex + 1 : resumeCheckpoint.cycleIndex
+        resumeCheckpoint.position === 'afterTools' ? resumeCheckpoint.cycleIndex + 1 : resumeCheckpoint.cycleIndex
       resumePosition = resumeCheckpoint.position
       currentArgs = undefined
     }
@@ -1559,8 +1559,8 @@ export class Agent implements LocalAgent, InvokableAgent {
               return result
             }
 
-            // after_model checkpoint: model returned tool use, tools have not run
-            // yet. Skipped when resuming from an after_model checkpoint: the
+            // afterModel checkpoint: model returned tool use, tools have not run
+            // yet. Skipped when resuming from an afterModel checkpoint: the
             // assistant tool-use message was not persisted (deferred append), so
             // this cycle re-invoked the model to regenerate it — now fall through
             // to run the tools. Cancel wins — the isCancelled branch above returns
@@ -1568,7 +1568,7 @@ export class Agent implements LocalAgent, InvokableAgent {
             if (this._checkpointing) {
               const priorResumePosition = resumePosition
               resumePosition = undefined
-              if (priorResumePosition !== 'after_model') {
+              if (priorResumePosition !== 'afterModel') {
                 this._meter.endCycle(cycleStartTime)
                 this._tracer.endAgentLoopSpan(cycleSpan)
                 result = new AgentResult({
@@ -1577,7 +1577,7 @@ export class Agent implements LocalAgent, InvokableAgent {
                   traces: this._tracer.localTraces,
                   metrics: this._meter.metrics,
                   invocationState,
-                  checkpoint: new Checkpoint({ position: 'after_model', cycleIndex }),
+                  checkpoint: new Checkpoint({ position: 'afterModel', cycleIndex }),
                 })
                 return result
               }
@@ -1657,7 +1657,7 @@ export class Agent implements LocalAgent, InvokableAgent {
             return result
           }
 
-          // after_tools checkpoint: tools finished, next model call pending. Placed
+          // afterTools checkpoint: tools finished, next model call pending. Placed
           // after the endTurn / structured-output returns so it only fires when the
           // loop would continue. Cancel wins: skip when cancelled and let the next
           // iteration's cancellation check return `cancelled`.
@@ -1668,7 +1668,7 @@ export class Agent implements LocalAgent, InvokableAgent {
               traces: this._tracer.localTraces,
               metrics: this._meter.metrics,
               invocationState,
-              checkpoint: new Checkpoint({ position: 'after_tools', cycleIndex }),
+              checkpoint: new Checkpoint({ position: 'afterTools', cycleIndex }),
             })
             return result
           }

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -112,6 +112,7 @@ import { DefaultModelRetryStrategy } from '../retry/default-model-retry-strategy
 import type { RetryStrategy } from '../retry/retry-strategy.js'
 import { warnOnDuplicateRetryStrategyTypes } from '../retry/retry-strategy.js'
 import { Interrupt, InterruptError, InterruptState, interruptFromAgent } from '../interrupt.js'
+import { Checkpoint, type CheckpointPosition, type CheckpointResumeContent } from '../experimental/checkpoint.js'
 import type { InterruptParams } from '../types/interrupt.js'
 import { isInterruptResponseContent, type InterruptResponseContent } from '../types/interrupt.js'
 import { takeSnapshot as takeSnapshotInternal, loadSnapshot as loadSnapshotInternal } from './snapshot.js'
@@ -295,6 +296,19 @@ export type AgentConfig = {
    * Defaults to `'concurrent'`. See {@link ToolExecutorStrategy} for details.
    */
   toolExecutor?: ToolExecutorStrategy
+  /**
+   * When `true`, the agent loop pauses at cycle boundaries (`after_model`,
+   * `after_tools`) and returns `stopReason: 'checkpoint'` with a populated
+   * `checkpoint` field. Resume by passing the checkpoint back as
+   * `{ checkpointResume: { checkpoint: ... } }`.
+   *
+   * The SDK does not capture conversation state in the checkpoint; pair with a
+   * `SessionManager` for cross-process state continuity. Defaults to `false`.
+   * See the experimental checkpoint module.
+   *
+   * @experimental
+   */
+  checkpointing?: boolean
   /**
    * Execution environment for running commands, code, and file operations.
    * When provided, sandbox-aware tools route operations through it.
@@ -480,6 +494,8 @@ export class Agent implements LocalAgent, InvokableAgent {
   _interruptState: InterruptState
   /** Strategy for executing tool calls from a single assistant turn. */
   private readonly _toolExecutor: ToolExecutorStrategy
+  /** When true, the agent loop pauses at cycle boundaries for durable execution. */
+  private readonly _checkpointing: boolean
   /** Direct tool caller — created via {@link ToolCaller.create} factory. */
   private readonly _toolCaller: ToolCallerProxy
 
@@ -606,6 +622,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     this._interruptState = new InterruptState()
 
     this._toolExecutor = config?.toolExecutor ?? 'concurrent'
+    this._checkpointing = config?.checkpointing ?? false
     // Pass a private helper into ToolCaller so message append + hook firing
     // remains an internal concern of Agent (not exposed as a public method).
     this._toolCaller = ToolCaller.create(this, (message, invocationState) =>
@@ -939,7 +956,7 @@ export class Agent implements LocalAgent, InvokableAgent {
   /**
    * Cancels the current agent invocation cooperatively.
    *
-   * The agent will stop at the next cancellation checkpoint:
+   * The agent will stop at the next cancellation-safe point:
    * - During model response streaming
    * - Before tool execution
    * - Between sequential tool executions
@@ -1368,6 +1385,22 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     this._validateLimits(options)
 
+    // Checkpoint resume: consume a { checkpointResume: { checkpoint } } arg.
+    // On resume we append no new input and re-derive the cycle position from the
+    // checkpoint. `cycleIndex` and `resumePosition` are loop-local, so a stale
+    // position never leaks from a prior invocation.
+    const resumeCheckpoint = this._extractCheckpointResume(args)
+    let cycleIndex = 0
+    let resumePosition: CheckpointPosition | undefined
+    if (resumeCheckpoint) {
+      // after_tools means the cycle finished; the next after_model checkpoint
+      // belongs to the following cycle.
+      cycleIndex =
+        resumeCheckpoint.position === 'after_tools' ? resumeCheckpoint.cycleIndex + 1 : resumeCheckpoint.cycleIndex
+      resumePosition = resumeCheckpoint.position
+      currentArgs = undefined
+    }
+
     // Resolve structured output schema from per-invocation options or constructor config
     const structuredOutputSchema = options?.structuredOutputSchema ?? this._structuredOutputSchema
     const structuredOutputTool = structuredOutputSchema ? new StructuredOutputTool(structuredOutputSchema) : undefined
@@ -1526,6 +1559,28 @@ export class Agent implements LocalAgent, InvokableAgent {
               return result
             }
 
+            // after_model checkpoint: model returned tool use, tools have not run
+            // yet. Skipped when resuming from an after_model checkpoint (we already
+            // emitted it last time and now proceed to run the tools). Cancel wins —
+            // the isCancelled branch above returns before we reach here.
+            if (this._checkpointing) {
+              const priorResumePosition = resumePosition
+              resumePosition = undefined
+              if (priorResumePosition !== 'after_model') {
+                this._meter.endCycle(cycleStartTime)
+                this._tracer.endAgentLoopSpan(cycleSpan)
+                result = new AgentResult({
+                  stopReason: 'checkpoint',
+                  lastMessage: modelResult.message,
+                  traces: this._tracer.localTraces,
+                  metrics: this._meter.metrics,
+                  invocationState,
+                  checkpoint: new Checkpoint({ position: 'after_model', cycleIndex }),
+                })
+                return result
+              }
+            }
+
             assistantMessage = modelResult.message
           }
 
@@ -1596,6 +1651,22 @@ export class Agent implements LocalAgent, InvokableAgent {
               structuredOutput,
               metrics: this._meter.metrics,
               invocationState,
+            })
+            return result
+          }
+
+          // after_tools checkpoint: tools finished, next model call pending. Placed
+          // after the endTurn / structured-output returns so it only fires when the
+          // loop would continue. Cancel wins: skip when cancelled and let the next
+          // iteration's cancellation check return `cancelled`.
+          if (this._checkpointing && !this.isCancelled) {
+            result = new AgentResult({
+              stopReason: 'checkpoint',
+              lastMessage: assistantMessage,
+              traces: this._tracer.localTraces,
+              metrics: this._meter.metrics,
+              invocationState,
+              checkpoint: new Checkpoint({ position: 'after_tools', cycleIndex }),
             })
             return result
           }
@@ -1739,6 +1810,36 @@ export class Agent implements LocalAgent, InvokableAgent {
     }
 
     return responses
+  }
+
+  /**
+   * Consumes a `{ checkpointResume: { checkpoint } }` invocation argument,
+   * returning the reconstructed {@link Checkpoint} or `undefined` when the args
+   * are not a checkpoint-resume payload.
+   *
+   * @throws Error if a checkpointResume block is passed but the agent was
+   *   created with `checkpointing: false`, or if the block is missing its
+   *   `checkpoint` key.
+   * @throws CheckpointError if the checkpoint schema version is incompatible.
+   */
+  private _extractCheckpointResume(args: InvokeArgs): Checkpoint | undefined {
+    if (typeof args !== 'object' || args === null || Array.isArray(args) || !('checkpointResume' in args)) {
+      return undefined
+    }
+
+    if (!this._checkpointing) {
+      throw new Error(
+        'Received checkpointResume block but agent was created with checkpointing: false. ' +
+          'Pass checkpointing: true when constructing the Agent.'
+      )
+    }
+
+    const payload = (args as CheckpointResumeContent).checkpointResume
+    if (typeof payload !== 'object' || payload === null || !('checkpoint' in payload)) {
+      throw new Error('checkpoint | missing required key in checkpointResume block')
+    }
+
+    return Checkpoint.fromJSON(payload.checkpoint)
   }
 
   /**

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1560,9 +1560,11 @@ export class Agent implements LocalAgent, InvokableAgent {
             }
 
             // after_model checkpoint: model returned tool use, tools have not run
-            // yet. Skipped when resuming from an after_model checkpoint (we already
-            // emitted it last time and now proceed to run the tools). Cancel wins —
-            // the isCancelled branch above returns before we reach here.
+            // yet. Skipped when resuming from an after_model checkpoint: the
+            // assistant tool-use message was not persisted (deferred append), so
+            // this cycle re-invoked the model to regenerate it — now fall through
+            // to run the tools. Cancel wins — the isCancelled branch above returns
+            // before we reach here.
             if (this._checkpointing) {
               const priorResumePosition = resumePosition
               resumePosition = undefined

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -107,7 +107,7 @@ import { Tracer } from '../telemetry/tracer.js'
 import { AgentMetrics, Meter } from '../telemetry/meter.js'
 import type { AttributeValue } from '@opentelemetry/api'
 import { logger } from '../logging/logger.js'
-import { CancelledError } from '../errors.js'
+import { CancelledError, CheckpointError } from '../errors.js'
 import { DefaultModelRetryStrategy } from '../retry/default-model-retry-strategy.js'
 import type { RetryStrategy } from '../retry/retry-strategy.js'
 import { warnOnDuplicateRetryStrategyTypes } from '../retry/retry-strategy.js'
@@ -1817,10 +1817,9 @@ export class Agent implements LocalAgent, InvokableAgent {
    * returning the reconstructed {@link Checkpoint} or `undefined` when the args
    * are not a checkpoint-resume payload.
    *
-   * @throws Error if a checkpointResume block is passed but the agent was
-   *   created with `checkpointing: false`, or if the block is missing its
-   *   `checkpoint` key.
-   * @throws CheckpointError if the checkpoint schema version is incompatible.
+   * @throws CheckpointError if a checkpointResume block is passed but the agent
+   *   was created with `checkpointing: false`, if the block is missing its
+   *   `checkpoint` key, or if the checkpoint schema version is incompatible.
    */
   private _extractCheckpointResume(args: InvokeArgs): Checkpoint | undefined {
     if (typeof args !== 'object' || args === null || Array.isArray(args) || !('checkpointResume' in args)) {
@@ -1828,15 +1827,15 @@ export class Agent implements LocalAgent, InvokableAgent {
     }
 
     if (!this._checkpointing) {
-      throw new Error(
-        'Received checkpointResume block but agent was created with checkpointing: false. ' +
+      throw new CheckpointError(
+        'Received a checkpointResume block but the agent was created with checkpointing: false. ' +
           'Pass checkpointing: true when constructing the Agent.'
       )
     }
 
     const payload = (args as CheckpointResumeContent).checkpointResume
     if (typeof payload !== 'object' || payload === null || !('checkpoint' in payload)) {
-      throw new Error('checkpoint | missing required key in checkpointResume block')
+      throw new CheckpointError('The checkpointResume block is missing its required "checkpoint" key.')
     }
 
     return Checkpoint.fromJSON(payload.checkpoint)

--- a/strands-ts/src/errors.ts
+++ b/strands-ts/src/errors.ts
@@ -254,3 +254,14 @@ export class DefaultNotConfiguredError extends Error {
     this.name = 'DefaultNotConfiguredError'
   }
 }
+
+/**
+ * Error thrown when checkpoint operations fail (e.g. an incompatible schema
+ * version when resuming a durable run). See the experimental checkpoint module.
+ */
+export class CheckpointError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CheckpointError'
+  }
+}

--- a/strands-ts/src/experimental/__tests__/checkpoint.test.ts
+++ b/strands-ts/src/experimental/__tests__/checkpoint.test.ts
@@ -9,19 +9,12 @@ describe('Checkpoint serialization', () => {
   })
 
   it('round-trips through toJSON/fromJSON', () => {
-    const checkpoint = new Checkpoint({
-      position: 'after_model',
-      cycleIndex: 1,
-      snapshot: { messages: [] },
-      appData: { workflowId: 'wf-123' },
-    })
+    const checkpoint = new Checkpoint({ position: 'after_model', cycleIndex: 1 })
 
     const restored = Checkpoint.fromJSON(checkpoint.toJSON())
 
     expect(restored.position).toBe('after_model')
     expect(restored.cycleIndex).toBe(1)
-    expect(restored.snapshot).toEqual({ messages: [] })
-    expect(restored.appData).toEqual({ workflowId: 'wf-123' })
     expect(restored.schemaVersion).toBe(CHECKPOINT_SCHEMA_VERSION)
   })
 
@@ -30,11 +23,9 @@ describe('Checkpoint serialization', () => {
     expect(checkpoint.schemaVersion).toBe(CHECKPOINT_SCHEMA_VERSION)
   })
 
-  it('applies defaults for cycleIndex, snapshot, and appData', () => {
+  it('defaults cycleIndex to 0', () => {
     const checkpoint = new Checkpoint({ position: 'after_model' })
     expect(checkpoint.cycleIndex).toBe(0)
-    expect(checkpoint.snapshot).toEqual({})
-    expect(checkpoint.appData).toEqual({})
   })
 
   it('throws CheckpointError on schema version mismatch', () => {
@@ -44,7 +35,7 @@ describe('Checkpoint serialization', () => {
   })
 
   it('throws CheckpointError when schemaVersion is missing', () => {
-    const data: CheckpointData = { position: 'after_model', cycleIndex: 0, snapshot: {}, appData: {} }
+    const data: CheckpointData = { position: 'after_model', cycleIndex: 0 }
     expect(() => Checkpoint.fromJSON(data)).toThrow(CheckpointError)
     expect(() => Checkpoint.fromJSON(data)).toThrow(/not compatible with current version/)
   })
@@ -60,5 +51,26 @@ describe('Checkpoint serialization', () => {
     // The unknown field is ignored, not carried onto the reconstructed checkpoint.
     expect(restored).not.toHaveProperty('unknownFutureField')
     expect(restored.toJSON()).not.toHaveProperty('unknownFutureField')
+  })
+
+  it('ignores legacy snapshot/appData fields from older serialized checkpoints', () => {
+    // Checkpoints serialized before snapshot/appData were removed must still
+    // deserialize: the now-unknown keys are warned about and dropped.
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const data = {
+      position: 'after_tools',
+      cycleIndex: 2,
+      snapshot: { messages: [] },
+      appData: { workflowId: 'wf-123' },
+      schemaVersion: CHECKPOINT_SCHEMA_VERSION,
+    } as unknown as CheckpointData
+
+    const restored = Checkpoint.fromJSON(data)
+
+    expect(restored.position).toBe('after_tools')
+    expect(restored.cycleIndex).toBe(2)
+    expect(restored).not.toHaveProperty('snapshot')
+    expect(restored).not.toHaveProperty('appData')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('snapshot'))
   })
 })

--- a/strands-ts/src/experimental/__tests__/checkpoint.test.ts
+++ b/strands-ts/src/experimental/__tests__/checkpoint.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CHECKPOINT_SCHEMA_VERSION, Checkpoint, type CheckpointData } from '../checkpoint.js'
+import { CheckpointError } from '../../errors.js'
+import { logger } from '../../logging/logger.js'
+
+describe('Checkpoint serialization', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('round-trips through toJSON/fromJSON', () => {
+    const checkpoint = new Checkpoint({
+      position: 'after_model',
+      cycleIndex: 1,
+      snapshot: { messages: [] },
+      appData: { workflowId: 'wf-123' },
+    })
+
+    const restored = Checkpoint.fromJSON(checkpoint.toJSON())
+
+    expect(restored.position).toBe('after_model')
+    expect(restored.cycleIndex).toBe(1)
+    expect(restored.snapshot).toEqual({ messages: [] })
+    expect(restored.appData).toEqual({ workflowId: 'wf-123' })
+    expect(restored.schemaVersion).toBe(CHECKPOINT_SCHEMA_VERSION)
+  })
+
+  it('always sets schemaVersion to the current constant', () => {
+    const checkpoint = new Checkpoint({ position: 'after_tools' })
+    expect(checkpoint.schemaVersion).toBe(CHECKPOINT_SCHEMA_VERSION)
+  })
+
+  it('applies defaults for cycleIndex, snapshot, and appData', () => {
+    const checkpoint = new Checkpoint({ position: 'after_model' })
+    expect(checkpoint.cycleIndex).toBe(0)
+    expect(checkpoint.snapshot).toEqual({})
+    expect(checkpoint.appData).toEqual({})
+  })
+
+  it('throws CheckpointError on schema version mismatch', () => {
+    const data = { ...new Checkpoint({ position: 'after_model' }).toJSON(), schemaVersion: '0.0' }
+    expect(() => Checkpoint.fromJSON(data)).toThrow(CheckpointError)
+    expect(() => Checkpoint.fromJSON(data)).toThrow(/not compatible with current version/)
+  })
+
+  it('throws CheckpointError when schemaVersion is missing', () => {
+    const data: CheckpointData = { position: 'after_model', cycleIndex: 0, snapshot: {}, appData: {} }
+    expect(() => Checkpoint.fromJSON(data)).toThrow(CheckpointError)
+    expect(() => Checkpoint.fromJSON(data)).toThrow(/not compatible with current version/)
+  })
+
+  it('warns and ignores unknown fields', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const data = { ...new Checkpoint({ position: 'after_tools' }).toJSON(), unknownFutureField: 'something' }
+
+    const restored = Checkpoint.fromJSON(data)
+
+    expect(restored.position).toBe('after_tools')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknownFutureField'))
+    // The unknown field is ignored, not carried onto the reconstructed checkpoint.
+    expect(restored).not.toHaveProperty('unknownFutureField')
+    expect(restored.toJSON()).not.toHaveProperty('unknownFutureField')
+  })
+})

--- a/strands-ts/src/experimental/__tests__/checkpoint.test.ts
+++ b/strands-ts/src/experimental/__tests__/checkpoint.test.ts
@@ -13,9 +13,11 @@ describe('Checkpoint serialization', () => {
 
     const restored = Checkpoint.fromJSON(checkpoint.toJSON())
 
-    expect(restored.position).toBe('after_model')
-    expect(restored.cycleIndex).toBe(1)
-    expect(restored.schemaVersion).toBe(CHECKPOINT_SCHEMA_VERSION)
+    expect(restored.toJSON()).toEqual({
+      position: 'after_model',
+      cycleIndex: 1,
+      schemaVersion: CHECKPOINT_SCHEMA_VERSION,
+    })
   })
 
   it('always sets schemaVersion to the current constant', () => {

--- a/strands-ts/src/experimental/__tests__/checkpoint.test.ts
+++ b/strands-ts/src/experimental/__tests__/checkpoint.test.ts
@@ -52,25 +52,4 @@ describe('Checkpoint serialization', () => {
     expect(restored).not.toHaveProperty('unknownFutureField')
     expect(restored.toJSON()).not.toHaveProperty('unknownFutureField')
   })
-
-  it('ignores legacy snapshot/appData fields from older serialized checkpoints', () => {
-    // Checkpoints serialized before snapshot/appData were removed must still
-    // deserialize: the now-unknown keys are warned about and dropped.
-    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
-    const data = {
-      position: 'after_tools',
-      cycleIndex: 2,
-      snapshot: { messages: [] },
-      appData: { workflowId: 'wf-123' },
-      schemaVersion: CHECKPOINT_SCHEMA_VERSION,
-    } as unknown as CheckpointData
-
-    const restored = Checkpoint.fromJSON(data)
-
-    expect(restored.position).toBe('after_tools')
-    expect(restored.cycleIndex).toBe(2)
-    expect(restored).not.toHaveProperty('snapshot')
-    expect(restored).not.toHaveProperty('appData')
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('snapshot'))
-  })
 })

--- a/strands-ts/src/experimental/__tests__/checkpoint.test.ts
+++ b/strands-ts/src/experimental/__tests__/checkpoint.test.ts
@@ -9,46 +9,46 @@ describe('Checkpoint serialization', () => {
   })
 
   it('round-trips through toJSON/fromJSON', () => {
-    const checkpoint = new Checkpoint({ position: 'after_model', cycleIndex: 1 })
+    const checkpoint = new Checkpoint({ position: 'afterModel', cycleIndex: 1 })
 
     const restored = Checkpoint.fromJSON(checkpoint.toJSON())
 
     expect(restored.toJSON()).toEqual({
-      position: 'after_model',
+      position: 'afterModel',
       cycleIndex: 1,
       schemaVersion: CHECKPOINT_SCHEMA_VERSION,
     })
   })
 
   it('always sets schemaVersion to the current constant', () => {
-    const checkpoint = new Checkpoint({ position: 'after_tools' })
+    const checkpoint = new Checkpoint({ position: 'afterTools' })
     expect(checkpoint.schemaVersion).toBe(CHECKPOINT_SCHEMA_VERSION)
   })
 
   it('defaults cycleIndex to 0', () => {
-    const checkpoint = new Checkpoint({ position: 'after_model' })
+    const checkpoint = new Checkpoint({ position: 'afterModel' })
     expect(checkpoint.cycleIndex).toBe(0)
   })
 
   it('throws CheckpointError on schema version mismatch', () => {
-    const data = { ...new Checkpoint({ position: 'after_model' }).toJSON(), schemaVersion: '0.0' }
+    const data = { ...new Checkpoint({ position: 'afterModel' }).toJSON(), schemaVersion: '0.0' }
     expect(() => Checkpoint.fromJSON(data)).toThrow(CheckpointError)
     expect(() => Checkpoint.fromJSON(data)).toThrow(/not compatible with current version/)
   })
 
   it('throws CheckpointError when schemaVersion is missing', () => {
-    const data: CheckpointData = { position: 'after_model', cycleIndex: 0 }
+    const data: CheckpointData = { position: 'afterModel', cycleIndex: 0 }
     expect(() => Checkpoint.fromJSON(data)).toThrow(CheckpointError)
     expect(() => Checkpoint.fromJSON(data)).toThrow(/not compatible with current version/)
   })
 
   it('warns and ignores unknown fields', () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
-    const data = { ...new Checkpoint({ position: 'after_tools' }).toJSON(), unknownFutureField: 'something' }
+    const data = { ...new Checkpoint({ position: 'afterTools' }).toJSON(), unknownFutureField: 'something' }
 
     const restored = Checkpoint.fromJSON(data)
 
-    expect(restored.position).toBe('after_tools')
+    expect(restored.position).toBe('afterTools')
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknownFutureField'))
     // The unknown field is ignored, not carried onto the reconstructed checkpoint.
     expect(restored).not.toHaveProperty('unknownFutureField')

--- a/strands-ts/src/experimental/checkpoint.ts
+++ b/strands-ts/src/experimental/checkpoint.ts
@@ -10,8 +10,8 @@
  * cross-process state continuity.
  *
  * Positions per ReAct cycle:
- * - `after_model`: model returned tool use; tools have not run yet.
- * - `after_tools`: tools finished; the next model call has not happened yet.
+ * - `afterModel`: model returned tool use; tools have not run yet.
+ * - `afterTools`: tools finished; the next model call has not happened yet.
  *
  * Per-tool granularity within a cycle is the tool executor's responsibility.
  *
@@ -21,7 +21,7 @@
  *
  * Precedence:
  * - Interrupt takes precedence over checkpoint: an interrupt during a
- *   checkpointing cycle returns `stopReason === 'interrupt'` and skips `after_tools`.
+ *   checkpointing cycle returns `stopReason === 'interrupt'` and skips `afterTools`.
  * - Cancel takes precedence over checkpoint: a cancel signal at either boundary
  *   returns `stopReason === 'cancelled'`.
  *
@@ -31,13 +31,13 @@
  * - Metrics reset per invocation; aggregate yourself if needed.
  * - `BeforeInvocationEvent` / `AfterInvocationEvent` fire on every resume,
  *   same as interrupts.
- * - Resuming from `after_model` re-invokes the model. The agent loop defers
+ * - Resuming from `afterModel` re-invokes the model. The agent loop defers
  *   appending the assistant tool-use message until after tools run (so history
  *   never holds a dangling tool-use), which means the tool-use message is not
- *   persisted at `after_model`; on resume the model runs again to regenerate it.
+ *   persisted at `afterModel`; on resume the model runs again to regenerate it.
  *   Completed tools are still never re-run — they execute once and their results
- *   persist at `after_tools`, which is the deterministic boundary. (In the Python
- *   SDK the assistant message is appended eagerly, so its `after_model` resume
+ *   persist at `afterTools`, which is the deterministic boundary. (In the Python
+ *   SDK the assistant message is appended eagerly, so its `afterModel` resume
  *   reuses the persisted message instead of re-invoking the model.)
  */
 
@@ -55,12 +55,12 @@ export const CHECKPOINT_SCHEMA_VERSION = '1.0'
 
 /**
  * Which cycle boundary a checkpoint was emitted at.
- * - `after_model`: model returned tool use; tools have not run yet.
- * - `after_tools`: tools finished; the next model call has not happened yet.
+ * - `afterModel`: model returned tool use; tools have not run yet.
+ * - `afterTools`: tools finished; the next model call has not happened yet.
  *
  * @experimental
  */
-export type CheckpointPosition = 'after_model' | 'after_tools'
+export type CheckpointPosition = 'afterModel' | 'afterTools'
 
 /**
  * Serialized form of a {@link Checkpoint}, as produced by {@link Checkpoint.toJSON}
@@ -93,7 +93,7 @@ export interface CheckpointResumeContent {
  * @experimental
  */
 export class Checkpoint {
-  /** Which boundary fired (`after_model` or `after_tools`). */
+  /** Which boundary fired (`afterModel` or `afterTools`). */
   readonly position: CheckpointPosition
 
   /** ReAct loop cycle (0-based). */

--- a/strands-ts/src/experimental/checkpoint.ts
+++ b/strands-ts/src/experimental/checkpoint.ts
@@ -31,6 +31,14 @@
  * - Metrics reset per invocation; aggregate yourself if needed.
  * - `BeforeInvocationEvent` / `AfterInvocationEvent` fire on every resume,
  *   same as interrupts.
+ * - Resuming from `after_model` re-invokes the model. The agent loop defers
+ *   appending the assistant tool-use message until after tools run (so history
+ *   never holds a dangling tool-use), which means the tool-use message is not
+ *   persisted at `after_model`; on resume the model runs again to regenerate it.
+ *   Completed tools are still never re-run — they execute once and their results
+ *   persist at `after_tools`, which is the deterministic boundary. (In the Python
+ *   SDK the assistant message is appended eagerly, so its `after_model` resume
+ *   reuses the persisted message instead of re-invoking the model.)
  */
 
 import { logger } from '../logging/logger.js'

--- a/strands-ts/src/experimental/checkpoint.ts
+++ b/strands-ts/src/experimental/checkpoint.ts
@@ -63,6 +63,7 @@ export type CheckpointPosition = 'after_model' | 'after_tools'
 export interface CheckpointData {
   position: CheckpointPosition
   cycleIndex?: number
+  /** Populated by {@link Checkpoint.toJSON}. {@link Checkpoint.fromJSON} requires it to match the current version. */
   schemaVersion?: string
 }
 
@@ -70,13 +71,9 @@ export interface CheckpointData {
  * Resume payload passed back to a checkpointing agent to continue a durable run.
  * The whole invocation argument is this object; the agent consumes it, restores
  * its cycle position, and continues without appending any new input messages.
+ * Resume with `{ checkpointResume: { checkpoint: ckpt.toJSON() } }`.
  *
  * @experimental
- *
- * @example
- * ```typescript
- * const result = await agent.invoke({ checkpointResume: { checkpoint: saved } })
- * ```
  */
 export interface CheckpointResumeContent {
   checkpointResume: { checkpoint: CheckpointData }

--- a/strands-ts/src/experimental/checkpoint.ts
+++ b/strands-ts/src/experimental/checkpoint.ts
@@ -1,0 +1,168 @@
+/**
+ * Checkpoint system for durable agent execution.
+ *
+ * **Experimental** — this module is experimental and subject to change in future
+ * revisions without notice.
+ *
+ * A {@link Checkpoint} is a pause-point marker emitted at agent cycle boundaries.
+ * It captures the position (which boundary fired) and the cycle index. It does
+ * **not** capture conversation state — pair with a `SessionManager` for
+ * cross-process state continuity.
+ *
+ * Positions per ReAct cycle:
+ * - `after_model`: model returned tool use; tools have not run yet.
+ * - `after_tools`: tools finished; the next model call has not happened yet.
+ *
+ * Per-tool granularity within a cycle is the tool executor's responsibility.
+ *
+ * Usage (mirrors interrupts):
+ * - Pause: `AgentResult` with `stopReason === 'checkpoint'` and `checkpoint` populated.
+ * - Resume: pass back `{ checkpointResume: { checkpoint: ckpt.toJSON() } }`.
+ *
+ * Precedence:
+ * - Interrupt takes precedence over checkpoint: an interrupt during a
+ *   checkpointing cycle returns `stopReason === 'interrupt'` and skips `after_tools`.
+ * - Cancel takes precedence over checkpoint: a cancel signal at either boundary
+ *   returns `stopReason === 'cancelled'`.
+ *
+ * Notes:
+ * - Checkpoints are only emitted on tool-use cycles. A turn with no tool calls
+ *   emits no checkpoint; use a `SessionManager` for durability of every turn.
+ * - Metrics reset per invocation; aggregate yourself if needed.
+ * - `BeforeInvocationEvent` / `AfterInvocationEvent` fire on every resume,
+ *   same as interrupts.
+ */
+
+import { logger } from '../logging/logger.js'
+import type { JSONValue } from '../types/json.js'
+import { CheckpointError } from '../errors.js'
+
+/**
+ * Current checkpoint schema version. Bumped when the serialized shape changes
+ * in a way that is not backward compatible; {@link Checkpoint.fromJSON} rejects
+ * checkpoints carrying any other version.
+ *
+ * @experimental
+ */
+export const CHECKPOINT_SCHEMA_VERSION = '1.0'
+
+/**
+ * Which cycle boundary a checkpoint was emitted at.
+ * - `after_model`: model returned tool use; tools have not run yet.
+ * - `after_tools`: tools finished; the next model call has not happened yet.
+ *
+ * @experimental
+ */
+export type CheckpointPosition = 'after_model' | 'after_tools'
+
+/**
+ * Serialized form of a {@link Checkpoint}, as produced by {@link Checkpoint.toJSON}
+ * and accepted by {@link Checkpoint.fromJSON}.
+ *
+ * @experimental
+ */
+export interface CheckpointData {
+  position: CheckpointPosition
+  cycleIndex?: number
+  snapshot?: Record<string, JSONValue>
+  appData?: Record<string, JSONValue>
+  schemaVersion?: string
+}
+
+/**
+ * Resume payload passed back to a checkpointing agent to continue a durable run.
+ * The whole invocation argument is this object; the agent consumes it, restores
+ * its cycle position, and continues without appending any new input messages.
+ *
+ * @experimental
+ *
+ * @example
+ * ```typescript
+ * const result = await agent.invoke({ checkpointResume: { checkpoint: saved } })
+ * ```
+ */
+export interface CheckpointResumeContent {
+  checkpointResume: { checkpoint: CheckpointData }
+}
+
+/**
+ * Pause-point marker. Treat as opaque — pass it back to resume.
+ *
+ * @experimental
+ */
+export class Checkpoint {
+  /** Which boundary fired (`after_model` or `after_tools`). */
+  readonly position: CheckpointPosition
+
+  /** ReAct loop cycle (0-based). */
+  readonly cycleIndex: number
+
+  /** Reserved for forward extensibility. Not read by the SDK; round-trips through serialization. */
+  readonly snapshot: Record<string, JSONValue>
+
+  /** Reserved for caller metadata. Not read by the SDK; round-trips through serialization. */
+  readonly appData: Record<string, JSONValue>
+
+  /**
+   * Schema version. Always set to {@link CHECKPOINT_SCHEMA_VERSION}; not accepted
+   * from the constructor so it cannot be forged. Rejects incompatible checkpoints
+   * on {@link Checkpoint.fromJSON}.
+   */
+  readonly schemaVersion: string = CHECKPOINT_SCHEMA_VERSION
+
+  constructor(data: {
+    position: CheckpointPosition
+    cycleIndex?: number
+    snapshot?: Record<string, JSONValue>
+    appData?: Record<string, JSONValue>
+  }) {
+    this.position = data.position
+    this.cycleIndex = data.cycleIndex ?? 0
+    this.snapshot = data.snapshot ?? {}
+    this.appData = data.appData ?? {}
+  }
+
+  /**
+   * Serializes the checkpoint for persistence.
+   */
+  toJSON(): Required<CheckpointData> {
+    return {
+      position: this.position,
+      cycleIndex: this.cycleIndex,
+      snapshot: this.snapshot,
+      appData: this.appData,
+      schemaVersion: this.schemaVersion,
+    }
+  }
+
+  /**
+   * Reconstructs a checkpoint from a value produced by {@link Checkpoint.toJSON}.
+   * Round-trips cleanly: `Checkpoint.fromJSON(ckpt.toJSON())` type-checks and
+   * returns an equivalent checkpoint.
+   *
+   * @param data - Serialized checkpoint data.
+   * @throws CheckpointError If `schemaVersion` does not match the current version.
+   */
+  static fromJSON(data: CheckpointData): Checkpoint {
+    const version = data.schemaVersion ?? ''
+    if (version !== CHECKPOINT_SCHEMA_VERSION) {
+      throw new CheckpointError(
+        `Checkpoints with schema version ${JSON.stringify(version)} are not compatible ` +
+          `with current version ${CHECKPOINT_SCHEMA_VERSION}.`
+      )
+    }
+
+    const knownKeys = new Set(['position', 'cycleIndex', 'snapshot', 'appData', 'schemaVersion'])
+    const unknownKeys = Object.keys(data).filter((key) => !knownKeys.has(key))
+    if (unknownKeys.length > 0) {
+      logger.warn(`unknown_keys=<${unknownKeys.join(', ')}> | ignoring unknown fields in checkpoint data`)
+    }
+
+    return new Checkpoint({
+      position: data.position,
+      ...(data.cycleIndex !== undefined && { cycleIndex: data.cycleIndex }),
+      ...(data.snapshot !== undefined && { snapshot: data.snapshot }),
+      ...(data.appData !== undefined && { appData: data.appData }),
+    })
+  }
+}

--- a/strands-ts/src/experimental/checkpoint.ts
+++ b/strands-ts/src/experimental/checkpoint.ts
@@ -34,7 +34,6 @@
  */
 
 import { logger } from '../logging/logger.js'
-import type { JSONValue } from '../types/json.js'
 import { CheckpointError } from '../errors.js'
 
 /**
@@ -64,8 +63,6 @@ export type CheckpointPosition = 'after_model' | 'after_tools'
 export interface CheckpointData {
   position: CheckpointPosition
   cycleIndex?: number
-  snapshot?: Record<string, JSONValue>
-  appData?: Record<string, JSONValue>
   schemaVersion?: string
 }
 
@@ -97,12 +94,6 @@ export class Checkpoint {
   /** ReAct loop cycle (0-based). */
   readonly cycleIndex: number
 
-  /** Reserved for forward extensibility. Not read by the SDK; round-trips through serialization. */
-  readonly snapshot: Record<string, JSONValue>
-
-  /** Reserved for caller metadata. Not read by the SDK; round-trips through serialization. */
-  readonly appData: Record<string, JSONValue>
-
   /**
    * Schema version. Always set to {@link CHECKPOINT_SCHEMA_VERSION}; not accepted
    * from the constructor so it cannot be forged. Rejects incompatible checkpoints
@@ -110,16 +101,9 @@ export class Checkpoint {
    */
   readonly schemaVersion: string = CHECKPOINT_SCHEMA_VERSION
 
-  constructor(data: {
-    position: CheckpointPosition
-    cycleIndex?: number
-    snapshot?: Record<string, JSONValue>
-    appData?: Record<string, JSONValue>
-  }) {
+  constructor(data: { position: CheckpointPosition; cycleIndex?: number }) {
     this.position = data.position
     this.cycleIndex = data.cycleIndex ?? 0
-    this.snapshot = data.snapshot ?? {}
-    this.appData = data.appData ?? {}
   }
 
   /**
@@ -129,8 +113,6 @@ export class Checkpoint {
     return {
       position: this.position,
       cycleIndex: this.cycleIndex,
-      snapshot: this.snapshot,
-      appData: this.appData,
       schemaVersion: this.schemaVersion,
     }
   }
@@ -152,7 +134,7 @@ export class Checkpoint {
       )
     }
 
-    const knownKeys = new Set(['position', 'cycleIndex', 'snapshot', 'appData', 'schemaVersion'])
+    const knownKeys = new Set(['position', 'cycleIndex', 'schemaVersion'])
     const unknownKeys = Object.keys(data).filter((key) => !knownKeys.has(key))
     if (unknownKeys.length > 0) {
       logger.warn(`unknown_keys=<${unknownKeys.join(', ')}> | ignoring unknown fields in checkpoint data`)
@@ -161,8 +143,6 @@ export class Checkpoint {
     return new Checkpoint({
       position: data.position,
       ...(data.cycleIndex !== undefined && { cycleIndex: data.cycleIndex }),
-      ...(data.snapshot !== undefined && { snapshot: data.snapshot }),
-      ...(data.appData !== undefined && { appData: data.appData }),
     })
   }
 }

--- a/strands-ts/src/experimental/index.ts
+++ b/strands-ts/src/experimental/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Experimental APIs for the Strands Agents TypeScript SDK.
+ *
+ * Everything exported here is experimental and subject to change in future
+ * revisions without notice.
+ */
+
+export { Checkpoint, CHECKPOINT_SCHEMA_VERSION } from './checkpoint.js'
+export type { CheckpointPosition, CheckpointData, CheckpointResumeContent } from './checkpoint.js'

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -38,12 +38,17 @@ export {
   StructuredOutputError,
   ToolNotFoundError,
   DefaultNotConfiguredError,
+  CheckpointError,
 } from './errors.js'
 
 // Interrupt system
 export type { Interrupt, InterruptSource } from './interrupt.js'
 export type { InterruptParams, InterruptResponse, InterruptResponseContentData } from './types/interrupt.js'
 export { InterruptResponseContent } from './types/interrupt.js'
+
+// Experimental: durable-execution checkpoints
+export { Checkpoint, CHECKPOINT_SCHEMA_VERSION } from './experimental/index.js'
+export type { CheckpointPosition, CheckpointData, CheckpointResumeContent } from './experimental/index.js'
 
 // JSON types
 export type { JSONSchema, JSONValue } from './types/json.js'

--- a/strands-ts/src/multiagent/multiagent.ts
+++ b/strands-ts/src/multiagent/multiagent.ts
@@ -1,4 +1,5 @@
 import type { InvocationState, InvokeArgs } from '../types/agent.js'
+import type { CheckpointResumeContent } from '../experimental/checkpoint.js'
 import type { Message, MessageData } from '../types/messages.js'
 import type { HookableEvent } from '../hooks/events.js'
 import type { HookCallback, HookableEventConstructor, HookCleanup } from '../hooks/types.js'
@@ -18,7 +19,7 @@ import type { MultiAgentResult, MultiAgentState, NodeState } from './state.js'
  * route responses to the interrupted nodes rather than flowing through dependency
  * resolution.
  */
-export type MultiAgentInput = Exclude<InvokeArgs, Message[] | MessageData[]>
+export type MultiAgentInput = Exclude<InvokeArgs, Message[] | MessageData[] | CheckpointResumeContent>
 
 /**
  * The non-resume subset of {@link MultiAgentInput}. Internal orchestrator helpers that

--- a/strands-ts/src/types/__tests__/agent.test.ts
+++ b/strands-ts/src/types/__tests__/agent.test.ts
@@ -6,7 +6,7 @@ import { Message } from '../messages.js'
 import { TextBlock, ReasoningBlock, ToolUseBlock, ToolResultBlock, CachePointBlock } from '../messages.js'
 import { CitationsBlock } from '../citations.js'
 import { Interrupt } from '../../interrupt.js'
-import { Checkpoint } from '../../experimental/checkpoint.js'
+import { Checkpoint, CHECKPOINT_SCHEMA_VERSION } from '../../experimental/checkpoint.js'
 
 describe('AgentResult', () => {
   describe('toString', () => {
@@ -607,10 +607,12 @@ describe('AgentResult', () => {
         invocationState: {},
         checkpoint: new Checkpoint({ position: 'after_tools', cycleIndex: 3 }),
       })
-      const json = result.toJSON() as { checkpoint?: { position: string; cycleIndex: number } }
-      expect(json.checkpoint).toBeDefined()
-      expect(json.checkpoint?.position).toBe('after_tools')
-      expect(json.checkpoint?.cycleIndex).toBe(3)
+      const json = result.toJSON() as { checkpoint?: unknown }
+      expect(json.checkpoint).toEqual({
+        position: 'after_tools',
+        cycleIndex: 3,
+        schemaVersion: CHECKPOINT_SCHEMA_VERSION,
+      })
     })
 
     it('omits checkpoint from toJSON when absent', () => {

--- a/strands-ts/src/types/__tests__/agent.test.ts
+++ b/strands-ts/src/types/__tests__/agent.test.ts
@@ -587,7 +587,7 @@ describe('AgentResult', () => {
     })
 
     it('accepts a checkpoint', () => {
-      const checkpoint = new Checkpoint({ position: 'after_model', cycleIndex: 0 })
+      const checkpoint = new Checkpoint({ position: 'afterModel', cycleIndex: 0 })
       const result = new AgentResult({
         stopReason: 'checkpoint',
         lastMessage: toolUseMessage,
@@ -596,7 +596,7 @@ describe('AgentResult', () => {
         checkpoint,
       })
       expect(result.checkpoint).toBe(checkpoint)
-      expect(result.checkpoint?.position).toBe('after_model')
+      expect(result.checkpoint?.position).toBe('afterModel')
     })
 
     it('includes the serialized checkpoint in toJSON when present', () => {
@@ -605,11 +605,11 @@ describe('AgentResult', () => {
         lastMessage: toolUseMessage,
         metrics: new AgentMetrics(),
         invocationState: {},
-        checkpoint: new Checkpoint({ position: 'after_tools', cycleIndex: 3 }),
+        checkpoint: new Checkpoint({ position: 'afterTools', cycleIndex: 3 }),
       })
       const json = result.toJSON() as { checkpoint?: unknown }
       expect(json.checkpoint).toEqual({
-        position: 'after_tools',
+        position: 'afterTools',
         cycleIndex: 3,
         schemaVersion: CHECKPOINT_SCHEMA_VERSION,
       })

--- a/strands-ts/src/types/__tests__/agent.test.ts
+++ b/strands-ts/src/types/__tests__/agent.test.ts
@@ -6,6 +6,7 @@ import { Message } from '../messages.js'
 import { TextBlock, ReasoningBlock, ToolUseBlock, ToolResultBlock, CachePointBlock } from '../messages.js'
 import { CitationsBlock } from '../citations.js'
 import { Interrupt } from '../../interrupt.js'
+import { Checkpoint } from '../../experimental/checkpoint.js'
 
 describe('AgentResult', () => {
   describe('toString', () => {
@@ -566,6 +567,60 @@ describe('AgentResult', () => {
       })
       expect(apiResponse).not.toHaveProperty('traces')
       expect(apiResponse).not.toHaveProperty('metrics')
+    })
+  })
+
+  describe('checkpoint', () => {
+    const toolUseMessage = new Message({
+      role: 'assistant',
+      content: [new ToolUseBlock({ toolUseId: '1', name: 't', input: {} })],
+    })
+
+    it('defaults checkpoint to undefined', () => {
+      const result = new AgentResult({
+        stopReason: 'endTurn',
+        lastMessage: new Message({ role: 'assistant', content: [new TextBlock('hi')] }),
+        metrics: new AgentMetrics(),
+        invocationState: {},
+      })
+      expect(result.checkpoint).toBeUndefined()
+    })
+
+    it('accepts a checkpoint', () => {
+      const checkpoint = new Checkpoint({ position: 'after_model', cycleIndex: 0 })
+      const result = new AgentResult({
+        stopReason: 'checkpoint',
+        lastMessage: toolUseMessage,
+        metrics: new AgentMetrics(),
+        invocationState: {},
+        checkpoint,
+      })
+      expect(result.checkpoint).toBe(checkpoint)
+      expect(result.checkpoint?.position).toBe('after_model')
+    })
+
+    it('includes the serialized checkpoint in toJSON when present', () => {
+      const result = new AgentResult({
+        stopReason: 'checkpoint',
+        lastMessage: toolUseMessage,
+        metrics: new AgentMetrics(),
+        invocationState: {},
+        checkpoint: new Checkpoint({ position: 'after_tools', cycleIndex: 3 }),
+      })
+      const json = result.toJSON() as { checkpoint?: { position: string; cycleIndex: number } }
+      expect(json.checkpoint).toBeDefined()
+      expect(json.checkpoint?.position).toBe('after_tools')
+      expect(json.checkpoint?.cycleIndex).toBe(3)
+    })
+
+    it('omits checkpoint from toJSON when absent', () => {
+      const result = new AgentResult({
+        stopReason: 'endTurn',
+        lastMessage: new Message({ role: 'assistant', content: [new TextBlock('hi')] }),
+        metrics: new AgentMetrics(),
+        invocationState: {},
+      })
+      expect(result.toJSON()).not.toHaveProperty('checkpoint')
     })
   })
 })

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -3,6 +3,7 @@ import type { StateStore } from '../state-store.js'
 import type { ContentBlock, ContentBlockData, Message, MessageData, StopReason, SystemPrompt } from './messages.js'
 import type { Interrupt } from '../interrupt.js'
 import type { InterruptResponseContent, InterruptResponseContentData } from './interrupt.js'
+import type { Checkpoint, CheckpointResumeContent } from '../experimental/checkpoint.js'
 import type { AgentTrace } from '../telemetry/tracer.js'
 import type { Snapshot } from './snapshot.js'
 import type { TakeSnapshotOptions } from '../agent/snapshot.js'
@@ -49,6 +50,9 @@ import { AgentMetrics } from '../telemetry/meter.js'
  * - `ContentBlock[]` | `ContentBlockData[]` - Array of content blocks (creates single user Message)
  * - `Message[]` | `MessageData[]` - Array of messages (appends all to conversation)
  * - `InterruptResponseContent[]` - Array of interrupt responses (resumes from interrupted state)
+ * - `CheckpointResumeContent` - Resume payload for a checkpointing agent
+ *
+ * @experimental The `CheckpointResumeContent` member is experimental and subject to change.
  */
 export type InvokeArgs =
   | string
@@ -58,6 +62,7 @@ export type InvokeArgs =
   | MessageData[]
   | InterruptResponseContent[]
   | InterruptResponseContentData[]
+  | CheckpointResumeContent
 
 /**
  * Per-invocation state threaded through hooks and tools for a single agent
@@ -439,6 +444,15 @@ export class AgentResult {
    */
   readonly interrupts?: Interrupt[]
 
+  /**
+   * Checkpoint captured when the agent paused for durable execution. Populated
+   * only when `stopReason` is `'checkpoint'`. See the experimental checkpoint
+   * module for usage.
+   *
+   * @experimental
+   */
+  readonly checkpoint?: Checkpoint
+
   constructor(data: {
     stopReason: StopReason
     lastMessage: Message
@@ -447,6 +461,7 @@ export class AgentResult {
     metrics?: AgentMetrics
     structuredOutput?: z.output<z.ZodType>
     interrupts?: Interrupt[]
+    checkpoint?: Checkpoint
   }) {
     this.stopReason = data.stopReason
     this.lastMessage = data.lastMessage
@@ -462,6 +477,9 @@ export class AgentResult {
     }
     if (data.interrupts !== undefined) {
       this.interrupts = data.interrupts
+    }
+    if (data.checkpoint !== undefined) {
+      this.checkpoint = data.checkpoint
     }
   }
 
@@ -499,6 +517,7 @@ export class AgentResult {
       stopReason: this.stopReason,
       lastMessage: this.lastMessage,
       ...(this.structuredOutput !== undefined && { structuredOutput: this.structuredOutput }),
+      ...(this.checkpoint !== undefined && { checkpoint: this.checkpoint.toJSON() }),
     }
   }
 

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -693,6 +693,7 @@ export class JsonBlock implements JsonBlockData, JSONSerializable<JsonBlockData>
  * - `contentFiltered` - Content was filtered by safety mechanisms
  * - `endTurn` - Natural end of the model's turn
  * - `guardrailIntervened` - A guardrail policy stopped generation
+ * - `checkpoint` - Agent paused at a cycle boundary for durable execution (experimental; see experimental checkpoint module)
  * - `interrupt` - Agent execution was interrupted for human input
  * - `maxTokens` - The model provider's per-call token cap was reached
  * - `limitOutputTokens` - Agent loop stopped because `InvokeOptions.limits.outputTokens` was reached
@@ -706,6 +707,7 @@ export class JsonBlock implements JsonBlockData, JSONSerializable<JsonBlockData>
  */
 export type StopReason =
   | 'cancelled'
+  | 'checkpoint'
   | 'contentFiltered'
   | 'endTurn'
   | 'guardrailIntervened'

--- a/strands-ts/test/integ/agent.checkpoint.test.node.ts
+++ b/strands-ts/test/integ/agent.checkpoint.test.node.ts
@@ -132,7 +132,7 @@ describe.skipIf(bedrock.skip)('Agent checkpointing (integration)', () => {
     )
 
     expect(checkpoints.length).toBeGreaterThanOrEqual(1)
-    expect(checkpoints.every((cp) => cp.position === 'after_model' || cp.position === 'after_tools')).toBe(true)
+    expect(checkpoints.every((cp) => cp.position === 'afterModel' || cp.position === 'afterTools')).toBe(true)
 
     // Cycle indices are non-decreasing.
     const cycleIndices = checkpoints.map((cp) => cp.cycleIndex)
@@ -182,7 +182,7 @@ describe.skipIf(bedrock.skip)('Agent checkpointing (integration)', () => {
 
     // The core durable guarantee: completed tool calls are not re-invoked on resume.
     expect(callCounts).toEqual({ time: 1, day: 1, weather: 1 })
-    expect(checkpoints.some((cp) => cp.position === 'after_tools')).toBe(true)
+    expect(checkpoints.some((cp) => cp.position === 'afterTools')).toBe(true)
 
     const text = conversationText(agent)
     expect(text).toContain('12:01')

--- a/strands-ts/test/integ/agent.checkpoint.test.node.ts
+++ b/strands-ts/test/integ/agent.checkpoint.test.node.ts
@@ -1,0 +1,217 @@
+/**
+ * Integration tests for agent checkpointing with Amazon Bedrock.
+ *
+ * These exercise the V0 durable-execution contract: an agent with
+ * `checkpointing: true` pauses at ReAct cycle boundaries and returns an
+ * `AgentResult` with `stopReason: 'checkpoint'` and a populated `checkpoint`.
+ * State persistence is the caller's job; these tests pair checkpointing with a
+ * file-backed `SessionManager` to demonstrate the recommended pattern —
+ * SessionManager for state continuity, Checkpoint for boundary signalling.
+ *
+ * Requires AWS credentials (skipped otherwise) and may incur Bedrock costs.
+ */
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { v7 as uuidv7 } from 'uuid'
+import { z } from 'zod'
+import {
+  Agent,
+  tool,
+  SessionManager,
+  FileStorage,
+  type Checkpoint,
+  type CheckpointData,
+  type Tool,
+} from '@strands-agents/sdk'
+import { bedrock } from './__fixtures__/model-providers.js'
+
+const SYSTEM_PROMPT =
+  'You are a helpful assistant. When a user asks a factual question, you MUST call the ' +
+  'provided tools to answer. Do not answer from memory.'
+
+/**
+ * Build a checkpointing agent backed by a file-based SessionManager. A fresh
+ * agent with the same `sessionId` rehydrates messages from the session store,
+ * so it can resume at a captured checkpoint position.
+ */
+function buildAgent(tools: Tool[], sessionId: string, storageDir: string): Agent {
+  return new Agent({
+    model: bedrock.createModel(),
+    tools,
+    systemPrompt: SYSTEM_PROMPT,
+    sessionManager: new SessionManager({ sessionId, storage: { snapshot: new FileStorage(storageDir) } }),
+    checkpointing: true,
+    printer: false,
+  })
+}
+
+/**
+ * Drive a checkpointing agent to `endTurn` across fresh Agent instances. Each
+ * pause: serialize the checkpoint (round-tripped through JSON to prove it
+ * survives persistence), discard the agent, build a fresh one with the same
+ * `sessionId`, and pass the checkpoint back as a `checkpointResume` block.
+ */
+async function driveToCompletion(
+  tools: Tool[],
+  firstPrompt: string,
+  sessionId: string,
+  storageDir: string,
+  maxResumes = 10
+): Promise<{ agent: Agent; checkpoints: Checkpoint[] }> {
+  let agent = buildAgent(tools, sessionId, storageDir)
+  let result = await agent.invoke(firstPrompt)
+
+  const checkpoints: Checkpoint[] = []
+  let resumes = 0
+  while (result.stopReason === 'checkpoint') {
+    expect(result.checkpoint).toBeDefined()
+    checkpoints.push(result.checkpoint!)
+
+    // Round-trip through JSON to prove the checkpoint survives serialization.
+    const persisted = JSON.parse(JSON.stringify(result.checkpoint!.toJSON())) as CheckpointData
+
+    // Discard the agent; a fresh one with the same sessionId rehydrates messages
+    // from the session store, then resumes at the captured checkpoint position.
+    agent = buildAgent(tools, sessionId, storageDir)
+    result = await agent.invoke({ checkpointResume: { checkpoint: persisted } })
+
+    resumes++
+    if (resumes > maxResumes) {
+      throw new Error(`exceeded maxResumes=${maxResumes} without reaching endTurn`)
+    }
+  }
+
+  expect(result.stopReason).toBe('endTurn')
+  return { agent, checkpoints }
+}
+
+/** Lower-cased concatenation of all text and tool-result text across the agent's messages. */
+function conversationText(agent: Agent): string {
+  const parts: string[] = []
+  for (const message of agent.messages) {
+    for (const block of message.content) {
+      if (block.type === 'textBlock') {
+        parts.push(block.text)
+      } else if (block.type === 'toolResultBlock') {
+        for (const c of block.content) {
+          if ('text' in c && typeof c.text === 'string') parts.push(c.text)
+        }
+      }
+    }
+  }
+  return parts.join(' ').toLowerCase()
+}
+
+describe.skipIf(bedrock.skip)('Agent checkpointing (integration)', () => {
+  let tempDir: string
+
+  beforeAll(async () => {
+    tempDir = join(tmpdir(), `strands-checkpoint-integ-${Date.now()}`)
+    await fs.mkdir(tempDir, { recursive: true })
+  })
+
+  afterAll(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('pauses at a cycle boundary and completes through a fresh agent', async () => {
+    const getColorOfSky = tool({
+      name: 'get_color_of_sky',
+      description: 'Return the color of the sky.',
+      inputSchema: z.object({}),
+      callback: async () => 'blue',
+    })
+
+    const { agent, checkpoints } = await driveToCompletion(
+      [getColorOfSky],
+      'What color is the sky? Use the get_color_of_sky tool.',
+      uuidv7(),
+      tempDir
+    )
+
+    expect(checkpoints.length).toBeGreaterThanOrEqual(1)
+    expect(checkpoints.every((cp) => cp.position === 'after_model' || cp.position === 'after_tools')).toBe(true)
+
+    // Cycle indices are non-decreasing.
+    const cycleIndices = checkpoints.map((cp) => cp.cycleIndex)
+    expect(cycleIndices).toEqual([...cycleIndices].sort((a, b) => a - b))
+
+    // The rehydrated history carries the tool result and a final answer that references it.
+    expect(conversationText(agent)).toContain('blue')
+  })
+
+  it('does not re-run completed tools across a checkpoint resume', async () => {
+    const callCounts = { time: 0, day: 0, weather: 0 }
+
+    const getTime = tool({
+      name: 'get_time',
+      description: 'Return the current time.',
+      inputSchema: z.object({}),
+      callback: async () => {
+        callCounts.time++
+        return '12:01'
+      },
+    })
+    const getDay = tool({
+      name: 'get_day',
+      description: 'Return the current day of the week.',
+      inputSchema: z.object({}),
+      callback: async () => {
+        callCounts.day++
+        return 'monday'
+      },
+    })
+    const getWeather = tool({
+      name: 'get_weather',
+      description: 'Return the current weather.',
+      inputSchema: z.object({}),
+      callback: async () => {
+        callCounts.weather++
+        return 'sunny'
+      },
+    })
+
+    const { agent, checkpoints } = await driveToCompletion(
+      [getTime, getDay, getWeather],
+      'What is the time, the day, and the weather? Use the get_time, get_day, and get_weather tools.',
+      uuidv7(),
+      tempDir
+    )
+
+    // The core durable guarantee: completed tool calls are not re-invoked on resume.
+    expect(callCounts).toEqual({ time: 1, day: 1, weather: 1 })
+    expect(checkpoints.some((cp) => cp.position === 'after_tools')).toBe(true)
+
+    const text = conversationText(agent)
+    expect(text).toContain('12:01')
+    expect(text).toContain('monday')
+    expect(text).toContain('sunny')
+  })
+
+  it('preserves the original prompt across the checkpoint/resume cycle', async () => {
+    const getFavoriteNumber = tool({
+      name: 'get_favorite_number',
+      description: "Return the user's favorite number.",
+      inputSchema: z.object({}),
+      callback: async () => 42,
+    })
+
+    const { agent } = await driveToCompletion(
+      [getFavoriteNumber],
+      'What is my favorite number? Use the get_favorite_number tool.',
+      uuidv7(),
+      tempDir
+    )
+
+    const firstUserMessage = agent.messages.find((m) => m.role === 'user')
+    expect(firstUserMessage).toBeDefined()
+    const firstUserText = JSON.stringify(firstUserMessage).toLowerCase()
+    expect(firstUserText).toContain('favorite number')
+
+    const lastMessage = agent.messages.at(-1)!
+    expect(lastMessage.role).toBe('assistant')
+    expect(JSON.stringify(lastMessage)).toContain('42')
+  })
+})


### PR DESCRIPTION
## Description

TypeScript parity for the provider-agnostic durable-execution **checkpoint** primitive that shipped in the Python SDK (#2190, building on #2181).

A durability provider (Temporal, Dapr, Step Functions) needs a way to persist a pause-point and resume a fresh agent process at a ReAct cycle boundary. Without this, a durable orchestrator can only wrap a whole `invoke()` as one opaque unit and re-executes everything — including already-completed model and tool calls — on crash. A `Checkpoint` is the small serializable marker that makes cycle-boundary resume possible.

A `Checkpoint` is a **position marker** (which boundary fired + cycle index), **not** a state snapshot — conversation-state continuity remains the caller's responsibility via a `SessionManager`. The design mirrors the existing interrupt pause/resume convention: pause with `stopReason: 'checkpoint'`, resume by invoking with a `checkpointResume` payload. It is opt-in and introduces no breaking changes.

### Public API Changes

New, all `@experimental`, reachable from `@strands-agents/sdk` and `@strands-agents/sdk/experimental`:

```typescript
import { Agent } from '@strands-agents/sdk'

const agent = new Agent({ tools, checkpointing: true })

let result = await agent.invoke('do the thing')
while (result.stopReason === 'checkpoint') {
  persist(result.checkpoint!.toJSON()) // orchestrator persists the marker

  // later — possibly in a fresh process / activity:
  const fresh = new Agent({ tools, checkpointing: true })
  result = await fresh.invoke({ checkpointResume: { checkpoint: load() } })
}
```

The added surface: `Checkpoint`, `CheckpointData`, `CheckpointPosition`, `CheckpointResumeContent`, `CHECKPOINT_SCHEMA_VERSION`, `CheckpointError`, `AgentConfig.checkpointing`, `AgentResult.checkpoint`, and a `'checkpoint'` member on `StopReason`.

### Behavior worth calling out (not obvious from the diff)

- Boundaries only fire on tool-use cycles; a plain end-turn emits no checkpoint.
- Precedence: **cancel** and **interrupt** both take priority over checkpoint at either boundary.
- Multi-agent is out of scope — `CheckpointResumeContent` is excluded from `MultiAgentInput`, so orchestrators reject the resume payload at compile time (node-level checkpointing is future work).

Notable translation choices from the Python source: the TS loop returns `AgentResult` directly (no `EventLoopStopEvent` tuple), cycle tracking is loop-local (so no cross-invocation leak), and `to_dict`/`from_dict` map to `toJSON`/`fromJSON`.

## Related Issues

Ports #2190 (and #2181) to TypeScript.

## Documentation PR

Module-level docstrings cover the V0 contract, precedence, and limitations. A user-guide page is a follow-up.

## Type of Change

New feature

## Testing

Verified the change does not break functionality or introduce new warnings: type-check, unit tests, lint, and format all pass locally.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly *(module docstrings cover it; user-guide page is a follow-up)*
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed *(provider adapter examples are a follow-up milestone)*
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published *(the Python counterparts #2181 and #2190 are merged)*

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
