### PR TITLE
docs(site): add missing meta descriptions and fix duplicate page titles

### DIFF
--- a/site/src/content/docs/api/python/index.mdx
+++ b/site/src/content/docs/api/python/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Strands Agents SDK API Reference
+description: 'The full API reference for the Strands Agents Python SDK: every class, method, tool, model provider, and hook with complete signatures.'
 ---
 
 import PythonApiList from '@components/PythonApiList.astro'

--- a/site/src/content/docs/api/typescript/index.mdx
+++ b/site/src/content/docs/api/typescript/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: TypeScript API Reference
+description: 'The full API reference for the Strands Agents TypeScript SDK: every class, interface, function, and type across the SDK packages.'
 ---
 
 import TypeScriptApiList from '@components/TypeScriptApiList.astro'

--- a/site/src/content/docs/community/community-packages.mdx
+++ b/site/src/content/docs/community/community-packages.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community catalog
+description: 'Browse community-built tools, model providers, plugins, and session managers that extend Strands agents in Python and TypeScript.'
 sidebar:
   label: "Community Catalog"
 ---

--- a/site/src/content/docs/community/get-featured.mdx
+++ b/site/src/content/docs/community/get-featured.mdx
@@ -1,5 +1,6 @@
 ---
 title: Get Featured in the Docs
+description: 'How to get your community package featured in the Strands Agents docs, from package requirements to submitting a catalog entry.'
 sidebar:
   label: "Get Featured"
 ---

--- a/site/src/content/docs/community/integrations/ag-ui.mdx
+++ b/site/src/content/docs/community/integrations/ag-ui.mdx
@@ -1,7 +1,7 @@
 ---
 title: Build chat experiences with AG-UI and CopilotKit
 community: true
-description: AG-UI integration
+description: 'Build streaming chat interfaces for Strands agents with the AG-UI protocol and CopilotKit front-end components.'
 integrationType: integration
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/model-providers/clova-studio.mdx
+++ b/site/src/content/docs/community/model-providers/clova-studio.mdx
@@ -1,7 +1,7 @@
 ---
 title: CLOVA Studio
 community: true
-description: Naver CLOVA Studio
+description: 'Connect Strands agents to Naver CLOVA Studio, Korean-optimized language models on Naver Cloud Platform, via strands-clova.'
 integrationType: model-provider
 languages: Python
 redirectFrom:

--- a/site/src/content/docs/community/model-providers/cohere.mdx
+++ b/site/src/content/docs/community/model-providers/cohere.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cohere
 community: true
-description: Cohere LLM
+description: 'Use Cohere language models with Strands agents through the OpenAI compatibility layer for chat, tool calling, and streaming.'
 integrationType: model-provider
 languages: Python
 redirectFrom:

--- a/site/src/content/docs/community/model-providers/fireworksai.mdx
+++ b/site/src/content/docs/community/model-providers/fireworksai.mdx
@@ -1,7 +1,7 @@
 ---
 title: FireworksAI
 community: true
-description: Fireworks AI
+description: 'Run Strands agents on Fireworks AI, fast hosted inference for open-source models, using the OpenAI-compatible API.'
 integrationType: model-provider
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/model-providers/mlx.mdx
+++ b/site/src/content/docs/community/model-providers/mlx.mdx
@@ -1,7 +1,7 @@
 ---
 title: MLX
 community: true
-description: MLX
+description: 'Run Strands agents locally on Apple Silicon with the MLX model provider, supporting inference, LoRA fine-tuning, and vision.'
 integrationType: model-provider
 languages: Python
 ---

--- a/site/src/content/docs/community/model-providers/nebius-token-factory.mdx
+++ b/site/src/content/docs/community/model-providers/nebius-token-factory.mdx
@@ -1,7 +1,7 @@
 ---
 title: Nebius Token Factory
 community: true
-description: Nebius Token Factory
+description: 'Use Nebius Token Factory with Strands agents for fast open-source model inference through the OpenAI-compatible API.'
 integrationType: model-provider
 languages: Python
 redirectFrom:

--- a/site/src/content/docs/community/model-providers/nvidia-nim.mdx
+++ b/site/src/content/docs/community/model-providers/nvidia-nim.mdx
@@ -1,7 +1,7 @@
 ---
 title: NVIDIA NIM
 community: true
-description: NVIDIA NIM
+description: 'Connect Strands agents to NVIDIA NIM inference microservices with the strands-nvidia-nim community model provider.'
 integrationType: model-provider
 languages: Python
 ---

--- a/site/src/content/docs/community/model-providers/ovhcloud-ai-endpoints.mdx
+++ b/site/src/content/docs/community/model-providers/ovhcloud-ai-endpoints.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud AI Endpoints
 community: true
-description: OVHcloud AI Endpoints
+description: 'Run Strands agents on OVHcloud AI Endpoints, a European, GDPR-compliant model service with an OpenAI-compatible API.'
 integrationType: model-provider
 languages: Python
 ---

--- a/site/src/content/docs/community/model-providers/sglang.mdx
+++ b/site/src/content/docs/community/model-providers/sglang.mdx
@@ -1,7 +1,7 @@
 ---
 title: SGLang
 community: true
-description: SGLang
+description: 'Use SGLang servers as a Strands model provider with Token-In/Token-Out support for agentic reinforcement learning training.'
 integrationType: model-provider
 languages: Python
 ---

--- a/site/src/content/docs/community/model-providers/vllm.mdx
+++ b/site/src/content/docs/community/model-providers/vllm.mdx
@@ -1,7 +1,7 @@
 ---
 title: vLLM
 community: true
-description: vLLM
+description: 'Serve Strands agents from vLLM with Token-In/Token-Out support for agentic RL training via the OpenAI-compatible API.'
 integrationType: model-provider
 languages: Python
 ---

--- a/site/src/content/docs/community/model-providers/xai.mdx
+++ b/site/src/content/docs/community/model-providers/xai.mdx
@@ -8,7 +8,7 @@ service:
   link: https://x.ai/
 title: xAI
 community: true
-description: xAI Grok
+description: 'Use xAI Grok models with Strands agents, including server-side tools for web search, X platform access, and code execution.'
 integrationType: model-provider
 languages: Python
 redirectFrom:

--- a/site/src/content/docs/community/plugins/agent-control.mdx
+++ b/site/src/content/docs/community/plugins/agent-control.mdx
@@ -1,7 +1,7 @@
 ---
 title: Agent Control 
 community: true
-description: Runtime policy enforcement for agents
+description: 'Enforce centrally managed runtime policies on Strands agents with Agent Control, blocking or steering violations at every step.'
 integrationType: plugin
 languages: Python
 project:

--- a/site/src/content/docs/community/plugins/datadog-ai-guard.mdx
+++ b/site/src/content/docs/community/plugins/datadog-ai-guard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Datadog AI Guard
 community: true
-description: Real-time AI security with Datadog AI Guard
+description: 'Protect Strands agents in real time with Datadog AI Guard, blocking prompt injection, jailbreaks, and unsafe tool calls.'
 integrationType: plugin
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/session-managers/agentcore-memory.mdx
+++ b/site/src/content/docs/community/session-managers/agentcore-memory.mdx
@@ -1,7 +1,7 @@
 ---
 title: AgentCore Memory Session Manager
 community: true
-description: Amazon AgentCore
+description: 'Persist Strands agent conversations with Amazon Bedrock AgentCore Memory, including short-term and long-term memory strategies.'
 integrationType: session-manager
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/session-managers/strands-valkey-session-manager.mdx
+++ b/site/src/content/docs/community/session-managers/strands-valkey-session-manager.mdx
@@ -1,7 +1,7 @@
 ---
 title: Strands Valkey Session Manager
 community: true
-description: Valkey session manager
+description: 'Store Strands agent sessions in Valkey or Redis for low-latency, distributed conversation persistence across interactions.'
 integrationType: session-manager
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/tools/strands-deepgram.mdx
+++ b/site/src/content/docs/community/tools/strands-deepgram.mdx
@@ -8,7 +8,7 @@ service:
   link: https://console.deepgram.com/
 title: strands-deepgram
 community: true
-description: Deepgram speech-to-text
+description: 'Add speech-to-text, text-to-speech, and audio intelligence to Strands agents with the Deepgram voice AI platform.'
 integrationType: tool
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/tools/strands-google.mdx
+++ b/site/src/content/docs/community/tools/strands-google.mdx
@@ -8,7 +8,7 @@ service:
   link: https://console.cloud.google.com/
 title: strands-google
 community: true
-description: Google API integration
+description: 'Give Strands agents access to 200+ Google APIs, including Gmail, Drive, Calendar, Sheets, and YouTube, from a single tool.'
 integrationType: tool
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/tools/strands-hubspot.mdx
+++ b/site/src/content/docs/community/tools/strands-hubspot.mdx
@@ -8,7 +8,7 @@ service:
   link: https://developers.hubspot.com/
 title: strands-hubspot
 community: true
-description: HubSpot CRM integration
+description: 'Query HubSpot CRM data from Strands agents with read-only tools for sales intelligence, customer research, and analytics.'
 integrationType: tool
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/tools/strands-perplexity.mdx
+++ b/site/src/content/docs/community/tools/strands-perplexity.mdx
@@ -8,7 +8,7 @@ service:
   link: https://docs.perplexity.ai/
 title: strands-perplexity
 community: true
-description: Perplexity web search
+description: 'Real-time web search for Strands agents using the Perplexity Search API, with citations and regional filtering.'
 integrationType: tool
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/tools/strands-spraay.mdx
+++ b/site/src/content/docs/community/tools/strands-spraay.mdx
@@ -8,7 +8,7 @@ service:
   link: https://spraay.app
 title: strands-spraay
 community: true
-description: Spraay batch payments on Base
+description: 'Send batch crypto payments from Strands agents with the Spraay Protocol: ETH or ERC-20 tokens to up to 200 recipients on Base.'
 integrationType: tool
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/tools/strands-teams.mdx
+++ b/site/src/content/docs/community/tools/strands-teams.mdx
@@ -8,7 +8,7 @@ service:
   link: https://teams.microsoft.com/
 title: strands-teams
 community: true
-description: Microsoft Teams
+description: 'Send Microsoft Teams notifications from Strands agents with rich Adaptive Cards and custom messaging support.'
 integrationType: tool
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/tools/strands-telegram-listener.mdx
+++ b/site/src/content/docs/community/tools/strands-telegram-listener.mdx
@@ -8,7 +8,7 @@ service:
   link: https://core.telegram.org/bots
 title: strands-telegram-listener
 community: true
-description: Telegram listener
+description: 'Process incoming Telegram messages in real time with Strands agents, with AI-powered auto-replies and event handling.'
 integrationType: tool
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/tools/strands-telegram.mdx
+++ b/site/src/content/docs/community/tools/strands-telegram.mdx
@@ -8,7 +8,7 @@ service:
   link: https://core.telegram.org/bots
 title: strands-telegram
 community: true
-description: Telegram bot
+description: 'Control Telegram bots from Strands agents with 60+ Bot API methods for messaging, media, and chat management.'
 integrationType: tool
 languages: Python
 sidebar:

--- a/site/src/content/docs/community/tools/utcp.mdx
+++ b/site/src/content/docs/community/tools/utcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: Universal Tool Calling Protocol (UTCP)
 community: true
-description: Universal Tool Calling Protocol
+description: 'Let Strands agents discover and call tools directly over native protocols with the Universal Tool Calling Protocol (UTCP).'
 integrationType: tool
 languages: Python
 sidebar:

--- a/site/src/content/docs/contribute/contributing/core-sdk.mdx
+++ b/site/src/content/docs/contribute/contributing/core-sdk.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contributing to the SDK
+description: 'Contribute to the Strands core SDK for Python and TypeScript: find open issues, set up your development environment, and submit changes for review.'
 sidebar:
   label: "SDK"
 ---

--- a/site/src/content/docs/contribute/contributing/documentation.mdx
+++ b/site/src/content/docs/contribute/contributing/documentation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contributing to Documentation
+description: 'Contribute to Strands Agents documentation: run the Astro site locally, use the docs agent skills, and submit anything from typo fixes to new guides.'
 sidebar:
   label: "Documentation"
 ---

--- a/site/src/content/docs/contribute/contributing/extensions.mdx
+++ b/site/src/content/docs/contribute/contributing/extensions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publishing Extensions
+description: 'Package and publish your own Strands components: share tools, model providers, and session managers so other developers can install them.'
 sidebar:
   label: "Extensions"
 ---

--- a/site/src/content/docs/contribute/contributing/feature-proposals.mdx
+++ b/site/src/content/docs/contribute/contributing/feature-proposals.mdx
@@ -1,5 +1,6 @@
 ---
 title: Feature Proposals
+description: 'Propose significant features for the Strands SDK: when to write a design document, what to include, and how the review process works.'
 ---
 
 Building a significant feature takes time. Before you invest that effort, we want to make sure we're aligned on direction. We use a design document process for larger contributions to ensure your work has the best chance of being merged.

--- a/site/src/content/docs/contribute/index.mdx
+++ b/site/src/content/docs/contribute/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contribute
+description: 'Ways to contribute to the Strands Agents ecosystem: fix bugs in the core SDK, improve the documentation, or build and publish extensions.'
 sidebar:
   label: "Overview"
 ---

--- a/site/src/content/docs/examples/README.mdx
+++ b/site/src/content/docs/examples/README.mdx
@@ -1,5 +1,6 @@
 ---
 title: Examples Overview
+description: 'Sample projects for building with Strands Agents: from single-agent tools to multi-agent systems, each example shows patterns you can adapt.'
 sidebar:
   label: "Overview"
 ---

--- a/site/src/content/docs/examples/python/agents_workflows.mdx
+++ b/site/src/content/docs/examples/python/agents_workflows.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Agentic Workflow: Research Assistant - Multi-Agent Collaboration Example"
+description: 'Build a multi-agent research workflow with Strands: researcher, fact-checker, and report writer agents collaborate in sequence on web research.'
 sidebar:
   label: "Agents Workflows"
 ---

