### PR TITLE
chore(python): remove dead private code

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/openai_realtime.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai_realtime.py
@@ -742,10 +742,6 @@ class BidiOpenAIRealtimeModel(BidiModel):
         await self._send_event({"type": "conversation.item.create", "item": item_data})
         await self._send_event({"type": "response.create"})
 
-    async def _send_interrupt(self) -> None:
-        """Internal: Send interruption signal to OpenAI."""
-        await self._send_event({"type": "response.cancel"})
-
     async def _send_tool_result(self, tool_result: ToolResult) -> None:
         """Internal: Send tool result back to OpenAI."""
         tool_use_id = tool_result.get("toolUseId")

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -1157,10 +1157,6 @@ class MCPClient(ToolProvider):
         invoke_future = asyncio.run_coroutine_threadsafe(coro=run_async(), loop=self._background_thread_event_loop)
         return invoke_future
 
-    def _should_include_tool(self, tool: MCPAgentTool) -> bool:
-        """Check if a tool should be included based on constructor filters."""
-        return self._should_include_tool_with_filters(tool, self._tool_filters)
-
     def _should_include_tool_with_filters(self, tool: MCPAgentTool, filters: ToolFilters | None) -> bool:
         """Check if a tool should be included based on provided filters."""
         if not filters:

--- a/strands-py/src/strands/types/_snapshot.py
+++ b/strands-py/src/strands/types/_snapshot.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal
 
 from .exceptions import SnapshotException
 
@@ -35,15 +35,6 @@ SNAPSHOT_SCHEMA_VERSION = "1.0"
 SNAPSHOT_PRESETS: dict[str, tuple[SnapshotField, ...]] = {
     "session": ("messages", "state", "conversation_manager_state", "interrupt_state", "model_state"),
 }
-
-
-class TakeSnapshotOptions(TypedDict, total=False):
-    """Internal options for take_snapshot. Not exported publicly."""
-
-    preset: SnapshotPreset
-    include: list[SnapshotField]
-    exclude: list[SnapshotField]
-    app_data: dict[str, Any]
 
 
 @dataclass


### PR DESCRIPTION
## Description

Removes three private symbols with zero callers across `src/`, `tests/`, and `tests_integ/`, verified by repo-wide grep:

- `MCPClient._should_include_tool` in `tools/mcp/mcp_client.py`: superseded by `_should_include_tool_with_filters`, which is the only variant the client calls.
- `TakeSnapshotOptions` in `types/_snapshot.py`: internal-only TypedDict that nothing references; `Agent.take_snapshot` takes explicit keyword arguments instead. The now-unused `TypedDict` import is dropped too.
- `BidiOpenAIRealtimeModel._send_interrupt` in `experimental/bidi/models/openai_realtime.py`: never invoked (the bidi tree is excluded from lint/coverage, so this was confirmed manually).

No behavior change; all removed symbols are private and unreferenced.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Other (please describe): dead code removal

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
