### PR TITLE
feat(ts): add ToolExecutor class hierarchy

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/executors.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/executors.mdx
@@ -6,7 +6,8 @@ tags: [tool-execution, event-loop]
 sourceLinks:
   - path: strands-py/src/strands/tools/executors/concurrent.py
   - path: strands-py/src/strands/tools/executors/sequential.py
-  - path: strands-ts/src/agent/agent.ts
+  - path: strands-ts/src/tools/executors/concurrent.ts
+  - path: strands-ts/src/tools/executors/sequential.ts
 ---
 
 Tool executors control whether tools from a single assistant turn run concurrently or sequentially. Both SDKs default to concurrent execution.
@@ -39,6 +40,8 @@ agent("What is the weather and time in New York?")
 
 --8<-- "user-guide/concepts/tools/executors.ts:concurrent"
 ```
+
+`toolExecutor: 'concurrent'` remains supported as shorthand.
 
 </Tab>
 </Tabs>
@@ -76,6 +79,8 @@ agent("Please take a screenshot and then email the screenshot to my friend")
 
 --8<-- "user-guide/concepts/tools/executors.ts:sequential"
 ```
+
+`toolExecutor: 'sequential'` remains supported as shorthand.
 
 </Tab>
 </Tabs>

--- a/site/src/content/docs/user-guide/concepts/tools/executors.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/executors.mdx
@@ -41,7 +41,7 @@ agent("What is the weather and time in New York?")
 --8<-- "user-guide/concepts/tools/executors.ts:concurrent"
 ```
 
-`toolExecutor: 'concurrent'` remains supported as shorthand.
+The `'concurrent'` string shorthand keeps your imports minimal. Passing `new ConcurrentToolExecutor()` is equivalent if you prefer to be explicit.
 
 </Tab>
 </Tabs>
@@ -80,7 +80,7 @@ agent("Please take a screenshot and then email the screenshot to my friend")
 --8<-- "user-guide/concepts/tools/executors.ts:sequential"
 ```
 
-`toolExecutor: 'sequential'` remains supported as shorthand.
+The `'sequential'` string shorthand keeps your imports minimal. Passing `new SequentialToolExecutor()` is equivalent if you prefer to be explicit.
 
 </Tab>
 </Tabs>

