### PR TITLE
ci(ts): fixed typescript release-workflow not running integ tests

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -82,7 +82,12 @@ jobs:
           # Skip on merge_group (gated by branch protection) and on
           # workflow_call (the caller — release.yml — is workflow_dispatch
           # gated, see the trigger comment above).
-          skip-check: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_call' }}
+          # `github.event_name` can't identify the release here — inside a
+          # reusable workflow it reports the caller's event, never
+          # 'workflow_call' — so key off `inputs.ref`, which only a
+          # workflow_call caller supplies (empty on pull_request_target /
+          # merge_group). Matches the validate-call-ref guard above.
+          skip-check: ${{ github.event_name == 'merge_group' || inputs.ref != '' }}
           username: ${{ github.event.pull_request.user.login || 'invalid' }}
           allowed-roles: 'maintain,triage,write,admin'
 

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -166,6 +166,7 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ needs.scan-commits.outputs.release_sha }}
+      full_suite: true
 
   # ── Security audit (informational) ─────────────────────────────────────
   security-audit:

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -31,6 +31,11 @@ on:
       ref:
         required: true
         type: string
+      full_suite:
+        description: 'Run the entire integ suite instead of the change-based selective set. Releases set this so the published artifact is always fully exercised.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   validate-call-ref:
@@ -131,7 +136,20 @@ jobs:
       - name: Build the package
         run: npm run build
 
-      - name: Run integration tests
+      # Releases pin a SHA on main history; the selective runner would diff it
+      # against origin/main, find no changes, and skip — so releases force the
+      # full suite to always exercise the artifact being published.
+      - name: Run integration tests (full suite)
+        if: ${{ inputs.full_suite == true }}
+        run: npm run test:integ:all
+
+      # Runs on every path that is NOT an explicit full-suite release: PR and
+      # merge_group (where `inputs.full_suite` is null, not false) and any
+      # workflow_call that leaves it defaulted. `!= true` makes this the exact
+      # complement of the full-suite step above, so exactly one always runs —
+      # a PR can never match neither and silently skip integ.
+      - name: Run integration tests (selective)
+        if: ${{ inputs.full_suite != true }}
         env:
           # PR events expose the base SHA directly; merge_group exposes it as
           # merge_group.base_sha. Falling back to the merge-queue base avoids

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -87,10 +87,14 @@ jobs:
         id: auth
         uses: strands-agents/devtools/authorization-check@main
         with:
-          # Skip on merge_group (gated by branch protection) and on
-          # workflow_call (the caller — release.yml — is workflow_dispatch
-          # gated, see the trigger comment above).
-          skip-check: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_call' }}
+          # Skip on merge_group (gated by branch protection) and on the release
+          # (the caller — release.yml — is workflow_dispatch gated, see the
+          # trigger comment above). `github.event_name` can't identify the
+          # release here — inside a reusable workflow it reports the caller's
+          # event, never 'workflow_call' — so key off `inputs.ref`, which only a
+          # workflow_call caller supplies (empty on pull_request_target /
+          # merge_group). Matches the validate-call-ref guard above.
+          skip-check: ${{ github.event_name == 'merge_group' || inputs.ref != '' }}
           username: ${{ github.event.pull_request.user.login || 'invalid' }}
           allowed-roles: 'triage,write,maintain,admin'
 


### PR DESCRIPTION
## Description
### Typescript integ tests got skipped during release workflow

In typescript integ test, we have a selective script to run the integ tests when there's the diff between changes and main.  

For the release workflow, there's no diff from `origin/main` (since the pinned SHA is main), then the integ tests are skipped in the release workflow.

Therefore, making the changes to add `Run integration tests (full suite)` for workflow to always run integ tests.

### Skip manual approval for ts / python releases

Currently in the release workflow, user will have to go and click manual approval to run integ tests.

Added `input.ref != ''` to bypass it. The reason why I am not using `github.event_name == 'workflow_dispatch'` is that in the future we might have other worflow_dispatch event, which makes the integ tests to always run.


## Related Issues

Release workflow

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
