### PR TITLE
feat(py): add unified storage interface

### DIFF
--- a/strands-py/src/strands/__init__.py
+++ b/strands-py/src/strands/__init__.py
@@ -1,6 +1,6 @@
 """A framework for building, deploying, and managing AI agents."""
 
-from . import agent, models, telemetry, types
+from . import agent, models, storage, telemetry, types
 from .agent.agent import Agent
 from .agent.base import AgentBase
 from .event_loop._retry import ModelRetryStrategy
@@ -32,6 +32,7 @@ __all__ = [
     "SandboxTimeoutError",
     "Skill",
     "Snapshot",
+    "storage",
     "tool",
     "ToolContext",
     "types",

--- a/strands-py/src/strands/storage/__init__.py
+++ b/strands-py/src/strands/storage/__init__.py
@@ -1,0 +1,26 @@
+"""Unified storage module.
+
+Provides the Storage interface and shipped implementations for persisting
+raw bytes under string keys. All SDK subsystems that need persistence
+consume this interface.
+
+Example:
+    ```python
+    from strands.storage import LocalFileStorage, InMemoryStorage
+
+    storage = LocalFileStorage("./.strands/")
+    await storage.write("sessions/abc/snapshot.json", data)
+    ```
+"""
+
+from .in_memory_storage import InMemoryStorage
+from .local_file_storage import LocalFileStorage
+from .s3_storage import S3Storage
+from .storage import Storage
+
+__all__ = [
+    "InMemoryStorage",
+    "LocalFileStorage",
+    "S3Storage",
+    "Storage",
+]

--- a/strands-py/src/strands/storage/in_memory_storage.py
+++ b/strands-py/src/strands/storage/in_memory_storage.py
@@ -1,0 +1,106 @@
+"""In-memory storage implementation."""
+
+from __future__ import annotations
+
+import threading
+
+from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
+
+
+class InMemoryStorage:
+    """Map-backed storage for testing and short-lived processes.
+
+    Content does not survive process restarts. The store is unbounded — consumers
+    manage eviction themselves.
+
+    Example:
+        ```python
+        from strands.storage import InMemoryStorage
+
+        storage = InMemoryStorage()
+        await storage.write("sessions/abc/state.json", b'{"messages": []}')
+        data = await storage.read("sessions/abc/state.json")
+        ```
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty in-memory store."""
+        self._store: dict[str, bytes] = {}
+        self._lock = threading.Lock()
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store data under key, overwriting any existing value.
+
+        Args:
+            key: Opaque, '/'-separated key identifying the value.
+            data: Raw bytes to persist.
+
+        Raises:
+            StorageError: If the key is invalid.
+        """
+        normalized = _normalize_key(key)
+        with self._lock:
+            self._store[normalized] = bytes(data)
+
+    async def read(self, key: str) -> bytes | None:
+        """Retrieve the bytes previously stored under key.
+
+        Args:
+            key: The key to read.
+
+        Returns:
+            The stored bytes, or None if no value exists for key.
+
+        Raises:
+            StorageError: If the key is invalid.
+        """
+        normalized = _normalize_key(key)
+        with self._lock:
+            value = self._store.get(normalized)
+        return value
+
+    async def delete(self, key: str) -> None:
+        """Delete the value stored under key. A no-op if the key does not exist.
+
+        Args:
+            key: The key to delete.
+
+        Raises:
+            StorageError: If the key is invalid.
+        """
+        normalized = _normalize_key(key)
+        with self._lock:
+            self._store.pop(normalized, None)
+
+    async def list(self, query: str = "") -> list[str]:
+        """List keys matching the given prefix.
+
+        Args:
+            query: A prefix string to filter keys. Empty string matches all.
+
+        Returns:
+            Matching keys sorted ascending.
+
+        Raises:
+            StorageError: If the prefix is invalid.
+        """
+        prefix = _normalize_prefix(query)
+        with self._lock:
+            keys = sorted(k for k in self._store if k.startswith(prefix))
+        return keys
+
+    def namespace(self, prefix: str) -> _NamespacedStorage:
+        """Return a view of this storage with all keys prefixed.
+
+        Args:
+            prefix: Prefix to prepend to all keys.
+
+        Returns:
+            A namespaced storage view.
+        """
+        return _NamespacedStorage(self, prefix)
+
+    def clear(self) -> None:
+        """Remove all stored entries."""
+        with self._lock:
+            self._store.clear()

--- a/strands-py/src/strands/storage/in_memory_storage.py
+++ b/strands-py/src/strands/storage/in_memory_storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import threading
 
 from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
@@ -72,7 +73,7 @@ class InMemoryStorage:
         with self._lock:
             self._store.pop(normalized, None)
 
-    async def list(self, query: str = "") -> list[str]:
+    async def list(self, query: str = "") -> builtins.list[str]:
         """List keys matching the given prefix.
 
         Args:

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import os
 import uuid
 from pathlib import Path
@@ -152,7 +153,7 @@ class LocalFileStorage:
         except Exception as error:
             raise StorageError(f"Failed to delete '{key}'") from error
 
-    async def list(self, query: str = "") -> list[str]:
+    async def list(self, query: str = "") -> builtins.list[str]:
         """List keys matching the given prefix by walking the directory tree.
 
         Args:
@@ -195,7 +196,7 @@ class LocalFileStorage:
         """Map a normalized key to a filesystem path."""
         return os.path.join(self._base_dir, key)
 
-    def _list_keys_host(self, prefix: str) -> list[str]:
+    def _list_keys_host(self, prefix: str) -> builtins.list[str]:
         """Recursively walk the base directory to find all stored keys."""
         base = Path(self._base_dir)
 
@@ -209,7 +210,7 @@ class LocalFileStorage:
                 else:
                     break
 
-        keys: list[str] = []
+        keys: builtins.list[str] = []
         if not narrow_dir.exists():
             return keys
 
@@ -224,15 +225,15 @@ class LocalFileStorage:
 
         return keys
 
-    async def _list_keys_sandbox(self, prefix: str) -> list[str]:
+    async def _list_keys_sandbox(self, prefix: str) -> builtins.list[str]:
         """List keys via sandbox file listing."""
         base = Path(self._base_dir)
 
-        keys: list[str] = []
+        keys: builtins.list[str] = []
         await self._walk_sandbox(base, keys)
         return keys
 
-    async def _walk_sandbox(self, directory: Path, keys: list[str]) -> None:
+    async def _walk_sandbox(self, directory: Path, keys: builtins.list[str]) -> None:
         """Recursively walk sandbox directories to collect keys."""
         try:
             entries = await self._sandbox.list_files(str(directory))  # type: ignore[union-attr]

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -73,7 +73,7 @@ class LocalFileStorage:
 
         try:
             if self._sandbox is not None:
-                await self._sandbox.write_file(path, data.decode("utf-8") if isinstance(data, bytes) else data)
+                await self._sandbox.write_file(path, data)
                 return
 
             parent = os.path.dirname(path)
@@ -112,8 +112,7 @@ class LocalFileStorage:
 
         try:
             if self._sandbox is not None:
-                content = await self._sandbox.read_file(path)
-                return content.encode("utf-8") if isinstance(content, str) else content
+                return await self._sandbox.read_file(path)
 
             with open(path, "rb") as f:
                 return f.read()

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -1,0 +1,248 @@
+"""Local filesystem storage implementation."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..types.exceptions import StorageError
+from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
+
+if TYPE_CHECKING:
+    from ..sandbox.base import Sandbox
+
+_TMP_MARKER = ".__strands_tmp"
+
+
+class LocalFileStorage:
+    """Persists each key as a file under a base directory.
+
+    Key segments separated by '/' map to directory segments. Writes on the host
+    filesystem are atomic (write to temp file, then rename).
+
+    Example:
+        ```python
+        from strands.storage import LocalFileStorage
+
+        storage = LocalFileStorage("./.strands/")
+        await storage.write("session/abc/state.json", data)
+        ```
+    """
+
+    def __init__(self, base_dir: str = "./.strands/", *, sandbox: Sandbox | None = None) -> None:
+        """Initialize local file storage.
+
+        Args:
+            base_dir: Root directory under which all keys are stored.
+            sandbox: Optional sandbox to route I/O through.
+        """
+        self._base_dir = base_dir
+        self._sandbox = sandbox
+
+    def for_sandbox(self, sandbox: Sandbox) -> LocalFileStorage:
+        """Return a copy bound to the given sandbox.
+
+        If already bound to the same sandbox, returns self.
+
+        Args:
+            sandbox: Sandbox to bind to.
+
+        Returns:
+            A LocalFileStorage instance bound to the sandbox.
+        """
+        if self._sandbox is sandbox:
+            return self
+        return LocalFileStorage(self._base_dir, sandbox=sandbox)
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store data as a file, creating parent directories as needed.
+
+        On the host filesystem, writes are atomic via write-to-temp-then-rename.
+
+        Args:
+            key: Opaque, '/'-separated key identifying the value.
+            data: Raw bytes to persist.
+
+        Raises:
+            StorageError: If the write fails.
+        """
+        normalized = _normalize_key(key)
+        path = self._path_for(normalized)
+
+        try:
+            if self._sandbox is not None:
+                await self._sandbox.write_file(path, data.decode("utf-8") if isinstance(data, bytes) else data)
+                return
+
+            parent = os.path.dirname(path)
+            os.makedirs(parent, exist_ok=True)
+
+            tmp_path = os.path.join(parent, f"{_TMP_MARKER}_{uuid.uuid4().hex}")
+            try:
+                with open(tmp_path, "wb") as f:
+                    f.write(data)
+                os.replace(tmp_path, path)
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except StorageError:
+            raise
+        except Exception as error:
+            raise StorageError(f"Failed to write '{key}'") from error
+
+    async def read(self, key: str) -> bytes | None:
+        """Read the file corresponding to key.
+
+        Args:
+            key: The key to read.
+
+        Returns:
+            The file contents as bytes, or None if the file does not exist.
+
+        Raises:
+            StorageError: If the read fails for a reason other than a missing file.
+        """
+        normalized = _normalize_key(key)
+        path = self._path_for(normalized)
+
+        try:
+            if self._sandbox is not None:
+                content = await self._sandbox.read_file(path)
+                return content.encode("utf-8") if isinstance(content, str) else content
+
+            with open(path, "rb") as f:
+                return f.read()
+        except (FileNotFoundError, NotADirectoryError):
+            return None
+        except StorageError:
+            raise
+        except Exception as error:
+            raise StorageError(f"Failed to read '{key}'") from error
+
+    async def delete(self, key: str) -> None:
+        """Delete the file corresponding to key. No-op if it does not exist.
+
+        Args:
+            key: The key to delete.
+
+        Raises:
+            StorageError: If the delete fails.
+        """
+        normalized = _normalize_key(key)
+        path = self._path_for(normalized)
+
+        try:
+            if self._sandbox is not None:
+                try:
+                    await self._sandbox.remove_file(path)
+                except (FileNotFoundError, NotADirectoryError):
+                    pass
+                return
+
+            try:
+                os.unlink(path)
+            except (FileNotFoundError, NotADirectoryError):
+                pass
+        except StorageError:
+            raise
+        except Exception as error:
+            raise StorageError(f"Failed to delete '{key}'") from error
+
+    async def list(self, query: str = "") -> list[str]:
+        """List keys matching the given prefix by walking the directory tree.
+
+        Args:
+            query: A prefix string to filter keys. Empty string matches all.
+
+        Returns:
+            Matching keys sorted ascending.
+
+        Raises:
+            StorageError: If the listing fails.
+        """
+        prefix = _normalize_prefix(query)
+
+        try:
+            if self._sandbox is not None:
+                keys = await self._list_keys_sandbox(prefix)
+            else:
+                keys = self._list_keys_host(prefix)
+            return sorted(k for k in keys if k.startswith(prefix))
+        except StorageError:
+            raise
+        except Exception as error:
+            raise StorageError(f"Failed to list keys with prefix '{query}'") from error
+
+    def namespace(self, prefix: str) -> _NamespacedStorage:
+        """Return a view of this storage with all keys prefixed.
+
+        Args:
+            prefix: Prefix to prepend to all keys.
+
+        Returns:
+            A namespaced storage view.
+        """
+        return _NamespacedStorage(self, prefix)
+
+    def _path_for(self, key: str) -> str:
+        """Map a normalized key to a filesystem path."""
+        return os.path.join(self._base_dir, key)
+
+    def _list_keys_host(self, prefix: str) -> list[str]:
+        """Recursively walk the base directory to find all stored keys."""
+        base = Path(self._base_dir)
+
+        narrow_dir = base
+        if prefix:
+            parts = prefix.rstrip("/").split("/")
+            for part in parts[:-1]:
+                candidate = narrow_dir / part
+                if candidate.is_dir():
+                    narrow_dir = candidate
+                else:
+                    break
+
+        keys: list[str] = []
+        if not narrow_dir.exists():
+            return keys
+
+        for dirpath, _, filenames in os.walk(narrow_dir):
+            for filename in filenames:
+                if _TMP_MARKER in filename:
+                    continue
+                full_path = os.path.join(dirpath, filename)
+                rel = os.path.relpath(full_path, self._base_dir)
+                key = rel.replace(os.sep, "/")
+                keys.append(key)
+
+        return keys
+
+    async def _list_keys_sandbox(self, prefix: str) -> list[str]:
+        """List keys via sandbox file listing."""
+        base = Path(self._base_dir)
+
+        keys: list[str] = []
+        await self._walk_sandbox(base, keys)
+        return keys
+
+    async def _walk_sandbox(self, directory: Path, keys: list[str]) -> None:
+        """Recursively walk sandbox directories to collect keys."""
+        try:
+            entries = await self._sandbox.list_files(str(directory))  # type: ignore[union-attr]
+        except (FileNotFoundError, NotADirectoryError):
+            return
+
+        for entry in entries:
+            if _TMP_MARKER in entry.name:
+                continue
+            full_path = directory / entry.name
+            if entry.is_dir:
+                await self._walk_sandbox(full_path, keys)
+            else:
+                rel = os.path.relpath(str(full_path), self._base_dir)
+                keys.append(rel.replace(os.sep, "/"))

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..types.exceptions import StorageError
-from .storage import _NAMESPACED, _NamespacedStorage, _normalize_key, _normalize_prefix
+from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
 
 if TYPE_CHECKING:
     from ..sandbox.base import Sandbox
@@ -178,19 +178,20 @@ class LocalFileStorage:
         except Exception as error:
             raise StorageError(f"Failed to list keys with prefix '{query}'") from error
 
-    def namespace(self, prefix: str) -> _NamespacedLocalFileStorage:
+    def namespace(self, prefix: str) -> _NamespacedStorage:
         """Return a view of this storage with all keys prefixed.
 
-        The returned view preserves ``for_sandbox`` so sandbox routing works
-        even when storage is pre-namespaced before being passed to a plugin.
+        The returned view preserves ``for_sandbox`` via delegation to the
+        underlying storage, so sandbox routing works even when storage is
+        pre-namespaced before being passed to a plugin.
 
         Args:
             prefix: Prefix to prepend to all keys.
 
         Returns:
-            A namespaced storage view that also supports ``for_sandbox``.
+            A namespaced storage view.
         """
-        return _NamespacedLocalFileStorage(self, prefix)
+        return _NamespacedStorage(self, prefix)
 
     def _path_for(self, key: str) -> str:
         """Map a normalized key to a filesystem path."""
@@ -251,27 +252,3 @@ class LocalFileStorage:
                 keys.append(rel.replace(os.sep, "/"))
 
 
-class _NamespacedLocalFileStorage(_NamespacedStorage):
-    """A namespaced view of LocalFileStorage that preserves sandbox routing.
-
-    When ``for_sandbox`` is called, it binds the underlying LocalFileStorage
-    to the sandbox and re-wraps with the same prefix.
-    """
-
-    _namespaced = _NAMESPACED
-
-    def __init__(self, storage: LocalFileStorage, prefix: str) -> None:
-        super().__init__(storage, prefix)
-        self._local_storage = storage
-
-    def for_sandbox(self, sandbox: Sandbox) -> _NamespacedStorage:
-        """Return a namespaced view bound to the given sandbox.
-
-        Args:
-            sandbox: Sandbox to bind to.
-
-        Returns:
-            A namespaced storage view routed through the sandbox.
-        """
-        bound = self._local_storage.for_sandbox(sandbox)
-        return _NamespacedStorage(bound, self._prefix.rstrip("/"))

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..types.exceptions import StorageError
-from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
+from .storage import _NAMESPACED, _NamespacedStorage, _normalize_key, _normalize_prefix
 
 if TYPE_CHECKING:
     from ..sandbox.base import Sandbox
@@ -178,16 +178,19 @@ class LocalFileStorage:
         except Exception as error:
             raise StorageError(f"Failed to list keys with prefix '{query}'") from error
 
-    def namespace(self, prefix: str) -> _NamespacedStorage:
+    def namespace(self, prefix: str) -> _NamespacedLocalFileStorage:
         """Return a view of this storage with all keys prefixed.
+
+        The returned view preserves ``for_sandbox`` so sandbox routing works
+        even when storage is pre-namespaced before being passed to a plugin.
 
         Args:
             prefix: Prefix to prepend to all keys.
 
         Returns:
-            A namespaced storage view.
+            A namespaced storage view that also supports ``for_sandbox``.
         """
-        return _NamespacedStorage(self, prefix)
+        return _NamespacedLocalFileStorage(self, prefix)
 
     def _path_for(self, key: str) -> str:
         """Map a normalized key to a filesystem path."""
@@ -246,3 +249,29 @@ class LocalFileStorage:
             else:
                 rel = os.path.relpath(str(full_path), self._base_dir)
                 keys.append(rel.replace(os.sep, "/"))
+
+
+class _NamespacedLocalFileStorage(_NamespacedStorage):
+    """A namespaced view of LocalFileStorage that preserves sandbox routing.
+
+    When ``for_sandbox`` is called, it binds the underlying LocalFileStorage
+    to the sandbox and re-wraps with the same prefix.
+    """
+
+    _namespaced = _NAMESPACED
+
+    def __init__(self, storage: LocalFileStorage, prefix: str) -> None:
+        super().__init__(storage, prefix)
+        self._local_storage = storage
+
+    def for_sandbox(self, sandbox: Sandbox) -> _NamespacedStorage:
+        """Return a namespaced view bound to the given sandbox.
+
+        Args:
+            sandbox: Sandbox to bind to.
+
+        Returns:
+            A namespaced storage view routed through the sandbox.
+        """
+        bound = self._local_storage.for_sandbox(sandbox)
+        return _NamespacedStorage(bound, self._prefix.rstrip("/"))

--- a/strands-py/src/strands/storage/s3_storage.py
+++ b/strands-py/src/strands/storage/s3_storage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 from typing import Any
 
 from ..types.exceptions import StorageError
@@ -122,7 +123,7 @@ class S3Storage:
         except Exception as error:
             raise StorageError(f"Failed to delete '{key}' from S3") from error
 
-    async def list(self, query: str = "") -> list[str]:
+    async def list(self, query: str = "") -> builtins.list[str]:
         """List S3 objects matching the given prefix.
 
         Paginates automatically for large result sets.
@@ -145,9 +146,9 @@ class S3Storage:
         except Exception as error:
             raise StorageError(f"Failed to list keys with prefix '{query}' from S3") from error
 
-    def _list_sync(self, client: Any, s3_prefix: str) -> list[str]:
+    def _list_sync(self, client: Any, s3_prefix: str) -> builtins.list[str]:
         """Paginate list_objects_v2 synchronously (called via to_thread)."""
-        keys: list[str] = []
+        keys: builtins.list[str] = []
         continuation_token: str | None = None
 
         while True:

--- a/strands-py/src/strands/storage/s3_storage.py
+++ b/strands-py/src/strands/storage/s3_storage.py
@@ -1,0 +1,204 @@
+"""Amazon S3 storage implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..types.exceptions import StorageError
+from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
+
+_S3_PAGE_SIZE = 1000
+
+
+class S3Storage:
+    """Persists bytes as objects in an Amazon S3 bucket.
+
+    The AWS SDK (boto3) is imported lazily on first use so applications that
+    never use S3 don't pay the import cost.
+
+    Example:
+        ```python
+        from strands.storage import S3Storage
+
+        storage = S3Storage("my-bucket", prefix="agents/")
+        await storage.write("session/abc/state.json", data)
+        ```
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        prefix: str = "",
+        region_name: str | None = None,
+        boto_session: Any = None,
+        boto_client_config: Any = None,
+    ) -> None:
+        """Initialize S3 storage.
+
+        Args:
+            bucket: S3 bucket name.
+            prefix: Key prefix prepended to every key (namespace within the bucket).
+            region_name: AWS region override.
+            boto_session: Pre-configured boto3 session. Cannot combine with region_name.
+            boto_client_config: Botocore Config object for the S3 client.
+
+        Raises:
+            StorageError: If both region_name and boto_session are provided.
+        """
+        if region_name is not None and boto_session is not None:
+            raise StorageError("Cannot specify both region_name and boto_session")
+
+        self._bucket = bucket
+        normalized = _normalize_prefix(prefix)
+        self._prefix = f"{normalized}/" if normalized else ""
+        self._region_name = region_name
+        self._boto_session = boto_session
+        self._boto_client_config = boto_client_config
+        self._client: Any = None
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store data as an S3 object.
+
+        Args:
+            key: Opaque, '/'-separated key identifying the value.
+            data: Raw bytes to persist.
+
+        Raises:
+            StorageError: If the write fails.
+        """
+        normalized = _normalize_key(key)
+        client = self._get_client()
+        object_key = f"{self._prefix}{normalized}"
+
+        try:
+            client.put_object(Bucket=self._bucket, Key=object_key, Body=data)
+        except Exception as error:
+            raise StorageError(f"Failed to write '{key}' to S3") from error
+
+    async def read(self, key: str) -> bytes | None:
+        """Read an S3 object.
+
+        Args:
+            key: The key to read.
+
+        Returns:
+            The object contents as bytes, or None if the key does not exist.
+
+        Raises:
+            StorageError: If the read fails for a reason other than a missing key.
+        """
+        normalized = _normalize_key(key)
+        client = self._get_client()
+        object_key = f"{self._prefix}{normalized}"
+
+        try:
+            response = client.get_object(Bucket=self._bucket, Key=object_key)
+            return response["Body"].read()
+        except client.exceptions.NoSuchKey:
+            return None
+        except Exception as error:
+            error_code = getattr(getattr(error, "response", None), "get", lambda *_: None)
+            if callable(error_code):
+                resp = getattr(error, "response", None)
+                if resp and resp.get("Error", {}).get("Code") == "NoSuchKey":
+                    return None
+            raise StorageError(f"Failed to read '{key}' from S3") from error
+
+    async def delete(self, key: str) -> None:
+        """Delete an S3 object. No-op if the key does not exist.
+
+        Args:
+            key: The key to delete.
+
+        Raises:
+            StorageError: If the delete fails.
+        """
+        normalized = _normalize_key(key)
+        client = self._get_client()
+        object_key = f"{self._prefix}{normalized}"
+
+        try:
+            client.delete_object(Bucket=self._bucket, Key=object_key)
+        except Exception as error:
+            raise StorageError(f"Failed to delete '{key}' from S3") from error
+
+    async def list(self, query: str = "") -> list[str]:
+        """List S3 objects matching the given prefix.
+
+        Paginates automatically for large result sets.
+
+        Args:
+            query: A prefix string to filter keys. Empty string matches all.
+
+        Returns:
+            Matching keys sorted ascending, with the storage-level prefix stripped.
+
+        Raises:
+            StorageError: If the listing fails.
+        """
+        prefix = _normalize_prefix(query)
+        client = self._get_client()
+        s3_prefix = f"{self._prefix}{prefix}"
+
+        try:
+            keys: list[str] = []
+            continuation_token: str | None = None
+
+            while True:
+                kwargs: dict[str, Any] = {
+                    "Bucket": self._bucket,
+                    "Prefix": s3_prefix,
+                    "MaxKeys": _S3_PAGE_SIZE,
+                }
+                if continuation_token:
+                    kwargs["ContinuationToken"] = continuation_token
+
+                response = client.list_objects_v2(**kwargs)
+
+                for obj in response.get("Contents", []):
+                    key = obj["Key"]
+                    if self._prefix and key.startswith(self._prefix):
+                        key = key[len(self._prefix) :]
+                    keys.append(key)
+
+                if not response.get("IsTruncated"):
+                    break
+                continuation_token = response.get("NextContinuationToken")
+
+            return sorted(keys)
+        except Exception as error:
+            raise StorageError(f"Failed to list keys with prefix '{query}' from S3") from error
+
+    def namespace(self, prefix: str) -> _NamespacedStorage:
+        """Return a view of this storage with all keys prefixed.
+
+        Args:
+            prefix: Prefix to prepend to all keys.
+
+        Returns:
+            A namespaced storage view.
+        """
+        return _NamespacedStorage(self, prefix)
+
+    def _get_client(self) -> Any:
+        """Lazily create and cache the S3 client."""
+        if self._client is not None:
+            return self._client
+
+        import boto3
+        from botocore.config import Config
+
+        config = self._boto_client_config
+        if config is None:
+            config = Config(user_agent_extra="strands-agents")
+        elif not getattr(config, "user_agent_extra", None):
+            config = config.merge(Config(user_agent_extra="strands-agents"))
+
+        if self._boto_session is not None:
+            session = self._boto_session
+        else:
+            session = boto3.Session(region_name=self._region_name)
+
+        self._client = session.client("s3", config=config)
+        return self._client

--- a/strands-py/src/strands/storage/s3_storage.py
+++ b/strands-py/src/strands/storage/s3_storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from ..types.exceptions import StorageError
@@ -72,7 +73,7 @@ class S3Storage:
         object_key = f"{self._prefix}{normalized}"
 
         try:
-            client.put_object(Bucket=self._bucket, Key=object_key, Body=data)
+            await asyncio.to_thread(client.put_object, Bucket=self._bucket, Key=object_key, Body=data)
         except Exception as error:
             raise StorageError(f"Failed to write '{key}' to S3") from error
 
@@ -93,16 +94,14 @@ class S3Storage:
         object_key = f"{self._prefix}{normalized}"
 
         try:
-            response = client.get_object(Bucket=self._bucket, Key=object_key)
-            return response["Body"].read()
+            response = await asyncio.to_thread(client.get_object, Bucket=self._bucket, Key=object_key)
+            return await asyncio.to_thread(response["Body"].read)
         except client.exceptions.NoSuchKey:
             return None
         except Exception as error:
-            error_code = getattr(getattr(error, "response", None), "get", lambda *_: None)
-            if callable(error_code):
-                resp = getattr(error, "response", None)
-                if resp and resp.get("Error", {}).get("Code") == "NoSuchKey":
-                    return None
+            resp = getattr(error, "response", None)
+            if resp and resp.get("Error", {}).get("Code") == "NoSuchKey":
+                return None
             raise StorageError(f"Failed to read '{key}' from S3") from error
 
     async def delete(self, key: str) -> None:
@@ -119,7 +118,7 @@ class S3Storage:
         object_key = f"{self._prefix}{normalized}"
 
         try:
-            client.delete_object(Bucket=self._bucket, Key=object_key)
+            await asyncio.to_thread(client.delete_object, Bucket=self._bucket, Key=object_key)
         except Exception as error:
             raise StorageError(f"Failed to delete '{key}' from S3") from error
 
@@ -142,33 +141,37 @@ class S3Storage:
         s3_prefix = f"{self._prefix}{prefix}"
 
         try:
-            keys: list[str] = []
-            continuation_token: str | None = None
-
-            while True:
-                kwargs: dict[str, Any] = {
-                    "Bucket": self._bucket,
-                    "Prefix": s3_prefix,
-                    "MaxKeys": _S3_PAGE_SIZE,
-                }
-                if continuation_token:
-                    kwargs["ContinuationToken"] = continuation_token
-
-                response = client.list_objects_v2(**kwargs)
-
-                for obj in response.get("Contents", []):
-                    key = obj["Key"]
-                    if self._prefix and key.startswith(self._prefix):
-                        key = key[len(self._prefix) :]
-                    keys.append(key)
-
-                if not response.get("IsTruncated"):
-                    break
-                continuation_token = response.get("NextContinuationToken")
-
-            return sorted(keys)
+            return await asyncio.to_thread(self._list_sync, client, s3_prefix)
         except Exception as error:
             raise StorageError(f"Failed to list keys with prefix '{query}' from S3") from error
+
+    def _list_sync(self, client: Any, s3_prefix: str) -> list[str]:
+        """Paginate list_objects_v2 synchronously (called via to_thread)."""
+        keys: list[str] = []
+        continuation_token: str | None = None
+
+        while True:
+            kwargs: dict[str, Any] = {
+                "Bucket": self._bucket,
+                "Prefix": s3_prefix,
+                "MaxKeys": _S3_PAGE_SIZE,
+            }
+            if continuation_token:
+                kwargs["ContinuationToken"] = continuation_token
+
+            response = client.list_objects_v2(**kwargs)
+
+            for obj in response.get("Contents", []):
+                key = obj["Key"]
+                if self._prefix and key.startswith(self._prefix):
+                    key = key[len(self._prefix) :]
+                keys.append(key)
+
+            if not response.get("IsTruncated"):
+                break
+            continuation_token = response.get("NextContinuationToken")
+
+        return sorted(keys)
 
     def namespace(self, prefix: str) -> _NamespacedStorage:
         """Return a view of this storage with all keys prefixed.