--- a/site/src/content/docs/user-guide/concepts/tools/executors.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/executors.ts
@@ -1,9 +1,4 @@
-import {
-  Agent,
-  ConcurrentToolExecutor,
-  SequentialToolExecutor,
-  tool,
-} from '@strands-agents/sdk'
+import { Agent, tool } from '@strands-agents/sdk'
 import { z } from 'zod'
 
 const weatherTool = tool({
@@ -44,7 +39,7 @@ const emailTool = tool({
   // --8<-- [start:concurrent]
   const agent = new Agent({
     tools: [weatherTool, timeTool],
-    toolExecutor: new ConcurrentToolExecutor(),
+    toolExecutor: 'concurrent',
   })
   // Omit toolExecutor to use concurrent execution by default.
 
@@ -56,7 +51,7 @@ const emailTool = tool({
   // --8<-- [start:sequential]
   const agent = new Agent({
     tools: [screenshotTool, emailTool],
-    toolExecutor: new SequentialToolExecutor(),
+    toolExecutor: 'sequential',
   })
 
   await agent.invoke('Take a screenshot and email it to my friend')

--- a/site/src/content/docs/user-guide/concepts/tools/executors.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/executors.ts
@@ -1,4 +1,9 @@
-import { Agent, tool } from '@strands-agents/sdk'
+import {
+  Agent,
+  ConcurrentToolExecutor,
+  SequentialToolExecutor,
+  tool,
+} from '@strands-agents/sdk'
 import { z } from 'zod'
 
 const weatherTool = tool({
@@ -39,9 +44,9 @@ const emailTool = tool({
   // --8<-- [start:concurrent]
   const agent = new Agent({
     tools: [weatherTool, timeTool],
-    toolExecutor: 'concurrent',
+    toolExecutor: new ConcurrentToolExecutor(),
   })
-  // or simply: new Agent({ tools: [weatherTool, timeTool] })
+  // Omit toolExecutor to use concurrent execution by default.
 
   await agent.invoke('What is the weather and time in New York?')
   // --8<-- [end:concurrent]
@@ -51,7 +56,7 @@ const emailTool = tool({
   // --8<-- [start:sequential]
   const agent = new Agent({
     tools: [screenshotTool, emailTool],
-    toolExecutor: 'sequential',
+    toolExecutor: new SequentialToolExecutor(),
   })
 
   await agent.invoke('Take a screenshot and email it to my friend')

--- a/site/src/content/docs/user-guide/concepts/tools/executors_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/executors_imports.ts
@@ -2,9 +2,9 @@
 // Imports for executors page snippets
 
 // --8<-- [start:concurrent_imports]
-import { Agent, ConcurrentToolExecutor } from '@strands-agents/sdk'
+import { Agent } from '@strands-agents/sdk'
 // --8<-- [end:concurrent_imports]
 
 // --8<-- [start:sequential_imports]
-import { Agent, SequentialToolExecutor } from '@strands-agents/sdk'
+import { Agent } from '@strands-agents/sdk'
 // --8<-- [end:sequential_imports]

--- a/site/src/content/docs/user-guide/concepts/tools/executors_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/executors_imports.ts
@@ -2,9 +2,9 @@
 // Imports for executors page snippets
 
 // --8<-- [start:concurrent_imports]
-import { Agent } from '@strands-agents/sdk'
+import { Agent, ConcurrentToolExecutor } from '@strands-agents/sdk'
 // --8<-- [end:concurrent_imports]
 
 // --8<-- [start:sequential_imports]
-import { Agent } from '@strands-agents/sdk'
+import { Agent, SequentialToolExecutor } from '@strands-agents/sdk'
 // --8<-- [end:sequential_imports]

--- a/strands-ts/src/__tests__/index.test.ts
+++ b/strands-ts/src/__tests__/index.test.ts
@@ -17,6 +17,23 @@ describe('index', () => {
       expect(provider.getConfig()).toBeDefined()
     })
 
+    it('exports zero-argument tool executors', () => {
+      const concurrent = new SDK.ConcurrentToolExecutor()
+      const sequential = new SDK.SequentialToolExecutor()
+
+      expect({
+        concurrent: concurrent instanceof SDK.ConcurrentToolExecutor,
+        sequential: sequential instanceof SDK.SequentialToolExecutor,
+      }).toEqual({
+        concurrent: true,
+        sequential: true,
+      })
+    })
+
+    it('does not export the internal ToolExecutor base', () => {
+      expect(SDK).not.toHaveProperty('ToolExecutor')
+    })
+
     it('exports all required types', () => {
       // This test ensures all type exports compile correctly
       // If any exports are missing, TypeScript will error

--- a/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { Agent } from '../agent.js'
 import {
   AfterToolCallEvent,
@@ -10,8 +10,13 @@ import {
 } from '../../hooks/index.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { MockPlugin } from '../../__fixtures__/mock-plugin.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import { ExecuteToolStage } from '../../middleware/index.js'
+import { Tracer } from '../../telemetry/tracer.js'
 import { Message, TextBlock, ToolResultBlock } from '../../types/messages.js'
 import { Tool, ToolStreamEvent, type ToolContext, type ToolStreamGenerator } from '../../tools/tool.js'
+import { ConcurrentToolExecutor } from '../../tools/executors/concurrent.js'
+import { SequentialToolExecutor } from '../../tools/executors/sequential.js'
 import type { ToolSpec } from '../../tools/types.js'
 
 /**
@@ -140,6 +145,59 @@ function twoToolTurn(): MockMessageModel {
 }
 
 describe('Agent concurrent tool execution', () => {
+  it('uses ConcurrentToolExecutor by default', () => {
+    const agent = new Agent()
+
+    expect(agent.toolExecutor).toBeInstanceOf(ConcurrentToolExecutor)
+  })
+
+  it('preserves a supplied tool executor instance', () => {
+    const toolExecutor = new SequentialToolExecutor()
+    const agent = new Agent({ toolExecutor })
+
+    expect(agent.toolExecutor).toBe(toolExecutor)
+  })
+
+  it('rejects an unknown tool executor string', () => {
+    expect(() => new Agent({ toolExecutor: 'unsupported' as never })).toThrow('Unknown toolExecutor: unsupported')
+  })
+
+  it('resolves a string shorthand assigned to toolExecutor', () => {
+    const agent = new Agent()
+
+    agent.toolExecutor = 'sequential'
+
+    expect(agent.toolExecutor).toBeInstanceOf(SequentialToolExecutor)
+  })
+
+  it('rejects an unknown string assigned to toolExecutor', () => {
+    const agent = new Agent()
+
+    expect(() => {
+      agent.toolExecutor = 'unsupported' as never
+    }).toThrow('Unknown toolExecutor: unsupported')
+  })
+
+  it('uses a reassigned tool executor for subsequent tool calls', async () => {
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools: [toolA, toolB],
+      printer: false,
+    })
+
+    agent.toolExecutor = new SequentialToolExecutor()
+
+    const invocation = agent.invoke('Go')
+    await toolA.started
+    expect(toolB.observations.started).toBe(false)
+    toolA.release()
+    await toolB.started
+    toolB.release()
+    await invocation
+  })
+
   it('runs tools concurrently by default', async () => {
     const toolA = new GatedTool('toolA')
     const toolB = new GatedTool('toolB')
@@ -163,13 +221,13 @@ describe('Agent concurrent tool execution', () => {
     expect(toolB.observations.completed).toBe(true)
   })
 
-  it('runs tools sequentially when toolExecutor is sequential', async () => {
+  it('runs tools sequentially with a SequentialToolExecutor instance', async () => {
     const toolA = new GatedTool('toolA')
     const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
       tools: [toolA, toolB],
-      toolExecutor: 'sequential',
+      toolExecutor: new SequentialToolExecutor(),
       printer: false,
     })
 
@@ -190,7 +248,7 @@ describe('Agent concurrent tool execution', () => {
     const agent = new Agent({
       model: twoToolTurn(),
       tools: [toolA, toolB],
-      toolExecutor: 'concurrent',
+      toolExecutor: new ConcurrentToolExecutor(),
       printer: false,
       plugins: [plugin],
     })
@@ -276,6 +334,39 @@ describe('Agent concurrent tool execution', () => {
 
     expect(beforeCalls.filter((n) => n === 'toolA')).toHaveLength(2)
     expect(beforeCalls.filter((n) => n === 'toolB')).toHaveLength(1)
+  })
+
+  it('uses replacement tool input while preserving the model-issued toolUseId', async () => {
+    let receivedToolUse: ToolContext['toolUse'] | undefined
+    const tool = createMockTool('captureTool', (context) => {
+      receivedToolUse = context.toolUse
+      return 'done'
+    })
+    const model = new MockMessageModel()
+      .addTurn({
+        type: 'toolUseBlock',
+        name: 'captureTool',
+        toolUseId: 'original-id',
+        input: { value: 'original' },
+      })
+      .addTurn({ type: 'textBlock', text: 'Done' })
+    const agent = new Agent({ model, tools: [tool], printer: false })
+
+    agent.addHook(BeforeToolCallEvent, (event) => {
+      event.toolUse = {
+        name: 'captureTool',
+        toolUseId: 'replacement-id',
+        input: { value: 'replacement' },
+      }
+    })
+
+    await agent.invoke('Go')
+
+    expect(receivedToolUse).toEqual({
+      name: 'captureTool',
+      toolUseId: 'original-id',
+      input: { value: 'replacement' },
+    })
   })
 
   it('cancels all tools when BeforeToolsEvent.cancel is set (concurrent mode)', async () => {
@@ -386,6 +477,54 @@ describe('Agent concurrent tool execution', () => {
     const [a, b] = results.sort((x, y) => x.toolUseId.localeCompare(y.toolUseId))
     expect(a!.status).toBe('error')
     expect(b!.status).toBe('success')
+  })
+
+  it('isolates unexpected middleware failures to the affected tool', async () => {
+    const model = new MockMessageModel()
+      .addTurn([
+        { type: 'toolUseBlock', name: 'tool', toolUseId: 'failed-tool', input: {} },
+        { type: 'toolUseBlock', name: 'tool', toolUseId: 'successful-tool', input: {} },
+      ])
+      .addTurn({ type: 'textBlock', text: 'Done' })
+    const tool = createMockTool('tool', (context) => `completed:${context.toolUse.toolUseId}`)
+    const agent = new Agent({
+      model,
+      tools: [tool],
+      toolExecutor: new ConcurrentToolExecutor(),
+      printer: false,
+    })
+
+    agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+      if (context.toolUse.toolUseId === 'failed-tool') {
+        throw new Error('middleware failed')
+      }
+      return yield* next(context)
+    })
+
+    let toolResultMessage: Message | undefined
+    agent.addHook(AfterToolsEvent, (event) => {
+      toolResultMessage = event.message
+    })
+
+    const result = await agent.invoke('Go')
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(
+      toolResultMessage!.content.map((block) => ({
+        toolUseId: (block as ToolResultBlock).toolUseId,
+        status: (block as ToolResultBlock).status,
+        text: ((block as ToolResultBlock).content[0] as TextBlock).text,
+        error: (block as ToolResultBlock).error?.message,
+      }))
+    ).toEqual([
+      { toolUseId: 'failed-tool', status: 'error', text: 'middleware failed', error: 'middleware failed' },
+      {
+        toolUseId: 'successful-tool',
+        status: 'success',
+        text: 'completed:successful-tool',
+        error: undefined,
+      },
+    ])
   })
 
   it('handles a hallucinated tool name in a batch without affecting siblings', async () => {
@@ -560,5 +699,34 @@ describe('Agent concurrent tool execution', () => {
     expect(blocks.map((b) => b.toolUseId)).toEqual(['a', 'b'])
     expect(blocks.find((b) => b.toolUseId === 'a')!.status).toBe('success')
     expect(blocks.find((b) => b.toolUseId === 'b')!.status).toBe('error')
+  })
+
+  it('records span and metric telemetry when a tool interrupts', async () => {
+    const endToolCallSpan = vi.spyOn(Tracer.prototype, 'endToolCallSpan')
+    const model = new MockMessageModel().addTurn({
+      type: 'toolUseBlock',
+      name: 'approvalTool',
+      toolUseId: 'tool-1',
+      input: {},
+    })
+    const tool = createMockTool('approvalTool', (context) => {
+      context.interrupt({ name: 'approve', reason: 'Approve this tool call?' })
+    })
+    const agent = new Agent({ model, tools: [tool], printer: false })
+
+    const result = await agent.invoke('Go')
+
+    expect(result.stopReason).toBe('interrupt')
+    expect(endToolCallSpan.mock.calls).toEqual([[expect.anything(), {}]])
+    expect(agent.metrics.toolMetrics).toEqual({
+      approvalTool: {
+        callCount: 1,
+        successCount: 0,
+        errorCount: 1,
+        totalTime: expect.any(Number),
+      },
+    })
+
+    endToolCallSpan.mockRestore()
   })
 })

--- a/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { Agent } from '../agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
-import { ToolResultBlock } from '../../types/messages.js'
+import { ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
 import { AfterToolCallEvent, BeforeToolCallEvent, BeforeToolsEvent, InterruptEvent } from '../../hooks/events.js'
 import { FunctionTool } from '../../tools/function-tool.js'
 import { InterruptResponseContent } from '../../types/interrupt.js'
@@ -892,6 +892,88 @@ describe('Agent interrupt system', () => {
       expect(executionLog).toContain('A')
       expect(executionLog).not.toContain('B')
     })
+  })
+
+  describe('resume with hook-rewritten toolUseId', () => {
+    // Guards provider correlation and resume lookup against hook-rewritten tool-use IDs (#3268).
+    it.each(['sequential', 'concurrent'] as const)(
+      'runs the completed tool exactly once across interrupt and resume (%s)',
+      async (toolExecutor) => {
+        const model = new MockMessageModel()
+          .addTurn([
+            { type: 'toolUseBlock', name: 'toolA', toolUseId: 'tool-a', input: {} },
+            { type: 'toolUseBlock', name: 'toolB', toolUseId: 'tool-b', input: {} },
+          ])
+          .addTurn({ type: 'textBlock', text: 'Done' })
+        const providerIdSnapshots: Array<{ toolUseIds: string[]; toolResultIds: string[] }> = []
+        const originalStream = model.stream.bind(model)
+        vi.spyOn(model, 'stream').mockImplementation((messages, options) => {
+          const content = messages.flatMap((message) => message.content)
+          const toolUseIds = content
+            .filter((block): block is ToolUseBlock => block instanceof ToolUseBlock)
+            .map((block) => block.toolUseId)
+          const toolResultIds = content
+            .filter((block): block is ToolResultBlock => block instanceof ToolResultBlock)
+            .map((block) => block.toolUseId)
+          if (toolResultIds.length > 0) {
+            providerIdSnapshots.push({ toolUseIds, toolResultIds })
+          }
+          return originalStream(messages, options)
+        })
+
+        const executionLog: string[] = []
+        const toolA = createMockTool('toolA', () => {
+          executionLog.push('A')
+          return 'A result'
+        })
+        const toolB = new FunctionTool({
+          name: 'toolB',
+          description: 'Interrupting tool B',
+          inputSchema: { type: 'object', properties: {} },
+          callback: (_input, context) => {
+            executionLog.push('B')
+            const response = context!.interrupt<string>({ name: 'confirm_b', reason: 'Approve B?' })
+            return `B: ${response}`
+          },
+        })
+
+        const agent = new Agent({ model, tools: [toolA, toolB], toolExecutor, printer: false })
+        agent.addHook(BeforeToolCallEvent, (event) => {
+          if (event.toolUse.name === 'toolA') {
+            event.toolUse = { ...event.toolUse, toolUseId: 'rewritten-a' }
+          }
+        })
+        agent.addHook(AfterToolCallEvent, (event) => {
+          if (event.toolUse.name === 'toolA') {
+            event.result = new ToolResultBlock({
+              toolUseId: 'after-rewritten-a',
+              status: event.result.status,
+              content: event.result.content,
+              ...(event.result.error !== undefined && { error: event.result.error }),
+            })
+          }
+        })
+
+        const interruptResult = await agent.invoke('Go')
+        expect(interruptResult.stopReason).toBe('interrupt')
+        expect(executionLog).toEqual(['A', 'B'])
+
+        const pendingExecution = getPendingToolExecution(agent)
+        expect(Object.keys(pendingExecution!.completedToolResults)).toEqual(['tool-a'])
+        expect(pendingExecution!.completedToolResults['tool-a']!.toolResult.toolUseId).toBe('tool-a')
+
+        // Resume — only B re-executes.
+        const finalResult = await agent.invoke([
+          new InterruptResponseContent({
+            interruptId: interruptResult.interrupts![0]!.id,
+            response: 'approved',
+          }),
+        ])
+        expect(finalResult.stopReason).toBe('endTurn')
+        expect(executionLog).toEqual(['A', 'B', 'B'])
+        expect(providerIdSnapshots).toEqual([{ toolUseIds: ['tool-a', 'tool-b'], toolResultIds: ['tool-a', 'tool-b'] }])
+      }
+    )
   })
 
   describe('InterruptEvent emission', () => {

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -20,13 +20,12 @@ import {
   type SystemPromptData,
   TextBlock,
   ToolResultBlock,
-  type ToolResultBlockData,
   ToolUseBlock,
 } from '../types/messages.js'
 import { deepCopy } from '../types/json.js'
 import type { JSONValue } from '../types/json.js'
 import { McpClient } from '../mcp/index.js'
-import { isValidToolName, type Tool, type ToolContext } from '../tools/tool.js'
+import { isValidToolName, type Tool } from '../tools/tool.js'
 import type { ToolChoice, ToolSpec } from '../tools/types.js'
 import { cloneSystemPrompt, systemPromptFromData } from '../types/messages.js'
 import { normalizeError, ConcurrentInvocationError, StructuredOutputError } from '../errors.js'
@@ -50,7 +49,8 @@ import { ConversationManager } from '../conversation-manager/conversation-manage
 import { ContextOffloader } from '../vended-plugins/context-offloader/plugin.js'
 import { InMemoryStorage } from '../storage/in-memory-storage.js'
 import { HookRegistryImplementation } from '../hooks/registry.js'
-import { MiddlewareRegistry, InvokeModelStage, ExecuteToolStage, AgentStreamStage } from '../middleware/index.js'
+import { createMiddlewareInterrupt } from '../middleware/interrupt.js'
+import { MiddlewareRegistry, InvokeModelStage, AgentStreamStage } from '../middleware/index.js'
 import type {
   MiddlewareStage,
   MiddlewareHandler,
@@ -64,22 +64,17 @@ import type {
 import type {
   InvokeModelContext,
   InvokeModelResult,
-  ExecuteToolContext,
-  ExecuteToolResult,
   AgentStreamContext,
   AgentStreamResult,
-  MiddlewareInterruptResult,
 } from '../middleware/index.js'
 import type { HookableEventConstructor, HookCallback, HookCallbackOptions, HookCleanup } from '../hooks/types.js'
 import {
   InitializedEvent,
   AfterInvocationEvent,
   AfterModelCallEvent,
-  AfterToolCallEvent,
   AfterToolsEvent,
   BeforeInvocationEvent,
   BeforeModelCallEvent,
-  BeforeToolCallEvent,
   BeforeToolsEvent,
   HookableEvent,
   MessageAddedEvent,
@@ -88,12 +83,12 @@ import {
   ModelMessageEvent,
   ToolResultEvent,
   AgentResultEvent,
-  ToolStreamUpdateEvent,
   InterruptEvent,
   type ModelStopData,
-  type ToolUseData,
 } from '../hooks/events.js'
 import { StructuredOutputTool, STRUCTURED_OUTPUT_TOOL_NAME } from '../tools/structured-output-tool.js'
+import { ConcurrentToolExecutor } from '../tools/executors/concurrent.js'
+import { SequentialToolExecutor } from '../tools/executors/sequential.js'
 import { AgentAsTool } from './agent-as-tool.js'
 import type { AgentAsToolOptions } from './agent-as-tool.js'
 import { ToolCaller } from './tool-caller.js'
@@ -111,9 +106,8 @@ import { CancelledError, CheckpointError } from '../errors.js'
 import { DefaultModelRetryStrategy } from '../retry/default-model-retry-strategy.js'
 import type { RetryStrategy } from '../retry/retry-strategy.js'
 import { warnOnDuplicateRetryStrategyTypes } from '../retry/retry-strategy.js'
-import { Interrupt, InterruptError, InterruptState, interruptFromAgent } from '../interrupt.js'
+import { InterruptError, InterruptState } from '../interrupt.js'
 import { Checkpoint, type CheckpointPosition, type CheckpointResumeContent } from '../experimental/checkpoint.js'
-import type { InterruptParams } from '../types/interrupt.js'
 import { isInterruptResponseContent, type InterruptResponseContent } from '../types/interrupt.js'
 import { takeSnapshot as takeSnapshotInternal, loadSnapshot as loadSnapshotInternal } from './snapshot.js'
 import type { TakeSnapshotOptions } from './snapshot.js'
@@ -292,10 +286,13 @@ export type AgentConfig = {
    */
   id?: string
   /**
-   * Strategy for executing tool calls from a single assistant turn.
-   * Defaults to `'concurrent'`. See {@link ToolExecutorStrategy} for details.
+   * Executor for tool calls from a single assistant turn.
+   *
+   * Accepts a {@link ConcurrentToolExecutor}, a {@link SequentialToolExecutor},
+   * or the corresponding {@link ToolExecutorStrategy} string shorthand.
+   * Defaults to concurrent execution.
    */
-  toolExecutor?: ToolExecutorStrategy
+  toolExecutor?: ConcurrentToolExecutor | SequentialToolExecutor | ToolExecutorStrategy
   /**
    * When `true`, the agent loop pauses at cycle boundaries (`afterModel`,
    * `afterTools`) and returns `stopReason: 'checkpoint'` with a populated
@@ -362,6 +359,26 @@ function resolveConversationManager(
   return conversationManager ?? new SlidingWindowConversationManager({ windowSize: 40 })
 }
 
+/**
+ * Resolves a tool executor instance from an executor or string shorthand.
+ */
+function resolveToolExecutor(
+  toolExecutor: ConcurrentToolExecutor | SequentialToolExecutor | ToolExecutorStrategy | undefined
+): ConcurrentToolExecutor | SequentialToolExecutor {
+  switch (toolExecutor) {
+    case 'sequential':
+      return new SequentialToolExecutor()
+    case 'concurrent':
+    case undefined:
+      return new ConcurrentToolExecutor()
+    default:
+      if (typeof toolExecutor === 'string') {
+        throw new Error(`Unknown toolExecutor: ${toolExecutor}`)
+      }
+      return toolExecutor
+  }
+}
+
 /** Default name assigned to agents when none is provided. */
 const DEFAULT_AGENT_NAME = 'Strands Agent'
 
@@ -370,37 +387,6 @@ const DEFAULT_AGENT_ID = 'agent'
 
 /** Result returned by tool-execution generators, threading the AfterToolsEvent back to the main loop. */
 type ToolsExecutionResult = { message: Message; afterToolsEvent: AfterToolsEvent }
-
-/**
- * Creates a non-mutating interrupt function for middleware contexts.
- * Reads existing responses from state (resume case) but never writes to it.
- * On first run (no response), throws InterruptError with a locally-created Interrupt.
- *
- * @param interruptState - The agent's interrupt state (read-only access)
- * @param idPrefix - Prefix for the interrupt ID (e.g., 'middleware:agentStream')
- */
-function createMiddlewareInterrupt(
-  interruptState: InterruptState,
-  idPrefix: string
-): <T = JSONValue>(params: InterruptParams) => MiddlewareInterruptResult<T> {
-  return <T = JSONValue>(params: InterruptParams): MiddlewareInterruptResult<T> => {
-    const interruptId = `${idPrefix}:${params.name}`
-    const existing = interruptState.interrupts[interruptId]
-    if (existing?.response !== undefined) {
-      return { response: existing.response as T }
-    }
-    if (params.response !== undefined) {
-      return { response: params.response as T }
-    }
-    const interrupt = new Interrupt({
-      id: interruptId,
-      name: params.name,
-      ...(params.reason !== undefined && { reason: params.reason }),
-      source: 'middleware',
-    })
-    throw new InterruptError(interrupt)
-  }
-}
 
 /**
  * Orchestrates the interaction between a model, a set of tools, and MCP clients.
@@ -492,8 +478,8 @@ export class Agent implements LocalAgent, InvokableAgent {
   private _meter: Meter
   /** Interrupt state for human-in-the-loop workflows. */
   _interruptState: InterruptState
-  /** Strategy for executing tool calls from a single assistant turn. */
-  private readonly _toolExecutor: ToolExecutorStrategy
+  /** Executor for tool calls from a single assistant turn. */
+  private _toolExecutor: ConcurrentToolExecutor | SequentialToolExecutor
   /** When true, the agent loop pauses at cycle boundaries for durable execution. */
   private readonly _checkpointing: boolean
   /** Direct tool caller — created via {@link ToolCaller.create} factory. */
@@ -621,7 +607,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     // Initialize interrupt state for human-in-the-loop workflows
     this._interruptState = new InterruptState()
 
-    this._toolExecutor = config?.toolExecutor ?? 'concurrent'
+    this._toolExecutor = resolveToolExecutor(config?.toolExecutor)
     this._checkpointing = config?.checkpointing ?? false
     // Pass a private helper into ToolCaller so message append + hook firing
     // remains an internal concern of Agent (not exposed as a public method).
@@ -906,6 +892,23 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   get toolRegistry(): ToolRegistry {
     return this._toolRegistry
+  }
+
+  /**
+   * Executor for tool calls from a single assistant turn.
+   *
+   * Reading always yields the resolved executor instance. Assigning accepts an
+   * executor instance or a {@link ToolExecutorStrategy} string shorthand, which is
+   * resolved to the matching instance on write.
+   *
+   * @throws Error if assigned an unrecognized string shorthand.
+   */
+  get toolExecutor(): ConcurrentToolExecutor | SequentialToolExecutor {
+    return this._toolExecutor
+  }
+
+  set toolExecutor(toolExecutor: ConcurrentToolExecutor | SequentialToolExecutor | ToolExecutorStrategy) {
+    this._toolExecutor = resolveToolExecutor(toolExecutor)
   }
 
   /**
@@ -1587,12 +1590,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           }
 
           // Execute tools
-          const toolsResult = yield* this.executeTools(
-            assistantMessage,
-            this._toolRegistry,
-            invocationState,
-            completedToolResults
-          )
+          const toolsResult = yield* this.executeTools(assistantMessage, invocationState, completedToolResults)
 
           // When the consumer breaks the stream (e.g. agent.cancel() + break),
           // yield* returns undefined because the inner generator was closed.
@@ -2172,17 +2170,15 @@ export class Agent implements LocalAgent, InvokableAgent {
 
   /**
    * Emits `BeforeToolsEvent`, handles the pre-launch cancel paths, then
-   * delegates per-tool execution to the configured {@link ToolExecutorStrategy}.
+   * delegates per-tool execution to the configured executor.
    * Always pairs `BeforeToolsEvent` with a terminal `AfterToolsEvent`, even on
    * the invariant-violation throw path.
    *
    * @param assistantMessage - The assistant message containing tool use blocks
-   * @param toolRegistry - Registry containing available tools
    * @returns Tool-result message and the dispatched AfterToolsEvent
    */
   private async *executeTools(
     assistantMessage: Message,
-    toolRegistry: ToolRegistry,
     invocationState: InvocationState,
     completedToolResults?: Map<string, ToolResultBlock>
   ): AsyncGenerator<AgentStreamEvent, ToolsExecutionResult, undefined> {
@@ -2204,132 +2200,45 @@ export class Agent implements LocalAgent, InvokableAgent {
     const toolUseBlocks = assistantMessage.content.filter(
       (block): block is ToolUseBlock => block.type === 'toolUseBlock'
     )
-    if (toolUseBlocks.length === 0) {
-      // Preserve BeforeToolsEvent/AfterToolsEvent bracket symmetry even on
-      // this invariant-violation branch.
-      yield new AfterToolsEvent({
-        agent: this,
-        message: new Message({ role: 'user', content: [] }),
-        invocationState,
-      })
-      throw new Error('Model indicated toolUse but no tool use blocks found in message')
-    }
-
-    // Pre-launch cancel paths are strategy-independent.
-    if (beforeToolsEvent.cancel) {
-      const message = typeof beforeToolsEvent.cancel === 'string' ? beforeToolsEvent.cancel : 'Tool cancelled by hook'
-      return yield* this._yieldCancelledToolResults(toolUseBlocks, message, invocationState)
-    }
-    if (this.isCancelled) {
-      return yield* this._yieldCancelledToolResults(toolUseBlocks, 'Tool execution cancelled', invocationState)
-    }
-
-    switch (this._toolExecutor) {
-      case 'sequential':
-        return yield* this._executeToolsSequential(
-          toolUseBlocks,
-          toolRegistry,
-          invocationState,
-          completedToolResults,
-          assistantMessage
-        )
-      case 'concurrent':
-        return yield* this._executeToolsConcurrent(
-          toolUseBlocks,
-          toolRegistry,
-          invocationState,
-          completedToolResults,
-          assistantMessage
-        )
-      default: {
-        const _exhaustive: never = this._toolExecutor
-        throw new Error(`Unknown toolExecutor: ${_exhaustive as string}`)
-      }
-    }
-  }
-
-  /**
-   * Emits a `ToolResultEvent` for every block plus an `AfterToolsEvent`, and
-   * returns the resulting tool-result message and dispatched event. Used by the pre-launch cancel
-   * paths shared across executors.
-   */
-  private async *_yieldCancelledToolResults(
-    toolUseBlocks: ToolUseBlock[],
-    message: string,
-    invocationState: InvocationState
-  ): AsyncGenerator<AgentStreamEvent, ToolsExecutionResult, undefined> {
-    const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, message)
-    for (const result of cancelBlocks) {
-      yield new ToolResultEvent({ agent: this, result, invocationState })
-    }
-    const toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
-    const afterToolsEvent = new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
-    yield afterToolsEvent
-    return { message: toolResultMessage, afterToolsEvent }
-  }
-
-  /**
-   * Executes tools one at a time, honoring `agent.cancelSignal` between
-   * iterations to short-circuit not-yet-started tools.
-   */
-  private async *_executeToolsSequential(
-    toolUseBlocks: ToolUseBlock[],
-    toolRegistry: ToolRegistry,
-    invocationState: InvocationState,
-    completedToolResults?: Map<string, ToolResultBlock>,
-    assistantMessage?: Message
-  ): AsyncGenerator<AgentStreamEvent, ToolsExecutionResult, undefined> {
     const toolResultBlocks: ToolResultBlock[] = []
     let toolResultMessage: Message
     let afterToolsEvent: AfterToolsEvent
 
     try {
-      for (const toolUseBlock of toolUseBlocks) {
-        // Skip tools that were already completed before the interrupt
-        if (completedToolResults?.has(toolUseBlock.toolUseId)) {
-          const completedResult = completedToolResults.get(toolUseBlock.toolUseId)!
-          // No events emitted for already-completed tools.
-          // The result is included in the final tool result message.
-          toolResultBlocks.push(completedResult)
-          continue
-        }
+      if (toolUseBlocks.length === 0) {
+        throw new Error('Model indicated toolUse but no tool use blocks found in message')
+      }
 
-        if (this.isCancelled) {
-          const cancelBlock = new ToolResultBlock({
-            toolUseId: toolUseBlock.toolUseId,
-            status: 'error',
-            content: [new TextBlock('Tool execution cancelled')],
-          })
-          toolResultBlocks.push(cancelBlock)
-          yield new ToolResultEvent({ agent: this, result: cancelBlock, invocationState })
-          continue
-        }
+      // Pre-launch cancellation is executor-independent.
+      const cancelMessage = beforeToolsEvent.cancel
+        ? typeof beforeToolsEvent.cancel === 'string'
+          ? beforeToolsEvent.cancel
+          : 'Tool cancelled by hook'
+        : this.isCancelled
+          ? 'Tool execution cancelled'
+          : undefined
 
-        try {
-          const toolResultBlock = yield* this.executeTool(toolUseBlock, toolRegistry, invocationState)
-          toolResultBlocks.push(toolResultBlock)
-          yield new ToolResultEvent({ agent: this, result: toolResultBlock, invocationState })
-        } catch (error) {
-          if (error instanceof InterruptError) {
-            // Store pending state with completed results so far
-            const completedSoFar: Record<string, { toolResult: ToolResultBlockData }> = {}
-            for (const block of toolResultBlocks) {
-              completedSoFar[block.toolUseId] = block.toJSON()
-            }
-            // Also include any previously completed results
-            if (completedToolResults) {
-              for (const [id, block] of completedToolResults) {
-                completedSoFar[id] = block.toJSON()
-              }
-            }
-            this._interruptState.setPendingToolExecution({
-              assistantMessageData: assistantMessage!.toJSON(),
-              completedToolResults: completedSoFar,
-            })
-            throw error
+      if (cancelMessage) {
+        toolResultBlocks.push(...this._cancelAllAsResults(toolUseBlocks, cancelMessage))
+        for (const result of toolResultBlocks) {
+          yield new ToolResultEvent({ agent: this, result, invocationState })
+        }
+      } else {
+        yield* this._toolExecutor.execute(
+          {
+            agent: this,
+            middlewareRegistry: this._middlewareRegistry,
+            tracer: this._tracer,
+            meter: this._meter,
+          },
+          {
+            toolUseBlocks,
+            toolResultBlocks,
+            invocationState,
+            assistantMessage,
+            ...(completedToolResults && { completedToolResults }),
           }
-          throw error
-        }
+        )
       }
     } finally {
       toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
@@ -2353,370 +2262,6 @@ export class Agent implements LocalAgent, InvokableAgent {
           content: [new TextBlock(message)],
         })
     )
-  }
-
-  /**
-   * Executes tools concurrently by merging N per-tool {@link executeTool}
-   * async generators via `Promise.race`. Per-tool event order is preserved
-   * (because each generator is iterated serially); cross-tool events may
-   * interleave at race resolution boundaries.
-   *
-   * Per-tool retry (`AfterToolCallEvent.retry`) is isolated — it lives inside
-   * `executeTool`'s own `while(true)` loop, so one tool retrying does not
-   * disturb its siblings.
-   */
-  private async *_executeToolsConcurrent(
-    toolUseBlocks: ToolUseBlock[],
-    toolRegistry: ToolRegistry,
-    invocationState: InvocationState,
-    completedToolResults?: Map<string, ToolResultBlock>,
-    assistantMessage?: Message
-  ): AsyncGenerator<AgentStreamEvent, ToolsExecutionResult, undefined> {
-    let toolResultMessage: Message
-    let afterToolsEvent: AfterToolsEvent
-
-    // Wrap each in-flight `.next()` so the raced promise always resolves to a
-    // tagged Step. That prevents one generator rejection from rejecting the
-    // whole race and lets us convert per-tool failures into ToolResultBlocks
-    // without orphaning other generators.
-    type Step =
-      | { idx: number; kind: 'next'; res: IteratorResult<AgentStreamEvent, ToolResultBlock> }
-      | { idx: number; kind: 'throw'; error: unknown }
-
-    const gens = toolUseBlocks.map((block) => ({
-      block,
-      gen: completedToolResults?.has(block.toolUseId)
-        ? undefined // Skip already-completed tools
-        : this.executeTool(block, toolRegistry, invocationState),
-    }))
-
-    const step = (idx: number): Promise<Step> =>
-      gens[idx]!.gen!.next().then(
-        (res): Step => ({ idx, kind: 'next', res }),
-        (error: unknown): Step => ({ idx, kind: 'throw', error })
-      )
-
-    // Seed completed results from resume state
-    const resultsByToolUseId = new Map<string, ToolResultBlock>()
-    if (completedToolResults) {
-      for (const [id, result] of completedToolResults) {
-        resultsByToolUseId.set(id, result)
-      }
-    }
-
-    // Only race tools that need execution
-    const pendingNext = new Map<number, Promise<Step>>()
-    for (let idx = 0; idx < gens.length; idx++) {
-      if (gens[idx]!.gen) {
-        pendingNext.set(idx, step(idx))
-      }
-    }
-
-    // Track interrupts — let all other tools finish before propagating
-    let interruptError: InterruptError | undefined
-
-    try {
-      while (pendingNext.size > 0) {
-        const winner = await Promise.race(pendingNext.values())
-        const { idx } = winner
-        const block = gens[idx]!.block
-
-        if (winner.kind === 'throw') {
-          pendingNext.delete(idx)
-
-          // Detect InterruptError — don't convert to error result, track it
-          if (winner.error instanceof InterruptError) {
-            interruptError = winner.error
-            continue
-          }
-
-          const err = normalizeError(winner.error)
-          const result = new ToolResultBlock({
-            toolUseId: block.toolUseId,
-            status: 'error',
-            content: [new TextBlock(err.message)],
-            error: err,
-          })
-          resultsByToolUseId.set(block.toolUseId, result)
-          yield new ToolResultEvent({ agent: this, result, invocationState })
-          continue
-        }
-
-        if (winner.res.done) {
-          pendingNext.delete(idx)
-          resultsByToolUseId.set(block.toolUseId, winner.res.value)
-          yield new ToolResultEvent({ agent: this, result: winner.res.value, invocationState })
-        } else {
-          try {
-            yield winner.res.value
-          } catch (e) {
-            // InterruptError thrown back into generator from stream() error injection
-            if (e instanceof InterruptError) {
-              interruptError = e
-              pendingNext.delete(idx)
-              continue
-            }
-            throw e
-          }
-          pendingNext.set(idx, step(idx))
-        }
-      }
-
-      // After all tools finish, propagate interrupt if one was raised
-      if (interruptError) {
-        const completedSoFar: Record<string, { toolResult: ToolResultBlockData }> = {}
-        for (const [id, result] of resultsByToolUseId) {
-          completedSoFar[id] = result.toJSON()
-        }
-        this._interruptState.setPendingToolExecution({
-          assistantMessageData: assistantMessage!.toJSON(),
-          completedToolResults: completedSoFar,
-        })
-        throw interruptError
-      }
-    } finally {
-      // Close any generators still in-flight (e.g. consumer broke out of stream).
-      await Promise.allSettled(
-        Array.from(pendingNext.keys(), (idx) => gens[idx]!.gen!.return(undefined as unknown as ToolResultBlock))
-      )
-
-      // Build the result message from whatever completed, in source order.
-      // Missing entries get a fallback error block so the message always
-      // accounts for every toolUseBlock the model emitted.
-      const toolResultBlocks: ToolResultBlock[] = []
-      for (const block of toolUseBlocks) {
-        const result = resultsByToolUseId.get(block.toolUseId)
-        if (result) {
-          toolResultBlocks.push(result)
-        } else {
-          toolResultBlocks.push(
-            new ToolResultBlock({
-              toolUseId: block.toolUseId,
-              status: 'error',
-              content: [new TextBlock('Tool execution interrupted')],
-            })
-          )
-        }
-      }
-
-      toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
-      afterToolsEvent = new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
-      yield afterToolsEvent
-    }
-
-    return { message: toolResultMessage, afterToolsEvent }
-  }
-
-  /**
-   * Executes a single tool and returns the result.
-   * If the tool is not found or fails to return a result, returns an error ToolResult
-   * instead of throwing an exception. This allows the agent loop to continue and
-   * let the model handle the error gracefully.
-   *
-   * @param toolUseBlock - Tool use block to execute
-   * @param toolRegistry - Registry containing available tools
-   * @returns Tool result block
-   */
-  private async *executeTool(
-    toolUseBlock: ToolUseBlock,
-    toolRegistry: ToolRegistry,
-    invocationState: InvocationState
-  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
-    const registryTool = toolRegistry.get(toolUseBlock.name)
-
-    // Create toolUse object for hook events and telemetry. Callbacks may mutate
-    // this object's fields (input/name/toolUseId) inside BeforeToolCallEvent.
-    const toolUse = {
-      name: toolUseBlock.name,
-      toolUseId: toolUseBlock.toolUseId,
-      input: toolUseBlock.input,
-    }
-
-    // Retry loop for tool execution
-    while (true) {
-      const beforeToolCallEvent = new BeforeToolCallEvent({
-        agent: this,
-        toolUse,
-        tool: registryTool,
-        invocationState,
-      })
-      yield beforeToolCallEvent
-
-      // Resolve the tool that would actually execute. selectedTool wins;
-      // otherwise if the hook renamed toolUse.name, re-resolve from the
-      // registry under the new name; otherwise use the original registry
-      // lookup. Resolved before the cancel check so AfterToolCallEvent.tool
-      // is consistent whether the cancel or execution branch runs.
-      const effectiveTool =
-        beforeToolCallEvent.selectedTool ??
-        (toolUse.name !== toolUseBlock.name ? toolRegistry.get(toolUse.name) : registryTool)
-
-      // Cancel individual tool if hook requested it
-      if (beforeToolCallEvent.cancel) {
-        const cancelMessage =
-          typeof beforeToolCallEvent.cancel === 'string' ? beforeToolCallEvent.cancel : 'Tool cancelled by hook'
-        const cancelResult = new ToolResultBlock({
-          toolUseId: toolUse.toolUseId,
-          status: 'error',
-          content: [new TextBlock(cancelMessage)],
-        })
-        const afterToolCallEvent = new AfterToolCallEvent({
-          agent: this,
-          toolUse,
-          tool: effectiveTool,
-          result: cancelResult,
-          invocationState,
-        })
-        yield afterToolCallEvent
-        if (afterToolCallEvent.retry) {
-          continue
-        }
-        return afterToolCallEvent.result
-      }
-
-      // Execute tool core logic through middleware chain
-      const toolResult = yield* this._executeToolWithMiddleware(effectiveTool, toolUse, invocationState)
-      const error = toolResult.error
-
-      // Single point for AfterToolCallEvent
-      const afterToolCallEvent = new AfterToolCallEvent({
-        agent: this,
-        toolUse,
-        tool: effectiveTool,
-        result: toolResult,
-        invocationState,
-        ...(error !== undefined && { error }),
-      })
-      yield afterToolCallEvent
-
-      if (afterToolCallEvent.retry) {
-        continue
-      }
-
-      // Return the (possibly mutated) result so hook transformations propagate
-      // to ToolResultEvent and the conversation message the model will see.
-      return afterToolCallEvent.result
-    }
-  }
-
-  private async *_executeToolWithMiddleware(
-    tool: Tool | undefined,
-    toolUse: ToolUseData,
-    invocationState: InvocationState
-  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
-    const context: ExecuteToolContext = {
-      agent: this,
-      tool,
-      toolUse: deepCopy(toolUse) as unknown as ToolUseData,
-      invocationState,
-      interrupt: createMiddlewareInterrupt(this._interruptState, `middleware:executeTool:${toolUse.toolUseId}`),
-    }
-
-    // async function* doesn't bind lexical `this`; capture for the terminal callback.
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const self = this
-    const middlewareResult = yield* this._middlewareRegistry.invoke(
-      ExecuteToolStage,
-      context,
-      async function* (ctx: ExecuteToolContext): AsyncGenerator<AgentStreamEvent, ExecuteToolResult, undefined> {
-        const result = yield* self._executeToolCore(ctx.tool, ctx.toolUse, ctx.invocationState)
-        return { result }
-      }
-    )
-    return middlewareResult.result
-  }
-
-  private async *_executeToolCore(
-    effectiveTool: Tool | undefined,
-    toolUse: ToolUseData,
-    invocationState: InvocationState
-  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
-    // Start tool span within loop span context
-    const toolSpan = this._tracer.startToolCallSpan({
-      tool: toolUse,
-    })
-
-    // Track tool execution time for metrics
-    const toolStartTime = Date.now()
-
-    let toolResult: ToolResultBlock
-    let error: Error | undefined
-
-    if (!effectiveTool) {
-      // Tool not found
-      toolResult = new ToolResultBlock({
-        toolUseId: toolUse.toolUseId,
-        status: 'error',
-        content: [new TextBlock(`Tool '${toolUse.name}' not found in registry`)],
-      })
-    } else {
-      // Execute tool within the tool span context
-      const toolContext: ToolContext = {
-        toolUse: {
-          name: toolUse.name,
-          toolUseId: toolUse.toolUseId,
-          input: toolUse.input,
-        },
-        agent: this,
-        invocationState,
-        interrupt: <T = JSONValue>(params: InterruptParams): T => {
-          return interruptFromAgent<T>(this, `tool:${toolUse.toolUseId}:${params.name}`, params, 'tool')
-        },
-      }
-
-      try {
-        // Manually iterate tool stream to wrap each ToolStreamEvent in ToolStreamUpdateEvent.
-        // This keeps the tool authoring interface unchanged — tools construct ToolStreamEvent
-        // without knowledge of agents or hooks, and we wrap at the boundary.
-        // Tool execution is ran within the tool span's context so that
-        // downstream calls (e.g., MCP clients) can propagate trace context
-        const toolGenerator = this._tracer.withSpanContext(toolSpan, () => effectiveTool.stream(toolContext))
-        let toolNext = await this._tracer.withSpanContext(toolSpan, () => toolGenerator.next())
-        while (!toolNext.done) {
-          yield new ToolStreamUpdateEvent({ agent: this, event: toolNext.value, invocationState })
-          toolNext = await this._tracer.withSpanContext(toolSpan, () => toolGenerator.next())
-        }
-        const result = toolNext.value
-
-        if (!result) {
-          // Tool didn't return a result
-          toolResult = new ToolResultBlock({
-            toolUseId: toolUse.toolUseId,
-            status: 'error',
-            content: [new TextBlock(`Tool '${toolUse.name}' did not return a result`)],
-          })
-        } else {
-          toolResult = result
-          error = result.error
-        }
-      } catch (e) {
-        // Re-throw InterruptError to allow interrupt handling
-        if (e instanceof InterruptError) {
-          throw e
-        }
-        // Tool execution failed with error
-        error = normalizeError(e)
-        toolResult = new ToolResultBlock({
-          toolUseId: toolUse.toolUseId,
-          status: 'error',
-          content: [new TextBlock(error.message)],
-          error,
-        })
-      }
-    }
-
-    // End tool span with the raw tool result — telemetry reflects what the
-    // tool actually returned, independent of AfterToolCallEvent mutations.
-    this._tracer.endToolCallSpan(toolSpan, { toolResult, ...(error && { error }) })
-
-    // End tool metrics tracking
-    this._meter.endToolCall({
-      tool: toolUse,
-      duration: Date.now() - toolStartTime,
-      success: toolResult.status === 'success',
-    })
-
-    return toolResult
   }
 
   /**

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -106,7 +106,7 @@ export abstract class HookableEvent extends StreamEvent {
  */
 export interface ToolUseData {
   name: string
-  readonly toolUseId: string
+  toolUseId: string
   input: JSONValue
 }
 

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -101,11 +101,12 @@ export abstract class HookableEvent extends StreamEvent {
  * Mutable tool-use descriptor carried on tool-call hook events.
  * Matches the shape of the tool use block the model emitted; hooks on
  * {@link BeforeToolCallEvent} may mutate its fields (or reassign the object)
- * to rewrite the input, id, or tool name before the tool executes.
+ * to rewrite the input or tool name before the tool executes. The model-issued
+ * tool-use ID remains the authoritative provider correlation key.
  */
 export interface ToolUseData {
   name: string
-  toolUseId: string
+  readonly toolUseId: string
   input: JSONValue
 }
 
@@ -238,9 +239,9 @@ export class MessageAddedEvent extends HookableEvent {
  * Hook callbacks can:
  * - Set {@link cancel} to prevent the tool from executing.
  * - Set {@link selectedTool} to execute a different tool in place of the registry's match.
- * - Mutate {@link toolUse} to rewrite the tool input, id, or name before execution.
- *   If `name` is changed and `selectedTool` is not set, the tool is re-resolved from
- *   the registry under the new name.
+ * - Mutate {@link toolUse} in place, or replace it wholesale, to rewrite the tool
+ *   input or name before execution. If `name` is changed and `selectedTool` is
+ *   not set, the tool is re-resolved from the registry under the new name.
  */
 export class BeforeToolCallEvent extends HookableEvent implements Interruptible {
   readonly type = 'beforeToolCallEvent' as const

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -144,6 +144,10 @@ export type { ZodToolConfig } from './tools/zod-tool.js'
 // Tool factory function
 export { tool } from './tools/tool-factory.js'
 
+// Tool executors
+export { ConcurrentToolExecutor } from './tools/executors/concurrent.js'
+export { SequentialToolExecutor } from './tools/executors/sequential.js'
+
 // Streaming event types
 export type {
   Usage,

--- a/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
+++ b/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
@@ -75,6 +75,45 @@ describe('Middleware interrupts', () => {
       expect(toolExecuted).toBe(true)
     })
 
+    it('uses interrupt state restored after executor construction', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'dangerousTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('dangerousTool', () => {
+        toolExecuted = true
+        return 'executed'
+      })
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+        context.interrupt({ name: 'approve_tool', reason: 'Confirm?' })
+        return yield* next(context)
+      })
+
+      const snapshot = agent.takeSnapshot({ include: ['interrupts'] })
+      agent.loadSnapshot(snapshot)
+
+      const interruptResult = await agent.invoke('Do it')
+      const finalResult = await agent.invoke([
+        new InterruptResponseContent({
+          interruptId: interruptResult.interrupts![0]!.id,
+          response: 'yes',
+        }),
+      ])
+
+      expect({
+        interruptStopReason: interruptResult.stopReason,
+        finalStopReason: finalResult.stopReason,
+        toolExecuted,
+      }).toEqual({
+        interruptStopReason: 'interrupt',
+        finalStopReason: 'endTurn',
+        toolExecuted: true,
+      })
+    })
+
     it('interrupt ID includes toolUseId for disambiguation', async () => {
       const model = new MockMessageModel()
         .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'unique-tool-id', input: {} })

--- a/strands-ts/src/middleware/interrupt.ts
+++ b/strands-ts/src/middleware/interrupt.ts
@@ -1,0 +1,41 @@
+import { Interrupt, InterruptError } from '../interrupt.js'
+
+import type { InterruptState } from '../interrupt.js'
+import type { InterruptParams } from '../types/interrupt.js'
+import type { JSONValue } from '../types/json.js'
+import type { MiddlewareInterruptResult } from './stages.js'
+
+/**
+ * Creates a non-mutating interrupt function backed by the provided interrupt state.
+ *
+ * Existing responses are read from state, but new interrupts remain local until
+ * the caller handles the thrown {@link InterruptError}.
+ *
+ * @param interruptState - State used to resolve prior responses
+ * @param idPrefix - Prefix used to construct the interrupt identifier
+ * @returns Interrupt function for a middleware context
+ *
+ * @internal
+ */
+export function createMiddlewareInterrupt(
+  interruptState: InterruptState,
+  idPrefix: string
+): <T = JSONValue>(params: InterruptParams) => MiddlewareInterruptResult<T> {
+  return <T = JSONValue>(params: InterruptParams): MiddlewareInterruptResult<T> => {
+    const interruptId = `${idPrefix}:${params.name}`
+    const existing = interruptState.interrupts[interruptId]
+    if (existing?.response !== undefined) {
+      return { response: existing.response as T }
+    }
+    if (params.response !== undefined) {
+      return { response: params.response as T }
+    }
+    const interrupt = new Interrupt({
+      id: interruptId,
+      name: params.name,
+      ...(params.reason !== undefined && { reason: params.reason }),
+      source: 'middleware',
+    })
+    throw new InterruptError(interrupt)
+  }
+}

--- a/strands-ts/src/tools/executors/concurrent.ts
+++ b/strands-ts/src/tools/executors/concurrent.ts
@@ -18,9 +18,11 @@ type ExecutionStep =
  * ```typescript
  * import { Agent, ConcurrentToolExecutor } from '@strands-agents/sdk'
  *
- * const agent = new Agent({
- *   toolExecutor: new ConcurrentToolExecutor(),
- * })
+ * // The string shorthand keeps imports minimal (concurrent is also the default).
+ * const agent = new Agent({ toolExecutor: 'concurrent' })
+ *
+ * // Passing an instance is equivalent if you prefer to be explicit.
+ * const explicitAgent = new Agent({ toolExecutor: new ConcurrentToolExecutor() })
  * ```
  */
 export class ConcurrentToolExecutor extends ToolExecutor {

--- a/strands-ts/src/tools/executors/concurrent.ts
+++ b/strands-ts/src/tools/executors/concurrent.ts
@@ -1,0 +1,154 @@
+import { normalizeError } from '../../errors.js'
+import { ToolResultEvent } from '../../hooks/events.js'
+import { InterruptError } from '../../interrupt.js'
+import { TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { ToolExecutor } from './executor.js'
+
+import type { AgentStreamEvent } from '../../types/agent.js'
+import type { ToolExecutionInput, ToolExecutorOptions } from './executor.js'
+
+type ExecutionStep =
+  | { index: number; kind: 'next'; result: IteratorResult<AgentStreamEvent, ToolResultBlock> }
+  | { index: number; kind: 'throw'; error: unknown }
+
+/**
+ * Executes tool calls concurrently.
+ *
+ * @example
+ * ```typescript
+ * import { Agent, ConcurrentToolExecutor } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({
+ *   toolExecutor: new ConcurrentToolExecutor(),
+ * })
+ * ```
+ */
+export class ConcurrentToolExecutor extends ToolExecutor {
+  /**
+   * Executes tool calls concurrently by racing per-tool generators. Each
+   * generator advances serially, preserving its event order while allowing
+   * events from different tools to interleave. Retries remain isolated within
+   * the affected tool's generator.
+   *
+   * @param options - Agent dependencies used to execute tools
+   * @param input - Tool calls and invocation state
+   * @returns Stream of tool lifecycle events
+   * @internal
+   */
+  override async *execute(
+    options: ToolExecutorOptions,
+    input: ToolExecutionInput
+  ): AsyncGenerator<AgentStreamEvent, void, undefined> {
+    const { toolUseBlocks, toolResultBlocks, invocationState, assistantMessage, completedToolResults } = input
+
+    // Restored results are included in the final message without replaying their events.
+    const executions = toolUseBlocks.map((toolUseBlock) => ({
+      toolUseBlock,
+      generator: completedToolResults?.has(toolUseBlock.toolUseId)
+        ? undefined
+        : this.executeTool(options, toolUseBlock, invocationState),
+    }))
+
+    // Convert generator rejections into tagged steps so one tool cannot reject
+    // the whole race before its failure is isolated and siblings can continue.
+    const takeNextStep = (index: number): Promise<ExecutionStep> =>
+      executions[index]!.generator!.next().then(
+        (result): ExecutionStep => ({ index, kind: 'next', result }),
+        (error: unknown): ExecutionStep => ({ index, kind: 'throw', error })
+      )
+
+    const resultsByToolUseId = new Map<string, ToolResultBlock>()
+    if (completedToolResults) {
+      for (const [toolUseId, result] of completedToolResults) {
+        resultsByToolUseId.set(toolUseId, result)
+      }
+    }
+
+    const pendingSteps = new Map<number, Promise<ExecutionStep>>()
+    for (let index = 0; index < executions.length; index++) {
+      if (executions[index]!.generator) {
+        pendingSteps.set(index, takeNextStep(index))
+      }
+    }
+
+    // Defer interrupts until all sibling tools have finished.
+    let interruptError: InterruptError | undefined
+
+    try {
+      while (pendingSteps.size > 0) {
+        const winner = await Promise.race(pendingSteps.values())
+        const { index } = winner
+        const toolUseBlock = executions[index]!.toolUseBlock
+
+        if (winner.kind === 'throw') {
+          pendingSteps.delete(index)
+
+          if (winner.error instanceof InterruptError) {
+            interruptError = winner.error
+            continue
+          }
+
+          // Generator-level failures belong to one tool call and must not stop its siblings.
+          const error = normalizeError(winner.error)
+          const result = new ToolResultBlock({
+            toolUseId: toolUseBlock.toolUseId,
+            status: 'error',
+            content: [new TextBlock(error.message)],
+            error,
+          })
+          resultsByToolUseId.set(toolUseBlock.toolUseId, result)
+          yield new ToolResultEvent({ agent: options.agent, result, invocationState })
+          continue
+        }
+
+        if (winner.result.done) {
+          pendingSteps.delete(index)
+          resultsByToolUseId.set(toolUseBlock.toolUseId, winner.result.value)
+          yield new ToolResultEvent({ agent: options.agent, result: winner.result.value, invocationState })
+        } else {
+          try {
+            yield winner.result.value
+          } catch (error) {
+            // Stream consumers can inject an interrupt at a yielded lifecycle event.
+            if (error instanceof InterruptError) {
+              interruptError = error
+              pendingSteps.delete(index)
+              continue
+            }
+            throw error
+          }
+          pendingSteps.set(index, takeNextStep(index))
+        }
+      }
+
+      if (interruptError) {
+        this._storePendingToolExecution(options, assistantMessage, resultsByToolUseId)
+        throw interruptError
+      }
+    } finally {
+      // Close generators that are still in flight when the stream consumer exits early.
+      await Promise.allSettled(
+        Array.from(pendingSteps.keys(), (index) =>
+          executions[index]!.generator!.return(undefined as unknown as ToolResultBlock)
+        )
+      )
+
+      // Preserve source order and account for every requested tool, including
+      // tools that did not finish before an interrupt or early stream exit.
+      for (const toolUseBlock of toolUseBlocks) {
+        const result = resultsByToolUseId.get(toolUseBlock.toolUseId)
+        if (result) {
+          toolResultBlocks.push(result)
+        } else {
+          toolResultBlocks.push(
+            new ToolResultBlock({
+              toolUseId: toolUseBlock.toolUseId,
+              status: 'error',
+              content: [new TextBlock('Tool execution interrupted')],
+            })
+          )
+        }
+      }
+    }
+  }
+}

--- a/strands-ts/src/tools/executors/executor.ts
+++ b/strands-ts/src/tools/executors/executor.ts
@@ -1,0 +1,302 @@
+import { normalizeError } from '../../errors.js'
+import { AfterToolCallEvent, BeforeToolCallEvent, ToolStreamUpdateEvent } from '../../hooks/events.js'
+import { InterruptError, interruptFromAgent } from '../../interrupt.js'
+import { createMiddlewareInterrupt } from '../../middleware/interrupt.js'
+import { ExecuteToolStage } from '../../middleware/index.js'
+import { deepCopy } from '../../types/json.js'
+import { TextBlock, ToolResultBlock } from '../../types/messages.js'
+
+import type { Agent } from '../../agent/agent.js'
+import type { ToolUseData } from '../../hooks/events.js'
+import type { ExecuteToolContext, ExecuteToolResult, MiddlewareRegistry } from '../../middleware/index.js'
+import type { Meter } from '../../telemetry/meter.js'
+import type { Tracer } from '../../telemetry/tracer.js'
+import type { AgentStreamEvent, InvocationState } from '../../types/agent.js'
+import type { InterruptParams } from '../../types/interrupt.js'
+import type { JSONValue } from '../../types/json.js'
+import type { Message, ToolResultBlockData, ToolUseBlock } from '../../types/messages.js'
+import type { Tool, ToolContext } from '../tool.js'
+
+/**
+ * Dependencies supplied for one tool-executor invocation.
+ *
+ * @internal
+ */
+export interface ToolExecutorOptions {
+  /** Agent whose tools are being executed. */
+  readonly agent: Agent
+  /** Registry containing middleware for the agent. */
+  readonly middlewareRegistry: MiddlewareRegistry
+  /** Tracer used to record tool calls. */
+  readonly tracer: Tracer
+  /** Meter used to record tool-call metrics. */
+  readonly meter: Meter
+}
+
+/**
+ * Input for executing the tool calls from one model turn.
+ *
+ * @internal
+ */
+export interface ToolExecutionInput {
+  /** Tool calls to execute. */
+  readonly toolUseBlocks: readonly ToolUseBlock[]
+  /** Accumulates completed tool results and may remain partial when execution exits early. */
+  readonly toolResultBlocks: ToolResultBlock[]
+  /** State shared across the current agent invocation. */
+  readonly invocationState: InvocationState
+  /** Assistant message that requested the tool calls. */
+  readonly assistantMessage: Message
+  /** Results restored when resuming interrupted execution. */
+  readonly completedToolResults?: ReadonlyMap<string, ToolResultBlock>
+}
+
+/**
+ * Shared pipeline for executing tool calls.
+ *
+ * @internal
+ */
+export abstract class ToolExecutor {
+  /**
+   * Executes the tool calls from one model turn.
+   *
+   * @param options - Agent dependencies used to execute tools
+   * @param input - Tool calls and invocation state
+   * @returns Stream of tool lifecycle events
+   * @internal
+   */
+  abstract execute(
+    options: ToolExecutorOptions,
+    input: ToolExecutionInput
+  ): AsyncGenerator<AgentStreamEvent, void, undefined>
+
+  // Tool lookup and tool-body failures become ToolResultBlocks so the model can
+  // respond to them; lifecycle and middleware failures may still propagate.
+  protected async *executeTool(
+    options: ToolExecutorOptions,
+    toolUseBlock: ToolUseBlock,
+    invocationState: InvocationState
+  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
+    const registryTool = options.agent.toolRegistry.get(toolUseBlock.name)
+
+    // Callbacks may replace or mutate this value inside BeforeToolCallEvent.
+    let toolUse = {
+      name: toolUseBlock.name,
+      toolUseId: toolUseBlock.toolUseId,
+      input: toolUseBlock.input,
+    }
+
+    while (true) {
+      const beforeToolCallEvent = new BeforeToolCallEvent({
+        agent: options.agent,
+        toolUse,
+        tool: registryTool,
+        invocationState,
+      })
+      yield beforeToolCallEvent
+
+      toolUse = {
+        ...beforeToolCallEvent.toolUse,
+        toolUseId: toolUseBlock.toolUseId,
+      }
+      // selectedTool takes precedence over resolving a hook-renamed toolUse;
+      // otherwise retain the original registry lookup. Resolve before cancellation
+      // so AfterToolCallEvent reports the same effective tool on every path.
+      const effectiveTool =
+        beforeToolCallEvent.selectedTool ??
+        (toolUse.name !== toolUseBlock.name ? options.agent.toolRegistry.get(toolUse.name) : registryTool)
+
+      if (beforeToolCallEvent.cancel) {
+        const cancelMessage =
+          typeof beforeToolCallEvent.cancel === 'string' ? beforeToolCallEvent.cancel : 'Tool cancelled by hook'
+        const cancelResult = new ToolResultBlock({
+          toolUseId: toolUse.toolUseId,
+          status: 'error',
+          content: [new TextBlock(cancelMessage)],
+        })
+        const afterToolCallEvent = new AfterToolCallEvent({
+          agent: options.agent,
+          toolUse,
+          tool: effectiveTool,
+          result: cancelResult,
+          invocationState,
+        })
+        yield afterToolCallEvent
+        if (afterToolCallEvent.retry) {
+          continue
+        }
+        return this._normalizeToolResultId(afterToolCallEvent.result, toolUseBlock.toolUseId)
+      }
+
+      const toolResult = this._normalizeToolResultId(
+        yield* this._executeToolWithMiddleware(options, effectiveTool, toolUse, invocationState),
+        toolUseBlock.toolUseId
+      )
+      const error = toolResult.error
+      const afterToolCallEvent = new AfterToolCallEvent({
+        agent: options.agent,
+        toolUse,
+        tool: effectiveTool,
+        result: toolResult,
+        invocationState,
+        ...(error !== undefined && { error }),
+      })
+      yield afterToolCallEvent
+
+      if (afterToolCallEvent.retry) {
+        continue
+      }
+
+      // Return the hook-transformed result so downstream events and the model
+      // observe the same value.
+      return this._normalizeToolResultId(afterToolCallEvent.result, toolUseBlock.toolUseId)
+    }
+  }
+
+  private _normalizeToolResultId(result: ToolResultBlock, toolUseId: string): ToolResultBlock {
+    if (result.toolUseId === toolUseId) {
+      return result
+    }
+
+    return new ToolResultBlock({
+      toolUseId,
+      status: result.status,
+      content: result.content,
+      ...(result.error !== undefined && { error: result.error }),
+    })
+  }
+
+  // Keys and serialized results use model-issued toolUseIds so resume and
+  // provider correlation match the assistant's tool-use blocks.
+  protected _storePendingToolExecution(
+    options: ToolExecutorOptions,
+    assistantMessage: Message,
+    completedToolResults: ReadonlyMap<string, ToolResultBlock>
+  ): void {
+    const serializedResults: Record<string, { toolResult: ToolResultBlockData }> = {}
+    for (const [toolUseId, result] of completedToolResults) {
+      serializedResults[toolUseId] = result.toJSON()
+    }
+    options.agent._interruptState.setPendingToolExecution({
+      assistantMessageData: assistantMessage.toJSON(),
+      completedToolResults: serializedResults,
+    })
+  }
+
+  private async *_executeToolWithMiddleware(
+    options: ToolExecutorOptions,
+    tool: Tool | undefined,
+    toolUse: ToolUseData,
+    invocationState: InvocationState
+  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
+    const context: ExecuteToolContext = {
+      agent: options.agent,
+      tool,
+      toolUse: deepCopy(toolUse) as unknown as ToolUseData,
+      invocationState,
+      interrupt: createMiddlewareInterrupt(
+        options.agent._interruptState,
+        `middleware:executeTool:${toolUse.toolUseId}`
+      ),
+    }
+
+    // async function* does not bind lexical `this`; capture the executor for the terminal callback.
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const executor = this
+    const middlewareResult = yield* options.middlewareRegistry.invoke(
+      ExecuteToolStage,
+      context,
+      async function* (
+        middlewareContext: ExecuteToolContext
+      ): AsyncGenerator<AgentStreamEvent, ExecuteToolResult, undefined> {
+        const result = yield* executor._executeToolCore(
+          options,
+          middlewareContext.tool,
+          middlewareContext.toolUse,
+          middlewareContext.invocationState
+        )
+        return { result }
+      }
+    )
+    return middlewareResult.result
+  }
+
+  private async *_executeToolCore(
+    options: ToolExecutorOptions,
+    effectiveTool: Tool | undefined,
+    toolUse: ToolUseData,
+    invocationState: InvocationState
+  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
+    const toolSpan = options.tracer.startToolCallSpan({ tool: toolUse })
+    const toolStartTime = Date.now()
+
+    let toolResult: ToolResultBlock | undefined
+    let error: Error | undefined
+
+    try {
+      if (!effectiveTool) {
+        toolResult = new ToolResultBlock({
+          toolUseId: toolUse.toolUseId,
+          status: 'error',
+          content: [new TextBlock(`Tool '${toolUse.name}' not found in registry`)],
+        })
+      } else {
+        const toolContext: ToolContext = {
+          toolUse: {
+            name: toolUse.name,
+            toolUseId: toolUse.toolUseId,
+            input: toolUse.input,
+          },
+          agent: options.agent,
+          invocationState,
+          interrupt: <T = JSONValue>(params: InterruptParams): T =>
+            interruptFromAgent<T>(options.agent, `tool:${toolUse.toolUseId}:${params.name}`, params, 'tool'),
+        }
+
+        // Iterate manually to wrap raw tool events at the agent boundary and
+        // re-enter the tool span for every asynchronous step.
+        const toolGenerator = options.tracer.withSpanContext(toolSpan, () => effectiveTool.stream(toolContext))
+        let toolNext = await options.tracer.withSpanContext(toolSpan, () => toolGenerator.next())
+        while (!toolNext.done) {
+          yield new ToolStreamUpdateEvent({ agent: options.agent, event: toolNext.value, invocationState })
+          toolNext = await options.tracer.withSpanContext(toolSpan, () => toolGenerator.next())
+        }
+
+        toolResult =
+          toolNext.value ??
+          new ToolResultBlock({
+            toolUseId: toolUse.toolUseId,
+            status: 'error',
+            content: [new TextBlock(`Tool '${toolUse.name}' did not return a result`)],
+          })
+        error = toolNext.value?.error
+      }
+
+      return toolResult
+    } catch (caughtError) {
+      if (caughtError instanceof InterruptError) {
+        throw caughtError
+      }
+
+      error = normalizeError(caughtError)
+      toolResult = new ToolResultBlock({
+        toolUseId: toolUse.toolUseId,
+        status: 'error',
+        content: [new TextBlock(error.message)],
+        error,
+      })
+      return toolResult
+    } finally {
+      // Record the raw execution outcome before AfterToolCallEvent can transform it.
+      options.tracer.endToolCallSpan(toolSpan, {
+        ...(toolResult !== undefined && { toolResult }),
+        ...(error !== undefined && { error }),
+      })
+      options.meter.endToolCall({
+        tool: toolUse,
+        duration: Date.now() - toolStartTime,
+        success: toolResult?.status === 'success',
+      })
+    }
+  }
+}

--- a/strands-ts/src/tools/executors/sequential.ts
+++ b/strands-ts/src/tools/executors/sequential.ts
@@ -1,0 +1,74 @@
+import { ToolResultEvent } from '../../hooks/events.js'
+import { InterruptError } from '../../interrupt.js'
+import { TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { ToolExecutor } from './executor.js'
+
+import type { AgentStreamEvent } from '../../types/agent.js'
+import type { ToolExecutionInput, ToolExecutorOptions } from './executor.js'
+
+/**
+ * Executes tool calls one at a time.
+ *
+ * @example
+ * ```typescript
+ * import { Agent, SequentialToolExecutor } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({
+ *   toolExecutor: new SequentialToolExecutor(),
+ * })
+ * ```
+ */
+export class SequentialToolExecutor extends ToolExecutor {
+  /**
+   * Executes tool calls in source order, honoring `agent.cancelSignal` between
+   * calls to short-circuit tools that have not started.
+   *
+   * @param options - Agent dependencies used to execute tools
+   * @param input - Tool calls and invocation state
+   * @returns Stream of tool lifecycle events
+   * @internal
+   */
+  override async *execute(
+    options: ToolExecutorOptions,
+    input: ToolExecutionInput
+  ): AsyncGenerator<AgentStreamEvent, void, undefined> {
+    const { toolUseBlocks, toolResultBlocks, invocationState, assistantMessage, completedToolResults } = input
+
+    // Keyed by the model-issued toolUseId so interrupt state matches the
+    // model's tool-use blocks.
+    const resultsByToolUseId = new Map<string, ToolResultBlock>(completedToolResults)
+
+    for (const toolUseBlock of toolUseBlocks) {
+      const completedResult = completedToolResults?.get(toolUseBlock.toolUseId)
+      if (completedResult) {
+        // Resume results belong in the final message without replaying lifecycle events.
+        toolResultBlocks.push(completedResult)
+        continue
+      }
+
+      if (options.agent.cancelSignal.aborted) {
+        const cancelBlock = new ToolResultBlock({
+          toolUseId: toolUseBlock.toolUseId,
+          status: 'error',
+          content: [new TextBlock('Tool execution cancelled')],
+        })
+        toolResultBlocks.push(cancelBlock)
+        resultsByToolUseId.set(toolUseBlock.toolUseId, cancelBlock)
+        yield new ToolResultEvent({ agent: options.agent, result: cancelBlock, invocationState })
+        continue
+      }
+
+      try {
+        const toolResultBlock = yield* this.executeTool(options, toolUseBlock, invocationState)
+        toolResultBlocks.push(toolResultBlock)
+        resultsByToolUseId.set(toolUseBlock.toolUseId, toolResultBlock)
+        yield new ToolResultEvent({ agent: options.agent, result: toolResultBlock, invocationState })
+      } catch (error) {
+        if (error instanceof InterruptError) {
+          this._storePendingToolExecution(options, assistantMessage, resultsByToolUseId)
+        }
+        throw error
+      }
+    }
+  }
+}

--- a/strands-ts/src/tools/executors/sequential.ts
+++ b/strands-ts/src/tools/executors/sequential.ts
@@ -13,9 +13,11 @@ import type { ToolExecutionInput, ToolExecutorOptions } from './executor.js'
  * ```typescript
  * import { Agent, SequentialToolExecutor } from '@strands-agents/sdk'
  *
- * const agent = new Agent({
- *   toolExecutor: new SequentialToolExecutor(),
- * })
+ * // The string shorthand keeps imports minimal.
+ * const agent = new Agent({ toolExecutor: 'sequential' })
+ *
+ * // Passing an instance is equivalent if you prefer to be explicit.
+ * const explicitAgent = new Agent({ toolExecutor: new SequentialToolExecutor() })
  * ```
  */
 export class SequentialToolExecutor extends ToolExecutor {


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

The Strands TypeScript SDK currently keeps sequential and concurrent tool execution inside the `Agent` implementation, while Python models them as [executor classes](https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/tools/executors). 

This PR ports that hierarchy so the built-in execution policies can be configured as concrete executor instances and the shared tool lifecycle is separated from the agent loop.

### Public API Changes

The existing string shorthand remains supported:

```typescript
const agent = new Agent({ toolExecutor: 'sequential' })
```

The built-in executors can now be supplied and replaced directly:

```typescript
import { 
  Agent,
  ConcurrentToolExecutor,
  SequentialToolExecutor 
} from '@strands-agents/sdk'

const agent = new Agent({
  toolExecutor: new SequentialToolExecutor(),
})

agent.toolExecutor = new ConcurrentToolExecutor()
```

For comparison, here's the Python DevX:

```python
from strands import Agent
from strands.tools.executors import (
  ConcurrentToolExecutor,
  SequentialToolExecutor,
)

agent = Agent(
  tool_executor=SequentialToolExecutor(),
)

agent.tool_executor = ConcurrentToolExecutor()
```

Concurrent execution remains the default. The ToolExecutor base remains internal; custom executors are tracked separately in #762.

## Related Issues

<!-- Link to related issues using #issue-number format -->

Closes #3166 

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

Updates are in this PR

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature / refactor

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
