### PR TITLE
revert: revert chore(deps): relax litellm upper bound to <2.0.0 (#3149)

### DIFF
--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.21.0,<1.0.0"]
 gemini = ["google-genai>=1.32.0,<3.0.0"]
-litellm = ["litellm>=1.75.9,<2.0.0", "openai>=1.68.0,<3.0.0"]
+litellm = ["litellm>=1.75.9,<=1.91.1", "openai>=1.68.0,<3.0.0"]
 llamaapi = ["llama-api-client>=0.1.0,<1.0.0"]
 mistral = ["mistralai>=2.0.0,<3.0.0"]
 ollama = ["ollama>=0.4.8,<1.0.0"]

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.21.0,<1.0.0"]
 gemini = ["google-genai>=1.32.0,<3.0.0"]
+# The latest litellm v1.92.0 do not support python 3.14, for the short term we will keep 
+# the version lower than 1.92.0 until litellm has the python 3.14 supported version.
 litellm = ["litellm>=1.75.9,<=1.91.1", "openai>=1.68.0,<3.0.0"]
 llamaapi = ["llama-api-client>=0.1.0,<1.0.0"]
 mistral = ["mistralai>=2.0.0,<3.0.0"]


### PR DESCRIPTION
This reverts commit 298c6ed7586c14426205a9250e9146a38e7b064b.

## Description
The latest litellm v1.92.0 do not support python 3.14, for the short term we will keep the version lower than 1.92.0 until litellm has the python 3.14 supported version.

## Related Issues

Python 3.14 unit tests are failing which block the PRs.

## Documentation PR

N/A

## Type of Change

Bug fix


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
