### PR TITLE
docs(changelog): sync strands-agents/evals backfill

### DIFF
--- a/site/src/content/changelog/evals/v1.0.2.md
+++ b/site/src/content/changelog/evals/v1.0.2.md
@@ -1,0 +1,12 @@
+---
+sdk: evals
+version: "1.0.2"
+tag: v1.0.2
+date: 2026-07-09
+releaseUrl: https://github.com/strands-agents/evals/releases/tag/v1.0.2
+packageUrl: https://pypi.org/project/strands-agents-evals/1.0.2/
+entries:
+  - { type: fix, breaking: false, scope: redteam, areas: [redteam], title: "rename structured-output models off leading underscore", pr: 294, prUrl: "https://github.com/strands-agents/evals/pull/294", commit: "bc8436a", commitUrl: "https://github.com/strands-agents/evals/commit/bc8436a", author: kevmyung }
+  - { type: other, breaking: false, scope: null, areas: [community], title: "added evals full release workflow", pr: 302, prUrl: "https://github.com/strands-agents/evals/pull/302", commit: "023f87f", commitUrl: "https://github.com/strands-agents/evals/commit/023f87f", author: poshinchen }
+  - { type: other, breaking: false, scope: null, areas: [community], title: "add aggregate CI Gate status check", pr: 303, prUrl: "https://github.com/strands-agents/evals/pull/303", commit: "aa4c1dc", commitUrl: "https://github.com/strands-agents/evals/commit/aa4c1dc", author: yonib05 }
+---


### PR DESCRIPTION
Automated evals changelog backstop.