### PR TITLE
fix(python): report actual latency in model provider metadata

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -7,6 +7,7 @@ import base64
 import json
 import logging
 import mimetypes
+import time
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -390,7 +391,7 @@ class AnthropicModel(Model):
                     "metadata": {
                         "usage": usage_chunk,
                         "metrics": {
-                            "latencyMs": 0,  # TODO
+                            "latencyMs": event.get("latency_ms", 0),
                         },
                     }
                 }
@@ -480,6 +481,7 @@ class AnthropicModel(Model):
         logger.debug("request=<%s>", request)
 
         logger.debug("invoking model")
+        start_time = time.perf_counter()
         try:
             async with self.client.messages.stream(**request) as stream:
                 logger.debug("got response from model")
@@ -504,7 +506,14 @@ class AnthropicModel(Model):
                 except AssertionError as e:
                     logger.warning("error=<%s> | failed to retrieve message snapshot, usage metadata unavailable", e)
                 else:
-                    yield self.format_chunk({"type": "metadata", "usage": message_snapshot.usage.model_dump()})
+                    latency_ms = round((time.perf_counter() - start_time) * 1000)
+                    yield self.format_chunk(
+                        {
+                            "type": "metadata",
+                            "usage": message_snapshot.usage.model_dump(),
+                            "latency_ms": latency_ms,
+                        }
+                    )
 
         except anthropic.RateLimitError as error:
             raise ModelThrottledException(str(error)) from error

--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -8,6 +8,7 @@ import json
 import logging
 import mimetypes
 import secrets
+import time
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -443,7 +444,7 @@ class GeminiModel(Model):
                     "metadata": {
                         "usage": usage_data,
                         "metrics": {
-                            "latencyMs": 0,  # TODO
+                            "latencyMs": event.get("latency_ms", 0),
                         },
                     },
                 }
@@ -541,6 +542,7 @@ class GeminiModel(Model):
 
         client = self._get_client().aio
 
+        start_time = time.perf_counter()
         try:
             response = await client.models.generate_content_stream(**request)
 
@@ -591,7 +593,10 @@ class GeminiModel(Model):
                 }
             )
             if event:
-                yield self._format_chunk({"chunk_type": "metadata", "data": event.usage_metadata})
+                latency_ms = round((time.perf_counter() - start_time) * 1000)
+                yield self._format_chunk(
+                    {"chunk_type": "metadata", "data": event.usage_metadata, "latency_ms": latency_ms}
+                )
 
         except genai.errors.ClientError as error:
             match error.status:

--- a/strands-py/src/strands/models/litellm.py
+++ b/strands-py/src/strands/models/litellm.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import time
 import uuid
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
@@ -299,7 +300,7 @@ class LiteLLMModel(OpenAIModel):
             return StreamEvent(
                 metadata=MetadataEvent(
                     metrics={
-                        "latencyMs": 0,  # TODO
+                        "latencyMs": event.get("latency_ms", 0),
                     },
                     usage=usage_data,
                 )
@@ -542,6 +543,7 @@ class LiteLLMModel(OpenAIModel):
         Yields:
             Formatted message chunks from the model.
         """
+        start_time = time.perf_counter()
         response = await litellm.acompletion(**self.client_args, **litellm_request)
 
         logger.debug("got non-streaming response from model")
@@ -577,7 +579,8 @@ class LiteLLMModel(OpenAIModel):
 
         # Add usage information if available
         if hasattr(response, "usage"):
-            yield self.format_chunk({"chunk_type": "metadata", "data": response.usage})
+            latency_ms = round((time.perf_counter() - start_time) * 1000)
+            yield self.format_chunk({"chunk_type": "metadata", "data": response.usage, "latency_ms": latency_ms})
 
     async def _handle_streaming_response(self, litellm_request: dict[str, Any]) -> AsyncGenerator[StreamEvent, None]:
         """Handle streaming response from LiteLLM.
@@ -589,6 +592,7 @@ class LiteLLMModel(OpenAIModel):
             Formatted message chunks from the model.
         """
         # For streaming, use the streaming API
+        start_time = time.perf_counter()
         response = await litellm.acompletion(**self.client_args, **litellm_request)
 
         logger.debug("got response from model")
@@ -627,7 +631,8 @@ class LiteLLMModel(OpenAIModel):
         async for event in response:
             _ = event
             if usage := getattr(event, "usage", None):
-                yield self.format_chunk({"chunk_type": "metadata", "data": usage})
+                latency_ms = round((time.perf_counter() - start_time) * 1000)
+                yield self.format_chunk({"chunk_type": "metadata", "data": usage, "latency_ms": latency_ms})
 
         logger.debug("finished streaming response from model")
 

--- a/strands-py/src/strands/models/llamaapi.py
+++ b/strands-py/src/strands/models/llamaapi.py
@@ -8,6 +8,7 @@ import base64
 import json
 import logging
 import mimetypes
+import time
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -332,7 +333,7 @@ class LlamaAPIModel(Model):
                     "metadata": {
                         "usage": usage_type,
                         "metrics": {
-                            "latencyMs": 0,  # TODO
+                            "latencyMs": event.get("latency_ms", 0),
                         },
                     },
                 }
@@ -374,6 +375,7 @@ class LlamaAPIModel(Model):
         logger.debug("request=<%s>", request)
 
         logger.debug("invoking model")
+        start_time = time.perf_counter()
         try:
             response = self.client.chat.completions.create(**request)
         except llama_api_client.RateLimitError as e:
@@ -431,7 +433,8 @@ class LlamaAPIModel(Model):
 
         # we may have a metrics event here
         if metrics_event:
-            yield self.format_chunk({"chunk_type": "metadata", "data": metrics_event})
+            latency_ms = round((time.perf_counter() - start_time) * 1000)
+            yield self.format_chunk({"chunk_type": "metadata", "data": metrics_event, "latency_ms": latency_ms})
 
         logger.debug("finished streaming response from model")
 

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -7,6 +7,7 @@ import base64
 import json
 import logging
 import mimetypes
+import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Protocol, TypeVar, cast
@@ -605,7 +606,7 @@ class OpenAIModel(Model):
                     "metadata": {
                         "usage": usage_data,
                         "metrics": {
-                            "latencyMs": 0,  # TODO
+                            "latencyMs": event.get("latency_ms", 0),
                         },
                     },
                 }
@@ -613,7 +614,7 @@ class OpenAIModel(Model):
             case _:
                 raise RuntimeError(f"chunk_type=<{event['chunk_type']} | unknown type")
 
-    def _format_non_streaming_response(self, response: Any) -> list[StreamEvent]:
+    def _format_non_streaming_response(self, response: Any, latency_ms: int) -> list[StreamEvent]:
         """Convert a non-streaming OpenAI chat completion into Strands stream events."""
         chunks = [self.format_chunk({"chunk_type": "message_start"})]
         choices = getattr(response, "choices", None) or []
@@ -647,7 +648,7 @@ class OpenAIModel(Model):
         )
 
         if usage := getattr(response, "usage", None):
-            chunks.append(self.format_chunk({"chunk_type": "metadata", "data": usage}))
+            chunks.append(self.format_chunk({"chunk_type": "metadata", "data": usage, "latency_ms": latency_ms}))
 
         return chunks
 
@@ -714,6 +715,7 @@ class OpenAIModel(Model):
         # client. The asyncio event loop does not allow connections to be shared. For more details, please refer to
         # https://github.com/encode/httpx/discussions/2959.
         async with self._get_client() as client:
+            start_time = time.perf_counter()
             try:
                 response = await client.chat.completions.create(**request)
             except openai.BadRequestError as e:
@@ -738,7 +740,8 @@ class OpenAIModel(Model):
                 raise
 
             if not request["stream"]:
-                for chunk in self._format_non_streaming_response(response):
+                latency_ms = round((time.perf_counter() - start_time) * 1000)
+                for chunk in self._format_non_streaming_response(response, latency_ms):
                     yield chunk
                 return
 
@@ -803,7 +806,8 @@ class OpenAIModel(Model):
                 _ = event
 
             if event and hasattr(event, "usage") and event.usage:
-                yield self.format_chunk({"chunk_type": "metadata", "data": event.usage})
+                latency_ms = round((time.perf_counter() - start_time) * 1000)
+                yield self.format_chunk({"chunk_type": "metadata", "data": event.usage, "latency_ms": latency_ms})
 
         logger.debug("finished streaming response from model")
 

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -22,6 +22,7 @@ import base64
 import json
 import logging
 import mimetypes
+import time
 from collections.abc import AsyncGenerator
 from importlib.metadata import version as get_package_version
 from types import SimpleNamespace
@@ -310,6 +311,7 @@ class OpenAIResponsesModel(Model):
         logger.debug("invoking OpenAI Responses API model")
 
         async with openai.AsyncOpenAI(**self._resolve_client_args()) as client:
+            start_time = time.perf_counter()
             try:
                 response = await client.responses.create(**request)
 
@@ -466,7 +468,8 @@ class OpenAIResponsesModel(Model):
             yield self._format_chunk({"chunk_type": "message_stop", "data": finish_reason})
 
             if final_usage:
-                yield self._format_chunk({"chunk_type": "metadata", "data": final_usage})
+                latency_ms = round((time.perf_counter() - start_time) * 1000)
+                yield self._format_chunk({"chunk_type": "metadata", "data": final_usage, "latency_ms": latency_ms})
 
         logger.debug("finished streaming response from OpenAI Responses API model")
 
@@ -859,7 +862,7 @@ class OpenAIResponsesModel(Model):
                     "metadata": {
                         "usage": usage_data,
                         "metrics": {
-                            "latencyMs": 0,  # TODO
+                            "latencyMs": event.get("latency_ms", 0),
                         },
                     },
                 }

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import mimetypes
 import unittest.mock
@@ -879,7 +880,12 @@ async def test_stream(anthropic_client, model, alist):
     tru_events = await alist(response)
     exp_events = [
         {"messageStart": {"role": "assistant"}},
-        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3},
+                "metrics": {"latencyMs": unittest.mock.ANY},
+            }
+        },
     ]
 
     assert tru_events == exp_events
@@ -892,6 +898,34 @@ async def test_stream(anthropic_client, model, alist):
         "tools": [],
     }
     anthropic_client.messages.stream.assert_called_once_with(**expected_request)
+
+
+@pytest.mark.asyncio
+async def test_stream_reports_measured_latency(anthropic_client, model, alist):
+    mock_event = unittest.mock.Mock(
+        type="message_start",
+        dict=lambda: {"type": "message_start"},
+        model_dump=lambda: {"type": "message_start"},
+    )
+
+    async def slow_aiter(self):
+        await asyncio.sleep(0.05)
+        yield mock_event
+
+    mock_stream = unittest.mock.AsyncMock()
+    mock_stream.__aiter__ = slow_aiter
+    mock_stream.get_final_message.return_value = unittest.mock.Mock(
+        usage=unittest.mock.Mock(model_dump=lambda: {"input_tokens": 1, "output_tokens": 2})
+    )
+    mock_context = unittest.mock.AsyncMock()
+    mock_context.__aenter__.return_value = mock_stream
+    anthropic_client.messages.stream.return_value = mock_context
+
+    messages = [{"role": "user", "content": [{"text": "hello"}]}]
+    events = await alist(model.stream(messages, None, None))
+
+    metadata_event = events[-1]
+    assert metadata_event["metadata"]["metrics"]["latencyMs"] >= 50
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -544,7 +544,12 @@ async def test_stream_response_text(gemini_client, model, messages, agenerator, 
         {"contentBlockDelta": {"delta": {"text": "test text"}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "end_turn"}},
-        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3},
+                "metrics": {"latencyMs": unittest.mock.ANY},
+            }
+        },
     ]
     assert tru_chunks == exp_chunks
 
@@ -659,7 +664,12 @@ async def test_stream_response_tool_use(gemini_client, model, messages, agenerat
         {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"expression": "2+2"}'}}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "tool_use"}},
-        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3},
+                "metrics": {"latencyMs": unittest.mock.ANY},
+            }
+        },
     ]
     assert tru_chunks == exp_chunks
 
@@ -708,7 +718,12 @@ async def test_stream_response_tool_use_with_thought_signature(gemini_client, mo
         {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"expression": "2+2"}'}}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "tool_use"}},
-        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3},
+                "metrics": {"latencyMs": unittest.mock.ANY},
+            }
+        },
     ]
     assert tru_chunks == exp_chunks
 
@@ -747,7 +762,12 @@ async def test_stream_response_reasoning(gemini_client, model, messages, agenera
         {"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "YWJj", "text": "test reason"}}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "end_turn"}},
-        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3},
+                "metrics": {"latencyMs": unittest.mock.ANY},
+            }
+        },
     ]
     assert tru_chunks == exp_chunks
 
@@ -813,7 +833,12 @@ async def test_stream_response_reasoning_and_text(gemini_client, model, messages
         {"contentBlockDelta": {"delta": {"text": "2 + 2 = 4"}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "end_turn"}},
-        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 4, "totalTokens": 5}, "metrics": {"latencyMs": 0}}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 4, "totalTokens": 5},
+                "metrics": {"latencyMs": unittest.mock.ANY},
+            }
+        },
     ]
     assert tru_chunks == exp_chunks
 
@@ -846,7 +871,12 @@ async def test_stream_response_max_tokens(gemini_client, model, messages, agener
         {"contentBlockDelta": {"delta": {"text": "test text"}}},
         {"contentBlockStop": {}},
         {"messageStop": {"stopReason": "max_tokens"}},
-        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3},
+                "metrics": {"latencyMs": unittest.mock.ANY},
+            }
+        },
     ]
     assert tru_chunks == exp_chunks
 
@@ -873,7 +903,12 @@ async def test_stream_response_safety_block_with_missing_counts(gemini_client, m
     exp_chunks = [
         {"messageStart": {"role": "assistant"}},
         {"messageStop": {"stopReason": "guardrail_intervened"}},
-        {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}, "metrics": {"latencyMs": 0}}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+                "metrics": {"latencyMs": unittest.mock.ANY},
+            }
+        },
     ]
     assert tru_chunks == exp_chunks
 
@@ -896,7 +931,12 @@ async def test_stream_response_none_candidates(gemini_client, model, messages, a
     exp_chunks = [
         {"messageStart": {"role": "assistant"}},
         {"messageStop": {"stopReason": "end_turn"}},
-        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}, "metrics": {"latencyMs": 0}}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3},
+                "metrics": {"latencyMs": unittest.mock.ANY},
+            }
+        },
     ]
     assert tru_chunks == exp_chunks
 

--- a/strands-py/tests/strands/models/test_litellm.py
+++ b/strands-py/tests/strands/models/test_litellm.py
@@ -260,7 +260,7 @@ async def test_stream(litellm_acompletion, api_key, model_id, model, agenerator,
                     "outputTokens": mock_event_9.usage.completion_tokens,
                     "totalTokens": mock_event_9.usage.total_tokens,
                 },
-                "metrics": {"latencyMs": 0},
+                "metrics": {"latencyMs": unittest.mock.ANY},
             }
         },
     ]
@@ -541,7 +541,7 @@ async def test_stream_non_streaming(litellm_acompletion, api_key, model_id, alis
                     "outputTokens": 20,
                     "totalTokens": 30,
                 },
-                "metrics": {"latencyMs": 0},
+                "metrics": {"latencyMs": unittest.mock.ANY},
             }
         },
     ]

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import unittest.mock
@@ -1062,7 +1063,7 @@ async def test_stream(openai_client, model_id, model, agenerator, alist):
                     "outputTokens": mock_event_6.usage.completion_tokens,
                     "totalTokens": mock_event_6.usage.total_tokens,
                 },
-                "metrics": {"latencyMs": 0},
+                "metrics": {"latencyMs": unittest.mock.ANY},
             }
         },
     ]
@@ -1186,7 +1187,7 @@ async def test_stream_with_empty_choices(openai_client, model, agenerator, alist
         {
             "metadata": {
                 "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
-                "metrics": {"latencyMs": 0},
+                "metrics": {"latencyMs": unittest.mock.ANY},
             }
         },
     ]
@@ -1223,7 +1224,7 @@ async def test_stream_can_use_non_streaming_chat_completion(openai_client, model
         {
             "metadata": {
                 "usage": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10},
-                "metrics": {"latencyMs": 0},
+                "metrics": {"latencyMs": unittest.mock.ANY},
             }
         },
     ]
@@ -1236,6 +1237,26 @@ async def test_stream_can_use_non_streaming_chat_completion(openai_client, model
         stream=False,
         tools=[],
     )
+
+
+@pytest.mark.asyncio
+async def test_stream_reports_measured_latency(openai_client, model_id, messages, alist):
+    async def slow_create(**kwargs):
+        await asyncio.sleep(0.05)
+        mock_usage = unittest.mock.Mock(
+            prompt_tokens=7, completion_tokens=3, total_tokens=10, prompt_tokens_details=None
+        )
+        mock_message = unittest.mock.Mock(content="done", tool_calls=None, reasoning_content=None, reasoning=None)
+        mock_choice = unittest.mock.Mock(message=mock_message, finish_reason="stop")
+        return unittest.mock.Mock(choices=[mock_choice], usage=mock_usage)
+
+    openai_client.chat.completions.create = slow_create
+    model = OpenAIModel(model_id=model_id, stream=False, params={"max_tokens": 1})
+
+    events = await alist(model.stream(messages))
+
+    metadata_event = events[-1]
+    assert metadata_event["metadata"]["metrics"]["latencyMs"] >= 50
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -624,9 +624,7 @@ async def test_stream(openai_client, model_id, model, agenerator, alist):
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -647,7 +645,7 @@ async def test_stream(openai_client, model_id, model, agenerator, alist):
         {
             "metadata": {
                 "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
-                "metrics": {"latencyMs": 0},
+                "metrics": {"latencyMs": unittest.mock.ANY},
             }
         },
     ]
@@ -737,9 +735,7 @@ async def test_stream_with_tool_calls(openai_client, model, agenerator, alist):
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -774,9 +770,7 @@ async def test_stream_with_tool_calls_done_event(openai_client, model, agenerato
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -835,9 +829,7 @@ async def test_stream_reasoning_content(openai_client, model, agenerator, alist,
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=20, total_tokens=30, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=20, total_tokens=30, input_tokens_details=None)
         ),
     )
 
@@ -883,9 +875,7 @@ async def test_stream_citation_annotations(openai_client, model, agenerator, ali
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -923,9 +913,7 @@ async def test_stream_unsupported_annotation_type(openai_client, model, agenerat
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -1433,7 +1421,7 @@ async def test_stream_stateful(openai_client, model_id, agenerator, alist):
     assert len(metadata_events) == 1
     assert metadata_events[0]["metadata"] == {
         "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
-        "metrics": {"latencyMs": 0},
+        "metrics": {"latencyMs": unittest.mock.ANY},
     }
 
 


### PR DESCRIPTION
## Description

The bedrock provider reports real latency from the Converse API metrics, but six providers (openai, anthropic, gemini, litellm, llamaapi, openai_responses) hardcoded `latencyMs: 0` with a TODO because their upstream APIs do not return latency. Anyone consuming `EventLoopMetrics` or the metadata metrics for these providers gets a misleading zero, which breaks latency dashboards and makes provider comparisons useless.

Since the upstream APIs do not supply the number, each provider now measures wall-clock time from just before the API call to the point the usage metadata is emitted (`time.perf_counter`, rounded to int ms) and reports that. This is the same quantity a caller would observe around the stream, so it is honest, and it flows through the existing `format_chunk` metadata path unchanged. The anthropic provider also picks up the measured value in place of its hardcoded zero snapshot path.

Test assertions that pinned `latencyMs: 0` on end-to-end stream tests now use `unittest.mock.ANY`; assertions on the pure `format_chunk` unit tests keep exact values since those are deterministic. Two new tests (openai, anthropic) drive a mocked slow response and assert the measured latency is at least the injected delay.

## Related Issues

None

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

`hatch run prepare` passes end to end: format, lint, typecheck, and 4424 tests passed / 5 skipped. The two new tests inject a 50ms delay via a mocked client and assert `latencyMs >= 50` flows through to the metadata event.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