--- a/site/src/content/docs/examples/python/file_operations.mdx
+++ b/site/src/content/docs/examples/python/file_operations.mdx
@@ -1,5 +1,6 @@
 ---
 title: File Operations - Strands Agent for File Management
+description: 'Build a Strands agent for file management: read, write, search, and modify files through natural language with file_read, file_write, and editor.'
 sidebar:
   label: "File Operations"
 ---

--- a/site/src/content/docs/examples/python/graph_loops_example.mdx
+++ b/site/src/content/docs/examples/python/graph_loops_example.mdx
@@ -1,5 +1,6 @@
 ---
 title: 🔄 Graph with Loops - Multi-Agent Feedback Cycles
+description: 'Build multi-agent graphs with feedback loops in Strands: a write-review-improve cycle where content iterates until quality standards are met.'
 sidebar:
   label: "Cyclic Graph"
 ---

--- a/site/src/content/docs/examples/python/knowledge_base_agent.mdx
+++ b/site/src/content/docs/examples/python/knowledge_base_agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: Knowledge Base Agent - Intelligent Information Storage and Retrieval
+description: 'Build a Strands agent that routes user queries to an Amazon Bedrock knowledge base, deciding whether to store or retrieve information.'
 sidebar:
   label: "Knowledge-Base Workflow"
 ---

--- a/site/src/content/docs/examples/python/mcp_calculator.mdx
+++ b/site/src/content/docs/examples/python/mcp_calculator.mdx
@@ -1,5 +1,6 @@
 ---
 title: MCP Calculator - Model Context Protocol Integration Example
+description: 'Connect a Strands agent to external tools with the Model Context Protocol: build an MCP calculator server and call its tools from an agent.'
 sidebar:
   label: "MCP"
 ---

--- a/site/src/content/docs/examples/python/memory_agent.mdx
+++ b/site/src/content/docs/examples/python/memory_agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 🧠 Mem0 Memory Agent - Personalized Context Through Persistent Memory
+description: 'Build a Strands agent with persistent memory using mem0.ai: store, retrieve, and apply memories across conversations for personalized responses.'
 sidebar:
   label: "Memory Agent"
 ---

--- a/site/src/content/docs/examples/python/meta_tooling.mdx
+++ b/site/src/content/docs/examples/python/meta_tooling.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Meta-Tooling Example - Strands Agent's Dynamic Tool Creation"
+description: 'Build a Strands agent that creates, loads, and uses new tools at runtime: meta-tooling with the load_tool, shell, and editor tools.'
 sidebar:
   label: "Meta Tooling"
 ---

--- a/site/src/content/docs/examples/python/multi_agent_example/multi_agent_example.mdx
+++ b/site/src/content/docs/examples/python/multi_agent_example/multi_agent_example.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Teacher's Assistant - Strands Multi-Agent Architecture Example"
+description: 'Build a teacher''s assistant with Strands multi-agent architecture: a central orchestrator routes queries to specialized subject-matter agents.'
 sidebar:
   label: "Multi Agents"
 ---

--- a/site/src/content/docs/examples/python/multimodal.mdx
+++ b/site/src/content/docs/examples/python/multimodal.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multi-modal - Strands Agents for Image Generation and Evaluation
+description: 'Build a multi-agent Strands system that generates and evaluates images: two specialized agents collaborate on multimodal content processing.'
 sidebar:
   label: "Multi-modal"
 ---

--- a/site/src/content/docs/examples/python/weather_forecaster.mdx
+++ b/site/src/content/docs/examples/python/weather_forecaster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Weather Forecaster - Strands Agents HTTP Integration Example
+description: 'Build a weather forecasting agent with Strands using the http_request tool and the National Weather Service API, with no API key required.'
 sidebar:
   label: "Weather Forecaster"
 ---

--- a/site/src/content/docs/examples/structured_output.mdx
+++ b/site/src/content/docs/examples/structured_output.mdx
@@ -1,5 +1,6 @@
 ---
 title: Structured Output Example
+description: 'Get type-safe, validated responses from Strands agents with structured output: define a schema in Python or TypeScript and receive a parsed object.'
 sidebar:
   label: "Structured Output"
 redirectFrom:

--- a/site/src/content/docs/labs/ai-functions.mdx
+++ b/site/src/content/docs/labs/ai-functions.mdx
@@ -1,5 +1,6 @@
 ---
 title: AI Functions
