### PR TITLE
ci(changelog): guard sync job to upstream; document workflow-scope requirement

### DIFF
--- a/.github/workflows/CHANGELOG-SYNC.md
+++ b/.github/workflows/CHANGELOG-SYNC.md
@@ -1,0 +1,44 @@
+# Changelog Sync — operations
+
+`changelog-sync.yml` keeps `site/src/content/changelog/**` current. It runs the
+generator in `site/scripts/changelog/` (single tag on release/dispatch, backfill
+on the daily cron) and opens a data-only PR via the `strands-agent` bot fork.
+Release workflows also dispatch it directly after creating a GitHub release
+(a `GITHUB_TOKEN`-created release does not emit a `release` event).
+
+## CHANGELOG_BOT_TOKEN (repo secret)
+
+A classic PAT on the **`strands-agent`** account (singular -- the dedicated bot
+account, not the `strands-agents` org). Required scopes:
+
+| Scope | Why |
+|---|---|
+| `public_repo` | Read releases/PRs, push branches to the bot's fork, open cross-repo PRs against this repo. |
+| `workflow` | Any fork operation that carries `.github/workflows/*` changes -- both the fork `merge-upstream` sync step and PR-branch pushes -- is rejected with HTTP 422 without it. Upstream workflow files change routinely, so this scope is load-bearing, not optional. |
+
+**When rotating the token, check both boxes.** A token with only
+`public_repo` works until the next time any upstream workflow file changes,
+then every scheduled run fails with:
+
+```
+refusing to allow a Personal Access Token to create or update workflow
+`.github/workflows/changelog-sync.yml` without `workflow` scope (HTTP 422)
+```
+
+## Why a bot fork + PAT (not GITHUB_TOKEN)
+
+PRs authored by `GITHUB_TOKEN` do not trigger `pull_request` workflows, so the
+required CI Gate would never run on sync PRs. The bot is a real user account
+pushing to its own fork (`strands-agent/harness-sdk`) and opening cross-repo
+PRs; it has no write access to this repo.
+
+## Recovery
+
+- **Fork drifted / 422 on push**: the `Sync bot fork with upstream` step
+  self-heals on the next run (given the `workflow` scope). Manual fix: the
+  "Sync fork" button on the fork, or
+  `gh api repos/strands-agent/harness-sdk/merge-upstream -f branch=main`.
+- **Missed release**: dispatch `Changelog: Sync` with the release tag, or wait
+  for the daily cron backstop (07:17 UTC).
+- **Duplicate sync PRs** (release event vs. cron): content is identical; close
+  the stale one.

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -55,11 +55,8 @@ jobs:
       # Keep the bot fork's default branch current with upstream before opening
       # PRs from it. create-pull-request cuts the PR branch from the fork's base;
       # if the fork is behind, the branch diff picks up files that changed
-      # upstream since. NOTE: whenever upstream changed anything under
-      # .github/workflows/, both this sync and the branch push below require the
-      # PAT to carry the `workflow` scope (in addition to public_repo) -- without
-      # it GitHub rejects the operation with HTTP 422 / "refusing to allow a
-      # Personal Access Token to ... update workflow ... without workflow scope".
+      # upstream since. Requires the PAT to carry the `workflow` scope --
+      # see CHANGELOG-SYNC.md (token scopes + recovery runbook).
       # continue-on-error: a failed/flaky sync (409 divergence, transient API
       # hiccup) must not abort a run that would otherwise succeed -- if the sync
       # was actually needed, the create-pull-request push below fails anyway with

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -17,15 +17,19 @@ permissions:
 
 jobs:
   sync:
+    # Upstream only: this workflow also exists on the bot fork (the fork mirrors
+    # main), where the cron would otherwise fire and fail -- the fork has no
+    # CHANGELOG_BOT_TOKEN secret.
     # On release: only our in-scope tag prefixes. The bare `v` prefix is for
     # pre-monorepo python releases; the action itself rejects any tag that
     # isn't `v<digit>`, so a stray non-version `v…` tag produces a no-op run.
     # Cron/dispatch: always run.
     if: >