--- a/strands-py/src/strands/storage/storage.py
+++ b/strands-py/src/strands/storage/storage.py
@@ -47,7 +47,8 @@ def _normalize_prefix(prefix: str) -> str:
     """Normalize a list prefix.
 
     Collapses slash runs, strips leading slashes. Unlike a key, an empty
-    prefix is valid and matches everything.
+    prefix is valid and matches everything. A trailing slash is preserved
+    because it is semantically significant for prefix matching.
 
     Args:
         prefix: The raw prefix to normalize.
@@ -145,7 +146,7 @@ class _NamespacedStorage:
     _namespaced = _NAMESPACED
 
     def __init__(self, storage: Storage, prefix: str) -> None:
-        normalized = _normalize_prefix(prefix)
+        normalized = _normalize_prefix(prefix).rstrip("/")
         self._storage = storage
         self._prefix = f"{normalized}/" if normalized else ""
 
@@ -169,3 +170,11 @@ class _NamespacedStorage:
     def namespace(self, prefix: str) -> _NamespacedStorage:
         """Return a further-scoped view by nesting prefixes."""
         return _NamespacedStorage(self._storage, f"{self._prefix}{prefix}")
+
+    def for_sandbox(self, sandbox: object) -> _NamespacedStorage:
+        """Delegate sandbox binding to the underlying storage and re-wrap."""
+        inner = self._storage
+        if not hasattr(inner, "for_sandbox"):
+            return self
+        bound = inner.for_sandbox(sandbox)  # type: ignore[union-attr]
+        return _NamespacedStorage(bound, self._prefix.rstrip("/"))

--- a/strands-py/src/strands/storage/storage.py
+++ b/strands-py/src/strands/storage/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import re
 from typing import Protocol, runtime_checkable
 
@@ -9,7 +10,7 @@ from typing_extensions import TypeVar
 
 from ..types.exceptions import StorageError
 
-ListQuery = TypeVar("ListQuery", default=str)
+ListQuery = TypeVar("ListQuery", default=str, contravariant=True)
 
 _NAMESPACED: object = object()
 """Internal sentinel marking a storage view as already namespace-scoped.
