### PR TITLE
fix(bidi): remove duplicate client creation in Nova Sonic start()

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
+++ b/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
@@ -274,14 +274,12 @@ class BidiNovaSonicModel(BidiModel):
             aws_session_token=credentials.token,
         )
 
-        self.client = BedrockRuntimeClient(config=config)
+        self._client = BedrockRuntimeClient(config=config)
         logger.debug("region=<%s> | nova sonic client initialized", self.region)
 
-        client = BedrockRuntimeClient(config=config)
-        self._stream = await client.invoke_model_with_bidirectional_stream(
+        self._stream = await self._client.invoke_model_with_bidirectional_stream(
             InvokeModelWithBidirectionalStreamOperationInput(model_id=self.model_id)
         )
-        logger.debug("region=<%s> | nova sonic client initialized", self.region)
 
         init_events = self._build_initialization_events(system_prompt, tools, messages)
         logger.debug("event_count=<%d> | sending nova sonic initialization events", len(init_events))

--- a/strands-py/tests/strands/experimental/bidi/models/test_nova_sonic.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_nova_sonic.py
@@ -205,7 +205,6 @@ async def test_model_stop_alone(nova_model):
 @pytest.mark.asyncio
 async def test_connection_with_message_history(nova_model, mock_client, mock_stream):
     """Test connection initialization with conversation history."""
-    nova_model.client = mock_client
 
     # Create message history
     messages = [


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

BidiNovaSonicModel.start() creates two BedrockRuntimeClient instances: one assigned to self.client (never referenced elsewhere in the class) and a second local variable that's actually used to open the bidirectional stream. This wastes resources by instantiating a client that is immediately discarded, and produces a duplicate "client initialized" log line that clutters debug output.

This change consolidates to a single client stored as `self._client`, logs once after initialization, and uses it for the stream. The test had a corresponding dead assignment (`nova_model.client = mock_client`),  that is also removed.

## Related Issues

<!-- Link to related issues using #issue-number format -->
#1722 

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