-      github.event_name != 'release' ||
+      github.repository == 'strands-agents/harness-sdk' &&
+      (github.event_name != 'release' ||
       startsWith(github.event.release.tag_name, 'python/v') ||
       startsWith(github.event.release.tag_name, 'typescript/v') ||
-      startsWith(github.event.release.tag_name, 'v')
+      startsWith(github.event.release.tag_name, 'v'))
     runs-on: ubuntu-latest
     # De-dupes runs of the same event type + tag. Deliberately does NOT
     # serialize release vs. cron: a cross-event duplicate PR has identical
@@ -51,9 +55,11 @@ jobs:
       # Keep the bot fork's default branch current with upstream before opening
       # PRs from it. create-pull-request cuts the PR branch from the fork's base;
       # if the fork is behind, the branch diff picks up files that changed
-      # upstream since -- notably this workflow under .github/workflows/, which
-      # the fork PAT (public_repo scope, no workflow scope) is forbidden to push,
-      # rejecting the whole push. Syncing first keeps every sync PR data-only.
+      # upstream since. NOTE: whenever upstream changed anything under
+      # .github/workflows/, both this sync and the branch push below require the
+      # PAT to carry the `workflow` scope (in addition to public_repo) -- without
+      # it GitHub rejects the operation with HTTP 422 / "refusing to allow a
+      # Personal Access Token to ... update workflow ... without workflow scope".
       # continue-on-error: a failed/flaky sync (409 divergence, transient API
       # hiccup) must not abort a run that would otherwise succeed -- if the sync
       # was actually needed, the create-pull-request push below fails anyway with


### PR DESCRIPTION
## Description

The scheduled changelog backstop has been failing in two distinct ways:

**1. The cron runs on the bot fork and fails there** ([fork run](https://github.com/strands-agent/harness-sdk/actions/runs/29404248564/job/87315759549)). The fork auto-sync (#3179) keeps `strands-agent/harness-sdk` mirroring main -- including this workflow, whose `schedule` trigger then fires on the fork. The fork has no `CHANGELOG_BOT_TOKEN` secret, so every generate step dies with `No token`. Fix: gate the job on `github.repository == 'strands-agents/harness-sdk'` so fork runs no-op instead of failing noisily.

**2. Upstream runs fail whenever a workflow file changed since the fork's last sync** ([upstream run](https://github.com/strands-agents/harness-sdk/actions/runs/29399048397)). Both the `merge-upstream` call and the PR-branch push are rejected with:

```
refusing to allow a Personal Access Token to create or update workflow
`.github/workflows/changelog-sync.yml` without `workflow` scope (HTTP 422)
```

The `public_repo`-scoped PAT cannot perform ANY fork operation that carries `.github/workflows/*` changes. Jul 11-13 crons succeeded only because no workflow files had changed since the July 10 manual fork sync; #3193 (merged Jul 13) touched three workflow files and broke the chain again. The evals PR-branch push fails for the same reason (its branch is cut from the stale fork base and therefore carries the missing workflow commits).

Fix for (2) is operational, documented in the workflow comment where the failure surfaces: **add the `workflow` scope to `CHANGELOG_BOT_TOKEN`** (classic PAT, check the `workflow` box, update the secret). The scope only broadens what the bot can do on its own fork -- it still has zero write on upstream. Once added, the existing auto-sync step self-heals the fork on every run and this failure class disappears.

## Testing

- YAML validates.
- The `github.repository` guard is the standard idiom for repo-pinned scheduled jobs; on the fork the job skips at the gate before any step runs.
- (2) is verified from the run logs: the 422 names the exact scope; the timeline (fork synced Jul 10 -> green Jul 11-13 -> #3193 merges Jul 13 touching workflows -> red Jul 14-15) matches exactly.

## Follow-up -- both done

- [x] `CHANGELOG_BOT_TOKEN` regenerated with `workflow` scope and the repo secret updated.
- [x] Fork sync verified: a dispatched run after the token update completed green end-to-end, with the `Sync bot fork with upstream` step healing the fork's drift (30 commits behind -> current). The scope requirement and recovery steps are now documented in `.github/workflows/CHANGELOG-SYNC.md` (added in this PR).
