### PR TITLE
docs(typescript): deduplicate testing guide and agents file

### DIFF
--- a/strands-ts/AGENTS.md
+++ b/strands-ts/AGENTS.md
@@ -74,7 +74,7 @@ Pre-commit hooks run automatically and must all pass: build (`npm run build`), u
 
 ### 5. Testing Guidelines
 
-When writing tests, you **MUST** follow the guidelines in [docs/TESTING.md](./docs/TESTING.md): test organization and file location, batching strategy, object-assertion best practices, coverage requirements, and multi-environment (Node.js + browser) testing. Canonical paths: unit tests co-located under `src/**/__tests__/`, integration tests under `test/integ/`.
+When writing tests, you **MUST** follow the guidelines in [docs/TESTING.md](./docs/TESTING.md); see [Testing](#testing) below.
 
 ## Coding Patterns and Best Practices
 
@@ -137,7 +137,7 @@ Order imports: (1) external dependencies, (2) internal modules via relative path
 
 ### File Organization
 
-- **Unit tests co-located** under `__tests__/` beside the source (`src/module.ts` ↔ `src/__tests__/module.test.ts`); integration tests under `test/integ/`.
+- **Test file locations and naming** are defined in [docs/TESTING.md](./docs/TESTING.md) (see [Testing](#testing) below).
 - **Function ordering within a file** reads top-down, most general to most specific: main entry-point/exported functions at the top, private helpers below in order of use.
 - **Keep functions small and focused** — a single responsibility each.
 
@@ -220,11 +220,7 @@ export class XModel extends Model<XModelConfig> {
 
 ## Testing
 
-When writing tests, you **MUST** follow [docs/TESTING.md](./docs/TESTING.md) — it is the authoritative reference. In short:
-
-- **Unit tests** co-located under `src/**/__tests__/`; **integration tests** under `test/integ/`.
-- **File naming** selects the environment: `*.test.ts` (Node + browser), `*.test.node.ts` (Node only), `*.test.browser.ts` (browser only).
-- Use the nested `describe` pattern; assert on whole objects with `toEqual`; reuse fixtures from `src/__fixtures__/` rather than hand-rolling mocks.
+When writing tests, you **MUST** follow [docs/TESTING.md](./docs/TESTING.md). It is the authoritative reference for test file location and naming (co-location, environment suffixes), the nested `describe` pattern, batching strategy, whole-object assertions, fixtures, coverage requirements, and multi-environment testing.
 
 ## Quick Rules
 

--- a/strands-ts/docs/TESTING.md
+++ b/strands-ts/docs/TESTING.md
@@ -389,14 +389,9 @@ const switchToolHook = {
 
 ## Test Fixtures Reference
 
-All test fixtures are located in `src/__fixtures__/`. Use these helpers to reduce boilerplate and ensure consistency.
+Usage details and examples for the fixtures indexed in the [Quick Reference table](#test-fixtures-quick-reference) above.
 
 ### Model Fixtures (`mock-message-model.ts`, `model-test-helpers.ts`)
-
-- **`MockMessageModel`** - Content-focused model for agent loop tests. Use `addTurn()` with content blocks.
-- **`TestModelProvider`** - Low-level model for precise control over `ModelStreamEvent` sequences.
-- **`collectIterator(stream)`** - Collects all items from an async iterable into an array.
-- **`collectGenerator(generator)`** - Collects yielded items and final return value from an async generator.
 
 ```typescript
 // MockMessageModel for agent tests
@@ -410,7 +405,7 @@ const events = await collectIterator(agent.stream('Hi'))
 
 ### Hook Fixtures (`mock-hook-provider.ts`)
 
-- **`MockHookProvider`** - Records all hook invocations for verification. Pass to `Agent({ hooks: [provider] })`.
+- **`MockHookProvider`** - Pass to `Agent({ hooks: [provider] })`.
   - Use `{ includeModelEvents: false }` to exclude model streaming and result events from recordings.
   - Access `provider.invocations` to verify hook events fired.
 
@@ -425,10 +420,6 @@ expect(hookProvider.invocations[0]).toEqual(new BeforeInvocationEvent({ agent })
 ```
 
 ### Tool Fixtures (`tool-helpers.ts`)
-
-- **`createMockTool(name, resultFn)`** - Creates a mock tool with custom result behavior.
-- **`createRandomTool(name?)`** - Creates a minimal mock tool (use when tool execution doesn't matter).
-- **`createMockContext(toolUse, agentState?)`** - Creates a mock `ToolContext` for testing tool implementations directly.
 
 ```typescript
 // Mock tool with custom result
@@ -461,7 +452,7 @@ const tool = new FunctionTool({ name: 'testTool', description: '...', inputSchem
 
 ### Agent Fixtures (`agent-helpers.ts`)
 
-- **`createMockAgent(data?)`** - Creates a minimal mock Agent with messages and state. Use for testing components that need an Agent reference without full agent behavior.
+- **`createMockAgent(data?)`** - Use for testing components that need an Agent reference without full agent behavior.
 
 ```typescript
 const agent = createMockAgent({
@@ -470,7 +461,7 @@ const agent = createMockAgent({
 })
 ```
 
-- **`expectAgentResult(options)`** - Creates an asymmetric matcher that validates `AgentResult` structure and values. Reduces deeply nested assertions by providing a clean, readable matcher that combines stop reason, message text, metrics, and traces validation.
+- **`expectAgentResult(options)`** - Asymmetric matcher for `AgentResult`. Reduces deeply nested assertions by combining stop reason, message text, metrics, and traces validation in one matcher.
 
 ```typescript
 import { expectAgentResult } from '../__fixtures__/agent-helpers'
@@ -544,7 +535,7 @@ expect(result).toEqual(
 - `toolNames` (optional) - Expected tool names that were invoked
 - `usage` (optional) - Expected token usage. When omitted, validates shape with `expect.any(Number)`
 
-- **`createCancellableAgent(id, delayMs, structuredOutput?)`** - Creates a minimal `InvokableAgent` that sleeps for `delayMs` before resolving, aborting the sleep early when the invocation's `cancelSignal` fires. Use for exercising timeout and cancellation behavior in multi-agent orchestrators (swarm, graph) without standing up a full Agent.
+- **`createCancellableAgent(id, delayMs, structuredOutput?)`** - Use for exercising timeout and cancellation behavior in multi-agent orchestrators (swarm, graph) without standing up a full Agent.
 
 ```typescript
 import { createCancellableAgent } from '../__fixtures__/agent-helpers'
@@ -557,11 +548,6 @@ const handoffAgent = createCancellableAgent('a', 30, { agentId: 'b', message: 't
 ```
 
 ### Environment Fixtures (`environment.ts`)
-
-- **`isNode`** - Boolean that detects if running in Node.js environment.
-- **`isBrowser`** - Boolean that detects if running in a browser environment.
-
-Use these for conditional test execution when tests depend on environment-specific features.
 
 ```typescript
 import { isNode } from '../__fixtures__/environment'
@@ -576,14 +562,12 @@ describe.skipIf(!isNode)('Node.js specific features', () => {
 
 ### Telemetry Fixtures (`mock-span.ts`, `mock-meter.ts`)
 
-- **`MockSpan`** - Implements the OTEL `Span` interface and records all calls (`setAttribute`, `addEvent`, `setStatus`, `end`, `recordException`) for assertion. Use with `vi.mock('@opentelemetry/api')` to intercept tracer span creation.
+- **`MockSpan`** - Use with `vi.mock('@opentelemetry/api')` to intercept tracer span creation.
   - Access `mockSpan.calls.setAttribute` etc. to verify recorded calls.
   - Use `mockSpan.getAttributeValue(key)` to look up a specific attribute.
   - Use `mockSpan.getEvents(name)` to filter events by name.
-- **`eventAttr(event, key)`** - Extracts a string attribute from a mock span event's attributes map.
-- **`MockMeter`** - Implements the OTEL `Meter` interface and records all instrument data points. Use with `vi.spyOn(otelMetrics, 'getMeter').mockReturnValue(mockMeter)` to intercept meter creation.
-  - Use `mockMeter.getCounter(name)` to retrieve a counter by metric name.
-  - Use `mockMeter.getHistogram(name)` to retrieve a histogram by metric name.
+- **`MockMeter`** - Use with `vi.spyOn(otelMetrics, 'getMeter').mockReturnValue(mockMeter)` to intercept meter creation.
+  - Use `mockMeter.getCounter(name)` / `mockMeter.getHistogram(name)` to retrieve an instrument by metric name.
   - Counters and histograms expose `.dataPoints` (array of `{ value, attributes }`) and `.sum` (total of all values).
 
 ```typescript
@@ -620,7 +604,7 @@ expect(mockMeter.getCounter('gen_ai.agent.tool.call.count')?.dataPoints).toStric
 
 ### Metrics Fixtures (`metrics-helpers.ts`)
 
-- **`expectLoopMetrics({ cycleCount, toolNames?, usage? })`** - Creates an asymmetric matcher that validates `AgentMetrics` structure and values. When `usage` is provided, asserts exact token counts. When omitted, falls back to shape-level assertions with `expect.any(Number)`.
+- **`expectLoopMetrics({ cycleCount, toolNames?, usage? })`** - When `usage` is provided, asserts exact token counts. When omitted, falls back to shape-level assertions with `expect.any(Number)`.
 - **`findMetricValue(resourceMetrics, metricName)`** - Flattens the OTEL ResourceMetrics → ScopeMetrics → MetricData hierarchy and returns the value of the last data point for the matching metric name. Returns `undefined` if not found.
 
 ```typescript
@@ -723,15 +707,7 @@ Similarly, you do **not** need to call `vi.unstubAllEnvs()` in `afterEach` since
 
 ## Development Commands
 
-```bash
-npm test              # Run unit tests in Node.js
-npm run test:browser  # Run unit tests in browser (Chromium via Playwright)
-npm run test:all      # Run all tests in all environments
-npm run test:integ    # Run integration tests
-npm run test:coverage # Run tests with coverage report
-```
-
-For detailed command usage, see [CONTRIBUTING.md - Testing Instructions](../CONTRIBUTING.md#testing-instructions-and-best-practices).
+See [AGENTS.md - Development Commands](../AGENTS.md#development-commands) for the test-related npm scripts.
 
 ## Checklist Items
 


### PR DESCRIPTION
## Description

strands-ts/docs/TESTING.md documented every fixture twice: once in the Quick Reference table at the top and again in the full Test Fixtures Reference, where each per-fixture bullet restated the table's one-line description before getting to the code sample. The full reference now keeps only what the table does not carry (usage details, option lists, and code samples), with the table serving as the index. The Development Commands section was also a verbatim copy of the block in strands-ts/AGENTS.md and is now a pointer.

Test co-location and file-naming rules were stated three times across the two files (TESTING.md Test Organization, AGENTS.md Testing Guidelines, and AGENTS.md File Organization/Testing). TESTING.md is the natural canonical home for testing rules, so it keeps the full statement and AGENTS.md now points there. The terse recap in AGENTS.md Quick Rules is left as is, since that list is intentionally a one-line-per-rule digest.

No information is removed, only restatements. TESTING.md drops from 742 to 718 lines and AGENTS.md loses the duplicated blocks.

## Related Issues

N/A

## Documentation PR

This PR is documentation-only (contributor/agent docs, not site content).

## Type of Change

Documentation update

## Testing

Docs-only change. Verified with `git grep` that no other file links to the trimmed sections, and that the `#development-commands` and `#test-fixtures-quick-reference` anchors used by the new pointers exist.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
