### PR TITLE
ci: fix integration test runs

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -90,6 +90,7 @@ jobs:
     name: Run integration tests
     runs-on: ubuntu-latest
     needs: authorization-check
+    if: always() && needs.authorization-check.result == 'success'
     environment:
       name: ${{ needs.authorization-check.outputs.approval-env }}
       deployment: false

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -93,6 +93,7 @@ jobs:
     name: Run integration tests
     runs-on: ubuntu-latest
     needs: authorization-check
+    if: always() && needs.authorization-check.result == 'success'
     environment:
       name: ${{ needs.authorization-check.outputs.approval-env }}
       deployment: false


### PR DESCRIPTION
## Description

Integration tests have been silently skipping on every PR since #2940 merged. The `Run integration tests` job reports `skipping` even when the PR is authorized and non-draft, so no integration coverage actually runs — for `strands-py` or `strands-ts` — in the merge gate.

#2940 added a `validate-call-ref` job that only runs on the `workflow_call` path (`if: inputs.ref != ''`). On `pull_request_target` and `merge_group` that job is skipped, and a skipped `needs` predecessor propagates transitively through the implicit `success()` gate of every downstream job. #2940 handled this for `authorization-check` by giving it `if: always() && ...`, but the test job (`check-access-and-checkout` / `run-integration-tests`) has no such guard, so the skip cascaded into it — the job was killed before it ever reached the environment approval gate.

This adds the same guard to the test job in both integration-test workflows:

```yaml
if: always() && needs.authorization-check.result == 'success'
```

`always()` detaches the job from the transitively-skipped `validate-call-ref`, while requiring `authorization-check` to have *succeeded* keeps the security posture unchanged: a fork/cross-repo ref fails `validate-call-ref`, which makes `authorization-check` evaluate to `skipped` (not `success`), so the test job still does not run. The auth gate and the environment-based manual-approval flow for drafts/non-writers are untouched.

## Related Issues

Investigation traced from #2836 (where the skip surfaced). Regression introduced by #2940.

## Documentation PR

Not applicable — CI-only change.

## Type of Change

Bug fix

## Testing

`pull_request_target` runs the workflow definition from the base branch, so the fix only takes effect once merged; it cannot be exercised from the PR branch itself. Validated statically:

- Both workflow files parse as valid YAML.
- Traced the guard against every trigger path — `pull_request_target` (writer/draft/non-writer), `merge_group`, `workflow_call` (valid ref), and `workflow_call` (rejected fork/cross-repo ref). Only the fork/bad-ref case keeps the job skipped, confirming the trust invariant holds.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