@@ -117,7 +118,7 @@ class Storage(Protocol[ListQuery]):
         """
         ...
 
-    async def list(self, query: ListQuery) -> list[str]:
+    async def list(self, query: ListQuery) -> builtins.list[str]:
         """List keys matching the given prefix query.
 
         Returns full keys (not the suffix after the prefix), sorted
@@ -160,7 +161,7 @@ class _NamespacedStorage:
         """Delete the prefixed key."""
         await self._storage.delete(f"{self._prefix}{key}")
 
-    async def list(self, query: str = "") -> list[str]:
+    async def list(self, query: str = "") -> builtins.list[str]:
         """List keys under the prefix, stripping it from results."""
         keys = await self._storage.list(f"{self._prefix}{query}")
         return [key[len(self._prefix) :] for key in keys]

--- a/strands-py/src/strands/storage/storage.py
+++ b/strands-py/src/strands/storage/storage.py
@@ -1,0 +1,170 @@
+"""Unified storage interface and key-normalization helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Protocol, runtime_checkable
+
+from typing_extensions import TypeVar
+
+from ..types.exceptions import StorageError
+
+ListQuery = TypeVar("ListQuery", default=str)
+
+_NAMESPACED: object = object()
+"""Internal sentinel marking a storage view as already namespace-scoped.
+
+SDK constructs use this to detect whether the caller already scoped the storage,
+so the default auto-prefix can be skipped.
+"""
+
+
+def _normalize_key(key: str) -> str:
+    """Validate and normalize a storage key.
+
+    Collapses runs of '/', strips leading and trailing '/', rejects empty
+    keys, and rejects any '..' segment.
+
+    Args:
+        key: The raw key to normalize.
+
+    Returns:
+        The normalized key.
+
+    Raises:
+        StorageError: If the key is empty or contains a '..' segment.
+    """
+    normalized = re.sub(r"/+", "/", key).strip("/")
+    if not normalized:
+        raise StorageError("Storage key must not be empty")
+    if ".." in normalized.split("/"):
+        raise StorageError(f"Invalid storage key '{key}': '..' path segments are not allowed")
+    return normalized
+
+
+def _normalize_prefix(prefix: str) -> str:
+    """Normalize a list prefix.
+
+    Collapses slash runs, strips leading slashes. Unlike a key, an empty
+    prefix is valid and matches everything.
+
+    Args:
+        prefix: The raw prefix to normalize.
+
+    Returns:
+        The normalized prefix.
+
+    Raises:
+        StorageError: If the prefix contains a '..' segment.
+    """
+    normalized = re.sub(r"/+", "/", prefix).lstrip("/")
+    if ".." in normalized.split("/"):
+        raise StorageError(f"Invalid storage prefix '{prefix}': '..' path segments are not allowed")
+    return normalized
+
+
+@runtime_checkable
+class Storage(Protocol[ListQuery]):
+    """A backend for storing and retrieving raw bytes under string keys.
+
+    The interface is deliberately minimal — four operations over opaque bytes
+    values. Implementations must treat keys as opaque path-like strings (segments
+    separated by '/') and must round-trip the bytes they are given unchanged.
+
+    The ``ListQuery`` type parameter controls what ``list`` accepts. It defaults to
+    ``str`` (a key prefix), which every backend supports. Implementations may
+    widen it to accept a richer query object while still accepting a plain string
+    for SDK-internal callers.
+
+    Implement this to add a custom backend; the SDK ships :class:`InMemoryStorage`,
+    :class:`LocalFileStorage`, and :class:`S3Storage`.
+    """
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store data under key, overwriting any existing value.
+
+        Args:
+            key: Opaque, '/'-separated key identifying the value.
+            data: Raw bytes to persist.
+
+        Raises:
+            StorageError: If the write fails.
+        """
+        ...
+
+    async def read(self, key: str) -> bytes | None:
+        """Retrieve the bytes previously stored under key.
+
+        Args:
+            key: The key to read.
+
+        Returns:
+            The stored bytes, or None if no value exists for key.
+
+        Raises:
+            StorageError: If the read fails for a reason other than a missing key.
+        """
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Delete the value stored under key. A no-op if the key does not exist.
+
+        Args:
+            key: The key to delete.
+
+        Raises:
+            StorageError: If the delete fails.
+        """
+        ...
+
+    async def list(self, query: ListQuery) -> list[str]:
+        """List keys matching the given prefix query.
+
+        Returns full keys (not the suffix after the prefix), sorted
+        lexicographically. An empty string lists every key.
+
+        Args:
+            query: A string prefix to match.
+
+        Returns:
+            The matching keys, sorted ascending.
+
+        Raises:
+            StorageError: If the listing fails.
+        """
+        ...
+
+
+class _NamespacedStorage:
+    """A storage view that prepends a prefix to all keys.
+
+    Composable — calling ``.namespace()`` on the result nests prefixes.
+    """
+
+    _namespaced = _NAMESPACED
+
+    def __init__(self, storage: Storage, prefix: str) -> None:
+        normalized = _normalize_prefix(prefix)
+        self._storage = storage
+        self._prefix = f"{normalized}/" if normalized else ""
+
+    async def write(self, key: str, data: bytes) -> None:
+        """Store data under the prefixed key."""
+        await self._storage.write(f"{self._prefix}{key}", data)
+
+    async def read(self, key: str) -> bytes | None:
+        """Read from the prefixed key."""
+        return await self._storage.read(f"{self._prefix}{key}")
+
+    async def delete(self, key: str) -> None:
+        """Delete the prefixed key."""
+        await self._storage.delete(f"{self._prefix}{key}")
+
+    async def list(self, query: str = "") -> list[str]:
+        """List keys under the prefix, stripping it from results."""
+        keys = await self._storage.list(f"{self._prefix}{query}")
+        return [key[len(self._prefix) :] for key in keys]
+
+    def namespace(self, prefix: str) -> _NamespacedStorage:
+        """Return a further-scoped view by nesting prefixes."""
+        return _NamespacedStorage(self._storage, f"{self._prefix}{prefix}")

--- a/strands-py/src/strands/storage/storage.py
+++ b/strands-py/src/strands/storage/storage.py
@@ -176,5 +176,5 @@ class _NamespacedStorage:
         inner = self._storage
         if not hasattr(inner, "for_sandbox"):
             return self
-        bound = inner.for_sandbox(sandbox)  # type: ignore[union-attr]
+        bound = inner.for_sandbox(sandbox)
         return _NamespacedStorage(bound, self._prefix.rstrip("/"))

--- a/strands-py/src/strands/types/exceptions.py
+++ b/strands-py/src/strands/types/exceptions.py
@@ -142,6 +142,16 @@ class CheckpointException(Exception):
     pass
 
 
+class StorageError(Exception):
+    """Raised when a storage operation fails.
+
+    Wraps backend-specific errors (filesystem, S3, network) with a uniform type
+    that consumers can catch without knowing which backend is in use.
+    """
+
+    pass
+
+
 class AggregateMemoryError(Exception):
     """Raised when one or more memory store operations fail.
 

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -41,7 +41,7 @@ from typing_extensions import TypedDict
 
 from ...hooks.events import AfterToolCallEvent, BeforeModelCallEvent
 from ...plugins import Plugin, hook
-from ...storage import LocalFileStorage, Storage
+from ...storage import Storage
 from ...storage.storage import _NAMESPACED, _NamespacedStorage
 from ...tools.decorator import tool
 from ...types.content import Message
@@ -238,9 +238,9 @@ class ContextOffloader(Plugin):
     def _storage_for_agent(self, agent: Agent) -> Storage | _LegacyStorage:
         """Return the storage for an agent, binding file-based storage to its sandbox.
 
-        FileStorage (legacy) and LocalFileStorage (unified) are bound once per
-        agent to that agent's sandbox via ``for_sandbox()``, then re-wrapped with
-        the namespace if applicable. All other backends are shared as-is.
+        Any storage (or namespaced view) exposing ``for_sandbox()`` is bound once
+        per agent to that agent's sandbox. Legacy FileStorage is handled the same
+        way. All other backends are shared as-is.
 
         Args:
             agent: The agent whose storage to resolve.
@@ -248,12 +248,15 @@ class ContextOffloader(Plugin):
         Returns:
             The storage instance for this agent.
         """
-        if not isinstance(self._raw_storage, (FileStorage, LocalFileStorage)):
+        sandboxable = self._storage if hasattr(self._storage, "for_sandbox") else None
+        if sandboxable is None and not isinstance(self._storage, FileStorage):
             return self._storage
         storage = self._storage_by_agent.get(agent)
         if storage is None:
-            bound = self._raw_storage.for_sandbox(agent.sandbox)
-            storage = self._resolve_storage(bound)
+            if sandboxable is not None:
+                storage = sandboxable.for_sandbox(agent.sandbox)  # type: ignore[union-attr]
+            else:
+                storage = self._storage.for_sandbox(agent.sandbox)  # type: ignore[union-attr]
             self._storage_by_agent[agent] = storage
         return storage
 
@@ -279,12 +282,13 @@ class ContextOffloader(Plugin):
             return
 
         # Cycle-based eviction for unified Storage
+        storage = self._storage_for_agent(event.agent)
         threshold = cycle - self._evict_after_cycles
         stale_keys = [key for key, stored_cycle in self._stored_cycles.items() if stored_cycle < threshold]
         if stale_keys:
             for key in stale_keys:
                 try:
-                    await self._storage.delete(key)  # type: ignore[union-attr]
+                    await storage.delete(key)  # type: ignore[union-attr]
                 except Exception:
                     pass
                 del self._stored_cycles[key]

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -89,9 +89,7 @@ def _unframe_content(frame: bytes) -> tuple[bytes, str]:
         raise ValueError(f"Corrupt storage frame: expected at least 2 bytes, got {len(frame)}")
     ct_len = (frame[0] << 8) | frame[1]
     if len(frame) < 2 + ct_len:
-        raise ValueError(
-            f"Corrupt storage frame: content-type length {ct_len} exceeds frame size {len(frame)}"
-        )
+        raise ValueError(f"Corrupt storage frame: content-type length {ct_len} exceeds frame size {len(frame)}")
     content_type = frame[2 : 2 + ct_len].decode("utf-8")
     content = frame[2 + ct_len :]
     return content, content_type
@@ -225,9 +223,7 @@ class ContextOffloader(Plugin):
 
         self._raw_storage: Storage | _LegacyStorage = storage
         self._storage: Storage | _LegacyStorage = self._resolve_storage(storage)
