### PR TITLE
fix(py): declarative rebuild for _fix_broken_tool_use

### DIFF
--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -25,11 +25,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _make_error_result(tool_use_id: str) -> ContentBlock:
-    """Create a single error toolResult content block for an interrupted tool."""
-    return generate_missing_tool_result_content([tool_use_id])[0]
-
-
 class RepositorySessionManager(SessionManager):
     """Session manager for persisting agents in a SessionRepository."""
 
@@ -303,8 +298,10 @@ class RepositorySessionManager(SessionManager):
                 continue
 
             logger.warning(
-                "Session message history has an orphaned toolUse with no toolResult. "
-                "Adding toolResult content blocks to create valid conversation."
+                "tool_use_ids=<%s>, result_ids=<%s> | session history has mismatched toolUse/toolResult pairing,"
+                " rebuilding",
+                tool_use_ids,
+                list(existing_results.keys()),
             )
 
             # Ensure a toolResult slot exists after this assistant message
@@ -314,7 +311,7 @@ class RepositorySessionManager(SessionManager):
                 non_tool_result_content = []
 
             next_message["content"] = [
-                existing_results.get(tid, _make_error_result(tid)) for tid in tool_use_ids
+                existing_results.get(tid, generate_missing_tool_result_content([tid])[0]) for tid in tool_use_ids
             ] + non_tool_result_content
 
         return messages

--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -5,8 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ..agent.state import AgentState
-from ..tools._tool_helpers import generate_missing_tool_result_content
-from ..types.content import Message
+from ..types.content import ContentBlock, Message
 from ..types.exceptions import SessionException
 from ..types.session import (
     Session,
@@ -23,6 +22,17 @@ if TYPE_CHECKING:
     from ..multiagent.base import MultiAgentBase
 
 logger = logging.getLogger(__name__)
+
+
+def _make_error_result(tool_use_id: str) -> ContentBlock:
+    """Create a single error toolResult content block for an interrupted tool."""
+    return {
+        "toolResult": {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Tool was interrupted."}],
+        }
+    }
 
 
 class RepositorySessionManager(SessionManager):
@@ -245,22 +255,19 @@ class RepositorySessionManager(SessionManager):
     def _fix_broken_tool_use(self, messages: list[Message]) -> list[Message]:
         """Fix broken tool use/result pairs in message history.
 
-        This method handles two issues:
-        1. Orphaned toolUse messages without corresponding toolResult.
-           Before 1.15.0, strands had a bug where they persisted sessions with a potentially broken messages array.
-           This method retroactively fixes that issue by adding a tool_result outside of session management.
-           After 1.15.0, this bug is no longer present.
-        2. Orphaned toolResult messages without corresponding toolUse (e.g., when pagination truncates messages)
+        Handles orphaned toolUse (no corresponding toolResult), stale toolResult (IDs that don't match
+        the preceding toolUse), and orphaned toolResult at conversation start (no preceding toolUse).
+
+        Uses a declarative rebuild: for each assistant message with toolUse, the next message's toolResult
+        content is rebuilt to have exactly one result per toolUse ID, filling gaps with error results and
+        dropping stale ones by construction.
 
         Args:
             messages: The list of messages to fix
-            agent_id: The agent ID for fetching previous messages
-            removed_message_count: Number of messages removed by the conversation manager
 
         Returns:
             Fixed list of messages with proper tool use/result pairs
         """
-        # First, check if the oldest message has orphaned toolResult (no preceding toolUse) and remove it.
         if messages:
             first_message = messages[0]
             if first_message["role"] == "user" and any("toolResult" in content for content in first_message["content"]):
@@ -271,48 +278,50 @@ class RepositorySessionManager(SessionManager):
                 )
                 messages.pop(0)
 
