### PR TITLE
fix(models/gemini): detect throttling via ClientError status attribute

### DIFF
--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -594,21 +594,11 @@ class GeminiModel(Model):
                 yield self._format_chunk({"chunk_type": "metadata", "data": event.usage_metadata})
 
         except genai.errors.ClientError as error:
-            if not error.message:
-                raise
-
-            try:
-                message = json.loads(error.message) if error.message else {}
-            except json.JSONDecodeError as e:
-                logger.warning("error_message=<%s> | Gemini API returned non-JSON error", error.message)
-                # Re-raise the original ClientError (not JSONDecodeError) and make the JSON error the explicit cause
-                raise error from e
-
-            match message["error"]["status"]:
+            match error.status:
                 case "RESOURCE_EXHAUSTED" | "UNAVAILABLE":
-                    raise ModelThrottledException(error.message) from error
+                    raise ModelThrottledException(error.message or str(error)) from error
                 case "INVALID_ARGUMENT":
-                    if "exceeds the maximum number of tokens" in message["error"]["message"]:
+                    if error.message and "exceeds the maximum number of tokens" in error.message:
                         raise ContextWindowOverflowException(error.message) from error
                     raise error
                 case _:

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import unittest.mock
 
@@ -921,11 +920,16 @@ async def test_stream_response_empty_stream(gemini_client, model, messages, agen
 
 @pytest.mark.asyncio
 async def test_stream_response_throttled_exception(gemini_client, model, messages):
+    """Regression test for https://github.com/strands-agents/harness-sdk/issues/3226.
+
+    Vertex AI returns 429s whose message is plain text rather than a JSON document; the status
+    attribute alone must be enough to classify them as throttling.
+    """
     gemini_client.aio.models.generate_content_stream.side_effect = genai.errors.ClientError(
-        429, {"message": '{"error": {"status": "RESOURCE_EXHAUSTED"}}'}
+        429, {"error": {"status": "RESOURCE_EXHAUSTED", "message": "Resource exhausted. Please try again later."}}
     )
 
-    with pytest.raises(ModelThrottledException, match="RESOURCE_EXHAUSTED"):
+    with pytest.raises(ModelThrottledException, match="Resource exhausted. Please try again later."):
         await anext(model.stream(messages))
 
 
@@ -934,18 +938,14 @@ async def test_stream_response_context_overflow_exception(gemini_client, model, 
     gemini_client.aio.models.generate_content_stream.side_effect = genai.errors.ClientError(
         400,
         {
-            "message": json.dumps(
-                {
-                    "error": {
-                        "message": "request exceeds the maximum number of tokens (100)",
-                        "status": "INVALID_ARGUMENT",
-                    },
-                }
-            ),
+            "error": {
+                "message": "request exceeds the maximum number of tokens (100)",
+                "status": "INVALID_ARGUMENT",
+            },
         },
     )
 
-    with pytest.raises(ContextWindowOverflowException, match="INVALID_ARGUMENT"):
+    with pytest.raises(ContextWindowOverflowException, match="exceeds the maximum number of tokens"):
         await anext(model.stream(messages))
 
 
@@ -1060,18 +1060,14 @@ async def test_stream_request_with_gemini_tools_and_function_tools(gemini_client
 
 
 @pytest.mark.asyncio
-async def test_stream_handles_non_json_error(gemini_client, model, messages, caplog, alist):
+async def test_stream_handles_non_json_error(gemini_client, model, messages, alist):
     error_message = "Invalid API key"
     gemini_client.aio.models.generate_content_stream.side_effect = genai.errors.ClientError(
-        error_message, {"message": error_message}
+        400, {"error": {"message": error_message}}
     )
 
-    with caplog.at_level(logging.WARNING):
-        with pytest.raises(genai.errors.ClientError, match=error_message):
-            await alist(model.stream(messages))
-
-    assert "Gemini API returned non-JSON error" in caplog.text
-    assert f"error_message=<{error_message}>" in caplog.text
+    with pytest.raises(genai.errors.ClientError, match=error_message):
+        await alist(model.stream(messages))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Vertex AI returns 429s whose `message` is plain text rather than a JSON document. `GeminiModel.stream()` detected throttling by parsing `error.message` as JSON, so these errors were re-raised as raw `ClientError`s instead of `ModelThrottledException` — the event loop's built-in retry never fired and the 429 surfaced directly to callers. Since pay-as-you-go Gemini on Vertex AI uses Dynamic Shared Quota, any concurrent traffic can hit this.

The google-genai SDK already populates structured `code`/`status`/`message` attributes on `ClientError` from the response, so the handler now classifies errors by `error.status` instead of parsing `error.message`. This makes throttling and context-overflow detection independent of the message format (the attributes behave identically on the lowest supported google-genai version, 1.32.0).

The non-JSON warning path added in #1062 is removed along with the JSON parsing: classification no longer depends on the message format, so there is no non-JSON case left to warn about. Unclassifiable errors are re-raised unchanged, as before.

## Related Issues

Fixes #3226

Related: #1024, #1062, #370

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Also reproduced the failure end to end with a mocked Vertex AI-style 429 (structured status, plain-text message): before this change the raw `ClientError` escaped `stream()`; after it, the error is converted to `ModelThrottledException` and the built-in retry handles it. Gemini integration tests (`tests_integ`) were not run locally (no credentials); relying on CI for those.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
