### PR TITLE
docs: add Crusoe as a community model provider

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -329,6 +329,7 @@ sidebar:
         items:
           - docs/community/model-providers/cohere
           - docs/community/model-providers/clova-studio
+          - docs/community/model-providers/crusoe
           - docs/community/model-providers/fireworksai
           - docs/community/model-providers/nebius-token-factory
           - docs/community/model-providers/nvidia-nim

--- a/site/src/content/docs/community/model-providers/crusoe.mdx
+++ b/site/src/content/docs/community/model-providers/crusoe.mdx
@@ -1,0 +1,77 @@
+---
+title: Crusoe
+community: true
+description: Crusoe Managed Inference
+integrationType: model-provider
+languages: Python
+---
+
+
+[Crusoe](https://www.crusoe.ai/cloud/managed-inference) provides managed inference for leading open-weight language models on renewable-powered GPU infrastructure. Crusoe Managed Inference is accessible through OpenAI's SDK via full API compatibility, allowing easy and portable integration with the Strands Agents SDK using the familiar OpenAI interface.
+
+## Installation
+
+The Strands Agents SDK provides access to Crusoe Managed Inference models through the OpenAI compatibility layer, configured as an optional dependency. To install, run:
+
+```bash
+pip install 'strands-agents[openai]' strands-agents-tools
+```
+
+## Usage
+
+After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Crusoe models as follows:
+
+```python
+from strands import Agent
+from strands.models.openai import OpenAIModel
+from strands_tools import calculator
+
+model = OpenAIModel(
+    client_args={
+        "api_key": "<CRUSOE_API_KEY>",
+        "base_url": "https://api.inference.crusoecloud.com/v1/",
+    },
+    model_id="zai/GLM-5.2",  # or see https://docs.crusoecloud.com/managed-inference/overview
+    params={
+        "max_tokens": 5000,
+        "temperature": 0.1
+    }
+)
+
+agent = Agent(model=model, tools=[calculator])
+agent("What is 2+2?")
+```
+
+## Configuration
+
+### Client Configuration
+
+The `client_args` configure the underlying OpenAI-compatible client. When using Crusoe Managed Inference, you must set:
+
+* `api_key`: Your Crusoe Inference API key. Generate one in the **Security** tab of the [Crusoe Cloud Console](https://console.crusoecloud.com/).
+* `base_url`: `https://api.inference.crusoecloud.com/v1/`
+
+Refer to [OpenAI Python SDK GitHub](https://github.com/openai/openai-python) for full client options.
+
+### Model Configuration
+
+The `model_config` specifies which Crusoe model to use and any additional parameters.
+
+| Parameter  | Description               | Example                                                   | Options                                                                        |
+| ---------- | ------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `model_id` | Model name                | `zai/GLM-5.2`                                             | See [Crusoe Managed Inference models](https://docs.crusoecloud.com/managed-inference/overview) |
+| `params`   | Model-specific parameters | `{"max_tokens": 5000, "temperature": 0.7, "top_p": 0.9}`  | OpenAI-compatible chat completion parameters                                   |
+
+## Troubleshooting
+
+### `ModuleNotFoundError: No module named 'openai'`
+
+You must install the `openai` dependency to use this provider:
+
+```bash
+pip install 'strands-agents[openai]'
+```
+
+### Unexpected model behavior?
+
+Ensure you're using a model ID available on Crusoe Managed Inference (e.g., `zai/GLM-5.2`, `nvidia/Nemotron-3-Super-120B-A12B`, `google/gemma-4-31b-it`), and your `base_url` is set to `https://api.inference.crusoecloud.com/v1/`.

--- a/site/test/known-routes.json
+++ b/site/test/known-routes.json
@@ -6,6 +6,7 @@
   "/latest/documentation/docs/community/integrations/ag-ui/",
   "/latest/documentation/docs/community/model-providers/clova-studio/",
   "/latest/documentation/docs/community/model-providers/cohere/",
+  "/latest/documentation/docs/community/model-providers/crusoe/",
   "/latest/documentation/docs/community/model-providers/fireworksai/",
   "/latest/documentation/docs/community/model-providers/mlx/",
   "/latest/documentation/docs/community/model-providers/nebius-token-factory/",


### PR DESCRIPTION
## Description

Adds Crusoe as a community model provider page, following the invitation on the community model providers docs ("Have your own integration? We'd love to add it here too!").

[Crusoe Managed Inference](https://docs.crusoecloud.com/managed-inference/overview) is OpenAI-API compatible, so the page follows the same pattern as the Nebius Token Factory and OVHcloud entries: Strands' `OpenAIModel` with `base_url="https://api.inference.crusoecloud.com/v1/"` — no SDK code changes needed.

## Changes

- `site/src/content/docs/community/model-providers/crusoe.mdx` — provider page (install, usage, configuration, troubleshooting), mirroring the structure of the existing community provider pages
- `site/src/config/navigation.yml` — nav entry (alphabetical)
- `site/test/known-routes.json` — route entry

## Context

I maintain Crusoe's ecosystem integrations, including the merged LiteLLM (BerriAI/litellm#23195) and SGLang (sgl-project/sglang#20475) providers.
