### PR TITLE
fix(site): escape all regex metacharacters in API counterpart anchor pattern

### DIFF
--- a/site/src/util/api-counterparts.ts
+++ b/site/src/util/api-counterparts.ts
@@ -37,11 +37,16 @@ function symbolMatchesSegment(symbol: string, segment: string): boolean {
   return symbol.toLowerCase() === segment.replace(/_/g, '').toLowerCase()
 }
 
+/** Escape every regex metacharacter so the string matches literally. */
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 /** Top-level symbols documented by a Python module page, in document order. */
 function extractPythonSymbols(moduleName: string, body: string): string[] {
   // Match anchors exactly one level below the module (members like
   // `module.Class.method` have a further dot and are excluded).
-  const escaped = moduleName.replace(/\./g, '\\.')
+  const escaped = escapeRegExp(moduleName)
   const anchorRe = new RegExp(`<a id="${escaped}\\.([A-Za-z_][A-Za-z0-9_]*)"`, 'g')
   const seen = new Set<string>()
   const symbols: string[] = []

--- a/site/test/api-counterparts.test.ts
+++ b/site/test/api-counterparts.test.ts
@@ -64,6 +64,21 @@ describe('buildApiCounterpartMap', () => {
     expect(map.has('docs/api/python/strands.agent.a2a_agent')).toBe(false)
   })
 
+  it('treats regex metacharacters in module ids literally', () => {
+    // A module id containing regex metacharacters must not let "x" match the
+    // "x+y" wildcard position, and must still match its own anchors exactly.
+    const metaEntries: ApiDocEntry[] = [
+      {
+        id: 'docs/api/python/strands.x+y',
+        body: '<a id="strands.x+y.Widget"></a>\n<a id="strands.xxy.Impostor"></a>',
+      },
+      { id: 'docs/api/typescript/Widget', body: '' },
+      { id: 'docs/api/typescript/Impostor', body: '' },
+    ]
+    const metaMap = buildApiCounterpartMap(metaEntries)
+    expect(metaMap.get('docs/api/python/strands.x+y')).toBe('/docs/api/typescript/Widget/')
+  })
+
   it('does not pair the section index pages', () => {
     expect(map.has('docs/api/typescript')).toBe(false)
     expect(map.has('docs/api/python')).toBe(false)


### PR DESCRIPTION
## Description

Resolves [code-scanning alert 38](https://github.com/strands-agents/harness-sdk/security/code-scanning/38) (`js/incomplete-sanitization`, high) flagged on `site/src/util/api-counterparts.ts` after #3205 merged.

`extractPythonSymbols` builds a `RegExp` from the module id but only escaped `.` characters (`moduleName.replace(/\./g, '\\.')`), leaving every other regex metacharacter — and notably backslashes — interpreted as pattern syntax. The fix replaces the single-character escape with a standard `escapeRegExp` helper that escapes all metacharacters (`[.*+?^${}()|[\]\\]`), so the module id always matches literally.

Practical risk was low — module ids come from our own doc generator and are dot-separated Python module paths, so no current id contains other metacharacters — but the pattern is exactly what the CodeQL rule exists to catch: sanitization that handles one character and silently mishandles the rest if the input shape ever changes.

## Related Issues

Code-scanning alert #38; follow-up to #3205.

## Type of Change

Bug fix

## Testing

- New unit test: a module id containing a regex metacharacter (`x+y`) must match its own anchors literally and must not let the metacharacter act as pattern syntax (an `xxy.Impostor` anchor that `x+y`-as-regex would match is excluded).
- Full counterpart + language-switch suites pass (22 tests); `npm run typecheck` clean; prettier clean.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
