### PR TITLE
feat(ts-metrics): expose metrics getter on LocalAgent

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -403,6 +403,19 @@ describe('Agent', () => {
       })
     })
 
+    describe('metrics getter', () => {
+      it('exposes accumulated metrics on the agent instance', async () => {
+        const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+        const agent = new Agent({ model })
+
+        expect(agent.metrics.cycleCount).toBe(0)
+
+        await agent.invoke('Test')
+
+        expect(agent.metrics.cycleCount).toBe(1)
+      })
+    })
+
     describe('metrics on errors', () => {
       it('tracks cycle count when maxTokens error occurs', async () => {
         const model = new MockMessageModel()

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -104,7 +104,7 @@ import { MemoryManager } from '../memory/memory-manager.js'
 import type { MemoryManagerConfig } from '../memory/index.js'
 import { SessionManager } from '../session/session-manager.js'
 import { Tracer } from '../telemetry/tracer.js'
-import { Meter } from '../telemetry/meter.js'
+import { AgentMetrics, Meter } from '../telemetry/meter.js'
 import type { AttributeValue } from '@opentelemetry/api'
 import { logger } from '../logging/logger.js'
 import { CancelledError } from '../errors.js'
@@ -889,6 +889,13 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   get toolRegistry(): ToolRegistry {
     return this._toolRegistry
+  }
+
+  /**
+   * Read-only snapshot of accumulated agent metrics (cycles, token usage, tool stats).
+   */
+  get metrics(): AgentMetrics {
+    return this._meter.metrics
   }
 
   /**

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -251,6 +251,11 @@ export interface LocalAgent {
   readonly id: string
 
   /**
+   * Read-only snapshot of accumulated agent metrics (cycles, token usage, tool stats).
+   */
+  readonly metrics: AgentMetrics
+
+  /**
    * App state storage accessible to tools and application logic.
    */
   appState: StateStore


### PR DESCRIPTION

## Description

Exposes `agent.metrics` as a public property on `LocalAgent` in the TypeScript SDK, matching the Python SDK's `agent.event_loop_metrics`. This lets plugins read accumulated metrics (cycle count, token usage, tool stats) directly from the agent reference they already have, rather than waiting for an `AgentResult` or reaching into private fields.

The `AgentMetrics` class is already public and returned on `AgentResult` — this just makes it accessible on the agent itself, which is what plugins receive in `initAgent` and hook callbacks.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

N/A — no new docs needed; `AgentMetrics` is already documented and exported.

## Type of Change

New feature

## Testing

- [x] Added a unit test verifying `agent.metrics.cycleCount` is 0 before invocation and 1 after
- [x] Type check passes (`tsc --noEmit`)
- [x] All 222 existing + new unit tests pass

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.