### PR TITLE
feat(py): configurable retry exceptions (#1597)

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
@@ -149,7 +149,22 @@ For more control over retry decisions, such as validating model responses or han
 <Tabs>
 <Tab label="Python">
 
-The Python SDK's `ModelRetryStrategy` is a concrete configurable class. To customize beyond its `max_attempts` / `initial_delay` / `max_delay` parameters, use the hook approach below.
+To extend or narrow which errors are retryable, subclass `ModelRetryStrategy` and override `is_retryable`. The default implementation retries `ModelThrottledException` only; `super().is_retryable(exception)` preserves that base behavior so you can opt additional error types in (or specific ones out) without reimplementing the rest of the retry policy.
+
+```python
+from strands import Agent, ModelRetryStrategy
+from strands.types.exceptions import ModelThrottledException
+
+class MyRetryStrategy(ModelRetryStrategy):
+    def is_retryable(self, exception: Exception) -> bool:
+        return super().is_retryable(exception) or isinstance(exception, TimeoutError)
+
+agent = Agent(
+    retry_strategy=MyRetryStrategy(max_attempts=4, initial_delay=2, max_delay=60)
+)
+```
+
+A retry-strategy instance carries per-turn state and must not be shared across agents. Create a new instance per agent.
 
 </Tab>
 <Tab label="TypeScript">

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -428,12 +428,10 @@ class Agent(AgentBase):
 
         self._concurrency = _ConcurrencyController(concurrent_invocation_mode)
 
-        # In the future, we'll have a RetryStrategy base class but until
-        # that API is determined we only allow ModelRetryStrategy
         if (
             retry_strategy is not None
             and not isinstance(retry_strategy, _DefaultRetryStrategySentinel)
-            and type(retry_strategy) is not ModelRetryStrategy
+            and not isinstance(retry_strategy, ModelRetryStrategy)
         ):
             raise ValueError("retry_strategy must be an instance of ModelRetryStrategy")
 

--- a/strands-py/src/strands/event_loop/_retry.py
+++ b/strands-py/src/strands/event_loop/_retry.py
@@ -21,12 +21,15 @@ logger = logging.getLogger(__name__)
 class ModelRetryStrategy(HookProvider):
     """Default retry strategy for model throttling with exponential backoff.
 
-    Retries model calls on ModelThrottledException using exponential backoff.
+    Retries model calls on retryable exceptions using exponential backoff.
     Delay doubles after each attempt: initial_delay, initial_delay*2, initial_delay*4,
     etc., capped at max_delay. State resets after successful calls.
 
     With defaults (initial_delay=4, max_delay=240, max_attempts=6), delays are:
     4s → 8s → 16s → 32s → 64s (5 retries before giving up on the 6th attempt).
+
+    Subclass and override ``is_retryable`` to expand or narrow the set of
+    retryable exceptions without reimplementing the rest of the retry policy.
 
     Args:
         max_attempts: Total model attempts before re-raising the exception.
@@ -54,6 +57,17 @@ class ModelRetryStrategy(HookProvider):
         self._max_delay = max_delay
         self._current_attempt = 0
         self._backwards_compatible_event_to_yield: TypedEvent | None = None
+
+    def is_retryable(self, exception: Exception) -> bool:
+        """Whether the exception should be retried.
+
+        Args:
+            exception: The exception raised by the model call.
+
+        Returns:
+            True if the exception should trigger a retry, False otherwise.
+        """
+        return isinstance(exception, ModelThrottledException)
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
         """Register callbacks for AfterModelCallEvent and AfterInvocationEvent.
@@ -93,7 +107,7 @@ class ModelRetryStrategy(HookProvider):
         """Handle model call completion and determine if retry is needed.
 
         This callback is invoked after each model call. If the call failed with
-        a ModelThrottledException and we haven't exceeded max_attempts, it sets
+        a retryable exception and we haven't exceeded max_attempts, it sets
         event.retry to True and sleeps for the current delay before returning.
 
         On successful calls, it resets the retry state to prepare for future calls.
@@ -123,8 +137,7 @@ class ModelRetryStrategy(HookProvider):
             self._reset_retry_state()
             return
 
-        # Only retry on ModelThrottledException
-        if not isinstance(event.exception, ModelThrottledException):
+        if not self.is_retryable(event.exception):
             return
 
         # Increment attempt counter first
@@ -144,10 +157,11 @@ class ModelRetryStrategy(HookProvider):
         # Retry the model call
         logger.debug(
             "retry_delay_seconds=<%s>, max_attempts=<%s>, current_attempt=<%s> "
-            "| throttling exception encountered | delaying before next retry",
+            "| %s encountered | delaying before next retry",
             delay,
             self._max_attempts,
             self._current_attempt,
+            type(event.exception).__name__,
         )
 
         # Sleep for current delay

--- a/strands-py/tests/strands/agent/test_agent_retry.py
+++ b/strands-py/tests/strands/agent/test_agent_retry.py
@@ -58,14 +58,13 @@ def test_agent_rejects_invalid_retry_strategy_type():
         Agent(retry_strategy=FakeRetryStrategy())
 
 
-def test_agent_rejects_subclass_of_model_retry_strategy():
-    """Test that Agent rejects subclasses of ModelRetryStrategy (strict type check)."""
+def test_agent_accepts_subclass_of_model_retry_strategy():
+    """Test that Agent accepts subclasses of ModelRetryStrategy."""
 
     class CustomRetryStrategy(ModelRetryStrategy):
         pass
 
-    with pytest.raises(ValueError, match="retry_strategy must be an instance of ModelRetryStrategy"):
-        Agent(retry_strategy=CustomRetryStrategy())
+    Agent(retry_strategy=CustomRetryStrategy())  # does not raise
 
 
 def test_agent_default_retry_strategy_uses_event_loop_constants():

--- a/strands-py/tests/strands/agent/test_retry.py
+++ b/strands-py/tests/strands/agent/test_retry.py
@@ -326,3 +326,28 @@ async def test_model_retry_strategy_no_retry_when_no_exception_and_no_stop_respo
     # Should not retry and should reset state
     assert event.retry is False
     assert strategy._current_attempt == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exception, expect_retry",
+    [
+        (TimeoutError("timed out"), True),
+        (ModelThrottledException("Throttled"), True),
+        (ValueError("unrelated"), False),
+    ],
+)
+async def test_model_retry_strategy_subclass_overrides_is_retryable(mock_sleep, exception, expect_retry):
+    """Test that subclassing and overriding is_retryable controls which exceptions are retried."""
+
+    class PermissiveRetryStrategy(ModelRetryStrategy):
+        def is_retryable(self, exception: Exception) -> bool:
+            return super().is_retryable(exception) or isinstance(exception, TimeoutError)
+
+    strategy = PermissiveRetryStrategy(max_attempts=3, initial_delay=2, max_delay=60)
+    mock_agent = Mock()
+
+    event = AfterModelCallEvent(agent=mock_agent, exception=exception)
+    await strategy._handle_after_model_call(event)
+
+    assert event.retry is expect_retry


### PR DESCRIPTION
## Description
This lets users define which exceptions should be retried automatically by the framework without having to roll out their own hooks.

Feature parity is improved as well since this is already supported by the Typescript SDK.

## Related Issues

#1597


## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
