### PR TITLE
fix: restore line break in hero headline

### DIFF
--- a/site/src/components/landing/HeroSection.astro
+++ b/site/src/components/landing/HeroSection.astro
@@ -179,6 +179,7 @@ await agent.invoke('Research AI agent frameworks')`
   }
 
   .hero-highlight {
+    display: block;
     color: var(--strands-green);
   }
 


### PR DESCRIPTION
## Description

The hero headline on the homepage renders as "buildingproduction agents." with no space between "building" and "production".

The headline splits the text across two source lines in `HeroSection.astro`, wrapping "production agents." in a `.hero-highlight` span on its own line and relying on the newline between the two as the separating space. Astro's `compressHTML` (on by default, not overridden in `astro.config.mjs`) collapses that inter-node whitespace at the text-node/element boundary down to nothing, so the browser receives `building<span>production agents.` and renders the two words mashed together.

This makes `.hero-highlight` `display: block` so the highlighted phrase sits on its own line, which is the intended design. A block-level element forces its own line break independent of source whitespace, so the fix also cannot silently regress if the JSX is reformatted later.

## Related Issues

<!-- none -->

## Documentation PR

Not applicable. This is a fix to a site component, not documentation content.

## Type of Change

Bug fix

## Testing

- Built the site with `npm run build` (845 pages) and confirmed the compiled CSS rule is `.hero-highlight{color:var(--strands-green);display:block}`.
- Ran `npm run dev` and visually confirmed the headline now renders on two lines: "The open source toolkit for building" with green "production agents." on its own line below.
- `npm run typecheck` passes; the edited file passes Prettier.

The `hatch run prepare` item below is Python-SDK specific and does not apply to this site-only change.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