-        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, Storage | _LegacyStorage] = (
-            weakref.WeakKeyDictionary()
-        )
+        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, Storage | _LegacyStorage] = weakref.WeakKeyDictionary()
         self._max_result_tokens = max_result_tokens
         self._preview_tokens = preview_tokens
         self._include_retrieval_tool = include_retrieval_tool
@@ -260,7 +256,7 @@ class ContextOffloader(Plugin):
             return self._storage
         storage = self._storage_by_agent.get(agent)
         if storage is None:
-            storage = self._storage.for_sandbox(agent.sandbox)  # type: ignore[union-attr]
+            storage = self._storage.for_sandbox(agent.sandbox)
             self._storage_by_agent[agent] = storage
         return storage
 

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -47,7 +47,7 @@ from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
 from .search import _is_searchable_content, _search_content
-from .storage import FileStorage, InMemoryStorage
+from .storage import InMemoryStorage
 from .storage import Storage as _LegacyStorage
 
 if TYPE_CHECKING:
@@ -248,8 +248,7 @@ class ContextOffloader(Plugin):
         """Return the storage for an agent, binding file-based storage to its sandbox.
 
         Any storage (or namespaced view) exposing ``for_sandbox()`` is bound once
-        per agent to that agent's sandbox. Legacy FileStorage is handled the same
-        way. All other backends are shared as-is.
+        per agent to that agent's sandbox. All other backends are shared as-is.
 
         Args:
             agent: The agent whose storage to resolve.
@@ -257,15 +256,11 @@ class ContextOffloader(Plugin):
         Returns:
             The storage instance for this agent.
         """
-        sandboxable = self._storage if hasattr(self._storage, "for_sandbox") else None
-        if sandboxable is None and not isinstance(self._storage, FileStorage):
+        if not hasattr(self._storage, "for_sandbox"):
             return self._storage
         storage = self._storage_by_agent.get(agent)
         if storage is None:
-            if sandboxable is not None:
-                storage = sandboxable.for_sandbox(agent.sandbox)
-            else:
-                storage = self._storage.for_sandbox(agent.sandbox)  # type: ignore[union-attr]
+            storage = self._storage.for_sandbox(agent.sandbox)  # type: ignore[union-attr]
             self._storage_by_agent[agent] = storage
         return storage
 
@@ -298,13 +293,17 @@ class ContextOffloader(Plugin):
         threshold = cycle - self._evict_after_cycles
         stale_keys = [key for key, stored_cycle in agent_cycles.items() if stored_cycle < threshold]
         if stale_keys:
+            evicted = 0
             for key in stale_keys:
                 try:
                     await storage.delete(key)  # type: ignore[union-attr]
                 except Exception:
                     logger.debug("key=<%s> | failed to evict stale entry", key)
+                    continue
                 del agent_cycles[key]
-            logger.debug("evicted=<%d>, cycle=<%d> | stale entries removed", len(stale_keys), cycle)
+                evicted += 1
+            if evicted:
+                logger.debug("evicted=<%d>, cycle=<%d> | stale entries removed", evicted, cycle)
 
     @tool(context=True)
     async def retrieve_offloaded_content(

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -41,16 +41,78 @@ from typing_extensions import TypedDict
 
 from ...hooks.events import AfterToolCallEvent, BeforeModelCallEvent
 from ...plugins import Plugin, hook
+from ...storage import LocalFileStorage
+from ...storage import Storage as UnifiedStorage
+from ...storage.storage import _NAMESPACED, _NamespacedStorage
 from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
 from .search import _is_searchable_content, _search_content
-from .storage import FileStorage, InMemoryStorage, Storage
+from .storage import FileStorage, InMemoryStorage
+from .storage import Storage as OffloaderStorage
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
 
 logger = logging.getLogger(__name__)
+
+
+def _is_offloader_storage(storage: UnifiedStorage | OffloaderStorage) -> bool:
+    """Detect legacy offloader storage by presence of store/retrieve methods."""
+    return hasattr(storage, "store") and hasattr(storage, "retrieve")
+
+
+def _frame_content(data: bytes, content_type: str) -> bytes:
+    """Frame content with its content-type for unified Storage.
+
+    Format: [2-byte BE content-type length][content-type UTF-8][content bytes]
+    """
+    ct_bytes = content_type.encode("utf-8")
+    ct_len = len(ct_bytes)
+    frame = bytearray(2 + ct_len + len(data))
+    frame[0] = (ct_len >> 8) & 0xFF
+    frame[1] = ct_len & 0xFF
+    frame[2 : 2 + ct_len] = ct_bytes
+    frame[2 + ct_len :] = data
+    return bytes(frame)
+
+
+def _unframe_content(frame: bytes) -> tuple[bytes, str]:
+    """Unframe content stored via unified Storage.
+
+    Returns:
+        Tuple of (content bytes, content type).
+    """
+    ct_len = (frame[0] << 8) | frame[1]
+    content_type = frame[2 : 2 + ct_len].decode("utf-8")
+    content = frame[2 + ct_len :]
+    return content, content_type
+
+
+async def _store_content(
+    storage: UnifiedStorage | OffloaderStorage,
+    key: str,
+    content: bytes,
+    content_type: str,
+) -> str:
+    """Store content via either unified or legacy storage."""
+    if _is_offloader_storage(storage):
+        return await storage.store(key, content, content_type)  # type: ignore[union-attr]
+    await storage.write(key, _frame_content(content, content_type))  # type: ignore[union-attr]
+    return key
+
+
+async def _retrieve_content(
+    storage: UnifiedStorage | OffloaderStorage,
+    reference: str,
+) -> tuple[bytes, str]:
+    """Retrieve content from either unified or legacy storage."""
+    if _is_offloader_storage(storage):
+        return await storage.retrieve(reference)  # type: ignore[union-attr]
+    data = await storage.read(reference)  # type: ignore[union-attr]
+    if data is None:
+        raise KeyError(f"Reference not found: {reference}")
+    return _unframe_content(data)
 
 
 class LineRange(TypedDict):
@@ -116,16 +178,19 @@ class ContextOffloader(Plugin):
 
     def __init__(
         self,
-        storage: Storage,
+        storage: UnifiedStorage | OffloaderStorage,
         max_result_tokens: int = _DEFAULT_MAX_RESULT_TOKENS,
         preview_tokens: int = _DEFAULT_PREVIEW_TOKENS,
         *,
         include_retrieval_tool: bool = True,
+        evict_after_cycles: int | None = 20,
     ) -> None:
         """Initialize the ContextOffloader plugin.
 
         Args:
-            storage: Backend for storing offloaded content.
+            storage: Backend for storing offloaded content. Accepts either a unified
+                ``Storage`` (from ``strands.storage``) or a legacy offloader ``Storage``
+                (from this module).
             max_result_tokens: Offload results whose estimated token count exceeds this
                 threshold. Defaults to ``_DEFAULT_MAX_RESULT_TOKENS`` (2,500).
             preview_tokens: Number of tokens to keep as a text preview in context.
@@ -133,10 +198,13 @@ class ContextOffloader(Plugin):
                 chars/4 heuristic. Defaults to ``_DEFAULT_PREVIEW_TOKENS`` (1,000).
             include_retrieval_tool: Whether to register the ``retrieve_offloaded_content``
                 tool so the agent can fetch offloaded content. Defaults to True.
+            evict_after_cycles: Number of agent loop cycles before an offloaded entry is
+                evicted (unified Storage only). Entries stored more than this many cycles
+                ago are deleted. Defaults to 20. Set to None to disable eviction.
 
         Raises:
             ValueError: If max_result_tokens is not positive, preview_tokens is negative,
-                or preview_tokens >= max_result_tokens.
+                preview_tokens >= max_result_tokens, or evict_after_cycles is invalid.
         """
         if max_result_tokens <= 0:
             raise ValueError("max_result_tokens must be positive")
@@ -144,22 +212,36 @@ class ContextOffloader(Plugin):
             raise ValueError("preview_tokens must be non-negative")
         if preview_tokens >= max_result_tokens:
             raise ValueError("preview_tokens must be less than max_result_tokens")
+        if evict_after_cycles is not None and (not isinstance(evict_after_cycles, int) or evict_after_cycles < 1):
+            raise ValueError("evict_after_cycles must be a positive integer or None")
 
-        self._storage = storage
-        # Per-agent FileStorage bound to that agent's sandbox; other backends are shared as-is.
-        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, Storage] = weakref.WeakKeyDictionary()
+        self._raw_storage: UnifiedStorage | OffloaderStorage = storage
+        self._storage: UnifiedStorage | OffloaderStorage = self._resolve_storage(storage)
+        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, UnifiedStorage | OffloaderStorage] = (
+            weakref.WeakKeyDictionary()
+        )
         self._max_result_tokens = max_result_tokens
         self._preview_tokens = preview_tokens
         self._include_retrieval_tool = include_retrieval_tool
+        self._evict_after_cycles = evict_after_cycles
+        self._stored_cycles: dict[str, int] = {}
         super().__init__()
 
-    def _storage_for_agent(self, agent: Agent) -> Storage:
-        """Return the storage for an agent, binding FileStorage to its sandbox.
+    @staticmethod
+    def _resolve_storage(storage: UnifiedStorage | OffloaderStorage) -> UnifiedStorage | OffloaderStorage:
+        """Auto-namespace unified storage with 'offloader' if not already scoped."""
+        if _is_offloader_storage(storage):
+            return storage
+        if getattr(storage, "_namespaced", None) is _NAMESPACED:
+            return storage
+        return _NamespacedStorage(storage, "offloader")
 
-        Non-FileStorage backends are shared across agents unchanged. A FileStorage
-        is bound once per agent to that agent's sandbox via
-        :meth:`FileStorage.for_sandbox`, so a shared plugin isolates artifacts per
-        agent sandbox.
+    def _storage_for_agent(self, agent: Agent) -> UnifiedStorage | OffloaderStorage:
+        """Return the storage for an agent, binding file-based storage to its sandbox.
+
+        FileStorage (legacy) and LocalFileStorage (unified) are bound once per
+        agent to that agent's sandbox via ``for_sandbox()``, then re-wrapped with
+        the namespace if applicable. All other backends are shared as-is.
 
         Args:
             agent: The agent whose storage to resolve.
@@ -167,11 +249,12 @@ class ContextOffloader(Plugin):
         Returns:
             The storage instance for this agent.
         """
-        if not isinstance(self._storage, FileStorage):
+        if not isinstance(self._raw_storage, (FileStorage, LocalFileStorage)):
             return self._storage
         storage = self._storage_by_agent.get(agent)
         if storage is None:
-            storage = self._storage.for_sandbox(agent.sandbox)
+            bound = self._raw_storage.for_sandbox(agent.sandbox)
+            storage = self._resolve_storage(bound)
             self._storage_by_agent[agent] = storage
         return storage
 
@@ -179,17 +262,34 @@ class ContextOffloader(Plugin):
         """Conditionally register the retrieval tool and bind storage."""
         if isinstance(self._storage, InMemoryStorage):
             self._storage._bind(id(agent))
-        # Bind FileStorage to this agent's sandbox up front (no-op for other backends).
+        # Bind file-based storage to this agent's sandbox up front (no-op for other backends).
         self._storage_for_agent(agent)
         if not self._include_retrieval_tool:
             # Remove the auto-discovered retrieval tool
             self._tools = [t for t in self._tools if t.tool_name != "retrieve_offloaded_content"]
 
     @hook
-    def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
+    async def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
         """Trigger eviction of stale entries based on the agent's cycle count."""
+        cycle = event.agent.event_loop_metrics.cycle_count
         if isinstance(self._storage, InMemoryStorage):
