### PR TITLE
feat(port): allow ports in either direction

### DIFF
--- a/.github/ISSUE_TEMPLATE/port_request.yml
+++ b/.github/ISSUE_TEMPLATE/port_request.yml
@@ -22,6 +22,7 @@ body:
       default: 0
       options:
         - strands-ts
+        - strands-py
     validations:
       required: true
 
@@ -33,6 +34,7 @@ body:
       default: 0
       options:
         - strands-py
+        - strands-ts
     validations:
       required: true
 


### PR DESCRIPTION
## Description

The port request issue template hardcoded a single direction: **Source SDK** offered only `strands-ts` and **Target SDK** offered only `strands-py`. This makes it impossible to file a port going the other way.

This change adds both SDKs to each dropdown so a port can be requested in either direction (`strands-ts` → `strands-py` or `strands-py` → `strands-ts`). Defaults are unchanged, so the existing TS→Py flow is still selected out of the box.

## Type of change

- [x] Documentation update

## Testing

Edit is confined to `.github/ISSUE_TEMPLATE/port_request.yml`. Validated it stays well-formed YAML.

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly