### PR TITLE
feat: added span redaction

### DIFF
--- a/strands-py/src/strands/telemetry/tracer.py
+++ b/strands-py/src/strands/telemetry/tracer.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+REDACTED_VALUE = "[REDACTED]"
+
 
 class JSONEncoder(json.JSONEncoder):
     """Custom JSON encoder that handles non-serializable types."""
@@ -89,6 +91,17 @@ class Tracer:
 
     Both attributes are controlled by including "gen_ai_latest_experimental", "gen_ai_tool_definitions",
     or "gen_ai_use_latest_invocation_tokens", respectively, in the OTEL_SEMCONV_STABILITY_OPT_IN environment variable.
+
+    Span attribute redaction is opt-in via the `gen_ai_unredacted_attributes=<list>` token in the same
+    environment variable. The list uses `;` as a separator and supports trailing-`*` glob patterns.
+    When the token is absent, all attributes are emitted unredacted (backward compatible).
+
+    Note: only a single trailing `*` is honored (e.g. `gen_ai.output.*`). A mid-string wildcard such
+    as `gen_ai.*.messages` will not match anything at the moment — it is treated as an exact name.
+
+    Sensitive attributes subject to the redaction policy are: `gen_ai.input.messages` (user messages
+    and tool inputs/results being fed into the model), `gen_ai.output.messages` (agent/model responses
+    and tool call responses), and `gen_ai.system_instructions` (system prompts).
     """
 
     def __init__(self) -> None:
@@ -106,14 +119,70 @@ class Tracer:
         self._include_tool_definitions = "gen_ai_tool_definitions" in opt_in_values
         self._use_latest_invocation_tokens = "gen_ai_use_latest_invocation_tokens" in opt_in_values
 
+        unredacted_token = next(
+            (t for t in opt_in_values if t.startswith("gen_ai_unredacted_attributes=")),
+            None,
+        )
+        self._redaction_enabled = unredacted_token is not None
+        self._unredacted_exact, self._unredacted_globs = self._compile_unredacted_patterns(
+            unredacted_token.partition("=")[2] if unredacted_token else ""
+        )
+
     def _parse_semconv_opt_in(self) -> set[str]:
         """Parse the OTEL_SEMCONV_STABILITY_OPT_IN environment variable.
 
         Returns:
-            A set of opt-in values from the environment variable.
+            A set of opt-in tokens from the environment variable.
         """
         opt_in_env = os.getenv("OTEL_SEMCONV_STABILITY_OPT_IN", "")
         return {value.strip() for value in opt_in_env.split(",")}
+
+    @staticmethod
+    def _compile_unredacted_patterns(value: str) -> tuple[frozenset[str], tuple[str, ...]]:
+        """Split an unredacted-attributes value into exact names and glob prefixes.
+
+        Globs are limited to a single trailing `*` (e.g. `gen_ai.output.*`). Empty entries are
+        ignored, which is how a value like `gen_ai_unredacted_attributes=` resolves to "redact
+        everything sensitive".
+        """
+        exact: set[str] = set()
+        globs: list[str] = []
+        for raw in value.split(";"):
+            entry = raw.strip()
+            if not entry:
+                continue
+            if entry.endswith("*"):
+                globs.append(entry[:-1])
+            else:
+                exact.add(entry)
+        return frozenset(exact), tuple(globs)
+
+    def _is_attribute_unredacted(self, attribute_name: str) -> bool:
+        """Return True if the attribute should be emitted as-is, False if it must be redacted."""
+        if not self._redaction_enabled:
+            return True
+        if attribute_name in self._unredacted_exact:
+            return True
+        return any(attribute_name.startswith(prefix) for prefix in self._unredacted_globs)
+
+    def _redact(self, attribute_name: str, value: str) -> str:
+        """Apply the redaction policy to a single sensitive attribute value.
+
+        Args:
+            attribute_name: The canonical semantic attribute name used for policy lookup
+                (one of `gen_ai.input.messages`, `gen_ai.output.messages`, or
+                `gen_ai.system_instructions`). This may differ from the physical event
+                field key emitted under legacy conventions (which uses `content`/`message`),
+                but the canonical name is always used so that allowlist entries are
+                independent of the convention in use.
+            value: The serialized attribute value to potentially redact.
+
+        Returns:
+            The original value if the attribute is unredacted, otherwise ``REDACTED_VALUE``.
+        """
+        if self._is_attribute_unredacted(attribute_name):
+            return value
+        return REDACTED_VALUE
 
     @property
     def is_langfuse(self) -> bool:
@@ -367,27 +436,29 @@ class Tracer:
         self._add_optional_usage_and_metrics_attributes(attributes, usage, metrics)
 
         if self.use_latest_genai_conventions:
+            output_messages = serialize(
+                [
+                    {
+                        "role": message["role"],
+                        "parts": self._map_content_blocks_to_otel_parts(message["content"]),
+                        "finish_reason": str(stop_reason),
+                    }
+                ]
+            )
             self._add_event(
                 span,
                 "gen_ai.client.inference.operation.details",
-                {
-                    "gen_ai.output.messages": serialize(
-                        [
-                            {
-                                "role": message["role"],
-                                "parts": self._map_content_blocks_to_otel_parts(message["content"]),
-                                "finish_reason": str(stop_reason),
-                            }
-                        ]
-                    ),
-                },
+                {"gen_ai.output.messages": self._redact("gen_ai.output.messages", output_messages)},
                 to_span_attributes=self.is_langfuse,
             )
         else:
             self._add_event(
                 span,
                 "gen_ai.choice",
-                event_attributes={"finish_reason": str(stop_reason), "message": serialize(message["content"])},
+                event_attributes={
+                    "finish_reason": str(stop_reason),
+                    "message": self._redact("gen_ai.output.messages", serialize(message["content"])),
+                },
             )
 
         self._end_span(span, attributes)
@@ -427,26 +498,25 @@ class Tracer:
         span = self._start_span(span_name, parent_span, attributes=attributes, span_kind=trace_api.SpanKind.INTERNAL)
 
         if self.use_latest_genai_conventions:
+            input_messages = serialize(
+                [
+                    {
+                        "role": "tool",
+                        "parts": [
+                            {
+                                "type": "tool_call",
+                                "name": tool["name"],
+                                "id": tool["toolUseId"],
+                                "arguments": tool["input"],
+                            }
+                        ],
+                    }
+                ]
+            )
             self._add_event(
                 span,
                 "gen_ai.client.inference.operation.details",
-                {
-                    "gen_ai.input.messages": serialize(
-                        [
-                            {
-                                "role": "tool",
-                                "parts": [
-                                    {
-                                        "type": "tool_call",
-                                        "name": tool["name"],
-                                        "id": tool["toolUseId"],
-                                        "arguments": tool["input"],
-                                    }
-                                ],
-                            }
-                        ]
-                    )
-                },
+                {"gen_ai.input.messages": self._redact("gen_ai.input.messages", input_messages)},
                 to_span_attributes=self.is_langfuse,
             )
         else:
@@ -455,7 +525,7 @@ class Tracer:
                 "gen_ai.tool.message",
                 event_attributes={
                     "role": "tool",
-                    "content": serialize(tool["input"]),
+                    "content": self._redact("gen_ai.input.messages", serialize(tool["input"])),
                     "id": tool["toolUseId"],
                 },
             )
@@ -480,25 +550,24 @@ class Tracer:
             attributes["gen_ai.tool.status"] = str(status) if status is not None else ""
 
             if self.use_latest_genai_conventions:
+                output_messages = serialize(
+                    [
+                        {
+                            "role": "tool",
+                            "parts": [
+                                {
+                                    "type": "tool_call_response",
+                                    "id": tool_result.get("toolUseId", ""),
+                                    "response": content,
+                                }
+                            ],
+                        }
+                    ]
+                )
                 self._add_event(
                     span,
                     "gen_ai.client.inference.operation.details",
-                    {
-                        "gen_ai.output.messages": serialize(
-                            [
-                                {
-                                    "role": "tool",
-                                    "parts": [
-                                        {
-                                            "type": "tool_call_response",
-                                            "id": tool_result.get("toolUseId", ""),
-                                            "response": content,
-                                        }
-                                    ],
-                                }
-                            ]
-                        )
-                    },
+                    {"gen_ai.output.messages": self._redact("gen_ai.output.messages", output_messages)},
                     to_span_attributes=self.is_langfuse,
                 )
             else:
@@ -506,7 +575,7 @@ class Tracer:
                     span,
                     "gen_ai.choice",
                     event_attributes={
-                        "message": serialize(content),
+                        "message": self._redact("gen_ai.output.messages", serialize(content)),
                         "id": tool_result.get("toolUseId", ""),
                     },
                 )
@@ -574,25 +643,30 @@ class Tracer:
         if not span or not span.is_recording():
             return
 
-        event_attributes: dict[str, AttributeValue] = {"message": serialize(message["content"])}
+        event_attributes: dict[str, AttributeValue] = {
+            "message": self._redact("gen_ai.output.messages", serialize(message["content"])),
+        }
 
         if tool_result_message:
-            event_attributes["tool.result"] = serialize(tool_result_message["content"])
+            # tool results are conceptually fed back to the model as input, so they are
+            # policied under gen_ai.input.messages even when the emitted attribute key differs
+            event_attributes["tool.result"] = self._redact(
+                "gen_ai.input.messages", serialize(tool_result_message["content"])
+            )
 
             if self.use_latest_genai_conventions:
+                tool_result_messages = serialize(
+                    [
+                        {
+                            "role": tool_result_message["role"],
+                            "parts": self._map_content_blocks_to_otel_parts(tool_result_message["content"]),
+                        }
+                    ]
+                )
                 self._add_event(
                     span,
                     "gen_ai.client.inference.operation.details",
-                    {
-                        "gen_ai.output.messages": serialize(
-                            [
-                                {
-                                    "role": tool_result_message["role"],
-                                    "parts": self._map_content_blocks_to_otel_parts(tool_result_message["content"]),
-                                }
-                            ]
-                        )
-                    },
+                    {"gen_ai.input.messages": self._redact("gen_ai.input.messages", tool_result_messages)},
                     to_span_attributes=self.is_langfuse,
                 )
             else:
@@ -676,27 +750,29 @@ class Tracer:
 
         if response:
             if self.use_latest_genai_conventions:
+                output_messages = serialize(
+                    [
+                        {
+                            "role": "assistant",
+                            "parts": [{"type": "text", "content": str(response)}],
+                            "finish_reason": str(response.stop_reason),
+                        }
+                    ]
+                )
                 self._add_event(
                     span,
                     "gen_ai.client.inference.operation.details",
-                    {
-                        "gen_ai.output.messages": serialize(
-                            [
-                                {
-                                    "role": "assistant",
-                                    "parts": [{"type": "text", "content": str(response)}],
-                                    "finish_reason": str(response.stop_reason),
-                                }
-                            ]
-                        )
-                    },
+                    {"gen_ai.output.messages": self._redact("gen_ai.output.messages", output_messages)},
                     to_span_attributes=self.is_langfuse,
                 )
             else:
                 self._add_event(
                     span,
                     "gen_ai.choice",
-                    event_attributes={"message": str(response), "finish_reason": str(response.stop_reason)},
+                    event_attributes={
+                        "message": self._redact("gen_ai.output.messages", str(response)),
+                        "finish_reason": str(response.stop_reason),
+                    },
                 )
 
             if hasattr(response, "metrics") and hasattr(response.metrics, "accumulated_usage"):
@@ -760,17 +836,19 @@ class Tracer:
                 parts = self._map_content_blocks_to_otel_parts(task)
             else:
                 parts = [{"type": "text", "content": task}]
+            input_messages = serialize([{"role": "user", "parts": parts}])
             self._add_event(
                 span,
                 "gen_ai.client.inference.operation.details",
-                {"gen_ai.input.messages": serialize([{"role": "user", "parts": parts}])},
+                {"gen_ai.input.messages": self._redact("gen_ai.input.messages", input_messages)},
                 to_span_attributes=self.is_langfuse,
             )
         else:
+            content_value = serialize(task) if isinstance(task, list) else task
             self._add_event(
                 span,
                 "gen_ai.user.message",
-                event_attributes={"content": serialize(task) if isinstance(task, list) else task},
+                event_attributes={"content": self._redact("gen_ai.input.messages", content_value)},
             )
 
         return span
@@ -783,26 +861,25 @@ class Tracer:
         """End a swarm span with results."""
         if result:
             if self.use_latest_genai_conventions:
+                output_messages = serialize(
+                    [
+                        {
+                            "role": "assistant",
+                            "parts": [{"type": "text", "content": result}],
+                        }
+                    ]
+                )
                 self._add_event(
                     span,
                     "gen_ai.client.inference.operation.details",
-                    {
-                        "gen_ai.output.messages": serialize(
-                            [
-                                {
-                                    "role": "assistant",
-                                    "parts": [{"type": "text", "content": result}],
-                                }
-                            ]
-                        )
-                    },
+                    {"gen_ai.output.messages": self._redact("gen_ai.output.messages", output_messages)},
                     to_span_attributes=self.is_langfuse,
                 )
             else:
                 self._add_event(
                     span,
                     "gen_ai.choice",
-                    event_attributes={"message": result},
+                    event_attributes={"message": self._redact("gen_ai.output.messages", result)},
                 )
 
     def _build_memory_span_attributes(
@@ -1168,17 +1245,19 @@ class Tracer:
 
         if self.use_latest_genai_conventions:
             parts = self._map_content_blocks_to_otel_parts(content_blocks)
+            # system prompts are sensitive and policed under gen_ai.system_instructions
             self._add_event(
                 span,
                 "gen_ai.client.inference.operation.details",
-                {"gen_ai.system_instructions": serialize(parts)},
+                {"gen_ai.system_instructions": self._redact("gen_ai.system_instructions", serialize(parts))},
                 to_span_attributes=self.is_langfuse,
             )
         else:
+            # system prompts are sensitive and policed under gen_ai.system_instructions
             self._add_event(
                 span,
                 "gen_ai.system.message",
-                {"content": serialize(content_blocks)},
+                {"content": self._redact("gen_ai.system_instructions", serialize(content_blocks))},
             )
 
     def _add_event_messages(self, span: Span, messages: Messages) -> None:
@@ -1197,15 +1276,18 @@ class Tracer:
             self._add_event(
                 span,
                 "gen_ai.client.inference.operation.details",
-                {"gen_ai.input.messages": serialize(input_messages)},
+                {"gen_ai.input.messages": self._redact("gen_ai.input.messages", serialize(input_messages))},
                 to_span_attributes=self.is_langfuse,
             )
         else:
             for message in messages:
+                redact_key = (
+                    "gen_ai.output.messages" if message.get("role") == "assistant" else "gen_ai.input.messages"
+                )
                 self._add_event(
                     span,
                     self._get_event_name_for_message(message),
-                    {"content": serialize(message["content"])},
+                    {"content": self._redact(redact_key, serialize(message["content"]))},
                 )
 
     def _map_content_blocks_to_otel_parts(

--- a/strands-py/tests/strands/telemetry/test_tracer.py
+++ b/strands-py/tests/strands/telemetry/test_tracer.py
@@ -846,7 +846,7 @@ def test_end_event_loop_cycle_span_latest_conventions(mock_span, monkeypatch):
     mock_span.add_event.assert_called_with(
         "gen_ai.client.inference.operation.details",
         attributes={
-            "gen_ai.output.messages": serialize(
+            "gen_ai.input.messages": serialize(
                 [
                     {
                         "role": "assistant",
@@ -2091,3 +2091,321 @@ class TestIsLangfuse:
         monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
         tracer = Tracer()
         assert tracer.is_langfuse is False
+
+
+class TestSpanAttributeRedaction:
+    """Tests for GDPR-compliant redaction of sensitive span attributes."""
+
+    def _user_message(self):
+        return [{"role": "user", "content": [{"text": "secret user input"}]}]
+
+    def _assistant_message(self):
+        return {"role": "assistant", "content": [{"text": "secret model output"}]}
+
+    def test_redaction_disabled_by_default(self, mock_tracer, monkeypatch):
+        """No env var set: sensitive content is emitted verbatim (backward compatible)."""
+        monkeypatch.delenv("OTEL_SEMCONV_STABILITY_OPT_IN", raising=False)
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_tracer.start_span.return_value = mock_span
+
+            tracer.start_model_invoke_span(messages=self._user_message(), model_id="m")
+
+            mock_span.add_event.assert_any_call(
+                "gen_ai.user.message",
+                attributes={"content": json.dumps([{"text": "secret user input"}])},
+            )
+
+    def test_redaction_disabled_when_other_tokens_present(self, mock_tracer, monkeypatch):
+        """Other opt-in tokens must not accidentally enable redaction."""
+        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental,gen_ai_tool_definitions")
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_tracer.start_span.return_value = mock_span
+
+            tracer.start_model_invoke_span(messages=self._user_message(), model_id="m")
+
+            input_messages = serialize([{"role": "user", "parts": [{"type": "text", "content": "secret user input"}]}])
+            mock_span.add_event.assert_any_call(
+                "gen_ai.client.inference.operation.details",
+                attributes={"gen_ai.input.messages": input_messages},
+            )
+
+    def test_empty_unredacted_list_redacts_everything(self, mock_tracer, monkeypatch):
+        """gen_ai_unredacted_attributes= (empty) redacts all sensitive attributes."""
+        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_unredacted_attributes=")
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_tracer.start_span.return_value = mock_span
+
+            tracer.start_model_invoke_span(messages=self._user_message(), model_id="m", system_prompt="secret system")
+            tracer.end_model_invoke_span(
+                mock_span,
+                self._assistant_message(),
+                Usage(inputTokens=1, outputTokens=2, totalTokens=3),
+                Metrics(latencyMs=0, timeToFirstByteMs=0),
+                "end_turn",
+            )
+
+            mock_span.add_event.assert_any_call("gen_ai.system.message", attributes={"content": "[REDACTED]"})
+            mock_span.add_event.assert_any_call("gen_ai.user.message", attributes={"content": "[REDACTED]"})
+            mock_span.add_event.assert_any_call(
+                "gen_ai.choice",
+                attributes={"finish_reason": "end_turn", "message": "[REDACTED]"},
+            )
+
+    def test_explicit_allowlist_with_semicolon(self, mock_tracer, monkeypatch):
+        """Allowlisted attributes pass through; others redact."""
+        monkeypatch.setenv(
+            "OTEL_SEMCONV_STABILITY_OPT_IN",
+            "gen_ai_latest_experimental,gen_ai_unredacted_attributes=gen_ai.input.messages;gen_ai.system_instructions",
+        )
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_tracer.start_span.return_value = mock_span
+
+            tracer.start_model_invoke_span(messages=self._user_message(), model_id="m", system_prompt="visible system")
+            tracer.end_model_invoke_span(
+                mock_span,
+                self._assistant_message(),
+                Usage(inputTokens=1, outputTokens=2, totalTokens=3),
+                Metrics(latencyMs=0, timeToFirstByteMs=0),
+                "end_turn",
+            )
+
+            visible_input = serialize([{"role": "user", "parts": [{"type": "text", "content": "secret user input"}]}])
+            visible_system = serialize([{"type": "text", "content": "visible system"}])
+            mock_span.add_event.assert_any_call(
+                "gen_ai.client.inference.operation.details",
+                attributes={"gen_ai.system_instructions": visible_system},
+            )
+            mock_span.add_event.assert_any_call(
+                "gen_ai.client.inference.operation.details",
+                attributes={"gen_ai.input.messages": visible_input},
+            )
+            mock_span.add_event.assert_any_call(
+                "gen_ai.client.inference.operation.details",
+                attributes={"gen_ai.output.messages": "[REDACTED]"},
+            )
+
+    def test_glob_match_for_output_messages(self, mock_tracer, monkeypatch):
+        """A trailing `*` glob matches by prefix."""
+        monkeypatch.setenv(
+            "OTEL_SEMCONV_STABILITY_OPT_IN",
+            "gen_ai_latest_experimental,gen_ai_unredacted_attributes=gen_ai.output.*",
+        )
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_tracer.start_span.return_value = mock_span
+
+            tracer.start_model_invoke_span(messages=self._user_message(), model_id="m")
+            tracer.end_model_invoke_span(
+                mock_span,
+                self._assistant_message(),
+                Usage(inputTokens=1, outputTokens=2, totalTokens=3),
+                Metrics(latencyMs=0, timeToFirstByteMs=0),
+                "end_turn",
+            )
+
+            visible_output = serialize(
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [{"type": "text", "content": "secret model output"}],
+                        "finish_reason": "end_turn",
+                    }
+                ]
+            )
+            mock_span.add_event.assert_any_call(
+                "gen_ai.client.inference.operation.details",
+                attributes={"gen_ai.input.messages": "[REDACTED]"},
+            )
+            mock_span.add_event.assert_any_call(
+                "gen_ai.client.inference.operation.details",
+                attributes={"gen_ai.output.messages": visible_output},
+            )
+
+    def test_redaction_preserves_tool_metadata(self, mock_tracer, monkeypatch):
+        """Tool name, ID, and status are preserved; only payload content is redacted."""
+        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_unredacted_attributes=")
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_tracer.start_span.return_value = mock_span
+
+            tool = {"name": "calculator", "toolUseId": "abc", "input": {"expression": "2+2"}}
+            tracer.start_tool_call_span(tool)
+            tracer.end_tool_call_span(
+                mock_span,
+                {"toolUseId": "abc", "status": "success", "content": [{"text": "4"}]},
+            )
+
+            start_attrs = mock_span.set_attributes.call_args_list[0][0][0]
+            assert start_attrs["gen_ai.tool.name"] == "calculator"
+            assert start_attrs["gen_ai.tool.call.id"] == "abc"
+
+            mock_span.add_event.assert_any_call(
+                "gen_ai.tool.message",
+                attributes={"role": "tool", "content": "[REDACTED]", "id": "abc"},
+            )
+            mock_span.add_event.assert_any_call(
+                "gen_ai.choice",
+                attributes={"message": "[REDACTED]", "id": "abc"},
+            )
+
+    def test_parser_handles_kv_and_bare_tokens(self, monkeypatch):
+        """Parser keeps bare flags working alongside the new key=value token."""
+        monkeypatch.setenv(
+            "OTEL_SEMCONV_STABILITY_OPT_IN",
+            " gen_ai_latest_experimental ,gen_ai_unredacted_attributes=gen_ai.input.messages ,gen_ai_tool_definitions",
+        )
+        tracer = Tracer()
+        assert tracer.use_latest_genai_conventions is True
+        assert tracer._include_tool_definitions is True
+        assert tracer._redaction_enabled is True
+        assert "gen_ai.input.messages" in tracer._unredacted_exact
+
+    def test_assistant_message_uses_output_key_for_redaction(self, mock_tracer, monkeypatch):
+        """Assistant messages in legacy `_add_event_messages` use the output-messages policy."""
+        monkeypatch.setenv(
+            "OTEL_SEMCONV_STABILITY_OPT_IN",
+            "gen_ai_unredacted_attributes=gen_ai.output.*",
+        )
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_span.is_recording.return_value = True
+
+            messages = [
+                {"role": "user", "content": [{"text": "user query"}]},
+                {"role": "assistant", "content": [{"text": "assistant reply"}]},
+            ]
+            tracer._add_event_messages(mock_span, messages)
+
+            mock_span.add_event.assert_any_call("gen_ai.user.message", attributes={"content": "[REDACTED]"})
+            mock_span.add_event.assert_any_call(
+                "gen_ai.assistant.message",
+                attributes={"content": serialize([{"text": "assistant reply"}])},
+            )
+
+    def test_system_instructions_redacted_in_latest_conventions(self, mock_tracer, monkeypatch):
+        """gen_ai.system_instructions must be redacted under an empty allowlist (latest conventions)."""
+        monkeypatch.setenv(
+            "OTEL_SEMCONV_STABILITY_OPT_IN",
+            "gen_ai_latest_experimental,gen_ai_unredacted_attributes=",
+        )
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_span.is_recording.return_value = True
+            mock_tracer.start_span.return_value = mock_span
+
+            tracer.start_model_invoke_span(
+                messages=[{"role": "user", "content": [{"text": "hi"}]}],
+                model_id="m",
+                system_prompt="confidential system prompt",
+            )
+
+            mock_span.add_event.assert_any_call(
+                "gen_ai.client.inference.operation.details",
+                attributes={"gen_ai.system_instructions": "[REDACTED]"},
+            )
+
+    def test_model_id_and_operation_never_redacted(self, mock_tracer, monkeypatch):
+        """Structural span attributes (model id, tool name, operation) are never replaced."""
+        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_unredacted_attributes=")
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_tracer.start_span.return_value = mock_span
+
+            tracer.start_model_invoke_span(
+                messages=[{"role": "user", "content": [{"text": "hi"}]}],
+                model_id="anthropic.claude-v3",
+            )
+
+            set_attrs_call = mock_span.set_attributes.call_args_list[0][0][0]
+            assert set_attrs_call["gen_ai.request.model"] == "anthropic.claude-v3"
+            assert set_attrs_call["gen_ai.operation.name"] == "chat"
+            assert "[REDACTED]" not in set_attrs_call.values()
+
+    def test_glob_only_trailing_star(self, monkeypatch):
+        """Only trailing `*` is treated as a glob; other entries are exact-match."""
+        monkeypatch.setenv(
+            "OTEL_SEMCONV_STABILITY_OPT_IN",
+            "gen_ai_unredacted_attributes=gen_ai.output.*;gen_ai.exact.name",
+        )
+        tracer = Tracer()
+        assert tracer._is_attribute_unredacted("gen_ai.output.messages")
+        assert tracer._is_attribute_unredacted("gen_ai.output.anything.else")
+        assert tracer._is_attribute_unredacted("gen_ai.exact.name")
+        assert not tracer._is_attribute_unredacted("gen_ai.input.messages")
+
+    def test_tool_result_cycle_span_uses_input_messages_key(self, mock_tracer, monkeypatch):
+        """tool_result_message in end_event_loop_cycle_span emits under gen_ai.input.messages, not output.messages."""
+        monkeypatch.setenv(
+            "OTEL_SEMCONV_STABILITY_OPT_IN",
+            "gen_ai_latest_experimental,gen_ai_unredacted_attributes=gen_ai.input.messages",
+        )
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_span.is_recording.return_value = True
+
+            message = {"role": "assistant", "content": [{"text": "calling tool"}]}
+            tool_result_message = {"role": "tool", "content": [{"text": "tool output"}]}
+
+            tracer.end_event_loop_cycle_span(mock_span, message, tool_result_message)
+
+            expected_payload = serialize(
+                [
+                    {
+                        "role": "tool",
+                        "parts": tracer._map_content_blocks_to_otel_parts([{"text": "tool output"}]),
+                    }
+                ]
+            )
+            mock_span.add_event.assert_any_call(
+                "gen_ai.client.inference.operation.details",
+                attributes={"gen_ai.input.messages": expected_payload},
+            )
+            all_attr_keys = set()
+            for call in mock_span.add_event.call_args_list:
+                attrs = call.kwargs.get("attributes") or (call.args[1] if len(call.args) > 1 else {})
+                all_attr_keys.update(attrs.keys())
+            assert "gen_ai.output.messages" not in all_attr_keys, (
+                "tool_result_message must not be emitted under gen_ai.output.messages"
+            )
+
+    def test_legacy_tool_result_redacts_under_input_messages_policy(self, mock_tracer, monkeypatch):
+        """Legacy gen_ai.choice path: tool.result field redacted under gen_ai.input.messages policy."""
+        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_unredacted_attributes=")
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_span.is_recording.return_value = True
+            message = {"role": "assistant", "content": [{"text": "visible"}]}
+            tool_result_message = {"role": "tool", "content": [{"text": "secret result"}]}
+            tracer.end_event_loop_cycle_span(mock_span, message, tool_result_message)
+            call_kwargs = {
+                k: v
+                for call in mock_span.add_event.call_args_list
+                for k, v in (call.kwargs.get("attributes") or {}).items()
+            }
+            assert call_kwargs.get("tool.result") == "[REDACTED]"


### PR DESCRIPTION
## Description

Allow users to opt-in redaction of the sensitive span attributes while preserving everything a trace is actually useful for: structure, timing, tool names/IDs/status, errors, and token/latency metrics. Redacted values are replaced with the `[REDACTED]` placeholder.

Three canonical policy keys classify every emission site, independent of which semantic-convention version is active: 
 - `gen_ai.input.messages` (user messages, tool inputs, and tool results fed back to the model), 
 - `gen_ai.output.messages` (model/agent responses and tool call responses)
 - `gen_ai.system_instructions` (system prompts).

Redaction is configured through a new `gen_ai_unredacted_attributes` token on the existing `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable, so no new configuration surface is introduced:

```bash
# Default (token absent): everything emitted verbatim — fully backward compatible
OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental

# Redact all sensitive attributes
OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_unredacted_attributes=

# Allowlist: unredact input messages and anything under gen_ai.output.*, redact the rest
OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_unredacted_attributes=gen_ai.input.messages;gen_ai.output.*
```

The allowlist is `;`-separated and supports a single trailing-`*` glob.

**Backward compatibility:** the default (no token) emits all attributes unredacted, matching today's behavior. Defaulting to redacted is a breaking change reserved for the v2 release; this PR intentionally keeps v1 opt-in.

## Related Issues

Closes #1292

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

Added `TestSpanAttributeRedaction` covering the disabled-by-default path, empty-allowlist (redact-all), explicit allowlists, glob matching, input/output policy classification for tool results and assistant messages, and confirmation that structural attributes (model id, tool name, operation name) are never redacted.
