### PR TITLE
fix(site): emit static redirect stubs for legacy MkDocs URLs

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -9,6 +9,7 @@ import remarkReadingTime from './src/plugins/remark-reading-time.ts'
 import watchNavigationPlugin from './src/plugins/vite-plugin-watch-navigation.ts'
 
 import { loadSidebarFromConfig } from "./src/sidebar.ts"
+import { buildStaticRedirects } from "./src/util/redirect.static.ts"
 import { sitemapWithLastmod } from "./src/plugins/sitemap-lastmod.ts"
 import AutoImport from './src/plugins/astro-auto-import.ts'
 import astroExpressiveCode from "astro-expressive-code"
@@ -22,10 +23,19 @@ const sidebar = loadSidebarFromConfig(
   path.resolve('./src/content')
 )
 
+const base = process.env.ASTRO_BASE_PATH || '/'
+
+// Static HTML redirect stubs for known legacy MkDocs URLs (meta refresh +
+// canonical link), so crawlers follow renames that the client-side 404
+// fallback only handles for humans. Dynamic legacy URLs (/latest/*, /1.x/*)
+// can't be enumerated and stay with the 404 fallback (Redirect404.astro).
+const redirects = buildStaticRedirects(path.resolve('./src/content'), base)
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://strandsagents.com',
-  base: process.env.ASTRO_BASE_PATH || '/',
+  base,
+  redirects,
   vite: {
     plugins: [sdkSetupPlugin(), watchNavigationPlugin()],
     // TODO once we separate out CMS build from TS verification, fix this
@@ -58,6 +68,9 @@ export default defineConfig({
       social: [],
       head: [
         { tag: 'meta', attrs: { property: 'og:image', content: 'https://strandsagents.com/og-image.png' } },
+        { tag: 'meta', attrs: { property: 'og:image:width', content: '1200' } },
+        { tag: 'meta', attrs: { property: 'og:image:height', content: '630' } },
+        { tag: 'meta', attrs: { property: 'og:image:alt', content: 'Strands Agents — open source AI agent SDK' } },
         { tag: 'meta', attrs: { name: 'twitter:image', content: 'https://strandsagents.com/og-image.png' } },
       ],
       markdown: {

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,11 +1,8 @@
 import { defineCollection, type SchemaContext } from 'astro:content'
 import { z } from 'astro/zod'
 import { docsSchema } from '@astrojs/starlight/schema'
-// github-slugger is used by Astro internally for default slug generation.
-// We use it here to maintain parity with Astro's default behavior while adding a docs/ prefix.
-import { slug as githubSlug } from 'github-slugger'
 import { glob, file } from 'astro/loaders'
-import { normalizePathToSlug } from './util/links'
+import { pathToDocsSlug } from './util/links'
 import { TagSchema } from './config/tags'
 
 const authorSchema = z.object({
@@ -165,26 +162,9 @@ export const collections = {
 /**
  * Custom generateId function for docs content collection.
  * This mimics Astro's default slug generation (see node_modules/astro/dist/content/loaders/glob.js)
- * but uses our shared normalizePathToSlug utility for consistency with link resolution.
+ * via the shared pathToDocsSlug utility, which redirect.static.ts also uses —
+ * both must agree on ids or redirect stubs point at 404s.
  */
 function generateDocsId({ entry, data }: { entry: string; data: Record<string, unknown> }): string {
-  // If frontmatter has a slug, use it directly
-  if (data.slug) {
-    return `${data.slug}`
-  }
-
-  // Normalize the entry path and slugify each segment using github-slugger (same as Astro default)
-  const normalized = normalizePathToSlug(entry)
-  
-  // Handle root README/index -> use 'index' as the slug (Starlight convention for homepage)
-  if (!normalized) {
-    return 'index'
-  }
-  
-  const slug = normalized
-    .split('/')
-    .map((segment) => githubSlug(segment))
-    .join('/')
-
-  return slug
+  return pathToDocsSlug(entry, data.slug)
 }

--- a/site/src/util/links.ts
+++ b/site/src/util/links.ts
@@ -3,6 +3,10 @@
  * using slugs everywhere, though that's always an option.
  */
 
+// github-slugger is what Astro uses internally for default slug generation;
+// pathToDocsSlug relies on it to stay byte-compatible with Astro's ids.
+import { slug as githubSlug } from 'github-slugger'
+
 /**
  * Check if a link uses the @api shorthand format.
  * Supported formats:
@@ -105,6 +109,35 @@ export function normalizePathToSlug(path: string): string {
   }
 
   return result
+}
+
+/**
+ * Derive the docs content-collection ID (slug) for a content file path:
+ * an explicit frontmatter `slug` wins, otherwise the path is normalized and
+ * each segment slugified the same way Astro's default loader does.
+ *
+ * Single source of truth shared by content.config.ts (generateDocsId) and
+ * redirect.static.ts, which must agree on ids or redirect stubs point at 404s.
+ *
+ * @param entryPath - Content-collection-relative file path (e.g. `docs/user-guide/state.mdx`)
+ * @param slugOverride - The frontmatter `slug` value, if any
+ */
+export function pathToDocsSlug(entryPath: string, slugOverride?: unknown): string {
+  if (slugOverride) {
+    return `${slugOverride}`
+  }
+
+  const normalized = normalizePathToSlug(entryPath)
+
+  // Root README/index -> 'index' (Starlight convention for the homepage)
+  if (!normalized) {
+    return 'index'
+  }
+
+  return normalized
+    .split('/')
+    .map((segment) => githubSlug(segment))
+    .join('/')
 }
 
 /**

--- a/site/src/util/redirect.static.ts
+++ b/site/src/util/redirect.static.ts
@@ -33,6 +33,11 @@ import { pathToDocsSlug } from './links'
 /**
  * Extract frontmatter from a markdown/MDX file. Returns an empty object when
  * the file has no frontmatter block.
+ *
+ * This must stay compatible with the frontmatter parsing Astro's content
+ * loader does (gray-matter): both treat the first `---`-fenced block as YAML.
+ * A divergence would produce a wrong target slug here, which the build-time
+ * "has no content file" validation below then catches.
  */
 function readFrontmatter(filePath: string): Record<string, unknown> {
   const source = fs.readFileSync(filePath, 'utf-8')
@@ -108,6 +113,19 @@ export function buildStaticRedirects(
   staticRedirects: Record<string, string> = STATIC_SLUG_REDIRECTS
 ): Record<string, string> {
   const { slugs, redirectFromEntries } = scanContent(contentDir)
+
+  // A redirectFrom entry that collides with a rename rule but points elsewhere
+  // is an authoring mistake — the rename rule would silently win. Same
+  // fail-fast treatment as duplicate redirectFrom entries.
+  for (const [source, target] of Object.entries(redirectFromEntries)) {
+    const staticTarget = staticRedirects[source]
+    if (staticTarget !== undefined && staticTarget !== target) {
+      throw new Error(
+        `[redirect.static] redirectFrom slug "${source}" conflicts with a static rename rule ` +
+          `("${target}" vs "${staticTarget}")`
+      )
+    }
+  }
 
   const slugMap: Record<string, string> = {
     ...redirectFromEntries,

--- a/site/src/util/redirect.static.ts
+++ b/site/src/util/redirect.static.ts
@@ -1,0 +1,158 @@
+/**
+ * Build-time static redirects for legacy MkDocs URLs.
+ *
+ * The site is deployed to GitHub Pages, so there are no server-side redirects.
+ * The client-side fallback in Redirect404.astro works for humans, but crawlers
+ * don't execute it — old URLs return HTTP 404 and backlink equity is lost.
+ *
+ * buildStaticRedirects() enumerates every *known* legacy URL at config time so
+ * astro.config.mjs can feed them to Astro's `redirects` option, which emits a
+ * static HTML stub per URL (meta refresh + canonical link) that crawlers do
+ * follow. Sources come from:
+ *
+ *   1. STATIC_SLUG_REDIRECTS in redirect.ts (exact-match slug renames)
+ *   2. `redirectFrom` frontmatter entries in src/content docs
+ *
+ * Dynamic rules — version-prefix stripping (/latest/, /1.x/) and
+ * /documentation/docs/ normalization — can't be enumerated and remain handled
+ * only by the client-side 404 fallback.
+ *
+ * This module runs at config time, before the content layer exists, so it
+ * reads frontmatter from disk instead of using astro:content (unlike
+ * redirect.build.ts, which serves the same map to the 404 page at build time).
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import fg from 'fast-glob'
+import yaml from 'js-yaml'
+import { slug as githubSlug } from 'github-slugger'
+
+import { STATIC_SLUG_REDIRECTS } from './redirect'
+import { normalizePathToSlug } from './links'
+
+/**
+ * Extract frontmatter from a markdown/MDX file. Returns an empty object when
+ * the file has no frontmatter block.
+ */
+function readFrontmatter(filePath: string): Record<string, unknown> {
+  const source = fs.readFileSync(filePath, 'utf-8')
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!match) return {}
+  const parsed = yaml.load(match[1] ?? '')
+  return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : {}
+}
+
+/**
+ * Derive the content-collection ID (slug) for a doc file, mirroring
+ * generateDocsId in content.config.ts: an explicit frontmatter `slug` wins,
+ * otherwise the path is normalised and each segment slugified.
+ */
+function docIdFor(relativePath: string, frontmatter: Record<string, unknown>): string {
+  if (typeof frontmatter.slug === 'string') return frontmatter.slug
+
+  const normalized = normalizePathToSlug(relativePath)
+  if (!normalized) return 'index'
+
+  return normalized
+    .split('/')
+    .map((segment) => githubSlug(segment))
+    .join('/')
+}
+
+/**
+ * Check whether a slug resolves to a real content file — used to reject
+ * redirect sources that would shadow an existing page. Mirrors the candidate
+ * list used by sidebar.ts, plus README variants (see normalizePathToSlug).
+ */
+function contentExists(slug: string, contentDir: string): boolean {
+  const candidates = [
+    path.join(contentDir, `${slug}.md`),
+    path.join(contentDir, `${slug}.mdx`),
+    path.join(contentDir, slug, 'index.md'),
+    path.join(contentDir, slug, 'index.mdx'),
+    path.join(contentDir, slug, 'README.md'),
+    path.join(contentDir, slug, 'README.mdx'),
+  ]
+  return candidates.some((p) => fs.existsSync(p))
+}
+
+/**
+ * Collect old-slug → new-slug pairs from `redirectFrom` frontmatter across the
+ * docs content directory (same source of truth as redirect.build.ts, read from
+ * disk because astro:content isn't available at config time).
+ */
+function collectRedirectFromEntries(contentDir: string): Record<string, string> {
+  const entries: Record<string, string> = {}
+
+  const files = fg.sync('docs/**/*.{md,mdx}', {
+    cwd: contentDir,
+    followSymbolicLinks: false,
+  })
+
+  for (const relativePath of files) {
+    const frontmatter = readFrontmatter(path.join(contentDir, relativePath))
+    const redirectFrom = frontmatter.redirectFrom
+    if (!Array.isArray(redirectFrom)) continue
+
+    const target = docIdFor(relativePath, frontmatter)
+    for (const source of redirectFrom) {
+      if (typeof source !== 'string') continue
+      const existing = entries[source]
+      if (existing !== undefined && existing !== target) {
+        throw new Error(
+          `[redirect.static] duplicate redirectFrom slug "${source}" points to both "${existing}" and "${target}"`
+        )
+      }
+      entries[source] = target
+    }
+  }
+
+  return entries
+}
+
+/** Format a slug as a root-relative URL path in the site's directory format. */
+function toUrlPath(slug: string, base: string): string {
+  const prefix = base.replace(/\/+$/, '')
+  return `${prefix}/${slug.replace(/^\/+|\/+$/g, '')}/`
+}
+
+/**
+ * Build the value for Astro's `redirects` config option: a map of
+ * old URL path → new URL path (or external URL).
+ *
+ * @param contentDir - Absolute path to src/content, used to validate that no
+ *   redirect source shadows a real page and every internal target exists
+ * @param base - The site's base path (Astro `base` config), prepended to
+ *   internal destinations so meta-refresh URLs work under a subpath deploy
+ */
+export function buildStaticRedirects(contentDir: string, base = '/'): Record<string, string> {
+  const slugMap: Record<string, string> = {
+    ...collectRedirectFromEntries(contentDir),
+    // Exact-match renames take priority, matching resolveRedirect's rule order
+    ...STATIC_SLUG_REDIRECTS,
+  }
+
+  const redirects: Record<string, string> = {}
+
+  for (const [source, target] of Object.entries(slugMap)) {
+    // A source that resolves to a real page would make Astro emit a redirect
+    // stub on top of it (or fail the build) — always a configuration mistake.
+    if (contentExists(source, contentDir)) {
+      throw new Error(`[redirect.static] redirect source "${source}" collides with an existing content file`)
+    }
+
+    if (/^https?:\/\//.test(target)) {
+      redirects[`/${source}`] = target
+      continue
+    }
+
+    if (!contentExists(target, contentDir)) {
+      throw new Error(`[redirect.static] redirect target "${target}" (from "${source}") has no content file`)
+    }
+
+    redirects[`/${source}`] = toUrlPath(target, base)
+  }
+
+  return redirects
+}

--- a/site/src/util/redirect.static.ts
+++ b/site/src/util/redirect.static.ts
@@ -26,10 +26,9 @@ import fs from 'node:fs'
 import path from 'node:path'
 import fg from 'fast-glob'
 import yaml from 'js-yaml'
-import { slug as githubSlug } from 'github-slugger'
 
 import { STATIC_SLUG_REDIRECTS } from './redirect'
-import { normalizePathToSlug } from './links'
+import { pathToDocsSlug } from './links'
 
 /**
  * Extract frontmatter from a markdown/MDX file. Returns an empty object when
@@ -44,46 +43,18 @@ function readFrontmatter(filePath: string): Record<string, unknown> {
 }
 
 /**
- * Derive the content-collection ID (slug) for a doc file, mirroring
- * generateDocsId in content.config.ts: an explicit frontmatter `slug` wins,
- * otherwise the path is normalised and each segment slugified.
+ * Scan the docs content directory once, producing the set of every real page
+ * slug (for validation) and the old-slug → new-slug pairs declared in
+ * `redirectFrom` frontmatter (same source of truth as redirect.build.ts, read
+ * from disk because astro:content isn't available at config time).
+ *
+ * Slugs come from pathToDocsSlug — including frontmatter `slug` overrides —
+ * so validation agrees with the ids the content collection actually uses,
+ * rather than guessing filenames from slugs.
  */
-function docIdFor(relativePath: string, frontmatter: Record<string, unknown>): string {
-  if (typeof frontmatter.slug === 'string') return frontmatter.slug
-
-  const normalized = normalizePathToSlug(relativePath)
-  if (!normalized) return 'index'
-
-  return normalized
-    .split('/')
-    .map((segment) => githubSlug(segment))
-    .join('/')
-}
-
-/**
- * Check whether a slug resolves to a real content file — used to reject
- * redirect sources that would shadow an existing page. Mirrors the candidate
- * list used by sidebar.ts, plus README variants (see normalizePathToSlug).
- */
-function contentExists(slug: string, contentDir: string): boolean {
-  const candidates = [
-    path.join(contentDir, `${slug}.md`),
-    path.join(contentDir, `${slug}.mdx`),
-    path.join(contentDir, slug, 'index.md'),
-    path.join(contentDir, slug, 'index.mdx'),
-    path.join(contentDir, slug, 'README.md'),
-    path.join(contentDir, slug, 'README.mdx'),
-  ]
-  return candidates.some((p) => fs.existsSync(p))
-}
-
-/**
- * Collect old-slug → new-slug pairs from `redirectFrom` frontmatter across the
- * docs content directory (same source of truth as redirect.build.ts, read from
- * disk because astro:content isn't available at config time).
- */
-function collectRedirectFromEntries(contentDir: string): Record<string, string> {
-  const entries: Record<string, string> = {}
+function scanContent(contentDir: string): { slugs: Set<string>; redirectFromEntries: Record<string, string> } {
+  const slugs = new Set<string>()
+  const redirectFromEntries: Record<string, string> = {}
 
   const files = fg.sync('docs/**/*.{md,mdx}', {
     cwd: contentDir,
@@ -92,23 +63,25 @@ function collectRedirectFromEntries(contentDir: string): Record<string, string> 
 
   for (const relativePath of files) {
     const frontmatter = readFrontmatter(path.join(contentDir, relativePath))
+    const target = pathToDocsSlug(relativePath, frontmatter.slug)
+    slugs.add(target)
+
     const redirectFrom = frontmatter.redirectFrom
     if (!Array.isArray(redirectFrom)) continue
 
-    const target = docIdFor(relativePath, frontmatter)
     for (const source of redirectFrom) {
       if (typeof source !== 'string') continue
-      const existing = entries[source]
+      const existing = redirectFromEntries[source]
       if (existing !== undefined && existing !== target) {
         throw new Error(
           `[redirect.static] duplicate redirectFrom slug "${source}" points to both "${existing}" and "${target}"`
         )
       }
-      entries[source] = target
+      redirectFromEntries[source] = target
     }
   }
 
-  return entries
+  return { slugs, redirectFromEntries }
 }
 
 /** Format a slug as a root-relative URL path in the site's directory format. */
@@ -127,8 +100,10 @@ function toUrlPath(slug: string, base: string): string {
  *   internal destinations so meta-refresh URLs work under a subpath deploy
  */
 export function buildStaticRedirects(contentDir: string, base = '/'): Record<string, string> {
+  const { slugs, redirectFromEntries } = scanContent(contentDir)
+
   const slugMap: Record<string, string> = {
-    ...collectRedirectFromEntries(contentDir),
+    ...redirectFromEntries,
     // Exact-match renames take priority, matching resolveRedirect's rule order
     ...STATIC_SLUG_REDIRECTS,
   }
@@ -138,7 +113,7 @@ export function buildStaticRedirects(contentDir: string, base = '/'): Record<str
   for (const [source, target] of Object.entries(slugMap)) {
     // A source that resolves to a real page would make Astro emit a redirect
     // stub on top of it (or fail the build) — always a configuration mistake.
-    if (contentExists(source, contentDir)) {
+    if (slugs.has(source)) {
       throw new Error(`[redirect.static] redirect source "${source}" collides with an existing content file`)
     }
 
@@ -147,7 +122,7 @@ export function buildStaticRedirects(contentDir: string, base = '/'): Record<str
       continue
     }
 
-    if (!contentExists(target, contentDir)) {
+    if (!slugs.has(target)) {
       throw new Error(`[redirect.static] redirect target "${target}" (from "${source}") has no content file`)
     }
 

--- a/site/src/util/redirect.static.ts
+++ b/site/src/util/redirect.static.ts
@@ -98,14 +98,21 @@ function toUrlPath(slug: string, base: string): string {
  *   redirect source shadows a real page and every internal target exists
  * @param base - The site's base path (Astro `base` config), prepended to
  *   internal destinations so meta-refresh URLs work under a subpath deploy
+ * @param staticRedirects - Exact-match rename rules; defaults to the production
+ *   STATIC_SLUG_REDIRECTS. Injectable so unit tests aren't coupled to the
+ *   production entries (adding a rename must not break the test suite).
  */
-export function buildStaticRedirects(contentDir: string, base = '/'): Record<string, string> {
+export function buildStaticRedirects(
+  contentDir: string,
+  base = '/',
+  staticRedirects: Record<string, string> = STATIC_SLUG_REDIRECTS
+): Record<string, string> {
   const { slugs, redirectFromEntries } = scanContent(contentDir)
 
   const slugMap: Record<string, string> = {
     ...redirectFromEntries,
     // Exact-match renames take priority, matching resolveRedirect's rule order
-    ...STATIC_SLUG_REDIRECTS,
+    ...staticRedirects,
   }
 
   const redirects: Record<string, string> = {}

--- a/site/src/util/redirect.ts
+++ b/site/src/util/redirect.ts
@@ -12,67 +12,60 @@ import { exactly } from '../utils/regex'
 
 // ── Slug-level rename rules ───────────────────────────────────────────────────
 
+/**
+ * Exact-match slug renames: old slug → new slug or explicit external URL.
+ *
+ * Exported so astro.config.mjs (via redirect.static.ts) can enumerate every
+ * entry into a build-time redirect stub — a static HTML page with a meta
+ * refresh and canonical link. Crawlers don't execute the client-side 404
+ * redirect, so these stubs are what preserve backlink equity for renamed pages.
+ *
+ * Only add enumerable, exact-match renames here. Dynamic rules (regex matches,
+ * computed targets) belong in SLUG_RULES below and are handled solely by the
+ * client-side 404 fallback.
+ */
+export const STATIC_SLUG_REDIRECTS: Record<string, string> = {
+  // gemini was renamed to google
+  'docs/user-guide/concepts/model-providers/gemini': 'docs/user-guide/concepts/model-providers/google',
+
+  // python-tools was renamed to custom-tools
+  'docs/user-guide/concepts/tools/python-tools': 'docs/user-guide/concepts/tools/custom-tools',
+
+  // multi_agent_example index redirects to the main example page
+  'docs/examples/python/multi_agent_example': 'docs/examples/python/multi_agent_example/multi_agent_example',
+
+  // Vanity URLs for community links
+  discord: 'https://discord.gg/strands',
+
+  // cli-reference-agent was archived (strands-agents/agent-builder)
+  'docs/examples/python/cli-reference-agent': 'docs/examples',
+
+  // CDK and deployment examples now live on GitHub
+  'docs/examples/cdk/deploy_to_apprunner':
+    'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_apprunner/README.md',
+  'docs/examples/cdk/deploy_to_ec2':
+    'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_ec2/README.md',
+  'docs/examples/cdk/deploy_to_fargate':
+    'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_fargate/README.md',
+  'docs/examples/cdk/deploy_to_lambda':
+    'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_lambda/README.md',
+  'docs/examples/deploy_to_eks':
+    'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/deploy_to_eks/README.md',
+  'docs/examples/typescript/deploy_to_bedrock_agentcore':
+    'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md',
+}
+
 type SlugRule =
   | { match: RegExp; to: string }
   | { match: RegExp; to: (m: RegExpMatchArray) => string }
 
-const SLUG_RULES: SlugRule[] = [
-  // gemini was renamed to google
-  {
-    match: exactly('docs/user-guide/concepts/model-providers/gemini'),
-    to: 'docs/user-guide/concepts/model-providers/google',
-  },
-
-  // python-tools was renamed to custom-tools
-  {
-    match: exactly('docs/user-guide/concepts/tools/python-tools'),
-    to: 'docs/user-guide/concepts/tools/custom-tools',
-  },
-
-  // multi_agent_example index redirects to the main example page
-  {
-    match: exactly('docs/examples/python/multi_agent_example'),
-    to: 'docs/examples/python/multi_agent_example/multi_agent_example',
-  },
-
-  // Vanity URLs for community links
-  {
-    match: exactly('discord'),
-    to: 'https://discord.gg/strands',
-  },
-
-  // cli-reference-agent was archived (strands-agents/agent-builder)
-  {
-    match: exactly('docs/examples/python/cli-reference-agent'),
-    to: 'docs/examples',
-  },
-
-  // CDK and deployment examples now live on GitHub
-  {
-    match: exactly('docs/examples/cdk/deploy_to_apprunner'),
-    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_apprunner/README.md',
-  },
-  {
-    match: exactly('docs/examples/cdk/deploy_to_ec2'),
-    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_ec2/README.md',
-  },
-  {
-    match: exactly('docs/examples/cdk/deploy_to_fargate'),
-    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_fargate/README.md',
-  },
-  {
-    match: exactly('docs/examples/cdk/deploy_to_lambda'),
-    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/cdk/deploy_to_lambda/README.md',
-  },
-  {
-    match: exactly('docs/examples/deploy_to_eks'),
-    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/deploy_to_eks/README.md',
-  },
-  {
-    match: exactly('docs/examples/typescript/deploy_to_bedrock_agentcore'),
-    to: 'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md',
-  },
-]
+// Exact-match rules generated from STATIC_SLUG_REDIRECTS, plus any dynamic
+// (regex-based) rules. Dynamic rules can't be enumerated into static stubs,
+// so they are only applied by the client-side 404 fallback.
+const SLUG_RULES: SlugRule[] = Object.entries(STATIC_SLUG_REDIRECTS).map(([from, to]) => ({
+  match: exactly(from),
+  to,
+}))
 
 // ── Public API ────────────────────────────────────────────────────────────────
 

--- a/site/test/redirect-static.test.ts
+++ b/site/test/redirect-static.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { buildStaticRedirects } from '../src/util/redirect.static'
+import { pathToDocsSlug } from '../src/util/links'
+
+/**
+ * Fixtures live in a temp content dir so tests exercise the real
+ * disk-reading path (buildStaticRedirects runs at config time, before
+ * astro:content exists).
+ */
+function writeDoc(contentDir: string, relativePath: string, frontmatter: string): void {
+  const filePath = path.join(contentDir, relativePath)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, `---\n${frontmatter}\n---\n\n# Page\n`)
+}
+
+describe('buildStaticRedirects', () => {
+  let contentDir: string
+
+  beforeAll(() => {
+    contentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'redirect-static-test-'))
+    // Targets for the STATIC_SLUG_REDIRECTS entries must exist, or the builder
+    // throws — create the current production set.
+    writeDoc(contentDir, 'docs/user-guide/concepts/model-providers/google.mdx', 'title: Google')
+    writeDoc(contentDir, 'docs/user-guide/concepts/tools/custom-tools.mdx', 'title: Custom Tools')
+    writeDoc(
+      contentDir,
+      'docs/examples/python/multi_agent_example/multi_agent_example.mdx',
+      'title: Multi-Agent Example'
+    )
+    writeDoc(contentDir, 'docs/examples/README.mdx', 'title: Examples')
+  })
+
+  afterAll(() => {
+    fs.rmSync(contentDir, { recursive: true, force: true })
+  })
+
+  it('maps a redirectFrom frontmatter entry to its page URL', () => {
+    writeDoc(contentDir, 'docs/user-guide/state.mdx', 'title: State\nredirectFrom:\n  - docs/old/state')
+
+    const redirects = buildStaticRedirects(contentDir)
+
+    expect(redirects['/docs/old/state']).toBe('/docs/user-guide/state/')
+  })
+
+  it('respects a frontmatter slug override on the target page', () => {
+    writeDoc(
+      contentDir,
+      'docs/user-guide/renamed.mdx',
+      'title: Renamed\nslug: docs/user-guide/custom-slug\nredirectFrom:\n  - docs/old/renamed'
+    )
+
+    const redirects = buildStaticRedirects(contentDir)
+
+    expect(redirects['/docs/old/renamed']).toBe('/docs/user-guide/custom-slug/')
+  })
+
+  it('passes external STATIC_SLUG_REDIRECTS targets through unchanged', () => {
+    const redirects = buildStaticRedirects(contentDir)
+
+    expect(redirects['/discord']).toBe('https://discord.gg/strands')
+  })
+
+  it('prefixes internal destinations with the base path', () => {
+    const redirects = buildStaticRedirects(contentDir, '/pr-preview/')
+
+    expect(redirects['/docs/user-guide/concepts/model-providers/gemini']).toBe(
+      '/pr-preview/docs/user-guide/concepts/model-providers/google/'
+    )
+  })
+
+  it('throws when a redirect source collides with an existing content file', () => {
+    writeDoc(
+      contentDir,
+      'docs/user-guide/collision.mdx',
+      'title: Collision\nredirectFrom:\n  - docs/user-guide/state'
+    )
+
+    expect(() => buildStaticRedirects(contentDir)).toThrow(/collides with an existing content file/)
+
+    fs.rmSync(path.join(contentDir, 'docs/user-guide/collision.mdx'))
+  })
+
+  it('throws when duplicate redirectFrom slugs point at different targets', () => {
+    writeDoc(contentDir, 'docs/user-guide/dupe-a.mdx', 'title: A\nredirectFrom:\n  - docs/old/dupe')
+    writeDoc(contentDir, 'docs/user-guide/dupe-b.mdx', 'title: B\nredirectFrom:\n  - docs/old/dupe')
+
+    expect(() => buildStaticRedirects(contentDir)).toThrow(/duplicate redirectFrom slug "docs\/old\/dupe"/)
+
+    fs.rmSync(path.join(contentDir, 'docs/user-guide/dupe-a.mdx'))
+    fs.rmSync(path.join(contentDir, 'docs/user-guide/dupe-b.mdx'))
+  })
+
+  it('throws when an internal redirect target has no content file', () => {
+    // The production STATIC_SLUG_REDIRECTS targets are fixtures here; removing
+    // one makes its redirect target dangle.
+    const target = path.join(contentDir, 'docs/user-guide/concepts/tools/custom-tools.mdx')
+    fs.rmSync(target)
+
+    expect(() => buildStaticRedirects(contentDir)).toThrow(/has no content file/)
+
+    writeDoc(contentDir, 'docs/user-guide/concepts/tools/custom-tools.mdx', 'title: Custom Tools')
+  })
+})
+
+describe('pathToDocsSlug', () => {
+  // redirect.static.ts derives redirect targets with pathToDocsSlug, and the
+  // docs collection derives entry ids from it (generateDocsId) — these cases
+  // pin the shared behavior both sides depend on.
+  it.each([
+    ['plain path', 'docs/user-guide/state.mdx', undefined, 'docs/user-guide/state'],
+    ['index collapses to parent', 'docs/examples/index.mdx', undefined, 'docs/examples'],
+    ['README collapses to parent', 'docs/examples/README.mdx', undefined, 'docs/examples'],
+    ['segments are slugified', 'docs/user-guide/deploy_to_aws_lambda.mdx', undefined, 'docs/user-guide/deploy_to_aws_lambda'],
+    ['root index becomes index', 'index.mdx', undefined, 'index'],
+    ['frontmatter slug wins', 'docs/user-guide/state.mdx', 'custom/slug', 'custom/slug'],
+  ])('%s', (_description, entryPath, slugOverride, expected) => {
+    expect(pathToDocsSlug(entryPath, slugOverride)).toBe(expected)
+  })
+})

--- a/site/test/redirect-static.test.ts
+++ b/site/test/redirect-static.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -6,9 +6,11 @@ import { buildStaticRedirects } from '../src/util/redirect.static'
 import { pathToDocsSlug } from '../src/util/links'
 
 /**
- * Fixtures live in a temp content dir so tests exercise the real
- * disk-reading path (buildStaticRedirects runs at config time, before
- * astro:content exists).
+ * Each test gets a fresh temp content dir and passes its own static-redirect
+ * rules, so tests are independent of each other and of the production
+ * STATIC_SLUG_REDIRECTS entries (adding a rename must not break this suite).
+ * buildStaticRedirects runs at config time, before astro:content exists, so
+ * the fixtures exercise the real disk-reading path.
  */
 function writeDoc(contentDir: string, relativePath: string, frontmatter: string): void {
   const filePath = path.join(contentDir, relativePath)
@@ -19,30 +21,20 @@ function writeDoc(contentDir: string, relativePath: string, frontmatter: string)
 describe('buildStaticRedirects', () => {
   let contentDir: string
 
-  beforeAll(() => {
+  beforeEach(() => {
     contentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'redirect-static-test-'))
-    // Targets for the STATIC_SLUG_REDIRECTS entries must exist, or the builder
-    // throws — create the current production set.
-    writeDoc(contentDir, 'docs/user-guide/concepts/model-providers/google.mdx', 'title: Google')
-    writeDoc(contentDir, 'docs/user-guide/concepts/tools/custom-tools.mdx', 'title: Custom Tools')
-    writeDoc(
-      contentDir,
-      'docs/examples/python/multi_agent_example/multi_agent_example.mdx',
-      'title: Multi-Agent Example'
-    )
-    writeDoc(contentDir, 'docs/examples/README.mdx', 'title: Examples')
   })
 
-  afterAll(() => {
+  afterEach(() => {
     fs.rmSync(contentDir, { recursive: true, force: true })
   })
 
   it('maps a redirectFrom frontmatter entry to its page URL', () => {
     writeDoc(contentDir, 'docs/user-guide/state.mdx', 'title: State\nredirectFrom:\n  - docs/old/state')
 
-    const redirects = buildStaticRedirects(contentDir)
+    const redirects = buildStaticRedirects(contentDir, '/', {})
 
-    expect(redirects['/docs/old/state']).toBe('/docs/user-guide/state/')
+    expect(redirects).toEqual({ '/docs/old/state': '/docs/user-guide/state/' })
   })
 
   it('respects a frontmatter slug override on the target page', () => {
@@ -52,56 +44,67 @@ describe('buildStaticRedirects', () => {
       'title: Renamed\nslug: docs/user-guide/custom-slug\nredirectFrom:\n  - docs/old/renamed'
     )
 
-    const redirects = buildStaticRedirects(contentDir)
+    const redirects = buildStaticRedirects(contentDir, '/', {})
 
-    expect(redirects['/docs/old/renamed']).toBe('/docs/user-guide/custom-slug/')
+    expect(redirects).toEqual({ '/docs/old/renamed': '/docs/user-guide/custom-slug/' })
   })
 
-  it('passes external STATIC_SLUG_REDIRECTS targets through unchanged', () => {
-    const redirects = buildStaticRedirects(contentDir)
+  it('resolves a rename rule against slugified page ids', () => {
+    // The file name slugifies (Custom_Tools.mdx → custom_tools), so a rule
+    // targeting the collection id only validates if ids — not raw file
+    // names — are what the builder checks against.
+    writeDoc(contentDir, 'docs/user-guide/Custom_Tools.mdx', 'title: Custom Tools')
 
-    expect(redirects['/discord']).toBe('https://discord.gg/strands')
+    const redirects = buildStaticRedirects(contentDir, '/', {
+      'docs/user-guide/python-tools': 'docs/user-guide/custom_tools',
+    })
+
+    expect(redirects).toEqual({ '/docs/user-guide/python-tools': '/docs/user-guide/custom_tools/' })
+  })
+
+  it('passes external targets through unchanged', () => {
+    const redirects = buildStaticRedirects(contentDir, '/', { discord: 'https://discord.gg/strands' })
+
+    expect(redirects).toEqual({ '/discord': 'https://discord.gg/strands' })
   })
 
   it('prefixes internal destinations with the base path', () => {
-    const redirects = buildStaticRedirects(contentDir, '/pr-preview/')
+    writeDoc(contentDir, 'docs/user-guide/state.mdx', 'title: State\nredirectFrom:\n  - docs/old/state')
 
-    expect(redirects['/docs/user-guide/concepts/model-providers/gemini']).toBe(
-      '/pr-preview/docs/user-guide/concepts/model-providers/google/'
-    )
+    const redirects = buildStaticRedirects(contentDir, '/pr-preview/', {})
+
+    expect(redirects).toEqual({ '/docs/old/state': '/pr-preview/docs/user-guide/state/' })
   })
 
   it('throws when a redirect source collides with an existing content file', () => {
-    writeDoc(
-      contentDir,
-      'docs/user-guide/collision.mdx',
-      'title: Collision\nredirectFrom:\n  - docs/user-guide/state'
-    )
+    writeDoc(contentDir, 'docs/user-guide/state.mdx', 'title: State')
+    writeDoc(contentDir, 'docs/user-guide/other.mdx', 'title: Other\nredirectFrom:\n  - docs/user-guide/state')
 
-    expect(() => buildStaticRedirects(contentDir)).toThrow(/collides with an existing content file/)
-
-    fs.rmSync(path.join(contentDir, 'docs/user-guide/collision.mdx'))
+    expect(() => buildStaticRedirects(contentDir, '/', {})).toThrow(/collides with an existing content file/)
   })
 
   it('throws when duplicate redirectFrom slugs point at different targets', () => {
     writeDoc(contentDir, 'docs/user-guide/dupe-a.mdx', 'title: A\nredirectFrom:\n  - docs/old/dupe')
     writeDoc(contentDir, 'docs/user-guide/dupe-b.mdx', 'title: B\nredirectFrom:\n  - docs/old/dupe')
 
-    expect(() => buildStaticRedirects(contentDir)).toThrow(/duplicate redirectFrom slug "docs\/old\/dupe"/)
-
-    fs.rmSync(path.join(contentDir, 'docs/user-guide/dupe-a.mdx'))
-    fs.rmSync(path.join(contentDir, 'docs/user-guide/dupe-b.mdx'))
+    expect(() => buildStaticRedirects(contentDir, '/', {})).toThrow(
+      /duplicate redirectFrom slug "docs\/old\/dupe"/
+    )
   })
 
   it('throws when an internal redirect target has no content file', () => {
-    // The production STATIC_SLUG_REDIRECTS targets are fixtures here; removing
-    // one makes its redirect target dangle.
-    const target = path.join(contentDir, 'docs/user-guide/concepts/tools/custom-tools.mdx')
-    fs.rmSync(target)
+    expect(() => buildStaticRedirects(contentDir, '/', { 'docs/old/page': 'docs/new/missing' })).toThrow(
+      /has no content file/
+    )
+  })
 
-    expect(() => buildStaticRedirects(contentDir)).toThrow(/has no content file/)
+  it('validates the production redirect map against the real content dir', () => {
+    // The same invocation astro.config.mjs makes — catches a production rename
+    // rule whose target page was deleted or moved, without pinning any
+    // specific entry.
+    const redirects = buildStaticRedirects(path.resolve(__dirname, '../src/content'))
 
-    writeDoc(contentDir, 'docs/user-guide/concepts/tools/custom-tools.mdx', 'title: Custom Tools')
+    expect(Object.keys(redirects).length).toBeGreaterThan(0)
   })
 })
 
@@ -113,7 +116,7 @@ describe('pathToDocsSlug', () => {
     ['plain path', 'docs/user-guide/state.mdx', undefined, 'docs/user-guide/state'],
     ['index collapses to parent', 'docs/examples/index.mdx', undefined, 'docs/examples'],
     ['README collapses to parent', 'docs/examples/README.mdx', undefined, 'docs/examples'],
-    ['segments are slugified', 'docs/user-guide/deploy_to_aws_lambda.mdx', undefined, 'docs/user-guide/deploy_to_aws_lambda'],
+    ['segments are slugified', 'docs/user-guide/Deploy_To_AWS.mdx', undefined, 'docs/user-guide/deploy_to_aws'],
     ['root index becomes index', 'index.mdx', undefined, 'index'],
     ['frontmatter slug wins', 'docs/user-guide/state.mdx', 'custom/slug', 'custom/slug'],
   ])('%s', (_description, entryPath, slugOverride, expected) => {

--- a/site/test/redirect-static.test.ts
+++ b/site/test/redirect-static.test.ts
@@ -98,6 +98,23 @@ describe('buildStaticRedirects', () => {
     )
   })
 
+  it('throws when a redirectFrom entry conflicts with a static rename rule', () => {
+    writeDoc(contentDir, 'docs/user-guide/state.mdx', 'title: State\nredirectFrom:\n  - docs/old/page')
+    writeDoc(contentDir, 'docs/user-guide/other.mdx', 'title: Other')
+
+    expect(() =>
+      buildStaticRedirects(contentDir, '/', { 'docs/old/page': 'docs/user-guide/other' })
+    ).toThrow(/conflicts with a static rename rule/)
+  })
+
+  it('allows a redirectFrom entry that agrees with a static rename rule', () => {
+    writeDoc(contentDir, 'docs/user-guide/state.mdx', 'title: State\nredirectFrom:\n  - docs/old/page')
+
+    const redirects = buildStaticRedirects(contentDir, '/', { 'docs/old/page': 'docs/user-guide/state' })
+
+    expect(redirects).toEqual({ '/docs/old/page': '/docs/user-guide/state/' })
+  })
+
   it('validates the production redirect map against the real content dir', () => {
     // The same invocation astro.config.mjs makes — catches a production rename
     // rule whose target page was deleted or moved, without pinning any


### PR DESCRIPTION
## Description

The site moved from MkDocs to Astro, but legacy URLs are handled only by client-side JS on the 404 page (`Redirect404.astro`): the old URL returns HTTP 404, then `location.replace()` fires. Crawlers don't execute that JS, so Google sees a dead page and every backlink pointing at an old URL — launch-era AWS blog coverage, Stack Overflow answers, community posts — passes no equity. `/docs/` itself (an URL users and LLMs routinely guess) was also a hard 404. GitHub Pages offers no server-side redirects, so a build-time answer is required.

This PR enumerates every *known* legacy URL at config time — `redirectFrom` frontmatter entries plus the exact-match rename rules from `redirect.ts` — and feeds them to Astro's `redirects` option, which emits a static stub page per URL (0-second meta refresh + absolute canonical + noindex). Google treats that combination as a permanent redirect. 21 stubs are generated. The new `buildStaticRedirects()` (`redirect.static.ts`) runs before the content layer exists, so it reads frontmatter from disk and mirrors `generateDocsId` from `content.config.ts`; it validates at config time, failing the build on a redirect source that collides with a real page, a target with no backing content file, or conflicting duplicate sources.

Dynamic rules (version-prefix stripping for `/latest/*`, `/1.x/*`, and `/documentation/docs/*` normalization) can't be enumerated and remain on the JS 404 fallback, which is unchanged. The exact-match rules in `redirect.ts` were refactored into an exported `STATIC_SLUG_REDIRECTS` map that `SLUG_RULES` is now generated from — behavior-preserving, so both the static stubs and the 404 fallback derive from the same source and cannot drift.

Also adds `og:image:width`/`og:image:height`/`og:image:alt` meta alongside the existing global `og:image` tags in `astro.config.mjs`.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

No documentation changes needed; this affects site build output only.

## Type of Change

Bug fix

## Testing

Full site build succeeds (broken-links checker green) with all 21 stubs confirmed in `dist/` carrying meta refresh, absolute canonical, and noindex. Verified the multi_agent_example stub sits at the parent path only and its target is a real page, the 404 page still embeds the JS redirect map, and rendered pages carry the new og:image meta. Existing `redirect.test.ts` passes unchanged against the refactored `SLUG_RULES`; `tsc --noEmit` clean.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
