### PR TITLE
feat(storage): port unified storage interface to Python

### DIFF
--- a/strands-py/src/strands/storage/__init__.py
+++ b/strands-py/src/strands/storage/__init__.py
@@ -1,0 +1,24 @@
+"""Unified storage module.
+
+Provides the :class:`Storage` protocol and shipped implementations for persisting
+raw bytes under string keys. It is the SDK's single low-level persistence
+primitive — a minimal four-operation contract (``write``, ``read``, ``delete``,
+``list``) over opaque ``bytes`` values, keyed by ``/``-separated path-like strings.
+
+Example:
+    ```python
+    from strands.storage import InMemoryStorage, LocalFileStorage, S3Storage
+    ```
+"""
+
+from .base import Storage
+from .in_memory_storage import InMemoryStorage
+from .local_file_storage import LocalFileStorage
+from .s3_storage import S3Storage
+
+__all__ = [
+    "Storage",
+    "InMemoryStorage",
+    "LocalFileStorage",
+    "S3Storage",
+]

--- a/strands-py/src/strands/storage/__init__.py
+++ b/strands-py/src/strands/storage/__init__.py
@@ -11,14 +11,17 @@ Example:
     ```
 """
 
-from .base import Storage
+from ..types.exceptions import StorageError
+from .base import Storage, namespace
 from .in_memory_storage import InMemoryStorage
 from .local_file_storage import LocalFileStorage
 from .s3_storage import S3Storage
 
 __all__ = [
     "Storage",
+    "StorageError",
     "InMemoryStorage",
     "LocalFileStorage",
     "S3Storage",
+    "namespace",
 ]

--- a/strands-py/src/strands/storage/base.py
+++ b/strands-py/src/strands/storage/base.py
@@ -1,0 +1,209 @@
+"""Core contract and helpers for the unified storage primitive.
+
+This module defines the :class:`Storage` protocol — the SDK's single persistence
+primitive — plus internal helpers for key normalization and namespacing. The
+shipped backends live in sibling modules and are re-exported from the package
+root.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Protocol, runtime_checkable
+
+from ..types.exceptions import StorageError
+
+# Attribute name marking a namespaced storage view. Constructs check for it (via
+# ``getattr``) to detect whether the caller already scoped the storage, so they
+# can skip applying a default prefix. This is the Python analog of the TypeScript
+# ``NAMESPACED`` symbol.
+NAMESPACED = "_strands_storage_namespaced"
+
+_SLASH_RUN = re.compile(r"/+")
+
+
+def normalize_key(key: str) -> str:
+    """Validate and normalize a storage key.
+
+    Collapses runs of ``/``, strips leading and trailing ``/``, and rejects empty
+    keys and any ``..`` segment.
+
+    Args:
+        key: The raw key to normalize.
+
+    Returns:
+        The normalized key.
+
+    Raises:
+        StorageError: If the key is empty or contains a ``..`` segment.
+    """
+    normalized = _SLASH_RUN.sub("/", key).strip("/")
+    if not normalized:
+        raise StorageError("Storage key must not be empty")
+    if ".." in normalized.split("/"):
+        raise StorageError(f"Invalid storage key '{key}': '..' path segments are not allowed")
+    return normalized
+
+
+def normalize_prefix(prefix: str) -> str:
+    """Normalize a list prefix.
+
+    Collapses slash runs and strips leading slashes. Unlike a key, an empty prefix
+    is valid and matches everything, and a trailing slash is preserved.
+
+    Args:
+        prefix: The raw prefix to normalize.
+
+    Returns:
+        The normalized prefix.
+
+    Raises:
+        StorageError: If the prefix contains a ``..`` segment.
+    """
+    normalized = _SLASH_RUN.sub("/", prefix).lstrip("/")
+    if ".." in normalized.split("/"):
+        raise StorageError(f"Invalid storage prefix '{prefix}': '..' path segments are not allowed")
+    return normalized
+
+
+@runtime_checkable
+class Storage(Protocol):
+    """A backend for storing and retrieving raw bytes under string keys.
+
+    The interface is deliberately minimal — four operations over opaque ``bytes``
+    values. Implementations must treat keys as opaque path-like strings (segments
+    separated by ``/``) and must round-trip the bytes they are given unchanged.
+
+    By default ``list`` performs a prefix match over a string, which every backend
+    supports. An implementation may *widen* the accepted ``prefix`` parameter to a
+    richer query object (e.g. a DynamoDB partition/sort-key filter) while still
+    accepting a plain string for SDK-internal callers.
+
+    Implement this to add a custom backend; the SDK ships :class:`InMemoryStorage`,
+    :class:`LocalFileStorage`, and :class:`S3Storage`. Those shipped backends also
+    expose a ``namespace(prefix)`` convenience method; a custom backend can instead
+    be scoped with the standalone :func:`namespace` factory.
+
+    Example:
+        ```python
+        from strands.storage import InMemoryStorage
+
+        storage = InMemoryStorage()
+        await storage.write("memory/notes.json", b"[]")
+        data = await storage.read("memory/notes.json")
+        ```
+    """
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store ``data`` under ``key``, overwriting any existing value.
+
+        Args:
+            key: Opaque, ``/``-separated key identifying the value.
+            data: Raw bytes to persist.
+
+        Raises:
+            StorageError: If the key is invalid or the write fails.
+        """
+        ...
+
+    async def read(self, key: str) -> bytes | None:
+        """Retrieve the bytes previously stored under ``key``.
+
+        Args:
+            key: The key to read.
+
+        Returns:
+            The stored bytes, or ``None`` if no value exists for ``key``.
+
+        Raises:
+            StorageError: If the read fails for a reason other than a missing key.
+        """
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Delete the value stored under ``key``. A no-op if the key does not exist.
+
+        Args:
+            key: The key to delete.
+
+        Raises:
+            StorageError: If the delete fails.
+        """
+        ...
+
+    async def list(self, prefix: str) -> list[str]:
+        """List keys matching the given prefix.
+
+        Returns full keys (not the suffix after the prefix), sorted
+        lexicographically. An empty string lists every key.
+
+        Args:
+            prefix: A key prefix. An empty string matches all keys.
+
+        Returns:
+            The matching keys, sorted ascending.
+
+        Raises:
+            StorageError: If the listing fails.
+        """
+        ...
+
+
+class _NamespacedStorage:
+    """A :class:`Storage` view that prefixes every key with a fixed namespace.
+
+    Returned by :func:`namespace`. Delegates to an underlying storage, prepending
+    the prefix on write/read/delete/list and stripping it back off listed keys.
+    """
+
+    def __init__(self, storage: Storage, prefix: str) -> None:
+        """Initialize the view.
+
+        Args:
+            storage: The underlying storage to delegate to.
+            prefix: The already-normalized prefix, including a trailing ``/`` when
+                non-empty (as produced by :func:`namespace`).
+        """
+        self._storage = storage
+        self._prefix = prefix
+        setattr(self, NAMESPACED, True)
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store ``data`` under the namespaced key."""
+        await self._storage.write(f"{self._prefix}{key}", data)
+
+    async def read(self, key: str) -> bytes | None:
+        """Read the bytes stored under the namespaced key."""
+        return await self._storage.read(f"{self._prefix}{key}")
+
+    async def delete(self, key: str) -> None:
+        """Delete the value stored under the namespaced key."""
+        await self._storage.delete(f"{self._prefix}{key}")
+
+    async def list(self, prefix: str) -> list[str]:
+        """List keys under the namespace, with the namespace prefix stripped off."""
+        keys = await self._storage.list(f"{self._prefix}{prefix}")
+        offset = len(self._prefix)
+        return [key[offset:] for key in keys]
+
+    def namespace(self, prefix: str) -> Storage:
+        """Return a further-nested namespaced view of the underlying storage."""
+        return namespace(self._storage, f"{self._prefix}{prefix}")
+
+
+def namespace(storage: Storage, prefix: str) -> Storage:
+    """Return a :class:`Storage` view with all keys prefixed by ``prefix``.
+
+    The original storage is not mutated. Composable — calling ``namespace()`` on
+    the result nests prefixes. An empty prefix yields a transparent pass-through.
+
+    Args:
+        storage: The underlying storage to delegate to.
+        prefix: Prefix to prepend to all keys.
+
+    Returns:
+        A namespaced Storage view.
+    """
+    normalized = normalize_prefix(prefix)
+    scoped = f"{normalized}/" if normalized else ""
+    return _NamespacedStorage(storage, scoped)

--- a/strands-py/src/strands/storage/base.py
+++ b/strands-py/src/strands/storage/base.py
@@ -9,7 +9,7 @@ root.
 from __future__ import annotations
 
 import re
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from ..types.exceptions import StorageError
 
@@ -17,7 +17,7 @@ from ..types.exceptions import StorageError
 # ``getattr``) to detect whether the caller already scoped the storage, so they
 # can skip applying a default prefix. This is the Python analog of the TypeScript
 # ``NAMESPACED`` symbol.
-NAMESPACED = "_strands_storage_namespaced"
+_NAMESPACED = "_strands_storage_namespaced"
 
 _SLASH_RUN = re.compile(r"/+")
 
@@ -82,7 +82,8 @@ class Storage(Protocol):
     Implement this to add a custom backend; the SDK ships :class:`InMemoryStorage`,
     :class:`LocalFileStorage`, and :class:`S3Storage`. Those shipped backends also
     expose a ``namespace(prefix)`` convenience method; a custom backend can instead
-    be scoped with the standalone :func:`namespace` factory.
+    be scoped with the standalone :func:`namespace` factory (exported from
+    ``strands.storage``).
 
     Example:
         ```python
