### PR TITLE
feat(ci): publish TypeScript integ test metrics to CloudWatch

### DIFF
--- a/.github/scripts/upload-integ-test-metrics.py
+++ b/.github/scripts/upload-integ-test-metrics.py
@@ -128,7 +128,7 @@ def publish_metrics(metric_data: list[dict[str, Any]], region: str):
 def main():
     if len(sys.argv) not in (3, 4):
         print("Usage: python upload-integ-test-metrics.py <xml_file> <repository_name> [sdk]")
-        sys.exit(0)
+        sys.exit(1)
 
     xml_file = sys.argv[1]
     repository = sys.argv[2]

--- a/.github/scripts/upload-integ-test-metrics.py
+++ b/.github/scripts/upload-integ-test-metrics.py
@@ -65,15 +65,16 @@ def parse_junit_xml(xml_file_path: str) -> list[TestResult]:
     return results
 
 
-def build_metric_data(test_results: list[TestResult], repository: str) -> list[MetricDatum]:
+def build_metric_data(test_results: list[TestResult], repository: str, sdk: str) -> list[MetricDatum]:
     metrics: list[MetricDatum] = []
     timestamp = datetime.utcnow()
-    
+
     for test in test_results:
         test_name = f"{test.classname}.{test.name}"
         dimensions: list[Dimension] = [
             Dimension(Name='TestName', Value=test_name),
-            Dimension(Name='Repository', Value=repository)
+            Dimension(Name='Repository', Value=repository),
+            Dimension(Name='SDK', Value=sdk)
         ]
         
         metrics.append(MetricDatum(
@@ -125,21 +126,22 @@ def publish_metrics(metric_data: list[dict[str, Any]], region: str):
 
 
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: python upload-integ-test-metrics.py <xml_file> <repository_name>")
+    if len(sys.argv) not in (3, 4):
+        print("Usage: python upload-integ-test-metrics.py <xml_file> <repository_name> [sdk]")
         sys.exit(0)
-    
+
     xml_file = sys.argv[1]
     repository = sys.argv[2]
+    sdk = sys.argv[3] if len(sys.argv) > 3 else 'python'
     region = os.environ.get('AWS_REGION', 'us-east-1')
-    
+
     test_results = parse_junit_xml(xml_file)
     if not test_results:
         print("No test results found")
         sys.exit(1)
-    
+
     print(f"Found {len(test_results)} test results")
-    metric_data = build_metric_data(test_results, repository)
+    metric_data = build_metric_data(test_results, repository, sdk)
     publish_metrics(metric_data, region)
 
 

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -171,3 +171,42 @@ jobs:
           retention-days: 4
           include-hidden-files: true # needed because the path has a directory starting with a '.'
           if-no-files-found: ignore
+
+  upload-metrics:
+    runs-on: ubuntu-latest
+    needs: run-integration-tests
+    # Publishes to the team's CloudWatch via STRANDS_INTEG_TEST_ROLE. Only run
+    # when the integration-test job actually executed; on fork PRs the auth
+    # environment gate skips the test job and no test-artifacts-integ artifact
+    # is produced, so this job would otherwise fail on artifact download.
+    if: needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'failure'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+         role-to-assume: ${{ secrets.STRANDS_INTEG_TEST_ROLE }}
+         aws-region: us-east-1
+         mask-aws-account-id: true
+
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          sparse-checkout: |
+            .github/scripts
+          persist-credentials: false
+
+      - name: Download test artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: test-artifacts-integ
+
+      - name: Publish test metrics to CloudWatch
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          pip install --no-cache-dir boto3
+          python .github/scripts/upload-integ-test-metrics.py test-report/junit/report.xml "$REPO_NAME" typescript

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -187,9 +187,9 @@ jobs:
       - name: Configure Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-         role-to-assume: ${{ secrets.STRANDS_INTEG_TEST_ROLE }}
-         aws-region: us-east-1
-         mask-aws-account-id: true
+          role-to-assume: ${{ secrets.STRANDS_INTEG_TEST_ROLE }}
+          aws-region: us-east-1
+          mask-aws-account-id: true
 
       - name: Checkout main
         uses: actions/checkout@v7
@@ -199,14 +199,30 @@ jobs:
             .github/scripts
           persist-credentials: false
 
+      # The artifact's contents come from PR test code, so extract it into its
+      # own directory rather than the workspace root — otherwise a crafted
+      # artifact containing .github/scripts/... would overwrite the trusted
+      # script checked out from main before the next step executes it.
+      #
+      # continue-on-error because selective runs that select no integ tests
+      # upload no artifact at all (if-no-files-found: ignore above); the
+      # publish step below skips gracefully when the report is absent.
       - name: Download test artifacts
+        id: download
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: test-artifacts-integ
+          path: downloaded-artifacts
 
       - name: Publish test metrics to CloudWatch
         env:
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
+          REPORT=downloaded-artifacts/test-report/junit/report.xml
+          if [ ! -f "$REPORT" ]; then
+            echo "No JUnit report found (integ tests skipped or failed before reporting); nothing to publish."
+            exit 0
+          fi
           pip install --no-cache-dir boto3
-          python .github/scripts/upload-integ-test-metrics.py test-report/junit/report.xml "$REPO_NAME" typescript
+          python .github/scripts/upload-integ-test-metrics.py "$REPORT" "$REPO_NAME" typescript


### PR DESCRIPTION
## Summary

- Add an `upload-metrics` job to `typescript-integration-test.yml`, mirroring the Python workflow's job, so TypeScript integ test results are published to the `Strands/Tests` CloudWatch namespace and surfaced on the flaky-test dashboard.
- Add an `SDK` dimension to `upload-integ-test-metrics.py` via an optional 3rd argument (defaults to `python`, so the Python workflow needs no change) to distinguish Python vs TypeScript metrics, since both publish under `Repository=harness-sdk`.

## Details

- The TypeScript workflow already produces JUnit XML at `strands-ts/test/.artifacts/test-report/junit/report.xml` (vitest junit reporter) and uploads it in the `test-artifacts-integ` artifact; after download the file sits at `test-report/junit/report.xml`.
- The new job uses the same `if: success() || failure()` guard as the Python workflow's `upload-metrics` job so it doesn't fail on fork PRs where the auth gate skipped the test job.
- Dashboards: a new `StrandsTypescriptIntegTests` CloudWatch dashboard (filtered on `SDK='typescript'`) has been created alongside `StrandsPythonIntegTests`, which now queries the new `SDK` dimension with the legacy 2-dimension widgets kept temporarily for historical data.

## Testing

- YAML validated.
- Script smoke-tested locally against a sample vitest JUnit report: parses vitest's `classname`/nested-suite output correctly, emits 4 metrics per test with the `SDK` dimension present, and defaults to `python` when the argument is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)