### PR TITLE
fix(vercel): retry transient network failures

### DIFF
--- a/strands-ts/src/models/__tests__/vercel.test.ts
+++ b/strands-ts/src/models/__tests__/vercel.test.ts
@@ -402,6 +402,37 @@ describe('VercelModel', () => {
         await expect(collectIterator(model.stream([]))).rejects.toThrow(ContextWindowOverflowError)
       })
 
+      it('throws ModelThrottledError for APICallError flagged isRetryable', async () => {
+        const { mock, model } = setupCaptureTest()
+        ;(mock.doStream as ReturnType<typeof vi.fn>).mockRejectedValue(
+          new APICallError({
+            message: 'Service unavailable',
+            url: 'https://api.example.com',
+            requestBodyValues: {},
+            statusCode: 503,
+            isRetryable: true,
+          })
+        )
+
+        await expect(collectIterator(model.stream([]))).rejects.toThrow(ModelThrottledError)
+      })
+
+      it('throws ModelThrottledError for browser fetch failures (TypeError: Failed to fetch)', async () => {
+        const { mock, model } = setupCaptureTest()
+        ;(mock.doStream as ReturnType<typeof vi.fn>).mockRejectedValue(new TypeError('Failed to fetch'))
+
+        await expect(collectIterator(model.stream([]))).rejects.toThrow(ModelThrottledError)
+      })
+
+      it('throws ModelThrottledError for transient connection errors by code', async () => {
+        const { mock, model } = setupCaptureTest()
+        ;(mock.doStream as ReturnType<typeof vi.fn>).mockRejectedValue(
+          Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' })
+        )
+
+        await expect(collectIterator(model.stream([]))).rejects.toThrow(ModelThrottledError)
+      })
+
       it('classifies errors thrown during reader.read()', async () => {
         const mock = createMockModel([])
         ;(mock.doStream as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/strands-ts/src/models/vercel.ts
+++ b/strands-ts/src/models/vercel.ts
@@ -57,6 +57,23 @@ const CONTEXT_WINDOW_OVERFLOW_PATTERNS = [
 ]
 
 /**
+ * Error message fragments that indicate a transient network failure where the request
+ * never reached (or never got a response from) the server. These are safe to retry.
+ *
+ * Browsers reject `fetch` with `TypeError: Failed to fetch` (Chromium/Firefox) or
+ * `TypeError: Load failed` (Safari); Node's undici uses `TypeError: fetch failed`.
+ * `@ai-sdk/provider-utils` only wraps these into a retryable `APICallError` when the
+ * error carries a `cause` (the Node case), so in browsers the raw `TypeError` passes
+ * through and must be detected here.
+ */
+const TRANSIENT_NETWORK_ERROR_MESSAGES = ['failed to fetch', 'fetch failed', 'load failed']
+
+/**
+ * Node/undici system error codes for transient connection failures that are safe to retry.
+ */
+const TRANSIENT_NETWORK_ERROR_CODES = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE', 'ENOTFOUND', 'EAI_AGAIN']
+
+/**
  * Call option fields from LanguageModelV3CallOptions that can be configured.
  * Excludes prompt, tools, and toolChoice which are managed by the agent loop.
  */
@@ -195,8 +212,11 @@ function classifyError(error: unknown): Error {
   const message = error instanceof Error ? error.message : String(error)
 
   if (APICallError.isInstance(error)) {
-    if (error.statusCode === 429) {
-      logger.debug(`throttled | error_message=<${message}>`)
+    // Throttling (429) and anything the provider already flagged retryable — transient
+    // 5xx responses and connection failures wrapped by @ai-sdk/provider-utils — route
+    // through ModelThrottledError so the model retry strategy can recover.
+    if (error.statusCode === 429 || error.isRetryable) {
+      logger.debug(`retryable model error | status=<${error.statusCode}> error_message=<${message}>`)
       return new ModelThrottledError(message, { cause: error })
     }
 
@@ -210,7 +230,31 @@ function classifyError(error: unknown): Error {
     return new ContextWindowOverflowError(message)
   }
 
+  // Transient network failures that never reached the server (notably browser
+  // `TypeError: Failed to fetch`, which the AI SDK leaves unwrapped). Treat as
+  // retryable so a single network blip doesn't fail the whole invocation.
+  if (isTransientNetworkError(error)) {
+    logger.debug(`transient network error, treating as retryable | error_message=<${message}>`)
+    return new ModelThrottledError(`Language model transient network error: ${message}`, { cause: error })
+  }
+
   return new ModelError(`Language model stream error: ${message}`, { cause: error })
+}
+
+/**
+ * Detects transient network failures that are safe to retry, matching on undici system
+ * error codes and the browser/runtime fetch-failure message fragments.
+ */
+function isTransientNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  const code = (error as { code?: unknown }).code
+  if (typeof code === 'string' && TRANSIENT_NETWORK_ERROR_CODES.includes(code)) {
+    return true
+  }
+  const message = error.message.toLowerCase()
+  return TRANSIENT_NETWORK_ERROR_MESSAGES.some((fragment) => message.includes(fragment))
 }
 
 /**


### PR DESCRIPTION
## Description

`VercelModel` invocations were failing on transient network blips instead of retrying them, which flaked the browser integration tests (`ModelError: Language model stream error: Failed to fetch`).

The root cause is a difference in how fetch failures surface across runtimes. In Node, undici throws `TypeError: fetch failed` **with** a `cause`, and `@ai-sdk/provider-utils` wraps that into a retryable `APICallError` (`isRetryable: true`). In the browser, `fetch` throws `TypeError: Failed to fetch` **without** a `cause`, so provider-utils leaves it unwrapped and it reaches the agent loop as a raw `TypeError`.

`classifyError` only mapped `APICallError` with status 429 to `ModelThrottledError`; everything else became a plain `ModelError`. Since `DefaultModelRetryStrategy` only retries `ModelThrottledError`, the unwrapped browser network error was treated as fatal and a single blip failed the whole invocation.

`classifyError` now routes transient, recoverable conditions through `ModelThrottledError` so the retry strategy can recover:

- Honor the provider's own signal — retry on `statusCode === 429 || error.isRetryable`, which also covers transient 5xx and the Node-wrapped connection failures the AI SDK already flags.
- Detect raw transient network errors the SDK leaves unwrapped, matching browser/runtime fetch-failure messages (`failed to fetch`, `fetch failed`, `load failed`) and connection error codes (`ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `EPIPE`, `ENOTFOUND`, `EAI_AGAIN`).

Auth failures (e.g. `403` with `isRetryable: false`) still fall through to a non-retryable `ModelError`, so we don't retry conditions that can't succeed on retry.

No public API changes.

## Related Issues

<!-- none -->

## Type of Change

Bug fix

## Testing

Verified the previously flaky browser integ case now passes end-to-end against Bedrock:

`VercelModel (Bedrock) > transform action > transform on beforeToolCall modifies tool input` — green.

Added unit coverage in `vercel.test.ts` for the new classification paths (provider `isRetryable`, browser `TypeError: Failed to fetch`, and a code-based `ECONNRESET`); full `vercel.test.ts` suite passes and lint/type-check are clean.

- [ ] I ran `hatch run prepare` (N/A — TypeScript package; ran `vitest` + `eslint` + `tsc` on the affected files)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective
- [x] My changes generate no new warnings
