### PR TITLE
fix(ci): harden npm lifecycle scripts for best practices

### DIFF
--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run test:browser:install
 
       - name: Build the package


### PR DESCRIPTION

## Description

Adds `--ignore-scripts` to `npm ci` in the TypeScript integration test workflow. This prevents npm lifecycle scripts (preinstall/postinstall) from running during dependency installation, following GitHub's best practices for `pull_request_target` workflows that handle credentials. The explicit `npm run build` step that follows handles compilation.

## Related Issues

## Documentation PR

N/A — CI-only change.

## Type of Change

Bug fix

## Testing

- Verified locally that `npm ci --ignore-scripts && npm run build` succeeds in `strands-ts/` (no native dependencies require lifecycle scripts)

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.