### PR TITLE
docs(evals): reduce boilerplate across evaluator pages

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -128,7 +128,9 @@ export const collections = {
         "404.mdx",
         "docs/README.mdx",
 
-        "docs/user-guide/**/*.mdx",
+        // [^_] excludes underscore-prefixed partials (same convention as
+        // Starlight's docsLoader) so shared fragments are not built as pages.
+        "docs/user-guide/**/[^_]*.mdx",
         "docs/community/**/*.mdx",
         "docs/contribute/**/*.mdx",
         "docs/examples/**/[!index]*.mdx",

--- a/site/src/content/docs/user-guide/evals-sdk/_session-id-caution.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/_session-id-caution.mdx
@@ -1,0 +1,9 @@
+{/*
+  Shared caution about session ID trace attributes, used by the evaluator
+  pages, the evaluators index, and the quickstart. Underscore prefix keeps
+  this file out of the docs collection.
+*/}
+
+:::caution[Required: Session ID Trace Attributes]
+When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
+:::

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/_usage_boilerplate.py
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/_usage_boilerplate.py
@@ -1,0 +1,51 @@
+# Shared boilerplate for the "Basic Usage" examples on the evaluator pages.
+# Included into the per-page code blocks via the mkdocs-style snippets plugin
+# (see src/plugins/remark-mkdocs-snippets.ts). The evaluator-specific lines
+# (imports, cases, Experiment construction) stay on each page.
+
+# --8<-- [start:trace_task_function]
+telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
+
+def task_function(case: Case) -> dict:
+    agent = Agent(
+        trace_attributes={"session.id": case.session_id},
+        callback_handler=None
+    )
+    response = agent(case.input)
+    spans = telemetry.in_memory_exporter.get_finished_spans()
+    mapper = StrandsInMemorySessionMapper()
+    session = mapper.map_to_session(spans, session_id=case.session_id)
+    return {"output": str(response), "trajectory": session}
+# --8<-- [end:trace_task_function]
+
+# --8<-- [start:run_experiment]
+async def main():
+    report = await experiment.run_evaluations_async(task_function)
+    report.run_display()
+
+asyncio.run(main())
+# --8<-- [end:run_experiment]
+
+# --8<-- [start:user_task_function]
+# Setup telemetry
+telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
+memory_exporter = telemetry.in_memory_exporter
+
+# Define task function
+def user_task_function(case: Case) -> dict:
+    agent = Agent(
+        trace_attributes={
+            "gen_ai.conversation.id": case.session_id,
+            "session.id": case.session_id
+        },
+        callback_handler=None
+    )
+    agent_response = agent(case.input)
+
+    # Map spans to session
+    finished_spans = memory_exporter.get_finished_spans()
+    mapper = StrandsInMemorySessionMapper()
+    session = mapper.map_to_session(finished_spans, session_id=case.session_id)
+
+    return {"output": str(agent_response), "trajectory": session}
+# --8<-- [end:user_task_function]

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/coherence_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/coherence_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Coherence"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `CoherenceEvaluator` assesses whether an agent's response maintains logical consistency, flows naturally, and presents ideas in a well-organized manner. It uses an LLM-as-judge approach with a five-level scoring rubric.
@@ -65,9 +67,7 @@ A response passes the evaluation if the score is >= 0.5.
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -78,18 +78,7 @@ from strands_evals.evaluators import CoherenceEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-
-def task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={"session.id": case.session_id},
-        callback_handler=None
-    )
-    response = agent(case.input)
-    spans = telemetry.in_memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(spans, session_id=case.session_id)
-    return {"output": str(response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:trace_task_function"
 
 cases = [
     Case(name="reasoning", input="Explain why the sky is blue in simple terms.")

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/conciseness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/conciseness_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Conciseness"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `ConcisenessEvaluator` evaluates how concise an agent's response is. It assesses whether the response communicates information efficiently without unnecessary verbosity, using a three-level scoring rubric.
@@ -63,9 +65,7 @@ A response passes the evaluation if the score is >= 0.5.
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -76,18 +76,7 @@ from strands_evals.evaluators import ConcisenessEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-
-def task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={"session.id": case.session_id},
-        callback_handler=None
-    )
-    response = agent(case.input)
-    spans = telemetry.in_memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(spans, session_id=case.session_id)
-    return {"output": str(response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:trace_task_function"
 
 cases = [
     Case(name="brief-answer", input="What is 2 + 2?")

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/correctness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/correctness_evaluator.mdx
@@ -4,6 +4,8 @@ sidebar:
   label: "Correctness"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `CorrectnessEvaluator` assesses whether an agent's response is factually correct. It supports two modes: a basic mode that evaluates correctness from conversation context alone, and a reference mode that compares the response against an expected answer.
@@ -67,9 +69,7 @@ A response passes if the score is `1.0`.
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ### Without Reference (3-level scoring)
 
@@ -82,18 +82,7 @@ from strands_evals.evaluators import CorrectnessEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-
-def task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={"session.id": case.session_id},
-        callback_handler=None
-    )
-    response = agent(case.input)
-    spans = telemetry.in_memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(spans, session_id=case.session_id)
-    return {"output": str(response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:trace_task_function"
 
 cases = [
     Case(name="capital", input="What is the capital of France?")

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/faithfulness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/faithfulness_evaluator.mdx
@@ -4,6 +4,8 @@ sidebar:
   label: "Faithfulness"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `FaithfulnessEvaluator` evaluates whether agent responses are grounded in the conversation history. It assesses if the agent's statements are faithful to the information available in the preceding context, helping detect hallucinations and unsupported claims. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/faithfulness_evaluator.py).
@@ -58,9 +60,7 @@ A response passes the evaluation if the score is >= 0.5.
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -71,27 +71,7 @@ from strands_evals.evaluators import FaithfulnessEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-# Setup telemetry
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-memory_exporter = telemetry.in_memory_exporter
-
-# Define task function
-def user_task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={
-            "gen_ai.conversation.id": case.session_id,
-            "session.id": case.session_id
-        },
-        callback_handler=None
-    )
-    agent_response = agent(case.input)
-    
-    # Map spans to session
-    finished_spans = memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(finished_spans, session_id=case.session_id)
-    
-    return {"output": str(agent_response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:user_task_function"
 
 # Create test cases
 test_cases = [

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/goal_success_rate_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/goal_success_rate_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Goal Success Rate"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `GoalSuccessRateEvaluator` evaluates whether all user goals were successfully achieved in a conversation. It provides a holistic assessment of whether the agent accomplished what the user set out to do, considering the entire conversation session. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/goal_success_rate_evaluator.py).
@@ -91,9 +93,7 @@ Assertions are human-authored statements describing expected agent actions, resp
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -104,27 +104,7 @@ from strands_evals.evaluators import GoalSuccessRateEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-# Setup telemetry
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-memory_exporter = telemetry.in_memory_exporter
-
-# Define task function
-def user_task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={
-            "gen_ai.conversation.id": case.session_id,
-            "session.id": case.session_id
-        },
-        callback_handler=None
-    )
-    agent_response = agent(case.input)
-    
-    # Map spans to session
-    finished_spans = memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(finished_spans, session_id=case.session_id)
-    
-    return {"output": str(agent_response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:user_task_function"
 
 # Create test cases
 test_cases = [

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/harmfulness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/harmfulness_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Harmfulness"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `HarmfulnessEvaluator` performs binary evaluation to detect harmful content in agent responses. It assesses whether a response contains dangerous, offensive, or otherwise harmful material.
@@ -57,9 +59,7 @@ A response passes the evaluation only if it is classified as **Not Harmful** (sc
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -70,18 +70,7 @@ from strands_evals.evaluators import HarmfulnessEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-
-def task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={"session.id": case.session_id},
-        callback_handler=None
-    )
-    response = agent(case.input)
-    spans = telemetry.in_memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(spans, session_id=case.session_id)
-    return {"output": str(response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:trace_task_function"
 
 cases = [
     Case(name="safety-check", input="Tell me about renewable energy sources.")

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/helpfulness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/helpfulness_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Helpfulness"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `HelpfulnessEvaluator` evaluates the helpfulness of agent responses from the user's perspective. It assesses whether responses effectively address user needs, provide useful information, and contribute positively to achieving the user's goals. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/helpfulness_evaluator.py).
@@ -66,9 +68,7 @@ A response passes the evaluation if the score is >= 0.5.
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -79,27 +79,7 @@ from strands_evals.evaluators import HelpfulnessEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-# Setup telemetry
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-memory_exporter = telemetry.in_memory_exporter
-
-# Define task function
-def user_task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={
-            "gen_ai.conversation.id": case.session_id,
-            "session.id": case.session_id
-        },
-        callback_handler=None
-    )
-    agent_response = agent(case.input)
-    
-    # Map spans to session
-    finished_spans = memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(finished_spans, session_id=case.session_id)
-    
-    return {"output": str(agent_response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:user_task_function"
 
 # Create test cases
 test_cases = [

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
@@ -4,6 +4,8 @@ sidebar:
   label: "Overview"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 Evaluators assess the quality and performance of conversational agents by analyzing their outputs, behaviors, and goal achievement. The Strands Evals SDK provides a comprehensive set of evaluators that can assess different aspects of agent performance, from individual response quality to multi-turn conversation success.
@@ -243,9 +245,7 @@ Evaluators and simulators complement each other. Use simulators to generate real
 
 Evaluators work seamlessly with simulator-generated conversations:
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/instruction_following_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/instruction_following_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Instruction Following"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `InstructionFollowingEvaluator` assesses whether an agent's response follows all explicit instructions provided in the user's prompt. It focuses strictly on instruction compliance — whether specific constraints, requirements, and directives were satisfied — regardless of response quality or factual accuracy.
@@ -77,9 +79,7 @@ The evaluator checks for compliance with specific directives such as:
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -90,18 +90,7 @@ from strands_evals.evaluators import InstructionFollowingEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-
-def task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={"session.id": case.session_id},
-        callback_handler=None
-    )
-    response = agent(case.input)
-    spans = telemetry.in_memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(spans, session_id=case.session_id)
-    return {"output": str(response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:trace_task_function"
 
 cases = [
     Case(

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/refusal_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/refusal_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Refusal"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `RefusalEvaluator` determines whether an agent response refuses to address the user's prompt request. It detects cases where the agent declines to answer or rejects a request by suggesting alternative topics instead.
@@ -69,9 +71,7 @@ The evaluator does **not** consider it a refusal if:
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -82,18 +82,7 @@ from strands_evals.evaluators import RefusalEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-
-def task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={"session.id": case.session_id},
-        callback_handler=None
-    )
-    response = agent(case.input)
-    spans = telemetry.in_memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(spans, session_id=case.session_id)
-    return {"output": str(response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:trace_task_function"
 
 cases = [
     Case(name="valid-request", input="Explain how photosynthesis works."),

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/response_relevance_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/response_relevance_evaluator.mdx
@@ -4,6 +4,8 @@ sidebar:
   label: "Response Relevance"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `ResponseRelevanceEvaluator` evaluates whether an agent's response is relevant to the user's question. It assesses if the response addresses what was actually asked, rather than going off-topic or providing unrelated information.
@@ -64,9 +66,7 @@ A response passes the evaluation if the score is >= 0.5.
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -77,18 +77,7 @@ from strands_evals.evaluators import ResponseRelevanceEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-
-def task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={"session.id": case.session_id},
-        callback_handler=None
-    )
-    response = agent(case.input)
-    spans = telemetry.in_memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(spans, session_id=case.session_id)
-    return {"output": str(response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:trace_task_function"
 
 cases = [
     Case(name="relevance-check", input="How do I reset my password?")

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/stereotyping_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/stereotyping_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Stereotyping"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `StereotypingEvaluator` detects bias or stereotypical content in agent responses directed against any group of people. It evaluates whether a response contains biased assumptions, stereotypes, or reinforces harmful generalizations — even if the response subsequently rejects them.
@@ -71,9 +73,7 @@ The evaluator classifies a response as **Not Stereotyping** if:
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio
@@ -84,18 +84,7 @@ from strands_evals.evaluators import StereotypingEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
-telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-
-def task_function(case: Case) -> dict:
-    agent = Agent(
-        trace_attributes={"session.id": case.session_id},
-        callback_handler=None
-    )
-    response = agent(case.input)
-    spans = telemetry.in_memory_exporter.get_finished_spans()
-    mapper = StrandsInMemorySessionMapper()
-    session = mapper.map_to_session(spans, session_id=case.session_id)
-    return {"output": str(response), "trajectory": session}
+--8<-- "user-guide/evals-sdk/evaluators/_usage_boilerplate.py:trace_task_function"
 
 cases = [
     Case(name="neutral-query", input="Describe the cultural contributions of different civilizations."),

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Tool Parameter Accuracy"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `ToolParameterAccuracyEvaluator` is a specialized evaluator that assesses whether tool call parameters faithfully use information from the preceding conversation context. It evaluates each tool call individually to ensure parameters are grounded in available information rather than hallucinated or incorrectly inferred. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/tool_parameter_accuracy_evaluator.py).
@@ -54,9 +56,7 @@ The evaluator uses a binary scoring system:
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_selection_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_selection_evaluator.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Tool Selection Accuracy"
 ---
 
+import SessionIdCaution from '../_session-id-caution.mdx'
+
 ## Overview
 
 The `ToolSelectionAccuracyEvaluator` evaluates whether tool calls are justified at specific points in the conversation. It assesses if the agent selected the right tool at the right time based on the conversation context and available tools. A complete example can be found [here](https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/evals-sdk/tool_selection_accuracy_evaluator.py).
@@ -54,9 +56,7 @@ The evaluator uses a binary scoring system:
 
 ## Basic Usage
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 ```python
 import asyncio

--- a/site/src/content/docs/user-guide/evals-sdk/quickstart.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/quickstart.mdx
@@ -7,6 +7,8 @@ redirectFrom:
   - docs/user-guide/observability-evaluation/evaluation
 ---
 
+import SessionIdCaution from './_session-id-caution.mdx'
+
 Strands Evaluation is a framework for evaluating AI agents and LLM applications. From simple output validation to complex multi-agent interaction analysis, trajectory evaluation, and automated experiment generation, Strands Evaluation provides features to measure and improve your AI systems.
 
 ## What Strands Evaluation Provides
@@ -253,9 +255,7 @@ print("\nExperiment saved to ./trajectory_evaluation.json")
 
 For more advanced evaluation, let's assess agent helpfulness using execution traces:
 
-:::caution[Required: Session ID Trace Attributes]
-When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
-:::
+<SessionIdCaution />
 
 The `TracedHandler` handles all of this automatically:
 


### PR DESCRIPTION
## Description

The evaluator pages under `user-guide/evals-sdk/evaluators/` repeat the same boilerplate: an identical session-ID caution admonition (15 pages plus the quickstart), a byte-identical telemetry-setup and `task_function` block (8 pages), and a byte-identical `user_task_function` variant (3 pages). A similarity audit measured 60%+ pairwise overlap across the directory. When the recommended telemetry setup changes, every copy has to be edited by hand.

This PR extracts only the clean, byte-identical wins, using mechanisms the site already has:

- `_session-id-caution.mdx`: the caution admonition, imported as a plain MDX partial into 14 evaluator pages, the evaluators index, and the quickstart.
- `_usage_boilerplate.py`: the two shared `task_function` blocks, pulled into each page's Basic Usage code block via the existing mkdocs-style snippets plugin, so each page still renders one continuous, copy-pasteable Python example with its own evaluator-specific imports, cases, and `Experiment` construction around the shared middle.

Partials are excluded from the docs collection by narrowing the user-guide glob to `[^_]*.mdx` (the same convention Starlight's `docsLoader` uses).

The audit's similarity numbers overstate how templatable these pages are: the Parameters, Scoring System, and Related Evaluators sections look parallel but diverge in substance per evaluator (different params, different scales, different cross-links), and several pages (multimodal, interactions, output, trajectory) use structurally different usage examples. Forcing those into a parameterized skeleton would be a leaky abstraction, so this PR deliberately stops at the verbatim-identical blocks. Page prose was moved, not rewritten.

Rendered output is unchanged: same headings and anchor slugs on every page, verified against the built HTML. Net: -205 / +119 lines (60 of the added lines are the two shared partials).

## Related Issues

N/A

## Documentation PR

This is a documentation-only change under `site/`.

## Type of Change

Documentation update

## Testing

- `npm ci`, then `npm run build` in `site/`: full static build succeeds, built-in broken-links checker reports no broken links across 844 pages
- `npm run test` in `site/`: 453 passed, 2 skipped (covers links, sidebar, content collection, routes)
- Manually inspected built HTML for `coherence_evaluator`, `helpfulness_evaluator`, `goal_success_rate_evaluator`, the evaluators index, and the quickstart: caution renders, shared code appears inline in the single Python block, heading ids unchanged, no partial routes emitted

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
