### PR TITLE
refactor(checkpoint): drop unused snapshot and app_data fields

### DIFF
--- a/strands-py/src/strands/experimental/checkpoint/checkpoint.py
+++ b/strands-py/src/strands/experimental/checkpoint/checkpoint.py
@@ -49,18 +49,11 @@ class Checkpoint:
     Attributes:
         position: Which boundary fired (``after_model`` or ``after_tools``).
         cycle_index: ReAct loop cycle (0-based).
-        snapshot: Reserved for forward extensibility (e.g. a future hook that lets
-            callers attach agent state to the checkpoint). The SDK does not
-            populate or read it today; it round-trips through serialization.
-        app_data: Reserved for forward extensibility — caller metadata that
-            round-trips through serialization. The SDK does not populate or read it.
         schema_version: Rejects incompatible checkpoints on resume.
     """
 
     position: CheckpointPosition
     cycle_index: int = 0
-    snapshot: dict[str, Any] = field(default_factory=dict)
-    app_data: dict[str, Any] = field(default_factory=dict)
     schema_version: str = field(init=False, default=CHECKPOINT_SCHEMA_VERSION)
 
     def to_dict(self) -> dict[str, Any]:

--- a/strands-py/tests/strands/experimental/checkpoint/test_checkpoint.py
+++ b/strands-py/tests/strands/experimental/checkpoint/test_checkpoint.py
@@ -7,12 +7,7 @@ from strands.types.exceptions import CheckpointException
 
 
 def test_checkpoint_to_dict_from_dict_round_trip():
-    checkpoint = Checkpoint(
-        position="after_model",
-        cycle_index=1,
-        snapshot={"messages": []},
-        app_data={"workflow_id": "wf-123"},
-    )
+    checkpoint = Checkpoint(position="after_model", cycle_index=1)
     data = checkpoint.to_dict()
     restored = Checkpoint.from_dict(data)
 
@@ -32,8 +27,6 @@ def test_checkpoint_init_schema_version_immutable():
 def test_checkpoint_init_defaults():
     checkpoint = Checkpoint(position="after_model")
     assert checkpoint.cycle_index == 0
-    assert checkpoint.snapshot == {}
-    assert checkpoint.app_data == {}
 
 
 def test_checkpoint_from_dict_schema_version_mismatch_raises():
@@ -44,7 +37,7 @@ def test_checkpoint_from_dict_schema_version_mismatch_raises():
 
 
 def test_checkpoint_from_dict_missing_schema_version_raises():
-    data = {"position": "after_model", "cycle_index": 0, "snapshot": {}, "app_data": {}}
+    data = {"position": "after_model", "cycle_index": 0}
     with pytest.raises(CheckpointException, match="not compatible with current version"):
         Checkpoint.from_dict(data)
 
@@ -55,3 +48,20 @@ def test_checkpoint_from_dict_unknown_fields_warns(caplog):
     restored = Checkpoint.from_dict(data)
     assert restored.position == "after_tools"
     assert "unknown_future_field" in caplog.text
+
+
+def test_checkpoint_from_dict_ignores_legacy_reserved_fields(caplog):
+    # Checkpoints serialized before snapshot/app_data were removed must still
+    # deserialize: the now-unknown keys are warned about and dropped.
+    data = {
+        "position": "after_tools",
+        "cycle_index": 2,
+        "snapshot": {"messages": []},
+        "app_data": {"workflow_id": "wf-123"},
+        "schema_version": CHECKPOINT_SCHEMA_VERSION,
+    }
+    restored = Checkpoint.from_dict(data)
+    assert restored == Checkpoint(position="after_tools", cycle_index=2)
+    assert not hasattr(restored, "snapshot")
+    assert not hasattr(restored, "app_data")
+    assert "snapshot" in caplog.text and "app_data" in caplog.text


### PR DESCRIPTION
## Description

Removes the reserved `snapshot` and `app_data` fields from the experimental `Checkpoint` dataclass. The SDK never populated or read them — the sole construction site (`event_loop._build_checkpoint_stop_event`) passes only `position` and `cycle_index`. A `Checkpoint` is a pause-point *position* marker, and its shape should say exactly that: `position`, `cycle_index`, `schema_version`.

Reserving unused fields buys no real forward-compatibility here. The serialized form is a named-key dict gated by `schema_version`, and `from_dict` already tolerates unknown keys, so either field can be reintroduced later as a non-breaking optional addition the moment a concrete consumer needs it. Meanwhile, an unused public field is a false affordance: a caller may reasonably assume `snapshot` will persist and restore agent state, when state continuity is explicitly the `SessionManager`'s responsibility.

Backward compatible: a checkpoint serialized with the old keys still deserializes — the now-unknown `snapshot`/`app_data` keys are logged and dropped.

### Public API Changes

```python
# Before
Checkpoint(position="after_tools", cycle_index=2, snapshot={...}, app_data={...})

# After
Checkpoint(position="after_tools", cycle_index=2)
```

`Checkpoint` remains experimental (`strands.experimental.checkpoint`).

## Related Issues

Follow-up to #2181 / #2190, trimming the checkpoint surface before the TypeScript port.

## Type of Change

Other (please describe): Refactor reducing the surface of an experimental API.

## Testing

Verified the change does not break functionality or introduce warnings:

- `hatch test` on the checkpoint, `agent_result`, and `event_loop` suites — all pass.
- `ruff check` and `mypy` clean.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly *(dataclass docstring updated)*
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
