### PR TITLE
docs(bidi): fix model_id, client config key, and missing import in docs

### DIFF
--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -218,7 +218,7 @@ Each model provider has specific configuration options:
 from strands.experimental.bidi.models import BidiNovaSonicModel
 
 model = BidiNovaSonicModel(
-    model_id="amazon.nova-sonic-v1:0",
+    model_id="amazon.nova-2-sonic-v1:0",
     provider_config={
         "audio": {
             "input_rate": 16000,

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
@@ -53,7 +53,7 @@ from strands_tools import calculator
 
 async def main() -> None:
     model = BidiNovaSonicModel(
-        model_id="amazon.nova-sonic-v1:0",
+        model_id="amazon.nova-2-sonic-v1:0",
         provider_config={
             "audio": {
                 "voice": "tiffany",
@@ -114,7 +114,7 @@ For more details on this approach, please refer to the [boto3 session docs](http
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `boto3_session` | A `boto3.Session` instance under which AWS credentials are configured. | `None` |
+| `boto_session` | A `boto3.Session` instance under which AWS credentials are configured. | `None` |
 | `region` | Region under which credentials are configured. Cannot use if providing `boto3_session`. | `us-east-1` |
 
 ### Provider Configs

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
@@ -537,6 +537,8 @@ from strands.experimental.bidi.models import BidiOpenAIRealtimeModel
 model = BidiOpenAIRealtimeModel()
 
 # Or handle restarts gracefully
+from strands.experimental.bidi import BidiConnectionRestartEvent
+
 async for event in agent.receive():
     if isinstance(event, BidiConnectionRestartEvent):
         print("Reconnecting...")


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

The bidirectional streaming documentation had three inaccuracies that cause user confusion:

1. The Nova Sonic code examples in `nova_sonic.mdx` and `agent.mdx` hardcoded `model_id="amazon.nova-sonic-v1:0"` (v1), but the SDK default is now "amazon.nova-2-sonic-v1:0" (v2). Users copying the example get the older model instead of the current default.

2. The client config table in `nova_sonic.mdx` listed the key as `boto3_session`, but the actual key accepted by BidiNovaSonicModel is boto_session (no 3).
3. The connection timeout troubleshooting snippet in `quickstart.mdx` used `BidiConnectionRestartEvent` without showing the import.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Documentation update

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
