### PR TITLE
fix(openai): surface Responses stream failures

### DIFF
--- a/strands-ts/src/models/openai/__tests__/errors.test.ts
+++ b/strands-ts/src/models/openai/__tests__/errors.test.ts
@@ -10,6 +10,7 @@ describe('classifyOpenAIError', () => {
     'Input is too long for requested model',
     'input length and `max_tokens` exceed context limit',
     'too many total text bytes',
+    'prompt tokens (320666) exceed customer model maximum (278528) for model-id',
   ])('classifies overflow phrase %p as contextOverflow', (phrase) => {
     expect(classifyOpenAIError(new Error(phrase))).toBe('contextOverflow')
   })

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -730,6 +730,77 @@ describe("OpenAIModel (api: 'responses')", () => {
   })
 
   describe('error mapping', () => {
+    it('throws response.failed instead of finalizing an empty successful response', async () => {
+      const client = createMockClient(async function* () {
+        yield { type: 'response.created', response: { id: 'r' } }
+        yield {
+          type: 'response.failed',
+          response: {
+            error: {
+              code: 'server_error',
+              message: 'The model failed while processing the request.',
+            },
+          },
+        }
+      })
+      const model = new OpenAIModel({ api: 'responses', client })
+
+      await expect(
+        collectIterator(model.stream([new Message({ role: 'user', content: [new TextBlock('x')] })]))
+      ).rejects.toMatchObject({
+        message: 'The model failed while processing the request.',
+        code: 'server_error',
+      })
+    })
+
+    it('wraps a response.failed context limit as ContextWindowOverflowError', async () => {
+      const client = createMockClient(async function* () {
+        yield {
+          type: 'response.failed',
+          response: {
+            error: {
+              code: 'invalid_prompt',
+              message: 'prompt tokens (320666) exceed customer model maximum (278528) for model-id',
+            },
+          },
+        }
+      })
+      const model = new OpenAIModel({ api: 'responses', client })
+
+      await expect(
+        collectIterator(model.stream([new Message({ role: 'user', content: [new TextBlock('x')] })]))
+      ).rejects.toBeInstanceOf(ContextWindowOverflowError)
+    })
+
+    it('throws the fallback message when response.failed has no error details', async () => {
+      const client = createMockClient(async function* () {
+        yield {
+          type: 'response.failed',
+          response: { error: null },
+        }
+      })
+      const model = new OpenAIModel({ api: 'responses', client })
+
+      await expect(
+        collectIterator(model.stream([new Message({ role: 'user', content: [new TextBlock('x')] })]))
+      ).rejects.toThrow('OpenAI Responses API response failed')
+    })
+
+    it('maps a Responses error event through the existing error classifier', async () => {
+      const client = createMockClient(async function* () {
+        yield {
+          type: 'error',
+          code: 'rate_limit_exceeded',
+          message: 'Rate limit exceeded while streaming.',
+        }
+      })
+      const model = new OpenAIModel({ api: 'responses', client })
+
+      await expect(
+        collectIterator(model.stream([new Message({ role: 'user', content: [new TextBlock('x')] })]))
+      ).rejects.toBeInstanceOf(ModelThrottledError)
+    })
+
     it('wraps 429 as ModelThrottledError', async () => {
       const client: any = {
         responses: {

--- a/strands-ts/src/models/openai/errors.ts
+++ b/strands-ts/src/models/openai/errors.ts
@@ -20,6 +20,7 @@ const CONTEXT_WINDOW_OVERFLOW_PATTERNS = [
   'input is too long for requested model',
   'input length and `max_tokens` exceed context limit',
   'too many total text bytes',
+  'exceed customer model maximum',
 ]
 
 /**

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -378,6 +378,17 @@ function mapResponsesUsage(usage: ResponseUsage): NonNullable<ResponsesStreamSta
   return mapped
 }
 
+function createResponsesStreamError(
+  message: string | undefined,
+  code: string | null | undefined
+): Error & { code?: string } {
+  const error = new Error(message || 'OpenAI Responses API response failed') as Error & { code?: string }
+  if (code) {
+    error.code = code
+  }
+  return error
+}
+
 /**
  * Maps a single Responses API stream event to zero or more SDK events. Mutates
  * `state` and, when `stateful` is `true`, writes `responseId` into `modelState`.
@@ -499,6 +510,15 @@ export function mapResponsesEventToSDK(
         state.stopReason = 'maxTokens'
       }
       break
+    }
+
+    case 'response.failed': {
+      const error = event.response.error
+      throw createResponsesStreamError(error?.message, error?.code)
+    }
+
+    case 'error': {
+      throw createResponsesStreamError(event.message, event.code)
     }
 
     case 'response.completed': {


### PR DESCRIPTION
## Description

The TypeScript OpenAI Responses adapter silently ignored terminal `response.failed` and `error` stream events. Since the adapter's default stop reason is `endTurn`, it then finalized a failed stream as an empty successful response. Applications saw no answer and no model error.

This was reproduced against Bedrock Mantle with a `response.failed` event containing:

```
prompt tokens (320666) exceed customer model maximum (278528) for model-id
```

This change throws terminal stream failures while preserving the provider message and code. The existing OpenAI error classifier can then map rate limits and context overflows to the SDK's standard model errors, so agents and applications handle them consistently with other model adapters. The Bedrock Mantle context-limit phrase is recognized as `ContextWindowOverflowError`.

There is no public API change and no change to request formatting.

## Related Issues

None.

## Documentation PR

No documentation change is needed; this fixes error propagation in the existing Responses API adapter.

## Type of Change

Bug fix

## Testing

- Focused OpenAI Responses/error unit tests: 61 passed
- `npm run type-check` and `npm run build` pass
- Pre-commit suite (build, coverage, lint, format check, type-check) passed
- New unit tests cover: `response.failed` mapped to `ContextWindowOverflowError` via the Mantle phrase, the fallback message when no error detail is present, and a Responses `error` event mapped through the existing classifier

- [x] I ran the TypeScript equivalents of the required checks

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.