### PR TITLE
docs(memory): add TestMemoryStore documentation

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -86,6 +86,7 @@ sidebar:
             items:
               - label: "Overview"
                 slug: docs/user-guide/concepts/memory/overview
+              - docs/user-guide/concepts/memory/test-memory-store
               - docs/user-guide/concepts/memory/bedrock-knowledge-base
           - docs/user-guide/concepts/agents/retry-strategies
           - label: Sandbox

--- a/site/src/content/docs/user-guide/concepts/memory/overview.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/overview.mdx
@@ -15,7 +15,7 @@ sidebar:
 
 By default a Strands agent starts every conversation from zero: it cannot recall a user's preferences, past decisions, or anything it learned in an earlier session. The `MemoryManager` gives an agent long-term memory that persists across sessions.
 
-It works through **memory stores**, the backends that hold the memories. A store can be a vector database, a managed service like [Amazon Bedrock Knowledge Bases](./bedrock-knowledge-base), or [your own implementation](#custom-stores). The manager handles three jobs across the stores you give it:
+It works through **memory stores**, the backends that hold the memories. A store can be the built-in zero-setup [test store](./test-memory-store), a managed service like [Amazon Bedrock Knowledge Bases](./bedrock-knowledge-base), or [your own implementation](#custom-stores). The manager handles three jobs across the stores you give it:
 
 1. **Recall** - the agent searches stored knowledge on demand through a tool.
 2. **Injection** - the manager folds relevant knowledge into the prompt automatically, before the model runs.
@@ -25,7 +25,7 @@ Recall and injection are enabled by default when you attach a store. Extraction 
 
 ## Getting Started
 
-Attach a memory manager to an agent through the <Syntax py="memory_manager" ts="memoryManager" /> parameter. The examples below use a `store`, a `MemoryStore` you provide; see [Bedrock Knowledge Base](./bedrock-knowledge-base) for a managed backend or [Custom Stores](#custom-stores) to create your own.
+Attach a memory manager to an agent through the <Syntax py="memory_manager" ts="memoryManager" /> parameter. The [test store](./test-memory-store) below needs no cloud account and persists to disk by default, so this agent remembers across restarts with no setup. For a managed backend see [Bedrock Knowledge Base](./bedrock-knowledge-base), or [Custom Stores](#custom-stores) to create your own.
 
 <Tabs>
 <Tab label="Python">
@@ -33,6 +33,10 @@ Attach a memory manager to an agent through the <Syntax py="memory_manager" ts="
 ```python
 from strands import Agent
 from strands.memory import MemoryManager
+from strands.vended_memory_stores.test_memory_store import TestMemoryStore
+
+# Persists to ~/.strands/memory/notes.json by default.
+store = TestMemoryStore(name="notes")
 
 agent = Agent(memory_manager=MemoryManager(stores=[store]))
 ```
@@ -500,6 +504,7 @@ Three SDK features manage different kinds of state; memory is the one that cross
 
 ## Related
 
+- [Test memory store](./test-memory-store) - the zero-setup vended `MemoryStore` backed by a local JSON file, for prototyping and testing.
 - [Bedrock Knowledge Base store](./bedrock-knowledge-base) - the vended `MemoryStore` backed by Amazon Bedrock Knowledge Bases.
 - [Context Injector](../plugins/context-injector) - the generic injection plugin that memory injection builds on.
 - [Session management](../agents/session-management) - persist the conversation itself across restarts.

--- a/site/src/content/docs/user-guide/concepts/memory/overview.ts
+++ b/site/src/content/docs/user-guide/concepts/memory/overview.ts
@@ -19,6 +19,7 @@ import {
   BedrockKnowledgeBaseStore,
   type BedrockKnowledgeBaseConfig,
 } from '@strands-agents/sdk/vended-memory-stores/bedrock-knowledge-base'
+import { TestMemoryStore } from '@strands-agents/sdk/vended-memory-stores/test-memory-store'
 
 // Stand-in for the reader's own managed backend, used by the server-side store example.
 declare const myBackend: {
@@ -32,12 +33,8 @@ declare const myBackend: {
 
 function gettingStarted() {
   // --8<-- [start:getting_started]
-  const store = new BedrockKnowledgeBaseStore({
-    name: 'preferences',
-    description: 'User preferences and stable facts about the user.',
-    writable: true,
-    config: { knowledgeBaseId: 'KB123', dataSourceType: 'CUSTOM', dataSourceId: 'DS456' },
-  })
+  // Persists to ~/.strands/memory/notes.json by default.
+  const store = new TestMemoryStore({ name: 'notes' })
 
   const agent = new Agent({
     model: new BedrockModel(),

--- a/site/src/content/docs/user-guide/concepts/memory/overview_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/memory/overview_imports.ts
@@ -2,7 +2,7 @@
 
 // --8<-- [start:getting_started_imports]
 import { Agent, BedrockModel } from '@strands-agents/sdk'
-import { BedrockKnowledgeBaseStore } from '@strands-agents/sdk/vended-memory-stores/bedrock-knowledge-base'
+import { TestMemoryStore } from '@strands-agents/sdk/vended-memory-stores/test-memory-store'
 // --8<-- [end:getting_started_imports]
 
 // --8<-- [start:turn_on_writes_imports]

--- a/site/src/content/docs/user-guide/concepts/memory/test-memory-store.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/test-memory-store.mdx
@@ -12,8 +12,8 @@ sidebar:
     variant: tip
 ---
 
-`TestMemoryStore` is a [`MemoryStore`](./overview#stores) backed by a JSON file. 
-It requires no setup and no provisioned resources, so you can give an agent memory 
+`TestMemoryStore` is a [`MemoryStore`](./overview#stores) backed by a JSON file.
+It requires no setup and no provisioned resources, so you can give an agent memory
 in one line and try recall, injection, and extraction for prototyping or writing tests.
 
 It persists to disk by default, so an agent remembers across restarts with no setup. Point
@@ -138,7 +138,7 @@ store = TestMemoryStore(name="notes")
 result = await store.add("User prefers aisle seats", {"category": "travel"})
 print(result.id)
 
-results = await store.search("what seat does the user prefer?")
+results = await store.search("which seats does the user prefer?")
 for entry in results:
     print(entry.content, entry.metadata.get("_relevanceScore"))
 ```
@@ -155,7 +155,7 @@ for entry in results:
 
 Writing to a store constructed with <Syntax py="writable=False" ts="writable: false" />,
 or adding empty content, raises. When the backing directory is unreachable or not
-writable, the write raises with the target path.
+writable, the write raises, naming the backing file.
 
 ## Extraction
 

--- a/site/src/content/docs/user-guide/concepts/memory/test-memory-store.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/test-memory-store.mdx
@@ -1,0 +1,210 @@
+---
+title: Test Memory Store
+description: "A zero-infrastructure memory store backed by a local JSON file: no cloud account, lexical recall, and memories that survive across sessions."
+tags: [memory]
+sourceLinks:
+  - path: strands-py/src/strands/vended_memory_stores/test_memory_store/store.py
+  - path: strands-ts/src/vended-memory-stores/test-memory-store/store.ts
+sidebar:
+  label: "Test Store"
+  badge:
+    text: New
+    variant: tip
+---
+
+`TestMemoryStore` is a [`MemoryStore`](./overview#stores) backed by a JSON file. 
+It requires no setup and no provisioned resources, so you can give an agent memory 
+in one line and try recall, injection, and extraction for prototyping or writing tests.
+
+It persists to disk by default, so an agent remembers across restarts with no setup. Point
+it at a store name and go:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.memory import MemoryManager
+from strands.vended_memory_stores.test_memory_store import TestMemoryStore
+
+# Persists to ~/.strands/memory/notes.json by default. Survives restarts.
+store = TestMemoryStore(name="notes")
+
+agent = Agent(memory_manager=MemoryManager(stores=[store]))
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/memory/test-memory-store_imports.ts:basic_imports"
+
+--8<-- "user-guide/concepts/memory/test-memory-store.ts:basic"
+```
+</Tab>
+</Tabs>
+
+The store is writable by default, unlike a read-only managed store. So the [`add_memory`
+tool](./overview#memory-tools) and [automatic extraction](./overview#automatic-extraction)
+work as soon as you enable them, with no data source to set up first.
+
+It suits prototyping and tests, not a production corpus: each write rewrites the whole
+file and recall is keyword matching rather than semantic. For a production backend, use
+the [Bedrock Knowledge Base store](./bedrock-knowledge-base).
+
+## Persistence and Location
+
+The store writes to `~/.strands/memory/<store-name>.json`, deriving the filename from
+`name`. Give it an explicit `path` to control where the file lands, or turn persistence
+off for a store that lives only in memory:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.vended_memory_stores.test_memory_store import TestMemoryStore
+
+# Ephemeral: nothing is written to disk, and a fresh instance forgets everything.
+scratch = TestMemoryStore(name="notes", persist=False)
+
+# Explicit file location instead of the default under ~/.strands/memory/.
+project = TestMemoryStore(name="notes", path="./notes.json")
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/memory/test-memory-store_imports.ts:persistence_imports"
+
+--8<-- "user-guide/concepts/memory/test-memory-store.ts:persistence"
+```
+</Tab>
+</Tabs>
+
+Reach for <Syntax py="persist=False" ts="persist: false" /> in tests and throwaway runs
+where you want recall and ranking without leaving a file behind. The default (persist to
+disk) is what demonstrates the feature: memory that survives a restart.
+
+Persistence runs on the SDK's `Storage` interface: <Syntax py="persist=False"
+ts="persist: false" /> uses an in-memory backend, and persisting to disk uses a local-file
+backend. The config above is all you configure; the store selects the backend for you.
+
+The on-disk format is shared between the Python and TypeScript SDKs. Records use the same
+keys and timestamp shape, so a file written by one SDK reads in the other.
+
+## Configuration
+
+`TestMemoryStore` takes the [shared `MemoryStore` fields](./overview#stores) (`name`,
+`description`, <Syntax py="max_search_results" ts="maxSearchResults" />, `writable`,
+`extraction`) plus two of its own:
+
+| Field | Purpose |
+|-------|---------|
+| `persist` | Whether to write entries to disk. On by default: flushes to `path`. When off, entries stay in memory only and are lost when the process exits. |
+| `path` | Full path to the backing JSON file. Defaults to `~/.strands/memory/<store-name>.json`. Ignored when persistence is off. |
+
+`writable` is on by default here. Construction rejects an empty `name`, an empty `path`,
+or a <Syntax py="max_search_results" ts="maxSearchResults" /> below `1`.
+
+## Recall
+
+`search` ranks entries by lexical overlap: it counts how many distinct words from the
+query appear in each entry's content, and returns the highest scorers first, breaking ties
+toward the most recent entry. Each result carries the count under a reserved
+`_relevanceScore` metadata key. A query with no usable words returns nothing.
+
+:::note
+Recall is keyword matching, not semantic search. A query word matches only the same word,
+not a synonym, so "seat" does not find an entry about "chair." For embedding-based
+semantic search over a managed vector store, use the [Bedrock Knowledge Base
+store](./bedrock-knowledge-base).
+:::
+
+## Writing Memories
+
+`add` stores a single piece of content and returns its id. Identical content is
+deduplicated: a repeat write returns the existing record's id instead of storing a second
+copy, so the at-least-once retries that extraction may perform never accumulate
+duplicates.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.vended_memory_stores.test_memory_store import TestMemoryStore
+
+store = TestMemoryStore(name="notes")
+
+# add returns the id of the stored (or already-present, on dedup) record.
+result = await store.add("User prefers aisle seats", {"category": "travel"})
+print(result.id)
+
+results = await store.search("what seat does the user prefer?")
+for entry in results:
+    print(entry.content, entry.metadata.get("_relevanceScore"))
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/memory/test-memory-store_imports.ts:search_and_add_imports"
+
+--8<-- "user-guide/concepts/memory/test-memory-store.ts:search_and_add"
+```
+</Tab>
+</Tabs>
+
+Writing to a store constructed with <Syntax py="writable=False" ts="writable: false" />,
+or adding empty content, raises. When the backing directory is unreachable or not
+writable, the write raises with the target path.
+
+## Extraction
+
+Enable [automatic extraction](./overview#automatic-extraction) to capture memories from
+the conversation without the agent calling a tool:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.vended_memory_stores.test_memory_store import TestMemoryStore
+
+store = TestMemoryStore(
+    name="notes",
+    extraction=True,  # distill facts from the conversation, every 5 turns
+)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/memory/test-memory-store_imports.ts:extraction_imports"
+
+--8<-- "user-guide/concepts/memory/test-memory-store.ts:extraction"
+```
+</Tab>
+</Tabs>
+
+The store implements <Syntax py="add" ts="add" /> but not <Syntax py="add_messages"
+ts="addMessages" />, so extraction runs client-side: a `ModelExtractor` distills facts
+from the conversation and writes each through `add`. To change the cadence or swap the
+extractor, see [Automatic Extraction](./overview#automatic-extraction) on the Memory page.
+
+## Scale and Limitations
+
+Each `add` reads the current file and rewrites it in full, replacing it atomically so a
+crash mid-write never leaves a partial file. That design suits prototyping and personal
+memory, hundreds to low thousands of entries, not a production corpus. For large or
+high-throughput workloads, use a managed store like the [Bedrock Knowledge Base
+store](./bedrock-knowledge-base).
+
+Concurrent `add` calls on one store instance are serialized, so they can't clobber one
+another. Separate instances or processes writing the same file are not coordinated, so
+avoid pointing two at the same file: the last write wins. A corrupt or wrong-shaped
+backing file raises rather than returning bad data; a missing file starts empty.
+
+## Related
+
+- [Memory](./overview) - the `MemoryManager` concept this store plugs into, including the
+  tools, extraction, and injection it enables.
+- [Bedrock Knowledge Base store](./bedrock-knowledge-base) - the managed `MemoryStore`
+  with semantic search, for production workloads.

--- a/site/src/content/docs/user-guide/concepts/memory/test-memory-store.ts
+++ b/site/src/content/docs/user-guide/concepts/memory/test-memory-store.ts
@@ -49,7 +49,7 @@ async function searchAndAdd() {
   // add returns the id of the stored (or already-present, on dedup) record.
   const { id } = await store.add('User prefers aisle seats', { category: 'travel' })
 
-  const results = await store.search('what seat does the user prefer?')
+  const results = await store.search('which seats does the user prefer?')
   for (const entry of results) {
     console.log(entry.content, entry.metadata?._relevanceScore)
   }

--- a/site/src/content/docs/user-guide/concepts/memory/test-memory-store.ts
+++ b/site/src/content/docs/user-guide/concepts/memory/test-memory-store.ts
@@ -1,0 +1,76 @@
+import { Agent, BedrockModel } from '@strands-agents/sdk'
+import { TestMemoryStore } from '@strands-agents/sdk/vended-memory-stores/test-memory-store'
+
+// =====================
+// Basic: persists to disk by default
+// =====================
+
+function basic() {
+  // --8<-- [start:basic]
+  // Persists to ~/.strands/memory/notes.json by default. Survives restarts.
+  const store = new TestMemoryStore({ name: 'notes' })
+
+  const agent = new Agent({
+    model: new BedrockModel(),
+    memoryManager: { stores: [store] },
+  })
+  // --8<-- [end:basic]
+
+  void agent
+}
+void basic
+
+// =====================
+// Persistence: ephemeral and explicit path
+// =====================
+
+function persistence() {
+  // --8<-- [start:persistence]
+  // Ephemeral: nothing is written to disk, and a fresh instance forgets everything.
+  const scratch = new TestMemoryStore({ name: 'notes', persist: false })
+
+  // Explicit file location instead of the default under ~/.strands/memory/.
+  const project = new TestMemoryStore({ name: 'notes', path: './notes.json' })
+  // --8<-- [end:persistence]
+
+  void scratch
+  void project
+}
+void persistence
+
+// =====================
+// Search and add
+// =====================
+
+async function searchAndAdd() {
+  // --8<-- [start:search_and_add]
+  const store = new TestMemoryStore({ name: 'notes' })
+
+  // add returns the id of the stored (or already-present, on dedup) record.
+  const { id } = await store.add('User prefers aisle seats', { category: 'travel' })
+
+  const results = await store.search('what seat does the user prefer?')
+  for (const entry of results) {
+    console.log(entry.content, entry.metadata?._relevanceScore)
+  }
+  // --8<-- [end:search_and_add]
+
+  void id
+}
+void searchAndAdd
+
+// =====================
+// Extraction
+// =====================
+
+function extraction() {
+  // --8<-- [start:extraction]
+  const store = new TestMemoryStore({
+    name: 'notes',
+    extraction: true, // distill facts from the conversation, every 5 turns
+  })
+  // --8<-- [end:extraction]
+
+  void store
+}
+void extraction

--- a/site/src/content/docs/user-guide/concepts/memory/test-memory-store_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/memory/test-memory-store_imports.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck
+
+// --8<-- [start:basic_imports]
+import { Agent, BedrockModel } from '@strands-agents/sdk'
+import { TestMemoryStore } from '@strands-agents/sdk/vended-memory-stores/test-memory-store'
+// --8<-- [end:basic_imports]
+
+// --8<-- [start:persistence_imports]
+import { TestMemoryStore } from '@strands-agents/sdk/vended-memory-stores/test-memory-store'
+// --8<-- [end:persistence_imports]
+
+// --8<-- [start:search_and_add_imports]
+import { TestMemoryStore } from '@strands-agents/sdk/vended-memory-stores/test-memory-store'
+// --8<-- [end:search_and_add_imports]
+
+// --8<-- [start:extraction_imports]
+import { TestMemoryStore } from '@strands-agents/sdk/vended-memory-stores/test-memory-store'
+// --8<-- [end:extraction_imports]


### PR DESCRIPTION
## Description

`TestMemoryStore` shipped in both SDKs but had no docs page, so the memory docs only demonstrated `BedrockKnowledgeBaseStore` — putting a cloud account and a provisioned knowledge base between a developer and their first taste of memory. This adds a concept page for the zero-setup store and makes it the Getting Started path on the Memory overview, so recall, injection, and extraction can be tried with one import and no infrastructure.

The page mirrors the `BedrockKnowledgeBaseStore` page's structure (frontmatter, opening example, `Configuration`/`Extraction`/`Related` sections) so the two read as siblings, and its "Scale and Limitations" section reflects the current `Storage`-backed implementation (fresh read per `add`, atomicity owned by the backend, per-instance write serialization) rather than the pre-refactor internals.

## Documentation PR

This is the documentation. All changes are under `site/`.

## Type of Change

Documentation update

## Testing

Ran `npm run build` (Astro): 844 pages, no broken links, all `--8<--` snippet references resolve, frontmatter and `sourceLinks` validate. Ran `npm run typecheck:snippets` against the current SDK so the TypeScript examples compile against the real `TestMemoryStore` subpath export, and Prettier over the snippet files. Also exercised the store end to end in both SDKs (default home-dir path, explicit `path`, `persist: false` ephemerality, dedup, cross-restart recall) to confirm every prose claim matches behavior.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.