### PR TITLE
fix(models/openai): use /openai/v1 Mantle base URL for the Responses API

### DIFF
--- a/strands-ts/src/models/openai/__tests__/mantle.test.ts
+++ b/strands-ts/src/models/openai/__tests__/mantle.test.ts
@@ -60,7 +60,7 @@ describe('OpenAIModel bedrockMantleConfig', () => {
 
       expect(OpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/v1',
+          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/openai/v1',
           apiKey: expect.any(Function),
         })
       )
@@ -120,7 +120,7 @@ describe('OpenAIModel bedrockMantleConfig', () => {
 
       expect(OpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/v1',
+          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/openai/v1',
           apiKey: expect.any(Function),
           timeout: 42,
           fetch: http,
@@ -137,12 +137,25 @@ describe('OpenAIModel bedrockMantleConfig', () => {
       ).not.toThrow()
     })
 
-    it('works for api: "chat" as well as the default responses api', async () => {
+    it('derives the /openai/v1 base URL for the default (responses) api', () => {
+      new OpenAIModel({
+        modelId: 'openai.gpt-5.6-luna',
+        bedrockMantleConfig: { region: 'us-west-2' },
+      })
+      expect(OpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'https://bedrock-mantle.us-west-2.api.aws/openai/v1' })
+      )
+    })
+
+    it('derives the /v1 base URL for api: "chat" and mints a bearer token', async () => {
       new OpenAIModel({
         api: 'chat',
         modelId: TEST_MODEL_ID,
         bedrockMantleConfig: { region: 'us-east-1' },
       })
+      expect(OpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'https://bedrock-mantle.us-east-1.api.aws/v1' })
+      )
       const apiKey = await lastApiKeySetter()()
       expect(apiKey).toBe(TEST_TOKEN)
     })
@@ -208,7 +221,7 @@ describe('OpenAIModel bedrockMantleConfig', () => {
         new OpenAIModel({ modelId: TEST_MODEL_ID, bedrockMantleConfig: {} })
         await lastApiKeySetter()()
         expect(OpenAI).toHaveBeenCalledWith(
-          expect.objectContaining({ baseURL: 'https://bedrock-mantle.eu-west-1.api.aws/v1' })
+          expect.objectContaining({ baseURL: 'https://bedrock-mantle.eu-west-1.api.aws/openai/v1' })
         )
         expect(getTokenProviderMock).toHaveBeenCalledWith({ region: 'eu-west-1' })
       })

--- a/strands-ts/src/models/openai/__tests__/mantle.test.ts
+++ b/strands-ts/src/models/openai/__tests__/mantle.test.ts
@@ -60,7 +60,7 @@ describe('OpenAIModel bedrockMantleConfig', () => {
 
       expect(OpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/openai/v1',
+          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/v1',
           apiKey: expect.any(Function),
         })
       )
