### PR TITLE
docs(py): document Bedrock strict_tools schema constraints

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -264,6 +264,7 @@ Common configuration parameters include:
 - `cache_prompt` - Cache point type for the system prompt (deprecated, use `cache_config`)
 - `cache_config` - Configuration for prompt caching (e.g., `CacheConfig(strategy="auto")`)
 - `cache_tools` - Enable tool caching
+- `strict_tools` - Enforce structured output on tool definitions. Bedrock's strict mode restricts which JSON Schema features tool input schemas may use (for example, `oneOf` is unsupported), so a schema that uses an unsupported feature fails at request time. See the [Bedrock structured output documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html)
 - `boto_session` - Custom boto3 session for AWS credentials
 - `additional_request_fields` - Additional model-specific parameters
 </Tab>

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -269,7 +269,7 @@ class AfterModelCallEvent(HookEvent):
     Note: This event is not fired for invocations to structured_output.
 
     Model Retrying:
-        When ``retry_model`` is set to True by a hook callback, the agent will discard
+        When ``retry`` is set to True by a hook callback, the agent will discard
         the current model response and invoke the model again. This has important
         implications for streaming consumers:
 

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -127,6 +127,11 @@ class BedrockModel(Model):
             strict_tools: Flag to enable structured output enforcement on tool definitions.
                 When True, adds strict: true to each tool spec and automatically injects
                 "additionalProperties": false into all object types in tool input schemas.
+                Bedrock's strict mode compiles tool schemas into a constrained-decoding grammar and
+                restricts which JSON Schema features tool input schemas may use (for example, "oneOf"
+                is unsupported and optional parameters are capped across all tools in the request).
+                A schema that uses an unsupported feature fails at request time with a
+                ValidationException.
                 See https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
             temperature: Controls randomness in generation (higher = more random)
             top_p: Controls diversity via nucleus sampling (alternative to temperature)

--- a/strands-py/tests/strands/agent/test_agent_hooks.py
+++ b/strands-py/tests/strands/agent/test_agent_hooks.py
@@ -428,7 +428,7 @@ async def test_hook_retry_on_exception_basic(alist, mock_sleep):
 
 @pytest.mark.asyncio
 async def test_hook_retry_not_set_on_success(alist):
-    """Test that model is not retried when hook doesn't set retry_model on success."""
+    """Test that model is not retried when hook doesn't set retry on success."""
     mock_provider = MockedModelProvider(
         [
             {
@@ -438,7 +438,7 @@ async def test_hook_retry_not_set_on_success(alist):
         ]
     )
 
-    # Hook that tries to set retry_model=True even on success
+    # Hook that tries to set retry=True even on success
     class NoRetryHook:
         def __init__(self):
             self.call_count = 0
@@ -449,14 +449,14 @@ async def test_hook_retry_not_set_on_success(alist):
         async def handle_after_model_call(self, event):
             self.call_count += 1
             # Try to set retry even on success
-            # Don't set retry_model (leave it as False)
+            # Don't set retry (leave it as False)
 
     retry_hook = NoRetryHook()
     agent = Agent(model=mock_provider, hooks=[retry_hook])
 
     result = agent("Test no retry when not set")
 
-    # Should only be called once since retry_model was not set
+    # Should only be called once since retry was not set
     assert retry_hook.call_count == 1
     assert result.message["content"][0]["text"] == "First successful response"
 
@@ -506,7 +506,7 @@ async def test_hook_retry_with_limit(alist, mock_sleep):
 
 @pytest.mark.asyncio
 async def test_hook_retry_multiple_hooks(alist, mock_sleep):
-    """Test that multiple hooks can modify retry_model and last one wins."""
+    """Test that multiple hooks can modify retry and last one wins."""
 
     class CustomException(Exception):
         pass
@@ -544,7 +544,7 @@ async def test_hook_retry_multiple_hooks(alist, mock_sleep):
 
 @pytest.mark.asyncio
 async def test_hook_retry_last_hook_wins(alist, mock_sleep):
-    """Test that when multiple hooks set retry_model, the last-called hook wins.
+    """Test that when multiple hooks set retry, the last-called hook wins.
 
     Note: AfterModelCallEvent callbacks are invoked in reverse order, so the first
     registered hook is called last.


### PR DESCRIPTION
## Description

When `BedrockModel(strict_tools=True)` sends a tool set that Bedrock's strict mode cannot compile, Bedrock rejects the request with a `ValidationException`. Strict mode compiles tool schemas into a constrained-decoding grammar and restricts which JSON Schema features a tool input schema may use (for example, `oneOf` is unsupported, and optional parameters are capped across all tools in the request). The failure surfaces deep in the model call and never mentions that `strict_tools` is the trigger, which made it hard to diagnose in the issue.

This change documents the behavior rather than adding runtime handling. It expands the `strict_tools` config docstring and adds a `strict_tools` bullet to the Bedrock provider page, both linking AWS's structured-output documentation for the authoritative constraint list.

We deliberately do not add SDK-side detection or validation. We explored translating the `ValidationException` into a clearer error, but the rejection messages are model-family-specific (Anthropic, Nova, and others word them differently and fail at different stages), so no reliable, non-brittle signal exists to key on. The model provider already enforces these constraints, and there is no Bedrock pre-flight endpoint to validate a tool set, so the SDK should defer to the provider and point users at the documentation rather than inspect or normalize tool schemas itself.

Drive-by: the `AfterModelCallEvent` docstring referenced a `retry_model` field that does not exist. The writable field is `retry`. Corrected the docstring and the stale references in the hook tests' comments.

### Why not TypeScript?

`strict_tools` is a Python-only feature. The TS `BedrockModel` has no `strictTools` config field and passes tool schemas to Bedrock verbatim, never setting `strict: true`, so this class of failure does not arise through the TS SDK and there is nothing to document on the TS side. The `AfterModelCallEvent.retry` field is already correctly named in TS.

## Related Issues

Relates to #2664

## Documentation PR

Included in this PR: `strict_tools` bullet added to the Bedrock provider page under `site/`.

## Type of Change

Documentation update

## Testing

- [x] I ran `hatch run prepare`

Ran `hatch run lint` (ruff + mypy, pass) and the affected unit tests (`tests/strands/models/test_bedrock.py`, `tests/strands/agent/test_agent_hooks.py`), 206 passed. Ran `prettier --check` on the edited docs page. Did not run the full `hatch test --all` matrix. The changes are documentation and a docstring correction; no runtime behavior changed.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