-        # Then check for orphaned toolUse messages. Snapshot the eligible indices before
-        # iterating so that inserting a toolResult (which shifts later indices) does not
-        # cause the loop to skip a subsequent orphaned toolUse. The trailing message is
-        # excluded from the snapshot because that case is handled in the agent class when
-        # a new prompt arrives, so we do not synthesize a toolResult into persisted
-        # history for it here. Walking in reverse means each insert only shifts already-
-        # processed positions, so the original snapshot indices remain valid.
+        # Snapshot eligible indices before iterating. Trailing message excluded (handled by agent class
+        # at prompt-arrival time). Reverse iteration keeps snapshotted indices valid after inserts.
         original_last_index = len(messages) - 1
         tool_use_indices = [
             index
             for index, message in enumerate(messages)
             if index < original_last_index and any("toolUse" in content for content in message["content"])
         ]
+
         for index in reversed(tool_use_indices):
             message = messages[index]
             tool_use_ids = [
                 content["toolUse"]["toolUseId"] for content in message["content"] if "toolUse" in content
             ]
 
-            # Check the toolResult ids already present in the next message.
-            tool_result_ids = [
-                content["toolResult"]["toolUseId"]
-                for content in messages[index + 1]["content"]
-                if "toolResult" in content
-            ]
+            next_message = messages[index + 1]
+            next_content = next_message["content"]
 
-            missing_tool_use_ids = list(set(tool_use_ids) - set(tool_result_ids))
-            if not missing_tool_use_ids:
+            existing_results: dict[str, ContentBlock] = {}
+            non_tool_result_content: list[ContentBlock] = []
+            for block in next_content:
+                if "toolResult" in block:
+                    existing_results[block["toolResult"]["toolUseId"]] = block
+                else:
+                    non_tool_result_content.append(block)
+
+            if set(existing_results.keys()) == set(tool_use_ids):
                 continue
 
             logger.warning(
                 "Session message history has an orphaned toolUse with no toolResult. "
                 "Adding toolResult content blocks to create valid conversation."
             )
-            missing_content_blocks = generate_missing_tool_result_content(missing_tool_use_ids)
 
-            if tool_result_ids:
-                # If there were any toolResult ids, that means only some of the content blocks are missing
-                messages[index + 1]["content"].extend(missing_content_blocks)
-            else:
-                # The message following the toolUse was not a toolResult, so lets insert it
-                messages.insert(index + 1, {"role": "user", "content": missing_content_blocks})
+            # Ensure a toolResult slot exists after this assistant message
+            if not existing_results and non_tool_result_content:
+                messages.insert(index + 1, {"role": "user", "content": []})
+                next_message = messages[index + 1]
+                non_tool_result_content = []
+
+            next_message["content"] = [
+                existing_results.get(tid, _make_error_result(tid)) for tid in tool_use_ids
+            ] + non_tool_result_content
+
         return messages
 
     def sync_multi_agent(self, source: "MultiAgentBase", **kwargs: Any) -> None:

