### PR TITLE
fix(sagemaker): support vLLM v0.16.0+ reasoning field in streaming and non-streaming paths

### DIFF
--- a/strands-py/src/strands/models/sagemaker.py
+++ b/strands-py/src/strands/models/sagemaker.py
@@ -369,7 +369,9 @@ class SageMakerAIModel(OpenAIModel):
                             )
 
                         # Handle reasoning content
-                        if choice["delta"].get("reasoning_content"):
+                        # vLLM v0.16.0+ uses "reasoning" instead of "reasoning_content"
+                        reasoning_text = choice["delta"].get("reasoning_content") or choice["delta"].get("reasoning")
+                        if reasoning_text:
                             if not reasoning_content_started:
                                 yield self.format_chunk(
                                     {"chunk_type": "content_start", "data_type": "reasoning_content"}
@@ -379,7 +381,7 @@ class SageMakerAIModel(OpenAIModel):
                                 {
                                     "chunk_type": "content_delta",
                                     "data_type": "reasoning_content",
-                                    "data": choice["delta"]["reasoning_content"],
+                                    "data": reasoning_text,
                                 }
                             )
 
@@ -455,13 +457,15 @@ class SageMakerAIModel(OpenAIModel):
                     yield self.format_chunk({"chunk_type": "content_stop", "data_type": "text"})
 
                 # Handle reasoning content
-                if message.get("reasoning_content"):
+                # vLLM v0.16.0+ uses "reasoning" instead of "reasoning_content"
+                reasoning_text = message.get("reasoning_content") or message.get("reasoning")
+                if reasoning_text:
                     yield self.format_chunk({"chunk_type": "content_start", "data_type": "reasoning_content"})
                     yield self.format_chunk(
                         {
                             "chunk_type": "content_delta",
                             "data_type": "reasoning_content",
-                            "data": message["reasoning_content"],
+                            "data": reasoning_text,
                         }
                     )
                     yield self.format_chunk({"chunk_type": "content_stop", "data_type": "reasoning_content"})

