### PR TITLE
fix(session): encode bytes in SessionAgent.to_dict() for JSON serialization

### DIFF
--- a/strands-py/src/strands/types/session.py
+++ b/strands-py/src/strands/types/session.py
@@ -166,11 +166,12 @@ class SessionAgent:
     @classmethod
     def from_dict(cls, env: dict[str, Any]) -> "SessionAgent":
         """Initialize a SessionAgent from a dictionary, ignoring keys that are not class parameters."""
-        return cls(**{k: v for k, v in env.items() if k in inspect.signature(cls).parameters})
+        extracted_relevant_parameters = {k: v for k, v in env.items() if k in inspect.signature(cls).parameters}
+        return cls(**decode_bytes_values(extracted_relevant_parameters))
 
     def to_dict(self) -> dict[str, Any]:
         """Convert the SessionAgent to a dictionary representation."""
-        return asdict(self)
+        return encode_bytes_values(asdict(self))  # type: ignore[no-any-return]
 
     def initialize_internal_state(self, agent: "Agent") -> None:
         """Initialize internal state of agent."""

--- a/strands-py/src/strands/types/session.py
+++ b/strands-py/src/strands/types/session.py
@@ -101,7 +101,7 @@ class SessionMessage:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert the SessionMessage to a dictionary representation."""
-        return encode_bytes_values(asdict(self))  # type: ignore
+        return encode_bytes_values(asdict(self))  # type: ignore[no-any-return]
 
 
 @dataclass

--- a/strands-py/tests/strands/types/test_session.py
+++ b/strands-py/tests/strands/types/test_session.py
@@ -151,7 +151,7 @@ def test_session_agent_with_bytes():
         state={"document": {"format": "pdf", "source": {"bytes": b"This is binary data"}}},
     )
 
-    # json dumps will fail if its not json serializable
+    # json dumps will fail if it's not json serializable
     agent_json_string = json.dumps(session_agent.to_dict())
 
     # Load it back and verify the full state round-trips, bytes included

--- a/strands-py/tests/strands/types/test_session.py
+++ b/strands-py/tests/strands/types/test_session.py
@@ -140,3 +140,20 @@ def test_session_agent_initialize_internal_state():
     tru_model_state = agent._model_state
     exp_model_state = {"response_id": "resp_abc"}
     assert tru_model_state == exp_model_state
+
+
+def test_session_agent_with_bytes():
+    # Agent state can hold binary content (e.g. inline PDF bytes from a multimodal prompt), which
+    # crashes json.dumps() unless to_dict() encodes it. Regression test for #1864.
+    session_agent = SessionAgent(
+        agent_id="a1",
+        conversation_manager_state={},
+        state={"document": {"format": "pdf", "source": {"bytes": b"This is binary data"}}},
+    )
+
+    # json dumps will fail if its not json serializable
+    agent_json_string = json.dumps(session_agent.to_dict())
+
+    # Load it back and verify the full state round-trips, bytes included
+    loaded_agent = SessionAgent.from_dict(json.loads(agent_json_string))
+    assert loaded_agent.state == session_agent.state


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Saving a session fails with `TypeError: Object of type bytes is not JSON serializable` when a `SessionAgent`'s state holds binary data.

### Cause

This can occur with multimodal prompts. If a document (e.g. a PDF) is sent inline as raw bytes (which is what a LiteLLM proxy requires) those bytes end up in the agent's state. Then, when an `S3SessionManager` or `FileSessionManager` saves the session, it converts that `SessionAgent` to JSON, and JSON can't handle raw bytes, leading to the error.

### Solution

Make `SessionAgent` convert bytes to base64 when saving (`to_dict()`) and back to bytes when loading (`from_dict()`) — exactly what `SessionMessage` already does. `Session` is left unchanged, since it never holds bytes.

## Related Issues

<!-- Link to related issues using #issue-number format -->

Closes #1864 

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
