### PR TITLE
docs: add Welt community integration page

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -315,6 +315,7 @@ sidebar:
       - label: Integrations
         items:
           - docs/community/integrations/ag-ui
+          - docs/community/integrations/welt
       - label: Agent Extensions
         items:
           - docs/community/agent-extensions/strands-code-agent

--- a/site/src/content/docs/community/integrations/welt.mdx
+++ b/site/src/content/docs/community/integrations/welt.mdx
@@ -15,53 +15,69 @@ service:
   link: https://slack.com/
 ---
 
-[Welt](https://github.com/iwamot/welt) is a self-hosted Slack front end for agents running on Amazon Bedrock AgentCore Runtime. Mention the agent in a channel or DM and it streams the reply into the thread; Slack uploads reach the agent as Converse file blocks, generated files come back as thread uploads, and a run that pauses for human input renders as Slack buttons and text fields — Strands interrupts become approval UIs your whole team can see and answer.
+[Welt](https://github.com/iwamot/welt) is a self-hosted Slack front end for agents running on Amazon Bedrock AgentCore Runtime. Mention the agent in a channel or DM and it streams the reply into the thread; Slack uploads reach the agent as Converse file blocks, the files your tools produce are uploaded back into the thread, and a run that pauses for human input renders as Slack buttons and text fields — Strands interrupts become approval UIs your whole team can see and answer.
 
-Welt drives the agent through a small JSON wire contract, and each Strands SDK has an adapter for it: [`welt-io-strands`](https://github.com/iwamot/welt-io-strands) for Python, [`@welt-io/strands`](https://github.com/iwamot/welt-io-strands-ts) for TypeScript. Either way it is the same five functions, translating between the wire's JSON and Strands values in both directions.
+Welt owns the Slack side of that entirely: bot tokens, event intake, thread history, streaming rendering, and file uploads. Your agent stays an ordinary AgentCore Runtime entrypoint — there is no base class to inherit, no server to embed, and nothing Welt-shaped in how you build the agent itself.
+
+## How the pieces fit
+
+Welt drives your agent over a small JSON wire contract:
+
+```
+Slack ⇄ Welt ⇄ AgentCore Runtime ⇄ your Strands agent
+```
+
+Each invocation carries one of two envelopes. A conversation turn arrives as `messages` — Converse-shaped, built by Welt from the Slack thread, by default the full history, so the agent needs no session state of its own. An answered approval question arrives instead as `interrupt_responses`, resuming a run that stopped earlier. Your entrypoint replies by yielding events, which the AgentCore SDK emits as SSE and Welt renders into the thread as they arrive.
+
+JSON is the reason an adapter exists at all. Inbound, file bytes travel base64-encoded because JSON cannot carry raw bytes. Outbound, raw `stream_async` events carry values that are not serializable in the first place — the Agent itself, UUIDs, traces — alongside far more than a Slack thread can show. Translating between the two is the adapter's whole job, and it comes to four functions:
+
+| Function | Direction | What it does |
+|---|---|---|
+| `decode_messages` | inbound | Restores the raw bytes of every image, document, and video block |
+| `decode_interrupt_responses` | inbound | Turns Welt's answers into the resume input Strands expects |
+| `renderable_events` | outbound | Reduces the event stream to what Welt renders, files included |
+| `interrupt_reason` | outbound | Builds the reason shape Welt renders as buttons and text fields |
+
+Both Strands SDKs have an adapter: [`welt-io-strands`](https://github.com/iwamot/welt-io-strands) for Python, [`@welt-io/strands`](https://github.com/iwamot/welt-io-strands-ts) for TypeScript. The four functions are the same on both sides, in each language's naming.
 
 ## Installation
-
-<Tabs>
-<Tab label="Python">
 
 ```bash
 pip install welt-io-strands
 ```
 
-</Tab>
-<Tab label="TypeScript">
-
 ```bash
 npm install @welt-io/strands
 ```
 
-</Tab>
-</Tabs>
-
 ## Usage
 
-A complete AgentCore entrypoint with a human-approval tool:
+The walkthrough below is Python. TypeScript works the same way with camelCase names, with two differences worth knowing up front: each event is yielded wrapped as `{data: event}`, since the AgentCore SDK reads the SSE payload from a yielded object's `data` field, and `renderableEvents` takes its options as a second argument. The [complete TypeScript entrypoint](https://github.com/iwamot/welt-io-strands-ts/tree/main/examples/agent) is deployable as-is.
 
-<Tabs>
-<Tab label="Python">
+### Receiving a turn and streaming the reply
+
+A turn is decoded, handed to an ordinary `Agent`, and streamed back:
 
 ```python
-from bedrock_agentcore.runtime import BedrockAgentCoreApp
-from strands import Agent, ToolContext, tool
-from welt_io_strands import (
-    decode_interrupt_responses,
-    decode_messages,
-    interrupt_reason,
-    renderable_events,
-)
-
-app = BedrockAgentCoreApp()
-
-# Where an interrupted Agent waits for its answers. One slot is enough:
-# AgentCore Runtime runs each session in its own microVM.
-_interrupted_agent: Agent | None = None
+# The tools whose files belong in the Slack thread.
+FILES_FROM = {"render_chart"}
 
 
+@app.entrypoint
+async def invoke(payload: dict):
+    agent = Agent(tools=[deploy, render_chart], callback_handler=None)
+    stream = agent.stream_async(decode_messages(payload["messages"]))
+    async for event in renderable_events(stream, agent=agent, files_from=FILES_FROM):
+        yield event
+```
+
+`renderable_events` keeps text chunks, tool-use indicators, files, and interrupts, and drops everything else — tool arguments that Strands re-sends on every delta, tool output text, empty chunks. `files_from` is how the agent says which of its files belong in the Slack thread: a tool that generates a chart for the user is named there, while a tool that reads a document *for the model* is left out and stays off the wire. Files the model itself returns are its reply, so they always go.
+
+### Asking a human mid-run
+
+Any tool can stop the run and put its question in the thread:
+
+```python
 @tool(context=True)
 def deploy(tool_context: ToolContext, target: str) -> str:
     """Deploy after a human approves in the Slack thread."""
@@ -73,137 +89,47 @@ def deploy(tool_context: ToolContext, target: str) -> str:
                 {"value": "y", "label": "Deploy", "style": "primary"},
                 {"value": "n", "label": "Cancel"},
             ],
+            input={"label": "Or type your answer"},
         ),
     )
     return f"Deployed {target}." if answer == "y" else "Deployment cancelled."
-
-
-@app.entrypoint
-async def invoke(payload: dict):
-    global _interrupted_agent
-
-    if "interrupt_responses" in payload:  # a human answered the buttons
-        agent = _interrupted_agent
-        _interrupted_agent = None
-        if agent is None:  # the microVM was recycled while the buttons waited
-            raise RuntimeError("No interrupted agent to resume in this session.")
-        stream = agent.stream_async(
-            decode_interrupt_responses(payload["interrupt_responses"])
-        )
-    else:  # a conversation turn, as Converse-shaped messages
-        agent = Agent(tools=[deploy], callback_handler=None)
-        stream = agent.stream_async(decode_messages(payload["messages"]))
-
-    interrupted = False
-    async for event in renderable_events(stream):
-        if "interrupt" in event:
-            interrupted = True
-        yield event
-    if interrupted:
-        _interrupted_agent = agent
-
-
-app.run()
 ```
 
-</Tab>
-<Tab label="TypeScript">
+Welt renders that reason as the message followed by two buttons and a free-text field; whichever answer comes first settles the question. A plain dict works here too — `ToolContext.interrupt` takes its `reason` as `Any` — but nothing would check it, and Welt answers a reason it cannot match with its default Approve / Deny buttons, silently. Building the reason through `interrupt_reason` is what turns a misspelled key into an error you see.
 
-```ts
-import { Agent, tool } from "@strands-agents/sdk";
-import type { RenderableEvent } from "@welt-io/strands";
-import {
-  decodeInterruptResponses,
-  decodeMessages,
-  interruptReason,
-  renderableEvents,
-} from "@welt-io/strands";
-import { BedrockAgentCoreApp } from "bedrock-agentcore/runtime";
-import { z } from "zod";
+Strands' ready-made [`HumanInTheLoop`](../../user-guide/concepts/agents/interventions/human-in-the-loop.md) intervention also works over Welt as-is.
 
-// Where an interrupted Agent waits for its answers. One slot is enough:
-// AgentCore Runtime runs each session in its own microVM.
-let interruptedAgent: Agent | null = null;
+### Resuming once someone answers
 
-const deploy = tool({
-  name: "deploy",
-  description: "Deploy after a human approves in the Slack thread.",
-  inputSchema: z.object({ target: z.string() }),
-  callback: ({ target }, context) => {
-    if (context === undefined) {
-      throw new Error("This tool needs its execution context to interrupt.");
-    }
-    const answer = context.interrupt<string>({
-      name: "deploy-approval",
-      reason: interruptReason(`Deploy ${target} to production?`, [
-        { value: "y", label: "Deploy", style: "primary" },
-        { value: "n", label: "Cancel" },
-      ]),
-    });
-    return answer === "y" ? `Deployed ${target}.` : "Deployment cancelled.";
-  },
-});
+Welt returns the answers keyed by interrupt id, and resuming needs the same `Agent` object that stopped:
 
-// Each event is wrapped as `{data: event}`: the AgentCore SDK reads the
-// SSE payload from a yielded object's `data` field.
-async function* replies(
-  agent: Agent,
-  stream: AsyncIterable<unknown>,
-): AsyncGenerator<{ data: RenderableEvent }> {
-  let interrupted = false;
-  for await (const event of renderableEvents(stream)) {
-    if ("interrupt" in event) {
-      interrupted = true;
-    }
-    yield { data: event };
-  }
-  if (interrupted) {
-    interruptedAgent = agent;
-  }
-}
-
-const app = new BedrockAgentCoreApp({
-  invocationHandler: {
-    process: async function* (payload: unknown) {
-      const record = payload as Record<string, unknown>;
-
-      if ("interrupt_responses" in record) {
-        // A human answered the buttons.
-        const agent = interruptedAgent;
-        interruptedAgent = null;
-        if (agent === null) {
-          // The microVM was recycled while the buttons waited.
-          throw new Error("No interrupted agent to resume in this session.");
-        }
-        const responses = decodeInterruptResponses(record.interrupt_responses);
-        yield* replies(agent, agent.stream(responses));
-        return;
-      }
-
-      // A conversation turn, as Converse-shaped messages.
-      const agent = new Agent({ tools: [deploy], printer: false });
-      yield* replies(agent, agent.stream(decodeMessages(record.messages)));
-    },
-  },
-});
-
-app.run();
+```python
+if "interrupt_responses" in payload:
+    agent = _interrupted_agent
+    _interrupted_agent = None
+    if agent is None:  # the microVM was recycled while the buttons waited
+        raise RuntimeError("No interrupted agent to resume in this session.")
+    stream = agent.stream_async(
+        decode_interrupt_responses(payload["interrupt_responses"])
+    )
 ```
 
-</Tab>
-</Tabs>
+So the entrypoint stashes the agent whenever the stream ends with an `interrupt` event. One module-level slot is enough: AgentCore Runtime gives each session its own microVM, so the process never serves two conversations. Nothing is persisted either — the slot dies with the microVM, and raising on a recycled one is the honest answer, which Welt renders as a resume-failure notice in the thread.
 
-Deploy this to AgentCore Runtime, point Welt at its agent ARN, and mention the bot in Slack. Strands' ready-made [`HumanInTheLoop`](https://strandsagents.com/docs/user-guide/concepts/agents/interventions/human-in-the-loop/) intervention also works over Welt as-is.
+One more thing the interrupt round trip asks of your tools: the interrupted tool [re-executes](../../user-guide/concepts/interrupts.md) from the start on resume, so work done *before* the interrupt runs twice. Where that matters — drafting the text a human is approving, say — memoize it on the tool use id, which is the same on both passes.
 
 ## Configuration
 
-The adapters themselves have nothing to configure — all configuration lives on the Welt side (Slack tokens, the agent ARN, feature toggles), covered by [Welt's README](https://github.com/iwamot/welt#readme). For local development, Welt runs against the AgentCore SDK's local server without any deployment.
+The adapters have nothing to configure. Everything lives on the Welt side — Slack tokens, the agent ARN, and the feature toggles, including file input, which stays off until `FILE_INPUT_MODALITIES` names the modalities your model accepts. [Welt's README](https://github.com/iwamot/welt#readme) covers them. For local development, Welt runs against the AgentCore SDK's local server without deploying anything.
+
+Adapter and front end ship as a pair: while both are 0.x, an adapter 0.Y release supports Welt v0.Y, and from 1.0 on any release sharing a major version. Support is best effort, and other combinations come with no guarantee. The Strands SDK versions each adapter is built against are stated in its README.
 
 ## References
 
 - [Welt](https://github.com/iwamot/welt) — the Slack front end (Quick Start, feature docs)
 - [welt-io-strands](https://github.com/iwamot/welt-io-strands) — the Python adapter's repo and API docs
 - [welt-io-strands-ts](https://github.com/iwamot/welt-io-strands-ts) — the TypeScript adapter's repo and API docs
-- Example agents ([Python](https://github.com/iwamot/welt-io-strands/tree/main/examples/agent), [TypeScript](https://github.com/iwamot/welt-io-strands-ts/tree/main/examples/agent)) — the snippets above, complete and deployable
+- Example agents ([Python](https://github.com/iwamot/welt-io-strands/tree/main/examples/agent), [TypeScript](https://github.com/iwamot/welt-io-strands-ts/tree/main/examples/agent)) — complete and deployable, the source of the snippets above
 - [Wire contract](https://github.com/iwamot/welt/blob/main/docs/wire.md) — the JSON protocol the adapters implement
+- [Files](https://github.com/iwamot/welt/blob/main/docs/files.md) — how uploads reach the agent and generated files reach the thread
 - [Interrupts over Slack](https://github.com/iwamot/welt/blob/main/docs/interrupts.md) — how each reason shape renders

--- a/site/src/content/docs/community/integrations/welt.mdx
+++ b/site/src/content/docs/community/integrations/welt.mdx
@@ -1,0 +1,209 @@
+---
+title: Chat with your Strands agent from Slack using Welt
+community: true
+description: Slack front end for Strands agents on Amazon Bedrock AgentCore — streaming replies, file exchange, and human-in-the-loop approvals in Slack threads
+integrationType: integration
+sidebar:
+  label: "Welt"
+project:
+  pypi: https://pypi.org/project/welt-io-strands/
+  npm: https://www.npmjs.com/package/@welt-io/strands
+  github: https://github.com/iwamot/welt
+  maintainer: iwamot
+service:
+  name: Slack
+  link: https://slack.com/
+---
+
+[Welt](https://github.com/iwamot/welt) is a self-hosted Slack front end for agents running on Amazon Bedrock AgentCore Runtime. Mention the agent in a channel or DM and it streams the reply into the thread; Slack uploads reach the agent as Converse file blocks, generated files come back as thread uploads, and a run that pauses for human input renders as Slack buttons and text fields — Strands interrupts become approval UIs your whole team can see and answer.
+
+Welt drives the agent through a small JSON wire contract, and each Strands SDK has an adapter for it: [`welt-io-strands`](https://github.com/iwamot/welt-io-strands) for Python, [`@welt-io/strands`](https://github.com/iwamot/welt-io-strands-ts) for TypeScript. Either way it is the same five functions, translating between the wire's JSON and Strands values in both directions.
+
+## Installation
+
+<Tabs>
+<Tab label="Python">
+
+```bash
+pip install welt-io-strands
+```
+
+</Tab>
+<Tab label="TypeScript">
+
+```bash
+npm install @welt-io/strands
+```
+
+</Tab>
+</Tabs>
+
+## Usage
+
+A complete AgentCore entrypoint with a human-approval tool:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from strands import Agent, ToolContext, tool
+from welt_io_strands import (
+    decode_interrupt_responses,
+    decode_messages,
+    interrupt_reason,
+    renderable_events,
+)
+
+app = BedrockAgentCoreApp()
+
+# Where an interrupted Agent waits for its answers. One slot is enough:
+# AgentCore Runtime runs each session in its own microVM.
+_interrupted_agent: Agent | None = None
+
+
+@tool(context=True)
+def deploy(tool_context: ToolContext, target: str) -> str:
+    """Deploy after a human approves in the Slack thread."""
+    answer = tool_context.interrupt(
+        "deploy-approval",
+        reason=interrupt_reason(
+            f"Deploy {target} to production?",
+            [
+                {"value": "y", "label": "Deploy", "style": "primary"},
+                {"value": "n", "label": "Cancel"},
+            ],
+        ),
+    )
+    return f"Deployed {target}." if answer == "y" else "Deployment cancelled."
+
+
+@app.entrypoint
+async def invoke(payload: dict):
+    global _interrupted_agent
+
+    if "interrupt_responses" in payload:  # a human answered the buttons
+        agent = _interrupted_agent
+        _interrupted_agent = None
+        if agent is None:  # the microVM was recycled while the buttons waited
+            raise RuntimeError("No interrupted agent to resume in this session.")
+        stream = agent.stream_async(
+            decode_interrupt_responses(payload["interrupt_responses"])
+        )
+    else:  # a conversation turn, as Converse-shaped messages
+        agent = Agent(tools=[deploy], callback_handler=None)
+        stream = agent.stream_async(decode_messages(payload["messages"]))
+
+    interrupted = False
+    async for event in renderable_events(stream):
+        if "interrupt" in event:
+            interrupted = True
+        yield event
+    if interrupted:
+        _interrupted_agent = agent
+
+
+app.run()
+```
+
+</Tab>
+<Tab label="TypeScript">
+
+```ts
+import { Agent, tool } from "@strands-agents/sdk";
+import type { RenderableEvent } from "@welt-io/strands";
+import {
+  decodeInterruptResponses,
+  decodeMessages,
+  interruptReason,
+  renderableEvents,
+} from "@welt-io/strands";
+import { BedrockAgentCoreApp } from "bedrock-agentcore/runtime";
+import { z } from "zod";
+
+// Where an interrupted Agent waits for its answers. One slot is enough:
+// AgentCore Runtime runs each session in its own microVM.
+let interruptedAgent: Agent | null = null;
+
+const deploy = tool({
+  name: "deploy",
+  description: "Deploy after a human approves in the Slack thread.",
+  inputSchema: z.object({ target: z.string() }),
+  callback: ({ target }, context) => {
+    if (context === undefined) {
+      throw new Error("This tool needs its execution context to interrupt.");
+    }
+    const answer = context.interrupt<string>({
+      name: "deploy-approval",
+      reason: interruptReason(`Deploy ${target} to production?`, [
+        { value: "y", label: "Deploy", style: "primary" },
+        { value: "n", label: "Cancel" },
+      ]),
+    });
+    return answer === "y" ? `Deployed ${target}.` : "Deployment cancelled.";
+  },
+});
+
+// Each event is wrapped as `{data: event}`: the AgentCore SDK reads the
+// SSE payload from a yielded object's `data` field.
+async function* replies(
+  agent: Agent,
+  stream: AsyncIterable<unknown>,
+): AsyncGenerator<{ data: RenderableEvent }> {
+  let interrupted = false;
+  for await (const event of renderableEvents(stream)) {
+    if ("interrupt" in event) {
+      interrupted = true;
+    }
+    yield { data: event };
+  }
+  if (interrupted) {
+    interruptedAgent = agent;
+  }
+}
+
+const app = new BedrockAgentCoreApp({
+  invocationHandler: {
+    process: async function* (payload: unknown) {
+      const record = payload as Record<string, unknown>;
+
+      if ("interrupt_responses" in record) {
+        // A human answered the buttons.
+        const agent = interruptedAgent;
+        interruptedAgent = null;
+        if (agent === null) {
+          // The microVM was recycled while the buttons waited.
+          throw new Error("No interrupted agent to resume in this session.");
+        }
+        const responses = decodeInterruptResponses(record.interrupt_responses);
+        yield* replies(agent, agent.stream(responses));
+        return;
+      }
+
+      // A conversation turn, as Converse-shaped messages.
+      const agent = new Agent({ tools: [deploy], printer: false });
+      yield* replies(agent, agent.stream(decodeMessages(record.messages)));
+    },
+  },
+});
+
+app.run();
+```
+
+</Tab>
+</Tabs>
+
+Deploy this to AgentCore Runtime, point Welt at its agent ARN, and mention the bot in Slack. Strands' ready-made [`HumanInTheLoop`](https://strandsagents.com/docs/user-guide/concepts/agents/interventions/human-in-the-loop/) intervention also works over Welt as-is.
+
+## Configuration
+
+The adapters themselves have nothing to configure — all configuration lives on the Welt side (Slack tokens, the agent ARN, feature toggles), covered by [Welt's README](https://github.com/iwamot/welt#readme). For local development, Welt runs against the AgentCore SDK's local server without any deployment.
+
+## References
+
+- [Welt](https://github.com/iwamot/welt) — the Slack front end (Quick Start, feature docs)
+- [welt-io-strands](https://github.com/iwamot/welt-io-strands) — the Python adapter's repo and API docs
+- [welt-io-strands-ts](https://github.com/iwamot/welt-io-strands-ts) — the TypeScript adapter's repo and API docs
+- Example agents ([Python](https://github.com/iwamot/welt-io-strands/tree/main/examples/agent), [TypeScript](https://github.com/iwamot/welt-io-strands-ts/tree/main/examples/agent)) — the snippets above, complete and deployable
+- [Wire contract](https://github.com/iwamot/welt/blob/main/docs/wire.md) — the JSON protocol the adapters implement
+- [Interrupts over Slack](https://github.com/iwamot/welt/blob/main/docs/interrupts.md) — how each reason shape renders


### PR DESCRIPTION
## Description

Adds a community integration page for [Welt](https://github.com/iwamot/welt) — a self-hosted Slack front end for Strands agents running on Amazon Bedrock AgentCore Runtime — featuring its Strands adapter packages for both languages, [`welt-io-strands`](https://pypi.org/project/welt-io-strands/) (PyPI) and [`@welt-io/strands`](https://www.npmjs.com/package/@welt-io/strands) (npm), following the [Get Featured](https://strandsagents.com/docs/community/get-featured/) guide:

- New page `site/src/content/docs/community/integrations/welt.mdx` with the catalog frontmatter (`community: true`, `integrationType: integration`, `description`, `project`; `languages` omitted since both are supported)
- Installation and usage in Python/TypeScript tabs, matching the user-guide convention
- Navigation entry under Community → Integrations in `site/src/config/navigation.yml`

The usage examples are condensed versions of each adapter's example agent ([Python](https://github.com/iwamot/welt-io-strands/tree/main/examples/agent), [TypeScript](https://github.com/iwamot/welt-io-strands-ts/tree/main/examples/agent)) — a complete AgentCore entrypoint with streaming and a human-approval interrupt that renders as Slack buttons in the thread.

## Related Issues

None.

## Documentation PR

This PR is documentation-only, entirely under `site/`.

## Type of Change

Documentation update

## Testing

Verified the frontmatter against the docs content schema (`site/src/content.config.ts`, via `astro sync`) and the page structure against the Get Featured guide and the existing `community/integrations/ag-ui.mdx` page. Relying on the docs preview build for rendering.

- [ ] I ran `hatch run prepare` (not run — no code changes)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works (N/A — docs only)
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (N/A)

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)