### PR TITLE
docs(pr-writer): scale description length to diff size

### DIFF
--- a/.agents/skills/pr-writer/SKILL.md
+++ b/.agents/skills/pr-writer/SKILL.md
@@ -52,12 +52,21 @@ Apply these rules:
 - **Title**: Must follow Conventional Commits format: `<type>(<optional scope>): <subject>`. The subject must start with a lowercase letter. Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `design`. Example: `feat(agents): add streaming support for tool results`.
 - **Why**: Lead with the motivation. What broke, what was missing, what's the business/user need. This is the most important part, and usually the longest.
 - **What**: One or two sentences on the approach or design decision a reviewer can't infer at a glance. Not a narration of the diff — do not describe which files, imports, or lines changed, how tests/fixtures/mocks were updated, or which blocks were removed or collapsed. The diff shows all of that.
-- **Keep it short**: A routine change is a few short paragraphs a reviewer can read in under a minute. Terse fragments beat padded sentences ("Python-only.", "No behavior change."). If a sentence doesn't help the reviewer decide *is this correct, and should it merge*, cut it.
+- **Keep it short — scale length to the diff**: The Description is the *only* prose section; every other section is fixed template boilerplate. Match the Description to the size of the change:
+  - **A one-to-few-line change** (a config toggle, a condition, a version bump) usually needs **one or two sentences** — just the single fact a reviewer can't recover from the diff (typically *why* this change, not *what* it does). Do not expand it to three paragraphs. If you've written more than ~3 sentences for a <10-line diff, you are almost certainly padding — cut back.
+  - **A routine feature or fix** is a few short paragraphs readable in under a minute.
+  - Terse fragments beat padded sentences ("Python-only.", "No behavior change."). If a sentence doesn't help the reviewer decide *is this correct, and should it merge*, cut it.
 - **Risks / Callouts**: Anything the reviewer should scrutinize. Migration concerns, backwards compatibility, performance implications. Omit this section if there's genuinely nothing to flag.
 
-### 5. Trim Pass
+### 5. Self-Review Pass (read it as the reviewer)
 
-Before output, reread the Description and delete every sentence that only restates the diff: file/import/line-level edits, test/fixture/mock updates, and mechanical "X collapses to one call" notes. A reviewer reads the diff for the *what*; the description exists for the *why*. If cutting a sentence loses no motivation and no invariant the reviewer needs, it was filler.
+Before output, stop and reread *only the Description* as if you were the senior engineer receiving this PR, with the diff open beside you. Run this pass explicitly:
+
+1. **Name the core fact.** In one sentence, what is the single thing this PR's reader cannot recover by reading the diff itself? (Usually the *why*, or a non-obvious constraint/risk.) That sentence is the spine of the Description.
+2. **Delete anything that isn't load-bearing.** Go sentence by sentence and cut every one that: restates the diff (file/line/import edits, test/fixture/mock changes, "X collapses to one call"), re-explains what the code plainly shows, or reassures the reviewer of something they can confirm at a glance. If cutting a sentence loses no motivation and no invariant the reviewer needs, it was filler.
+3. **Check length against the diff.** Reread the length heuristic in step 4. If the diff is a handful of lines and your Description is more than ~2 sentences, delete until it isn't. A senior reviewer is annoyed by a five-paragraph essay attached to a one-line change — brevity is respect for their time, not a missing detail.
+
+The goal: a reviewer finishes the Description faster than they'd finish this sentence, and comes away knowing the one thing the diff couldn't tell them.
 
 ## Retrieving Information from GitHub
 


### PR DESCRIPTION
## Description

The `pr-writer` skill was producing PR descriptions that were too long for the size of the change — a one-line diff would get three paragraphs of prose. The existing "keep it short" guidance was too abstract to bite, so it got ignored in practice.

This replaces it with a concrete length heuristic scaled to diff size (a <10-line change should be one or two sentences; more than ~3 sentences on a small diff is a padding signal) and reframes the old trim step as a reader's-POV self-review: name the single fact a reviewer can't recover from the diff, cut everything that isn't load-bearing, then check length against the diff.

Verified on three real merged PRs spanning 1 / 246 / 490 changed lines: descriptions scaled to 2 / 4 / 6 sentences respectively, and — compared against the actual merged descriptions — the shorter output kept the load-bearing motivation and invariants rather than dropping them.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

No documentation changes required.

## Type of Change

Other: tweak to the pr-writer agent skill.

## Testing

Ran the updated skill in isolated sub-agents against three merged PRs of varying diff size and compared the generated descriptions to the real ones.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
