### PR TITLE
fix(bidi): export BidiConnectionRestartEvent and add 8kHz sample rate support

### DIFF
--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
@@ -121,8 +121,12 @@ For more details on this approach, please refer to the [boto3 session docs](http
 
 | Parameter | Description | Example | Options |
 | --------- | ----------- | ------- | ------- |
-| `audio` | `AudioConfig` instance. | `{"voice": "tiffany"}` | [reference](@api/python/strands.experimental.bidi.types.model#AudioConfig) |
+| `audio` | `AudioConfig` instance. | `{"voice": "tiffany", "output_rate": 24000}` | [reference](@api/python/strands.experimental.bidi.types.model#AudioConfig) |
 | `inference` | Session start `inferenceConfiguration`'s (as snake_case). | `{"top_p": 0.9}` | [reference](https://docs.aws.amazon.com/nova/latest/userguide/input-events.html)
+
+:::note
+The `audio` config accepts any sample rate supported by the underlying model API. Refer to the [Nova Sonic documentation](https://docs.aws.amazon.com/nova/latest/userguide/speech.html) for the full list of supported rates.
+:::
 
 ## Troubleshooting
 

--- a/strands-py/src/strands/experimental/bidi/__init__.py
+++ b/strands-py/src/strands/experimental/bidi/__init__.py
@@ -22,6 +22,7 @@ from .types.events import (
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
     BidiConnectionCloseEvent,
+    BidiConnectionRestartEvent,
     BidiConnectionStartEvent,
     BidiErrorEvent,
     BidiImageInputEvent,
@@ -46,6 +47,7 @@ __all__ = [
     "BidiInputEvent",
     # Output Event types
     "BidiConnectionStartEvent",
+    "BidiConnectionRestartEvent",
     "BidiConnectionCloseEvent",
     "BidiResponseStartEvent",
     "BidiResponseCompleteEvent",

--- a/strands-py/src/strands/experimental/bidi/types/events.py
+++ b/strands-py/src/strands/experimental/bidi/types/events.py
@@ -40,7 +40,7 @@ AudioChannel = Literal[1, 2]
 """
 AudioFormat = Literal["pcm", "wav", "opus", "mp3"]
 """Audio encoding format."""
-AudioSampleRate = Literal[16000, 24000, 48000]
+AudioSampleRate = Literal[8000, 16000, 24000, 48000]
 """Audio sample rate in Hz."""
 
 Role = Literal["user", "assistant"]

--- a/strands-py/src/strands/experimental/bidi/types/model.py
+++ b/strands-py/src/strands/experimental/bidi/types/model.py
@@ -22,8 +22,8 @@ class AudioConfig(TypedDict, total=False):
     audio I/O implementations to configure hardware appropriately.
 
     Attributes:
-        input_rate: Input sample rate in Hz (e.g., 16000, 24000, 48000)
-        output_rate: Output sample rate in Hz (e.g., 16000, 24000, 48000)
+        input_rate: Input sample rate in Hz (e.g., 8000, 16000, 24000, 48000)
+        output_rate: Output sample rate in Hz (e.g., 8000, 16000, 24000, 48000)
         channels: Number of audio channels (1=mono, 2=stereo)
         format: Audio encoding format
         voice: Voice identifier for text-to-speech (e.g., "alloy", "matthew")


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

This PR addresses two gaps in the public API surface that affect users working with bidirectional streaming:

1. `BidiConnectionRestartEvent` is yielded to users via `agent.receive()` when the model connection times out and restarts, and it's part of the `BidiOutputEvent` union type. However, it's not re-exported from the top-level `bidi/__init__.py`, so users handling reconnection events can't import it from thepublic package without reaching into the internal types.events submodule.
2. Separately, the AudioSampleRate type literal and AudioConfig docstring only list [16000, 24000, 48000] as supported rates. This led users to believe 8kHz output wasn't supported, even though Nova Sonic v2 accepts it and it works at runtime. Adding 8000 to the literal and updating the documentation makes it clear that telephony-standard rates are valid.


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
Documentation update

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
