### PR TITLE
ci(deps): group Python dev tooling by name pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,14 +34,28 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     groups:
-      # All development dependencies in one PR.
+      # Dev tooling in one PR, matched by name because Dependabot does not
+      # classify PEP 621 pyproject dependencies as development vs production,
+      # so dependency-type grouping never matches for pip and every bump,
+      # including dev tooling like mypy, opens its own PR.
       development-dependencies:
-        dependency-type: 'development'
         applies-to: version-updates
-      # Production minor + patch bumps in one PR.
+        patterns:
+          - 'boto3-stubs'
+          - 'commitizen'
+          - 'hatch'
+          - 'moto'
+          - 'mypy'
+          - 'pre-commit'
+          - 'pytest*'
+          - 'ruff'
+          - 'sphinx*'
+      # Everything else: minor + patch bumps in one PR. A dependency joins the
+      # first group it matches, so dev tooling above never lands here.
       production-minor:
-        dependency-type: 'production'
         applies-to: version-updates
+        patterns:
+          - '*'
         update-types:
           - 'minor'
           - 'patch'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,9 @@ updates:
       # classify PEP 621 pyproject dependencies as development vs production,
       # so dependency-type grouping never matches for pip and every bump,
       # including dev tooling like mypy, opens its own PR.
+      # Keep these patterns in sync with the dev/docs extras in
+      # strands-py/pyproject.toml — anything missed here silently falls into
+      # production-minor.
       development-dependencies:
         applies-to: version-updates
         patterns:
@@ -50,6 +53,7 @@ updates:
           - 'pytest*'
           - 'ruff'
           - 'sphinx*'
+          - 'tenacity'
       # Everything else: minor + patch bumps in one PR. A dependency joins the
       # first group it matches, so dev tooling above never lands here.
       production-minor:


### PR DESCRIPTION
## Description

The Python (`/strands-py`) Dependabot section uses `dependency-type` groups, but Dependabot does not classify PEP 621 pyproject dependencies as development vs production, so those groups never match for pip. Every Python bump has been opening its own PR (mypy, cedarpy, litellm, etc. in the recent Dependabot PR list), while the identical config works as intended for the npm sections.

This switches the pip section to pattern-based groups, mirroring the behavior npm already gets:

- `development-dependencies`: boto3-stubs, commitizen, hatch, moto, mypy, pre-commit, pytest*, ruff, sphinx* batch into one PR.
- `production-minor`: wildcard minor/patch group for everything else. A dependency joins the first group it matches, so dev tooling never lands here.
- Majors remain unmatched by any group and arrive as individual PRs, gated by the existing 30-day semver-major cooldown.

The npm, docs, and actions sections are unchanged.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Other: CI/dependency-management configuration

## Testing

YAML validated with a parser. Verified against the Dependabot PR history that pip groups have never produced a grouped PR while npm groups have.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works