### PR TITLE
fix(changelog): restore changelog:sync npm script

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -19,6 +19,7 @@
     "sdk:generate": "npm run sdk:generate:py && npm run sdk:generate:ts",
     "sdk:sync": "npm run sdk:generate && npm install",
     "routes:update": "tsx scripts/update-known-routes.ts",
+    "changelog:sync": "tsx scripts/changelog/sync.ts",
     "astro": "astro"
   },
   "author": "",


### PR DESCRIPTION
## Description

The first scheduled run of the changelog-sync workflow failed (https://github.com/strands-agents/harness-sdk/actions/runs/29004708404/job/86073434999): both Generate steps exited with

```
npm error Missing script: "changelog:sync"
```

The workflow invokes `npm run changelog:sync`, but the script entry was lost from `site/package.json` when #2765 was rebased onto main -- the generator files, workflow, and @octokit/rest dep all made it, the one-line script entry did not. This restores it.

## Testing

- `npm run changelog:sync` (no tag) prints the single-mode guard and exits 1 -- script resolves.
- `npm run changelog:sync -- --tag python/v1.41.0` regenerates the committed file.
- The exact failing cron invocation (`MODE=backfill SKIP_EXISTING=true` via env) ran clean locally and generated the two releases currently missing from main (python/v1.46.0, typescript/v1.8.0), which the next scheduled run will PR automatically once this merges.