### PR TITLE
fix(agent): bound context-overflow recovery retries

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -133,6 +133,13 @@ _AGENTIC_CONTEXT_MANAGER_MAX_RESULT_TOKENS = 8_000
 """Higher offload threshold for agentic mode - the model manages its own context, so we preserve more inline."""
 
 _CONTEXT_MANAGER_PREVIEW_TOKENS = 750
+
+# Maximum consecutive context-overflow recoveries per invocation. Each recovery
+# calls ``ConversationManager.reduce_context`` and retries the model call; a
+# manager that cannot actually shrink the context (e.g. the token mass sits
+# inside ``SummarizingConversationManager.preserve_recent_messages``) would
+# otherwise retry forever and eventually die with an unrelated RecursionError.
+_MAX_CONTEXT_OVERFLOW_RECOVERY_ATTEMPTS = 10
 """Benchmark-validated preview token count for offloaded results."""
 
 _CONTEXT_MANAGER_SUMMARY_RATIO = 0.3
@@ -1338,7 +1345,12 @@ class Agent(AgentBase):
 
         This internal method handles the execution of the event loop cycle and implements
         retry logic for handling context window overflow exceptions by reducing the
-        conversation context and retrying.
+        conversation context and retrying, bounded by
+        ``_MAX_CONTEXT_OVERFLOW_RECOVERY_ATTEMPTS``. The bound guards against a
+        conversation manager whose ``reduce_context`` succeeds without actually
+        shrinking the context — an unbounded retry would loop until the Python
+        recursion limit and surface as a ``RecursionError`` instead of the
+        underlying overflow.
 
         Args:
             invocation_state: Additional parameters to pass to the event loop.
@@ -1347,6 +1359,10 @@ class Agent(AgentBase):
 
         Yields:
             Events of the loop cycle.
+
+        Raises:
+            ContextWindowOverflowException: If the context still overflows after the
+                maximum number of reduce-and-retry attempts.
         """
         # Add `Agent` to invocation_state to keep backwards-compatibility
         invocation_state["agent"] = self
@@ -1355,26 +1371,31 @@ class Agent(AgentBase):
             structured_output_context.register_tool(self.tool_registry)
 
         try:
-            events = event_loop_cycle(
-                agent=self,
-                invocation_state=invocation_state,
-                structured_output_context=structured_output_context,
-                limits=limits,
-            )
-            async for event in events:
-                yield event
+            for attempt in range(_MAX_CONTEXT_OVERFLOW_RECOVERY_ATTEMPTS + 1):
+                try:
+                    events = event_loop_cycle(
+                        agent=self,
+                        invocation_state=invocation_state,
+                        structured_output_context=structured_output_context,
+                        limits=limits,
+                    )
+                    async for event in events:
+                        yield event
+                    return
 
-        except ContextWindowOverflowException as e:
-            # Try reducing the context size and retrying
-            self.conversation_manager.reduce_context(self, e=e)
+                except ContextWindowOverflowException as e:
+                    if attempt >= _MAX_CONTEXT_OVERFLOW_RECOVERY_ATTEMPTS:
+                        logger.error(
+                            "attempts=<%d> | context overflow recovery did not converge, re-raising",
+                            attempt,
+                        )
+                        raise
+                    # Try reducing the context size and retrying
+                    self.conversation_manager.reduce_context(self, e=e)
 
-            # Sync agent after reduce_context to keep conversation_manager_state up to date in the session
-            if self._session_manager:
-                self._session_manager.sync_agent(self)
-
-            events = self._execute_event_loop_cycle(invocation_state, structured_output_context, limits)
-            async for event in events:
-                yield event
+                    # Sync agent after reduce_context to keep conversation_manager_state up to date in the session
+                    if self._session_manager:
+                        self._session_manager.sync_agent(self)
 
         finally:
             if structured_output_context:

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -3473,3 +3473,25 @@ async def test_checkpoint_resume_schema_mismatch_raises_checkpoint_exception() -
     prompt = {"checkpointResume": {"checkpoint": {"schema_version": "0.1", "position": "after_model"}}}
     with pytest.raises(CheckpointException, match="schema version"):
         await agent.invoke_async(prompt)
+
+
+def test_agent__call__non_converging_reduce_context_doesnt_infinite_loop(mock_model, agent, quiet_strands_logging):
+    """A conversation manager whose reduce_context succeeds without shrinking the
+    context (e.g. the token mass sits inside SummarizingConversationManager's
+    preserve_recent_messages) must surface the overflow after a bounded number of
+    recovery attempts — not recurse until RecursionError."""
+    conversation_manager = unittest.mock.Mock(spec=SlidingWindowConversationManager)
+    conversation_manager.reduce_context.return_value = None  # "succeeds", reduces nothing
+    conversation_manager.apply_management.return_value = None
+    agent.conversation_manager = conversation_manager
+
+    mock_model.mock_stream.side_effect = ContextWindowOverflowException(
+        RuntimeError("Input is too long for requested model")
+    )
+
+    with pytest.raises(ContextWindowOverflowException):
+        agent("Test!")
+
+    from strands.agent.agent import _MAX_CONTEXT_OVERFLOW_RECOVERY_ATTEMPTS
+
+    assert conversation_manager.reduce_context.call_count == _MAX_CONTEXT_OVERFLOW_RECOVERY_ATTEMPTS


### PR DESCRIPTION
## Description

`ContextWindowOverflowException` recovery in `Agent._execute_event_loop_cycle` calls `conversation_manager.reduce_context(e=e)` and recurses into itself with no attempt limit and no convergence check. A conversation manager whose `reduce_context` succeeds without actually shrinking the context retries forever. This is reachable with the default `SummarizingConversationManager`: when the token mass sits inside `preserve_recent_messages` (e.g. one turn's parallel tool results each landed under the ContextOffloader threshold but together exceed the model window), `_summarize_oldest` replaces small old messages with a similar-sized summary — net reduction ~0 — and `max(1, …)` in the split calculation means it never raises while any unprotected message remains. In production we observed 965 consecutive overflow model calls (a 26-token band — the context never shrank) from one agent task, terminated only by a `RecursionError` from the `copy.deepcopy(agent.messages)` in `_handle_model_execution` — masking the real failure.

This change converts the recursion into a bounded retry loop: after `_MAX_CONTEXT_OVERFLOW_RECOVERY_ATTEMPTS` (10) recoveries the original overflow is re-raised, so callers see the actual `ContextWindowOverflowException` instead of a recursion-limit crash. Normal recovery (one reduce, one retry) is unaffected; the loop-instead-of-recursion shape also removes the per-retry generator frame growth.

## Related Issues

Fixes #3338

## Documentation PR

No docs changes — internal recovery behavior; the exception surfaced was already documented as possible.

## Type of Change

Bug fix

## Testing

- New unit test: a manager whose `reduce_context` succeeds without reducing + a model that always overflows → the invocation raises `ContextWindowOverflowException` after exactly the bounded number of recovery attempts (previously: `RecursionError`).
- `tests/strands/agent/`: 718 passed. Broader unit suite passes except modules requiring extras my environment can't build (`cedar`, model-provider SDKs) — failures reproduce identically on a clean checkout.
- `ruff format` / `ruff check` clean on touched files.

- [ ] I ran `hatch run prepare` (hatch env build fails locally on the `cedar` extra's native build; ran the equivalent ruff + pytest directly as above)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
