### PR TITLE
fix(bidi): fix typo and inconsistent error messages across model providers

### DIFF
--- a/strands-py/src/strands/experimental/bidi/agent/loop.py
+++ b/strands-py/src/strands/experimental/bidi/agent/loop.py
@@ -50,7 +50,7 @@ class _BidiAgentLoop:
             This allows passing custom data (user_id, session_id, database connections, etc.)
             that tools can access via their invocation_state parameter.
         _send_gate: Gate the sending of events to the model.
-            Blocks when agent is reseting the model connection after timeout.
+            Blocks when agent is resetting the model connection after timeout.
     """
 
     def __init__(self, agent: "BidiAgent") -> None:
@@ -182,7 +182,7 @@ class _BidiAgentLoop:
         Args:
             timeout_error: Timeout error reported by the model.
         """
-        logger.debug("reseting model connection")
+        logger.debug("resetting model connection")
 
         self._send_gate.clear()
 

--- a/strands-py/src/strands/experimental/bidi/models/gemini_live.py
+++ b/strands-py/src/strands/experimental/bidi/models/gemini_live.py
@@ -385,7 +385,7 @@ class BidiGeminiLiveModel(BidiModel):
             ValueError: If content type not supported (e.g., image content).
         """
         if not self._connection_id:
-            raise RuntimeError("model not started | call start before sending/receiving")
+            raise RuntimeError("model not started | call start before sending")
 
         if isinstance(content, BidiTextInputEvent):
             await self._send_text_content(content.text)

--- a/strands-py/src/strands/experimental/bidi/models/openai_realtime.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai_realtime.py
@@ -419,7 +419,7 @@ class BidiOpenAIRealtimeModel(BidiModel):
     async def receive(self) -> AsyncGenerator[BidiOutputEvent, None]:
         """Receive OpenAI events and convert to Strands TypedEvent format."""
         if not self._connection_id:
-            raise RuntimeError("model not started | call start before sending/receiving")
+            raise RuntimeError("model not started | call start before receiving")
 
         yield BidiConnectionStartEvent(connection_id=self._connection_id, model=self.model_id)
 

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -41,13 +41,13 @@ class MockBidiModel:
 
     async def send(self, content):
         if not self._started:
-            raise RuntimeError("model not started | call start before sending/receiving")
+            raise RuntimeError("model not started | call start before sending")
         # Mock implementation - in real tests, this would trigger events
 
     async def receive(self):
         """Async generator yielding mock events."""
         if not self._started:
-            raise RuntimeError("model not started | call start before sending/receiving")
+            raise RuntimeError("model not started | call start before receiving")
 
         # Yield connection start event
         yield BidiConnectionStartEvent(connection_id=self._connection_id, model=self.model_id)


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
The bidi model providers have inconsistent error messages when methods are called before start(). Gemini's send() raises `"call start before sending/receiving"` and OpenAI's receive() raises the same combined message, even though each method only performs one operation. Nova Sonic uses the correct pattern which is `"call start before sending"` in send() and `"call start before receiving"` in receive(). This inconsistency makes debugging harder since the error message doesn't accurately reflect which operation failed.

Additionally, the agent loop has a "reseting" typo in both a docstring and a log message.

This PR fixes both the above issues. 

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): logging fix 

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