-            self._storage._evict(event.agent.event_loop_metrics.cycle_count)
+            self._storage._evict(cycle)
+            return
+
+        if _is_offloader_storage(self._storage) or self._evict_after_cycles is None:
+            return
+
+        # Cycle-based eviction for unified Storage
+        threshold = cycle - self._evict_after_cycles
+        stale_keys = [key for key, stored_cycle in self._stored_cycles.items() if stored_cycle < threshold]
+        if stale_keys:
+            for key in stale_keys:
+                try:
+                    await self._storage.delete(key)  # type: ignore[union-attr]
+                except Exception:
+                    pass
+                del self._stored_cycles[key]
+            logger.debug("evicted=<%d>, cycle=<%d> | stale entries removed", len(stale_keys), cycle)
 
     @tool(context=True)
     async def retrieve_offloaded_content(
@@ -231,7 +331,7 @@ class ContextOffloader(Plugin):
         """
         storage = self._storage_for_agent(tool_context.agent)
         try:
-            content_bytes, content_type = await storage.retrieve(reference)
+            content_bytes, content_type = await _retrieve_content(storage, reference)
         except KeyError:
             return f"Error: reference not found: {reference}"
 
@@ -312,24 +412,28 @@ class ContextOffloader(Plugin):
 
         # Store each content block individually
         storage = self._storage_for_agent(event.agent)
+        cycle = event.agent.event_loop_metrics.cycle_count
         references: list[tuple[str, str, str]] = []  # (ref, content_type, description)
         try:
             for i, block in enumerate(content):
                 key = f"{tool_use_id}_{i}"
                 if block.get("text"):
-                    ref = await storage.store(key, block["text"].encode("utf-8"), "text/plain")
+                    ref = await _store_content(storage, key, block["text"].encode("utf-8"), "text/plain")
                     references.append((ref, "text/plain", f"text, {len(block['text']):,} chars"))
+                    self._track_stored_cycle(ref, cycle)
                 elif "json" in block:
                     json_bytes = json.dumps(block["json"], indent=2).encode("utf-8")
-                    ref = await storage.store(key, json_bytes, "application/json")
+                    ref = await _store_content(storage, key, json_bytes, "application/json")
                     references.append((ref, "application/json", f"json, {len(json_bytes):,} bytes"))
+                    self._track_stored_cycle(ref, cycle)
                 elif "image" in block:
                     image = block["image"]
                     img_format = image.get("format", "unknown")
                     img_bytes = image.get("source", {}).get("bytes", b"")
                     if img_bytes:
-                        ref = await storage.store(key, img_bytes, f"image/{img_format}")
+                        ref = await _store_content(storage, key, img_bytes, f"image/{img_format}")
                         references.append((ref, f"image/{img_format}", f"image/{img_format}, {len(img_bytes):,} bytes"))
+                        self._track_stored_cycle(ref, cycle)
                     else:
                         references.append(("", f"image/{img_format}", f"image/{img_format}, 0 bytes"))
                 elif "document" in block:
@@ -338,8 +442,9 @@ class ContextOffloader(Plugin):
                     doc_name = doc.get("name", "unknown")
                     doc_bytes = doc.get("source", {}).get("bytes", b"")
                     if doc_bytes:
-                        ref = await storage.store(key, doc_bytes, f"application/{doc_format}")
+                        ref = await _store_content(storage, key, doc_bytes, f"application/{doc_format}")
                         references.append((ref, f"application/{doc_format}", f"{doc_name}, {len(doc_bytes):,} bytes"))
+                        self._track_stored_cycle(ref, cycle)
                     else:
                         references.append(("", f"application/{doc_format}", f"{doc_name}, 0 bytes"))
         except Exception:
@@ -415,6 +520,11 @@ class ContextOffloader(Plugin):
             status=result["status"],
             content=new_content,
         )
+
+    def _track_stored_cycle(self, ref: str, cycle: int) -> None:
+        """Record the cycle at which a key was stored (unified Storage eviction)."""
+        if not _is_offloader_storage(self._storage):
+            self._stored_cycles[ref] = cycle
 
     def _slice_preview(self, text: str) -> str:
         """Slice text to approximately preview_tokens using character-based estimation.

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -81,8 +81,17 @@ def _unframe_content(frame: bytes) -> tuple[bytes, str]:
 
     Returns:
         Tuple of (content bytes, content type).
+
+    Raises:
+        ValueError: If the frame is truncated or corrupt.
     """
+    if len(frame) < 2:
+        raise ValueError(f"Corrupt storage frame: expected at least 2 bytes, got {len(frame)}")
     ct_len = (frame[0] << 8) | frame[1]
+    if len(frame) < 2 + ct_len:
+        raise ValueError(
+            f"Corrupt storage frame: content-type length {ct_len} exceeds frame size {len(frame)}"
+        )
     content_type = frame[2 : 2 + ct_len].decode("utf-8")
     content = frame[2 + ct_len :]
     return content, content_type
@@ -223,7 +232,7 @@ class ContextOffloader(Plugin):
         self._preview_tokens = preview_tokens
         self._include_retrieval_tool = include_retrieval_tool
         self._evict_after_cycles = evict_after_cycles
-        self._stored_cycles: dict[str, int] = {}
+        self._stored_cycles: weakref.WeakKeyDictionary[Agent, dict[str, int]] = weakref.WeakKeyDictionary()
         super().__init__()
 
     @staticmethod
@@ -233,7 +242,7 @@ class ContextOffloader(Plugin):
             return storage
         if getattr(storage, "_namespaced", None) is _NAMESPACED:
             return storage
-        return _NamespacedStorage(storage, "offloader")
+        return _NamespacedStorage(storage, "offloader")  # type: ignore[arg-type]
 
     def _storage_for_agent(self, agent: Agent) -> Storage | _LegacyStorage:
         """Return the storage for an agent, binding file-based storage to its sandbox.
@@ -254,7 +263,7 @@ class ContextOffloader(Plugin):
         storage = self._storage_by_agent.get(agent)
         if storage is None:
             if sandboxable is not None:
-                storage = sandboxable.for_sandbox(agent.sandbox)  # type: ignore[union-attr]
+                storage = sandboxable.for_sandbox(agent.sandbox)
             else:
                 storage = self._storage.for_sandbox(agent.sandbox)  # type: ignore[union-attr]
             self._storage_by_agent[agent] = storage
@@ -283,15 +292,18 @@ class ContextOffloader(Plugin):
 
         # Cycle-based eviction for unified Storage
         storage = self._storage_for_agent(event.agent)
+        agent_cycles = self._stored_cycles.get(event.agent)
+        if not agent_cycles:
+            return
         threshold = cycle - self._evict_after_cycles
-        stale_keys = [key for key, stored_cycle in self._stored_cycles.items() if stored_cycle < threshold]
+        stale_keys = [key for key, stored_cycle in agent_cycles.items() if stored_cycle < threshold]
         if stale_keys:
             for key in stale_keys:
                 try:
                     await storage.delete(key)  # type: ignore[union-attr]
                 except Exception:
-                    pass
-                del self._stored_cycles[key]
+                    logger.debug("key=<%s> | failed to evict stale entry", key)
+                del agent_cycles[key]
             logger.debug("evicted=<%d>, cycle=<%d> | stale entries removed", len(stale_keys), cycle)
 
     @tool(context=True)
@@ -423,12 +435,12 @@ class ContextOffloader(Plugin):
                 if block.get("text"):
                     ref = await _store_content(storage, key, block["text"].encode("utf-8"), "text/plain")
                     references.append((ref, "text/plain", f"text, {len(block['text']):,} chars"))
-                    self._track_stored_cycle(ref, cycle)
+                    self._track_stored_cycle(event.agent, ref, cycle)
                 elif "json" in block:
                     json_bytes = json.dumps(block["json"], indent=2).encode("utf-8")
                     ref = await _store_content(storage, key, json_bytes, "application/json")
                     references.append((ref, "application/json", f"json, {len(json_bytes):,} bytes"))
-                    self._track_stored_cycle(ref, cycle)
+                    self._track_stored_cycle(event.agent, ref, cycle)
                 elif "image" in block:
                     image = block["image"]
                     img_format = image.get("format", "unknown")
@@ -436,7 +448,7 @@ class ContextOffloader(Plugin):
                     if img_bytes:
                         ref = await _store_content(storage, key, img_bytes, f"image/{img_format}")
                         references.append((ref, f"image/{img_format}", f"image/{img_format}, {len(img_bytes):,} bytes"))
-                        self._track_stored_cycle(ref, cycle)
+                        self._track_stored_cycle(event.agent, ref, cycle)
                     else:
                         references.append(("", f"image/{img_format}", f"image/{img_format}, 0 bytes"))
                 elif "document" in block:
@@ -447,7 +459,7 @@ class ContextOffloader(Plugin):
                     if doc_bytes:
                         ref = await _store_content(storage, key, doc_bytes, f"application/{doc_format}")
                         references.append((ref, f"application/{doc_format}", f"{doc_name}, {len(doc_bytes):,} bytes"))
-                        self._track_stored_cycle(ref, cycle)
+                        self._track_stored_cycle(event.agent, ref, cycle)
                     else:
                         references.append(("", f"application/{doc_format}", f"{doc_name}, 0 bytes"))
         except Exception:
@@ -524,10 +536,14 @@ class ContextOffloader(Plugin):
             content=new_content,
         )
 
-    def _track_stored_cycle(self, ref: str, cycle: int) -> None:
+    def _track_stored_cycle(self, agent: Agent, ref: str, cycle: int) -> None:
         """Record the cycle at which a key was stored (unified Storage eviction)."""
         if not _is_offloader_storage(self._storage):
-            self._stored_cycles[ref] = cycle
+            agent_cycles = self._stored_cycles.get(agent)
+            if agent_cycles is None:
+                agent_cycles = {}
+                self._stored_cycles[agent] = agent_cycles
+            agent_cycles[ref] = cycle
 
     def _slice_preview(self, text: str) -> str:
         """Slice text to approximately preview_tokens using character-based estimation.

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -41,15 +41,14 @@ from typing_extensions import TypedDict
 
 from ...hooks.events import AfterToolCallEvent, BeforeModelCallEvent
 from ...plugins import Plugin, hook
-from ...storage import LocalFileStorage
-from ...storage import Storage as UnifiedStorage
+from ...storage import LocalFileStorage, Storage
 from ...storage.storage import _NAMESPACED, _NamespacedStorage
 from ...tools.decorator import tool
 from ...types.content import Message
 from ...types.tools import ToolContext, ToolResult, ToolResultContent
 from .search import _is_searchable_content, _search_content
 from .storage import FileStorage, InMemoryStorage
-from .storage import Storage as OffloaderStorage
+from .storage import Storage as _LegacyStorage
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
@@ -57,7 +56,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _is_offloader_storage(storage: UnifiedStorage | OffloaderStorage) -> bool:
+def _is_offloader_storage(storage: Storage | _LegacyStorage) -> bool:
     """Detect legacy offloader storage by presence of store/retrieve methods."""
     return hasattr(storage, "store") and hasattr(storage, "retrieve")
 
@@ -90,7 +89,7 @@ def _unframe_content(frame: bytes) -> tuple[bytes, str]:
 
 
 async def _store_content(
-    storage: UnifiedStorage | OffloaderStorage,
+    storage: Storage | _LegacyStorage,
     key: str,
     content: bytes,
     content_type: str,
@@ -103,7 +102,7 @@ async def _store_content(
 
 
 async def _retrieve_content(
-    storage: UnifiedStorage | OffloaderStorage,
+    storage: Storage | _LegacyStorage,
     reference: str,
 ) -> tuple[bytes, str]:
     """Retrieve content from either unified or legacy storage."""
@@ -178,7 +177,7 @@ class ContextOffloader(Plugin):
 
     def __init__(
         self,
-        storage: UnifiedStorage | OffloaderStorage,
+        storage: Storage | _LegacyStorage,
         max_result_tokens: int = _DEFAULT_MAX_RESULT_TOKENS,
         preview_tokens: int = _DEFAULT_PREVIEW_TOKENS,
         *,
@@ -215,9 +214,9 @@ class ContextOffloader(Plugin):
         if evict_after_cycles is not None and (not isinstance(evict_after_cycles, int) or evict_after_cycles < 1):
             raise ValueError("evict_after_cycles must be a positive integer or None")
 
-        self._raw_storage: UnifiedStorage | OffloaderStorage = storage
-        self._storage: UnifiedStorage | OffloaderStorage = self._resolve_storage(storage)
-        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, UnifiedStorage | OffloaderStorage] = (
+        self._raw_storage: Storage | _LegacyStorage = storage
+        self._storage: Storage | _LegacyStorage = self._resolve_storage(storage)
+        self._storage_by_agent: weakref.WeakKeyDictionary[Agent, Storage | _LegacyStorage] = (
             weakref.WeakKeyDictionary()
         )
         self._max_result_tokens = max_result_tokens
@@ -228,7 +227,7 @@ class ContextOffloader(Plugin):
         super().__init__()
 
     @staticmethod
-    def _resolve_storage(storage: UnifiedStorage | OffloaderStorage) -> UnifiedStorage | OffloaderStorage:
+    def _resolve_storage(storage: Storage | _LegacyStorage) -> Storage | _LegacyStorage:
         """Auto-namespace unified storage with 'offloader' if not already scoped."""
         if _is_offloader_storage(storage):
             return storage
@@ -236,7 +235,7 @@ class ContextOffloader(Plugin):
             return storage
         return _NamespacedStorage(storage, "offloader")
 
-    def _storage_for_agent(self, agent: Agent) -> UnifiedStorage | OffloaderStorage:
+    def _storage_for_agent(self, agent: Agent) -> Storage | _LegacyStorage:
         """Return the storage for an agent, binding file-based storage to its sandbox.
 
         FileStorage (legacy) and LocalFileStorage (unified) are bound once per

--- a/strands-py/tests/strands/storage/test_in_memory_storage.py
+++ b/strands-py/tests/strands/storage/test_in_memory_storage.py
@@ -71,12 +71,11 @@ class TestInMemoryStorage:
         with pytest.raises(StorageError):
             await storage.write("../etc/passwd", b"data")
 
-    def test_clear(self, storage):
-        import asyncio
-
-        asyncio.get_event_loop().run_until_complete(storage.write("key", b"data"))
+    @pytest.mark.asyncio
+    async def test_clear(self, storage):
+        await storage.write("key", b"data")
         storage.clear()
-        result = asyncio.get_event_loop().run_until_complete(storage.read("key"))
+        result = await storage.read("key")
         assert result is None
 
     @pytest.mark.asyncio

