### PR TITLE
docs(memory): add memory stores section on community page

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -337,6 +337,9 @@ sidebar:
           - docs/community/model-providers/mlx
           - docs/community/model-providers/ovhcloud-ai-endpoints
           - docs/community/model-providers/xai
+      - label: Memory Stores
+        items:
+          - docs/community/memory-stores/overview
       - label: Session Managers
         items:
           - docs/community/session-managers/agentcore-memory

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -148,7 +148,7 @@ export const collections = {
         // Category for TypeScript API docs (classes, interfaces, type-aliases, functions)
         category: z.string().optional(),
         // Integration type for filtering (e.g., 'model-provider' for model providers)
-        integrationType: z.enum(['model-provider', 'tool', 'session-manager', 'integration', 'plugin', 'agent-extension']).optional(),
+        integrationType: z.enum(['model-provider', 'tool', 'session-manager', 'memory-store', 'integration', 'plugin', 'agent-extension']).optional(),
         // Short description for catalog listings
         description: z.string().optional(),
         // Array of slugs that should redirect to this page (e.g., old URLs)

--- a/site/src/content/docs/community/community-packages.mdx
+++ b/site/src/content/docs/community/community-packages.mdx
@@ -14,6 +14,7 @@ export const communityIntegrations = getIntegrationEntries(allDocs, 'integration
 export const communityPlugins = getIntegrationEntries(allDocs, 'plugin', true)
 export const communityModelProviders = getIntegrationEntries(allDocs, 'model-provider', true)
 export const communitySessionManagers = getIntegrationEntries(allDocs, 'session-manager', true)
+export const communityMemoryStores = getIntegrationEntries(allDocs, 'memory-store', true)
 export const communityTools = getIntegrationEntries(allDocs, 'tool', true)
 export const communityAgentExtensions = getIntegrationEntries(allDocs, 'agent-extension', true)
 
@@ -68,6 +69,14 @@ Model providers add support for additional LLM services beyond the built-in prov
 Session managers provide alternative storage backends for conversation history. Use these when you need persistent, scalable, or distributed session storage.
 
 <SimpleTable data={communitySessionManagers} columns={packageColumns}>
+  {renderCell}
+</SimpleTable>
+
+## Memory stores
+
+Memory stores are backends that give agents long-term memory across sessions. Each implements the `MemoryStore` interface and plugs into an agent through a `MemoryManager`. See the [Memory Stores overview](./memory-stores/overview.md) for how they fit together.
+
+<SimpleTable data={communityMemoryStores} columns={packageColumns}>
   {renderCell}
 </SimpleTable>
 

--- a/site/src/content/docs/community/get-featured.mdx
+++ b/site/src/content/docs/community/get-featured.mdx
@@ -12,7 +12,8 @@ We feature **reusable packages** that extend Strands Agents capabilities:
 
 - **Model Providers** — integrations with LLM services (OpenAI-compatible endpoints, custom APIs, etc.)
 - **Tools** — packaged tools that solve common problems (API integrations, utilities, etc.)
-- **Session Managers** — custom session/memory implementations
+- **Session Managers** — custom storage backends for conversation history
+- **Memory Stores** — `MemoryStore` implementations giving agents long-term knowledge across sessions
 - **Plugins** — extend or modify agent behavior during lifecycle events
 - **Integrations** — protocol implementations, framework bridges, etc.
 - **Agent Extensions** — specialized agent subclasses that change how agents reason and act
@@ -39,6 +40,7 @@ Place your documentation in the right spot:
 | Model Providers | `community/model-providers/` | `cohere.mdx` |
 | Tools | `community/tools/` | `strands-deepgram.mdx` |
 | Session Managers | `community/session-managers/` | `agentcore-memory.mdx` |
+| Memory Stores | `community/memory-stores/` | `overview.mdx` |
 | Plugins | `community/plugins/` | `my-plugin.mdx` |
 | Integrations | `community/integrations/` | `ag-ui.mdx` |
 | Agent Extensions | `community/agent-extensions/` | `strands-code-agent.mdx` |
@@ -79,7 +81,7 @@ Links to your repo, PyPI, official docs, etc.
 
 Every community page needs frontmatter with catalog fields so it appears in the [community catalog](./community-packages.md). Without `community: true`, `integrationType`, `description`, and `languages`, your page won't show up in the catalog tables.
 
-Here's the full frontmatter for a **Tool** (adapt `integrationType` for your package type — `tool`, `model-provider`, `session-manager`, `plugin`, `integration`, or `agent-extension`):
+Here's the full frontmatter for a **Tool** (adapt `integrationType` for your package type — `tool`, `model-provider`, `session-manager`, `memory-store`, `plugin`, `integration`, or `agent-extension`):
 
 ```yaml
 ---
@@ -103,7 +105,7 @@ service:
 | Field | Required | Notes |
 |-------|----------|-------|
 | `community` | ✅ | Must be `true` |
-| `integrationType` | ✅ | `tool`, `model-provider`, `session-manager`, `plugin`, or `integration` |
+| `integrationType` | ✅ | `tool`, `model-provider`, `session-manager`, `memory-store`, `plugin`, or `integration` |
 | `description` | ✅ | Shown in the catalog table |
 | `languages` | ✅ | `Python`, `TypeScript`, or omit for both |
 | `project` | Recommended | PyPI/npm link, GitHub repo, maintainer |

--- a/site/src/content/docs/community/get-featured.mdx
+++ b/site/src/content/docs/community/get-featured.mdx
@@ -40,7 +40,7 @@ Place your documentation in the right spot:
 | Model Providers | `community/model-providers/` | `cohere.mdx` |
 | Tools | `community/tools/` | `strands-deepgram.mdx` |
 | Session Managers | `community/session-managers/` | `agentcore-memory.mdx` |
-| Memory Stores | `community/memory-stores/` | `overview.mdx` |
+| Memory Stores | `community/memory-stores/` | `my-store.mdx` |
 | Plugins | `community/plugins/` | `my-plugin.mdx` |
 | Integrations | `community/integrations/` | `ag-ui.mdx` |
 | Agent Extensions | `community/agent-extensions/` | `strands-code-agent.mdx` |
@@ -105,7 +105,7 @@ service:
 | Field | Required | Notes |
 |-------|----------|-------|
 | `community` | ✅ | Must be `true` |
-| `integrationType` | ✅ | `tool`, `model-provider`, `session-manager`, `memory-store`, `plugin`, or `integration` |
+| `integrationType` | ✅ | `tool`, `model-provider`, `session-manager`, `memory-store`, `plugin`, `integration`, or `agent-extension` |
 | `description` | ✅ | Shown in the catalog table |
 | `languages` | ✅ | `Python`, `TypeScript`, or omit for both |
 | `project` | Recommended | PyPI/npm link, GitHub repo, maintainer |

--- a/site/src/content/docs/community/memory-stores/overview.mdx
+++ b/site/src/content/docs/community/memory-stores/overview.mdx
@@ -1,0 +1,36 @@
+---
+title: Community Memory Stores
+description: Community-built memory stores that give agents long-term memory across sessions.
+tags: [memory]
+sidebar:
+  label: "Overview"
+---
+
+A **memory store** is the backend that holds an agent's long-term knowledge. The
+[`MemoryManager`](../../user-guide/concepts/memory/overview.md) orchestrates one or
+more stores to recall, inject, and extract memories across sessions. Any backend that
+implements the `MemoryStore` interface can plug in: see
+[Custom Stores](../../user-guide/concepts/memory/overview.md#custom-stores) for the
+contract.
+
+The SDK ships reference stores like the
+[Bedrock Knowledge Base store](../../user-guide/concepts/memory/bedrock-knowledge-base.md).
+The packages below go further: they are **community-built** memory stores you can install
+and attach to an agent, backed by vector databases, managed services, and other stores the
+SDK does not vend itself.
+
+:::note[Community maintained]
+These packages are maintained by their authors, not the Strands team. Review packages
+before using them in production. Quality and support may vary.
+:::
+
+## Browse the catalog
+
+See the [Memory stores section of the community catalog](../community-packages.md#memory-stores)
+for the current list, with language support and links to each package.
+
+## Add your memory store
+
+Built a `MemoryStore` implementation? See the [Get Featured guide](../get-featured.md) to
+list it here, and the [Extensions guide](../../contribute/contributing/extensions.md) for
+how to build and publish a package.

--- a/site/src/util/integration-content.ts
+++ b/site/src/util/integration-content.ts
@@ -2,7 +2,7 @@
  * Utilities for querying and filtering integration content from the docs collection.
  *
  * This module provides typed helper functions for working with integration pages
- * (model providers, tools, session managers, etc.) that have `integrationType` frontmatter.
+ * (model providers, tools, session managers, memory stores, etc.) that have `integrationType` frontmatter.
  */
 
 import type { CollectionEntry } from 'astro:content'
@@ -14,6 +14,7 @@ export type IntegrationType =
   | 'model-provider'
   | 'tool'
   | 'session-manager'
+  | 'memory-store'
   | 'integration'
   | 'plugin'
   | 'agent-extension'


### PR DESCRIPTION
## Description

`MemoryStore` is a new first-class SDK concept, but the community catalog had no category for it. New community stores that implement the `MemoryStore` interface had nowhere accurate to go.

This adds a dedicated **Memory Stores** community category so those packages have a correct, discoverable home, following the same end-to-end pattern every other community category already uses.

A category is defined in six coordinated places, all updated here so the section renders and stays in sync:

- New `memory-store` value in the `integrationType` enum, added at the same position in both `content.config.ts` (Zod schema) and `integration-content.ts` (the `IntegrationType` union) per the cross-file sync convention.
- New `community/memory-stores/overview.mdx` landing page. It intentionally carries no `community`/`integrationType` frontmatter: it is a concept/landing page, not a catalog entry, and it gives the nav group a content leaf so the group isn't dropped at build time.
- New **Memory Stores** nav group under Community in `navigation.yml`.
- New `## Memory stores` catalog section (plus the `communityMemoryStores` query) in `community-packages.mdx`.
- Contributor guide (`get-featured.mdx`) updated: the category list, the directory table, and the allowed `integrationType` values. The pre-existing Session Managers entry, which read "custom session/memory implementations," is retightened to "custom storage backends for conversation history" so the two categories no longer look overlapping.

The catalog table renders empty (headers only) until the first package is added and fills in automatically as contributors ship stores. Seeding an actual store page is left as a follow-up.

## Related Issues

Related: #3082

## Documentation PR

This PR is the documentation change. All edits are under `site/`.

## Type of Change

Documentation update

## Testing

Ran the site build locally (`npm run build`): 823 pages built, and the broken-link checker reported no broken links across all 822 HTML pages, which validates every relative link added here and the `#memory-stores` catalog anchor. Confirmed the new page builds at `/docs/community/memory-stores/overview/`, the **Memory Stores** group appears in the Community sidebar, and the catalog page exposes the `id="memory-stores"` section. `astro sync` confirmed the schema accepts the new `memory-store` enum value.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