+description: 'Build reliable AI-powered applications with Strands AI Functions: Python functions evaluated by reasoning agents, with post-condition checking.'
 ---
 
 [Strands AI Functions](https://github.com/strands-labs/ai-functions) is a Python library for building reliable AI-powered applications through a new abstraction: functions that behave like standard Python functions, but are evaluated by reasoning AI Agents.

--- a/site/src/content/docs/labs/index.mdx
+++ b/site/src/content/docs/labs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Strands Labs
+description: 'Explore Strands Labs, the experimental arm of Strands Agents: open source projects covering robotics, simulation, and new programming abstractions.'
 sidebar:
   label: "Overview"
 ---

--- a/site/src/content/docs/labs/robots-sim.mdx
+++ b/site/src/content/docs/labs/robots-sim.mdx
@@ -1,5 +1,6 @@
 ---
 title: Robots Sim
+description: 'Control robots in simulated environments with natural language through Strands Agents: test vision-language-action policies without hardware.'
 ---
 
 [Strands Robots Sim](https://github.com/strands-labs/robots-sim) is a Python library for controlling robots in simulated environments with natural language through Strands Agents. It lets you develop and test robot control strategies without physical hardware, using the same policy abstraction as [Strands Robots](robots.md).

--- a/site/src/content/docs/labs/robots.mdx
+++ b/site/src/content/docs/labs/robots.mdx
@@ -1,5 +1,6 @@
 ---
 title: Robots
+description: 'Control physical robots with natural language through Strands Agents: vision-language-action policy inference, camera capture, and control loops.'
 ---
 
 [Strands Robots](https://github.com/strands-labs/robots) is a Python library for controlling physical robots with natural language. It provides a policy abstraction layer for vision-language-action (VLA) models and a hardware abstraction layer for robot control, letting you tell a robot what to do without programming it.

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: Conversation Management
+description: 'Keep long agent conversations within token limits using sliding window and summarizing conversation managers in the Strands Agents SDK.'
 tags: [conversation-management, session-management, token-management]
 sourceLinks:
   - path: strands-py/src/strands/agent/conversation_manager/conversation_manager.py

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/steering.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/steering.mdx
@@ -1,11 +1,12 @@
 ---
-title: Steering
-description: "LLM-based contextual guidance for agents using the interventions framework — just-in-time feedback instead of front-loaded prompts."
+title: Steering (Interventions)
+description: 'LLM-based contextual guidance for agents using the interventions framework: just-in-time feedback instead of front-loaded prompts.'
 tags: [hooks, event-loop, tool-execution]
 sourceLinks:
   - path: strands-py/src/strands/vended_plugins/steering/core/handler.py
   - path: strands-ts/src/vended-interventions/steering/handlers/llm.ts
 sidebar:
+  label: Steering
   badge:
     text: New
     variant: tip

--- a/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Prompts
+description: 'Write system prompts and user messages for Strands agents. Covers multi-modal prompting, direct tool calls, and prompt engineering with agent SOPs.'
 tags: [safety, conversation-management, prompt-authoring]
 sourceLinks:
   - path: strands-py/src/strands/agent/agent.py

--- a/site/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
@@ -1,5 +1,6 @@
 ---
 title: Retry Strategies
+description: 'Handle model provider rate limits in Strands agents. Configure retry strategies with exponential backoff, custom parameters, or your own retry logic.'
 tags: [event-loop, error-handling]
 sourceLinks:
   - path: strands-py/src/strands/event_loop/_retry.py

--- a/site/src/content/docs/user-guide/concepts/agents/state.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/state.mdx
@@ -1,5 +1,6 @@
 ---
 title: State Management
+description: 'Maintain state in Strands agents across turns and sessions: conversation history, key-value agent state, and per-request invocation state.'
 sidebar:
   label: "State"
 tags: [state, snapshots, session-management]

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: BidiAgent
+description: 'Build real-time voice conversations with BidiAgent. Stream audio and text over persistent connections with interruptions and concurrent tool calling.'
 experimental: true
 tags: [bidi-streaming]
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
@@ -1,5 +1,6 @@
 ---
 title: Events
+description: 'Send and receive bidirectional streaming events in Strands agents. Process audio, text, and tool activity in real time over persistent connections.'
 experimental: true
 tags: [bidi-streaming]
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: Bidirectional Streaming Hooks
+description: 'Extend BidiAgent with hooks for bidirectional streaming events: connection lifecycle, interruptions, restarts, and real-time conversation logging.'
 sidebar:
   label: "Hooks"
 experimental: true

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/interruption.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/interruption.mdx
@@ -1,5 +1,6 @@
 ---
 title: Interruptions
+description: 'Handle real-time voice interruptions in BidiAgent. Voice Activity Detection stops responses mid-stream for natural, human-like conversations.'
 experimental: true
 tags: [bidi-streaming]
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/io.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/io.mdx
@@ -1,5 +1,6 @@
 ---
 title: I/O Channels
+description: 'Connect microphones, speakers, consoles, and WebSockets to a Strands bidi-agent with BidiInput and BidiOutput channels for audio and text.'
 experimental: true
 sidebar:
   label: "IO"

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
@@ -1,5 +1,6 @@
 ---
 title: Gemini Live
+description: 'Build real-time voice agents with Gemini Live and Strands. Stream audio and text over WebSocket with interruptions and tool calling.'
 experimental: true
 tags: [bidi-streaming]
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
@@ -1,5 +1,6 @@
 ---
 title: Nova Sonic
+description: 'Build real-time speech-to-speech agents with Amazon Nova Sonic and Strands. Bidirectional audio streaming with interruption handling and tool calling.'
 experimental: true
 tags: [bidi-streaming, aws, bedrock]
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenAI Realtime
+description: 'Build low-latency voice agents with the OpenAI Realtime API and Strands. Configure speech-to-speech streaming, interruptions, and tool calling.'
 experimental: true
 tags: [bidi-streaming]
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: Quickstart
+title: Voice & Realtime Quickstart
 tags: [bidi-streaming, quickstart]
 description: "Build voice-enabled AI agents with real-time audio streaming. Works with Amazon Nova Sonic, Gemini Live, and OpenAI Realtime."
 experimental: true

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/session-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/session-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: Bidirectional Streaming Session Management
+description: 'Persist BidiAgent conversation history and state across bidirectional streaming sessions so voice assistants resume where they left off.'
 sidebar:
   label: "Session Management"
 experimental: true

--- a/site/src/content/docs/user-guide/concepts/experimental/agent-config.mdx
+++ b/site/src/content/docs/user-guide/concepts/experimental/agent-config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Agent Configuration
+description: 'Create Strands agents from JSON files or dictionaries with the experimental config_to_agent function, including tool loading and model settings.'
 tags: [tool-authoring, bedrock, prompt-authoring]
 experimental: true
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -1,5 +1,6 @@
 ---
 title: Amazon Bedrock
+description: 'Use Amazon Bedrock models in Strands agents. Configure AWS credentials, model settings, guardrails, prompt caching, and multi-modal input.'
 integrationType: model-provider
 tags: [bedrock, aws, vision, safety, caching]
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-nova.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-nova.mdx
@@ -1,5 +1,6 @@
 ---
 title: Amazon Nova
+description: 'Use Amazon Nova models in Strands agents with the strands-amazon-nova package. Install the provider, configure NovaAPIModel, and generate text.'
 languages: Python
 integrationType: model-provider
 tags: [bedrock, aws, vision]

--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -1,5 +1,6 @@
 ---
 title: Anthropic
+description: 'Run Strands agents on Claude models through the Anthropic API. Install the provider, configure AnthropicModel, and enable structured output and caching.'
 tags: [structured-output, caching]
 integrationType: model-provider
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
@@ -1,5 +1,6 @@
 ---
 title: Creating a Custom Model Provider
+description: 'Build a custom model provider for the Strands Agents SDK. Implement the Model interface to run agents against your own LLM service.'
 tags: [tool-execution]
 sidebar:
   label: "Custom Providers"

--- a/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -1,5 +1,6 @@
 ---
 title: Google
+description: 'Run Strands agents on Google Gemini models. Configure the provider, use built-in tools and structured output, and send image and video input.'
 tags: [vision]
 integrationType: model-provider
 redirectFrom:

--- a/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
@@ -1,5 +1,6 @@
 ---
 title: LiteLLM
+description: 'Use LiteLLM with Strands agents to access models from OpenAI, Anthropic, Amazon, and more through one API. Install and configure LiteLLMModel.'
 tags: [structured-output]
 languages: Python
 integrationType: model-provider

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
@@ -1,5 +1,6 @@
 ---
 title: Llama API
+description: 'Run Strands agents on Meta-hosted Llama models with the Llama API provider. Install, configure LlamaAPIModel, and build without managing inference.'
 tags: [local-models]
 languages: Python
 sidebar:

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
@@ -1,5 +1,6 @@
 ---
 title: llama.cpp
+description: 'Run Strands agents against a local llama.cpp server with quantized models. Configure LlamaCppModel, grammar constraints, and advanced sampling.'
 tags: [local-models]
 languages: Python
 integrationType: model-provider

--- a/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
@@ -1,5 +1,6 @@
 ---
 title: Mistral AI
+description: 'Use Mistral AI models in Strands agents. Install the Mistral provider, configure MistralModel, and run agents with tool calling and streaming.'
 languages: Python
 sidebar:
   label: "MistralAI"

--- a/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -1,5 +1,6 @@
 ---
 title: Ollama
+description: 'Run Strands agents on local models with Ollama. Configure OllamaModel for text generation, image understanding, tool calling, and streaming.'
 tags: [local-models]
 languages: Python
 integrationType: model-provider

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenAI Responses API
+description: 'Use the OpenAI Responses API with Strands agents for built-in tools like web search and code interpreter, plus server-side conversation state.'
 tags: [mcp, state]
 integrationType: model-provider
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenAI
+description: 'Run Strands agents on OpenAI models or any OpenAI-compatible API. Install the provider, configure OpenAIModel, and enable vision and structured output.'
 tags: [vision, structured-output]
 integrationType: model-provider
 sourceLinks:

--- a/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
@@ -1,5 +1,6 @@
 ---
 title: Amazon SageMaker
+description: 'Run Strands agents against models deployed on Amazon SageMaker inference endpoints, including JumpStart models and custom fine-tuned models.'
 languages: Python
 sidebar:
   label: "SageMaker"

--- a/site/src/content/docs/user-guide/concepts/model-providers/vercel.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/vercel.mdx
@@ -1,5 +1,6 @@
 ---
 title: Vercel
+description: 'Bring any Vercel AI SDK provider into Strands agents with the VercelModel adapter. Use @ai-sdk packages for OpenAI, Anthropic, Bedrock, and more.'
 tags: [vision]
 languages: TypeScript
 integrationType: model-provider

--- a/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
@@ -1,5 +1,6 @@
 ---
 title: Writer
+description: 'Use Writer Palmyra models in Strands agents. Configure WriterModel for tool calling, structured output, and domain-specific enterprise tasks.'
 tags: [vision, structured-output]
 languages: Python
 integrationType: model-provider

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: Agent-to-Agent (A2A) Protocol
+description: 'Connect Strands agents across platforms with the Agent-to-Agent (A2A) protocol. Serve agents over A2A and call remote agents from your own.'
 sidebar:
   label: "Agent2Agent (A2A)"
 tags: [multi-agent]

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -1,5 +1,6 @@
 ---
 title: Agents as Tools with Strands Agents SDK
+description: 'Wrap specialized Strands agents as callable tools so an orchestrator agent can delegate tasks to domain experts in a hierarchical pattern.'
 sidebar:
   label: "Agents as Tools"
 tags: [multi-agent, tool-authoring, tool-execution]

--- a/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
@@ -1,5 +1,6 @@
 ---
 title: Graph Multi-Agent Pattern
+description: 'Orchestrate multi-agent systems with the Strands Graph pattern: deterministic DAG or cyclic execution, conditional edges, and nested agents.'
 sidebar:
   label: "Graph"
 tags: [multi-agent]

--- a/site/src/content/docs/user-guide/concepts/multi-agent/swarm.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/swarm.mdx
@@ -1,5 +1,6 @@
 ---
 title: Swarm Multi-Agent Pattern
+description: 'Build self-organizing agent teams with the Strands Swarm pattern. Agents collaborate through autonomous handoffs, shared context, and working memory.'
 sidebar:
   label: "Swarm"
 tags: [multi-agent]

--- a/site/src/content/docs/user-guide/concepts/multi-agent/workflow.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/workflow.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Agent Workflows: Building Multi-Agent Systems with Strands Agents SDK"
+description: 'Coordinate multiple AI agents in sequential workflows with Strands. Define tasks, manage dependencies, and pass context between specialized agents.'
 sidebar:
   label: "Workflow"
 tags: [multi-agent]

--- a/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -1,5 +1,6 @@
 ---
 title: Context Offloader
+description: 'Prevent large tool results from consuming the context window. ContextOffloader stores oversized results externally and leaves retrievable references.'
 tags: [conversation-management, hooks, token-management]
 sourceLinks:
   - path: strands-py/src/strands/vended_plugins/context_offloader/plugin.py

--- a/site/src/content/docs/user-guide/concepts/plugins/skills.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/skills.mdx
@@ -1,5 +1,6 @@
 ---
 title: Skills
+description: 'Give Strands agents on-demand access to specialized instructions with the AgentSkills plugin. Progressive disclosure keeps the system prompt lean.'
 tags: [token-management, prompt-authoring]
 sourceLinks:
   - path: strands-py/src/strands/vended_plugins/skills/agent_skills.py

--- a/site/src/content/docs/user-guide/concepts/plugins/steering.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/steering.mdx
@@ -1,7 +1,10 @@
 ---
-title: Steering
+title: Steering (Plugins)
+description: 'Guide Strands agents with just-in-time contextual feedback using plugin-based steering handlers instead of monolithic prompts.'
 tags: [hooks, conversation-management, prompt-authoring]
 languages: [python]
+sidebar:
+  label: Steering
 sourceLinks:
   - path: strands-py/src/strands/vended_plugins/steering/core/handler.py
   - path: strands-py/src/strands/vended_plugins/steering/handlers/llm/llm_handler.py

--- a/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
@@ -1,5 +1,6 @@
 ---
 title: Async Iterators for Streaming
+description: 'Stream Strands agent events asynchronously with async iterators. Process text, tool usage, and lifecycle events in FastAPI and other async frameworks.'
 sidebar:
   label: "Async Iterators"
 tags: [streaming]

--- a/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Callback Handlers
+description: 'Intercept Strands agent events in Python with callback handlers. Monitor streaming text and tool usage in real time or format custom output.'
 tags: [streaming]
 sourceLinks:
   - path: strands-py/src/strands/handlers/callback_handler.py

--- a/site/src/content/docs/user-guide/concepts/tools/community-tools-package.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/community-tools-package.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Built Tools
+description: 'Get started fast with pre-built community tools for Strands agents: file operations, shell, web requests, memory, and more via strands-agents-tools.'
 tags: [tool-authoring]
 sidebar:
   label: "Community Tools Package"

--- a/site/src/content/docs/user-guide/concepts/tools/executors.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/executors.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tool Executors
+description: 'Control whether Strands agents run tool calls concurrently or sequentially. Covers tool executors, event ordering, cancellation, and custom executors.'
 sidebar:
   label: "Executors"
 tags: [tool-execution, event-loop]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_amazon_ec2.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_amazon_ec2.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploying Strands Agents SDK Agents to Amazon EC2
+description: 'Deploy Strands agents to Amazon EC2 with the AWS CDK: run a FastAPI agent on a virtual server with full control over the infrastructure.'
 sidebar:
   label: "Amazon EC2"
 tags: [deployment, aws]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_amazon_eks.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_amazon_eks.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploying Strands Agents SDK Agents to Amazon EKS
+description: 'Deploy Strands agents to Amazon EKS Auto Mode: containerize a FastAPI agent and run it on managed Kubernetes with high availability.'
 sidebar:
   label: "Amazon EKS"
 tags: [deployment, aws]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_aws_apprunner.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_aws_apprunner.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploying Strands Agents SDK Agents to AWS App Runner
+description: 'Deploy Strands agents to AWS App Runner: containerize a FastAPI agent and get a fully managed HTTPS endpoint with auto scaling built in.'
 sidebar:
   label: "AWS App Runner"
 tags: [deployment, aws]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_aws_fargate.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_aws_fargate.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploying Strands Agents SDK Agents to AWS Fargate
+description: 'Deploy Strands agents to AWS Fargate: run a containerized FastAPI agent with streaming responses on serverless Amazon ECS infrastructure.'
 sidebar:
   label: "AWS Fargate"
 tags: [deployment, aws]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploying Strands Agents SDK Agents to AWS Lambda
+description: 'Deploy Strands agents to AWS Lambda with the AWS CDK: package a Python agent handler and run it serverless, paying only for compute you use.'
 sidebar:
   label: "AWS Lambda"
 tags: [deployment, aws]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/index.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploying Strands Agents to Amazon Bedrock AgentCore Runtime
+description: 'Deploy Strands agents to Amazon Bedrock AgentCore Runtime: a serverless, session-isolated platform that scales agents without managing servers.'
 sidebar:
   label: "Overview"
 tags: [deployment, aws, bedrock, agentcore]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/python.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/python.mdx
@@ -1,5 +1,6 @@
 ---
 title: Python Deployment to Amazon Bedrock AgentCore Runtime
+description: 'Deploy a Python Strands agent to Amazon Bedrock AgentCore Runtime using the SDK integration wrapper or a custom FastAPI implementation.'
 sidebar:
   label: "Python"
 tags: [deployment, aws, bedrock, agentcore]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/typescript.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/typescript.mdx
@@ -1,5 +1,6 @@
 ---
 title: TypeScript Deployment to Amazon Bedrock AgentCore Runtime
+description: 'Deploy a TypeScript Strands agent to Amazon Bedrock AgentCore Runtime: build an Express server, containerize it with Docker, and push to ECR.'
 sidebar:
   label: "TypeScript"
 tags: [deployment, aws, bedrock, agentcore]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_docker/index.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_docker/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploying Strands Agents to Docker
+description: 'Containerize Strands agents with Docker: package your Python or TypeScript agent into a portable image and test it before cloud deployment.'
 sidebar:
   label: "Overview"
 tags: [deployment]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_docker/python.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_docker/python.mdx
@@ -1,5 +1,6 @@
 ---
 title: Python Deployment to Docker
+description: 'Containerize a Python Strands agent with Docker: set up a FastAPI server with uv, write a Dockerfile, and run the agent locally in a container.'
 sidebar:
   label: "Python"
 tags: [deployment]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_docker/typescript.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_docker/typescript.mdx
@@ -1,5 +1,6 @@
 ---
 title: TypeScript Deployment to Docker
+description: 'Containerize a TypeScript Strands agent with Docker: build an Express server with the SDK, write a Dockerfile, and test the container locally.'
 sidebar:
   label: "TypeScript"
 tags: [deployment]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_kubernetes.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_kubernetes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploy to Kubernetes
+description: 'Deploy containerized Strands agents to Kubernetes: create a local Kind cluster, write deployment manifests, and run your Docker agent image.'
 sidebar:
   label: "Kubernetes"
 tags: [deployment]

--- a/site/src/content/docs/user-guide/deploy/deploy_to_terraform.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_terraform.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploy to Terraform
+description: 'Deploy Strands agents with Terraform infrastructure as code to AWS App Runner, AWS Lambda, Google Cloud Run, or Azure Container Instances.'
 sidebar:
   label: "Terraform"
 tags: [deployment]

--- a/site/src/content/docs/user-guide/deploy/deploy_with_nx_plugin_for_aws.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_with_nx_plugin_for_aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploy with Nx Plugin for AWS
+description: 'Scaffold and deploy Strands agents on AWS with the Nx Plugin for AWS: generate Python or TypeScript agents with CDK or Terraform included.'
 sidebar:
   label: "Nx Plugin for AWS"
 tags: [deployment]

--- a/site/src/content/docs/user-guide/evals-sdk/chaos_testing.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/chaos_testing.mdx
@@ -1,5 +1,6 @@
 ---
 title: Chaos Testing
+description: 'Test agent resilience by injecting controlled tool failures with ChaosPlugin: simulate timeouts, network errors, and corrupted responses safely.'
 tags: [error-handling, simulation]
 sidebar:
   label: "Chaos Testing"

--- a/site/src/content/docs/user-guide/evals-sdk/cli.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/cli.mdx
@@ -1,5 +1,6 @@
 ---
 title: Command-Line Interface
+description: 'Run agent evaluations from the command line with strands-evals: execute experiments, validate JSON, render reports, and diagnose failures in CI.'
 sidebar:
   label: "CLI"
 ---

--- a/site/src/content/docs/user-guide/evals-sdk/detectors/diagnosis.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/detectors/diagnosis.mdx
@@ -1,5 +1,6 @@
 ---
 title: Session Diagnosis
+description: 'Run the full failure diagnosis pipeline with diagnose_session: detect failures, analyze root causes, and get deduplicated fix recommendations.'
 tags: [failure-diagnosis, observability, error-handling]
 sidebar:
   label: "Session Diagnosis"

--- a/site/src/content/docs/user-guide/evals-sdk/detectors/failure_detection.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/detectors/failure_detection.mdx
@@ -1,5 +1,6 @@
 ---
 title: Failure Detection
+description: 'Detect semantic failures in agent traces with detect_failures: hallucinations, tool misuse, and policy violations across a 20+ category taxonomy.'
 tags: [failure-diagnosis, error-handling]
 sidebar:
   label: "Failure Detection"

--- a/site/src/content/docs/user-guide/evals-sdk/detectors/index.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/detectors/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Detectors
+description: 'Find out why your agent failed: detectors analyze execution traces to detect failures, classify root causes, and recommend concrete fixes.'
 tags: [failure-diagnosis, error-handling]
 sidebar:
   label: "Overview"

--- a/site/src/content/docs/user-guide/evals-sdk/detectors/root_cause_analysis.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/detectors/root_cause_analysis.mdx
@@ -1,5 +1,6 @@
 ---
 title: Root Cause Analysis
+description: 'Trace failure chains in agent sessions with analyze_root_cause: classify causality, assess propagation impact, and get fix recommendations.'
 tags: [failure-diagnosis, observability, error-handling]
 sidebar:
   label: "Root Cause Analysis"

--- a/site/src/content/docs/user-guide/evals-sdk/eval-sop.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/eval-sop.mdx
@@ -1,5 +1,6 @@
 ---
 title: Eval SOP - AI-Powered Evaluation Workflow
+description: 'Follow a structured AI-assisted evaluation workflow with Eval SOP, from planning and test data generation to evaluation execution and reporting.'
 sidebar:
   label: "Eval SOP"
 ---

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/coherence_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/coherence_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Coherence Evaluator
+description: 'Assess the logical consistency and flow of agent responses with CoherenceEvaluator, an LLM judge with a five-level scoring rubric.'
 tags: [conversation-management]
 sidebar:
   label: "Coherence"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/conciseness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/conciseness_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Conciseness Evaluator
+description: 'Catch verbose agent responses with ConcisenessEvaluator, which scores how efficiently a response communicates on a three-level scale.'
 tags: [conversation-management]
 sidebar:
   label: "Conciseness"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/correctness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/correctness_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Correctness Evaluator
+description: 'Check the factual correctness of agent responses with CorrectnessEvaluator, from conversation context alone or against an expected reference answer.'
 sidebar:
   label: "Correctness"
 ---

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/custom_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/custom_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Custom Evaluator
+description: 'Build domain-specific evaluation logic by extending the Evaluator base class: custom scoring, external services, and specialized data analysis.'
 sidebar:
   label: "Custom"
 ---

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/deterministic_evaluators.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/deterministic_evaluators.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deterministic Evaluators
+description: 'Run fast, code-based checks without LLM judges: deterministic evaluators match outputs, verify tool calls, and compare state for CI/CD pipelines.'
 tags: [tool-evaluation]
 sidebar:
   label: "Deterministic"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/failure_communication_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/failure_communication_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Failure Communication Evaluator
+description: 'Rate how clearly your agent explains tool failures to users with FailureCommunicationEvaluator: clarity, actionability, transparency, and tone.'
 tags: [error-handling, tool-evaluation, simulation]
 sidebar:
   label: "Failure Communication"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/faithfulness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/faithfulness_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Faithfulness Evaluator
+description: 'Detect hallucinations with FaithfulnessEvaluator by checking whether agent statements stay grounded in the preceding conversation history.'
 sidebar:
   label: "Faithfulness"
 ---

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/goal_success_rate_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/goal_success_rate_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Goal Success Rate Evaluator
+description: 'Determine whether an agent accomplished all user goals across an entire conversation session with the GoalSuccessRateEvaluator''s binary score.'
 tags: [conversation-management]
 sidebar:
   label: "Goal Success Rate"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/harmfulness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/harmfulness_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Harmfulness Evaluator
+description: 'Screen agent responses for dangerous or offensive content with the binary harmful or not-harmful classification of HarmfulnessEvaluator.'
 tags: [safety]
 sidebar:
   label: "Harmfulness"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/helpfulness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/helpfulness_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Helpfulness Evaluator
+description: 'Measure how helpful agent responses are from the user''s perspective with HelpfulnessEvaluator and its seven-level scoring scale.'
 tags: [conversation-management]
 sidebar:
   label: "Helpfulness"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Evaluators
+description: 'Choose the right evaluator for your agent: browse built-in LLM-judge and deterministic evaluators for output quality, tool use, and goal success.'
 sidebar:
   label: "Overview"
 ---

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/instruction_following_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/instruction_following_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Instruction Following Evaluator
+description: 'Evaluate whether agent responses comply with explicit prompt instructions using the binary scoring of InstructionFollowingEvaluator.'
 tags: [safety, prompt-authoring]
 sidebar:
   label: "Instruction Following"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/interactions_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/interactions_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Interactions Evaluator
+description: 'Evaluate multi-agent workflows step by step with InteractionsEvaluator, scoring each interaction with node-specific rubrics and dependencies.'
 tags: [conversation-management]
 sidebar:
   label: "Interactions"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multimodal Correctness Evaluator
+description: 'Fact-check agent responses against image content with MultimodalCorrectnessEvaluator: objects, counts, colors, positions, and readable text.'
 tags: [multimodal-evaluation, vision]
 sidebar:
   label: "Multimodal Correctness"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multimodal Faithfulness Evaluator
+description: 'Catch visual hallucinations with MultimodalFaithfulnessEvaluator, which checks agent responses for invented details not grounded in the image.'
 tags: [multimodal-evaluation, vision]
 sidebar:
   label: "Multimodal Faithfulness"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multimodal Instruction Following Evaluator
+description: 'Verify responses on image tasks satisfy explicit constraints like count, format, and scope with MultimodalInstructionFollowingEvaluator.'
 tags: [multimodal-evaluation, vision]
 sidebar:
   label: "Multimodal Instruction Following"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multimodal Output Evaluator
+description: 'Evaluate agent outputs on image and document tasks with MultimodalOutputEvaluator, which judges responses against a custom rubric using an MLLM.'
 tags: [multimodal-evaluation, vision]
 sidebar:
   label: "Multimodal Output"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multimodal Overall Quality Evaluator
+description: 'Score overall response quality on image tasks with MultimodalOverallQualityEvaluator: visual accuracy, instruction adherence, and coherence.'
 tags: [multimodal-evaluation, vision]
 sidebar:
   label: "Multimodal Overall Quality"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/output_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/output_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Output Evaluator
+description: 'Score agent responses against a custom rubric with OutputEvaluator, an LLM-as-a-judge evaluator for safety, relevance, accuracy, and completeness.'
 tags: [conversation-management]
 sidebar:
   label: "Output"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/partial_completion_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/partial_completion_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Partial Completion Evaluator
+description: 'Measure the fraction of a user goal an agent achieved with PartialCompletionEvaluator, a continuous 0.0 to 1.0 score for multi-step tasks.'
 tags: [error-handling, tool-evaluation, simulation]
 sidebar:
   label: "Partial Completion"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/recovery_strategy_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/recovery_strategy_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Recovery Strategy Evaluator
+description: 'Score how well an agent recovers from tool failures with RecoveryStrategyEvaluator: alternative approaches, retries, and strategy variation.'
 tags: [error-handling, tool-evaluation, simulation]
 sidebar:
   label: "Recovery Strategy"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/refusal_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/refusal_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Refusal Evaluator
+description: 'Detect when an agent refuses a user request with RefusalEvaluator, which separates true refusals from merely irrelevant responses.'
 tags: [safety]
 sidebar:
   label: "Refusal"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/response_relevance_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/response_relevance_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Response Relevance Evaluator
+description: 'Verify agent responses address what the user actually asked with ResponseRelevanceEvaluator and its five-level relevance scale.'
 sidebar:
   label: "Response Relevance"
 ---

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/stereotyping_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/stereotyping_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stereotyping Evaluator
+description: 'Flag biased or stereotypical content in agent responses with StereotypingEvaluator, including stereotypes the response later rejects.'
 tags: [safety]
 sidebar:
   label: "Stereotyping"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tool Parameter Accuracy Evaluator
+description: 'Verify tool call parameters are grounded in conversation context, not hallucinated, with per-call checks from ToolParameterAccuracyEvaluator.'
 tags: [tool-evaluation]
 sidebar:
   label: "Tool Parameter Accuracy"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_selection_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_selection_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tool Selection Accuracy Evaluator
+description: 'Check that your agent picks the right tool at the right time with ToolSelectionAccuracyEvaluator, which judges each tool call in context.'
 tags: [tool-evaluation]
 sidebar:
   label: "Tool Selection Accuracy"

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/trajectory_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/trajectory_evaluator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Trajectory Evaluator
+description: 'Judge the sequence of tool calls and actions an agent took with TrajectoryEvaluator, including exact, in-order, and any-order matching tools.'
 tags: [tool-evaluation]
 sidebar:
   label: "Trajectory"

--- a/site/src/content/docs/user-guide/evals-sdk/experiment_generator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/experiment_generator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Experiment Generator
+description: 'Generate evaluation experiments automatically with ExperimentGenerator: LLM-created test cases, rubrics, and topic-based coverage for your agent.'
 tags: [simulation]
 ---
 

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/agentcore_evaluation_dashboard.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/agentcore_evaluation_dashboard.mdx
@@ -1,5 +1,6 @@
 ---
 title: AgentCore Evaluation Dashboard Configuration
+description: 'Configure ADOT to send Strands evaluation results to Amazon CloudWatch and visualize scores in the Bedrock AgentCore observability dashboard.'
 tags: [agentcore, aws, bedrock, observability]
 ---
 

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
@@ -1,5 +1,6 @@
 ---
 title: Task Decorator
+description: 'Write evaluation task functions with the @eval_task decorator, which handles telemetry, session mapping, and result normalization for you.'
 tags: [observability]
 sidebar:
   label: "Task Decorator"

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/experiment_management.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/experiment_management.mdx
@@ -1,5 +1,6 @@
 ---
 title: Experiment Management
+description: 'Organize evaluation test cases into experiments: use metadata for filtering, group related cases, and adapt experiments across agent versions.'
 ---
 
 ## Overview

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/result_caching.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/result_caching.mdx
@@ -1,5 +1,6 @@
 ---
 title: Result Caching
+description: 'Cache task execution results with EvaluationDataStore so you can iterate on evaluators without re-invoking expensive or slow agent calls.'
 tags: [caching]
 sidebar:
   label: "Result Caching"

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/serialization.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/serialization.mdx
@@ -1,5 +1,6 @@
 ---
 title: Serialization
+description: 'Save, load, version, and share evaluation work with JSON serialization for Strands Evals experiments and evaluation reports.'
 tags: [snapshots]
 ---
 

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Evaluating Remote Traces
+description: 'Evaluate production agent traces without re-running them: fetch execution data from CloudWatch, Langfuse, or OpenSearch with trace providers.'
 tags: [observability]
 ---
 

--- a/site/src/content/docs/user-guide/evals-sdk/quickstart.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: Strands Evaluation Quickstart
+description: 'Start evaluating AI agents with Strands Evaluation: install the SDK, build your first experiment, run built-in evaluators, and analyze results.'
 tags: [quickstart]
 sidebar:
   label: "Getting Started"

--- a/site/src/content/docs/user-guide/evals-sdk/simulators/index.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/simulators/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Simulators
+description: 'Evaluate agents with dynamic simulators that drive multi-turn conversations and generate realistic tool responses beyond static test cases.'
 tags: [simulation]
 sidebar:
   label: "Overview"

--- a/site/src/content/docs/user-guide/evals-sdk/simulators/tool_simulation.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/simulators/tool_simulation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tool Simulation
+description: 'Replace real tool execution with LLM-generated, schema-validated responses using ToolSimulator to evaluate agents without live infrastructure.'
 tags: [simulation, tool-evaluation]
 ---
 

--- a/site/src/content/docs/user-guide/evals-sdk/simulators/user_simulation.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/simulators/user_simulation.mdx
@@ -1,5 +1,6 @@
 ---
 title: User Simulation
+description: 'Simulate realistic end users with ActorSimulator to evaluate agents in dynamic, goal-oriented multi-turn conversations without scripted inputs.'
 tags: [simulation, conversation-management]
 ---
 

--- a/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Logging
+description: 'Configure logging for Strands agents in Python and TypeScript: set log levels, add handlers, and capture debug output from SDK operations.'
 sidebar:
   label: "Logs"
 tags: [observability, pii]

--- a/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
@@ -1,5 +1,6 @@
 ---
 title: Metrics
+description: 'Track agent performance metrics in Strands: token usage, latency, tool call counts, and event loop cycles, all available through AgentResult.'
 tags: [observability]
 ---
 

--- a/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -1,5 +1,6 @@
 ---
 title: Traces
+description: 'Trace agent execution end to end with OpenTelemetry in Strands: capture model interactions, tool calls, token usage, and event loop cycles.'
 tags: [observability]
 ---
 

--- a/site/src/content/docs/user-guide/safety-security/pii-redaction.mdx
+++ b/site/src/content/docs/user-guide/safety-security/pii-redaction.mdx
@@ -1,5 +1,6 @@
 ---
 title: PII Redaction
+description: 'Protect personal data in agent telemetry: integrate PII redaction with third-party libraries or OpenTelemetry Collector masking in Strands.'
 tags: [safety, pii, observability, aws]
 ---
 

--- a/site/src/content/docs/user-guide/safety-security/prompt-engineering.mdx
+++ b/site/src/content/docs/user-guide/safety-security/prompt-engineering.mdx
@@ -1,5 +1,6 @@
 ---
 title: Prompt Engineering
+description: 'Write secure system prompts for Strands agents: defend against prompt injection, sanitize inputs, and validate parameters and outputs.'
 tags: [safety, conversation-management, prompt-authoring]
 ---
 

--- a/site/src/content/docs/user-guide/safety-security/responsible-ai.mdx
+++ b/site/src/content/docs/user-guide/safety-security/responsible-ai.mdx
@@ -1,5 +1,6 @@
 ---
 title: Responsible AI
+description: 'Build AI agents responsibly with Strands: least-privilege tool design, input validation, audit logging, and ethical deployment practices.'
 tags: [safety]
 ---
 

--- a/site/src/content/docs/user-guide/versioning-and-support.mdx
+++ b/site/src/content/docs/user-guide/versioning-and-support.mdx
@@ -1,5 +1,6 @@
 ---
 title: Versioning and Support Policy
+description: 'How the Strands SDK versions releases: semantic versioning guarantees, experimental feature policies, and deprecation timelines explained.'
 sidebar:
   label: "Versioning & Support"
 ---


### PR DESCRIPTION
## Description

An SEO audit of strandsagents.com found that 133 of 212 docs pages (63%) had no `description` frontmatter, so search engines synthesize their own snippets and the TechArticle JSON-LD omits its description field. Another 24 community catalog pages had one-to-three-word descriptions ("MLX", "vLLM", "Telegram bot") that double as meta descriptions. Two pages both titled "Steering" (interventions vs plugins) rendered identical `<title>` tags, and one bare "Quickstart" title collided in feel with the four other, qualified quickstart titles.

This PR fills in every missing description (deploy, examples, concepts, evals-sdk, observability, community, contribute, labs, API landing pages) and rewrites the terse catalog blurbs. Each description is 100–160 characters, unique site-wide, written from the page's actual content, and follows the docs voice guide and terminology lock. The community descriptions were kept at the punchy end (~109–129 chars) because they also render in the community-packages catalog table.

Title fixes: the two Steering pages become "Steering (Interventions)" and "Steering (Plugins)" — matching how the pages already cross-reference each other — with `sidebar.label: Steering` added so the sidebar rendering is unchanged. The bare "Quickstart" becomes "Voice & Realtime Quickstart", matching its navigation.yml section label.

Descriptions also flow into `llms.txt` (a companion PR adds per-link description output), so this doubles as GEO groundwork.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

This PR is entirely documentation frontmatter under `site/`.

## Type of Change

Documentation update

## Testing

Verified programmatically across the full diff: every changed content file has exactly one added `description:` line (or the title/sidebar-label change), all descriptions are 100–160 characters, zero duplicates site-wide, and YAML parses (including escaped quotes). Full site build succeeds; built HTML spot-checked for the new `<title>` tags, meta descriptions, unchanged sidebar labels, and the community catalog table rendering the longer blurbs.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