--- a/strands-py/tests/strands/storage/test_in_memory_storage.py
+++ b/strands-py/tests/strands/storage/test_in_memory_storage.py
@@ -1,0 +1,94 @@
+"""Tests for InMemoryStorage."""
+
+import pytest
+
+from strands.storage import InMemoryStorage
+from strands.types.exceptions import StorageError
+
+
+class TestInMemoryStorage:
+    @pytest.fixture
+    def storage(self):
+        return InMemoryStorage()
+
+    @pytest.mark.asyncio
+    async def test_write_and_read(self, storage):
+        await storage.write("key", b"hello")
+        assert await storage.read("key") == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_read_missing_returns_none(self, storage):
+        assert await storage.read("nonexistent") is None
+
+    @pytest.mark.asyncio
+    async def test_write_overwrites(self, storage):
+        await storage.write("key", b"first")
+        await storage.write("key", b"second")
+        assert await storage.read("key") == b"second"
+
+    @pytest.mark.asyncio
+    async def test_delete_existing(self, storage):
+        await storage.write("key", b"data")
+        await storage.delete("key")
+        assert await storage.read("key") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_is_noop(self, storage):
+        await storage.delete("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_list_all(self, storage):
+        await storage.write("b/2", b"")
+        await storage.write("a/1", b"")
+        await storage.write("c/3", b"")
+        keys = await storage.list("")
+        assert keys == ["a/1", "b/2", "c/3"]
+
+    @pytest.mark.asyncio
+    async def test_list_with_prefix(self, storage):
+        await storage.write("sessions/a", b"")
+        await storage.write("sessions/b", b"")
+        await storage.write("offloader/x", b"")
+        keys = await storage.list("sessions/")
+        assert keys == ["sessions/a", "sessions/b"]
+
+    @pytest.mark.asyncio
+    async def test_list_empty_store(self, storage):
+        assert await storage.list("") == []
+
+    @pytest.mark.asyncio
+    async def test_key_normalization(self, storage):
+        await storage.write("//foo///bar//", b"data")
+        assert await storage.read("/foo/bar/") == b"data"
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_key(self, storage):
+        with pytest.raises(StorageError):
+            await storage.write("", b"data")
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal(self, storage):
+        with pytest.raises(StorageError):
+            await storage.write("../etc/passwd", b"data")
+
+    def test_clear(self, storage):
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(storage.write("key", b"data"))
+        storage.clear()
+        result = asyncio.get_event_loop().run_until_complete(storage.read("key"))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_namespace(self, storage):
+        ns = storage.namespace("scope")
+        await ns.write("key", b"value")
+        assert await ns.read("key") == b"value"
+        assert await storage.read("scope/key") == b"value"
+
+    @pytest.mark.asyncio
+    async def test_bytes_are_copied_on_write(self, storage):
+        data = bytearray(b"mutable")
+        await storage.write("key", data)
+        data[0] = 0xFF
+        assert await storage.read("key") == b"mutable"

--- a/strands-py/tests/strands/storage/test_local_file_storage.py
+++ b/strands-py/tests/strands/storage/test_local_file_storage.py
@@ -189,17 +189,17 @@ class TestLocalFileStorage:
         assert "sub/nested.txt" in keys
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(os.name == "nt", reason="Windows allows writing to arbitrary paths differently")
     async def test_write_error_raises_storage_error(self, tmp_path):
         storage = LocalFileStorage("/nonexistent/readonly/path/")
         with pytest.raises(StorageError):
             await storage.write("key", b"data")
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(os.name == "nt", reason="Windows does not enforce chmod restrictions")
     async def test_read_error_raises_storage_error(self, tmp_path):
         storage = LocalFileStorage(str(tmp_path) + "/")
         await storage.write("key", b"data")
-        import os
-
         os.chmod(os.path.join(str(tmp_path), "key"), 0o000)
         try:
             with pytest.raises(StorageError):

--- a/strands-py/tests/strands/storage/test_local_file_storage.py
+++ b/strands-py/tests/strands/storage/test_local_file_storage.py
@@ -101,6 +101,12 @@ class TestLocalFileStorage:
         await storage.write("//foo///bar//", b"data")
         assert await storage.read("foo/bar") == b"data"
 
+    @pytest.mark.asyncio
+    async def test_binary_round_trip(self, storage):
+        binary_data = bytes(range(256))
+        await storage.write("binary.bin", binary_data)
+        assert await storage.read("binary.bin") == binary_data
+
     def test_for_sandbox_returns_self_if_same(self, tmp_path):
         from unittest.mock import MagicMock
 
@@ -116,3 +122,30 @@ class TestLocalFileStorage:
         storage = LocalFileStorage(str(tmp_path), sandbox=sandbox1)
         new_storage = storage.for_sandbox(sandbox2)
         assert new_storage is not storage
+
+    @pytest.mark.asyncio
+    async def test_sandbox_binary_round_trip(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        binary_data = bytes(range(256))
+        sandbox = MagicMock()
+        sandbox.write_file = AsyncMock()
+        sandbox.read_file = AsyncMock(return_value=binary_data)
+
+        storage = LocalFileStorage(str(tmp_path), sandbox=sandbox)
+        await storage.write("img.png", binary_data)
+        sandbox.write_file.assert_called_once()
+        assert sandbox.write_file.call_args[0][1] == binary_data
+
+        result = await storage.read("img.png")
+        assert result == binary_data
+
+    def test_namespace_preserves_for_sandbox(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        sandbox = MagicMock()
+        storage = LocalFileStorage(str(tmp_path))
+        ns = storage.namespace("scope")
+        assert hasattr(ns, "for_sandbox")
+        bound = ns.for_sandbox(sandbox)
+        assert bound is not ns

--- a/strands-py/tests/strands/storage/test_local_file_storage.py
+++ b/strands-py/tests/strands/storage/test_local_file_storage.py
@@ -1,0 +1,118 @@
+"""Tests for LocalFileStorage."""
+
+import os
+
+import pytest
+
+from strands.storage import LocalFileStorage
+from strands.types.exceptions import StorageError
+
+
+class TestLocalFileStorage:
+    @pytest.fixture
+    def storage(self, tmp_path):
+        return LocalFileStorage(str(tmp_path) + "/")
+
+    @pytest.mark.asyncio
+    async def test_write_and_read(self, storage):
+        await storage.write("key.txt", b"hello")
+        assert await storage.read("key.txt") == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_write_creates_directories(self, storage, tmp_path):
+        await storage.write("a/b/c/file.txt", b"deep")
+        assert await storage.read("a/b/c/file.txt") == b"deep"
+        assert os.path.isfile(os.path.join(str(tmp_path), "a/b/c/file.txt"))
+
+    @pytest.mark.asyncio
+    async def test_read_missing_returns_none(self, storage):
+        assert await storage.read("nonexistent") is None
+
+    @pytest.mark.asyncio
+    async def test_write_overwrites(self, storage):
+        await storage.write("key", b"first")
+        await storage.write("key", b"second")
+        assert await storage.read("key") == b"second"
+
+    @pytest.mark.asyncio
+    async def test_delete_existing(self, storage):
+        await storage.write("key", b"data")
+        await storage.delete("key")
+        assert await storage.read("key") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_is_noop(self, storage):
+        await storage.delete("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_list_all(self, storage):
+        await storage.write("b", b"")
+        await storage.write("a", b"")
+        await storage.write("c", b"")
+        keys = await storage.list("")
+        assert keys == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_list_with_prefix(self, storage):
+        await storage.write("sessions/a", b"")
+        await storage.write("sessions/b", b"")
+        await storage.write("offloader/x", b"")
+        keys = await storage.list("sessions/")
+        assert keys == ["sessions/a", "sessions/b"]
+
+    @pytest.mark.asyncio
+    async def test_list_nested(self, storage):
+        await storage.write("a/1", b"")
+        await storage.write("a/2", b"")
+        await storage.write("a/sub/3", b"")
+        keys = await storage.list("a/")
+        assert keys == ["a/1", "a/2", "a/sub/3"]
+
+    @pytest.mark.asyncio
+    async def test_list_empty_dir(self, storage):
+        assert await storage.list("") == []
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal(self, storage):
+        with pytest.raises(StorageError):
+            await storage.write("../escape", b"data")
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_key(self, storage):
+        with pytest.raises(StorageError):
+            await storage.write("", b"data")
+
+    @pytest.mark.asyncio
+    async def test_atomic_write(self, storage, tmp_path):
+        await storage.write("file.txt", b"content")
+        # No temp files remain
+        all_files = list(tmp_path.rglob("*"))
+        assert not any("__strands_tmp" in str(f) for f in all_files)
+
+    @pytest.mark.asyncio
+    async def test_namespace(self, storage):
+        ns = storage.namespace("scope")
+        await ns.write("key", b"value")
+        assert await ns.read("key") == b"value"
+        assert await storage.read("scope/key") == b"value"
+
+    @pytest.mark.asyncio
+    async def test_key_normalization(self, storage):
+        await storage.write("//foo///bar//", b"data")
+        assert await storage.read("foo/bar") == b"data"
+
+    def test_for_sandbox_returns_self_if_same(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        sandbox = MagicMock()
+        storage = LocalFileStorage(str(tmp_path), sandbox=sandbox)
+        assert storage.for_sandbox(sandbox) is storage
+
+    def test_for_sandbox_returns_new_if_different(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        sandbox1 = MagicMock()
+        sandbox2 = MagicMock()
+        storage = LocalFileStorage(str(tmp_path), sandbox=sandbox1)
+        new_storage = storage.for_sandbox(sandbox2)
+        assert new_storage is not storage

--- a/strands-py/tests/strands/storage/test_local_file_storage.py
+++ b/strands-py/tests/strands/storage/test_local_file_storage.py
@@ -216,3 +216,60 @@ class TestLocalFileStorage:
         assert hasattr(ns, "for_sandbox")
         bound = ns.for_sandbox(sandbox)
         assert bound is not ns
+
+    @pytest.mark.asyncio
+    async def test_list_prefix_narrows_directory(self, storage, tmp_path):
+        await storage.write("deep/nested/a.txt", b"a")
+        await storage.write("deep/nested/b.txt", b"b")
+        await storage.write("deep/other/c.txt", b"c")
+        keys = await storage.list("deep/nested/")
+        assert keys == ["deep/nested/a.txt", "deep/nested/b.txt"]
+
+    @pytest.mark.asyncio
+    async def test_list_prefix_nonexistent_dir(self, storage):
+        keys = await storage.list("nonexistent/path/")
+        assert keys == []
+
+    @pytest.mark.asyncio
+    async def test_list_prefix_partial_match_dir(self, storage, tmp_path):
+        await storage.write("ab/file.txt", b"data")
+        keys = await storage.list("abc/")
+        assert keys == []
+
+    @pytest.mark.asyncio
+    async def test_delete_error_raises_storage_error(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        sandbox = MagicMock()
+        sandbox.remove_file = AsyncMock(side_effect=PermissionError("forbidden"))
+        storage = LocalFileStorage(str(tmp_path) + "/", sandbox=sandbox)
+        with pytest.raises(StorageError):
+            await storage.delete("key.txt")
+
+    @pytest.mark.asyncio
+    async def test_list_error_raises_storage_error(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        sandbox = MagicMock()
+        sandbox.list_files = AsyncMock(side_effect=PermissionError("forbidden"))
+        storage = LocalFileStorage(str(tmp_path) + "/", sandbox=sandbox)
+        with pytest.raises(StorageError):
+            await storage.list("")
+
+    @pytest.mark.asyncio
+    async def test_write_atomic_cleanup_on_replace_failure(self, tmp_path, monkeypatch):
+        storage = LocalFileStorage(str(tmp_path) + "/")
+        # First write succeeds to create the directory
+        await storage.write("key", b"original")
+
+        # Patch os.replace to fail, simulating atomic rename failure
+        def failing_replace(src, dst):
+            raise OSError("replace failed")
+
+        monkeypatch.setattr(os, "replace", failing_replace)
+        with pytest.raises(StorageError):
+            await storage.write("key", b"new data")
+
+        # Temp file should be cleaned up
+        all_files = list(tmp_path.rglob("*"))
+        assert not any("__strands_tmp" in str(f) for f in all_files)

--- a/strands-py/tests/strands/storage/test_local_file_storage.py
+++ b/strands-py/tests/strands/storage/test_local_file_storage.py
@@ -140,6 +140,73 @@ class TestLocalFileStorage:
         result = await storage.read("img.png")
         assert result == binary_data
 
+    @pytest.mark.asyncio
+    async def test_sandbox_delete(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        sandbox = MagicMock()
+        sandbox.remove_file = AsyncMock()
+        storage = LocalFileStorage(str(tmp_path), sandbox=sandbox)
+        await storage.delete("key.txt")
+        sandbox.remove_file.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sandbox_delete_missing_is_noop(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        sandbox = MagicMock()
+        sandbox.remove_file = AsyncMock(side_effect=FileNotFoundError)
+        storage = LocalFileStorage(str(tmp_path), sandbox=sandbox)
+        await storage.delete("missing.txt")
+
+    @pytest.mark.asyncio
+    async def test_sandbox_list(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        entry = MagicMock()
+        entry.name = "file.txt"
+        entry.is_dir = False
+        sandbox = MagicMock()
+        sandbox.list_files = AsyncMock(return_value=[entry])
+        storage = LocalFileStorage(str(tmp_path) + "/", sandbox=sandbox)
+        keys = await storage.list("")
+        assert keys == ["file.txt"]
+
+    @pytest.mark.asyncio
+    async def test_sandbox_list_nested(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        dir_entry = MagicMock()
+        dir_entry.name = "sub"
+        dir_entry.is_dir = True
+        file_entry = MagicMock()
+        file_entry.name = "nested.txt"
+        file_entry.is_dir = False
+        sandbox = MagicMock()
+        sandbox.list_files = AsyncMock(side_effect=[[dir_entry], [file_entry]])
+        storage = LocalFileStorage(str(tmp_path) + "/", sandbox=sandbox)
+        keys = await storage.list("")
+        assert "sub/nested.txt" in keys
+
+    @pytest.mark.asyncio
+    async def test_write_error_raises_storage_error(self, tmp_path):
+        storage = LocalFileStorage("/nonexistent/readonly/path/")
+        with pytest.raises(StorageError):
+            await storage.write("key", b"data")
+
+    @pytest.mark.asyncio
+    async def test_read_error_raises_storage_error(self, tmp_path):
+        storage = LocalFileStorage(str(tmp_path) + "/")
+        await storage.write("key", b"data")
+        import os
+
+        os.chmod(os.path.join(str(tmp_path), "key"), 0o000)
+        try:
+            with pytest.raises(StorageError):
+                await storage.read("key")
+        finally:
+            os.chmod(os.path.join(str(tmp_path), "key"), 0o644)
+
     def test_namespace_preserves_for_sandbox(self, tmp_path):
         from unittest.mock import MagicMock
 

--- a/strands-py/tests/strands/storage/test_s3_storage.py
+++ b/strands-py/tests/strands/storage/test_s3_storage.py
@@ -90,6 +90,123 @@ class TestS3Storage:
             S3Storage("bucket", region_name="us-east-1", boto_session=boto3.Session())
 
 
+    @pytest.mark.asyncio
+    async def test_write_error_raises_storage_error(self, s3_bucket):
+        storage = S3Storage("nonexistent-bucket-xyz", boto_session=s3_bucket)
+        with pytest.raises(StorageError, match="Failed to write"):
+            await storage.write("key", b"data")
+
+    @pytest.mark.asyncio
+    async def test_read_error_raises_storage_error(self):
+        from unittest.mock import MagicMock
+
+        storage = S3Storage("bucket", region_name="us-east-1")
+        mock_client = MagicMock()
+        mock_client.exceptions = MagicMock()
+        mock_client.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+        mock_client.get_object.side_effect = RuntimeError("connection reset")
+        storage._client = mock_client
+        with pytest.raises(StorageError, match="Failed to read"):
+            await storage.read("key")
+
+    @pytest.mark.asyncio
+    async def test_read_nosuchkey_via_response_code(self):
+        from unittest.mock import MagicMock
+
+        storage = S3Storage("bucket", region_name="us-east-1")
+        mock_client = MagicMock()
+        mock_client.exceptions = MagicMock()
+        mock_client.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+        error = Exception("not found")
+        error.response = {"Error": {"Code": "NoSuchKey"}}
+        mock_client.get_object.side_effect = error
+        storage._client = mock_client
+        assert await storage.read("key") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_error_raises_storage_error(self, s3_bucket):
+        storage = S3Storage("nonexistent-bucket-xyz", boto_session=s3_bucket)
+        with pytest.raises(StorageError, match="Failed to delete"):
+            await storage.delete("key")
+
+    @pytest.mark.asyncio
+    async def test_list_error_raises_storage_error(self, s3_bucket):
+        storage = S3Storage("nonexistent-bucket-xyz", boto_session=s3_bucket)
+        with pytest.raises(StorageError, match="Failed to list"):
+            await storage.list("")
+
+    @pytest.mark.asyncio
+    async def test_list_pagination(self, storage):
+        # Write more than would fit in a single page to exercise pagination
+        for i in range(5):
+            await storage.write(f"item_{i:03d}", b"data")
+        keys = await storage.list("")
+        assert len(keys) == 5
+        assert keys == sorted(keys)
+
+    def test_client_created_with_boto_session(self):
+        from unittest.mock import MagicMock
+
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        storage = S3Storage("bucket", boto_session=mock_session)
+        client = storage._get_client()
+        mock_session.client.assert_called_once()
+        assert client is mock_client
+
+    def test_client_created_with_region(self):
+        from unittest.mock import MagicMock, patch
+
+        with patch("boto3.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_client = MagicMock()
+            mock_session.client.return_value = mock_client
+            mock_session_cls.return_value = mock_session
+            storage = S3Storage("bucket", region_name="eu-west-1")
+            client = storage._get_client()
+            mock_session_cls.assert_called_once_with(region_name="eu-west-1")
+            assert client is mock_client
+
+    def test_client_merges_user_agent_on_existing_config(self):
+        from unittest.mock import MagicMock
+
+        from botocore.config import Config
+
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        config = Config(read_timeout=30)
+        storage = S3Storage("bucket", boto_session=mock_session, boto_client_config=config)
+        storage._get_client()
+        call_kwargs = mock_session.client.call_args[1]
+        assert "strands-agents" in call_kwargs["config"].user_agent_extra
+
+    @pytest.mark.asyncio
+    async def test_list_paginates(self):
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        mock_client.list_objects_v2.side_effect = [
+            {
+                "IsTruncated": True,
+                "NextContinuationToken": "token_1",
+                "Contents": [{"Key": "a"}, {"Key": "b"}],
+            },
+            {
+                "IsTruncated": False,
+                "Contents": [{"Key": "c"}],
+            },
+        ]
+        storage = S3Storage("bucket", region_name="us-east-1")
+        storage._client = mock_client
+        keys = await storage.list("")
+        assert keys == ["a", "b", "c"]
+        # Verify continuation token was passed on second call
+        second_call_kwargs = mock_client.list_objects_v2.call_args_list[1][1]
+        assert second_call_kwargs["ContinuationToken"] == "token_1"
+
+
 class TestS3StorageWithPrefix:
     @pytest.fixture
     def prefixed_storage(self, s3_bucket):

--- a/strands-py/tests/strands/storage/test_s3_storage.py
+++ b/strands-py/tests/strands/storage/test_s3_storage.py
@@ -1,0 +1,111 @@
+"""Tests for S3Storage."""
+
+import pytest
+
+from strands.storage import S3Storage
+from strands.types.exceptions import StorageError
+
+
+@pytest.fixture
+def s3_bucket():
+    """Create a moto-mocked S3 bucket."""
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        session = boto3.Session(region_name="us-east-1")
+        client = session.client("s3")
+        client.create_bucket(Bucket="test-bucket")
+        yield session
+
+
+@pytest.fixture
+def storage(s3_bucket):
+    return S3Storage("test-bucket", boto_session=s3_bucket)
+
+
+class TestS3Storage:
+    @pytest.mark.asyncio
+    async def test_write_and_read(self, storage):
+        await storage.write("key", b"hello")
+        assert await storage.read("key") == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_read_missing_returns_none(self, storage):
+        assert await storage.read("nonexistent") is None
+
+    @pytest.mark.asyncio
+    async def test_write_overwrites(self, storage):
+        await storage.write("key", b"first")
+        await storage.write("key", b"second")
+        assert await storage.read("key") == b"second"
+
+    @pytest.mark.asyncio
+    async def test_delete(self, storage):
+        await storage.write("key", b"data")
+        await storage.delete("key")
+        assert await storage.read("key") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_is_noop(self, storage):
+        await storage.delete("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_list_all(self, storage):
+        await storage.write("b", b"")
+        await storage.write("a", b"")
+        await storage.write("c", b"")
+        keys = await storage.list("")
+        assert keys == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_list_with_prefix(self, storage):
+        await storage.write("sessions/a", b"")
+        await storage.write("sessions/b", b"")
+        await storage.write("offloader/x", b"")
+        keys = await storage.list("sessions/")
+        assert keys == ["sessions/a", "sessions/b"]
+
+    @pytest.mark.asyncio
+    async def test_key_normalization(self, storage):
+        await storage.write("//foo///bar//", b"data")
+        assert await storage.read("foo/bar") == b"data"
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal(self, storage):
+        with pytest.raises(StorageError):
+            await storage.write("../bad", b"data")
+
+    @pytest.mark.asyncio
+    async def test_namespace(self, storage):
+        ns = storage.namespace("scope")
+        await ns.write("key", b"value")
+        assert await ns.read("key") == b"value"
+        assert await storage.read("scope/key") == b"value"
+
+    def test_rejects_both_region_and_session(self):
+        import boto3
+
+        with pytest.raises(StorageError, match="Cannot specify both"):
+            S3Storage("bucket", region_name="us-east-1", boto_session=boto3.Session())
+
+
+class TestS3StorageWithPrefix:
+    @pytest.fixture
+    def prefixed_storage(self, s3_bucket):
+        return S3Storage("test-bucket", prefix="agents/data", boto_session=s3_bucket)
+
+    @pytest.mark.asyncio
+    async def test_prefix_scopes_keys(self, prefixed_storage, s3_bucket):
+        await prefixed_storage.write("key", b"hello")
+        # Verify the actual S3 key includes the prefix
+        client = s3_bucket.client("s3")
+        response = client.get_object(Bucket="test-bucket", Key="agents/data/key")
+        assert response["Body"].read() == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_list_strips_prefix(self, prefixed_storage):
+        await prefixed_storage.write("a", b"")
+        await prefixed_storage.write("b", b"")
+        keys = await prefixed_storage.list("")
+        assert keys == ["a", "b"]

--- a/strands-py/tests/strands/storage/test_storage.py
+++ b/strands-py/tests/strands/storage/test_storage.py
@@ -1,0 +1,127 @@
+"""Tests for the storage Protocol, normalize helpers, and namespace function."""
+
+import pytest
+
+from strands.storage.storage import (
+    _NAMESPACED,
+    _NamespacedStorage,
+    _normalize_key,
+    _normalize_prefix,
+)
+from strands.types.exceptions import StorageError
+
+
+class TestNormalizeKey:
+    def test_simple_key(self):
+        assert _normalize_key("foo/bar") == "foo/bar"
+
+    def test_collapses_multiple_slashes(self):
+        assert _normalize_key("foo//bar///baz") == "foo/bar/baz"
+
+    def test_strips_leading_slash(self):
+        assert _normalize_key("/foo/bar") == "foo/bar"
+
+    def test_strips_trailing_slash(self):
+        assert _normalize_key("foo/bar/") == "foo/bar"
+
+    def test_strips_both(self):
+        assert _normalize_key("///foo///bar///") == "foo/bar"
+
+    def test_rejects_empty_key(self):
+        with pytest.raises(StorageError, match="must not be empty"):
+            _normalize_key("")
+
+    def test_rejects_only_slashes(self):
+        with pytest.raises(StorageError, match="must not be empty"):
+            _normalize_key("///")
+
+    def test_rejects_dot_dot_segment(self):
+        with pytest.raises(StorageError, match="path segments are not allowed"):
+            _normalize_key("foo/../bar")
+
+    def test_rejects_dot_dot_at_start(self):
+        with pytest.raises(StorageError, match="path segments are not allowed"):
+            _normalize_key("../foo")
+
+    def test_allows_dots_in_segment(self):
+        assert _normalize_key("foo/bar.txt") == "foo/bar.txt"
+        assert _normalize_key("foo/...bar") == "foo/...bar"
+
+
+class TestNormalizePrefix:
+    def test_simple_prefix(self):
+        assert _normalize_prefix("foo/bar") == "foo/bar"
+
+    def test_empty_prefix_is_valid(self):
+        assert _normalize_prefix("") == ""
+
+    def test_collapses_slashes(self):
+        assert _normalize_prefix("foo//bar///") == "foo/bar/"
+
+    def test_strips_leading_slash(self):
+        assert _normalize_prefix("/foo/bar") == "foo/bar"
+
+    def test_preserves_trailing_slash(self):
+        assert _normalize_prefix("foo/bar/") == "foo/bar/"
+
+    def test_rejects_dot_dot(self):
+        with pytest.raises(StorageError, match="path segments are not allowed"):
+            _normalize_prefix("foo/../bar")
+
+
+class TestNamespacedStorage:
+    @pytest.fixture
+    def storage(self):
+        from strands.storage import InMemoryStorage
+
+        return InMemoryStorage()
+
+    def test_has_namespaced_sentinel(self, storage):
+        ns = _NamespacedStorage(storage, "prefix")
+        assert ns._namespaced is _NAMESPACED
+
+    @pytest.mark.asyncio
+    async def test_write_read_round_trip(self, storage):
+        ns = _NamespacedStorage(storage, "scope")
+        await ns.write("key", b"hello")
+        assert await ns.read("key") == b"hello"
+        # The underlying storage has the prefixed key
+        assert await storage.read("scope/key") == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_delete(self, storage):
+        ns = _NamespacedStorage(storage, "scope")
+        await ns.write("key", b"data")
+        await ns.delete("key")
+        assert await ns.read("key") is None
+
+    @pytest.mark.asyncio
+    async def test_list_strips_prefix(self, storage):
+        ns = _NamespacedStorage(storage, "scope")
+        await ns.write("a", b"1")
+        await ns.write("b", b"2")
+        await storage.write("other/x", b"3")
+        keys = await ns.list("")
+        assert keys == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_composable_nesting(self, storage):
+        ns1 = _NamespacedStorage(storage, "a")
+        ns2 = ns1.namespace("b")
+        await ns2.write("key", b"nested")
+        assert await storage.read("a/b/key") == b"nested"
+        assert await ns2.read("key") == b"nested"
+
+    @pytest.mark.asyncio
+    async def test_empty_prefix(self, storage):
+        ns = _NamespacedStorage(storage, "")
+        await ns.write("key", b"data")
+        assert await storage.read("key") == b"data"
+
+
+class TestStorageProtocol:
+    def test_isinstance_check(self):
+        from strands.storage import InMemoryStorage, Storage
+
+        storage = InMemoryStorage()
+        assert isinstance(storage, Storage)

--- a/strands-py/tests/strands/storage/test_storage.py
+++ b/strands-py/tests/strands/storage/test_storage.py
@@ -118,6 +118,13 @@ class TestNamespacedStorage:
         await ns.write("key", b"data")
         assert await storage.read("key") == b"data"
 
+    @pytest.mark.asyncio
+    async def test_trailing_slash_prefix_does_not_corrupt_keys(self, storage):
+        ns = _NamespacedStorage(storage, "sessions/")
+        await ns.write("key1", b"hello")
+        keys = await ns.list("")
+        assert keys == ["key1"]
+
 
 class TestStorageProtocol:
     def test_isinstance_check(self):

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -827,19 +827,21 @@ class TestBeforeModelCallHook:
         agent.event_loop_metrics.cycle_count = cycle_count
         return BeforeModelCallEvent(agent=agent, invocation_state={})
 
-    def test_calls_evict_with_cycle_count(self):
+    @pytest.mark.asyncio
+    async def test_calls_evict_with_cycle_count(self):
         storage = InMemoryStorage(evict_after_turns=5)
         plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
 
-        plugin._on_before_model_call(self._make_event(7))
+        await plugin._on_before_model_call(self._make_event(7))
 
         assert storage._current_cycle == 7
 
-    def test_does_not_crash_on_storage_without_evict(self):
+    @pytest.mark.asyncio
+    async def test_does_not_crash_on_storage_without_evict(self):
         storage = MagicMock(spec=["store", "retrieve"])
         plugin = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
 
-        plugin._on_before_model_call(self._make_event(1))
+        await plugin._on_before_model_call(self._make_event(1))
 
     @pytest.mark.asyncio
     async def test_eviction_triggered_via_hook(self):
@@ -849,6 +851,6 @@ class TestBeforeModelCallHook:
         ref = await storage.store("key_1", b"content")
 
         # stored at cycle 0, evict at cycle 3: threshold = 3 - 2 = 1, 0 < 1 → evicted
-        plugin._on_before_model_call(self._make_event(3))
+        await plugin._on_before_model_call(self._make_event(3))
         with pytest.raises(KeyError):
             await storage.retrieve(ref)

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -854,3 +854,269 @@ class TestBeforeModelCallHook:
         await plugin._on_before_model_call(self._make_event(3))
         with pytest.raises(KeyError):
             await storage.retrieve(ref)
+
+
+class TestUnifiedStorage:
+    """Tests for the unified Storage code path (framing, eviction, per-agent scoping)."""
+
+    @pytest.fixture
+    def unified_storage(self):
+        from strands.storage import InMemoryStorage as UnifiedInMemory
+
+        return UnifiedInMemory()
+
+    @pytest.fixture
+    def unified_plugin(self, unified_storage):
+        return ContextOffloader(
+            storage=unified_storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            evict_after_cycles=3,
+        )
+
+    @pytest.fixture
+    def unified_mock_agent(self):
+        agent = MagicMock()
+        agent.model = MagicMock()
+        agent.model.count_tokens = AsyncMock(side_effect=_heuristic_count_tokens)
+        agent.sandbox = None
+        agent.event_loop_metrics.cycle_count = 1
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_frame_unframe_round_trip(self):
+        from strands.vended_plugins.context_offloader.plugin import _frame_content, _unframe_content
+
+        data = b"hello world"
+        content_type = "text/plain"
+        frame = _frame_content(data, content_type)
+        result_data, result_type = _unframe_content(frame)
+        assert result_data == data
+        assert result_type == content_type
+
+    @pytest.mark.asyncio
+    async def test_frame_unframe_binary(self):
+        from strands.vended_plugins.context_offloader.plugin import _frame_content, _unframe_content
+
+        data = bytes(range(256))
+        content_type = "image/png"
+        frame = _frame_content(data, content_type)
+        result_data, result_type = _unframe_content(frame)
+        assert result_data == data
+        assert result_type == content_type
+
+    def test_unframe_truncated_frame_raises(self):
+        from strands.vended_plugins.context_offloader.plugin import _unframe_content
+
+        with pytest.raises(ValueError, match="at least 2 bytes"):
+            _unframe_content(b"\x00")
+
+    def test_unframe_corrupt_length_raises(self):
+        from strands.vended_plugins.context_offloader.plugin import _unframe_content
+
+        # Header claims 255 bytes of content-type but frame is only 4 bytes
+        with pytest.raises(ValueError, match="exceeds frame size"):
+            _unframe_content(b"\x00\xff\x41\x42")
+
+    @pytest.mark.asyncio
+    async def test_offloads_via_unified_storage(self, unified_plugin, unified_storage, unified_mock_agent):
+        large_text = "a" * 200
+        event = _make_event(unified_mock_agent, large_text)
+
+        await unified_plugin._handle_tool_result(event)
+
+        result_text = event.result["content"][0]["text"]
+        assert "[Offloaded:" in result_text
+        # Verify content was stored (namespaced under "offloader/")
+        keys = await unified_storage.list("")
+        assert len(keys) == 1
+        assert keys[0].startswith("offloader/")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_via_unified_storage(self, unified_storage, unified_mock_agent):
+        plugin = ContextOffloader(
+            storage=unified_storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=True,
+        )
+        large_text = "hello world " * 50
+        event = _make_event(unified_mock_agent, large_text)
+        await plugin._handle_tool_result(event)
+
+        # Extract reference from the offloaded result
+        result_text = event.result["content"][0]["text"]
+        ref_line = [line for line in result_text.split("\n") if "tool_123_0" in line][0]
+        ref = ref_line.strip().split(" ")[0]
+
+        tool_context = MagicMock(spec=ToolContext)
+        tool_context.agent = unified_mock_agent
+        content = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
+        assert "hello world" in content
+
+    @pytest.mark.asyncio
+    async def test_eviction_with_unified_storage(self, unified_storage, unified_mock_agent):
+        plugin = ContextOffloader(
+            storage=unified_storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            evict_after_cycles=3,
+        )
+
+        # Offload at cycle 1
+        unified_mock_agent.event_loop_metrics.cycle_count = 1
+        event = _make_event(unified_mock_agent, "x" * 200)
+        await plugin._handle_tool_result(event)
+
+        keys_before = await unified_storage.list("")
+        assert len(keys_before) == 1
+
+        # Cycle 3: not yet stale (stored at 1, threshold = 3-3 = 0, 1 >= 0)
+        bmc_event = BeforeModelCallEvent(agent=unified_mock_agent, invocation_state={})
+        unified_mock_agent.event_loop_metrics.cycle_count = 3
+        await plugin._on_before_model_call(bmc_event)
+        assert len(await unified_storage.list("")) == 1
+
+        # Cycle 5: stale (stored at 1, threshold = 5-3 = 2, 1 < 2)
+        unified_mock_agent.event_loop_metrics.cycle_count = 5
+        await plugin._on_before_model_call(bmc_event)
+        assert len(await unified_storage.list("")) == 0
+
+    @pytest.mark.asyncio
+    async def test_eviction_scoped_per_agent(self, unified_storage):
+        plugin = ContextOffloader(
+            storage=unified_storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            evict_after_cycles=2,
+        )
+
+        agent_a = MagicMock()
+        agent_a.model = MagicMock()
+        agent_a.model.count_tokens = AsyncMock(side_effect=_heuristic_count_tokens)
+        agent_a.sandbox = None
+        agent_a.event_loop_metrics.cycle_count = 1
+
+        agent_b = MagicMock()
+        agent_b.model = MagicMock()
+        agent_b.model.count_tokens = AsyncMock(side_effect=_heuristic_count_tokens)
+        agent_b.sandbox = None
+        agent_b.event_loop_metrics.cycle_count = 1
+
+        # Agent A stores at cycle 1
+        event_a = _make_event(agent_a, "a" * 200, tool_use_id="tool_a")
+        await plugin._handle_tool_result(event_a)
+
+        # Agent B stores at cycle 1
+        event_b = _make_event(agent_b, "b" * 200, tool_use_id="tool_b")
+        await plugin._handle_tool_result(event_b)
+
+        assert len(await unified_storage.list("")) == 2
+
+        # Evict agent A at cycle 4 (stored at 1, threshold = 4-2 = 2, 1 < 2)
+        agent_a.event_loop_metrics.cycle_count = 4
+        bmc_a = BeforeModelCallEvent(agent=agent_a, invocation_state={})
+        await plugin._on_before_model_call(bmc_a)
+
+        # Agent A's entry evicted, agent B's remains
+        keys = await unified_storage.list("")
+        assert len(keys) == 1
+        assert "tool_b" in keys[0]
+
+    @pytest.mark.asyncio
+    async def test_eviction_disabled_when_none(self, unified_storage, unified_mock_agent):
+        plugin = ContextOffloader(
+            storage=unified_storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            evict_after_cycles=None,
+        )
+
+        unified_mock_agent.event_loop_metrics.cycle_count = 1
+        event = _make_event(unified_mock_agent, "x" * 200)
+        await plugin._handle_tool_result(event)
+
+        # Even at a very high cycle count, nothing is evicted
+        unified_mock_agent.event_loop_metrics.cycle_count = 1000
+        bmc = BeforeModelCallEvent(agent=unified_mock_agent, invocation_state={})
+        await plugin._on_before_model_call(bmc)
+        assert len(await unified_storage.list("")) == 1
+
+    @pytest.mark.asyncio
+    async def test_eviction_debug_log_on_delete_failure(self, unified_mock_agent, caplog):
+
+        from strands.storage import InMemoryStorage as UnifiedInMemory
+
+        storage = UnifiedInMemory()
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            evict_after_cycles=2,
+        )
+
+        # Offload at cycle 1
+        unified_mock_agent.event_loop_metrics.cycle_count = 1
+        event = _make_event(unified_mock_agent, "x" * 200)
+        await plugin._handle_tool_result(event)
+
+        # Make the underlying storage's delete fail
+        async def failing_delete(key):
+            raise RuntimeError("delete failed")
+
+        storage.delete = failing_delete
+
+        unified_mock_agent.event_loop_metrics.cycle_count = 5
+        bmc = BeforeModelCallEvent(agent=unified_mock_agent, invocation_state={})
+        with caplog.at_level(logging.DEBUG, logger="strands.vended_plugins.context_offloader.plugin"):
+            await plugin._on_before_model_call(bmc)
+
+        assert "failed to evict" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_storage_auto_namespaced(self, unified_storage):
+        plugin = ContextOffloader(
+            storage=unified_storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+        )
+        # Internal storage should be namespaced under "offloader/"
+        from strands.storage.storage import _NAMESPACED
+
+        assert getattr(plugin._storage, "_namespaced", None) is _NAMESPACED
+
+    @pytest.mark.asyncio
+    async def test_pre_namespaced_storage_not_double_namespaced(self):
+        from strands.storage import InMemoryStorage as UnifiedInMemory
+        from strands.storage.storage import _NamespacedStorage
+
+        raw = UnifiedInMemory()
+        pre_namespaced = _NamespacedStorage(raw, "custom")
+        plugin = ContextOffloader(
+            storage=pre_namespaced,
+            max_result_tokens=25,
+            preview_tokens=10,
+        )
+        # Should use the pre-namespaced storage as-is
+        assert plugin._storage is pre_namespaced
+
+    def test_raises_on_invalid_evict_after_cycles(self):
+        with pytest.raises(ValueError, match="evict_after_cycles must be a positive integer"):
+            ContextOffloader(
+                storage=MagicMock(spec=["store", "retrieve"]),
+                max_result_tokens=25,
+                preview_tokens=10,
+                evict_after_cycles=0,
+            )
+        with pytest.raises(ValueError, match="evict_after_cycles must be a positive integer"):
+            ContextOffloader(
+                storage=MagicMock(spec=["store", "retrieve"]),
+                max_result_tokens=25,
+                preview_tokens=10,
+                evict_after_cycles=-1,
+            )


### PR DESCRIPTION
## Description

Ports the unified Storage primitive from PR #3099 (TypeScript SDK) to the Python SDK — a single persistence interface (`write`/`read`/`delete`/`list` over opaque bytes) that all SDK subsystems can share. This eliminates per-subsystem persistence re-invention and gives every consumer the same backend options (local file, S3, in-memory, or custom) for free.

The context offloader plugin is adapted to accept both the new unified `Storage` and the legacy offloader `Storage`, selecting the code path at runtime via duck-type detection. Unified storage gets content framing (2-byte BE content-type header) and cycle-based eviction; the legacy path is unchanged.

Session integration is deferred — Python's `SessionRepository` is architecturally different from TS's snapshot storage and deserves its own design.

## Public API

### New module: `strands.storage`

```python
from strands.storage import Storage, InMemoryStorage, LocalFileStorage, S3Storage
```

### `Storage` Protocol (generic on `ListQuery`, defaults to `str`)

```python
@runtime_checkable
class Storage(Protocol[ListQuery]):
    async def write(self, key: str, data: bytes) -> None: ...
    async def read(self, key: str) -> bytes | None: ...
    async def delete(self, key: str) -> None: ...
    async def list(self, query: ListQuery) -> list[str]: ...
```

All keys are opaque, '/'-separated strings. All data is raw `bytes`. `read` returns `None` for missing keys. `delete` is a no-op for missing keys. `list` returns keys sorted ascending; empty string matches all.

### `InMemoryStorage`

```python
storage = InMemoryStorage()
await storage.write("key", b"value")
storage.clear()  # testing helper
```

Thread-safe dict backend. Unbounded — consumers manage eviction.

### `LocalFileStorage`

```python
storage = LocalFileStorage("./.strands/")
await storage.write("sessions/abc/state.json", data)

# Sandbox routing
sandbox_storage = storage.for_sandbox(agent.sandbox)

# Namespacing
scoped = storage.namespace("offloader")
```

Maps key segments to filesystem paths. Writes are atomic (temp file + `os.replace`). Supports sandbox routing via `for_sandbox()` — the returned view routes I/O through the sandbox's file API. `namespace()` returns a `_NamespacedLocalFileStorage` that preserves `for_sandbox` through the namespace layer.

### `S3Storage`

```python
storage = S3Storage(
    "my-bucket",
    prefix="agents/",
    region_name="us-east-1",
    # OR
    boto_session=my_session,
    boto_client_config=Config(read_timeout=30),
)
```

- Lazy client creation (no import cost until first use)
- All boto3 calls wrapped in `asyncio.to_thread` (non-blocking)
- Paginated listing via `list_objects_v2`
- User-agent tagging (`strands-agents`)
- `namespace()` for key prefix scoping

### Key normalization

All implementations share `_normalize_key` / `_normalize_prefix`:
- Collapses `//` → `/`, strips leading/trailing `/`
- Rejects empty keys, `..` segments → raises `StorageError`

### Namespace support

```python
scoped = storage.namespace("offloader")
await scoped.write("key", data)
# equivalent to: await storage.write("offloader/key", data)
```

Composable — `storage.namespace("a").namespace("b")` scopes to `"a/b/"`. `_NAMESPACED` sentinel allows SDK constructs to detect pre-scoped storage and skip auto-prefixing.

## Context Offloader Changes

The `ContextOffloader` constructor now accepts `storage: Storage | _LegacyStorage`:

```python
from strands.storage import LocalFileStorage
from strands.vended_plugins.context_offloader import ContextOffloader

agent = Agent(plugins=[
    ContextOffloader(
        storage=LocalFileStorage("./.strands/"),
        evict_after_cycles=20,
    )
])
```

New parameters:
- `evict_after_cycles: int | None = 20` — entries stored more than N cycles ago are deleted on `BeforeModelCallEvent`. Set to `None` to disable.

Internal changes:
- Content framing: `[2-byte BE content-type length][content-type UTF-8][content bytes]`
- Per-agent eviction tracking via `WeakKeyDictionary[Agent, dict[str, int]]`
- Duck-type detection for sandbox routing (`hasattr(storage, "for_sandbox")`)
- Auto-namespaces unified storage under `"offloader/"` if not already scoped

## Developer Experience

```python
# Minimal — in-memory, no persistence
from strands.storage import InMemoryStorage
storage = InMemoryStorage()

# Local file — atomic writes, sandbox-aware
from strands.storage import LocalFileStorage
storage = LocalFileStorage("./.strands/")

# S3 — non-blocking, paginated, lazy client
from strands.storage import S3Storage
storage = S3Storage("my-bucket", prefix="agents/")

# Custom backend — just implement the 4-method Protocol
class MyStorage:
    async def write(self, key: str, data: bytes) -> None: ...
    async def read(self, key: str) -> bytes | None: ...
    async def delete(self, key: str) -> None: ...
    async def list(self, query: str) -> list[str]: ...

# isinstance checks work at runtime
from strands.storage import Storage
assert isinstance(InMemoryStorage(), Storage)  # True (runtime_checkable)
```

## Related Issues

#3099 (TS implementation), #3258 (TS bug fixes ported here)

## Type of Change

New feature

## Testing

- 90 storage unit tests (InMemory, LocalFile, S3 via moto)
- 13 unified-storage plugin tests (framing, eviction, per-agent scoping)
- All existing offloader tests continue to pass (legacy path unchanged)
- Lint (ruff + mypy strict) passes
- Python 3.10–3.14, Linux + macOS + Windows CI

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.