### PR TITLE
fix(docs): resolve TS API cross-links to variables and enums

### DIFF
--- a/site/scripts/api-generation-typescript.ts
+++ b/site/scripts/api-generation-typescript.ts
@@ -21,7 +21,7 @@ const OUTPUT_DIR = '.build/api-docs/typescript'
 
 interface FileInfo {
   path: string
-  category: string // 'classes', 'interfaces', 'type-aliases', 'functions', or 'index'
+  category: string // 'classes', 'interfaces', 'type-aliases', 'functions', 'variables', 'enumerations', or 'index'
   name: string
   namespace?: string // set for members under namespaces/<ns>/
 }
@@ -149,13 +149,13 @@ async function processFile(file: FileInfo): Promise<void> {
   // For namespace index pages, rewrite category-prefixed links to absolute slug paths
   //   e.g. interfaces/TracerConfig.md -> /api/typescript/telemetry:TracerConfig
   let linkedFixed = content
-    .replace(/\]\(\.\.\/(classes|interfaces|type-aliases|functions)\/([^)]+)\)/g, '](../$2)')
+    .replace(/\]\(\.\.\/(classes|interfaces|type-aliases|functions|variables|enumerations)\/([^)]+)\)/g, '](../$2)')
     .replace(/\]\(\.\.\/([^./][^)]+\.md(?:#[^)]*)?)\)/g, ']($1)')
 
   if (file.namespace) {
     // Rewrite category-prefixed links in namespace pages/members to relative paths
     linkedFixed = linkedFixed.replace(
-      /\]\((classes|interfaces|type-aliases|functions|namespaces)\/([^)]+?)\.md((?:#[^)]*)?)\)/g,
+      /\]\((classes|interfaces|type-aliases|functions|variables|enumerations|namespaces)\/([^)]+?)\.md((?:#[^)]*)?)\)/g,
       (_match, _cat, name, hash) => `](../${file.namespace}:${name}/${hash})`,
     )
     // Also rewrite bare Name.md links (after ../category/ was already stripped) to relative paths


### PR DESCRIPTION
## Summary

The TypeScript API doc generator (`site/scripts/api-generation-typescript.ts`) flattens typedoc's category folders (`classes/`, `interfaces/`, `type-aliases/`, `functions/`, `variables/`, `enumerations/`) into flat page slugs like `/docs/api/typescript/CHECKPOINT_SCHEMA_VERSION/`. It then strips those category prefixes from cross-reference links so they resolve to the flat slugs.

The two strip regexes only covered `classes|interfaces|type-aliases|functions`, so a `{@link}` to an exported `const` (a typedoc "variable") or `enum` kept its `../variables/` / `../enumerations/` prefix and pointed at a page that doesn't exist.

`CHECKPOINT_SCHEMA_VERSION` — the first exported `const` in the SDK, added by the checkpoint port (#3103) — is the first symbol to hit this. The `Checkpoint` class links to it via `{@link CHECKPOINT_SCHEMA_VERSION}`, and `astro-broken-links-checker` failed the docs build with:

```
Broken link: /docs/api/typescript/variables/CHECKPOINT_SCHEMA_VERSION/
  Found in:
    - /docs/api/typescript/Checkpoint/
```

## Why it surfaced now

\#3103 only touched `strands-ts/`, so the path-filtered docs CI was skipped on that merge. It first failed on the next docs-touching PR (#3132), which is otherwise unrelated (a blog post).

## Fix

Add `variables` and `enumerations` to both category-stripping regexes.

## Verification

- Regenerated TS API docs: the `Checkpoint` cross-link is now `CHECKPOINT_SCHEMA_VERSION.mdx` (flat, matching the generated slug).
- Scanned all generated pages: zero remaining category-prefixed cross-links.
- Ran the full `npm run build` in `site/` with both SDKs generated: build completes, `astro-broken-links-checker` reports no broken links, no `broken-links.log` written.