### PR TITLE
refactor(ts): extract generic async Queue from multiagent

### DIFF
--- a/strands-ts/src/__tests__/queue.test.ts
+++ b/strands-ts/src/__tests__/queue.test.ts
@@ -1,26 +1,17 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { Queue } from '../queue.js'
-import type { QueueData } from '../queue.js'
-import type { Node } from '../nodes.js'
-import { NodeResult, Status } from '../state.js'
 
 describe('Queue', () => {
-  let queue: Queue
-  let mockNode: Node
+  let queue: Queue<{ value: string }>
 
   beforeEach(() => {
-    mockNode = { id: 'node-1' } as Node
-    queue = new Queue()
+    queue = new Queue<{ value: string }>()
   })
 
   describe('push and shift', () => {
     it('dequeues in FIFO order', () => {
-      const data1: QueueData = {
-        type: 'result',
-        node: mockNode,
-        result: new NodeResult({ nodeId: 'node-1', status: Status.COMPLETED, duration: 10 }),
-      }
-      const data2: QueueData = { type: 'error', node: mockNode, error: new Error('fail') }
+      const data1 = { value: 'first' }
+      const data2 = { value: 'second' }
 
       queue.push(data1)
       queue.push(data2)
@@ -34,7 +25,7 @@ describe('Queue', () => {
     })
 
     it('provides a no-op ack for fire-and-forget pushes', () => {
-      queue.push({ type: 'error', node: mockNode, error: new Error('a') })
+      queue.push({ value: 'a' })
       const entry = queue.shift()!
       expect(() => entry.ack()).not.toThrow()
     })
@@ -42,7 +33,7 @@ describe('Queue', () => {
 
   describe('send', () => {
     it('resolves when consumer calls ack', async () => {
-      const data: QueueData = { type: 'error', node: mockNode, error: new Error('a') }
+      const data = { value: 'a' }
       let resolved = false
 
       const waiting = queue.send(data).then(() => {
@@ -68,8 +59,8 @@ describe('Queue', () => {
     it('reflects the current number of entries', () => {
       expect(queue.size).toBe(0)
 
-      queue.push({ type: 'error', node: mockNode, error: new Error('a') })
-      queue.push({ type: 'error', node: mockNode, error: new Error('b') })
+      queue.push({ value: 'a' })
+      queue.push({ value: 'b' })
       expect(queue.size).toBe(2)
 
       queue.shift()
@@ -79,7 +70,7 @@ describe('Queue', () => {
 
   describe('wait', () => {
     it('resolves immediately when entries are available', async () => {
-      queue.push({ type: 'error', node: mockNode, error: new Error('a') })
+      queue.push({ value: 'a' })
 
       await queue.wait()
 
@@ -96,7 +87,7 @@ describe('Queue', () => {
       await Promise.resolve()
       expect(resolved).toBe(false)
 
-      queue.push({ type: 'error', node: mockNode, error: new Error('a') })
+      queue.push({ value: 'a' })
 
       await waiting
       expect(resolved).toBe(true)
@@ -112,9 +103,8 @@ describe('Queue', () => {
       await Promise.resolve()
       expect(resolved).toBe(false)
 
-      const data: QueueData = { type: 'error', node: mockNode, error: new Error('a') }
       // Don't await send — it won't resolve until ack
-      const sending = queue.send(data)
+      const sending = queue.send({ value: 'a' })
 
       await waiting
       expect(resolved).toBe(true)
@@ -128,8 +118,7 @@ describe('Queue', () => {
   describe('dispose', () => {
     it('resolves pending send acks and drains entries', async () => {
       let resolved = false
-      const data: QueueData = { type: 'error', node: mockNode, error: new Error('a') }
-      const sending = queue.send(data).then(() => {
+      const sending = queue.send({ value: 'a' }).then(() => {
         resolved = true
       })
 
@@ -147,8 +136,7 @@ describe('Queue', () => {
     it('causes future send calls to resolve immediately', async () => {
       queue.dispose()
 
-      const data: QueueData = { type: 'error', node: mockNode, error: new Error('a') }
-      await queue.send(data)
+      await queue.send({ value: 'a' })
 
       expect(queue.size).toBe(0)
     })

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -39,10 +39,18 @@ import {
 } from './events.js'
 import type { EdgeDefinition } from './edge.js'
 import { Edge } from './edge.js'
-import { Queue } from './queue.js'
+import { Queue } from '../queue.js'
 import { Tracer } from '../telemetry/tracer.js'
 import type { Span } from '@opentelemetry/api'
 import { normalizeError } from '../errors.js'
+
+/**
+ * Data produced by a running node: a streaming event, a completion signal, or an error.
+ */
+type NodeExecutionOutput =
+  | { type: 'event'; node: Node; event: MultiAgentStreamEvent }
+  | { type: 'result'; node: Node; result: NodeResult }
+  | { type: 'error'; node: Node; error: Error }
 
 /**
  * Runtime configuration for graph execution.
@@ -268,7 +276,7 @@ export class Graph implements MultiAgent {
     const state = this._pendingInterruptState ?? new MultiAgentState({ nodeIds: [...this.nodes.keys()] })
     delete this._pendingInterruptState
 
-    const queue = new Queue()
+    const queue = new Queue<NodeExecutionOutput>()
     const streams = new Map<string, Promise<void>>()
 
     const multiAgentSpan = this._tracer.startMultiAgentSpan({
@@ -511,7 +519,7 @@ export class Graph implements MultiAgent {
     node: Node,
     input: MultiAgentInput,
     state: MultiAgentState,
-    queue: Queue,
+    queue: Queue<NodeExecutionOutput>,
     nodeSpan: Span | null,
     invocationState: InvocationState,
     executionSignal?: AbortSignal

--- a/strands-ts/src/queue.ts
+++ b/strands-ts/src/queue.ts
@@ -1,22 +1,12 @@
-import type { Node } from './nodes.js'
-import type { MultiAgentStreamEvent } from './events.js'
-import type { NodeResult } from './state.js'
-
-/**
- * Data produced by a running node: a streaming event, a completion signal, or an error.
- */
-export type QueueData =
-  | { type: 'event'; node: Node; event: MultiAgentStreamEvent }
-  | { type: 'result'; node: Node; result: NodeResult }
-  | { type: 'error'; node: Node; error: Error }
-
 /**
  * Queue data paired with an acknowledgement callback.
  * The consumer must call {@link ack} after fully processing the data
  * to unblock any producer waiting via {@link Queue.send}.
+ *
+ * @internal
  */
-export interface QueueEntry {
-  data: QueueData
+export interface QueueEntry<T> {
+  data: T
   ack: () => void
 }
 
@@ -27,9 +17,11 @@ export interface QueueEntry {
  * block until the consumer has fully processed the data. The consumer calls
  * {@link shift} to dequeue, then {@link QueueEntry.ack} after
  * processing to unblock the producer.
+ *
+ * @internal
  */
-export class Queue {
-  private readonly _entries: QueueEntry[] = []
+export class Queue<T> {
+  private readonly _entries: QueueEntry<T>[] = []
   /** Resolve function for the pending wait() promise, if any. */
   private _notify?: (() => void) | undefined
   private _disposed = false
@@ -37,7 +29,7 @@ export class Queue {
   /**
    * Push data to the queue, waking any waiting consumer.
    */
-  push(data: QueueData): void {
+  push(data: T): void {
     this._entries.push({ data, ack: () => {} })
     this._notify?.()
     this._notify = undefined
@@ -45,13 +37,13 @@ export class Queue {
 
   /**
    * Push data and wait until the consumer has fully processed it.
-   * Provides back-pressure so the producer pauses until the event
-   * has been yielded and hook callbacks have been invoked.
+   * Provides back-pressure so the producer pauses until the consumer
+   * calls {@link QueueEntry.ack}.
    *
    * @param data - The queue data to push
    * @returns Promise that resolves when the consumer calls {@link QueueEntry.ack}
    */
-  send(data: QueueData): Promise<void> {
+  send(data: T): Promise<void> {
     if (this._disposed) return Promise.resolve()
 
     return new Promise((resolve) => {
@@ -74,7 +66,7 @@ export class Queue {
   /**
    * Remove and return the next entry, or undefined if empty.
    */
-  shift(): QueueEntry | undefined {
+  shift(): QueueEntry<T> | undefined {
     return this._entries.shift()
   }
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

The async `Queue` primitive used by `Graph` is coupled to the multi-agent module even though its notification, back-pressure and disposal mechanics could be of use across the SDK.

This PR extracts it as an internal generic primitive, allowing other SDK subsystems to reuse it rather than duplicating/reengineering queueing logic. As part of this, we also rename `QueueData` to `NodeExecutionOutput` + move it to graph.ts .

## Related Issues

<!-- Link to related issues using #issue-number format -->

Sprung out of on-going work for #2496 (will make use of `Queue` primitive internally)

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

N/A (internal)

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Refactor

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