@@ -120,7 +120,7 @@ describe('OpenAIModel bedrockMantleConfig', () => {
 
       expect(OpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/openai/v1',
+          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/v1',
           apiKey: expect.any(Function),
           timeout: 42,
           fetch: http,
@@ -137,27 +137,55 @@ describe('OpenAIModel bedrockMantleConfig', () => {
       ).not.toThrow()
     })
 
-    it('derives the /openai/v1 base URL for the default (responses) api', () => {
-      new OpenAIModel({
-        modelId: 'openai.gpt-5.6-luna',
-        bedrockMantleConfig: { region: 'us-west-2' },
-      })
-      expect(OpenAI).toHaveBeenCalledWith(
-        expect.objectContaining({ baseURL: 'https://bedrock-mantle.us-west-2.api.aws/openai/v1' })
-      )
-    })
-
-    it('derives the /v1 base URL for api: "chat" and mints a bearer token', async () => {
+    it('mints a bearer token regardless of api mode', async () => {
       new OpenAIModel({
         api: 'chat',
         modelId: TEST_MODEL_ID,
         bedrockMantleConfig: { region: 'us-east-1' },
       })
-      expect(OpenAI).toHaveBeenCalledWith(
-        expect.objectContaining({ baseURL: 'https://bedrock-mantle.us-east-1.api.aws/v1' })
-      )
       const apiKey = await lastApiKeySetter()()
       expect(apiKey).toBe(TEST_TOKEN)
+    })
+  })
+
+  // The Mantle base path is keyed by model family, not API surface:
+  // `openai.gpt-5.*` is served from `/openai/v1`, everything else from `/v1`,
+  // on both the responses and chat/completions endpoints.
+  describe('base path resolution by model family', () => {
+    const baseURLFor = (options: ConstructorParameters<typeof OpenAIModel>[0]): string => {
+      new OpenAIModel(options)
+      const calls = (OpenAI as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      return (calls[calls.length - 1]![0] as { baseURL: string }).baseURL
+    }
+
+    it('uses /openai/v1 for gpt-5.* on the responses api', () => {
+      expect(baseURLFor({ modelId: 'openai.gpt-5.6-luna', bedrockMantleConfig: { region: 'us-west-2' } })).toBe(
+        'https://bedrock-mantle.us-west-2.api.aws/openai/v1'
+      )
+    })
+
+    it('uses /openai/v1 for gpt-5.* on the chat api', () => {
+      expect(
+        baseURLFor({ api: 'chat', modelId: 'openai.gpt-5.6-luna', bedrockMantleConfig: { region: 'us-west-2' } })
+      ).toBe('https://bedrock-mantle.us-west-2.api.aws/openai/v1')
+    })
+
+    it('uses /v1 for gpt-oss-* on the responses api', () => {
+      expect(baseURLFor({ modelId: 'openai.gpt-oss-120b', bedrockMantleConfig: { region: 'us-west-2' } })).toBe(
+        'https://bedrock-mantle.us-west-2.api.aws/v1'
+      )
+    })
+
+    it('uses /v1 for gpt-oss-* on the chat api', () => {
+      expect(
+        baseURLFor({ api: 'chat', modelId: 'openai.gpt-oss-120b', bedrockMantleConfig: { region: 'us-west-2' } })
+      ).toBe('https://bedrock-mantle.us-west-2.api.aws/v1')
+    })
+
+    it('matches only Bedrock-style ids: openai.gpt-5.* → /openai/v1, bare gpt-5.* → /v1', () => {
+      expect(baseURLFor({ modelId: 'gpt-5.4', bedrockMantleConfig: { region: 'us-west-2' } })).toBe(
+        'https://bedrock-mantle.us-west-2.api.aws/v1'
+      )
     })
   })
 
@@ -221,7 +249,7 @@ describe('OpenAIModel bedrockMantleConfig', () => {
         new OpenAIModel({ modelId: TEST_MODEL_ID, bedrockMantleConfig: {} })
         await lastApiKeySetter()()
         expect(OpenAI).toHaveBeenCalledWith(
-          expect.objectContaining({ baseURL: 'https://bedrock-mantle.eu-west-1.api.aws/openai/v1' })
+          expect.objectContaining({ baseURL: 'https://bedrock-mantle.eu-west-1.api.aws/v1' })
         )
         expect(getTokenProviderMock).toHaveBeenCalledWith({ region: 'eu-west-1' })
       })

--- a/strands-ts/src/models/openai/mantle.ts
+++ b/strands-ts/src/models/openai/mantle.ts
@@ -13,9 +13,18 @@
  */
 
 import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smithy/types'
-import type { OpenAIApi } from './types.js'
 
 const MANTLE_DOCS_URL = 'https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html'
+
+/**
+ * Mantle-routed model id prefixes served from `/openai/v1` instead of `/v1`.
+ *
+ * On Mantle the base path is keyed by model family, not API surface: hosted
+ * OpenAI models (`openai.gpt-5.*`) are served from `/openai/v1`, while other
+ * models (e.g. `openai.gpt-oss-*`) use `/v1` — both on the same `/responses`
+ * and `/chat/completions` endpoints.
+ */
+const OPENAI_PATH_MODEL_PREFIXES = ['openai.gpt-5.'] as const
 
 /**
  * Async function that returns a freshly minted Bedrock Mantle bearer token.
@@ -84,19 +93,16 @@ export function resolveMantleRegion(config: BedrockMantleConfig): string {
 }
 
 /**
- * Builds the Mantle base URL for a region and API surface.
+ * Builds the Mantle base URL for a region and model id.
  *
- * Bedrock Mantle exposes two path prefixes:
- *   - Responses API        → `/openai/v1` (hosted OpenAI models, e.g. `gpt-5.x`)
- *   - Chat Completions API → `/v1`        (OSS models, e.g. `gpt-oss-*`)
- *
- * This mirrors the official `openai` SDK's Bedrock provider, which derives
- * `.../openai/v1` for its Responses-based client.
+ * The base path is keyed by model family: `openai.gpt-5.*` is served from
+ * `/openai/v1`, all other Mantle-routed models from `/v1`. This mirrors the
+ * Python SDK's `_resolve_mantle_base_path`.
  *
  * @internal
  */
-export function bedrockMantleBaseUrl(region: string, api: OpenAIApi): string {
-  const suffix = api === 'responses' ? '/openai/v1' : '/v1'
+export function bedrockMantleBaseUrl(region: string, modelId: string): string {
+  const suffix = OPENAI_PATH_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix)) ? '/openai/v1' : '/v1'
   return `https://bedrock-mantle.${region}.api.aws${suffix}`
 }
 

--- a/strands-ts/src/models/openai/mantle.ts
+++ b/strands-ts/src/models/openai/mantle.ts
@@ -13,6 +13,7 @@
  */
 
 import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smithy/types'
+import type { OpenAIApi } from './types.js'
 
 const MANTLE_DOCS_URL = 'https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html'
 
@@ -83,12 +84,20 @@ export function resolveMantleRegion(config: BedrockMantleConfig): string {
 }
 
 /**
- * Builds the Mantle base URL for a region.
+ * Builds the Mantle base URL for a region and API surface.
+ *
+ * Bedrock Mantle exposes two path prefixes:
+ *   - Responses API        → `/openai/v1` (hosted OpenAI models, e.g. `gpt-5.x`)
+ *   - Chat Completions API → `/v1`        (OSS models, e.g. `gpt-oss-*`)
+ *
+ * This mirrors the official `openai` SDK's Bedrock provider, which derives
+ * `.../openai/v1` for its Responses-based client.
  *
  * @internal
  */
-export function bedrockMantleBaseUrl(region: string): string {
-  return `https://bedrock-mantle.${region}.api.aws/v1`
+export function bedrockMantleBaseUrl(region: string, api: OpenAIApi): string {
+  const suffix = api === 'responses' ? '/openai/v1' : '/v1'
+  return `https://bedrock-mantle.${region}.api.aws${suffix}`
 }
 
 /**

--- a/strands-ts/src/models/openai/model.ts
+++ b/strands-ts/src/models/openai/model.ts
@@ -100,7 +100,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
     if (client) {
       this._client = client
     } else if (bedrockMantleConfig) {
-      this._client = buildMantleClient(bedrockMantleConfig, apiKey, clientConfig)
+      this._client = buildMantleClient(bedrockMantleConfig, apiKey, clientConfig, this._api)
     } else {
       const hasEnvKey =
         typeof process !== 'undefined' && typeof process.env !== 'undefined' && process.env.OPENAI_API_KEY
@@ -269,7 +269,8 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
 function buildMantleClient(
   bedrockMantleConfig: NonNullable<OpenAIModelOptions['bedrockMantleConfig']>,
   apiKey: OpenAIModelOptions['apiKey'],
-  clientConfig: OpenAIModelOptions['clientConfig']
+  clientConfig: OpenAIModelOptions['clientConfig'],
+  api: OpenAIApi
 ): OpenAI {
   if (apiKey !== undefined) {
     throw new Error(
@@ -292,7 +293,7 @@ function buildMantleClient(
 
   return new OpenAI({
     ...clientConfig,
-    baseURL: bedrockMantleBaseUrl(region),
+    baseURL: bedrockMantleBaseUrl(region, api),
     apiKey: createMantleApiKeySetter(bedrockMantleConfig, region),
   })
 }

--- a/strands-ts/src/models/openai/model.ts
+++ b/strands-ts/src/models/openai/model.ts
@@ -100,7 +100,8 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
     if (client) {
       this._client = client
     } else if (bedrockMantleConfig) {
-      this._client = buildMantleClient(bedrockMantleConfig, apiKey, clientConfig, this._api)
+      const modelId = modelConfig.modelId ?? MODEL_DEFAULTS.openai.modelId
+      this._client = buildMantleClient(bedrockMantleConfig, apiKey, clientConfig, modelId)
     } else {
       const hasEnvKey =
         typeof process !== 'undefined' && typeof process.env !== 'undefined' && process.env.OPENAI_API_KEY
@@ -270,7 +271,7 @@ function buildMantleClient(
   bedrockMantleConfig: NonNullable<OpenAIModelOptions['bedrockMantleConfig']>,
   apiKey: OpenAIModelOptions['apiKey'],
   clientConfig: OpenAIModelOptions['clientConfig'],
-  api: OpenAIApi
+  modelId: string
 ): OpenAI {
   if (apiKey !== undefined) {
     throw new Error(
@@ -293,7 +294,7 @@ function buildMantleClient(
 
   return new OpenAI({
     ...clientConfig,
-    baseURL: bedrockMantleBaseUrl(region, api),
+    baseURL: bedrockMantleBaseUrl(region, modelId),
     apiKey: createMantleApiKeySetter(bedrockMantleConfig, region),
   })
 }


### PR DESCRIPTION
## Description

`OpenAIModel({ bedrockMantleConfig })` was unusable with Bedrock-hosted `openai.gpt-5.*` models on the Responses API (the default `api` mode). `bedrockMantleBaseUrl` hardcoded `/v1`, so requests hit `POST /v1/responses` and Mantle returned a misleading 400 blaming the model, not the route:

```
400 The model 'openai.gpt-5.6-luna' does not support the '/v1/responses' API
```

On Mantle the base path prefix is keyed by **model family**, not API surface: `openai.gpt-5.*` models are served from `/openai/v1` and all other Mantle-routed models (e.g. `openai.gpt-oss-*`) from `/v1`, on both the `/responses` and `/chat/completions` endpoints. Verified against live Mantle — notably `openai.gpt-oss-120b` returns 200 on `/v1/responses`, so keying the prefix off the API surface would break OSS models on the Responses API.

This resolves the prefix from `modelId` (`openai.gpt-5.*` → `/openai/v1`, else `/v1`), threading the resolved model id through `buildMantleClient`. It mirrors the Python SDK's `_resolve_mantle_base_path`. No new public API.

```typescript
// gpt-5.* → /openai/v1
const model = new OpenAIModel({
  modelId: 'openai.gpt-5.6-luna',
  bedrockMantleConfig: { region: 'us-west-2' },
})

// gpt-oss-* → /v1 (on both responses and chat)
const oss = new OpenAIModel({
  modelId: 'openai.gpt-oss-120b',
  bedrockMantleConfig: { region: 'us-west-2' },
})
```

## Related Issues

Resolves #3279

## Documentation PR

No docs changes in this PR. The Mantle section of `openai-responses.mdx` should note that `openai.gpt-5.*` models use `/openai/v1` while other models use `/v1` — proposed as a separate follow-up to keep this change focused.

## Type of Change

Bug fix

## Testing

Unit tests in `mantle.test.ts` cover all four family×surface combinations (`gpt-5.*` and `gpt-oss-*` on both `responses` and `chat`). Verified end-to-end against live Bedrock Mantle (`us-west-2`): `gpt-5.6-luna` on responses (`/openai/v1`), and `gpt-oss-120b` on both responses and chat (`/v1`) all stream text. TS SDK gate (`npm run build`, `test:coverage`, `lint`, `type-check`) passes.

- [x] I ran the TypeScript SDK checks (`npm run build && npm run test:coverage && npm run lint && npm run type-check`)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
