### PR TITLE
fix(ci): create release tag via git push instead of gh release --target

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -377,24 +377,43 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.scan-commits.outputs.release_sha }}
-          persist-credentials: false
+          # This job creates the tag, so keep the GITHUB_TOKEN in git config
+          # for the push below. Other jobs use persist-credentials: false.
+          persist-credentials: true
 
       - name: Download release notes artifact
         uses: actions/download-artifact@v8
         with:
           name: release-notes
 
-      - name: Create release (atomically tags the pinned SHA)
+      - name: Tag the pinned SHA and create the release
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_TAG: ${{ needs.scan-commits.outputs.new_tag }}
           RELEASE_SHA: ${{ needs.scan-commits.outputs.release_sha }}
         run: |
           set -euo pipefail
-          gh release create "$NEW_TAG" \
-            --target "$RELEASE_SHA" \
-            --title "$NEW_TAG" \
-            --notes-file release-notes.md
+          # Push the tag over git rather than letting `gh release create
+          # --target <sha>` create it through the releases API. The API path
+          # returns "403 Resource not accessible by integration" for the
+          # GITHUB_TOKEN (see cli/cli#9514); a plain ref push with the same
+          # token succeeds.
+          #
+          # Both steps are guarded so re-running the job after a partial
+          # failure is safe: if a prior run pushed the tag but errored before
+          # the release was made, git push would otherwise refuse the existing
+          # tag. This keeps the "tag is source of truth, just re-run" contract.
+          if ! git ls-remote --exit-code --tags origin "refs/tags/$NEW_TAG" >/dev/null 2>&1; then
+            git tag "$NEW_TAG" "$RELEASE_SHA"
+            git push origin "refs/tags/$NEW_TAG"
+          fi
+
+          # Tag now exists on the remote, so this only attaches notes to it.
+          if ! gh release view "$NEW_TAG" >/dev/null 2>&1; then
+            gh release create "$NEW_TAG" \
+              --title "$NEW_TAG" \
+              --notes-file release-notes.md
+          fi
 
   # ── Publish to PyPI ────────────────────────────────────────────────────
   # Last step. On a fork this fails at the OIDC step — by design.

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -360,24 +360,43 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.scan-commits.outputs.release_sha }}
-          persist-credentials: false
+          # This job creates the tag, so keep the GITHUB_TOKEN in git config
+          # for the push below. Other jobs use persist-credentials: false.
+          persist-credentials: true
 
       - name: Download release notes artifact
         uses: actions/download-artifact@v8
         with:
           name: release-notes
 
-      - name: Create release (atomically tags the pinned SHA)
+      - name: Tag the pinned SHA and create the release
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_TAG: ${{ needs.scan-commits.outputs.new_tag }}
           RELEASE_SHA: ${{ needs.scan-commits.outputs.release_sha }}
         run: |
           set -euo pipefail
-          gh release create "$NEW_TAG" \
-            --target "$RELEASE_SHA" \
-            --title "$NEW_TAG" \
-            --notes-file release-notes.md
+          # Push the tag over git rather than letting `gh release create
+          # --target <sha>` create it through the releases API. The API path
+          # returns "403 Resource not accessible by integration" for the
+          # GITHUB_TOKEN (see cli/cli#9514); a plain ref push with the same
+          # token succeeds.
+          #
+          # Both steps are guarded so re-running the job after a partial
+          # failure is safe: if a prior run pushed the tag but errored before
+          # the release was made, git push would otherwise refuse the existing
+          # tag. This keeps the "tag is source of truth, just re-run" contract.
+          if ! git ls-remote --exit-code --tags origin "refs/tags/$NEW_TAG" >/dev/null 2>&1; then
+            git tag "$NEW_TAG" "$RELEASE_SHA"
+            git push origin "refs/tags/$NEW_TAG"
+          fi
+
+          # Tag now exists on the remote, so this only attaches notes to it.
+          if ! gh release view "$NEW_TAG" >/dev/null 2>&1; then
+            gh release create "$NEW_TAG" \
+              --title "$NEW_TAG" \
+              --notes-file release-notes.md
+          fi
 
   # ── Publish to npm ─────────────────────────────────────────────────────
   # Last step. On a fork this fails at the OIDC step — by design.


### PR DESCRIPTION
## Description

The release workflows create the GitHub release with:

```bash
gh release create "$NEW_TAG" --target "$RELEASE_SHA" ...
```

With `--target <sha>`, the releases API creates the tag ref as a side effect of the `POST /releases` call, and that call is refused for the Actions `GITHUB_TOKEN` with:

```
HTTP 403: Resource not accessible by integration
```

The job already declares `permissions: contents: write`, and a plain `git push` of a ref with the same token succeeds in this repo (e.g. `docs-deploy-github-pages.yml` pushes to `gh-pages` with the default token).

This PR splits the two operations:

- **Create the tag over git** — `git tag "$NEW_TAG" "$RELEASE_SHA"` then `git push origin`, so the tag is created through the git protocol (which works) rather than the releases API (which 403s). The checkout for this job sets `persist-credentials: true` so the push authenticates with the job's `GITHUB_TOKEN`; every other job keeps `persist-credentials: false`.
- **Attach the release to the existing tag** — `gh release create "$NEW_TAG"` without `--target`, so the API only creates the release object and never touches the tag.

The SHA pin is preserved: the tag still lands on the exact reviewed `release_sha`, so the tagged commit matches the built/inspected/approved artifact. Applied identically to `release-python.yml` and `release-typescript.yml`.

## Related Issues

Fixes the `create-gh-release` 403 seen on the first run of the release pipeline (introduced in #2940).

## Type of Change

Bug fix

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
