### PR TITLE
chore: lazy-load pyyaml and jsonschema, dedupe extras

### DIFF
--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -45,6 +45,12 @@ dependencies = [
 
 
 [project.optional-dependencies]
+# pyyaml and jsonschema are still listed in [project.dependencies] for backwards
+# compatibility. These extras exist so that installs can start depending on them
+# explicitly; the base dependencies can then be dropped in the next major version.
+agent-config = ["jsonschema>=4.0.0,<5.0.0"]
+skills = ["pyyaml>=6.0.0,<7.0.0"]
+
 anthropic = ["anthropic>=0.21.0,<1.0.0"]
 gemini = ["google-genai>=1.32.0,<3.0.0"]
 # The latest litellm v1.92.0 do not support python 3.14, for the short term we will keep 
@@ -67,7 +73,6 @@ docs = [
 ]
 
 a2a = [
-    "a2a-sdk>=0.3.0,<0.4.0",
     "a2a-sdk[sql]>=0.3.0,<0.4.0",
     "uvicorn>=0.34.2,<1.0.0",
     "httpx>=0.28.1,<1.0.0",
@@ -83,12 +88,12 @@ bidi-io = [
     "prompt_toolkit>=3.0.0,<4.0.0",
     "pyaudio>=0.2.13,<1.0.0",
 ]
-bidi-gemini = ["google-genai>=1.32.0,<3.0.0"]
+bidi-gemini = ["strands-agents[gemini]"]
 bidi-openai = ["websockets>=15.0.0,<17.0.0"]
 
 cedar = ["cedarpy==4.8.6", "cedar-policy-mcp-schema-generator==0.6.0"]
 
-all = ["strands-agents[a2a,anthropic,cedar,docs,gemini,litellm,llamaapi,mistral,ollama,openai,writer,sagemaker,otel]"]
+all = ["strands-agents[a2a,agent-config,anthropic,cedar,docs,gemini,litellm,llamaapi,mistral,ollama,openai,skills,writer,sagemaker,otel]"]
 bidi-all = ["strands-agents[a2a,bidi,bidi-io,bidi-gemini,bidi-openai,docs,otel]"]
 
 dev = [

--- a/strands-py/src/strands/experimental/__init__.py
+++ b/strands-py/src/strands/experimental/__init__.py
@@ -3,7 +3,20 @@
 This module implements experimental features that are subject to change in future revisions without notice.
 """
 
+from typing import Any
+
 from . import checkpoint, steering, tools
-from .agent_config import config_to_agent
 
 __all__ = ["checkpoint", "config_to_agent", "tools", "steering"]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy load config_to_agent only when accessed.
+
+    This defers the import of jsonschema until actually needed.
+    """
+    if name == "config_to_agent":
+        from .agent_config import config_to_agent
+
+        return config_to_agent
+    raise AttributeError(f"cannot import name '{name}' from '{__name__}' ({__file__})")

--- a/strands-py/src/strands/experimental/agent_config.py
+++ b/strands-py/src/strands/experimental/agent_config.py
@@ -13,10 +13,29 @@ programmatic approach after creating the agent:
 
 import json
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
-import jsonschema
-from jsonschema import ValidationError
+
+def _import_jsonschema() -> ModuleType:
+    """Import jsonschema lazily so it is only required when validating configurations.
+
+    Returns:
+        The imported ``jsonschema`` module.
+
+    Raises:
+        ImportError: If jsonschema is not installed.
+    """
+    try:
+        import jsonschema
+    except ImportError as e:
+        raise ImportError(
+            "config_to_agent requires the 'jsonschema' package. "
+            "Install it with: pip install strands-agents[agent-config]"
+        ) from e
+
+    return jsonschema
+
 
 # JSON Schema for agent configuration
 AGENT_CONFIG_SCHEMA = {
@@ -46,9 +65,6 @@ AGENT_CONFIG_SCHEMA = {
     },
     "additionalProperties": False,
 }
-
-# Pre-compile validator for better performance
-_VALIDATOR = jsonschema.Draft7Validator(AGENT_CONFIG_SCHEMA)
 
 
 def config_to_agent(config: str | dict[str, Any], **kwargs: dict[str, Any]) -> Any:
@@ -106,9 +122,10 @@ def config_to_agent(config: str | dict[str, Any], **kwargs: dict[str, Any]) -> A
         raise ValueError("Config must be a file path string or dictionary")
 
     # Validate configuration against schema
+    jsonschema = _import_jsonschema()
     try:
-        _VALIDATOR.validate(config_dict)
-    except ValidationError as e:
+        jsonschema.Draft7Validator(AGENT_CONFIG_SCHEMA).validate(config_dict)
+    except jsonschema.ValidationError as e:
         # Provide more detailed error message
         error_path = " -> ".join(str(p) for p in e.absolute_path) if e.absolute_path else "root"
         raise ValueError(f"Configuration validation error at {error_path}: {e.message}") from e

--- a/strands-py/src/strands/vended_plugins/skills/skill.py
+++ b/strands-py/src/strands/vended_plugins/skills/skill.py
@@ -14,11 +14,30 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
-import yaml
-
 logger = logging.getLogger(__name__)
+
+
+def _import_yaml() -> ModuleType:
+    """Import pyyaml lazily so it is only required when parsing skills.
+
+    Returns:
+        The imported ``yaml`` module.
+
+    Raises:
+        ImportError: If pyyaml is not installed.
+    """
+    try:
+        import yaml
+    except ImportError as e:
+        raise ImportError(
+            "Skill loading requires the 'pyyaml' package. Install it with: pip install strands-agents[skills]"
+        ) from e
+
+    return yaml
+
 
 _SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 _MAX_SKILL_NAME_LENGTH = 64
@@ -61,6 +80,8 @@ def _parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     Raises:
         ValueError: If the frontmatter is malformed or missing required delimiters.
     """
+    yaml = _import_yaml()
+
     stripped = content.strip()
     if not stripped.startswith("---"):
         raise ValueError("SKILL.md must start with --- frontmatter delimiter")

--- a/strands-py/tests/strands/experimental/test_agent_config.py
+++ b/strands-py/tests/strands/experimental/test_agent_config.py
@@ -170,3 +170,28 @@ def test_config_to_agent_with_tool():
     config = {"model": "test-model", "tools": ["tests.fixtures.say_tool:say"]}
     agent = config_to_agent(config)
     assert "say" in agent.tool_names
+
+
+def test_config_to_agent_without_jsonschema_raises_helpful_error():
+    """Test that config_to_agent raises an ImportError naming the agent-config extra when jsonschema is absent."""
+    import sys
+    from unittest.mock import patch
+
+    with patch.dict(sys.modules, {"jsonschema": None}):
+        with pytest.raises(ImportError, match=r"pip install strands-agents\[agent-config\]"):
+            config_to_agent({"model": "test-model"})
+
+
+def test_experimental_import_does_not_require_jsonschema():
+    """Test that importing strands.experimental does not eagerly import jsonschema."""
+    import subprocess
+    import sys
+
+    code = (
+        "import sys\n"
+        "sys.modules['jsonschema'] = None\n"
+        "import strands.experimental\n"
+        "assert callable(strands.experimental.config_to_agent)\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr

--- a/strands-py/tests/strands/vended_plugins/skills/test_skill.py
+++ b/strands-py/tests/strands/vended_plugins/skills/test_skill.py
@@ -647,3 +647,18 @@ class TestSkillClassmethods:
         assert callable(getattr(Skill, "from_content", None))
         assert callable(getattr(Skill, "from_directory", None))
         assert callable(getattr(Skill, "from_url", None))
+
+
+class TestMissingPyyaml:
+    """Tests for the lazy pyyaml import guard."""
+
+    def test_parse_frontmatter_without_pyyaml_raises_helpful_error(self):
+        """Test that parsing raises an ImportError naming the skills extra when pyyaml is absent."""
+        import sys
+        from unittest.mock import patch
+
+        content = "---\nname: my-skill\ndescription: A skill\n---\nBody."
+
+        with patch.dict(sys.modules, {"yaml": None}):
+            with pytest.raises(ImportError, match=r"pip install strands-agents\[skills\]"):
+                Skill.from_content(content)


### PR DESCRIPTION
## Description

A dependency audit found that two hard runtime dependencies of strands-agents are each used by exactly one feature: `pyyaml` only by `Skill` frontmatter parsing (`strands.vended_plugins.skills.skill`), and `jsonschema` only by the experimental `config_to_agent` validation. Since the compatibility policy (team/COMPATIBILITY.md) does not cover install-footprint changes, removing them from `[project.dependencies]` outside a major release could break consumers who rely on them transitively. This PR takes the non-breaking path:

- Both packages stay in `[project.dependencies]`, so nothing changes for existing installs.
- Their imports become lazy, guarded inside the using function with the SDK's standard ImportError message naming the extra (same convention as the optional model providers and the cedar handler).
- New `skills` and `agent-config` extras carry the pins, so dropping the base dependencies later is a one-line change per package.
- `strands.experimental` no longer imports `agent_config` (and therefore `jsonschema`) eagerly; `config_to_agent` is now resolved through the package's existing lazy `__getattr__` pattern, matching `strands.models`.

Two extras cleanups from the same audit: the `a2a` extra listed both `a2a-sdk` and `a2a-sdk[sql]` at the same pin (the first entry is redundant), and `bidi-gemini` duplicated the `gemini` pin instead of referencing it.

**Proposed for the next major version (2.0):** remove `pyyaml` and `jsonschema` from `[project.dependencies]`, making `strands-agents[skills]` and `strands-agents[agent-config]` required for those features. The lazy guards and error messages in this PR make that a pyproject-only change.

Verified in a clean venv with `pyyaml` and `jsonschema` uninstalled: `import strands` and `import strands.experimental` succeed, and both features raise the helpful ImportError naming their extra.

## Related Issues

N/A (dependency audit follow-up)

## Documentation PR

N/A

## Type of Change

Other (please describe): dependency hygiene, no behavior change for existing installs

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Additional: new tests assert the ImportError messages fire when the packages are absent (via `sys.modules` patching) and that `strands.experimental` imports without `jsonschema` installed.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
