### PR TITLE
docs: extract shared content from aws deploy guides

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -128,7 +128,9 @@ export const collections = {
         "404.mdx",
         "docs/README.mdx",
 
-        "docs/user-guide/**/*.mdx",
+        // [^_] excludes underscore-prefixed partials (same convention as
+        // Starlight's docsLoader) so shared fragments are not built as pages.
+        "docs/user-guide/**/[^_]*.mdx",
         "docs/community/**/*.mdx",
         "docs/contribute/**/*.mdx",
         "docs/examples/**/[!index]*.mdx",

--- a/site/src/content/docs/user-guide/deploy/_cdk-deploy-intro.mdx
+++ b/site/src/content/docs/user-guide/deploy/_cdk-deploy-intro.mdx
@@ -1,0 +1,19 @@
+{/*
+  Shared CDK bootstrap-and-deploy steps used by the Fargate and App Runner
+  deploy guides. Underscore prefix keeps this file out of the docs collection.
+*/}
+
+Assuming that Python & Node dependencies are already installed, run the CDK and deploy which will also run the Docker file for deployment:
+
+```bash
+# Bootstrap your AWS environment (if not already done)
+npx cdk bootstrap
+
+# Ensure Docker or Podman is running
+podman machine start 
+
+# Deploy the stack
+CDK_DOCKER=podman npx cdk deploy  
+```
+
+Once deployed, you can test your agent using the Application Load Balancer URL:

--- a/site/src/content/docs/user-guide/deploy/_containerization.mdx
+++ b/site/src/content/docs/user-guide/deploy/_containerization.mdx
@@ -1,0 +1,40 @@
+{/*
+  Shared "Containerization" section body used by the Fargate, App Runner, and
+  EKS deploy guides. Underscore prefix keeps this file out of the docs
+  collection.
+
+  Props:
+  - target: deployment target name, e.g. "Fargate", "App Runner", "EKS"
+  - dockerfileUrl: absolute URL of the example Dockerfile for this guide
+*/}
+
+To deploy your agent to {props.target}, you need to containerize it using Podman or Docker. The Dockerfile defines how your application is packaged and run.  Below is an example Docker file that installs all needed dependencies, the application, and configures the FastAPI server to run via Uvicorn (<a href={props.dockerfileUrl}>Dockerfile</a>):
+
+```dockerfile
+FROM public.ecr.aws/docker/library/python:3.12-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY app/ .
+
+# Create a non-root user to run the application
+RUN useradd -m appuser
+USER appuser
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Command to run the application with Uvicorn
+# - port: 8000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+```

--- a/site/src/content/docs/user-guide/deploy/_creating-your-agent-intro.mdx
+++ b/site/src/content/docs/user-guide/deploy/_creating-your-agent-intro.mdx
@@ -1,0 +1,20 @@
+{/*
+  Shared intro for the "Creating Your Agent in Python" section of the AWS
+  deploy guides. Underscore prefix keeps this file out of the docs collection.
+
+  Props:
+  - target: deployment target name, e.g. "Fargate", "EC2", "App Runner"
+  - containerized: set when the application is deployed as a container
+  - appPyUrl: absolute URL of the example app.py for this guide
+*/}
+
+The core of your {props.target} deployment is a {props.containerized ? 'containerized ' : ''}FastAPI application that hosts your Strands Agents SDK agent. This Python application initializes your agent and processes incoming HTTP requests.
+
+The FastAPI application follows these steps:
+
+1. Define endpoints for agent interactions
+2. Create a Strands Agents SDK agent with the specified system prompt and tools
+3. Process incoming requests through the agent
+4. Return the response back to the client
+
+Here's an example of a weather forecasting agent application (<a href={props.appPyUrl}><code>app.py</code></a>):

--- a/site/src/content/docs/user-guide/deploy/_fastapi-app-example.mdx
+++ b/site/src/content/docs/user-guide/deploy/_fastapi-app-example.mdx
@@ -1,0 +1,54 @@
+{/*
+  Shared FastAPI weather-agent example used by the Fargate, App Runner, and
+  EKS deploy guides. Underscore prefix keeps this file out of the docs
+  collection.
+*/}
+
+```python
+app = FastAPI(title="Weather API")
+
+# Define a weather-focused system prompt
+WEATHER_SYSTEM_PROMPT = """You are a weather assistant with HTTP capabilities. You can:
+
+1. Make HTTP requests to the National Weather Service API
+2. Process and display weather forecast data
+3. Provide weather information for locations in the United States
+
+When retrieving weather information:
+1. First get the coordinates or grid information using https://api.weather.gov/points/{latitude},{longitude} or https://api.weather.gov/points/{zipcode}
+2. Then use the returned forecast URL to get the actual forecast
+
+When displaying responses:
+- Format weather data in a human-readable way
+- Highlight important information like temperature, precipitation, and alerts
+- Handle errors appropriately
+- Don't ask follow-up questions
+
+Always explain the weather conditions clearly and provide context for the forecast.
+
+At the point where tools are done being invoked and a summary can be presented to the user, invoke the ready_to_summarize
+tool and then continue with the summary.
+"""
+
+class PromptRequest(BaseModel):
+    prompt: str
+
+@app.post('/weather')
+async def get_weather(request: PromptRequest):
+    """Endpoint to get weather information."""
+    prompt = request.prompt
+    
+    if not prompt:
+        raise HTTPException(status_code=400, detail="No prompt provided")
+
+    try:
+        weather_agent = Agent(
+            system_prompt=WEATHER_SYSTEM_PROMPT,
+            tools=[http_request],
+        )
+        response = weather_agent(prompt)
+        content = str(response)
+        return PlainTextResponse(content=content)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+```

--- a/site/src/content/docs/user-guide/deploy/_streaming-responses.mdx
+++ b/site/src/content/docs/user-guide/deploy/_streaming-responses.mdx
@@ -1,0 +1,48 @@
+{/*
+  Shared "Streaming responses" section body used by the Fargate and EKS
+  deploy guides. Underscore prefix keeps this file out of the docs collection.
+*/}
+
+Streaming responses can significantly improve the user experience by providing real-time responses back to the customer. This is especially valuable for longer responses.
+
+Python web-servers commonly implement streaming through the use of iterators, and the Strands Agents SDK facilitates response streaming via the `stream_async(prompt)` function:
+
+```python
+async def run_weather_agent_and_stream_response(prompt: str):
+    is_summarizing = False
+
+    @tool
+    def ready_to_summarize():
+        nonlocal is_summarizing
+        is_summarizing = True
+        return "Ok - continue providing the summary!"
+
+    weather_agent = Agent(
+        system_prompt=WEATHER_SYSTEM_PROMPT,
+        tools=[http_request, ready_to_summarize],
+        callback_handler=None
+    )
+
+    async for item in weather_agent.stream_async(prompt):
+        if not is_summarizing:
+            continue
+        if "data" in item:
+            yield item['data']
+
+@app.route('/weather-streaming', methods=['POST'])
+async def get_weather_streaming(request: PromptRequest):
+    try:
+        prompt = request.prompt
+
+        if not prompt:
+            raise HTTPException(status_code=400, detail="No prompt provided")
+
+        return StreamingResponse(
+            run_weather_agent_and_stream_response(prompt),
+            media_type="text/plain"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+```
+
+The implementation above employs a [custom tool](../concepts/tools/custom-tools.md#creating-custom-tools) to mark the boundary between information gathering and summary generation phases. This approach ensures that only the final, user-facing content is streamed to the client, maintaining consistency with the non-streaming endpoint while providing the benefits of incremental response delivery.

--- a/site/src/content/docs/user-guide/deploy/deploy_to_amazon_ec2.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_amazon_ec2.mdx
@@ -5,6 +5,8 @@ sidebar:
 tags: [deployment, aws]
 ---
 
+import CreatingYourAgentIntro from './_creating-your-agent-intro.mdx'
+
 Amazon EC2 (Elastic Compute Cloud) provides resizable compute capacity in the cloud, making it a flexible option for deploying Strands Agents SDK agents. This deployment approach gives you full control over the underlying infrastructure while maintaining the ability to scale as needed.
 
 If you're not familiar with the AWS CDK, check out the [official documentation](https://docs.aws.amazon.com/cdk/v2/guide/home.html).
@@ -13,16 +15,7 @@ This guide discusses EC2 integration at a high level - for a complete example pr
 
 ## Creating Your Agent in Python
 
-The core of your EC2 deployment is a FastAPI application that hosts your Strands Agents SDK agent. This Python application initializes your agent and processes incoming HTTP requests.
-
-The FastAPI application follows these steps:
-
-1. Define endpoints for agent interactions
-2. Create a Strands Agents SDK agent with the specified system prompt and tools
-3. Process incoming requests through the agent
-4. Return the response back to the client
-
-Here's an example of a weather forecasting agent application ([`app.py`][app_py]):
+<CreatingYourAgentIntro target="EC2" appPyUrl="https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_ec2/app/app.py" />
 
 ```python
 app = FastAPI(title="Weather API")
@@ -284,5 +277,4 @@ For the complete example code, including all files and configurations, see the [
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 
 [project_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_ec2
-[app_py]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_ec2/app/app.py
 [agent_ec2_stack]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_ec2/lib/agent-ec2-stack.ts

--- a/site/src/content/docs/user-guide/deploy/deploy_to_amazon_eks.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_amazon_eks.mdx
@@ -5,6 +5,11 @@ sidebar:
 tags: [deployment, aws]
 ---
 
+import CreatingYourAgentIntro from './_creating-your-agent-intro.mdx'
+import FastApiAppExample from './_fastapi-app-example.mdx'
+import StreamingResponses from './_streaming-responses.mdx'
+import Containerization from './_containerization.mdx'
+
 Amazon Elastic Kubernetes Service (EKS) is a managed container orchestration service that makes it easy to deploy, manage, and scale containerized applications using Kubernetes, while AWS manages the Kubernetes control plane.
 
 In this tutorial we are using [Amazon EKS Auto Mode](https://aws.amazon.com/eks/auto-mode), EKS Auto Mode extends AWS management of Kubernetes clusters beyond the cluster itself, to allow AWS to also set up and manage the infrastructure that enables the smooth operation of your workloads. This makes it an excellent choice for deploying Strands Agents SDK agents as containerized applications with high availability and scalability.
@@ -13,144 +18,17 @@ This guide discuss EKS integration at a high level - for a complete example proj
 
 ## Creating Your Agent in Python
 
-The core of your EKS deployment is a containerized FastAPI application that hosts your Strands Agents SDK agent. This Python application initializes your agent and processes incoming HTTP requests.
+<CreatingYourAgentIntro target="EKS" containerized appPyUrl="https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks/docker/app/app.py" />
 
-The FastAPI application follows these steps:
-
-1. Define endpoints for agent interactions
-2. Create a Strands agent with the specified system prompt and tools
-3. Process incoming requests through the agent
-4. Return the response back to the client
-
-Here's an example of a weather forecasting agent application ([`app.py`][app_py]):
-
-```python
-app = FastAPI(title="Weather API")
-
-# Define a weather-focused system prompt
-WEATHER_SYSTEM_PROMPT = """You are a weather assistant with HTTP capabilities. You can:
-
-1. Make HTTP requests to the National Weather Service API
-2. Process and display weather forecast data
-3. Provide weather information for locations in the United States
-
-When retrieving weather information:
-1. First get the coordinates or grid information using https://api.weather.gov/points/{latitude},{longitude} or https://api.weather.gov/points/{zipcode}
-2. Then use the returned forecast URL to get the actual forecast
-
-When displaying responses:
-- Format weather data in a human-readable way
-- Highlight important information like temperature, precipitation, and alerts
-- Handle errors appropriately
-- Don't ask follow-up questions
-
-Always explain the weather conditions clearly and provide context for the forecast.
-
-At the point where tools are done being invoked and a summary can be presented to the user, invoke the ready_to_summarize
-tool and then continue with the summary.
-"""
-
-class PromptRequest(BaseModel):
-    prompt: str
-
-@app.post('/weather')
-async def get_weather(request: PromptRequest):
-    """Endpoint to get weather information."""
-    prompt = request.prompt
-    
-    if not prompt:
-        raise HTTPException(status_code=400, detail="No prompt provided")
-
-    try:
-        weather_agent = Agent(
-            system_prompt=WEATHER_SYSTEM_PROMPT,
-            tools=[http_request],
-        )
-        response = weather_agent(prompt)
-        content = str(response)
-        return PlainTextResponse(content=content)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-```
+<FastApiAppExample />
 
 ### Streaming responses
 
-Streaming responses can significantly improve the user experience by providing real-time responses back to the customer. This is especially valuable for longer responses.
-
-Python web-servers commonly implement streaming through the use of iterators, and the Strands Agents SDK facilitates response streaming via the `stream_async(prompt)` function:
-
-```python
-async def run_weather_agent_and_stream_response(prompt: str):
-    is_summarizing = False
-
-    @tool
-    def ready_to_summarize():
-        nonlocal is_summarizing
-        is_summarizing = True
-        return "Ok - continue providing the summary!"
-
-    weather_agent = Agent(
-        system_prompt=WEATHER_SYSTEM_PROMPT,
-        tools=[http_request, ready_to_summarize],
-        callback_handler=None
-    )
-
-    async for item in weather_agent.stream_async(prompt):
-        if not is_summarizing:
-            continue
-        if "data" in item:
-            yield item['data']
-
-@app.route('/weather-streaming', methods=['POST'])
-async def get_weather_streaming(request: PromptRequest):
-    try:
-        prompt = request.prompt
-
-        if not prompt:
-            raise HTTPException(status_code=400, detail="No prompt provided")
-
-        return StreamingResponse(
-            run_weather_agent_and_stream_response(prompt),
-            media_type="text/plain"
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-```
-
-The implementation above employs a [custom tool](../concepts/tools/custom-tools.md#creating-custom-tools) to mark the boundary between information gathering and summary generation phases. This approach ensures that only the final, user-facing content is streamed to the client, maintaining consistency with the non-streaming endpoint while providing the benefits of incremental response delivery.
+<StreamingResponses />
 
 ## Containerization
 
-To deploy your agent to EKS, you need to containerize it using Podman or Docker. The Dockerfile defines how your application is packaged and run.  Below is an example Docker file that installs all needed dependencies, the application, and configures the FastAPI server to run via Uvicorn ([Dockerfile][dockerfile]):
-
-```dockerfile
-FROM public.ecr.aws/docker/library/python:3.12-slim
-
-WORKDIR /app
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Python dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy application code
-COPY app/ .
-
-# Create a non-root user to run the application
-RUN useradd -m appuser
-USER appuser
-
-# Expose the port the app runs on
-EXPOSE 8000
-
-# Command to run the application with Uvicorn
-# - port: 8000
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
-```
+<Containerization target="EKS" dockerfileUrl="https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks/docker/Dockerfile" />
 
 ## Infrastructure
 
@@ -226,6 +104,4 @@ For the complete example code, including all files and configurations, see the  
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 
 [project_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks
-[app_py]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks/docker/app/app.py
-[dockerfile]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks/docker/Dockerfile
 [values_yaml]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/deploy_to_eks/chart/values.yaml

--- a/site/src/content/docs/user-guide/deploy/deploy_to_aws_apprunner.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_aws_apprunner.mdx
@@ -5,6 +5,11 @@ sidebar:
 tags: [deployment, aws]
 ---
 
+import CreatingYourAgentIntro from './_creating-your-agent-intro.mdx'
+import FastApiAppExample from './_fastapi-app-example.mdx'
+import Containerization from './_containerization.mdx'
+import CdkDeployIntro from './_cdk-deploy-intro.mdx'
+
 AWS App Runner is the easiest way to deploy web applications on AWS, including API services, backend web services, and websites. App Runner eliminates the need for infrastructure management or container orchestration by providing a fully managed platform with automatic integration and delivery pipelines, high performance, scalability, and security.
 
 AWS App Runner automatically deploys containerized applications with secure HTTPS endpoints while handling infrastructure provisioning, auto-scaling, and TLS certificate management. This makes App Runner an excellent choice for deploying Strands Agents SDK agents as highly available and scalable containerized applications.
@@ -15,65 +20,9 @@ This guide discusses AWS App Runner integration at a high level - for a complete
 
 ## Creating Your Agent in Python
 
-The core of your App Runner deployment is a containerized FastAPI application that hosts your Strands Agents SDK agent. This Python application initializes your agent and processes incoming HTTP requests.
+<CreatingYourAgentIntro target="App Runner" containerized appPyUrl="https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner/docker/app/app.py" />
 
-The FastAPI application follows these steps:
-
-1. Define endpoints for agent interactions
-2. Create a Strands Agents SDK agent with the specified system prompt and tools
-3. Process incoming requests through the agent
-4. Return the response back to the client
-
-Here's an example of a weather forecasting agent application ([`app.py`][app_py]):
-
-```python
-app = FastAPI(title="Weather API")
-
-# Define a weather-focused system prompt
-WEATHER_SYSTEM_PROMPT = """You are a weather assistant with HTTP capabilities. You can:
-
-1. Make HTTP requests to the National Weather Service API
-2. Process and display weather forecast data
-3. Provide weather information for locations in the United States
-
-When retrieving weather information:
-1. First get the coordinates or grid information using https://api.weather.gov/points/{latitude},{longitude} or https://api.weather.gov/points/{zipcode}
-2. Then use the returned forecast URL to get the actual forecast
-
-When displaying responses:
-- Format weather data in a human-readable way
-- Highlight important information like temperature, precipitation, and alerts
-- Handle errors appropriately
-- Don't ask follow-up questions
-
-Always explain the weather conditions clearly and provide context for the forecast.
-
-At the point where tools are done being invoked and a summary can be presented to the user, invoke the ready_to_summarize
-tool and then continue with the summary.
-"""
-
-class PromptRequest(BaseModel):
-    prompt: str
-
-@app.post('/weather')
-async def get_weather(request: PromptRequest):
-    """Endpoint to get weather information."""
-    prompt = request.prompt
-    
-    if not prompt:
-        raise HTTPException(status_code=400, detail="No prompt provided")
-
-    try:
-        weather_agent = Agent(
-            system_prompt=WEATHER_SYSTEM_PROMPT,
-            tools=[http_request],
-        )
-        response = weather_agent(prompt)
-        content = str(response)
-        return PlainTextResponse(content=content)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-```
+<FastApiAppExample />
 
 ### Streaming responses
 
@@ -131,36 +80,7 @@ The implementation above employs a [custom tool](../concepts/tools/custom-tools.
 
 ## Containerization
 
-To deploy your agent to App Runner, you need to containerize it using Podman or Docker. The Dockerfile defines how your application is packaged and run.  Below is an example Docker file that installs all needed dependencies, the application, and configures the FastAPI server to run via Uvicorn ([Dockerfile][dockerfile]):
-
-```dockerfile
-FROM public.ecr.aws/docker/library/python:3.12-slim
-
-WORKDIR /app
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Python dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy application code
-COPY app/ .
-
-# Create a non-root user to run the application
-RUN useradd -m appuser
-USER appuser
-
-# Expose the port the app runs on
-EXPOSE 8000
-
-# Command to run the application with Uvicorn
-# - port: 8000
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
-```
+<Containerization target="App Runner" dockerfileUrl="https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner/docker/Dockerfile" />
 
 ## Infrastructure
 
@@ -254,20 +174,7 @@ The full example ([agent-apprunner-stack.ts][agent_apprunner_stack]):
 
 ## Deploying Your Agent & Testing
 
-Assuming that Python & Node dependencies are already installed, run the CDK and deploy which will also run the Docker file for deployment:
-
-```bash
-# Bootstrap your AWS environment (if not already done)
-npx cdk bootstrap
-
-# Ensure Docker or Podman is running
-podman machine start 
-
-# Deploy the stack
-CDK_DOCKER=podman npx cdk deploy  
-```
-
-Once deployed, you can test your agent using the Application Load Balancer URL:
+<CdkDeployIntro />
 
 ```bash
 # Get the service URL from the CDK output
@@ -307,7 +214,5 @@ For the complete example code, including all files and configurations, see the [
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 
 [project_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner
-[app_py]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner/docker/app/app.py
-[dockerfile]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner/docker/Dockerfile
 [agent_apprunner_stack]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_apprunner/lib/agent-apprunner-stack.ts
 

--- a/site/src/content/docs/user-guide/deploy/deploy_to_aws_fargate.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_aws_fargate.mdx
@@ -5,6 +5,12 @@ sidebar:
 tags: [deployment, aws]
 ---
 
+import CreatingYourAgentIntro from './_creating-your-agent-intro.mdx'
+import FastApiAppExample from './_fastapi-app-example.mdx'
+import StreamingResponses from './_streaming-responses.mdx'
+import Containerization from './_containerization.mdx'
+import CdkDeployIntro from './_cdk-deploy-intro.mdx'
+
 AWS Fargate is a serverless compute engine for containers that works with Amazon ECS and EKS. It allows you to run containers without having to manage servers or clusters. This makes it an excellent choice for deploying Strands Agents SDK agents as containerized applications with high availability and scalability.
 
 If you're not familiar with the AWS CDK, check out the [official documentation](https://docs.aws.amazon.com/cdk/v2/guide/home.html).
@@ -13,144 +19,17 @@ This guide discusses Fargate integration at a high level - for a complete exampl
 
 ## Creating Your Agent in Python
 
-The core of your Fargate deployment is a containerized FastAPI application that hosts your Strands Agents SDK agent. This Python application initializes your agent and processes incoming HTTP requests.
+<CreatingYourAgentIntro target="Fargate" containerized appPyUrl="https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate/docker/app/app.py" />
 
-The FastAPI application follows these steps:
-
-1. Define endpoints for agent interactions
-2. Create a Strands Agents SDK agent with the specified system prompt and tools
-3. Process incoming requests through the agent
-4. Return the response back to the client
-
-Here's an example of a weather forecasting agent application ([`app.py`][app_py]):
-
-```python
-app = FastAPI(title="Weather API")
-
-# Define a weather-focused system prompt
-WEATHER_SYSTEM_PROMPT = """You are a weather assistant with HTTP capabilities. You can:
-
-1. Make HTTP requests to the National Weather Service API
-2. Process and display weather forecast data
-3. Provide weather information for locations in the United States
-
-When retrieving weather information:
-1. First get the coordinates or grid information using https://api.weather.gov/points/{latitude},{longitude} or https://api.weather.gov/points/{zipcode}
-2. Then use the returned forecast URL to get the actual forecast
-
-When displaying responses:
-- Format weather data in a human-readable way
-- Highlight important information like temperature, precipitation, and alerts
-- Handle errors appropriately
-- Don't ask follow-up questions
-
-Always explain the weather conditions clearly and provide context for the forecast.
-
-At the point where tools are done being invoked and a summary can be presented to the user, invoke the ready_to_summarize
-tool and then continue with the summary.
-"""
-
-class PromptRequest(BaseModel):
-    prompt: str
-
-@app.post('/weather')
-async def get_weather(request: PromptRequest):
-    """Endpoint to get weather information."""
-    prompt = request.prompt
-    
-    if not prompt:
-        raise HTTPException(status_code=400, detail="No prompt provided")
-
-    try:
-        weather_agent = Agent(
-            system_prompt=WEATHER_SYSTEM_PROMPT,
-            tools=[http_request],
-        )
-        response = weather_agent(prompt)
-        content = str(response)
-        return PlainTextResponse(content=content)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-```
+<FastApiAppExample />
 
 ### Streaming responses
 
-Streaming responses can significantly improve the user experience by providing real-time responses back to the customer. This is especially valuable for longer responses.
-
-Python web-servers commonly implement streaming through the use of iterators, and the Strands Agents SDK facilitates response streaming via the `stream_async(prompt)` function:
-
-```python
-async def run_weather_agent_and_stream_response(prompt: str):
-    is_summarizing = False
-
-    @tool
-    def ready_to_summarize():
-        nonlocal is_summarizing
-        is_summarizing = True
-        return "Ok - continue providing the summary!"
-
-    weather_agent = Agent(
-        system_prompt=WEATHER_SYSTEM_PROMPT,
-        tools=[http_request, ready_to_summarize],
-        callback_handler=None
-    )
-
-    async for item in weather_agent.stream_async(prompt):
-        if not is_summarizing:
-            continue
-        if "data" in item:
-            yield item['data']
-
-@app.route('/weather-streaming', methods=['POST'])
-async def get_weather_streaming(request: PromptRequest):
-    try:
-        prompt = request.prompt
-
-        if not prompt:
-            raise HTTPException(status_code=400, detail="No prompt provided")
-
-        return StreamingResponse(
-            run_weather_agent_and_stream_response(prompt),
-            media_type="text/plain"
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-```
-
-The implementation above employs a [custom tool](../concepts/tools/custom-tools.md#creating-custom-tools) to mark the boundary between information gathering and summary generation phases. This approach ensures that only the final, user-facing content is streamed to the client, maintaining consistency with the non-streaming endpoint while providing the benefits of incremental response delivery.
+<StreamingResponses />
 
 ## Containerization
 
-To deploy your agent to Fargate, you need to containerize it using Podman or Docker. The Dockerfile defines how your application is packaged and run.  Below is an example Docker file that installs all needed dependencies, the application, and configures the FastAPI server to run via unicorn ([Dockerfile][dockerfile]):
-
-```dockerfile
-FROM public.ecr.aws/docker/library/python:3.12-slim
-
-WORKDIR /app
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Python dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy application code
-COPY app/ .
-
-# Create a non-root user to run the application
-RUN useradd -m appuser
-USER appuser
-
-# Expose the port the app runs on
-EXPOSE 8000
-
-# Command to run the application with Uvicorn
-# - port: 8000
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
-```
+<Containerization target="Fargate" dockerfileUrl="https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate/docker/Dockerfile" />
 
 ## Infrastructure
 
@@ -244,20 +123,7 @@ The full example ([agent-fargate-stack.ts][agent_fargate_stack]):
 
 ## Deploying Your Agent & Testing
 
-Assuming that Python & Node dependencies are already installed, run the CDK and deploy which will also run the Docker file for deployment:
-
-```bash
-# Bootstrap your AWS environment (if not already done)
-npx cdk bootstrap
-
-# Ensure Docker or Podman is running
-podman machine start 
-
-# Deploy the stack
-CDK_DOCKER=podman npx cdk deploy  
-```
-
-Once deployed, you can test your agent using the Application Load Balancer URL:
+<CdkDeployIntro />
 
 ```bash
 # Get the service URL from the CDK output
@@ -305,7 +171,5 @@ For the complete example code, including all files and configurations, see the [
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 
 [project_code]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate
-[app_py]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate/docker/app/app.py
-[dockerfile]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate/docker/Dockerfile
 [agent_fargate_stack]: https://github.com/strands-agents/harness-sdk/tree/main/site/docs/examples/cdk/deploy_to_fargate/lib/agent-fargate-stack.ts
 


### PR DESCRIPTION
## Description

The four AWS deploy guides (EC2, EKS, Fargate, App Runner) repeat the same prose and code nearly verbatim: the "Creating Your Agent in Python" intro, the FastAPI weather-agent example, the streaming-responses section, the Dockerfile walkthrough, and the CDK bootstrap-and-deploy steps. A similarity audit measured 52-72% pairwise overlap across the 1,147 lines. Any fix to the shared example (for instance the FastAPI app or Dockerfile) currently has to be applied four times, and the copies have already drifted (docstrings, `unicorn` vs `Uvicorn`, `@app.route` vs `@app.post`).

This PR moves the genuinely shared sections into underscore-prefixed MDX partials in `site/src/content/docs/user-guide/deploy/`, imported by each guide via plain MDX imports (the same native mechanism Astro provides; no new components or plugins). Prose was moved, not rewritten; where copies had drifted, the most recent/correct variant was kept (Uvicorn spelling, `PromptRequest` FastAPI model). Target-specific content (infrastructure stacks, deployment commands for EKS/EC2, summaries) stays in each guide, parameterized only by target name and example-repo URLs.

Partials are excluded from the docs content collection by narrowing the user-guide glob to `[^_]*.mdx`, matching the convention Starlight's own `docsLoader` uses.

Rendered output is unchanged in structure: same headings, same anchor slugs (`#creating-your-agent-in-python`, `#streaming-responses`, `#containerization`, etc.), verified against the built HTML. No inbound cross-page links target anchors on these four pages.

Net: -396 / +35 lines across the four guides (plus ~180 lines of partials), removing roughly 360 lines of duplicated content.

## Related Issues

N/A

## Documentation PR

This is a documentation-only change under `site/`.

## Type of Change

Documentation update

## Testing

- `npm ci`, then `npm run build` in `site/`: full static build succeeds, built-in broken-links checker reports no broken links across 844 pages
- `npm run test` in `site/`: 453 passed, 2 skipped (covers links, sidebar, content collection, routes)
- Manually inspected `dist/docs/user-guide/deploy/deploy_to_aws_fargate/index.html` (and the other three pages): heading ids unchanged, shared code blocks and example-repo links render correctly per target

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
