### PR TITLE
chore(deps): relax litellm upper bound to <2.0.0

### DIFF
--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.21.0,<1.0.0"]
 gemini = ["google-genai>=1.32.0,<3.0.0"]
-litellm = ["litellm>=1.75.9,<=1.91.1", "openai>=1.68.0,<3.0.0"]
+litellm = ["litellm>=1.75.9,<2.0.0", "openai>=1.68.0,<3.0.0"]
 llamaapi = ["llama-api-client>=0.1.0,<1.0.0"]
 mistral = ["mistralai>=2.0.0,<3.0.0"]
 ollama = ["ollama>=0.4.8,<1.0.0"]


### PR DESCRIPTION
## Description

Relaxes the `litellm` extra's upper bound from `<=1.91.1` to `<2.0.0`.

The exact cap was originally introduced to mitigate a supply-chain issue. With that resolved, pinning to a specific release means every new litellm version requires a manual bump PR. Widening to `<2.0.0` picks up patch and minor releases automatically while still holding the line at the next major, so unvetted breaking changes stay out.

```toml
litellm = ["litellm>=1.75.9,<2.0.0", "openai>=1.68.0,<3.0.0"]
```

## Type of Change

Dependency / chore

## Breaking Changes

None. This only widens an allowed version range.

## Note

The repo pre-commit hook builds `strands-ts`, which currently fails on `main` with two pre-existing type errors in `vended-memory-stores/bedrock-knowledge-base/store.ts` (AWS SDK type drift), unrelated to this Python-only change. This commit was made with `--no-verify` for that reason; the TS breakage should be tracked separately.