### PR TITLE
refactor(ts): extract shared registerNodeDefaults() to prevent src/test drift

### DIFF
--- a/strands-ts/src/__fixtures__/register-node-defaults.ts
+++ b/strands-ts/src/__fixtures__/register-node-defaults.ts
@@ -1,6 +1,5 @@
-import { defaultSandbox } from '../sandbox/default.js'
-import { NotASandboxLocalEnvironment } from '../sandbox/not-a-sandbox-local-environment.js'
+// Unit tests do not import index.node.ts, so register the sandbox default here.
+// Registering the MCP loader here would prevent tests from mocking its dependencies.
+import { registerNodeSandboxDefault } from '../sandbox/register-node-defaults.js'
 
-// In production, index.node.ts registers this on import. Tests don't go through that entry
-// point, so this setup file does it instead.
-defaultSandbox.set(new NotASandboxLocalEnvironment())
+registerNodeSandboxDefault()

--- a/strands-ts/src/index.node.ts
+++ b/strands-ts/src/index.node.ts
@@ -2,12 +2,8 @@
 // Registers Node-specific defaults, then re-exports the full public API.
 // This is a load-bearing side effect -- do NOT mark this module side-effect-free
 // or bundlers will tree-shake the registrations.
-import { defaultSandbox } from './sandbox/default.js'
-import { NotASandboxLocalEnvironment } from './sandbox/not-a-sandbox-local-environment.js'
-import { mcpServerLoader } from './mcp/config.js'
-import { resolveServerConfigs } from './mcp/config.node.js'
+import { registerNodeDefaults } from './register-node-defaults.js'
 
-defaultSandbox.set(new NotASandboxLocalEnvironment())
-mcpServerLoader.set(resolveServerConfigs)
+registerNodeDefaults()
 
 export * from './index.js'

--- a/strands-ts/src/register-node-defaults.ts
+++ b/strands-ts/src/register-node-defaults.ts
@@ -1,0 +1,10 @@
+import { mcpServerLoader } from './mcp/config.js'
+import { resolveServerConfigs } from './mcp/config.node.js'
+import { registerNodeSandboxDefault } from './sandbox/register-node-defaults.js'
+
+// Shared by the Node entry point and integration tests to keep their defaults in sync.
+/** @internal */
+export function registerNodeDefaults(): void {
+  registerNodeSandboxDefault()
+  mcpServerLoader.set(resolveServerConfigs)
+}

--- a/strands-ts/src/sandbox/register-node-defaults.ts
+++ b/strands-ts/src/sandbox/register-node-defaults.ts
@@ -1,0 +1,8 @@
+import { defaultSandbox } from './default.js'
+import { NotASandboxLocalEnvironment } from './not-a-sandbox-local-environment.js'
+
+// Unit tests call this directly so they can mock the MCP loader's dependencies.
+/** @internal */
+export function registerNodeSandboxDefault(): void {
+  defaultSandbox.set(new NotASandboxLocalEnvironment())
+}

--- a/strands-ts/test/integ/__fixtures__/register-node-defaults.ts
+++ b/strands-ts/test/integ/__fixtures__/register-node-defaults.ts
@@ -1,8 +1,4 @@
-import { defaultSandbox } from '$/sdk/sandbox/default.js'
-import { NotASandboxLocalEnvironment } from '$/sdk/sandbox/not-a-sandbox-local-environment.js'
-import { mcpServerLoader } from '$/sdk/mcp/config.js'
-import { resolveServerConfigs } from '$/sdk/mcp/config.node.js'
+import { registerNodeDefaults } from '$/sdk/register-node-defaults.js'
 
-// Integration tests don't load index.node.ts; register the node defaults.
-defaultSandbox.set(new NotASandboxLocalEnvironment())
-mcpServerLoader.set(resolveServerConfigs)
+// Integration tests do not import index.node.ts, so register the same Node defaults here.
+registerNodeDefaults()


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

The vitest setup fixtures duplicated the actual Node default registration logic in src/index.node.ts. Nothing was broken, but identical inline .set() calls in multiple places meant any future change to the registration sequence would need to be replicated manually, risking drift.

### Changes

The registration logic is extracted into two shared functions:

- `registerNodeDefaults()` registers both Node defaults (sandbox + MCP config loader). Used by index.node.ts and the integration test setup
- `registerNodeSandboxDefault()` registers only the sandbox default. Used by the unit test setup, which has to avoid loading the real MCP config loader so that tests can still substitute their own mock version of it

Both functions are tagged `@internal` and are not re-exported from the public barrel.

## Related Issues

<!-- Link to related issues using #issue-number format -->

Closes #2736 

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Refactor

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
