### PR TITLE
ci: run docs CI on python and typescript changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
   docs:
     name: Docs
     needs: detect-changes
-    if: needs.detect-changes.outputs.docs == 'true'
+    if: needs.detect-changes.outputs.docs == 'true' || needs.detect-changes.outputs.python == 'true' || needs.detect-changes.outputs.typescript == 'true'
     uses: ./.github/workflows/docs-ci.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Description

The docs site build typechecks documentation code snippets against the freshly-built SDK types, so an SDK change (e.g. renaming or removing a public member) can break it. The `docs` job previously ran only on `site/**` changes, letting these breakages slip through SDK-only PRs. This also gates it on `python`/`typescript` changes so they're caught at PR time.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

No documentation changes required.

## Type of Change

Other: CI configuration change

## Testing

CI-only change. Verified the workflow condition and confirmed `ci-gate` still permits `docs` as a skip.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
