### PR TITLE
feat(context-offloader): add should_offload callback for selective offloading

### DIFF
--- a/strands-py/src/strands/vended_plugins/context_offloader/__init__.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/__init__.py
@@ -29,7 +29,7 @@ Example Usage:
     ```
 """
 
-from .plugin import ContextOffloader
+from .plugin import ContextOffloader, ShouldOffload
 from .storage import (
     FileStorage,
     InMemoryStorage,
@@ -42,5 +42,6 @@ __all__ = [
     "FileStorage",
     "InMemoryStorage",
     "S3Storage",
+    "ShouldOffload",
     "Storage",
 ]

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -27,6 +27,16 @@ Example:
             include_retrieval_tool=True,
         )
     ])
+
+    # Selective offloading: only offload results from specific tools
+    agent = Agent(plugins=[
+        ContextOffloader(
+            storage=InMemoryStorage(),
+            should_offload=lambda tool_name, token_count, **kwargs: (
+                tool_name == "get_document_text"
+            ),
+        )
+    ])
     ```
 """
 
@@ -35,7 +45,7 @@ from __future__ import annotations
 import json
 import logging
 import weakref
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol
 
 from typing_extensions import TypedDict
 
@@ -138,6 +148,21 @@ _CHARS_PER_TOKEN = 4
 """Approximate characters per token, fallback for preview slicing without tiktoken."""
 
 
+class ShouldOffload(Protocol):
+    """Callback protocol for deciding whether a tool result should be offloaded."""
+
+    def __call__(self, tool_name: str, token_count: int, **kwargs: Any) -> bool:
+        """Return True to offload, False to keep the result in context.
+
+        Args:
+            tool_name: Name of the tool that produced the result.
+            token_count: Estimated token count of the result.
+            **kwargs: Reserved for future parameters. Implementations should accept
+                ``**kwargs`` for forward compatibility.
+        """
+        ...
+
+
 class ContextOffloader(Plugin):
     """Plugin that offloads oversized tool results to reduce context consumption.
 
@@ -168,6 +193,8 @@ class ContextOffloader(Plugin):
         preview_tokens: Number of tokens to keep as a text preview in context.
         include_retrieval_tool: Whether to register the ``retrieve_offloaded_content`` tool.
             Defaults to True.
+        should_offload: Callback to control which tool results are offloaded.
+            Defaults to None (all oversized results offloaded).
 
     Example:
         ```python
@@ -176,6 +203,16 @@ class ContextOffloader(Plugin):
 
         agent = Agent(plugins=[
             ContextOffloader(storage=InMemoryStorage())
+        ])
+
+        # Only offload results from large-output tools
+        agent = Agent(plugins=[
+            ContextOffloader(
+                storage=InMemoryStorage(),
+                should_offload=lambda tool_name, token_count, **kwargs: (
+                    tool_name == "get_document_text"
+                ),
+            )
         ])
         ```
     """
@@ -189,6 +226,7 @@ class ContextOffloader(Plugin):
         preview_tokens: int = _DEFAULT_PREVIEW_TOKENS,
         *,
         include_retrieval_tool: bool = True,
+        should_offload: ShouldOffload | None = None,
         evict_after_cycles: int | None = 20,
     ) -> None:
         """Initialize the ContextOffloader plugin.
@@ -204,6 +242,10 @@ class ContextOffloader(Plugin):
                 chars/4 heuristic. Defaults to ``_DEFAULT_PREVIEW_TOKENS`` (1,000).
             include_retrieval_tool: Whether to register the ``retrieve_offloaded_content``
                 tool so the agent can fetch offloaded content. Defaults to True.
+            should_offload: Callback ``(tool_name, token_count, **kwargs) -> bool`` to decide
+                whether a specific tool result should be offloaded. Called only when the result
+                exceeds ``max_result_tokens``. Return ``True`` to offload, ``False`` to keep
+                in context. Defaults to None (all oversized results offloaded).
             evict_after_cycles: Number of agent loop cycles before an offloaded entry is
                 evicted (unified Storage only). Entries stored more than this many cycles
                 ago are deleted. Defaults to 20. Set to None to disable eviction.
@@ -227,6 +269,7 @@ class ContextOffloader(Plugin):
         self._max_result_tokens = max_result_tokens
         self._preview_tokens = preview_tokens
         self._include_retrieval_tool = include_retrieval_tool
+        self._should_offload = should_offload
         self._evict_after_cycles = evict_after_cycles
         self._stored_cycles: weakref.WeakKeyDictionary[Agent, dict[str, int]] = weakref.WeakKeyDictionary()
         super().__init__()
@@ -415,6 +458,9 @@ class ContextOffloader(Plugin):
         token_count = await event.agent.model.count_tokens([tool_result_message])
 
         if token_count <= self._max_result_tokens:
+            return
+
+        if self._should_offload is not None and not self._should_offload(event.tool_use.get("name"), token_count):
             return
 
         # Build text preview from text+JSON blocks.

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -47,7 +47,7 @@ import json
 import logging
 import weakref
 from collections.abc import Awaitable
-from typing import TYPE_CHECKING, Any, Protocol, Union
+from typing import TYPE_CHECKING, Any, Protocol
 
 from typing_extensions import TypedDict
 
@@ -153,7 +153,7 @@ _CHARS_PER_TOKEN = 4
 class ShouldOffload(Protocol):
     """Callback protocol for deciding whether a tool result should be offloaded."""
 
-    def __call__(self, tool_name: str, token_count: int, **kwargs: Any) -> Union[bool, Awaitable[bool]]:
+    def __call__(self, tool_name: str, token_count: int, **kwargs: Any) -> bool | Awaitable[bool]:
         """Return True to offload, False to keep the result in context. May be sync or async.
 
         Args:

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -46,7 +46,8 @@ import inspect
 import json
 import logging
 import weakref
-from typing import TYPE_CHECKING, Any, Protocol
+from collections.abc import Awaitable
+from typing import TYPE_CHECKING, Any, Protocol, Union
 
 from typing_extensions import TypedDict
 
@@ -152,8 +153,8 @@ _CHARS_PER_TOKEN = 4
 class ShouldOffload(Protocol):
     """Callback protocol for deciding whether a tool result should be offloaded."""
 
-    def __call__(self, tool_name: str, token_count: int, **kwargs: Any) -> bool:
-        """Return True to offload, False to keep the result in context.
+    def __call__(self, tool_name: str, token_count: int, **kwargs: Any) -> Union[bool, Awaitable[bool]]:
+        """Return True to offload, False to keep the result in context. May be sync or async.
 
         Args:
             tool_name: Name of the tool that produced the result.

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -42,6 +42,7 @@ Example:
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import weakref
@@ -460,8 +461,19 @@ class ContextOffloader(Plugin):
         if token_count <= self._max_result_tokens:
             return
 
-        if self._should_offload is not None and not self._should_offload(event.tool_use.get("name"), token_count):
-            return
+        if self._should_offload is not None:
+            try:
+                verdict = self._should_offload(event.tool_use.get("name", ""), token_count)
+                if inspect.isawaitable(verdict):
+                    verdict = await verdict
+                if not verdict:
+                    return
+            except Exception:
+                logger.warning(
+                    "tool_use_id=<%s> | should_offload callback failed, falling back to default offload",
+                    tool_use_id,
+                    exc_info=True,
+                )
 
         # Build text preview from text+JSON blocks.
         # Empty text blocks are intentionally excluded — they add no content value.

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -59,7 +59,9 @@ async def _heuristic_count_tokens(messages, **kwargs):
     return total
 
 
-def _make_event(agent, text_content, status="success", tool_use_id="tool_123", cancel_message=None):
+def _make_event(
+    agent, text_content, status="success", tool_use_id="tool_123", cancel_message=None, tool_name="test_tool"
+):
     """Helper to create an AfterToolCallEvent with content."""
     if isinstance(text_content, str):
         content = [{"text": text_content}]
@@ -71,7 +73,7 @@ def _make_event(agent, text_content, status="success", tool_use_id="tool_123", c
         "status": status,
         "content": content,
     }
-    tool_use = {"toolUseId": tool_use_id, "name": "test_tool", "input": {}}
+    tool_use = {"toolUseId": tool_use_id, "name": tool_name, "input": {}}
 
     return AfterToolCallEvent(
         agent=agent,
@@ -1164,3 +1166,127 @@ class TestUnifiedStorage:
                 preview_tokens=10,
                 evict_after_cycles=-1,
             )
+
+
+class TestShouldOffloadCallback:
+    """Tests for the should_offload callback parameter."""
+
+    @pytest.fixture
+    def storage(self):
+        return InMemoryStorage()
+
+    @pytest.fixture
+    def mock_agent(self):
+        agent = MagicMock()
+        agent.model = MagicMock()
+        agent.model.count_tokens = AsyncMock(side_effect=_heuristic_count_tokens)
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_callback_receives_tool_name_and_token_count(self, storage, mock_agent):
+        received_args = []
+
+        def capture_args(tool_name, token_count, **kwargs):
+            received_args.append((tool_name, token_count))
+            return True
+
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            should_offload=capture_args,
+        )
+        event = _make_event(mock_agent, "x" * 200, tool_name="my_tool")
+
+        await plugin._handle_tool_result(event)
+
+        assert len(received_args) == 1
+        assert received_args[0][0] == "my_tool"
+        assert received_args[0][1] == 50
+
+    @pytest.mark.asyncio
+    async def test_callback_returning_true_offloads(self, storage, mock_agent):
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            should_offload=lambda name, tokens, **kwargs: True,
+        )
+        event = _make_event(mock_agent, "x" * 200, tool_name="large_tool")
+
+        await plugin._handle_tool_result(event)
+
+        assert "[Offloaded:" in event.result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_callback_returning_false_skips_offload(self, storage, mock_agent):
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            should_offload=lambda name, tokens, **kwargs: False,
+        )
+        large_text = "x" * 200
+        event = _make_event(mock_agent, large_text, tool_name="search_tool")
+
+        await plugin._handle_tool_result(event)
+
+        assert event.result["content"][0]["text"] == large_text
+
+    @pytest.mark.asyncio
+    async def test_callback_filters_by_tool_name(self, storage, mock_agent):
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            should_offload=lambda name, tokens, **kwargs: name == "get_document_text",
+        )
+        large_text = "x" * 200
+
+        event1 = _make_event(mock_agent, large_text, tool_use_id="t1", tool_name="get_document_text")
+        await plugin._handle_tool_result(event1)
+        assert "[Offloaded:" in event1.result["content"][0]["text"]
+
+        event2 = _make_event(mock_agent, large_text, tool_use_id="t2", tool_name="search_opensearch")
+        await plugin._handle_tool_result(event2)
+        assert event2.result["content"][0]["text"] == large_text
+
+    @pytest.mark.asyncio
+    async def test_none_callback_offloads_all(self, storage, mock_agent):
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            should_offload=None,
+        )
+        event = _make_event(mock_agent, "x" * 200, tool_name="any_tool")
+
+        await plugin._handle_tool_result(event)
+
+        assert "[Offloaded:" in event.result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_callback_not_called_when_under_threshold(self, storage, mock_agent):
+        call_count = {"n": 0}
+
+        def counting_callback(name, tokens, **kwargs):
+            call_count["n"] += 1
+            return True
+
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            should_offload=counting_callback,
+        )
+        event = _make_event(mock_agent, "short", tool_name="small_tool")
+
+        await plugin._handle_tool_result(event)
+
+        assert call_count["n"] == 0

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -1235,6 +1235,7 @@ class TestShouldOffloadCallback:
         await plugin._handle_tool_result(event)
 
         assert event.result["content"][0]["text"] == large_text
+        assert len(storage._store) == 0
 
     @pytest.mark.asyncio
     async def test_callback_filters_by_tool_name(self, storage, mock_agent):
@@ -1290,3 +1291,59 @@ class TestShouldOffloadCallback:
         await plugin._handle_tool_result(event)
 
         assert call_count["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_raising_callback_falls_back_to_offload(self, storage, mock_agent):
+        def boom(tool_name, token_count, **kwargs):
+            raise RuntimeError("boom")
+
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            should_offload=boom,
+        )
+        event = _make_event(mock_agent, "x" * 200, tool_name="my_tool")
+
+        await plugin._handle_tool_result(event)
+
+        assert "[Offloaded:" in event.result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_async_callback_returning_false_skips_offload(self, storage, mock_agent):
+        async def never(tool_name, token_count, **kwargs):
+            return False
+
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            should_offload=never,
+        )
+        large_text = "x" * 200
+        event = _make_event(mock_agent, large_text, tool_name="search_tool")
+
+        await plugin._handle_tool_result(event)
+
+        assert event.result["content"][0]["text"] == large_text
+        assert len(storage._store) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_callback_returning_true_offloads(self, storage, mock_agent):
+        async def always(tool_name, token_count, **kwargs):
+            return True
+
+        plugin = ContextOffloader(
+            storage=storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=False,
+            should_offload=always,
+        )
+        event = _make_event(mock_agent, "x" * 200, tool_name="large_tool")
+
+        await plugin._handle_tool_result(event)
+
+        assert "[Offloaded:" in event.result["content"][0]["text"]


### PR DESCRIPTION
## Description

Add a `should_offload` callback parameter to `ContextOffloader` that lets users control which tool results are offloaded based on tool name and token count. When provided, the callback is invoked after the token threshold check — returning `False` skips offloading for that result.

### Changes

- **New `ShouldOffload` Protocol** (`plugin.py`): Extensible callback type using `Protocol` with `**kwargs` for forward compatibility, following the project style guide.
- **Updated `ContextOffloader.__init__`**: Added `should_offload: ShouldOffload | None` keyword argument. When `None` (default), existing behavior is preserved (backward compatible).
- **Updated `_handle_tool_result` hook**: Guard clause after the token threshold check that consults the callback.
- **Updated `__init__.py`**: Export `ShouldOffload` from the package.
- **Tests** (`test_plugin.py`): 6 new tests covering callback invocation, filtering by tool name, and backward compatibility. Extended `_make_event` helper with `tool_name` parameter.

## Related Issues

Closes #3266
Related: #2548 (TypeScript, full `shouldOffload` design)

## Documentation PR

Documentation updated in this PR (docstrings and inline examples).

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch test` — 65/65 tests pass
- [x] `ruff check` and `ruff format` clean

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.