### PR TITLE
fix(ci): upgrade ts release workflow to npm 12

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -415,12 +415,12 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm to latest
         # Trusted publishing needs npm >= 11.5.1.
-        run: npm install -g npm@11
+        run: npm install -g npm@latest
 
       - name: Download verified tarball
         uses: actions/download-artifact@v8

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -420,7 +420,7 @@ jobs:
 
       - name: Update npm to latest
         # Trusted publishing needs npm >= 11.5.1.
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Download verified tarball
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

npm 12.0.0 (released today) requires Node ^22.22.2. The publish job was running Node 20, so `npm install -g npm@latest` started failing with `EBADENGINE`.

Bumps `node-version` from 20 to 22 (current LTS) so `npm@latest` continues to work without pinning.

## Test plan

- [ ] Next `release-typescript` workflow run installs npm successfully