### PR TITLE
feat(ts): preserve MCP output schemas

### DIFF
--- a/strands-ts/src/mcp/__tests__/client.test.ts
+++ b/strands-ts/src/mcp/__tests__/client.test.ts
@@ -273,8 +273,13 @@ describe('MCP Integration', () => {
     })
 
     it('converts SDK tool specs to McpTool instances', async () => {
+      const outputSchema = {
+        type: 'object' as const,
+        properties: { forecast: { type: 'string' as const } },
+        required: ['forecast'],
+      }
       sdkClientMock.listTools.mockResolvedValue({
-        tools: [{ name: 'weather', description: 'Get weather', inputSchema: {} }],
+        tools: [{ name: 'weather', description: 'Get weather', inputSchema: {}, outputSchema }],
       })
 
       const tools = await client.listTools()
@@ -282,7 +287,12 @@ describe('MCP Integration', () => {
       expect(sdkClientMock.connect).toHaveBeenCalled()
       expect(tools).toHaveLength(1)
       expect(tools[0]).toBeInstanceOf(McpTool)
-      expect(tools[0]!.name).toBe('weather')
+      expect(tools[0]!.toolSpec).toEqual({
+        name: 'weather',
+        description: 'Get weather',
+        inputSchema: {},
+        outputSchema,
+      })
     })
 
     it('paginates through all pages of tools', async () => {

--- a/strands-ts/src/mcp/client.ts
+++ b/strands-ts/src/mcp/client.ts
@@ -332,6 +332,7 @@ export class McpClient {
               name: toolSpec.name,
               description: toolSpec.description || `Tool which performs ${toolSpec.name}`,
               inputSchema: toolSpec.inputSchema as JSONSchema,
+              ...(toolSpec.outputSchema !== undefined && { outputSchema: toolSpec.outputSchema as JSONSchema }),
               client: this,
             })
         )

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -666,6 +666,37 @@ describe('BedrockModel', () => {
       expect(toolConfig.tools.length).toBe(1)
     })
 
+    it('formats tool specs without outputSchema in Bedrock requests', async () => {
+      const provider = new BedrockModel()
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = {
+        toolSpecs: [
+          {
+            name: 'calculator',
+            description: 'Calculate',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              type: 'object',
+              properties: { result: { type: 'number' } },
+            },
+          },
+        ],
+      }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.toolConfig?.tools).toStrictEqual([
+        {
+          toolSpec: {
+            name: 'calculator',
+            description: 'Calculate',
+            inputSchema: { json: { type: 'object' } },
+          },
+        },
+      ])
+    })
+
     it('formats reasoning messages properly', async () => {
       const provider = new BedrockModel()
       const messages = [

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -13,6 +13,7 @@ export interface McpToolConfig {
   name: string
   description: string
   inputSchema: JSONSchema
+  outputSchema?: JSONSchema
   client: McpClient
 }
 
@@ -37,6 +38,7 @@ export class McpTool extends Tool {
       name: config.name,
       description: config.description,
       inputSchema: config.inputSchema,
+      ...(config.outputSchema !== undefined && { outputSchema: config.outputSchema }),
     }
     this.mcpClient = config.client
   }

--- a/strands-ts/src/tools/types.ts
+++ b/strands-ts/src/tools/types.ts
@@ -27,6 +27,11 @@ export interface ToolSpec {
    * If omitted, defaults to an empty object schema allowing no input parameters.
    */
   inputSchema?: JSONSchema
+
+  /**
+   * JSON Schema defining the expected output structure for the tool.
+   */
+  outputSchema?: JSONSchema
 }
 
 /**


### PR DESCRIPTION
## Description

Ports [strands-agents/harness-sdk#818](https://github.com/strands-agents/harness-sdk/pull/818) to the TypeScript SDK: MCP tools can optionally declare an `outputSchema` per the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#data-types), and this metadata is useful to expose on `ToolSpec` for callers that want to inspect a tool's declared output shape. Today `McpClient.listTools()` drops it, so consumers can't see it even when the MCP server returns one.

This change preserves the field. When the MCP SDK's tool spec includes `outputSchema`, it flows through into `McpTool.toolSpec.outputSchema`; when it's absent, the property is omitted (not set to `undefined`) to keep `ToolSpec` shapes clean under `exactOptionalPropertyTypes`. Model providers continue to forward only the tool fields their APIs accept — Bedrock, Anthropic, Google, OpenAI, and Vercel adapters project `ToolSpec` field-by-field into their provider request shapes, so `outputSchema` is naturally not sent over the wire. A regression test on the Bedrock adapter locks that behavior in.

Backward compatible - `outputSchema` is optional and absent by default.

## Related Issues

Ports [strands-agents/harness-sdk#818](https://github.com/strands-agents/harness-sdk/pull/818) (Python SDK) to TypeScript, which was part of [strands-agents/harness-sdk#787](https://github.com/strands-agents/harness-sdk/issues/787).

## Documentation PR

No documentation changes.

## Type of Change

New feature

## Testing

- [x] `npm run check`

Added new tests/

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly - N/A
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed - N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
