### PR TITLE
fix(ci): make the release pip-audit step actually run

### DIFF
--- a/.github/workflows/python-security-audit.yml
+++ b/.github/workflows/python-security-audit.yml
@@ -48,4 +48,4 @@ jobs:
           python -m venv /tmp/audit-env
           /tmp/audit-env/bin/pip install --upgrade pip
           /tmp/audit-env/bin/pip install .
-          /tmp/audit-env/bin/pip-audit
+          pip-audit --path /tmp/audit-env/lib/python*/site-packages


### PR DESCRIPTION
## Description

Make the release security-audit step actually run pip-audit.

The step resolves the package's dependency closure into `/tmp/audit-env`, then invoked `/tmp/audit-env/bin/pip-audit`. But `pip-audit` was installed into the **outer runner Python**, never into the venv, so the step failed:

```
/tmp/audit-env/bin/pip-audit: No such file or directory
##[error]Process completed with exit code 127.
```

Because the step is `continue-on-error: true`, the job still went green — so the dependency audit has silently never run on any release. Observed on the 1.48.0 release run.

The fix keeps `pip-audit` installed in the outer environment (where it already was) and points it at the closure venv with `--path`, so it runs and audits exactly the user-installed package set — pip-audit's own dependencies are not swept in. The audit remains informational/non-blocking, matching the existing intent and the TypeScript sibling workflow.

## Related Issues

<!-- none -->

## Documentation PR

<!-- none; CI-only change -->

## Type of Change

Bug fix

## Testing

Reproduced the fixed step locally:

```
python -m venv /tmp/audit-env
/tmp/audit-env/bin/pip install .
pip-audit --path /tmp/audit-env/lib/python*/site-packages
No known vulnerabilities found                # exit 0
```

pip-audit now runs (no more exit 127) and audits the installed closure. `strands-agents` itself is listed as skipped (local dev build not on PyPI), which is expected — its dependencies are all audited.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
