### PR TITLE
feat(site): revamp docs search with doc-type filtering

### DIFF
--- a/site/SITE-ARCHITECTURE.md
+++ b/site/SITE-ARCHITECTURE.md
@@ -296,7 +296,8 @@ These override default Starlight components:
 - **`Head.astro`**: Adds Mermaid diagram support and loads `SiteScripts` (Shortbread + WebSDK).
 - **`Header.astro`**: Custom header with navigation tabs and theme-aware logos (see [Header Navigation](#header-navigation) below).
 - **`Hero.astro`**: Suppresses the Starlight hero on `/blog/` paths. Blog pages pass a dummy `hero: { actions: [] }` to collapse Starlight's two-panel layout, and this override ensures that dummy hero has no visual output.
-- **`MarkdownContent.astro`**: Injects the custom frontmatter banners (experimental, community, languages) at the top of page content.
+- **`MarkdownContent.astro`**: Injects the custom frontmatter banners (experimental, community, languages) at the top of page content, and emits the Pagefind `Type` filter tag on the content wrapper (see [Search (Pagefind)](#search-pagefind)).
+- **`Search.astro`**: Replaces Starlight's default search with Pagefind's Component UI, adding a doc-type (`Type`) filter with OR support and context-aware/persisted defaults (see [Search (Pagefind)](#search-pagefind)).
 - **`PageFrame.astro`**: Extends Starlight's default `PageFrame` to add a full-width site footer containing the `Copyright` component. The footer spans the content area (respecting sidebar offset) with `--sl-color-bg-nav` background to match the header.
 - **`Sidebar.astro`** and **`SidebarSublist.astro`**: Custom sidebar navigation that mimics MkDocs Material theme's `navigation.sections` behavior.
 
@@ -800,6 +801,52 @@ SITE_DOMAIN=https://strandsagents.com npm run build
 
 Without `SITE_DOMAIN`, links remain relative (e.g. `/user-guide/quickstart/`). With it set, they become absolute (e.g. `https://strandsagents.com/user-guide/quickstart/`).
 
+## Search (Pagefind)
+
+Site search is powered by [Pagefind](https://pagefind.app/), which Starlight bundles and wires up automatically. Pagefind is a **post-build indexer**: after `astro build` emits the static HTML, Pagefind crawls `dist/**/*.html` and builds a search index from the rendered markup. It has no concept of Astro frontmatter or components — it only reads `data-pagefind-*` attributes on the page. So the indexing customization comes down to emitting the right attributes at build time, while the search *UI* is a custom component (see below).
+
+The shared classification logic lives in **`src/util/search.ts`**, which maps a page's content id to its doc-type facet value.
+
+### Doc-type facet (`Type`)
+
+Every indexed page is tagged with a Pagefind filter via `data-pagefind-filter="Type:<value>"`, where the value is one of:
+
+| Facet value | Pages | Detected by |
+|-------------|-------|-------------|
+| `User Docs` | Hand-written guides, examples, contribute, community, labs | default (anything not API/Blog) |
+| `Python API` | Auto-generated Python API reference | id starts with `docs/api/python` |
+| `TypeScript API` | Auto-generated TypeScript API reference | id starts with `docs/api/typescript` |
+| `Blog`      | Blog posts (not listing pages) | id starts with `blog/` |
+
+The tag is emitted on the `MarkdownContent.astro` wrapper (which sits inside Starlight's `<main data-pagefind-body>`), guarded so pages that opt out of indexing (`pagefind: false`) get no tag. This facet powers the `Type` filter control in the search UI below.
+
+### Search UI: Pagefind Component UI (`Search.astro`)
+
+`src/components/overrides/Search.astro` replaces Starlight's default search (which uses Pagefind's older `@pagefind/default-ui`) with Pagefind's newer **Component UI** (v1.5.x web components: `pagefind-modal`, `pagefind-input`, `pagefind-results`, `pagefind-summary`, `pagefind-modal-trigger`, etc.). The Component UI assets (`/pagefind/pagefind-component-ui.{js,css}`) are emitted into `dist/pagefind/` at build time.
+
+**Why not the default UI:** the default UI translates a multi-value selection within one filter group into a plain array `{Type: [a, b]}`, which Pagefind treats as **AND** → 0 results (a page can't be two types at once). It exposes no option or hook to make that an OR. The Component UI, by contrast, gives us a public instance API we can drive ourselves.
+
+**Custom `Type` control with OR support.** Rather than Pagefind's `<pagefind-filter-pane>`, we render our **own** checkbox control (`fieldset.sl-search-types`) and drive filtering through the instance's public `triggerFilters(filtersObj)`:
+
+- One selected value → `{ Type: 'User Docs' }`.
+- Multiple → Pagefind's OR form `{ Type: { any: ['User Docs', 'API Docs'] } }`.
+
+`triggerFilters` passes the object straight through to `pagefind.search(term, { filters })`, and typing re-reads the instance's public `searchFilters`, so selection stays in sync — with **no access to private (`__`-prefixed) internals**.
+
+> **Class naming:** our own elements deliberately use an `sl-search-*` prefix, **not** `pf-*`. The Component UI ships a global reset `:is(*,#\#):is(*,#\#) :is([class^="pf-"],[class*=" pf-"]):not(svg,svg *) { all: revert }` (specificity 0,3,0) that would strip color/layout off any `pf-*` element. Staying off that prefix lets ordinary CSS apply without `!important`. Where we *do* restyle Pagefind's own `pf-*` elements (trigger button, summary, scrollbar), `!important` is used to beat that reset.
+
+**Selection — user-driven, persisted, no page default.** All three `Type` boxes are checked by default, so search spans everything until the user narrows it. There is **no page-specific default** — the Type filter is entirely user-driven (persistence + the always-visible control make context defaults unnecessary, and they avoided a confusing edge case where a blog reader's persisted "User Docs only" would hollow out search on a blog page). When the user changes the selection it is **saved to `localStorage`** (key `sl-search-types`) and restored on later visits — so unchecking "API Docs" keeps it off. An intentional empty selection ("search all") is stored and honored distinctly from "no preference yet" (`null`).
+
+**Per-result badges:** each result is tagged with its doc type (`User Docs` / `Python API` / `TypeScript API` / `Blog`) so the reader knows where a hit will land. The Component UI has no per-result render hook, so a `MutationObserver` on the results list derives the type from each result's link URL (`getDocTypeFromUrl`) and injects a badge. The badge label is the doc-type value verbatim — the **same vocabulary as the filter toggle**, so the two can't drift.
+
+**Other touches:** the modal is widened (`--pf-modal-max-width: 52rem`) to fit the Type sidebar; the sidebar is `position: sticky` so it stays visible while results scroll; the summary italicizes the search term and, when the true total exceeds the render cap, appends a "(showing top 20)" note; results are capped (`max-results="20"`, kept in sync with `MAX_RESULTS` in the script) so a broad query doesn't inject thousands of DOM rows; and the modal is themed to match Starlight in both light and dark (mirroring `data-theme` to Pagefind's `data-pf-theme`, plus `color-scheme: dark` on the scroll container so the scrollbar matches).
+
+> **Behavior note:** `<pagefind-config>` sets `faceted`, so the modal runs a search and shows results (and filter counts) **the instant it opens** — an empty query returns the full corpus rather than waiting for a keystroke.
+
+### What is *not* indexed
+
+Blog listing pages, the landing page, and the changelog opt out via `pagefind: false` in their layouts (`BlogLayout.astro` defaults to `false`; `LandingLayout.astro`, `ChangelogLayout.astro`). Blog **posts** opt back in — see [Blog › Layouts](#layouts).
+
 ## Blog
 
 The blog is a standalone section at `/blog/` with its own content collection, layouts, components, and routes — outside of Starlight's docs collection. It follows the same pattern as the custom landing page: reuses the Starlight header via `BlogLayout.astro` while opting out of the docs chrome (sidebar, table of contents, etc.).
@@ -855,9 +902,9 @@ Helper functions used across all blog pages:
 
 ### Layouts
 
-**`BlogLayout.astro`** — Base layout for all blog pages. Uses Starlight's `<StarlightPage>` component to get the full page shell (head, styles, theme, header) for free. Passes `hasSidebar={false}` and `template: 'splash'` to suppress sidebar and doc-page chrome. Passes `hero: { actions: [] }` to collapse Starlight's two-panel layout into a single content panel (suppressing the auto-generated `PageTitle`). Extra head tags (canonical URL, OG/Twitter meta, RSS autodiscovery) are injected via the `frontmatter.head` array. A named `<slot name="head" />` is forwarded for page-specific head content (e.g. JSON-LD). The `Hero` component override (`src/components/overrides/Hero.astro`) suppresses the hero on `/blog/` paths so the dummy hero value has no visual effect.
+**`BlogLayout.astro`** — Base layout for all blog pages. Uses Starlight's `<StarlightPage>` component to get the full page shell (head, styles, theme, header) for free. Passes `hasSidebar={false}` and `template: 'splash'` to suppress sidebar and doc-page chrome. Passes `hero: { actions: [] }` to collapse Starlight's two-panel layout into a single content panel (suppressing the auto-generated `PageTitle`). Extra head tags (canonical URL, OG/Twitter meta, RSS autodiscovery) are injected via the `frontmatter.head` array. A named `<slot name="head" />` is forwarded for page-specific head content (e.g. JSON-LD). The `Hero` component override (`src/components/overrides/Hero.astro`) suppresses the hero on `/blog/` paths so the dummy hero value has no visual effect. Accepts a `pagefind` prop (default `false`) that controls whether the page is included in the search index; listing pages (index, tags, authors) leave it at the default so they stay out of search.
 
-**`BlogPostLayout.astro`** — Wraps `BlogLayout` with article-specific chrome: title, date, reading time, description, author byline, tags, cover image. Injects JSON-LD Article schema via the head slot. OG image URL: `/blog/og/{slug}.png`.
+**`BlogPostLayout.astro`** — Wraps `BlogLayout` with article-specific chrome: title, date, reading time, description, author byline, tags, cover image. Injects JSON-LD Article schema via the head slot. OG image URL: `/blog/og/{slug}.png`. Passes `pagefind={true}` so blog posts are indexed and surface under the `Blog` search facet (see [Search (Pagefind)](#search-pagefind)).
 
 ### Components (`src/components/blog/`)
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -85,6 +85,7 @@ export default defineConfig({
         Header: './src/components/overrides/Header.astro',
         Hero: './src/components/overrides/Hero.astro',
         MarkdownContent: './src/components/overrides/MarkdownContent.astro',
+        Search: './src/components/overrides/Search.astro',
         Sidebar: './src/components/overrides/Sidebar.astro',
         PageFrame: './src/components/overrides/PageFrame.astro',
       },

--- a/site/src/components/overrides/MarkdownContent.astro
+++ b/site/src/components/overrides/MarkdownContent.astro
@@ -4,12 +4,22 @@ import CommunityContributionAside from '../CommunityContributionAside.astro';
 import LanguageSupportAside from '../LanguageSupportAside.astro';
 import ExperimentalAside from '../ExperimentalAside.astro';
 import PageTags from '../PageTags.astro';
+import { getDocTypeFilter } from '../../util/search';
 
 const { starlightRoute } = Astro.locals;
 const { languages, community, experimental } = starlightRoute.entry.data;
+
+// Search (Pagefind) doc-type facet. This wrapper lives inside
+// <main data-pagefind-body>, so its data-pagefind-filter attribute tags the
+// page with a "Type" facet (User Docs / API Docs / Blog) that the search UI
+// surfaces as a toggle. Pages that opt out of the search index
+// (pagefind: false — e.g. landing/changelog pages) get no tag, since they
+// aren't indexed anyway.
+const indexed = starlightRoute.entry.data.pagefind !== false;
+const docTypeFilter = indexed ? getDocTypeFilter(starlightRoute.id) : undefined;
 ---
 
-<div class="sl-markdown-content">
+<div class="sl-markdown-content" data-pagefind-filter={docTypeFilter}>
   {experimental && <ExperimentalAside />}
   {community && <CommunityContributionAside />}
   {/* Language support aside is omitted for community pages — the CommunityContributionAside already

--- a/site/src/components/overrides/MarkdownContent.astro
+++ b/site/src/components/overrides/MarkdownContent.astro
@@ -11,10 +11,10 @@ const { languages, community, experimental } = starlightRoute.entry.data;
 
 // Search (Pagefind) doc-type facet. This wrapper lives inside
 // <main data-pagefind-body>, so its data-pagefind-filter attribute tags the
-// page with a "Type" facet (User Docs / API Docs / Blog) that the search UI
-// surfaces as a toggle. Pages that opt out of the search index
-// (pagefind: false — e.g. landing/changelog pages) get no tag, since they
-// aren't indexed anyway.
+// page with a "Type" facet that the search UI surfaces as a toggle (the facet
+// values are defined in src/util/search.ts — the single source of truth).
+// Pages that opt out of the search index (pagefind: false — e.g.
+// landing/changelog pages) get no tag, since they aren't indexed anyway.
 const indexed = starlightRoute.entry.data.pagefind !== false;
 const docTypeFilter = indexed ? getDocTypeFilter(starlightRoute.id) : undefined;
 ---

--- a/site/src/components/overrides/Search.astro
+++ b/site/src/components/overrides/Search.astro
@@ -293,12 +293,24 @@ const typeValues = [DOC_TYPE_USER, DOC_TYPE_API_PYTHON, DOC_TYPE_API_TYPESCRIPT,
         return true
       }
 
+      // The Component UI bundle loads as a module and registers its custom
+      // elements + `window.PagefindComponents` during one synchronous execution.
+      // Try immediately (already-loaded / warm nav), otherwise wait for the
+      // bundle via `whenDefined`: when `pagefind-config` is defined, the module
+      // has finished executing, so `window.PagefindComponents` is set and
+      // getInstance('default') resolves (verified — the whenDefined microtask
+      // can only run after the whole module completes).
       if (setup()) return
-      // Components register asynchronously after the bundle loads; poll briefly.
-      let tries = 0
-      const timer = setInterval(() => {
-        if (setup() || ++tries > 100) clearInterval(timer)
-      }, 50)
+      customElements.whenDefined('pagefind-config').then(() => {
+        if (!setup()) {
+          // Should not happen; log rather than fail silently so a future Pagefind
+          // rename of the global/instance API is diagnosable.
+          console.error(
+            '[search] Pagefind Component UI loaded but its instance API was not found; ' +
+              'the Type filter is inert. Check window.PagefindComponents.getInstanceManager().'
+          )
+        }
+      })
     }
   }
 

--- a/site/src/components/overrides/Search.astro
+++ b/site/src/components/overrides/Search.astro
@@ -173,9 +173,7 @@ const typeValues = [DOC_TYPE_USER, DOC_TYPE_API_PYTHON, DOC_TYPE_API_TYPESCRIPT,
         return null
       }
 
-      // Italicize the search term in the summary line ("N results for <em>term</em>")
-      // and, when the rendered result count is capped below the true total, append
-      // a "showing top N" note so the cap isn't silently misleading.
+      // Italicize the search term in the summary line ("N results for <em>term</em>").
       //
       // Pagefind creates an inner `<div class="pf-summary">` and rewrites ITS
       // textContent on every search. We must decorate THAT container (mutating
@@ -198,9 +196,16 @@ const typeValues = [DOC_TYPE_USER, DOC_TYPE_API_PYTHON, DOC_TYPE_API_TYPESCRIPT,
           const text = container.textContent || ''
           const match = text.match(/^(\d+ )(results? for )(.+)$/)
           if (match && !container.querySelector('em')) {
-            container.innerHTML =
-              `<span>${match[1]}${match[2]}</span>` +
-              `<em class="sl-search-summary__term">${match[3]}</em>`
+            // Build nodes and set text via textContent — never innerHTML. match[3]
+            // is the user's search term, so interpolating it into innerHTML would
+            // be a DOM-XSS sink (a query like `<img src=x onerror=...>` would
+            // execute, and becomes reflected XSS if the query is ever URL-driven).
+            const count = document.createElement('span')
+            count.textContent = match[1] + match[2]
+            const term = document.createElement('em')
+            term.className = 'sl-search-summary__term'
+            term.textContent = match[3]
+            container.replaceChildren(count, term)
           }
         })
         observer.observe(summaryEl, { childList: true, subtree: true, characterData: true })

--- a/site/src/components/overrides/Search.astro
+++ b/site/src/components/overrides/Search.astro
@@ -1,0 +1,736 @@
+---
+/**
+ * Search override — Pagefind Component UI.
+ *
+ * Replaces Starlight's default Search (which wraps @pagefind/default-ui) with
+ * Pagefind's newer Component UI (v1.5.x web components). The default UI can only
+ * express a same-key multi-select as a plain array, which Pagefind treats as AND
+ * → 0 results, with no hook to change it.
+ *
+ * OR filtering, public API only: instead of Pagefind's <pagefind-filter-pane>
+ * (whose internal `on('search')` listener re-syncs its checkboxes and only
+ * understands plain arrays), we render our OWN Type control and drive filtering
+ * through the instance's PUBLIC `triggerFilters(filtersObj)` method. We build the
+ * filters object ourselves: a single string for one selection, or Pagefind's
+ * `{ any: [...] }` OR form for multiple. triggerFilters passes the object
+ * straight through to `pagefind.search(term, { filters })`, and <pagefind-input>
+ * typing calls `triggerSearch(value)` which re-reads the instance's public
+ * `searchFilters`, so selection stays in sync while typing — with zero access to
+ * private (`__`-prefixed) fields or methods.
+ *
+ * Facet: Type only (User Docs / Python API / TypeScript API / Blog), emitted in
+ * the MarkdownContent override.
+ *
+ * Selection: all types are checked by default (search spans everything); the
+ * user narrows via the Type control and their choice is persisted in
+ * localStorage (see the script below). There is no page-specific default.
+ *
+ * Coupling: this depends on Pagefind Component UI internals-by-convention — the
+ * `PagefindComponents.getInstanceManager()` global, several `pf-*` class names
+ * we restyle, and the English summary text format we parse. All are stable
+ * within a Pagefind major version; pin @pagefind/* and re-check on upgrade.
+ */
+import {
+  DOC_TYPE_FILTER_KEY,
+  DOC_TYPE_USER,
+  DOC_TYPE_API_PYTHON,
+  DOC_TYPE_API_TYPESCRIPT,
+  DOC_TYPE_BLOG,
+} from '../../util/search'
+import { pathWithBase } from '../../util/links'
+
+// Component UI assets are emitted into /pagefind at build time by Pagefind.
+const bundlePath = pathWithBase('/pagefind/')
+const componentJs = pathWithBase('/pagefind/pagefind-component-ui.js')
+const componentCss = pathWithBase('/pagefind/pagefind-component-ui.css')
+
+// Every Type value we render, in display order.
+const typeValues = [DOC_TYPE_USER, DOC_TYPE_API_PYTHON, DOC_TYPE_API_TYPESCRIPT, DOC_TYPE_BLOG]
+---
+
+<link rel="stylesheet" href={componentCss} />
+
+<starlight-pagefind-search class={Astro.props.class} data-type-key={DOC_TYPE_FILTER_KEY}>
+  {/* Loads Pagefind and shares it across the components below via instance="default". */}
+  <pagefind-config bundle-path={bundlePath} instance="default" faceted preload></pagefind-config>
+
+  {/* Header trigger: the Component UI renders its own button (icon + label +
+      shortcut) from the `placeholder` attribute; it ignores slotted markup, so
+      we don't provide any. Styling to match Starlight's default search button is
+      in the global style block below (.pf-trigger-btn). */}
+  <pagefind-modal-trigger instance="default" placeholder="Search"></pagefind-modal-trigger>
+
+  {/* Modal: search box + our own Type control + results. */}
+  <pagefind-modal instance="default" reset-on-close>
+    <pagefind-modal-header>
+      {/* Bare input (not <pagefind-searchbox>, which renders its own results
+          dropdown) so results render only in <pagefind-results> below. */}
+      <pagefind-input instance="default" placeholder="Search the docs" autofocus></pagefind-input>
+    </pagefind-modal-header>
+    <pagefind-modal-body>
+      {/* NOTE: our own elements deliberately AVOID the `pf-` class prefix. The
+          Component UI stylesheet has a global reset
+          `:is(*,#\#):is(*,#\#) :is([class^="pf-"],[class*=" pf-"]):not(svg,svg *) { all: revert }`
+          (specificity 0,3,0) that reverts color/display to UA defaults on ANY
+          pf-* element — which would break our text color and layout. Naming
+          ours `sl-search-*` keeps them out of that reset so ordinary CSS
+          applies. */}
+      <div class="sl-search-layout">
+        {/* Our OWN Type control. Not a <pagefind-filter-pane> — we own the
+            selection state and drive Pagefind via the public triggerFilters(). */}
+        <fieldset class="sl-search-types" aria-label="Filter by type">
+          <legend class="sl-search-types__legend">Type</legend>
+          {typeValues.map((value) => (
+            <label class="sl-search-types__option">
+              {/* All types start checked so "everything selected" reads as
+                  "searching everything"; a persisted selection (if any) is
+                  applied by the client script on connect. */}
+              <input type="checkbox" name="Type" value={value} checked />
+              <span>{value}</span>
+            </label>
+          ))}
+        </fieldset>
+        <div style="min-width:0;">
+          {/* Summary ABOVE results (matches strandsagents.com). max-results caps
+              the rendered list so a very broad query doesn't inject the entire
+              corpus into the DOM, but it's set high enough (100) that all
+              realistic result sets render in full — one render, native scroll,
+              no pagination jank. */}
+          <pagefind-summary instance="default" default-message="Type to search."></pagefind-summary>
+          <pagefind-results instance="default" show-sub-results max-results="100"></pagefind-results>
+        </div>
+      </div>
+    </pagefind-modal-body>
+    <pagefind-modal-footer>
+      <pagefind-keyboard-hints instance="default"></pagefind-keyboard-hints>
+    </pagefind-modal-footer>
+  </pagefind-modal>
+</starlight-pagefind-search>
+
+{/* Runtime asset (emitted by Pagefind into dist/pagefind); not resolvable at
+    build time, so load it as a plain module script by URL, not a bundled import. */}
+<script type="module" src={componentJs} is:inline></script>
+
+<script>
+  import { getDocTypeFromUrl } from '../../util/search'
+
+  const STORAGE_KEY = 'sl-search-types'
+
+  class StarlightPagefindSearch extends HTMLElement {
+    connectedCallback() {
+      const typeKey = this.dataset.typeKey || 'Type'
+
+      // Drive the Component UI's built-in `[data-pf-theme]` block from
+      // Starlight's own `data-theme` on <html>, and keep them in sync when the
+      // user toggles the theme.
+      const syncTheme = () => {
+        const theme = document.documentElement.dataset.theme === 'light' ? 'light' : 'dark'
+        document.documentElement.setAttribute('data-pf-theme', theme)
+      }
+      syncTheme()
+      new MutationObserver(syncTheme).observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['data-theme'],
+      })
+
+      const checkboxes = Array.from(
+        this.querySelectorAll<HTMLInputElement>('.sl-search-types input[name="Type"]')
+      )
+
+      // Turn the currently-checked Type boxes into a Pagefind filters object,
+      // using the OR (`{ any: [...] }`) form for multiple selections and a bare
+      // string for a single one. Returns an empty object when nothing is checked
+      // (Pagefind then searches across all types).
+      const buildFilters = (): Record<string, unknown> => {
+        const selected = checkboxes.filter((c) => c.checked).map((c) => c.value)
+        if (selected.length === 0) return {}
+        if (selected.length === 1) return { [typeKey]: selected[0] }
+        return { [typeKey]: { any: selected } }
+      }
+
+      // Persist the current selection so it survives across sessions. An empty
+      // array is a valid, intentional choice ("search all types") and is stored
+      // as such — loadSelection() distinguishes it from "no preference yet".
+      const saveSelection = () => {
+        try {
+          const selected = checkboxes.filter((c) => c.checked).map((c) => c.value)
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(selected))
+        } catch {}
+      }
+
+      // Restore the saved selection. Returns an array (possibly empty) when a
+      // preference is stored, or null when the user has never chosen — so the
+      // caller can leave the server-rendered checkbox state untouched in that
+      // case rather than forcing a default.
+      const loadSelection = (): string[] | null => {
+        try {
+          const stored = localStorage.getItem(STORAGE_KEY)
+          if (stored) {
+            const parsed = JSON.parse(stored)
+            if (Array.isArray(parsed)) return parsed.filter((v) => typeof v === 'string')
+          }
+        } catch {}
+        return null
+      }
+
+      // Italicize the search term in the summary line ("N results for <em>term</em>")
+      // and, when the rendered result count is capped below the true total, append
+      // a "showing top N" note so the cap isn't silently misleading.
+      //
+      // Pagefind creates an inner `<div class="pf-summary">` and rewrites ITS
+      // textContent on every search. We must decorate THAT container (mutating
+      // its children), never the outer <pagefind-summary> — replacing the outer
+      // element's innerHTML would detach Pagefind's div, freezing the summary at
+      // a stale value while Pagefind writes to the orphaned node. Pagefind's next
+      // textContent write wipes our <em> and re-fires the observer, which
+      // re-decorates — so it stays in sync across query changes.
+      //
+      // NOTE: the parsing is English-only (the site ships English only); the
+      // regex matches Pagefind's "[COUNT] result(s) for [TERM]" format. A
+      // non-English locale would simply skip the styling (no breakage).
+      const stylizeSummary = () => {
+        const summaryEl = this.querySelector('pagefind-summary')
+        if (!summaryEl) return
+        const observer = new MutationObserver(() => {
+          // Pagefind's own container; skip until it exists (nothing to decorate).
+          const container = summaryEl.querySelector<HTMLElement>('.pf-summary')
+          if (!container) return
+          const text = container.textContent || ''
+          const match = text.match(/^(\d+ )(results? for )(.+)$/)
+          if (match && !container.querySelector('em')) {
+            container.innerHTML =
+              `<span>${match[1]}${match[2]}</span>` +
+              `<em class="sl-search-summary__term">${match[3]}</em>`
+          }
+        })
+        observer.observe(summaryEl, { childList: true, subtree: true, characterData: true })
+      }
+
+      // Tag each result with a small type badge (User Docs / Python API /
+      // TypeScript API / Blog) derived from its link URL, so the reader knows
+      // where a hit will land. The
+      // Component UI has no per-result hook, so we observe the results list and
+      // badge each card's title as it renders. Idempotent per card via a marker
+      // attribute; the derived type is data-driven (getDocTypeFromUrl), not
+      // hardcoded here.
+      const badgeResults = () => {
+        const resultsEl = this.querySelector('pagefind-results')
+        if (!resultsEl) return
+        const tag = () => {
+          const titles = resultsEl.querySelectorAll<HTMLElement>(
+            '.pf-result-card .pf-result-title'
+          )
+          for (const title of titles) {
+            if (title.dataset.slTyped) continue
+            const href = title.querySelector('a')?.getAttribute('href') || ''
+            const type = getDocTypeFromUrl(href)
+            if (!type) continue
+            title.dataset.slTyped = 'true'
+            const badge = document.createElement('span')
+            badge.className = 'sl-search-badge'
+            // The doc-type value is the badge label (single vocabulary shared
+            // with the filter toggle — see src/util/search.ts).
+            badge.textContent = type
+            // Lead with the badge so it reads before the title.
+            title.insertBefore(badge, title.firstChild)
+          }
+        }
+        tag()
+        new MutationObserver(tag).observe(resultsEl, { childList: true, subtree: true })
+      }
+
+      const setup = () => {
+        const PC = (window as any).PagefindComponents
+        // getInstance is a PUBLIC accessor; the returned instance is used only
+        // through its public API (triggerFilters). No `__`-prefixed access.
+        const instance = PC?.getInstanceManager?.()?.getInstance?.('default')
+        if (!instance) return false
+
+        // Re-run the search with the current Type selection whenever a box
+        // changes. triggerFilters(filtersObj) is the public method that both
+        // stores the selection (instance.searchFilters) and re-runs the search,
+        // passing our object straight through to pagefind.search.
+        const applySelection = () => {
+          instance.triggerFilters(buildFilters())
+          saveSelection()
+        }
+
+        if (!this.dataset.wired) {
+          this.dataset.wired = 'true'
+          for (const box of checkboxes) {
+            box.addEventListener('change', applySelection)
+          }
+        }
+
+        // Restore a persisted selection if one exists. With no stored preference
+        // the server-rendered checkboxes (all checked) stand — search spans every
+        // type by default, and the user narrows from there. There is no
+        // page-specific default: the Type filter is fully user-driven.
+        if (!this.dataset.defaultsApplied) {
+          this.dataset.defaultsApplied = 'true'
+          const stored = loadSelection()
+          if (stored) {
+            let changed = false
+            for (const box of checkboxes) {
+              const shouldCheck = stored.includes(box.value)
+              if (shouldCheck !== box.checked) {
+                box.checked = shouldCheck
+                changed = true
+              }
+            }
+            if (changed) instance.triggerFilters(buildFilters())
+          }
+        }
+
+        // Wire up summary italicization and per-result type badges.
+        stylizeSummary()
+        badgeResults()
+        return true
+      }
+
+      if (setup()) return
+      // Components register asynchronously after the bundle loads; poll briefly.
+      let tries = 0
+      const timer = setInterval(() => {
+        if (setup() || ++tries > 100) clearInterval(timer)
+      }, 50)
+    }
+  }
+
+  customElements.define('starlight-pagefind-search', StarlightPagefindSearch)
+</script>
+
+<style>
+  @layer starlight.core {
+    starlight-pagefind-search {
+      display: contents;
+    }
+
+    /* The modal and its portaled dialog must not affect header layout. */
+    starlight-pagefind-search pagefind-config,
+    starlight-pagefind-search pagefind-modal {
+      display: contents;
+    }
+  }
+</style>
+
+{/* Component UI theming.
+
+    The Component UI ships a complete `[data-pf-theme="dark"]` variable block; we
+    activate it (mirroring Starlight's data-theme, see the script above) instead
+    of hand-rolling every color. On top of that base we re-map a few variables to
+    Strands's own tokens so the modal matches the site rather than the generic
+    dark palette. Doubled selectors (`:root:root`, `[data-pf-theme][data-pf-theme]`)
+    give specificity 0,2,0 so these win over the Component UI's own single-class
+    declarations regardless of stylesheet load order. Our own Type control is
+    styled here too (plain classes, nothing to fight). */}
+<style is:global>
+  :root:root {
+    --pf-font: var(--sl-font, inherit);
+    /* Wider than the Component UI default so the Type sidebar (13rem + gap)
+       doesn't squeeze the results column — leaves results ~600px, close to
+       strandsagents.com's ~640px all-results modal. */
+    --pf-modal-max-width: 52rem;
+  }
+
+  /* Strands tokens layered over the Component UI's built-in dark base. */
+  [data-pf-theme='dark'][data-pf-theme='dark'] {
+    --pf-text: var(--sl-color-white);
+    --pf-text-secondary: var(--sl-color-gray-2);
+    --pf-text-muted: var(--sl-color-gray-3);
+    --pf-background: var(--sl-color-gray-6);
+    --pf-border: var(--sl-color-gray-5);
+    --pf-border-focus: var(--sl-color-accent);
+    --pf-outline-focus: var(--sl-color-accent);
+    --pf-hover: var(--sl-color-gray-5);
+    /* Matched terms read as bold bright text (see the `mark` rule), matching
+       strandsagents.com — NOT a green highlight. --pf-mark drives the Component
+       UI's own mark color, so point it at the normal bright text color. */
+    --pf-mark: var(--sl-color-white);
+    --pf-modal-backdrop: var(--sl-color-backdrop-overlay, rgba(0, 0, 0, 0.7));
+  }
+
+  /* Light theme (Starlight toggled to light) — nudge accents to Strands green. */
+  [data-pf-theme='light'][data-pf-theme='light'] {
+    --pf-border-focus: var(--sl-color-accent);
+    --pf-outline-focus: var(--sl-color-accent);
+    /* Matched terms: high-contrast text (bold), NOT a green highlight. NOTE:
+       Starlight INVERTS --sl-color-white/black per theme — --sl-color-white is
+       the high-contrast *text* color in BOTH themes (dark text in light mode,
+       light text in dark mode), while --sl-color-black is the deep *background*.
+       So --pf-mark uses --sl-color-white in both blocks. Using --sl-color-black
+       here previously rendered white-on-white (invisible) in light mode. */
+    --pf-mark: var(--sl-color-white);
+  }
+
+  /* Header trigger button — match Starlight's default search button so the
+     Component UI swap is visually seamless with strandsagents.com.
+
+     The Component UI renders its own `.pf-trigger-btn` (icon + label + ⌘K) and
+     styles it with a 3,0,0 specificity hack (`:is(*,#\#)` ×3 — the `#\#` id makes
+     each `:is()` worth an ID). Matching that from userland is brittle, so we use
+     `!important` here — the honest tool for overriding a vendored specificity
+     hack. The trigger already lays out correctly internally (label flex:1,
+     shortcut pushed right); we fix the collapsed width, dimensions (40px tall /
+     8px radius vs the CU defaults of 36/6), and colors. */
+
+  /* Fill the 300px header search slot. pagefind-modal-trigger is display:block
+     but doesn't stretch inside the flex .search-wrapper, so the 100%-width
+     button collapses to its content. Make the whole chain fill the slot. */
+  .search-wrapper starlight-pagefind-search,
+  .search-wrapper pagefind-modal-trigger {
+    display: block;
+    width: 100%;
+  }
+
+  .pf-trigger-btn {
+    height: 40px !important;
+    border-radius: 8px !important;
+    border-color: var(--sl-color-gray-5) !important;
+    background-color: var(--sl-color-black) !important;
+    color: var(--sl-color-gray-2) !important;
+    padding-inline: 12px 8px !important;
+  }
+  .pf-trigger-btn:hover {
+    border-color: var(--sl-color-gray-2) !important;
+    color: var(--sl-color-white) !important;
+  }
+  /* Icon (a mask-image box, colored via background) + label share the muted
+     color; capitalize so the label reads "Search". */
+  .pf-trigger-icon {
+    background-color: var(--sl-color-gray-2) !important;
+  }
+  .pf-trigger-text {
+    color: var(--sl-color-gray-2) !important;
+    text-transform: capitalize;
+  }
+  /* ⌘K badge — match Starlight's gray-6 keycap look. */
+  .pf-trigger-key {
+    background-color: var(--sl-color-gray-6) !important;
+    color: var(--sl-color-gray-2) !important;
+    font-family: var(--__sl-font);
+  }
+
+  /* Search input — match the reference's taller, green-bordered input. */
+  .pf-input {
+    height: 51px !important;
+    border: 1px solid var(--pf-border-focus, var(--sl-color-accent)) !important;
+    border-radius: 8px !important;
+    font-size: 16px !important;
+  }
+
+  /* Clear button — reference uses an X icon; our Component UI renders text "Clear".
+     Replace the text with a visually-hidden approach + an X icon via mask. */
+  .pf-input-clear {
+    font-size: 0 !important;  /* hide text */
+    width: 24px !important;
+    height: 24px !important;
+    background-color: var(--pf-text-muted, var(--sl-color-gray-3)) !important;
+    border: none !important;
+    border-radius: 50% !important;
+    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='m13.41 12 6.3-6.29a1 1 0 1 0-1.42-1.42L12 10.59l-6.29-6.3a1 1 0 0 0-1.42 1.42l6.3 6.29-6.3 6.29a1 1 0 0 0 .33 1.64 1 1 0 0 0 1.09-.22l6.29-6.3 6.29 6.3a1 1 0 0 0 1.64-.33 1 1 0 0 0-.22-1.09L13.41 12Z'/%3E%3C/svg%3E") center / 60% no-repeat !important;
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='m13.41 12 6.3-6.29a1 1 0 1 0-1.42-1.42L12 10.59l-6.29-6.3a1 1 0 0 0-1.42 1.42l6.3 6.29-6.3 6.29a1 1 0 0 0 .33 1.64 1 1 0 0 0 1.09-.22l6.29-6.3 6.29 6.3a1 1 0 0 0 1.64-.33 1 1 0 0 0-.22-1.09L13.41 12Z'/%3E%3C/svg%3E") center / 60% no-repeat !important;
+    cursor: pointer;
+  }
+
+  /* Unified result card (matches strandsagents.com): the reference renders each
+     page as ONE rounded card — title header + its sub-results inside the same
+     bordered box, separated by hairlines. The Component UI instead borders the
+     parent (.pf-result-card) and hangs the sub-results (.pf-heading-chips) below
+     as a separate panel. We re-unify: move the card treatment to the OUTER
+     .pf-result, neutralize the inner card, and let the sub-results share the
+     same box. `!important` beats the pf-* reset's 0,3,0 specificity. */
+  .pf-result {
+    border: 1px solid var(--pf-border, var(--sl-color-gray-5)) !important;
+    border-radius: 0.5rem !important;
+    overflow: hidden !important;
+    margin-block-end: 1rem !important;
+    gap: 0 !important;
+  }
+  .pf-result-card {
+    border: 0 !important;
+    background: transparent !important;
+    /* Round the top corners to match the container so the hover OUTLINE (which
+       follows border-radius) curves with the card instead of getting its square
+       corners clipped by the rounded, overflow-hidden .pf-result. The card is
+       always the top row. */
+    border-radius: 0.5rem 0.5rem 0 0 !important;
+  }
+  /* When a result has no sub-results, the card is the only row → round all 4. */
+  .pf-result-card:last-child {
+    border-radius: 0.5rem !important;
+  }
+
+  /* Result titles — add a page icon to the left (matches strandsagents.com). */
+  .pf-result-title {
+    position: relative !important;
+    padding-inline-start: 2rem !important;
+    font-size: 1.05rem !important;
+    font-weight: 700 !important;
+  }
+  .pf-result-title::before {
+    content: '';
+    position: absolute;
+    inset-inline-start: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1.25rem;
+    height: 1.25rem;
+    background: var(--pf-text-muted, var(--sl-color-gray-3));
+    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 24 24'%3E%3Cpath d='M9 10h1a1 1 0 1 0 0-2H9a1 1 0 0 0 0 2Zm0 2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2H9Zm11-3V8l-6-6a1 1 0 0 0-1 0H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V9Zm-6-4 3 3h-2a1 1 0 0 1-1-1V5Zm4 14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5v3a3 3 0 0 0 3 3h3v9Zm-3-3H9a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2Z'/%3E%3C/svg%3E") center / contain no-repeat;
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 24 24'%3E%3Cpath d='M9 10h1a1 1 0 1 0 0-2H9a1 1 0 0 0 0 2Zm0 2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2H9Zm11-3V8l-6-6a1 1 0 0 0-1 0H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V9Zm-6-4 3 3h-2a1 1 0 0 1-1-1V5Zm4 14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5v3a3 3 0 0 0 3 3h3v9Zm-3-3H9a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2Z'/%3E%3C/svg%3E") center / contain no-repeat;
+  }
+
+  /* Parent-result hover/focus (matches strandsagents.com): a green outline on
+     the full-width title block + green title link text. The outline goes on
+     .pf-result-card (the parent's title+excerpt block, which spans the full card
+     width) — NOT on .pf-result-title, which is inset by the card's padding and
+     would draw a cramped box floating inside the card. This makes the parent
+     outline span the row exactly like the sub-result rows do. We use `outline`
+     (not border) because the card border is zeroed above, and outline doesn't
+     shift layout. focus-within covers keyboard nav landing on the link. */
+  .pf-result-card:hover,
+  .pf-result-card:focus-within {
+    outline: 1px solid var(--sl-color-accent-high) !important;
+    outline-offset: -1px !important;
+  }
+  .pf-result-card:hover a,
+  .pf-result-card:focus-within a {
+    color: var(--sl-color-accent) !important;
+    text-decoration: none !important;
+  }
+  /* Whole parent card is the click target (reference parity): anchor on the card
+     and stretch the title link across it, so hovering/clicking anywhere in the
+     card (title or excerpt) activates the result. The decorative ::before
+     icon/tree don't intercept clicks. */
+  .pf-result-card {
+    position: relative !important;
+    cursor: pointer !important;
+  }
+  .pf-result-card a::after {
+    content: '' !important;
+    position: absolute !important;
+    inset: 0 !important;
+  }
+
+  /* Sub-results (heading chips) — render as a directory-style tree INSIDE the
+     shared result card, matching strandsagents.com: each child is a row divided
+     from the previous by a hairline, with a vertical connector line branching
+     into it. No separate panel/background — the card unifies parent + children
+     (see .pf-result above). Our DOM differs from the default UI
+     (`.pf-heading-chip` li vs `.pf-result-nested`), so we rebuild the connector
+     with a `::before` on each chip. `!important` beats the pf-* reset. */
+  .pf-heading-chips {
+    /* Override the Component UI's flex + 6px gap + inset padding: sub-results
+       are full-width rows stacked flush, separated only by our hairlines. */
+    display: block !important;
+    gap: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    list-style: none !important;
+    background: transparent !important;
+    /* Hairline separating the parent title/excerpt from its first sub-result. */
+    border-top: 1px solid var(--pf-border, var(--sl-color-gray-5)) !important;
+  }
+  .pf-heading-chip {
+    /* Neutralize the Component UI's per-chip rounded box (border + radius +
+       inline-flex): each sub-result is a plain full-width block row. Straight
+       hairline dividers (below) do the separating; no gap, no rounded corners. */
+    display: block !important;
+    position: relative !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    padding-block: 0.55rem !important;
+    /* Left space holds the tree connector; matches the parent title's icon gutter. */
+    padding-inline-start: 2.75rem !important;
+    padding-inline-end: 0.75rem !important;
+    list-style: none !important;
+  }
+  /* Straight hairline between adjacent sub-results (no gap between them). */
+  .pf-heading-chip + .pf-heading-chip {
+    border-top: 1px solid var(--pf-border, var(--sl-color-gray-5)) !important;
+  }
+  /* Round the last sub-result's bottom corners to match the container, so its
+     hover outline curves with the card instead of being clipped square by the
+     rounded, overflow-hidden .pf-result (it's always the bottom row). */
+  .pf-heading-chip:last-child {
+    border-radius: 0 0 0.5rem 0.5rem !important;
+  }
+  /* Sub-result hover/focus (matches strandsagents.com): green outline around the
+     row + green link text (no fill — the reference uses outline only).
+     focus-within gives keyboard nav a clear selected state (the Component UI's
+     own :focus outline is reset away and its per-chip border is zeroed above). */
+  .pf-heading-chip:hover,
+  .pf-heading-chip:focus-within {
+    outline: 1px solid var(--sl-color-accent-high) !important;
+    outline-offset: -1px !important;
+  }
+  .pf-heading-chip:hover .pf-heading-link,
+  .pf-heading-chip:focus-within .pf-heading-link {
+    color: var(--sl-color-accent) !important;
+    text-decoration: none !important;
+  }
+  /* Whole sub-row is the click target (reference parity). */
+  .pf-heading-chip {
+    cursor: pointer !important;
+  }
+  .pf-heading-link::after {
+    content: '' !important;
+    position: absolute !important;
+    inset: 0 !important;
+  }
+  /* Sub-result title/excerpt — nearly as prominent as the parent (reference
+     uses ~15px titles), not the cramped 12px the Component UI defaults to. */
+  .pf-heading-link {
+    font-size: 0.95rem !important;
+    font-weight: 600 !important;
+  }
+  .pf-heading-excerpt {
+    font-size: 0.9rem !important;
+    line-height: 1.6 !important;
+  }
+  /* Vertical line + branch into each child (SVG mask, same shape the default UI
+     uses). The line runs full-height; the last child uses a shorter "elbow". */
+  .pf-heading-chip::before {
+    content: '';
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 1.1rem;
+    width: 1rem;
+    background-color: var(--sl-color-gray-4);
+    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' viewBox='0 0 16 1000' preserveAspectRatio='xMinYMin slice'%3E%3Cpath d='M8 0v1000m6-988H8'/%3E%3C/svg%3E") 0 0 / 100% no-repeat;
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' viewBox='0 0 16 1000' preserveAspectRatio='xMinYMin slice'%3E%3Cpath d='M8 0v1000m6-988H8'/%3E%3C/svg%3E") 0 0 / 100% no-repeat;
+  }
+  /* Last child: stop the vertical line at the branch (elbow) instead of running on. */
+  .pf-heading-chip:last-child::before {
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='M8 0v12m6 0H8'/%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='M8 0v12m6 0H8'/%3E%3C/svg%3E");
+  }
+  /* Flip the connector for RTL layouts. */
+  [dir='rtl'] .pf-heading-chip::before {
+    transform: matrix(-1, 0, 0, 1, 0, 0);
+  }
+
+  /* Highlighted search matches: bold text, no background — matches
+     strandsagents.com (which bolds matches rather than boxing them in color). */
+  pagefind-results mark,
+  .pf-result mark {
+    background-color: transparent;
+    color: inherit;
+    font-weight: 700;
+  }
+
+  /* Dark-mode scrollbar: the scrolling element is pagefind-modal-body, which the
+     Component UI reset leaves at `color-scheme: normal` → a light native
+     scrollbar on the dark modal. Match Starlight (whose scroller inherits
+     `color-scheme: dark`). `!important` beats the reset's 0,3,0 specificity
+     (same approach as .pf-trigger-btn). Scoped to dark so light keeps its bar. */
+  [data-pf-theme='dark'] pagefind-modal-body,
+  [data-pf-theme='dark'] .pf-modal-body {
+    color-scheme: dark !important;
+  }
+
+  /* Summary ("N results for X") — the Component UI leaves it at `canvastext`
+     (black), invisible in dark mode. Give it an explicit themed color in both
+     modes. `!important` beats the pf-* reset. (The count/term text lives
+     directly on <pagefind-summary>, so we target the element itself.) */
+  pagefind-summary {
+    color: var(--pf-text-secondary, var(--sl-color-gray-2)) !important;
+  }
+  /* Search term rendered by the script: emphasized so it's clear what was
+     searched (e.g. "179 results for <em>conversation ma</em>"). */
+  .sl-search-summary__term {
+    font-style: italic;
+    color: var(--pf-text, var(--sl-color-white));
+  }
+
+  /* Per-result type badge (User Docs / Python API / TypeScript API / Blog).
+     Injected by the script as the first child of each result title; a small pill
+     so the reader can tell at a glance what kind of page a hit lands on. The
+     label is the doc-type value verbatim, so it reads in natural case (no
+     uppercase transform). Uses the `sl-search-*` prefix so the Component UI's
+     pf-* reset doesn't touch it, but it lives inside a `.pf-result-title` (which
+     we pad-start by 2rem for the page icon), so vertical-align it with the
+     title text. */
+  .sl-search-badge {
+    display: inline-block;
+    margin-inline-end: 0.5rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 0.25rem;
+    font-size: 0.7em;
+    font-weight: 600;
+    white-space: nowrap;
+    vertical-align: middle;
+    color: var(--pf-text-secondary, var(--sl-color-gray-2));
+    background-color: var(--sl-color-gray-5);
+  }
+
+  /* ---- Our own filter + results layout ----
+     These use the `sl-search-*` prefix (NOT `pf-*`) on purpose so the Component
+     UI's `[class^="pf-"] { all: revert }` reset can't touch them — so plain,
+     low-specificity CSS below just works, no !important needed. */
+
+  /* Two columns: sticky Type sidebar + results. Grid lives here (not inline) so
+     the narrow-viewport media query can collapse it. */
+  .sl-search-layout {
+    display: grid;
+    grid-template-columns: 13rem minmax(0, 1fr);
+    gap: 1.25rem;
+    align-items: start;
+  }
+
+  /* Type control — matches the modal in both themes via --pf-* vars (which the
+     Component UI keeps theme-correct), so no per-theme rules needed. */
+  .sl-search-types {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: var(--sl-text-sm);
+    /* Sticky so the filter stays in view while results scroll. Offsets past the
+       modal header; scrolling happens on pagefind-modal-body. */
+    position: sticky;
+    top: 0;
+  }
+  .sl-search-types__legend {
+    padding: 0;
+    margin-block-end: 0.5rem;
+    color: var(--pf-text, var(--sl-color-white));
+    font-weight: 600;
+    font-size: var(--sl-text-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .sl-search-types__option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    padding-block: 0.15rem;
+    white-space: nowrap;
+    color: var(--pf-text-secondary, var(--sl-color-gray-2));
+  }
+  .sl-search-types__option:hover {
+    color: var(--pf-text, var(--sl-color-white));
+  }
+  .sl-search-types__option input[type='checkbox'] {
+    flex: 0 0 auto;
+    accent-color: var(--sl-color-accent);
+    inline-size: 1rem;
+    block-size: 1rem;
+    margin: 0;
+  }
+
+  /* Collapse to a single column on narrow viewports; drop the sticky sidebar. */
+  @media (max-width: 40rem) {
+    .sl-search-layout {
+      grid-template-columns: 1fr;
+    }
+    .sl-search-types {
+      position: static;
+    }
+  }
+</style>

--- a/site/src/layouts/BlogLayout.astro
+++ b/site/src/layouts/BlogLayout.astro
@@ -13,9 +13,15 @@ interface Props {
   description?: string
   ogImage?: string
   canonicalUrl?: string
+  /**
+   * Whether this page is included in the Pagefind search index. Defaults to
+   * false so listing pages (index, tags, authors) stay out of search; blog
+   * posts opt in via BlogPostLayout so they surface under the "Blog" facet.
+   */
+  pagefind?: boolean
 }
 
-const { title, description, ogImage, canonicalUrl: canonicalOverride } = Astro.props
+const { title, description, ogImage, canonicalUrl: canonicalOverride, pagefind = false } = Astro.props
 
 const pageUrl = new URL(Astro.url.pathname, Astro.site).href
 const canonicalUrl = canonicalOverride || pageUrl
@@ -43,7 +49,7 @@ if (ogImage) {
 ---
 
 <StarlightPage
-  frontmatter={{ title, description, template: 'splash', pagefind: false, head, hero: { actions: [] } }}
+  frontmatter={{ title, description, template: 'splash', pagefind, head, hero: { actions: [] } }}
   hasSidebar={false}
 >
   <slot name="head" slot="head" />

--- a/site/src/layouts/BlogPostLayout.astro
+++ b/site/src/layouts/BlogPostLayout.astro
@@ -41,7 +41,7 @@ const jsonLd = {
 }
 ---
 
-<BlogLayout title={title} description={description} ogImage={ogImageUrl} canonicalUrl={canonicalUrl}>
+<BlogLayout title={title} description={description} ogImage={ogImageUrl} canonicalUrl={canonicalUrl} pagefind={true}>
   <Fragment slot="head">
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   </Fragment>

--- a/site/src/util/search.ts
+++ b/site/src/util/search.ts
@@ -1,0 +1,82 @@
+/**
+ * Search (Pagefind) doc-type helpers.
+ *
+ * The site search is powered by Starlight's bundled Pagefind index. Pagefind
+ * tags a page with a filter facet via the `data-pagefind-filter` data attribute
+ * on the indexed page body. Every indexed page is tagged with a `Type` facet,
+ * which the search UI surfaces as a doc-type toggle. The Python and TypeScript
+ * API references are separate facet values so users can target one language.
+ */
+
+/** Filter key surfaced in the search UI (rendered as the facet's label). */
+export const DOC_TYPE_FILTER_KEY = 'Type'
+
+/**
+ * Doc-type facet values. This is the single source of truth for the vocabulary:
+ * the same strings label the search filter toggle AND the per-result badge, so
+ * the two never drift.
+ */
+export const DOC_TYPE_USER = 'User Docs'
+export const DOC_TYPE_API_PYTHON = 'Python API'
+export const DOC_TYPE_API_TYPESCRIPT = 'TypeScript API'
+export const DOC_TYPE_BLOG = 'Blog'
+
+export type DocType =
+  | typeof DOC_TYPE_USER
+  | typeof DOC_TYPE_API_PYTHON
+  | typeof DOC_TYPE_API_TYPESCRIPT
+  | typeof DOC_TYPE_BLOG
+
+/**
+ * Whether a content id points at an auto-generated API reference page (either
+ * language). Mirrors the id checks in dynamic-sidebar.ts and route-middleware.ts.
+ */
+export function isApiDocId(id: string): boolean {
+  return id.startsWith('docs/api/python') || id.startsWith('docs/api/typescript')
+}
+
+/** Whether a content id points at a blog post. */
+export function isBlogId(id: string): boolean {
+  return id.startsWith('blog/')
+}
+
+/**
+ * Classify a page into its search doc type. Blog posts render through
+ * StarlightPage, whose id is derived from the URL (e.g. `blog/my-post`);
+ * docs use their content-collection id (e.g. `docs/user-guide/...`). The two
+ * API references are split by language.
+ */
+export function getDocType(id: string): DocType {
+  if (id.startsWith('docs/api/python')) return DOC_TYPE_API_PYTHON
+  if (id.startsWith('docs/api/typescript')) return DOC_TYPE_API_TYPESCRIPT
+  if (isBlogId(id)) return DOC_TYPE_BLOG
+  return DOC_TYPE_USER
+}
+
+/** The `data-pagefind-filter` attribute value for a page's Type facet. */
+export function getDocTypeFilter(id: string): string {
+  return `${DOC_TYPE_FILTER_KEY}:${getDocType(id)}`
+}
+
+/**
+ * Classify a result by its rendered URL path (e.g. `/docs/api/python/...`),
+ * for badging search results client-side. Unlike getDocType (which keys off the
+ * content-collection id), this must tolerate the deploy base path, so it looks
+ * for the `docs/api/...` / `blog/` segments anywhere in the path rather than at
+ * the start. Returns null when the path matches no known type. The returned
+ * DocType value is shown verbatim as the result's badge label.
+ */
+export function getDocTypeFromUrl(url: string): DocType | null {
+  // Strip origin + normalize to a leading-slashed pathname.
+  let path = url
+  try {
+    path = new URL(url, 'https://x').pathname
+  } catch {
+    /* already a path */
+  }
+  if (/\/docs\/api\/python(\/|$)/.test(path)) return DOC_TYPE_API_PYTHON
+  if (/\/docs\/api\/typescript(\/|$)/.test(path)) return DOC_TYPE_API_TYPESCRIPT
+  if (/\/blog\//.test(path)) return DOC_TYPE_BLOG
+  if (/\/docs\//.test(path)) return DOC_TYPE_USER
+  return null
+}

--- a/site/test/search.test.ts
+++ b/site/test/search.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DOC_TYPE_USER,
+  DOC_TYPE_API_PYTHON,
+  DOC_TYPE_API_TYPESCRIPT,
+  DOC_TYPE_BLOG,
+  isApiDocId,
+  isBlogId,
+  getDocType,
+  getDocTypeFilter,
+  getDocTypeFromUrl,
+} from '../src/util/search'
+
+describe('search doc-type classification', () => {
+  describe('isApiDocId', () => {
+    it('is true for python and typescript API content ids', () => {
+      expect(isApiDocId('docs/api/python/strands.agent.agent')).toBe(true)
+      expect(isApiDocId('docs/api/typescript/Agent')).toBe(true)
+    })
+
+    it('is false for guides, blog, and unrelated ids', () => {
+      expect(isApiDocId('docs/user-guide/quickstart/overview')).toBe(false)
+      expect(isApiDocId('blog/my-post')).toBe(false)
+      expect(isApiDocId('docs/community/plugins/x')).toBe(false)
+    })
+  })
+
+  describe('isBlogId', () => {
+    it('is true only for blog/ ids', () => {
+      expect(isBlogId('blog/my-post')).toBe(true)
+      expect(isBlogId('docs/user-guide/x')).toBe(false)
+      expect(isBlogId('docs/api/python/x')).toBe(false)
+    })
+  })
+
+  describe('getDocType', () => {
+    it('splits API reference by language', () => {
+      expect(getDocType('docs/api/python/strands.agent.agent')).toBe(DOC_TYPE_API_PYTHON)
+      expect(getDocType('docs/api/typescript/Agent')).toBe(DOC_TYPE_API_TYPESCRIPT)
+    })
+
+    it('classifies blog posts', () => {
+      expect(getDocType('blog/interleaved-thinking')).toBe(DOC_TYPE_BLOG)
+    })
+
+    it('defaults everything else to User Docs', () => {
+      expect(getDocType('docs/user-guide/quickstart/overview')).toBe(DOC_TYPE_USER)
+      expect(getDocType('docs/community/plugins/x')).toBe(DOC_TYPE_USER)
+      expect(getDocType('docs/examples/y')).toBe(DOC_TYPE_USER)
+    })
+  })
+
+  describe('getDocTypeFilter', () => {
+    it('prefixes the doc type with the Type filter key', () => {
+      expect(getDocTypeFilter('docs/api/python/strands.agent.agent')).toBe('Type:Python API')
+      expect(getDocTypeFilter('docs/user-guide/x')).toBe('Type:User Docs')
+      expect(getDocTypeFilter('blog/my-post')).toBe('Type:Blog')
+    })
+  })
+
+  describe('getDocTypeFromUrl', () => {
+    it('classifies base-relative URL paths', () => {
+      expect(getDocTypeFromUrl('/docs/api/python/strands.agent.agent/')).toBe(DOC_TYPE_API_PYTHON)
+      expect(getDocTypeFromUrl('/docs/api/typescript/Agent/')).toBe(DOC_TYPE_API_TYPESCRIPT)
+      expect(getDocTypeFromUrl('/blog/my-post/')).toBe(DOC_TYPE_BLOG)
+      expect(getDocTypeFromUrl('/docs/user-guide/quickstart/overview/')).toBe(DOC_TYPE_USER)
+    })
+
+    it('tolerates a deploy base path prefix (segments not at the start)', () => {
+      // Unlike getDocType (id-based, matches at the start), URL classification
+      // must find the segment anywhere in the path — e.g. a site served at /sub/.
+      expect(getDocTypeFromUrl('/sub/docs/api/python/x/')).toBe(DOC_TYPE_API_PYTHON)
+      expect(getDocTypeFromUrl('/sub/blog/my-post/')).toBe(DOC_TYPE_BLOG)
+    })
+
+    it('accepts absolute URLs', () => {
+      expect(getDocTypeFromUrl('https://strandsagents.com/docs/api/typescript/Agent/')).toBe(
+        DOC_TYPE_API_TYPESCRIPT
+      )
+    })
+
+    it('returns null when no known type matches', () => {
+      expect(getDocTypeFromUrl('/changelog/')).toBeNull()
+      expect(getDocTypeFromUrl('/')).toBeNull()
+      expect(getDocTypeFromUrl('https://example.com/')).toBeNull()
+    })
+
+    it('does not misclassify api/blog segments outside the docs tree', () => {
+      // "/docs/api/python" must win over the generic "/docs/" fallback.
+      expect(getDocTypeFromUrl('/docs/api/python/')).toBe(DOC_TYPE_API_PYTHON)
+      // A guide page that merely mentions api in its slug is still User Docs.
+      expect(getDocTypeFromUrl('/docs/user-guide/api-reference-intro/')).toBe(DOC_TYPE_USER)
+    })
+  })
+})


### PR DESCRIPTION
## Description

Docs site search was the stock Starlight/Pagefind default UI with no good way to scope a search to a doc type, so a query for a common term (e.g. `agent`, `conversation`) buried hand-written guides under hundreds of auto-generated API-reference hits, and blog posts weren't searchable at all.

This replaces the search with Pagefind's newer **Component UI** and adds a doc-type filter. The switch is deliberate: Pagefind's *default* UI can only express a same-key multi-select as a plain array, which Pagefind treats as **AND** (a page can't be two types at once) → zero results, with no hook to change it. The Component UI exposes a public instance API, so we render our own `Type` control and drive filtering through `triggerFilters()`, building the `{ any: [...] }` OR form ourselves. Everything is public API — no reliance on Pagefind internals — so a version bump won't silently break it.

Behavior notes for reviewers:
- **Blog posts are now indexed.** They were previously excluded (`pagefind: false`); they opt in and get a `Blog` facet. Listing/tag/author pages stay out.
- **No page-specific default** — all types are searched until the user narrows, and the selection persists in `localStorage`.
- **Custom result styling.** The Component UI's result DOM differs from the default UI's, so the unified cards, sub-result tree, per-result type badges, and hover/focus states are rebuilt in CSS to match strandsagents.com. This leans on Pagefind's `pf-*` class names and its instance global (`getInstanceManager`) — stable within a Pagefind major, flagged in code comments to re-check on upgrade.

## Related Issues

<!-- none -->

## Documentation PR

`site/SITE-ARCHITECTURE.md` updated with a Search (Pagefind) section documenting the facet, the Component UI choice, and the coupling surface.

## Type of Change

New feature

## Testing

Built the site (`npm run build`) — 825 pages, Pagefind index generated, no broken links, typecheck clean. Verified in a real browser (Playwright, dark + light) that: the `Type` filter multi-selects with OR and returns results; blog posts appear under the `Blog` facet; selection persists across reloads; result badges match the filter vocabulary; and result text/hover/focus render with adequate contrast in both themes (matched-term contrast ≥ 16:1).

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