@@ -94,23 +95,25 @@ class Storage(Protocol):
         ```
     """
 
-    async def write(self, key: str, data: bytes) -> None:
+    async def write(self, key: str, data: bytes, **kwargs: Any) -> None:
         """Store ``data`` under ``key``, overwriting any existing value.
 
         Args:
             key: Opaque, ``/``-separated key identifying the value.
             data: Raw bytes to persist.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Raises:
             StorageError: If the key is invalid or the write fails.
         """
         ...
 
-    async def read(self, key: str) -> bytes | None:
+    async def read(self, key: str, **kwargs: Any) -> bytes | None:
         """Retrieve the bytes previously stored under ``key``.
 
         Args:
             key: The key to read.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Returns:
             The stored bytes, or ``None`` if no value exists for ``key``.
@@ -120,18 +123,19 @@ class Storage(Protocol):
         """
         ...
 
-    async def delete(self, key: str) -> None:
+    async def delete(self, key: str, **kwargs: Any) -> None:
         """Delete the value stored under ``key``. A no-op if the key does not exist.
 
         Args:
             key: The key to delete.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Raises:
             StorageError: If the delete fails.
         """
         ...
 
-    async def list(self, prefix: str) -> list[str]:
+    async def list(self, prefix: str, **kwargs: Any) -> list[str]:
         """List keys matching the given prefix.
 
         Returns full keys (not the suffix after the prefix), sorted
@@ -139,6 +143,7 @@ class Storage(Protocol):
 
         Args:
             prefix: A key prefix. An empty string matches all keys.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Returns:
             The matching keys, sorted ascending.
@@ -166,23 +171,23 @@ class _NamespacedStorage:
         """
         self._storage = storage
         self._prefix = prefix
-        setattr(self, NAMESPACED, True)
+        setattr(self, _NAMESPACED, True)
 
-    async def write(self, key: str, data: bytes) -> None:
+    async def write(self, key: str, data: bytes, **kwargs: Any) -> None:
         """Store ``data`` under the namespaced key."""
-        await self._storage.write(f"{self._prefix}{key}", data)
+        await self._storage.write(f"{self._prefix}{key}", data, **kwargs)
 
-    async def read(self, key: str) -> bytes | None:
+    async def read(self, key: str, **kwargs: Any) -> bytes | None:
         """Read the bytes stored under the namespaced key."""
-        return await self._storage.read(f"{self._prefix}{key}")
+        return await self._storage.read(f"{self._prefix}{key}", **kwargs)
 
-    async def delete(self, key: str) -> None:
+    async def delete(self, key: str, **kwargs: Any) -> None:
         """Delete the value stored under the namespaced key."""
-        await self._storage.delete(f"{self._prefix}{key}")
+        await self._storage.delete(f"{self._prefix}{key}", **kwargs)
 
-    async def list(self, prefix: str) -> list[str]:
+    async def list(self, prefix: str, **kwargs: Any) -> list[str]:
         """List keys under the namespace, with the namespace prefix stripped off."""
-        keys = await self._storage.list(f"{self._prefix}{prefix}")
+        keys = await self._storage.list(f"{self._prefix}{prefix}", **kwargs)
         offset = len(self._prefix)
         return [key[offset:] for key in keys]
 

--- a/strands-py/src/strands/storage/in_memory_storage.py
+++ b/strands-py/src/strands/storage/in_memory_storage.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from .base import Storage, namespace, normalize_key, normalize_prefix
 
 
@@ -31,7 +33,7 @@ class InMemoryStorage:
         """Initialize an empty in-memory store."""
         self._store: dict[str, bytes] = {}
 
-    async def write(self, key: str, data: bytes) -> None:
+    async def write(self, key: str, data: bytes, **kwargs: Any) -> None:
         """Store ``data`` under ``key``, overwriting any existing value.
 
         The bytes are copied on write so later mutation of a caller-supplied
@@ -40,17 +42,19 @@ class InMemoryStorage:
         Args:
             key: Opaque, ``/``-separated key identifying the value.
             data: Raw bytes to persist.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Raises:
             StorageError: If the key is empty or contains ``..`` segments.
         """
         self._store[normalize_key(key)] = bytes(data)
 
-    async def read(self, key: str) -> bytes | None:
+    async def read(self, key: str, **kwargs: Any) -> bytes | None:
         """Retrieve the bytes previously stored under ``key``.
 
         Args:
             key: The key to read.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Returns:
             The stored bytes, or ``None`` if no value exists for ``key``. The
@@ -61,22 +65,24 @@ class InMemoryStorage:
         """
         return self._store.get(normalize_key(key))
 
-    async def delete(self, key: str) -> None:
+    async def delete(self, key: str, **kwargs: Any) -> None:
         """Delete the value stored under ``key``. A no-op if the key does not exist.
 
         Args:
             key: The key to delete.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Raises:
             StorageError: If the key is empty or contains ``..`` segments.
         """
         self._store.pop(normalize_key(key), None)
 
-    async def list(self, prefix: str) -> list[str]:
+    async def list(self, prefix: str, **kwargs: Any) -> list[str]:
         """List the keys whose names begin with ``prefix``, sorted lexicographically.
 
         Args:
             prefix: Key prefix to match. An empty string matches all keys.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Returns:
             The matching keys, sorted ascending.

--- a/strands-py/src/strands/storage/in_memory_storage.py
+++ b/strands-py/src/strands/storage/in_memory_storage.py
@@ -1,0 +1,96 @@
+"""In-memory :class:`~strands.storage.Storage` backend."""
+
+from __future__ import annotations
+
+from .base import Storage, namespace, normalize_key, normalize_prefix
+
+
+class InMemoryStorage:
+    """In-memory :class:`~strands.storage.Storage` backend backed by a ``dict``.
+
+    Useful for testing and for serverless environments where disk access is
+    unavailable. Content does not survive process restarts — for persistence use
+    :class:`~strands.storage.LocalFileStorage` or :class:`~strands.storage.S3Storage`.
+
+    This is a plain unbounded store with no eviction. Consumers that need eviction
+    manage it themselves.
+
+    Keys are normalized identically to :class:`~strands.storage.LocalFileStorage`:
+    slash runs are collapsed, leading/trailing slashes are stripped, and ``..``
+    segments are rejected.
+
+    Example:
+        ```python
+        storage = InMemoryStorage()
+        await storage.write("memory/notes.json", b"[]")
+        data = await storage.read("memory/notes.json")
+        ```
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty in-memory store."""
+        self._store: dict[str, bytes] = {}
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store ``data`` under ``key``, overwriting any existing value.
+
+        The bytes are copied on write so later mutation of a caller-supplied
+        ``bytearray`` cannot alias the stored value.
+
+        Args:
+            key: Opaque, ``/``-separated key identifying the value.
+            data: Raw bytes to persist.
+
+        Raises:
+            StorageError: If the key is empty or contains ``..`` segments.
+        """
+        self._store[normalize_key(key)] = bytes(data)
+
+    async def read(self, key: str) -> bytes | None:
+        """Retrieve the bytes previously stored under ``key``.
+
+        Args:
+            key: The key to read.
+
+        Returns:
+            The stored bytes, or ``None`` if no value exists for ``key``. The
+            returned ``bytes`` object is immutable, so it never aliases the store.
+
+        Raises:
+            StorageError: If the key is empty or contains ``..`` segments.
+        """
+        return self._store.get(normalize_key(key))
+
+    async def delete(self, key: str) -> None:
+        """Delete the value stored under ``key``. A no-op if the key does not exist.
+
+        Args:
+            key: The key to delete.
+
+        Raises:
+            StorageError: If the key is empty or contains ``..`` segments.
+        """
+        self._store.pop(normalize_key(key), None)
+
+    async def list(self, prefix: str) -> list[str]:
+        """List the keys whose names begin with ``prefix``, sorted lexicographically.
+
+        Args:
+            prefix: Key prefix to match. An empty string matches all keys.
+
+        Returns:
+            The matching keys, sorted ascending.
+
+        Raises:
+            StorageError: If the prefix contains ``..`` segments.
+        """
+        normalized = normalize_prefix(prefix)
+        return sorted(key for key in self._store if key.startswith(normalized))
+
+    def namespace(self, prefix: str) -> Storage:
+        """Return a prefixed view of this storage without mutating the original."""
+        return namespace(self, prefix)
+
+    def clear(self) -> None:
+        """Remove all stored entries. Useful for resetting state between tests."""
+        self._store.clear()

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -1,0 +1,223 @@
+"""Local-filesystem :class:`~strands.storage.Storage` backend."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from ..types.exceptions import StorageError
+from .base import Storage, namespace, normalize_key, normalize_prefix
+
+if TYPE_CHECKING:
+    from ..sandbox.base import Sandbox
+
+_SCRATCH_MARKER = ".__strands_tmp"
+
+
+class LocalFileStorage:
+    """Local-filesystem :class:`~strands.storage.Storage` backend.
+
+    Persists each key as a file under a base directory, mapping the key's ``/``
+    segments onto directory segments. On the host filesystem, writes are atomic
+    (write to a scratch sibling, then rename) so a crash mid-write never leaves a
+    partially written file. When bound to a
+    :class:`~strands.sandbox.base.Sandbox` via :meth:`for_sandbox`, all I/O is
+    routed through that sandbox instead of the host filesystem (atomicity then
+    depends on the sandbox implementation).
+
+    Example:
+        ```python
+        from strands.storage import LocalFileStorage
+
+        storage = LocalFileStorage("./.strands/")
+        await storage.write("sessions/abc/snapshot.json", data)
+        ```
+    """
+
+    def __init__(self, base_dir: str = "./.strands/", *, sandbox: Sandbox | None = None) -> None:
+        """Initialize file-based storage.
+
+        Args:
+            base_dir: Root directory under which keys are stored.
+            sandbox: Optional sandbox to route I/O through. Usually set via
+                :meth:`for_sandbox`.
+        """
+        self._base_dir = base_dir
+        self._sandbox = sandbox
+
+    def for_sandbox(self, sandbox: Sandbox) -> LocalFileStorage:
+        """Return a storage instance whose I/O is routed through ``sandbox``.
+
+        Instances already bound to a sandbox return themselves unchanged.
+
+        Args:
+            sandbox: Sandbox to route the returned instance's I/O through.
+
+        Returns:
+            A ``LocalFileStorage`` with the same base directory, routed through
+            ``sandbox``.
+        """
+        if self._sandbox is not None:
+            return self
+        return LocalFileStorage(self._base_dir, sandbox=sandbox)
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store ``data`` under ``key``, overwriting any existing value.
+
+        Args:
+            key: Opaque, ``/``-separated key identifying the value.
+            data: Raw bytes to persist.
+
+        Raises:
+            StorageError: If the key is invalid or the write fails.
+        """
+        normalized = normalize_key(key)
+        path = self._path_for(normalized)
+        if self._sandbox is not None:
+            try:
+                await self._sandbox.write_file(path, bytes(data))
+            except Exception as error:
+                raise StorageError(f"Failed to write '{normalized}' to sandbox storage") from error
+            return
+        tmp_path: str | None = None
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp_path = f"{path}{_SCRATCH_MARKER}_{uuid4()}"
+            with open(tmp_path, "wb") as file:
+                file.write(data)
+            os.replace(tmp_path, path)
+        except OSError as error:
+            if tmp_path is not None:
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+            raise StorageError(f"Failed to write '{normalized}' to local storage") from error
+
+    async def read(self, key: str) -> bytes | None:
+        """Retrieve the bytes previously stored under ``key``.
+
+        Args:
+            key: The key to read.
+
+        Returns:
+            The stored bytes, or ``None`` if no value exists for ``key``.
+
+        Raises:
+            StorageError: If the key is invalid or the read fails.
+        """
+        normalized = normalize_key(key)
+        path = self._path_for(normalized)
+        if self._sandbox is not None:
+            try:
+                return await self._sandbox.read_file(path)
+            except FileNotFoundError:
+                return None
+            except Exception as error:
+                raise StorageError(f"Failed to read '{normalized}' from sandbox storage") from error
+        try:
+            with open(path, "rb") as file:
+                return file.read()
+        except (FileNotFoundError, NotADirectoryError):
+            return None
+        except OSError as error:
+            raise StorageError(f"Failed to read '{normalized}' from local storage") from error
+
+    async def delete(self, key: str) -> None:
+        """Delete the value stored under ``key``. A no-op if the key does not exist.
+
+        Args:
+            key: The key to delete.
+
+        Raises:
+            StorageError: If the key is invalid or the delete fails.
+        """
+        normalized = normalize_key(key)
+        path = self._path_for(normalized)
+        if self._sandbox is not None:
+            try:
+                await self._sandbox.remove_file(path)
+            except FileNotFoundError:
+                return
+            except Exception as error:
+                raise StorageError(f"Failed to delete '{normalized}' from sandbox storage") from error
+            return
+        try:
+            os.remove(path)
+        except (FileNotFoundError, NotADirectoryError):
+            return
+        except OSError as error:
+            raise StorageError(f"Failed to delete '{normalized}' from local storage") from error
+
+    async def list(self, prefix: str) -> list[str]:
+        """List the keys whose names begin with ``prefix``, sorted lexicographically.
+
+        Args:
+            prefix: Key prefix to match. An empty string matches all keys.
+
+        Returns:
+            The matching keys, sorted ascending.
+
+        Raises:
+            StorageError: If the prefix is invalid or the listing fails.
+        """
+        normalized = normalize_prefix(prefix)
+        base = self._base_dir.rstrip("/")
+        # Narrow the walk to the deepest directory the prefix fully specifies.
+        last_slash = normalized.rfind("/")
+        dir_portion = normalized[:last_slash] if last_slash >= 0 else ""
+        start_dir = f"{base}/{dir_portion}" if dir_portion else base
+        if self._sandbox is not None:
+            keys = await _list_keys_sandbox(self._sandbox, start_dir, dir_portion)
+        else:
+            keys = _list_keys_host(start_dir, dir_portion)
+        return sorted(key for key in keys if key.startswith(normalized))
+
+    def _path_for(self, key: str) -> str:
+        return f"{self._base_dir.rstrip('/')}/{key}"
+
+    def namespace(self, prefix: str) -> Storage:
+        """Return a prefixed view of this storage without mutating the original."""
+        return namespace(self, prefix)
+
+
+def _list_keys_host(dir_path: str, key_prefix: str) -> list[str]:
+    """Recursively collect file keys under ``dir_path`` on the host filesystem."""
+    try:
+        entries = list(os.scandir(dir_path))
+    except (FileNotFoundError, NotADirectoryError):
+        return []
+    except OSError as error:
+        raise StorageError(f"Failed to list local storage under '{key_prefix}'") from error
+    found: list[str] = []
+    for entry in entries:
+        is_dir = entry.is_dir()
+        if not is_dir and _SCRATCH_MARKER in entry.name:
+            continue
+        child_key = f"{key_prefix}/{entry.name}" if key_prefix else entry.name
+        if is_dir:
+            found.extend(_list_keys_host(f"{dir_path}/{entry.name}", child_key))
+        else:
+            found.append(child_key)
+    return found
+
+
+async def _list_keys_sandbox(sandbox: Sandbox, dir_path: str, key_prefix: str) -> list[str]:
+    """Recursively collect file keys under ``dir_path`` through a sandbox."""
+    try:
+        entries = await sandbox.list_files(dir_path)
+    except FileNotFoundError:
+        return []
+    except Exception as error:
+        raise StorageError(f"Failed to list sandbox storage under '{key_prefix}'") from error
+    found: list[str] = []
+    for entry in entries:
+        if not entry.is_dir and _SCRATCH_MARKER in entry.name:
+            continue
+        child_key = f"{key_prefix}/{entry.name}" if key_prefix else entry.name
+        if entry.is_dir:
+            found.extend(await _list_keys_sandbox(sandbox, f"{dir_path}/{entry.name}", child_key))
+        else:
+            found.append(child_key)
+    return found

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -114,7 +114,7 @@ class LocalFileStorage:
         if self._sandbox is not None:
             try:
                 return await self._sandbox.read_file(path)
-            except FileNotFoundError:
+            except (FileNotFoundError, NotADirectoryError):
                 return None
             except Exception as error:
                 raise StorageError(f"Failed to read '{normalized}' from sandbox storage") from error
@@ -141,7 +141,7 @@ class LocalFileStorage:
         if self._sandbox is not None:
             try:
                 await self._sandbox.remove_file(path)
-            except FileNotFoundError:
+            except (FileNotFoundError, NotADirectoryError):
                 return
             except Exception as error:
                 raise StorageError(f"Failed to delete '{normalized}' from sandbox storage") from error
@@ -211,7 +211,7 @@ async def _list_keys_sandbox(sandbox: Sandbox, dir_path: str, key_prefix: str) -
     """Recursively collect file keys under ``dir_path`` through a sandbox."""
     try:
         entries = await sandbox.list_files(dir_path)
-    except FileNotFoundError:
+    except (FileNotFoundError, NotADirectoryError):
         return []
     except Exception as error:
         raise StorageError(f"Failed to list sandbox storage under '{key_prefix}'") from error

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from ..types.exceptions import StorageError
@@ -62,12 +62,13 @@ class LocalFileStorage:
             return self
         return LocalFileStorage(self._base_dir, sandbox=sandbox)
 
-    async def write(self, key: str, data: bytes) -> None:
+    async def write(self, key: str, data: bytes, **kwargs: Any) -> None:
         """Store ``data`` under ``key``, overwriting any existing value.
 
         Args:
             key: Opaque, ``/``-separated key identifying the value.
             data: Raw bytes to persist.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Raises:
             StorageError: If the key is invalid or the write fails.
@@ -95,11 +96,12 @@ class LocalFileStorage:
                     pass
             raise StorageError(f"Failed to write '{normalized}' to local storage") from error
 
-    async def read(self, key: str) -> bytes | None:
+    async def read(self, key: str, **kwargs: Any) -> bytes | None:
         """Retrieve the bytes previously stored under ``key``.
 
         Args:
             key: The key to read.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Returns:
             The stored bytes, or ``None`` if no value exists for ``key``.
@@ -124,11 +126,12 @@ class LocalFileStorage:
         except OSError as error:
             raise StorageError(f"Failed to read '{normalized}' from local storage") from error
 
-    async def delete(self, key: str) -> None:
+    async def delete(self, key: str, **kwargs: Any) -> None:
         """Delete the value stored under ``key``. A no-op if the key does not exist.
 
         Args:
             key: The key to delete.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Raises:
             StorageError: If the key is invalid or the delete fails.
@@ -150,11 +153,12 @@ class LocalFileStorage:
         except OSError as error:
             raise StorageError(f"Failed to delete '{normalized}' from local storage") from error
 
-    async def list(self, prefix: str) -> list[str]:
+    async def list(self, prefix: str, **kwargs: Any) -> list[str]:
         """List the keys whose names begin with ``prefix``, sorted lexicographically.
 
         Args:
             prefix: Key prefix to match. An empty string matches all keys.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Returns:
             The matching keys, sorted ascending.

--- a/strands-py/src/strands/storage/s3_storage.py
+++ b/strands-py/src/strands/storage/s3_storage.py
@@ -1,0 +1,187 @@
+"""Amazon S3 :class:`~strands.storage.Storage` backend."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import boto3
+from botocore.config import Config as BotocoreConfig
+from botocore.exceptions import ClientError
+
+from ..types.exceptions import StorageError
+from .base import Storage, namespace, normalize_key, normalize_prefix
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+
+_S3_PAGE_SIZE = 1000
+_NOT_FOUND_CODES = frozenset({"NoSuchKey", "NotFound", "404"})
+
+
+class S3Storage:
+    """Amazon S3 :class:`~strands.storage.Storage` backend.
+
+    Stores each key as an S3 object under an optional prefix. The boto3 client is
+    created lazily on first use, so constructing an ``S3Storage`` never requires
+    AWS credentials or a configured region.
+
+    Example:
+        ```python
+        from strands.storage import S3Storage
+
+        storage = S3Storage("my-bucket", prefix="agents/")
+        await storage.write("sessions/abc/snapshot.json", data)
+        ```
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        prefix: str = "",
+        region: str | None = None,
+        boto_session: boto3.Session | None = None,
+        boto_client_config: BotocoreConfig | None = None,
+    ) -> None:
+        """Initialize S3-based storage.
+
+        Args:
+            bucket: Target S3 bucket name.
+            prefix: Optional key prefix prepended to every key (a leading namespace
+                within the bucket).
+            region: AWS region override. When omitted, the standard boto3
+                resolution chain applies. Cannot be combined with ``boto_session``.
+            boto_session: Pre-configured boto3 session. Cannot be combined with
+                ``region``.
+            boto_client_config: Optional botocore client configuration.
+
+        Raises:
+            StorageError: If both ``region`` and ``boto_session`` are provided.
+        """
+        if boto_session is not None and region is not None:
+            raise StorageError(
+                "Cannot specify both boto_session and region. Configure the region on the boto session instead."
+            )
+        self._bucket = bucket
+        self._prefix = f"{prefix.rstrip('/')}/" if prefix else ""
+        self._region = region
+        self._boto_session = boto_session
+        self._boto_client_config = boto_client_config
+        self._client: S3Client | None = None
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store ``data`` under ``key``, overwriting any existing value.
+
+        Args:
+            key: Opaque, ``/``-separated key identifying the value.
+            data: Raw bytes to persist.
+
+        Raises:
+            StorageError: If the key is invalid or the upload fails.
+        """
+        normalized = normalize_key(key)
+        client = self._get_client()
+        try:
+            client.put_object(Bucket=self._bucket, Key=self._object_key(normalized), Body=bytes(data))
+        except Exception as error:
+            raise StorageError(f"Failed to write '{normalized}' to S3 bucket '{self._bucket}'") from error
+
+    async def read(self, key: str) -> bytes | None:
+        """Retrieve the bytes previously stored under ``key``.
+
+        Args:
+            key: The key to read.
+
+        Returns:
+            The stored bytes, or ``None`` if no value exists for ``key``.
+
+        Raises:
+            StorageError: If the key is invalid or the download fails.
+        """
+        normalized = normalize_key(key)
+        client = self._get_client()
+        try:
+            response = client.get_object(Bucket=self._bucket, Key=self._object_key(normalized))
+            body: bytes = response["Body"].read()
+            return body
+        except ClientError as error:
+            if error.response.get("Error", {}).get("Code") in _NOT_FOUND_CODES:
+                return None
+            raise StorageError(f"Failed to read '{normalized}' from S3 bucket '{self._bucket}'") from error
+        except Exception as error:
+            raise StorageError(f"Failed to read '{normalized}' from S3 bucket '{self._bucket}'") from error
+
+    async def delete(self, key: str) -> None:
+        """Delete the value stored under ``key``. A no-op if the key does not exist.
+
+        Args:
+            key: The key to delete.
+
+        Raises:
+            StorageError: If the key is invalid or the delete request fails.
+        """
+        normalized = normalize_key(key)
+        client = self._get_client()
+        try:
+            client.delete_object(Bucket=self._bucket, Key=self._object_key(normalized))
+        except Exception as error:
+            raise StorageError(f"Failed to delete '{normalized}' from S3 bucket '{self._bucket}'") from error
+
+    async def list(self, prefix: str) -> list[str]:
+        """List the keys whose names begin with ``prefix``, sorted lexicographically.
+
+        Args:
+            prefix: Key prefix to match. An empty string matches all keys.
+
+        Returns:
+            The matching keys, sorted ascending.
+
+        Raises:
+            StorageError: If the prefix is invalid or the list request fails.
+        """
+        normalized = normalize_prefix(prefix)
+        client = self._get_client()
+        list_prefix = f"{self._prefix}{normalized}"
+        keys: list[str] = []
+        continuation_token: str | None = None
+        try:
+            while True:
+                params: dict[str, Any] = {
+                    "Bucket": self._bucket,
+                    "Prefix": list_prefix,
+                    "MaxKeys": _S3_PAGE_SIZE,
+                }
+                if continuation_token is not None:
+                    params["ContinuationToken"] = continuation_token
+                response = client.list_objects_v2(**params)
+                for obj in response.get("Contents", []):
+                    obj_key = obj.get("Key")
+                    if obj_key is None:
+                        continue
+                    keys.append(obj_key[len(self._prefix) :] if self._prefix else obj_key)
+                if not response.get("IsTruncated"):
+                    break
+                continuation_token = response.get("NextContinuationToken")
+        except Exception as error:
+            raise StorageError(f"Failed to list S3 bucket '{self._bucket}' under '{normalized}'") from error
+        return sorted(keys)
+
+    def _get_client(self) -> S3Client:
+        if self._client is not None:
+            return self._client
+        session = self._boto_session or boto3.Session(region_name=self._region)
+        if self._boto_client_config:
+            existing_user_agent = getattr(self._boto_client_config, "user_agent_extra", None)
+            new_user_agent = f"{existing_user_agent} strands-agents" if existing_user_agent else "strands-agents"
+            client_config = self._boto_client_config.merge(BotocoreConfig(user_agent_extra=new_user_agent))
+        else:
+            client_config = BotocoreConfig(user_agent_extra="strands-agents")
+        self._client = session.client("s3", config=client_config)
+        return self._client
+
+    def namespace(self, prefix: str) -> Storage:
+        """Return a prefixed view of this storage without mutating the original."""
+        return namespace(self, prefix)
+
+    def _object_key(self, key: str) -> str:
+        return f"{self._prefix}{key}"

--- a/strands-py/src/strands/storage/s3_storage.py
+++ b/strands-py/src/strands/storage/s3_storage.py
@@ -39,7 +39,7 @@ class S3Storage:
         bucket: str,
         *,
         prefix: str = "",
-        region: str | None = None,
+        region_name: str | None = None,
         boto_session: boto3.Session | None = None,
         boto_client_config: BotocoreConfig | None = None,
     ) -> None:
@@ -49,32 +49,33 @@ class S3Storage:
             bucket: Target S3 bucket name.
             prefix: Optional key prefix prepended to every key (a leading namespace
                 within the bucket).
-            region: AWS region override. When omitted, the standard boto3
+            region_name: AWS region override. When omitted, the standard boto3
                 resolution chain applies. Cannot be combined with ``boto_session``.
             boto_session: Pre-configured boto3 session. Cannot be combined with
-                ``region``.
+                ``region_name``.
             boto_client_config: Optional botocore client configuration.
 
         Raises:
-            StorageError: If both ``region`` and ``boto_session`` are provided.
+            StorageError: If both ``region_name`` and ``boto_session`` are provided.
         """
-        if boto_session is not None and region is not None:
+        if boto_session is not None and region_name is not None:
             raise StorageError(
-                "Cannot specify both boto_session and region. Configure the region on the boto session instead."
+                "Cannot specify both boto_session and region_name. Configure the region on the boto session instead."
             )
         self._bucket = bucket
         self._prefix = f"{prefix.rstrip('/')}/" if prefix else ""
-        self._region = region
+        self._region_name = region_name
         self._boto_session = boto_session
         self._boto_client_config = boto_client_config
         self._client: S3Client | None = None
 
-    async def write(self, key: str, data: bytes) -> None:
+    async def write(self, key: str, data: bytes, **kwargs: Any) -> None:
         """Store ``data`` under ``key``, overwriting any existing value.
 
         Args:
             key: Opaque, ``/``-separated key identifying the value.
             data: Raw bytes to persist.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Raises:
             StorageError: If the key is invalid or the upload fails.
@@ -86,11 +87,12 @@ class S3Storage:
         except Exception as error:
             raise StorageError(f"Failed to write '{normalized}' to S3 bucket '{self._bucket}'") from error
 
-    async def read(self, key: str) -> bytes | None:
+    async def read(self, key: str, **kwargs: Any) -> bytes | None:
         """Retrieve the bytes previously stored under ``key``.
 
         Args:
             key: The key to read.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Returns:
             The stored bytes, or ``None`` if no value exists for ``key``.
@@ -111,11 +113,12 @@ class S3Storage:
         except Exception as error:
             raise StorageError(f"Failed to read '{normalized}' from S3 bucket '{self._bucket}'") from error
 
-    async def delete(self, key: str) -> None:
+    async def delete(self, key: str, **kwargs: Any) -> None:
         """Delete the value stored under ``key``. A no-op if the key does not exist.
 
         Args:
             key: The key to delete.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Raises:
             StorageError: If the key is invalid or the delete request fails.
@@ -127,11 +130,12 @@ class S3Storage:
         except Exception as error:
             raise StorageError(f"Failed to delete '{normalized}' from S3 bucket '{self._bucket}'") from error
 
-    async def list(self, prefix: str) -> list[str]:
+    async def list(self, prefix: str, **kwargs: Any) -> list[str]:
         """List the keys whose names begin with ``prefix``, sorted lexicographically.
 
         Args:
             prefix: Key prefix to match. An empty string matches all keys.
+            **kwargs: Additional keyword arguments for forward compatibility.
 
         Returns:
             The matching keys, sorted ascending.
@@ -171,7 +175,7 @@ class S3Storage:
     def _get_client(self) -> S3Client:
         if self._client is not None:
             return self._client
-        session = self._boto_session or boto3.Session(region_name=self._region)
+        session = self._boto_session or boto3.Session(region_name=self._region_name)
         if self._boto_client_config:
             existing_user_agent = getattr(self._boto_client_config, "user_agent_extra", None)
             new_user_agent = f"{existing_user_agent} strands-agents" if existing_user_agent else "strands-agents"

--- a/strands-py/src/strands/storage/s3_storage.py
+++ b/strands-py/src/strands/storage/s3_storage.py
@@ -159,9 +159,11 @@ class S3Storage:
                     if obj_key is None:
                         continue
                     keys.append(obj_key[len(self._prefix) :] if self._prefix else obj_key)
-                if not response.get("IsTruncated"):
+                # Continue only while the response is truncated AND hands back a token;
+                # a truncated response with no token terminates (matches strands-ts).
+                continuation_token = response.get("NextContinuationToken") if response.get("IsTruncated") else None
+                if not continuation_token:
                     break
-                continuation_token = response.get("NextContinuationToken")
         except Exception as error:
             raise StorageError(f"Failed to list S3 bucket '{self._bucket}' under '{normalized}'") from error
         return sorted(keys)

--- a/strands-py/src/strands/types/exceptions.py
+++ b/strands-py/src/strands/types/exceptions.py
@@ -159,3 +159,14 @@ class AggregateMemoryError(Exception):
         """
         super().__init__(message)
         self.errors = errors
+
+
+class StorageError(Exception):
+    """Exception raised when a unified :class:`~strands.storage.Storage` operation fails.
+
+    Raised for invalid keys (empty or containing ``..`` segments) and for backend
+    failures (filesystem, S3, etc.). Backend failures chain the underlying error via
+    ``raise ... from`` so the original cause is preserved.
+    """
+
+    pass

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -57,7 +57,7 @@ logger = logging.getLogger(__name__)
 # A storage backend accepted by ContextOffloader: either the SDK's unified
 # ``strands.storage.Storage`` (write/read/delete/list) or a legacy offloader
 # ``Storage`` (store/retrieve, deprecated).
-StorageBackend: TypeAlias = UnifiedStorage | OffloaderStorage
+_StorageBackend: TypeAlias = UnifiedStorage | OffloaderStorage
 
 # Framed byte layout for a unified-Storage value: a 2-byte big-endian content-type
 # length, the UTF-8 content-type, then the content bytes. This keeps the content-type
@@ -65,7 +65,7 @@ StorageBackend: TypeAlias = UnifiedStorage | OffloaderStorage
 _CONTENT_TYPE_LENGTH_BYTES = 2
 
 
-def _is_offloader_storage(storage: StorageBackend) -> TypeGuard[OffloaderStorage]:
+def _is_offloader_storage(storage: _StorageBackend) -> TypeGuard[OffloaderStorage]:
     """Return whether ``storage`` is a legacy offloader backend (has store/retrieve)."""
     return hasattr(storage, "store") and hasattr(storage, "retrieve")
 
@@ -85,7 +85,7 @@ def _unframe_content(frame: bytes) -> tuple[bytes, str]:
     return content, content_type
 
 
-async def _store_content(storage: StorageBackend, key: str, content: bytes, content_type: str) -> str:
+async def _store_content(storage: _StorageBackend, key: str, content: bytes, content_type: str) -> str:
     """Store one content block and return its retrieval reference.
 
     Legacy backends persist the content-type natively via ``store()``; unified
@@ -98,7 +98,7 @@ async def _store_content(storage: StorageBackend, key: str, content: bytes, cont
     return key
 
 
-async def _retrieve_content(storage: StorageBackend, reference: str) -> tuple[bytes, str]:
+async def _retrieve_content(storage: _StorageBackend, reference: str) -> tuple[bytes, str]:
     """Retrieve one content block as ``(content, content_type)``.
 
     Raises:
@@ -157,16 +157,21 @@ class ContextOffloader(Plugin):
     which truncates reactively after context overflow.
 
     Args:
-        storage: Backend for storing offloaded content (required).
+        storage: Backend for storing offloaded content (required). Accepts either a unified
+            :class:`strands.storage.Storage` (``write``/``read``/``delete``/``list``; preferred)
+            or a legacy offloader ``Storage`` (``store``/``retrieve``; deprecated) from this module.
         max_result_tokens: Offload results whose estimated token count exceeds this threshold.
         preview_tokens: Number of tokens to keep as a text preview in context.
         include_retrieval_tool: Whether to register the ``retrieve_offloaded_content`` tool.
             Defaults to True.
+        evict_after_cycles: Agent loop cycles after which an offloaded entry is evicted. Applies
+            to unified ``Storage`` backends (which have no built-in eviction). Defaults to 20;
+            ``None`` disables eviction.
 
     Example:
         ```python
         from strands import Agent