--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ..agent.state import AgentState
+from ..tools._tool_helpers import generate_missing_tool_result_content
 from ..types.content import ContentBlock, Message
 from ..types.exceptions import SessionException
 from ..types.session import (
@@ -26,13 +27,7 @@ logger = logging.getLogger(__name__)
 
 def _make_error_result(tool_use_id: str) -> ContentBlock:
     """Create a single error toolResult content block for an interrupted tool."""
-    return {
-        "toolResult": {
-            "toolUseId": tool_use_id,
-            "status": "error",
-            "content": [{"text": "Tool was interrupted."}],
-        }
-    }
+    return generate_missing_tool_result_content([tool_use_id])[0]
 
 
 class RepositorySessionManager(SessionManager):

--- a/strands-py/tests/strands/session/test_repository_session_manager.py
+++ b/strands-py/tests/strands/session/test_repository_session_manager.py
@@ -371,6 +371,33 @@ def test_fix_broken_tool_use_extends_partial_tool_results(existing_session_manag
     assert missing_result["toolResult"]["content"][0]["text"] == "Tool was interrupted."
 
 
+def test_fix_broken_tool_use_removes_stale_tool_results(session_manager):
+    """Test that toolResults with IDs not matching any preceding toolUse are dropped."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"toolUse": {"toolUseId": "valid-123", "name": "test_tool", "input": {"input": "test"}}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"toolResult": {"toolUseId": "stale-999", "status": "success", "content": [{"text": "stale"}]}},
+                {"toolResult": {"toolUseId": "valid-123", "status": "success", "content": [{"text": "result"}]}},
+            ],
+        },
+        {"role": "user", "content": [{"text": "Final message"}]},
+    ]
+
+    fixed_messages = session_manager._fix_broken_tool_use(messages)
+
+    assert len(fixed_messages) == 3
+    assert len(fixed_messages[1]["content"]) == 1
+    assert fixed_messages[1]["content"][0]["toolResult"]["toolUseId"] == "valid-123"
+    assert fixed_messages[1]["content"][0]["toolResult"]["status"] == "success"
+
+
 def test_fix_broken_tool_use_handles_multiple_orphaned_tools(existing_session_manager):
     """Test fixing multiple orphaned toolUse messages."""
 

--- a/strands-py/tests/strands/session/test_repository_session_manager.py
+++ b/strands-py/tests/strands/session/test_repository_session_manager.py
@@ -372,7 +372,7 @@ def test_fix_broken_tool_use_extends_partial_tool_results(existing_session_manag
 
 
 def test_fix_broken_tool_use_removes_stale_tool_results(session_manager):
-    """Test that toolResults with IDs not matching any preceding toolUse are dropped."""
+    """Test that toolResults with IDs not matching any preceding toolUse are dropped (#2296)."""
     messages = [
         {
             "role": "assistant",
@@ -393,9 +393,9 @@ def test_fix_broken_tool_use_removes_stale_tool_results(session_manager):
     fixed_messages = session_manager._fix_broken_tool_use(messages)
 
     assert len(fixed_messages) == 3
-    assert len(fixed_messages[1]["content"]) == 1
-    assert fixed_messages[1]["content"][0]["toolResult"]["toolUseId"] == "valid-123"
-    assert fixed_messages[1]["content"][0]["toolResult"]["status"] == "success"
+    assert fixed_messages[1]["content"] == [
+        {"toolResult": {"toolUseId": "valid-123", "status": "success", "content": [{"text": "result"}]}}
+    ]
 
 
 def test_fix_broken_tool_use_handles_multiple_orphaned_tools(existing_session_manager):


### PR DESCRIPTION

## Description

`_fix_broken_tool_use` previously detected and repaired broken toolUse/toolResult pairings through sequential mutation steps: find stale results, remove them, recompute what's missing, then extend/insert/reuse depending on the state. Each step read state that the previous step mutated, and each edge case (stale-only results, partial results, empty messages) required its own branch.

This PR replaces the loop body with a declarative rebuild:

1. **Partition** the next message's content into a `dict[toolUseId → ContentBlock]` and a list of non-toolResult blocks.
2. **Short-circuit** if the result IDs already match the toolUse IDs exactly.
3. **Ensure a slot** exists (insert an empty user message only when the next message is text-only).
4. **Rebuild unconditionally**: `[existing.get(tid, error_result(tid)) for tid in tool_use_ids] + non_tool_result_content`.

Correctness falls out of the data structure choice — stale results are never selected from the dict, missing results are filled by the default, and the comprehension produces exactly one result per toolUse ID by definition.

## Related Issues

#2296

## Documentation PR

N/A — internal repair logic with no public API surface.

## Type of Change

Other (please describe): Refactor of internal session repair logic that also fixes the stale-toolResult bug (#2296).

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`
- All 44 existing tests in `test_repository_session_manager.py` pass unchanged
- Added `test_fix_broken_tool_use_removes_stale_tool_results` covering the case where the next message has toolResult IDs that don't match any toolUse in the preceding assistant message

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.