### PR TITLE
docs: deduplicate pr guidelines summary in sdk agents files

### DIFF
--- a/strands-py/AGENTS.md
+++ b/strands-py/AGENTS.md
@@ -57,15 +57,7 @@ pre-commit install -t pre-commit -t commit-msg # Install hooks
 
 ### 3. Pull Request Guidelines
 
-When creating pull requests, you MUST follow the guidelines in [PR.md](../team/PR.md). Key principles:
-
-- Focus on WHY: Explain motivation and user impact, not implementation details
-- Document public API changes: Show before/after code examples
-- Be concise: Use prose over bullet lists; avoid exhaustive checklists
-- Target senior engineers: Assume familiarity with the SDK
-- Exclude implementation details: Leave these to code comments and diffs
-
-See [PR.md](../team/PR.md) for the complete guidance and template.
+When creating pull requests, you MUST follow the guidelines and template in [PR.md](../team/PR.md).
 
 ### 4. Quality Gates
 

--- a/strands-ts/AGENTS.md
+++ b/strands-ts/AGENTS.md
@@ -56,15 +56,7 @@ See [CONTRIBUTING.md - TypeScript SDK](../CONTRIBUTING.md#typescript-sdk) for pr
 
 ### 3. Pull Request Guidelines
 
-When creating pull requests, you **MUST** follow the guidelines in [PR.md](../team/PR.md) and use the [PR template](../.github/PULL_REQUEST_TEMPLATE.md). Key principles:
-
-- **Focus on WHY**: Explain motivation and user impact, not implementation details
-- **Document public API changes**: Show before/after code examples
-- **Be concise**: Use prose over bullet lists; avoid exhaustive checklists
-- **Target senior engineers**: Assume familiarity with the SDK
-- **Exclude implementation details**: Leave these to code comments and diffs
-
-See [PR.md](../team/PR.md) for the complete guidance and template.
+When creating pull requests, you **MUST** follow the guidelines in [PR.md](../team/PR.md) and use the [PR template](../.github/PULL_REQUEST_TEMPLATE.md).
 
 ### 4. Quality Gates
 


### PR DESCRIPTION
## Description

The five-bullet "Focus on WHY / Document public API changes / Be concise / Target senior engineers / Exclude implementation details" summary of team/PR.md appeared verbatim in both strands-py/AGENTS.md and strands-ts/AGENTS.md, and both blocks already closed with "See PR.md for the complete guidance and template", so the same principles were stated three times. Any edit to the guidelines had to be mirrored in two summaries or they drift. Each file now keeps a single MUST-follow pointer to team/PR.md, which remains the canonical statement.

This touches both SDK directories, but it is one logical docs change (removing two copies of the same block) and small enough that splitting it would be noise.

## Related Issues

N/A

## Documentation PR

This PR is documentation-only (agent context docs, not site content).

## Type of Change

Documentation update

## Testing

Docs-only change. Verified with `git grep` that nothing links into the removed bullet lists and that both pointer links resolve to team/PR.md.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