-        from strands.vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
+        from strands.storage import InMemoryStorage
 
         agent = Agent(plugins=[
             ContextOffloader(storage=InMemoryStorage())
@@ -178,7 +183,7 @@ class ContextOffloader(Plugin):
 
     def __init__(
         self,
-        storage: StorageBackend,
+        storage: _StorageBackend,
         max_result_tokens: int = _DEFAULT_MAX_RESULT_TOKENS,
         preview_tokens: int = _DEFAULT_PREVIEW_TOKENS,
         *,
@@ -200,6 +205,8 @@ class ContextOffloader(Plugin):
                 is evicted. Applies to unified ``Storage`` backends (which have no built-in
                 eviction) and, when the backend is a legacy ``InMemoryStorage`` left at its
                 default window, is forwarded to it. Defaults to 20. ``None`` disables eviction.
+                For unified backends the window is measured from when an entry was *stored*
+                (not last accessed), so a still-referenced entry is evicted once it ages out.
 
         Raises:
             ValueError: If max_result_tokens is not positive, preview_tokens is negative,
@@ -212,12 +219,14 @@ class ContextOffloader(Plugin):
             raise ValueError("preview_tokens must be non-negative")
         if preview_tokens >= max_result_tokens:
             raise ValueError("preview_tokens must be less than max_result_tokens")
-        if evict_after_cycles is not None and (not isinstance(evict_after_cycles, int) or evict_after_cycles < 1):
+        if evict_after_cycles is not None and (
+            not isinstance(evict_after_cycles, int) or isinstance(evict_after_cycles, bool) or evict_after_cycles < 1
+        ):
             raise ValueError("evict_after_cycles must be a positive integer or None")
 
-        self._storage: StorageBackend = storage
+        self._storage: _StorageBackend = storage
         # Per-agent FileStorage bound to that agent's sandbox; other backends are shared as-is.
-        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, StorageBackend] = weakref.WeakKeyDictionary()
+        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, _StorageBackend] = weakref.WeakKeyDictionary()
         self._max_result_tokens = max_result_tokens
         self._preview_tokens = preview_tokens
         self._include_retrieval_tool = include_retrieval_tool
@@ -227,7 +236,7 @@ class ContextOffloader(Plugin):
         self._key_stored_at: dict[str, int] = {}
         super().__init__()
 
-    def _storage_for_agent(self, agent: Agent) -> StorageBackend:
+    def _storage_for_agent(self, agent: Agent) -> _StorageBackend:
         """Return the storage for an agent, binding FileStorage to its sandbox.
 
         Non-FileStorage backends are shared across agents unchanged. A FileStorage

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -35,22 +35,81 @@ from __future__ import annotations
 import json
 import logging
 import weakref
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias, TypeGuard, cast
 
 from typing_extensions import TypedDict
 
 from ...hooks.events import AfterToolCallEvent, BeforeModelCallEvent
 from ...plugins import Plugin, hook
+from ...storage import Storage as UnifiedStorage
 from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
 from .search import _is_searchable_content, _search_content
-from .storage import FileStorage, InMemoryStorage, Storage
+from .storage import FileStorage, InMemoryStorage
+from .storage import Storage as OffloaderStorage
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
 
 logger = logging.getLogger(__name__)
+
+# A storage backend accepted by ContextOffloader: either the SDK's unified
+# ``strands.storage.Storage`` (write/read/delete/list) or a legacy offloader
+# ``Storage`` (store/retrieve, deprecated).
+StorageBackend: TypeAlias = UnifiedStorage | OffloaderStorage
+
+# Framed byte layout for a unified-Storage value: a 2-byte big-endian content-type
+# length, the UTF-8 content-type, then the content bytes. This keeps the content-type
+# metadata in the same key as the content (one key per block), mirroring strands-ts.
+_CONTENT_TYPE_LENGTH_BYTES = 2
+
+
+def _is_offloader_storage(storage: StorageBackend) -> TypeGuard[OffloaderStorage]:
+    """Return whether ``storage`` is a legacy offloader backend (has store/retrieve)."""
+    return hasattr(storage, "store") and hasattr(storage, "retrieve")
+
+
+def _frame_content(content: bytes, content_type: str) -> bytes:
+    """Frame ``content`` with its ``content_type`` into a single unified-Storage value."""
+    ct_bytes = content_type.encode("utf-8")
+    return len(ct_bytes).to_bytes(_CONTENT_TYPE_LENGTH_BYTES, "big") + ct_bytes + content
+
+
+def _unframe_content(frame: bytes) -> tuple[bytes, str]:
+    """Split a framed unified-Storage value back into ``(content, content_type)``."""
+    ct_len = int.from_bytes(frame[:_CONTENT_TYPE_LENGTH_BYTES], "big")
+    start = _CONTENT_TYPE_LENGTH_BYTES
+    content_type = frame[start : start + ct_len].decode("utf-8")
+    content = frame[start + ct_len :]
+    return content, content_type
+
+
+async def _store_content(storage: StorageBackend, key: str, content: bytes, content_type: str) -> str:
+    """Store one content block and return its retrieval reference.
+
+    Legacy backends persist the content-type natively via ``store()``; unified
+    backends frame it into the stored bytes under ``key`` and use the key as the
+    reference.
+    """
+    if _is_offloader_storage(storage):
+        return await storage.store(key, content, content_type)
+    await cast(UnifiedStorage, storage).write(key, _frame_content(content, content_type))
+    return key
+
+
+async def _retrieve_content(storage: StorageBackend, reference: str) -> tuple[bytes, str]:
+    """Retrieve one content block as ``(content, content_type)``.
+
+    Raises:
+        KeyError: If the reference is not found.
+    """
+    if _is_offloader_storage(storage):
+        return await storage.retrieve(reference)
+    data = await cast(UnifiedStorage, storage).read(reference)
+    if data is None:
+        raise KeyError(f"Reference not found: {reference}")
+    return _unframe_content(data)
 
 
 class LineRange(TypedDict):
@@ -68,6 +127,9 @@ _DEFAULT_PREVIEW_TOKENS = 1_000
 
 _CHARS_PER_TOKEN = 4
 """Approximate characters per token, fallback for preview slicing without tiktoken."""
+
+_DEFAULT_EVICT_AFTER_CYCLES = 20
+"""Default agent-loop cycles before an offloaded entry is evicted (unified Storage backends)."""
 
 
 class ContextOffloader(Plugin):
@@ -116,11 +178,12 @@ class ContextOffloader(Plugin):
 
     def __init__(
         self,
-        storage: Storage,
+        storage: StorageBackend,
         max_result_tokens: int = _DEFAULT_MAX_RESULT_TOKENS,
         preview_tokens: int = _DEFAULT_PREVIEW_TOKENS,
         *,
         include_retrieval_tool: bool = True,
+        evict_after_cycles: int | None = _DEFAULT_EVICT_AFTER_CYCLES,
     ) -> None:
         """Initialize the ContextOffloader plugin.
 
@@ -133,10 +196,15 @@ class ContextOffloader(Plugin):
                 chars/4 heuristic. Defaults to ``_DEFAULT_PREVIEW_TOKENS`` (1,000).
             include_retrieval_tool: Whether to register the ``retrieve_offloaded_content``
                 tool so the agent can fetch offloaded content. Defaults to True.
+            evict_after_cycles: Number of agent loop cycles after which an offloaded entry
+                is evicted. Applies to unified ``Storage`` backends (which have no built-in
+                eviction) and, when the backend is a legacy ``InMemoryStorage`` left at its
+                default window, is forwarded to it. Defaults to 20. ``None`` disables eviction.
 
         Raises:
             ValueError: If max_result_tokens is not positive, preview_tokens is negative,
-                or preview_tokens >= max_result_tokens.
+                preview_tokens >= max_result_tokens, or evict_after_cycles is not a
+                positive integer or None.
         """
         if max_result_tokens <= 0:
             raise ValueError("max_result_tokens must be positive")
@@ -144,16 +212,22 @@ class ContextOffloader(Plugin):
             raise ValueError("preview_tokens must be non-negative")
         if preview_tokens >= max_result_tokens:
             raise ValueError("preview_tokens must be less than max_result_tokens")
+        if evict_after_cycles is not None and (not isinstance(evict_after_cycles, int) or evict_after_cycles < 1):
+            raise ValueError("evict_after_cycles must be a positive integer or None")
 
-        self._storage = storage
+        self._storage: StorageBackend = storage
         # Per-agent FileStorage bound to that agent's sandbox; other backends are shared as-is.
-        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, Storage] = weakref.WeakKeyDictionary()
+        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, StorageBackend] = weakref.WeakKeyDictionary()
         self._max_result_tokens = max_result_tokens
         self._preview_tokens = preview_tokens
         self._include_retrieval_tool = include_retrieval_tool
+        self._evict_after_cycles = evict_after_cycles
+        # Cycle each unified-storage key was stored at, for plugin-driven eviction.
+        # Unified Storage has no built-in eviction; a legacy InMemoryStorage evicts itself.
+        self._key_stored_at: dict[str, int] = {}
         super().__init__()
 
-    def _storage_for_agent(self, agent: Agent) -> Storage:
+    def _storage_for_agent(self, agent: Agent) -> StorageBackend:
         """Return the storage for an agent, binding FileStorage to its sandbox.
 
         Non-FileStorage backends are shared across agents unchanged. A FileStorage
@@ -178,7 +252,7 @@ class ContextOffloader(Plugin):
     def init_agent(self, agent: Agent) -> None:
         """Conditionally register the retrieval tool and bind storage."""
         if isinstance(self._storage, InMemoryStorage):
-            self._storage._bind(id(agent))
+            self._storage._bind(id(agent), self._evict_after_cycles)
         # Bind FileStorage to this agent's sandbox up front (no-op for other backends).
         self._storage_for_agent(agent)
         if not self._include_retrieval_tool:
@@ -186,10 +260,39 @@ class ContextOffloader(Plugin):
             self._tools = [t for t in self._tools if t.tool_name != "retrieve_offloaded_content"]
 
     @hook
-    def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
-        """Trigger eviction of stale entries based on the agent's cycle count."""
+    async def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
+        """Trigger eviction of stale entries based on the agent's cycle count.
+
+        A legacy ``InMemoryStorage`` evicts internally; unified ``Storage`` backends
+        have no built-in eviction, so the plugin evicts their stale keys here.
+        """
+        cycle = event.agent.event_loop_metrics.cycle_count
         if isinstance(self._storage, InMemoryStorage):
-            self._storage._evict(event.agent.event_loop_metrics.cycle_count)
+            self._storage._evict(cycle)
+        elif self._evict_after_cycles is not None:
+            await self._evict(cycle)
+
+    async def _evict(self, current_cycle: int) -> None:
+        """Delete unified-storage entries stored more than ``evict_after_cycles`` cycles ago.
+
+        Args:
+            current_cycle: The agent's current event loop cycle count.
+        """
+        if self._evict_after_cycles is None:
+            return
+        threshold = current_cycle - self._evict_after_cycles
+        to_evict = [key for key, stored_cycle in self._key_stored_at.items() if stored_cycle < threshold]
+        if not to_evict:
+            return
+        storage = cast(UnifiedStorage, self._storage)
+        for key in to_evict:
+            # Stop tracking first, so a failed delete is not retried every cycle (matches strands-ts).
+            del self._key_stored_at[key]
+            try:
+                await storage.delete(key)
+            except Exception:
+                logger.debug("key=<%s> | failed to evict offloaded entry", key, exc_info=True)
+        logger.debug("evicted=<%d>, threshold=<%d> | evicted stale offloaded entries", len(to_evict), threshold)
 
     @tool(context=True)
     async def retrieve_offloaded_content(
@@ -231,7 +334,7 @@ class ContextOffloader(Plugin):
         """
         storage = self._storage_for_agent(tool_context.agent)
         try:
-            content_bytes, content_type = await storage.retrieve(reference)
+            content_bytes, content_type = await _retrieve_content(storage, reference)
         except KeyError:
             return f"Error: reference not found: {reference}"
 
@@ -317,18 +420,18 @@ class ContextOffloader(Plugin):
             for i, block in enumerate(content):
                 key = f"{tool_use_id}_{i}"
                 if block.get("text"):
-                    ref = await storage.store(key, block["text"].encode("utf-8"), "text/plain")
+                    ref = await _store_content(storage, key, block["text"].encode("utf-8"), "text/plain")
                     references.append((ref, "text/plain", f"text, {len(block['text']):,} chars"))
                 elif "json" in block:
                     json_bytes = json.dumps(block["json"], indent=2).encode("utf-8")
-                    ref = await storage.store(key, json_bytes, "application/json")
+                    ref = await _store_content(storage, key, json_bytes, "application/json")
                     references.append((ref, "application/json", f"json, {len(json_bytes):,} bytes"))
                 elif "image" in block:
                     image = block["image"]
                     img_format = image.get("format", "unknown")
                     img_bytes = image.get("source", {}).get("bytes", b"")
                     if img_bytes:
-                        ref = await storage.store(key, img_bytes, f"image/{img_format}")
+                        ref = await _store_content(storage, key, img_bytes, f"image/{img_format}")
                         references.append((ref, f"image/{img_format}", f"image/{img_format}, {len(img_bytes):,} bytes"))
                     else:
                         references.append(("", f"image/{img_format}", f"image/{img_format}, 0 bytes"))
@@ -338,7 +441,7 @@ class ContextOffloader(Plugin):
                     doc_name = doc.get("name", "unknown")
                     doc_bytes = doc.get("source", {}).get("bytes", b"")
                     if doc_bytes:
-                        ref = await storage.store(key, doc_bytes, f"application/{doc_format}")
+                        ref = await _store_content(storage, key, doc_bytes, f"application/{doc_format}")
                         references.append((ref, f"application/{doc_format}", f"{doc_name}, {len(doc_bytes):,} bytes"))
                     else:
                         references.append(("", f"application/{doc_format}", f"{doc_name}, 0 bytes"))
@@ -349,6 +452,14 @@ class ContextOffloader(Plugin):
                 exc_info=True,
             )
             return
+
+        # Track unified-storage keys so the plugin can evict them later (legacy backends
+        # self-evict). Mirrors strands-ts, which records regardless of the eviction window.
+        if not _is_offloader_storage(storage):
+            stored_at = event.agent.event_loop_metrics.cycle_count
+            for ref, _content_type, _description in references:
+                if ref:
+                    self._key_stored_at[ref] = stored_at
 
         logger.debug(
             "tool_use_id=<%s>, blocks=<%d>, tokens=<%d> | tool result offloaded",

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -1,4 +1,10 @@
-"""Storage backends for offloaded tool result content.
+"""Legacy storage backends for offloaded tool result content.
+
+.. deprecated::
+    Use the unified :mod:`strands.storage` interface instead (its ``InMemoryStorage``,
+    ``LocalFileStorage``, and ``S3Storage``). Pass one directly to ``ContextOffloader``;
+    the plugin adapts it internally. This module's ``Storage`` protocol and its
+    implementations are retained for backwards compatibility only.
 
 This module defines the Storage protocol and provides three built-in
 implementations: file-based, in-memory, and S3 storage. Each content block
@@ -43,6 +49,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _Unset:
+    """Sentinel type distinguishing "argument not provided" from an explicit ``None``."""
+
+
+_UNSET = _Unset()
+
+
 def _sanitize_id(raw_id: str) -> str:
     """Sanitize an ID for safe use in filenames and object keys.
 
@@ -63,6 +76,10 @@ def _sanitize_id(raw_id: str) -> str:
 @runtime_checkable
 class Storage(Protocol):
     """Backend for storing and retrieving offloaded content blocks.
+
+    .. deprecated::
+        Use the unified :class:`strands.storage.Storage` instead and pass it directly
+        to ``ContextOffloader`` — the plugin adapts it internally.
 
     Each content block from a tool result is stored individually with its
     content type preserved. The SDK ships three built-in implementations:
@@ -107,6 +124,9 @@ class Storage(Protocol):
 
 class FileStorage:
     """Store offloaded content as files, on the host filesystem or through a sandbox.
+
+    .. deprecated::
+        Use :class:`strands.storage.LocalFileStorage` instead.
 
     Files are written to the configured artifact directory with unique names.
     File extensions are derived from the content type. A ``.metadata.json``
@@ -287,6 +307,9 @@ class FileStorage:
 class InMemoryStorage:
     """Store offloaded content in memory.
 
+    .. deprecated::
+        Use :class:`strands.storage.InMemoryStorage` instead.
+
     Useful for testing and serverless environments where disk access
     is not available or not desired. Thread-safe.
 
@@ -372,8 +395,17 @@ class InMemoryStorage:
             self._store[reference] = (content, content_type, self._current_cycle)
             return content, content_type
 
-    def _bind(self, agent_id: int) -> None:
+    def _bind(self, agent_id: int, evict_after_cycles: "int | None | _Unset" = _UNSET) -> None:
         """Claim this storage for a single agent.
+
+        Optionally overrides the eviction window with the ``ContextOffloader``'s
+        ``evict_after_cycles``, but only when this storage still has the default
+        window (i.e. the user did not set one explicitly at construction time).
+
+        Args:
+            agent_id: Identity of the agent claiming this storage.
+            evict_after_cycles: Eviction window forwarded by the plugin. Left unset
+                when ``_bind`` is called directly.
 
         Raises:
             ValueError: If already bound to a different agent.
@@ -386,6 +418,9 @@ class InMemoryStorage:
                     "InMemoryStorage cannot be shared across multiple agents. "
                     "Use a separate InMemoryStorage instance per agent."
                 )
+            at_default_window = self._evict_after_turns == self._DEFAULT_EVICT_AFTER_TURNS
+            if not isinstance(evict_after_cycles, _Unset) and at_default_window:
+                self._evict_after_turns = evict_after_cycles
 
     def _evict(self, cycle: int) -> None:
         """Update current cycle and evict stale entries.
@@ -420,6 +455,9 @@ class InMemoryStorage:
 
 class S3Storage:
     """Store offloaded content in Amazon S3.
+
+    .. deprecated::
+        Use :class:`strands.storage.S3Storage` instead.
 
     Objects are stored with unique keys under the configured prefix.
     Content type is preserved as S3 object metadata.

--- a/strands-py/tests/strands/storage/test_in_memory_storage.py
+++ b/strands-py/tests/strands/storage/test_in_memory_storage.py
@@ -1,0 +1,118 @@
+"""Tests for the in-memory unified storage backend."""
+
+import pytest
+
+from strands.storage import InMemoryStorage
+from strands.types.exceptions import StorageError
+
+
+@pytest.fixture
+def storage():
+    return InMemoryStorage()
+
+
+class TestWrite:
+    @pytest.mark.asyncio
+    async def test_stores_data_under_the_given_key(self, storage):
+        await storage.write("test/key", b"hello")
+        assert await storage.read("test/key") == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_overwrites_existing_data(self, storage):
+        await storage.write("key", b"first")
+        await storage.write("key", b"second")
+        assert await storage.read("key") == b"second"
+
+    @pytest.mark.asyncio
+    async def test_copies_bytes_on_write_to_prevent_aliasing(self, storage):
+        data = bytearray([1, 2, 3])
+        await storage.write("key", data)
+        data[0] = 99
+        tru_result = await storage.read("key")
+        assert tru_result[0] == 1
+
+
+class TestRead:
+    @pytest.mark.asyncio
+    async def test_returns_none_for_missing_keys(self, storage):
+        assert await storage.read("nonexistent") is None
+
+    @pytest.mark.asyncio
+    async def test_returned_bytes_are_immutable_and_do_not_alias(self, storage):
+        await storage.write("key", bytes([1, 2, 3]))
+        first = await storage.read("key")
+        with pytest.raises(TypeError):
+            first[0] = 99  # bytes is immutable — cannot alias the store
+        assert (await storage.read("key"))[0] == 1
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_removes_an_existing_key(self, storage):
+        await storage.write("key", bytes([1]))
+        await storage.delete("key")
+        assert await storage.read("key") is None
+
+    @pytest.mark.asyncio
+    async def test_is_a_no_op_for_missing_keys(self, storage):
+        assert await storage.delete("nonexistent") is None
+
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_returns_keys_matching_a_prefix(self, storage):
+        await storage.write("sessions/a/data", bytes([1]))
+        await storage.write("sessions/b/data", bytes([2]))
+        await storage.write("memory/notes", bytes([3]))
+
+        tru_keys = await storage.list("sessions/")
+        assert tru_keys == ["sessions/a/data", "sessions/b/data"]
+
+    @pytest.mark.asyncio
+    async def test_returns_all_keys_when_prefix_is_empty(self, storage):
+        await storage.write("a", bytes([1]))
+        await storage.write("b", bytes([2]))
+        assert await storage.list("") == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_returns_keys_sorted_lexicographically(self, storage):
+        await storage.write("c", bytes([3]))
+        await storage.write("a", bytes([1]))
+        await storage.write("b", bytes([2]))
+        assert await storage.list("") == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_keys_match(self, storage):
+        await storage.write("other/key", bytes([1]))
+        assert await storage.list("sessions/") == []
+
+
+class TestClear:
+    @pytest.mark.asyncio
+    async def test_removes_all_entries(self, storage):
+        await storage.write("a", bytes([1]))
+        await storage.write("b", bytes([2]))
+        storage.clear()
+        assert await storage.list("") == []
+
+
+class TestKeyNormalization:
+    @pytest.mark.asyncio
+    async def test_normalizes_slashes_so_equivalent_keys_resolve_to_the_same_entry(self, storage):
+        await storage.write("/a//b/", bytes([1]))
+        assert await storage.read("a/b") == bytes([1])
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_keys(self, storage):
+        with pytest.raises(StorageError):
+            await storage.write("", bytes([1]))
+
+    @pytest.mark.asyncio
+    async def test_rejects_keys_with_dotdot_segments(self, storage):
+        with pytest.raises(StorageError):
+            await storage.write("a/../b", bytes([1]))
+
+    @pytest.mark.asyncio
+    async def test_rejects_prefixes_with_dotdot_segments(self, storage):
+        with pytest.raises(StorageError):
+            await storage.list("../")

--- a/strands-py/tests/strands/storage/test_in_memory_storage.py
+++ b/strands-py/tests/strands/storage/test_in_memory_storage.py
@@ -116,3 +116,25 @@ class TestKeyNormalization:
     async def test_rejects_prefixes_with_dotdot_segments(self, storage):
         with pytest.raises(StorageError):
             await storage.list("../")
+
+
+class TestPublicApiSurface:
+    def test_namespace_and_error_are_exported_from_package(self):
+        from strands.storage import InMemoryStorage, S3Storage, Storage, namespace
+        from strands.storage import LocalFileStorage as _LFS
+        from strands.storage import StorageError as _SE
+
+        assert callable(namespace)
+        assert isinstance(InMemoryStorage(), Storage)
+        assert issubclass(_SE, Exception)
+        assert _LFS is not None and S3Storage is not None
+
+    @pytest.mark.asyncio
+    async def test_operations_tolerate_forward_compat_kwargs(self, storage):
+        # Protocol methods carry **kwargs for forward compatibility; unknown kwargs
+        # must not break existing implementations.
+        await storage.write("k", b"v", request_id="abc")
+        assert await storage.read("k", request_id="abc") == b"v"
+        assert await storage.list("", request_id="abc") == ["k"]
+        await storage.delete("k", request_id="abc")
+        assert await storage.read("k") is None

--- a/strands-py/tests/strands/storage/test_local_file_storage.py
+++ b/strands-py/tests/strands/storage/test_local_file_storage.py
@@ -1,0 +1,122 @@
+"""Tests for the local-filesystem unified storage backend."""
+
+import os
+import sys
+
+import pytest
+
+from strands.storage import LocalFileStorage
+from strands.types.exceptions import StorageError
+
+
+@pytest.fixture
+def base_dir(tmp_path):
+    return str(tmp_path / "strands-test")
+
+
+@pytest.fixture
+def storage(base_dir):
+    return LocalFileStorage(base_dir)
+
+
+class TestWriteAndRead:
+    @pytest.mark.asyncio
+    async def test_round_trips_bytes(self, storage):
+        data = b"hello world"
+        await storage.write("test/file.txt", data)
+        assert await storage.read("test/file.txt") == data
+
+    @pytest.mark.asyncio
+    async def test_creates_nested_directories(self, storage, base_dir):
+        await storage.write("deep/nested/path/file.bin", bytes([1, 2, 3]))
+        assert os.path.isfile(os.path.join(base_dir, "deep/nested/path/file.bin"))
+
+    @pytest.mark.asyncio
+    async def test_overwrites_existing_values(self, storage):
+        await storage.write("key", b"first")
+        await storage.write("key", b"second")
+        assert await storage.read("key") == b"second"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_missing_keys(self, storage):
+        assert await storage.read("nonexistent/key") is None
+
+    @pytest.mark.asyncio
+    async def test_writes_atomically_leaving_no_scratch_file(self, storage, base_dir):
+        await storage.write("atomic/test", bytes([1]))
+        with open(os.path.join(base_dir, "atomic/test"), "rb") as file:
+            assert file.read() == bytes([1])
+        scratch = [name for _, _, files in os.walk(base_dir) for name in files if ".__strands_tmp" in name]
+        assert scratch == []
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod on a directory does not block rename on Windows")
+    @pytest.mark.asyncio
+    async def test_cleans_up_scratch_file_on_rename_failure(self, storage, base_dir):
+        read_only_dir = os.path.join(base_dir, "readonly")
+        os.makedirs(read_only_dir, exist_ok=True)
+        with open(os.path.join(read_only_dir, "target"), "w") as file:
+            file.write("original")
+        os.chmod(read_only_dir, 0o555)
+        try:
+            with pytest.raises(StorageError):
+                await storage.write("readonly/target", bytes([1]))
+            os.chmod(read_only_dir, 0o755)
+            leftovers = [name for name in os.listdir(read_only_dir) if ".__strands_tmp" in name]
+            assert leftovers == []
+        finally:
+            os.chmod(read_only_dir, 0o755)
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_removes_an_existing_key(self, storage):
+        await storage.write("deleteme", bytes([1]))
+        await storage.delete("deleteme")
+        assert await storage.read("deleteme") is None
+
+    @pytest.mark.asyncio
+    async def test_is_a_no_op_for_missing_keys(self, storage):
+        assert await storage.delete("nonexistent") is None
+
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_lists_keys_under_a_prefix(self, storage):
+        await storage.write("sessions/a/data.json", bytes([1]))
+        await storage.write("sessions/b/data.json", bytes([2]))
+        await storage.write("memory/notes.json", bytes([3]))
+
+        tru_keys = await storage.list("sessions/")
+        assert tru_keys == ["sessions/a/data.json", "sessions/b/data.json"]
+
+    @pytest.mark.asyncio
+    async def test_returns_all_keys_for_empty_prefix(self, storage):
+        await storage.write("a", bytes([1]))
+        await storage.write("b", bytes([2]))
+        assert await storage.list("") == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_base_directory_does_not_exist(self, tmp_path):
+        fresh = LocalFileStorage(str(tmp_path / "does-not-exist"))
+        assert await fresh.list("") == []
+
+    @pytest.mark.asyncio
+    async def test_excludes_scratch_files(self, storage, base_dir):
+        await storage.write("real", bytes([1]))
+        os.makedirs(base_dir, exist_ok=True)
+        with open(os.path.join(base_dir, "leftover.__strands_tmp"), "w") as file:
+            file.write("garbage")
+
+        assert "leftover.__strands_tmp" not in await storage.list("")
+
+    @pytest.mark.asyncio
+    async def test_does_not_exclude_user_dot_tmp_files(self, storage):
+        await storage.write("notes.tmp", bytes([1]))
+        assert "notes.tmp" in await storage.list("")
+
+    @pytest.mark.asyncio
+    async def test_returns_keys_sorted_lexicographically(self, storage):
+        await storage.write("c", bytes([3]))
+        await storage.write("a", bytes([1]))
+        await storage.write("b", bytes([2]))
+        assert await storage.list("") == ["a", "b", "c"]

--- a/strands-py/tests/strands/storage/test_local_file_storage.py
+++ b/strands-py/tests/strands/storage/test_local_file_storage.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -132,3 +132,50 @@ class TestList:
         await storage.write("a", bytes([1]))
         await storage.write("b", bytes([2]))
         assert await storage.list("") == ["a", "b", "c"]
+
+
+class TestSandboxNotFoundParity:
+    """Sandbox-mode read/delete/list treat a non-directory parent (``NotADirectoryError``)
+    as 'not found', exactly like a missing path — parity with the host paths and with
+    strands-ts ``isNotFoundError`` (which lumps ``ENOENT`` and ``ENOTDIR``)."""
+
+    @staticmethod
+    def _sandbox():
+        sandbox = MagicMock()
+        sandbox.read_file = AsyncMock()
+        sandbox.remove_file = AsyncMock()
+        sandbox.list_files = AsyncMock()
+        sandbox.write_file = AsyncMock()
+        return sandbox
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exc", [FileNotFoundError, NotADirectoryError])
+    async def test_read_returns_none(self, base_dir, exc):
+        sandbox = self._sandbox()
+        sandbox.read_file.side_effect = exc("not found")
+        storage = LocalFileStorage(base_dir, sandbox=sandbox)
+        assert await storage.read("a/b") is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exc", [FileNotFoundError, NotADirectoryError])
+    async def test_delete_is_a_no_op(self, base_dir, exc):
+        sandbox = self._sandbox()
+        sandbox.remove_file.side_effect = exc("not found")
+        storage = LocalFileStorage(base_dir, sandbox=sandbox)
+        await storage.delete("a/b")  # must not raise
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exc", [FileNotFoundError, NotADirectoryError])
+    async def test_list_returns_empty(self, base_dir, exc):
+        sandbox = self._sandbox()
+        sandbox.list_files.side_effect = exc("not found")
+        storage = LocalFileStorage(base_dir, sandbox=sandbox)
+        assert await storage.list("a/b") == []
+
+    @pytest.mark.asyncio
+    async def test_read_still_wraps_other_sandbox_errors(self, base_dir):
+        sandbox = self._sandbox()
+        sandbox.read_file.side_effect = RuntimeError("boom")
+        storage = LocalFileStorage(base_dir, sandbox=sandbox)
+        with pytest.raises(StorageError):
+            await storage.read("a/b")

--- a/strands-py/tests/strands/storage/test_local_file_storage.py
+++ b/strands-py/tests/strands/storage/test_local_file_storage.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -65,6 +66,17 @@ class TestWriteAndRead:
             assert leftovers == []
         finally:
             os.chmod(read_only_dir, 0o755)
+
+    @pytest.mark.asyncio
+    async def test_removes_scratch_file_when_rename_fails(self, storage, base_dir):
+        # Force the atomic rename to fail *after* the scratch file is written, so the
+        # cleanup branch (which removes the leftover scratch file) is exercised.
+        with patch("strands.storage.local_file_storage.os.replace", side_effect=OSError("boom")):
+            with pytest.raises(StorageError):
+                await storage.write("dir/key", bytes([1]))
+
+        scratch = [name for _, _, files in os.walk(base_dir) for name in files if ".__strands_tmp" in name]
+        assert scratch == []
 
 
 class TestDelete:

--- a/strands-py/tests/strands/storage/test_namespaced_storage.py
+++ b/strands-py/tests/strands/storage/test_namespaced_storage.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from strands.storage import InMemoryStorage
-from strands.storage.base import NAMESPACED, namespace
+from strands.storage import InMemoryStorage, namespace
+from strands.storage.base import _NAMESPACED
 
 
 @pytest.fixture
@@ -80,8 +80,8 @@ async def test_handles_empty_namespace_as_no_op_prefix(backend):
 
 
 def test_sets_namespaced_marker_on_returned_view(namespaced):
-    assert getattr(namespaced, NAMESPACED, False) is True
+    assert getattr(namespaced, _NAMESPACED, False) is True
 
 
 def test_does_not_set_namespaced_marker_on_raw_storage(backend):
-    assert getattr(backend, NAMESPACED, False) is False
+    assert getattr(backend, _NAMESPACED, False) is False

--- a/strands-py/tests/strands/storage/test_namespaced_storage.py
+++ b/strands-py/tests/strands/storage/test_namespaced_storage.py
@@ -1,0 +1,87 @@
+"""Tests for the namespace() factory that scopes a storage under a key prefix."""
+
+import pytest
+
+from strands.storage import InMemoryStorage
+from strands.storage.base import NAMESPACED, namespace
+
+
+@pytest.fixture
+def backend():
+    return InMemoryStorage()
+
+
+@pytest.fixture
+def namespaced(backend):
+    return namespace(backend, "prefix")
+
+
+@pytest.mark.asyncio
+async def test_prepends_namespace_to_write_keys(backend, namespaced):
+    await namespaced.write("key", bytes([1, 2, 3]))
+    assert await backend.read("prefix/key") == bytes([1, 2, 3])
+
+
+@pytest.mark.asyncio
+async def test_prepends_namespace_to_read_keys(backend, namespaced):
+    await backend.write("prefix/key", bytes([4, 5]))
+    assert await namespaced.read("key") == bytes([4, 5])
+
+
+@pytest.mark.asyncio
+async def test_returns_none_for_missing_keys(namespaced):
+    assert await namespaced.read("nonexistent") is None
+
+
+@pytest.mark.asyncio
+async def test_prepends_namespace_to_delete_keys(backend, namespaced):
+    await backend.write("prefix/key", bytes([1]))
+    await namespaced.delete("key")
+    assert await backend.read("prefix/key") is None
+
+
+@pytest.mark.asyncio
+async def test_lists_keys_with_namespace_stripped(backend, namespaced):
+    await backend.write("prefix/a", bytes([1]))
+    await backend.write("prefix/b", bytes([2]))
+    await backend.write("other/c", bytes([3]))
+
+    assert await namespaced.list("") == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_lists_keys_with_sub_prefix(backend, namespaced):
+    await backend.write("prefix/session/abc", bytes([1]))
+    await backend.write("prefix/session/def", bytes([2]))
+    await backend.write("prefix/offloader/xyz", bytes([3]))
+
+    assert await namespaced.list("session/") == ["session/abc", "session/def"]
+
+
+@pytest.mark.asyncio
+async def test_composes_nested_namespaces(backend):
+    nested = namespace(namespace(backend, "prefix"), "sub")
+    await nested.write("key", bytes([9]))
+    assert await backend.read("prefix/sub/key") == bytes([9])
+
+
+@pytest.mark.asyncio
+async def test_composes_nested_namespaces_via_method(backend):
+    nested = namespace(backend, "prefix").namespace("sub")
+    await nested.write("key", bytes([9]))
+    assert await backend.read("prefix/sub/key") == bytes([9])
+
+
+@pytest.mark.asyncio
+async def test_handles_empty_namespace_as_no_op_prefix(backend):
+    empty = namespace(backend, "")
+    await empty.write("key", bytes([7]))
+    assert await backend.read("key") == bytes([7])
+
+
+def test_sets_namespaced_marker_on_returned_view(namespaced):
+    assert getattr(namespaced, NAMESPACED, False) is True
+
+
+def test_does_not_set_namespaced_marker_on_raw_storage(backend):
+    assert getattr(backend, NAMESPACED, False) is False

--- a/strands-py/tests/strands/storage/test_s3_storage.py
+++ b/strands-py/tests/strands/storage/test_s3_storage.py
@@ -121,6 +121,15 @@ class TestList:
         assert mock_client.list_objects_v2.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_terminates_when_truncated_without_a_continuation_token(self, mock_client):
+        # A truncated page that omits NextContinuationToken must not loop forever.
+        mock_client.list_objects_v2.return_value = {"Contents": [{"Key": "a"}], "IsTruncated": True}
+        storage = S3Storage("my-bucket")
+
+        assert await storage.list("") == ["a"]
+        assert mock_client.list_objects_v2.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_wraps_errors_in_storage_error(self, mock_client):
         mock_client.list_objects_v2.side_effect = _client_error("BucketNotFound")
         storage = S3Storage("my-bucket")

--- a/strands-py/tests/strands/storage/test_s3_storage.py
+++ b/strands-py/tests/strands/storage/test_s3_storage.py
@@ -23,9 +23,9 @@ def _client_error(code):
 
 
 class TestConstructor:
-    def test_raises_when_both_boto_session_and_region_are_provided(self):
+    def test_raises_when_both_boto_session_and_region_name_are_provided(self):
         with pytest.raises(StorageError):
-            S3Storage("bucket", region="us-west-2", boto_session=object())
+            S3Storage("bucket", region_name="us-west-2", boto_session=object())
 
     def test_accepts_just_a_bucket_name(self):
         S3Storage("my-bucket")

--- a/strands-py/tests/strands/storage/test_s3_storage.py
+++ b/strands-py/tests/strands/storage/test_s3_storage.py
@@ -1,0 +1,129 @@
+"""Tests for the Amazon S3 unified storage backend."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from strands.storage import S3Storage
+from strands.types.exceptions import StorageError
+
+
+@pytest.fixture
+def mock_client():
+    """A mock boto3 S3 client wired in via a patched ``boto3.Session``."""
+    client = MagicMock()
+    with patch("boto3.Session") as session_cls:
+        session_cls.return_value.client.return_value = client
+        yield client
+
+
+def _client_error(code):
+    return ClientError({"Error": {"Code": code, "Message": code}}, "GetObject")
+
+
+class TestConstructor:
+    def test_raises_when_both_boto_session_and_region_are_provided(self):
+        with pytest.raises(StorageError):
+            S3Storage("bucket", region="us-west-2", boto_session=object())
+
+    def test_accepts_just_a_bucket_name(self):
+        S3Storage("my-bucket")
+
+
+class TestWrite:
+    @pytest.mark.asyncio
+    async def test_puts_object_with_the_correct_params(self, mock_client):
+        mock_client.put_object.return_value = {}
+        storage = S3Storage("my-bucket", prefix="agents/")
+
+        await storage.write("sessions/abc/data.json", b"payload")
+
+        mock_client.put_object.assert_called_once_with(
+            Bucket="my-bucket", Key="agents/sessions/abc/data.json", Body=b"payload"
+        )
+
+    @pytest.mark.asyncio
+    async def test_wraps_sdk_errors_in_storage_error(self, mock_client):
+        mock_client.put_object.side_effect = _client_error("AccessDenied")
+        storage = S3Storage("my-bucket")
+
+        with pytest.raises(StorageError):
+            await storage.write("key", bytes([1]))
+
+
+class TestRead:
+    @pytest.mark.asyncio
+    async def test_returns_bytes_when_the_object_exists(self, mock_client):
+        body = MagicMock()
+        body.read.return_value = bytes([1, 2, 3])
+        mock_client.get_object.return_value = {"Body": body}
+        storage = S3Storage("my-bucket")
+
+        assert await storage.read("some/key") == bytes([1, 2, 3])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("code", ["NoSuchKey", "NotFound"])
+    async def test_returns_none_for_missing_object(self, mock_client, code):
+        mock_client.get_object.side_effect = _client_error(code)
+        storage = S3Storage("my-bucket")
+
+        assert await storage.read("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_wraps_other_errors_in_storage_error(self, mock_client):
+        mock_client.get_object.side_effect = _client_error("InternalError")
+        storage = S3Storage("my-bucket")
+
+        with pytest.raises(StorageError):
+            await storage.read("key")
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_deletes_object_with_the_correct_params(self, mock_client):
+        mock_client.delete_object.return_value = {}
+        storage = S3Storage("my-bucket", prefix="p/")
+
+        await storage.delete("key")
+
+        mock_client.delete_object.assert_called_once_with(Bucket="my-bucket", Key="p/key")
+
+    @pytest.mark.asyncio
+    async def test_wraps_errors_in_storage_error(self, mock_client):
+        mock_client.delete_object.side_effect = _client_error("InternalError")
+        storage = S3Storage("my-bucket")
+
+        with pytest.raises(StorageError):
+            await storage.delete("key")
+
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_returns_keys_with_prefix_stripped(self, mock_client):
+        mock_client.list_objects_v2.return_value = {
+            "Contents": [{"Key": "prefix/a"}, {"Key": "prefix/b/c"}],
+            "IsTruncated": False,
+        }
+        storage = S3Storage("my-bucket", prefix="prefix/")
+
+        assert await storage.list("") == ["a", "b/c"]
+
+    @pytest.mark.asyncio
+    async def test_paginates_until_is_truncated_is_false(self, mock_client):
+        mock_client.list_objects_v2.side_effect = [
+            {"Contents": [{"Key": "a"}], "IsTruncated": True, "NextContinuationToken": "token1"},
+            {"Contents": [{"Key": "b"}], "IsTruncated": False},
+        ]
+        storage = S3Storage("my-bucket")
+
+        assert await storage.list("") == ["a", "b"]
+        assert mock_client.list_objects_v2.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_wraps_errors_in_storage_error(self, mock_client):
+        mock_client.list_objects_v2.side_effect = _client_error("BucketNotFound")
+        storage = S3Storage("my-bucket")
+
+        with pytest.raises(StorageError):
+            await storage.list("prefix/")

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -827,19 +827,21 @@ class TestBeforeModelCallHook:
         agent.event_loop_metrics.cycle_count = cycle_count
         return BeforeModelCallEvent(agent=agent, invocation_state={})
 
-    def test_calls_evict_with_cycle_count(self):
+    @pytest.mark.asyncio
+    async def test_calls_evict_with_cycle_count(self):
         storage = InMemoryStorage(evict_after_turns=5)
         plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
 
-        plugin._on_before_model_call(self._make_event(7))
+        await plugin._on_before_model_call(self._make_event(7))
 
         assert storage._current_cycle == 7
 
-    def test_does_not_crash_on_storage_without_evict(self):
+    @pytest.mark.asyncio
+    async def test_does_not_crash_on_storage_without_evict(self):
         storage = MagicMock(spec=["store", "retrieve"])
         plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
 
-        plugin._on_before_model_call(self._make_event(1))
+        await plugin._on_before_model_call(self._make_event(1))
 
     @pytest.mark.asyncio
     async def test_eviction_triggered_via_hook(self):
@@ -849,6 +851,6 @@ class TestBeforeModelCallHook:
         ref = await storage.store("key_1", b"content")
 
         # stored at cycle 0, evict at cycle 3: threshold = 3 - 2 = 1, 0 < 1 → evicted
-        plugin._on_before_model_call(self._make_event(3))
+        await plugin._on_before_model_call(self._make_event(3))
         with pytest.raises(KeyError):
             await storage.retrieve(ref)

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_unified_storage_bridge.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_unified_storage_bridge.py
@@ -219,6 +219,11 @@ class TestEvictAfterCyclesValidation:
         ContextOffloader(storage=UnifiedInMemoryStorage(), evict_after_cycles=None)
         ContextOffloader(storage=UnifiedInMemoryStorage(), evict_after_cycles=1)
 
+    def test_rejects_bool(self):
+        # bool is an int subclass; True must not be silently accepted as 1.
+        with pytest.raises(ValueError, match="evict_after_cycles"):
+            ContextOffloader(storage=UnifiedInMemoryStorage(), evict_after_cycles=True)
+
 
 class TestLegacyWindowForwarding:
     def test_forwards_window_when_legacy_storage_at_default(self):

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_unified_storage_bridge.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_unified_storage_bridge.py
@@ -1,0 +1,238 @@
+"""Tests for the ContextOffloader bridge onto the unified ``strands.storage`` interface.
+
+Covers the pieces added to wire the offloader onto a unified ``Storage`` backend
+(write/read/delete/list), matching the strands-ts integration:
+
+- content-type framing round-trip,
+- legacy-vs-unified backend detection,
+- store/retrieve adapters,
+- end-to-end offload + retrieve through a unified backend,
+- plugin-driven eviction (unified backends have no built-in eviction),
+- ``evict_after_cycles`` validation, and
+- forwarding the eviction window to a legacy ``InMemoryStorage``.
+"""
+
+import json
+import math
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from strands.hooks.events import AfterToolCallEvent, BeforeModelCallEvent
+from strands.storage import InMemoryStorage as UnifiedInMemoryStorage
+from strands.vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
+from strands.vended_plugins.context_offloader.plugin import (
+    _frame_content,
+    _is_offloader_storage,
+    _retrieve_content,
+    _store_content,
+    _unframe_content,
+)
+
+
+async def _count_tokens(messages, **kwargs):
+    """Heuristic token counter for tests: chars / 4 over tool-result text/json."""
+    total = 0
+    for msg in messages:
+        for block in msg.get("content", []):
+            if "toolResult" in block:
+                for content in block["toolResult"].get("content", []):
+                    if "text" in content:
+                        total += math.ceil(len(content["text"]) / 4)
+                    elif "json" in content:
+                        total += math.ceil(len(json.dumps(content["json"])) / 4)
+    return total
+
+
+def _agent(cycle_count=0):
+    agent = MagicMock()
+    agent.model.count_tokens = AsyncMock(side_effect=_count_tokens)
+    agent.event_loop_metrics.cycle_count = cycle_count
+    return agent
+
+
+def _after_tool_event(agent, content, tool_use_id="tool_123"):
+    result = {"toolUseId": tool_use_id, "status": "success", "content": content}
+    tool_use = {"toolUseId": tool_use_id, "name": "test_tool", "input": {}}
+    return AfterToolCallEvent(
+        agent=agent,
+        selected_tool=None,
+        tool_use=tool_use,
+        invocation_state={},
+        result=result,
+        cancel_message=None,
+    )
+
+
+def _before_model_event(agent, cycle_count):
+    agent.event_loop_metrics.cycle_count = cycle_count
+    return BeforeModelCallEvent(agent=agent, invocation_state={})
+
+
+class TestFraming:
+    @pytest.mark.parametrize(
+        "content, content_type",
+        [
+            (b"hello world", "text/plain"),
+            (b'{"a": 1}', "application/json"),
+            (b"\x89PNG\r\n\x1a\n\x00\xff", "image/png"),
+            (b"", "application/octet-stream"),
+            (bytes(range(256)), "application/pdf"),
+        ],
+    )
+    def test_round_trips_content_and_type(self, content, content_type):
+        content_out, type_out = _unframe_content(_frame_content(content, content_type))
+        assert content_out == content
+        assert type_out == content_type
+
+    def test_layout_is_big_endian_length_prefixed(self):
+        frame = _frame_content(b"BODY", "text/plain")
+        assert frame[:2] == len("text/plain").to_bytes(2, "big")
+        assert frame[2:].startswith(b"text/plain")
+        assert frame.endswith(b"BODY")
+
+
+class TestStorageDetection:
+    def test_legacy_offloader_storage_detected(self):
+        assert _is_offloader_storage(InMemoryStorage()) is True
+
+    def test_unified_storage_not_detected(self):
+        assert _is_offloader_storage(UnifiedInMemoryStorage()) is False
+
+
+class TestUnifiedAdapters:
+    @pytest.mark.asyncio
+    async def test_store_frames_and_returns_key_as_reference(self):
+        storage = UnifiedInMemoryStorage()
+        ref = await _store_content(storage, "tool_1_0", b"payload", "application/json")
+        assert ref == "tool_1_0"
+        content, content_type = await _retrieve_content(storage, ref)
+        assert content == b"payload"
+        assert content_type == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_retrieve_missing_reference_raises_keyerror(self):
+        with pytest.raises(KeyError):
+            await _retrieve_content(UnifiedInMemoryStorage(), "does-not-exist")
+
+    @pytest.mark.asyncio
+    async def test_store_delegates_to_legacy_backend(self):
+        storage = InMemoryStorage()
+        ref = await _store_content(storage, "k", b"data", "text/plain")
+        content, content_type = await _retrieve_content(storage, ref)
+        assert content == b"data"
+        assert content_type == "text/plain"
+
+
+class TestPluginWithUnifiedStorage:
+    @pytest.mark.asyncio
+    async def test_offloads_text_block_to_one_framed_key(self):
+        storage = UnifiedInMemoryStorage()
+        plugin = ContextOffloader(
+            storage=storage, max_result_tokens=25, preview_tokens=10, include_retrieval_tool=False
+        )
+        agent = _agent()
+
+        await plugin._handle_tool_result(_after_tool_event(agent, [{"text": "x" * 400}]))
+
+        assert await storage.list("") == ["tool_123_0"]
+        content, content_type = await _retrieve_content(storage, "tool_123_0")
+        assert content == b"x" * 400
+        assert content_type == "text/plain"
+
+    @pytest.mark.asyncio
+    async def test_offloads_json_block_preserving_content_type(self):
+        storage = UnifiedInMemoryStorage()
+        plugin = ContextOffloader(storage=storage, max_result_tokens=10, preview_tokens=5, include_retrieval_tool=False)
+        agent = _agent()
+        payload = {"data": "y" * 400}
+
+        await plugin._handle_tool_result(_after_tool_event(agent, [{"json": payload}]))
+
+        content, content_type = await _retrieve_content(storage, "tool_123_0")
+        assert content_type == "application/json"
+        assert json.loads(content) == payload
+
+    @pytest.mark.asyncio
+    async def test_retrieval_tool_reads_back_offloaded_content(self):
+        storage = UnifiedInMemoryStorage()
+        plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10, include_retrieval_tool=True)
+        agent = _agent()
+        await plugin._handle_tool_result(_after_tool_event(agent, [{"text": "z" * 400}]))
+
+        tool_context = MagicMock()
+        tool_context.agent = agent
+        result = await plugin.retrieve_offloaded_content("tool_123_0", tool_context=tool_context)
+
+        assert result == "z" * 400
+
+
+class TestUnifiedEviction:
+    @pytest.mark.asyncio
+    async def test_evicts_entries_older_than_window(self):
+        storage = UnifiedInMemoryStorage()
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            evict_after_cycles=3,
+        )
+        agent = _agent(cycle_count=0)
+
+        await plugin._handle_tool_result(_after_tool_event(agent, [{"text": "x" * 400}]))
+        assert await storage.list("") == ["tool_123_0"]
+
+        # cycle 3: threshold = 3 - 3 = 0, stored at 0, 0 < 0 is False -> retained
+        await plugin._on_before_model_call(_before_model_event(agent, 3))
+        assert await storage.list("") == ["tool_123_0"]
+
+        # cycle 4: threshold = 4 - 3 = 1, stored at 0, 0 < 1 -> evicted
+        await plugin._on_before_model_call(_before_model_event(agent, 4))
+        assert await storage.list("") == []
+
+    @pytest.mark.asyncio
+    async def test_no_eviction_when_disabled(self):
+        storage = UnifiedInMemoryStorage()
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            evict_after_cycles=None,
+        )
+        agent = _agent(cycle_count=0)
+
+        await plugin._handle_tool_result(_after_tool_event(agent, [{"text": "x" * 400}]))
+        await plugin._on_before_model_call(_before_model_event(agent, 10_000))
+
+        assert await storage.list("") == ["tool_123_0"]
+
+
+class TestEvictAfterCyclesValidation:
+    @pytest.mark.parametrize("bad", [0, -1, -5])
+    def test_rejects_non_positive(self, bad):
+        with pytest.raises(ValueError, match="evict_after_cycles"):
+            ContextOffloader(storage=UnifiedInMemoryStorage(), evict_after_cycles=bad)
+
+    def test_accepts_none_and_positive(self):
+        ContextOffloader(storage=UnifiedInMemoryStorage(), evict_after_cycles=None)
+        ContextOffloader(storage=UnifiedInMemoryStorage(), evict_after_cycles=1)
+
+
+class TestLegacyWindowForwarding:
+    def test_forwards_window_when_legacy_storage_at_default(self):
+        storage = InMemoryStorage()  # default window (20)
+        plugin = ContextOffloader(storage=storage, evict_after_cycles=5)
+
+        plugin.init_agent(MagicMock())
+
+        assert storage._evict_after_turns == 5
+
+    def test_does_not_override_explicit_legacy_window(self):
+        storage = InMemoryStorage(evict_after_turns=100)
+        plugin = ContextOffloader(storage=storage, evict_after_cycles=5)
+
+        plugin.init_agent(MagicMock())
+
+        assert storage._evict_after_turns == 100


### PR DESCRIPTION
## Description

Ports the **unified storage interface** from strands-ts (#3099) into the Python SDK.

Adds a new `strands.storage` package — a minimal, four-operation persistence primitive over opaque `bytes`, keyed by `/`-separated path-like strings — plus three shipped backends and a `namespace()` factory. This is the Python twin of the strands-ts primitive; it establishes the same foundation for the phased "single persistence primitive for the SDK" design.

```python
from strands.storage import InMemoryStorage, LocalFileStorage, S3Storage

storage = LocalFileStorage("./.strands/")
await storage.write("sessions/abc/snapshot.json", data)   # -> None
raw = await storage.read("sessions/abc/snapshot.json")     # -> bytes | None
keys = await storage.list("sessions/")                      # -> sorted list[str]
await storage.delete("sessions/abc/snapshot.json")

scoped = storage.namespace("offloader")   # a prefixed view; composable
```

| Class | Backend |
|---|---|
| `InMemoryStorage` | `dict` (testing / serverless) |
| `LocalFileStorage` | filesystem, atomic host writes (tmp + `os.replace`), sandbox-aware via `for_sandbox()` |
| `S3Storage` | Amazon S3 via boto3 (lazy client, paginated `list`, `region`/`boto_session` mutual-exclusion) |

Also adds `StorageError` (`strands.types.exceptions`). Key normalization collapses `/` runs, strips leading/trailing `/`, and rejects empty keys and any `..` segment (path-traversal guard). `list` is a lexicographically-sorted prefix match.

## Related Issues

Port of strands-ts #3099. Requested by `lizradway` on that PR.

## Scope — primitive + context-offloader integration

This PR ships the unified primitive **and** wires the context-offloader onto it (per maintainer request on this PR), plus a sandbox parity fix. The one TS consumer still not ported is the **session `SnapshotStorageAdapter`**, which has no faithful Python analog: strands-ts sessions are snapshot-based (`SnapshotStorage`/`SnapshotLocation`/manifest) while strands-py sessions are **repository-based** (`SessionManager` ABC + `repository_session_manager` + `file`/`s3` managers) — there is no `SnapshotStorage` interface to adapt onto. That one is genuinely N/A rather than deferred.

### Context-offloader bridged onto the unified interface

`ContextOffloader` now accepts **either** a unified `strands.storage.Storage` (`write`/`read`/`delete`/`list`) **or** the legacy offloader `Storage` (`store`/`retrieve`, now deprecated), mirroring strands-ts #3099:

- **Detection:** `_is_offloader_storage` routes on `hasattr(store) and hasattr(retrieve)` (TS `'store' in storage && 'retrieve' in storage`).
- **Content-type framing:** for unified backends each block occupies one key, with the content-type framed into the bytes — `[2-byte BE content-type length][utf-8 content-type][content]` (`_frame_content`/`_unframe_content`); `_store_content`/`_retrieve_content` adapt between backends.
- **Plugin-driven eviction:** unified `Storage` has no built-in eviction, so the plugin tracks the store cycle per key and deletes entries older than a new keyword-only `evict_after_cycles` (default 20, `None` disables) on `BeforeModelCallEvent`; the window is forwarded to a legacy `InMemoryStorage` left at its default. `_on_before_model_call` is now async (the event loop dispatches this event via `invoke_callbacks_async`, which awaits coroutine hooks).
- **Deprecation:** the legacy offloader `Storage`/`InMemoryStorage`/`FileStorage`/`S3Storage` get doc-only `.. deprecated::` notes (mirrors TS's doc-only `@deprecated`).

### LocalFileStorage sandbox not-found parity

Sandbox-mode `read`/`delete`/`_list_keys_sandbox` now treat `NotADirectoryError` as not-found alongside `FileNotFoundError`, matching the host paths and TS `isNotFoundError` (ENOENT+ENOTDIR). `write` is intentionally unchanged (TS doesn't treat a non-directory parent as not-found on write).

## Type of Change

New feature

<details>
<summary><b>Behavior traceability — every strands-ts storage test has a Python counterpart</b></summary>

All 53 source `it(...)` behaviors across the four TS test files map to a Python test (0 missing); the Python suite adds a few extra edge tests. Independently verified by a fresh-context validation pass.

| TS test file | behaviors | Python test file |
|---|---|---|
| `in-memory-storage.test.ts` | 16 | `test_in_memory_storage.py` |
| `namespaced-storage.test.ts` | 10 | `test_namespaced_storage.py` (+ `.namespace()` method compose) |
| `local-file-storage.test.node.ts` | 14 | `test_local_file_storage.py` (+ forced rename-failure cleanup) |
| `s3-storage.test.ts` | 13 | `test_s3_storage.py` (+ truncated-without-token termination) |

**58 Python tests, all passing.**
</details>

<details>
<summary><b>Decision log — deviations from the source and why</b></summary>

- **`Storage` is a non-generic `Protocol`.** TS uses `Storage<ListQuery = string>`. PEP 696 `TypeVar` defaults are Python 3.13+ and the SDK targets 3.10+, so the generic-with-default isn't expressible. Dropped it: `list(prefix: str)`. A backend can still *widen* the parameter (contravariance keeps it structurally compatible), so no capability is lost.
- **`NAMESPACED` symbol → marker attribute.** TS uses `Symbol.for('strands.storage.namespaced')` + `NAMESPACED in obj`. Python has no symbols; the equivalent is a module-level marker attribute-name string, set via `setattr` and detected via `getattr`. Kept internal (not exported).
- **Copy-on-write only.** TS copies bytes on both read and write (`Uint8Array.slice()`). Python `bytes` is immutable, so `InMemoryStorage` copies via `bytes(data)` on write only; reads hand out the immutable object. The TS "copies on read" test becomes an immutability assertion.
- **`S3Storage` config = keyword args, boto conventions.** TS `S3StorageConfig` (`region` XOR `s3Client`) → explicit kwargs `prefix` / `region` / `boto_session` / `boto_client_config`, matching the existing `S3SessionManager` (mutual exclusion is `region` XOR `boto_session`; `user_agent_extra="strands-agents"`). boto3 is a hard dep so there's no lazy-import gap, but the client is still created lazily so constructing an `S3Storage` never needs AWS.
- **Top-level export.** TS surfaces the `Storage` type from its root barrel. Python idiom is submodule access (`from strands.storage import ...`), consistent with `strands.session`/`strands.memory`, so `strands/__init__.py` is left untouched. Easy to add a re-export if preferred.
- **Shared latent edges kept faithful to TS (not "fixed"):** the scratch-file exclusion uses the same `.__strands_tmp` substring check as TS (`local-file-storage.ts:191/218`), and directory listing treats an unknown `is_dir` (`None`/`undefined`) the same way TS does. Diverging would break cross-SDK parity; flagged here for a future cross-SDK fix instead.
</details>

<details>
<summary><b>One genuine divergence found in review — fixed</b></summary>

An independent review pass caught that `S3Storage.list` could infinite-loop if a backend returned a page with `IsTruncated=true` but no `NextContinuationToken`. strands-ts terminates in that case (`continuationToken = IsTruncated ? NextContinuationToken : undefined; while (continuationToken)`). Fixed to match, with a regression test. (Unreachable with a spec-compliant S3, but now equivalent to the source.)
</details>

<details>
<summary><b>Sensitive-surface scan</b></summary>

- **Path traversal:** `..` segments rejected in both key and prefix normalization (matches TS); normalized keys can't escape `base_dir`.
- **Filesystem:** atomic tmp + `os.replace`; scratch file removed on failure.
- **AWS:** boto3 client lazy; no credentials logged; error messages contain only bucket + normalized key.
- **No subprocess, no deserialization** (storage round-trips opaque bytes).
</details>

## Testing

Ran locally (no functional warnings):

- `pytest tests/strands/storage/ tests/strands/vended_plugins/context_offloader/` — **235 passed** (+18 new for the offloader bridge and sandbox parity)
- `ruff check` + `ruff format --check` on touched source & tests — clean
- `mypy ./src` — clean in `storage/` and `context_offloader/` (`boto3-stubs[s3]`)
- Full `tests/strands/vended_plugins/` — **487 passed** (no regressions)
- Two independent fresh-context review passes: correctness → *ship*; API bar-raiser → *land-these-then-approve* (all items addressed: privatized the internal `_StorageBackend` alias, documented `evict_after_cycles` + unified-storage acceptance, `bool` rejected in validation).

- [x] Ran the equivalent of `hatch run prepare` (ruff check, ruff format --check, mypy, pytest) directly — hatch not available in this environment.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

🤖 Generated by Strandly (an experimental AI agent). A human should review before merge. Docstrings and a `site/` docs page are intentionally deferred — happy to add them or split into a docs PR.