--- a/strands-py/tests/strands/models/test_sagemaker.py
+++ b/strands-py/tests/strands/models/test_sagemaker.py
@@ -682,3 +682,186 @@ def test_update_config_validation_warns_on_unknown_keys(model, captured_warnings
     assert len(captured_warnings) == 1
     assert "Invalid configuration parameters" in str(captured_warnings[0].message)
     assert "wrong_param" in str(captured_warnings[0].message)
+
+
+class TestSageMakerReasoningContent:
+    """Tests for vLLM reasoning field support in streaming and non-streaming paths."""
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_with_reasoning_field(self, sagemaker_client, model, messages):
+        """vLLM v0.16.0+ sends reasoning in 'reasoning' field instead of 'reasoning_content'."""
+        mock_response = {
+            "Body": [
+                {
+                    "PayloadPart": {
+                        "Bytes": json.dumps(
+                            {"choices": [{"delta": {"reasoning": "Let me think..."}, "finish_reason": None}]}
+                        ).encode("utf-8")
+                    }
+                },
+                {
+                    "PayloadPart": {
+                        "Bytes": json.dumps(
+                            {"choices": [{"delta": {"content": "Paris."}, "finish_reason": "stop"}]}
+                        ).encode("utf-8")
+                    }
+                },
+            ]
+        }
+        sagemaker_client.invoke_endpoint_with_response_stream.return_value = mock_response
+
+        response = [chunk async for chunk in model.stream(messages)]
+
+        reasoning_deltas = [
+            e for e in response if "contentBlockDelta" in e and "reasoningContent" in e["contentBlockDelta"]["delta"]
+        ]
+        assert len(reasoning_deltas) == 1
+        assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"]["text"] == "Let me think..."
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_with_reasoning_content_field(self, sagemaker_client, model, messages):
+        """Old vLLM versions send reasoning in 'reasoning_content' field."""
+        mock_response = {
+            "Body": [
+                {
+                    "PayloadPart": {
+                        "Bytes": json.dumps(
+                            {"choices": [{"delta": {"reasoning_content": "Thinking..."}, "finish_reason": None}]}
+                        ).encode("utf-8")
+                    }
+                },
+                {
+                    "PayloadPart": {
+                        "Bytes": json.dumps(
+                            {"choices": [{"delta": {"content": "Paris."}, "finish_reason": "stop"}]}
+                        ).encode("utf-8")
+                    }
+                },
+            ]
+        }
+        sagemaker_client.invoke_endpoint_with_response_stream.return_value = mock_response
+
+        response = [chunk async for chunk in model.stream(messages)]
+
+        reasoning_deltas = [
+            e for e in response if "contentBlockDelta" in e and "reasoningContent" in e["contentBlockDelta"]["delta"]
+        ]
+        assert len(reasoning_deltas) == 1
+        assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"]["text"] == "Thinking..."
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_prefers_reasoning_content_over_reasoning(self, sagemaker_client, model, messages):
+        """When both fields are present, reasoning_content takes precedence."""
+        mock_response = {
+            "Body": [
+                {
+                    "PayloadPart": {
+                        "Bytes": json.dumps(
+                            {
+                                "choices": [
+                                    {
+                                        "delta": {"reasoning_content": "From old field", "reasoning": "From new field"},
+                                        "finish_reason": "stop",
+                                    }
+                                ]
+                            }
+                        ).encode("utf-8")
+                    }
+                },
+            ]
+        }
+        sagemaker_client.invoke_endpoint_with_response_stream.return_value = mock_response
+
+        response = [chunk async for chunk in model.stream(messages)]
+
+        reasoning_deltas = [
+            e for e in response if "contentBlockDelta" in e and "reasoningContent" in e["contentBlockDelta"]["delta"]
+        ]
+        assert len(reasoning_deltas) == 1
+        assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"]["text"] == "From old field"
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_skips_none_values(self, sagemaker_client, model, messages):
+        """Reasoning fields with None values should not emit reasoning content."""
+        mock_response = {
+            "Body": [
+                {
+                    "PayloadPart": {
+                        "Bytes": json.dumps(
+                            {
+                                "choices": [
+                                    {
+                                        "delta": {"reasoning_content": None, "reasoning": None, "content": "Hello"},
+                                        "finish_reason": "stop",
+                                    }
+                                ]
+                            }
+                        ).encode("utf-8")
+                    }
+                },
+            ]
+        }
+        sagemaker_client.invoke_endpoint_with_response_stream.return_value = mock_response
+
+        response = [chunk async for chunk in model.stream(messages)]
+
+        reasoning_deltas = [
+            e for e in response if "contentBlockDelta" in e and "reasoningContent" in e["contentBlockDelta"]["delta"]
+        ]
+        assert len(reasoning_deltas) == 0
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_reasoning_with_reasoning_field(self, sagemaker_client, model, messages):
+        """Non-streaming path: vLLM v0.16.0+ sends reasoning in 'reasoning' field."""
+        model.payload_config["stream"] = False
+
+        mock_response = {"Body": unittest.mock.MagicMock()}
+        mock_response["Body"].read.return_value = json.dumps(
+            {
+                "choices": [
+                    {
+                        "message": {"content": "Paris.", "reasoning": "Let me think...", "tool_calls": None},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30, "prompt_tokens_details": 0},
+            }
+        ).encode("utf-8")
+
+        sagemaker_client.invoke_endpoint.return_value = mock_response
+
+        response = [chunk async for chunk in model.stream(messages)]
+
+        reasoning_deltas = [
+            e for e in response if "contentBlockDelta" in e and "reasoningContent" in e["contentBlockDelta"]["delta"]
+        ]
+        assert len(reasoning_deltas) == 1
+        assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"]["text"] == "Let me think..."
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_reasoning_with_reasoning_content_field(self, sagemaker_client, model, messages):
+        """Non-streaming path: old vLLM versions send reasoning in 'reasoning_content' field."""
+        model.payload_config["stream"] = False
+
+        mock_response = {"Body": unittest.mock.MagicMock()}
+        mock_response["Body"].read.return_value = json.dumps(
+            {
+                "choices": [
+                    {
+                        "message": {"content": "Paris.", "reasoning_content": "Thinking...", "tool_calls": None},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30, "prompt_tokens_details": 0},
+            }
+        ).encode("utf-8")
+
+        sagemaker_client.invoke_endpoint.return_value = mock_response
+
+        response = [chunk async for chunk in model.stream(messages)]
+
+        reasoning_deltas = [
+            e for e in response if "contentBlockDelta" in e and "reasoningContent" in e["contentBlockDelta"]["delta"]
+        ]
+        assert len(reasoning_deltas) == 1
+        assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"]["text"] == "Thinking..."


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

vLLM deprecated reasoning_content in favor of reasoning in v0.16.0. The current SageMaker DLC runs v0.20.1, so reasoning content was being silently dropped. This aligns with the fix already merged for the OpenAI provider in #2354.

This PR updates the stale PR #2265 and adds unit tests. 
## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
