### PR TITLE
feat(ts): add AgentCore Harness agent

### DIFF
--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/src/vended-tools/bash/index.d.ts",
       "default": "./dist/src/vended-tools/bash/index.js"
     },
+    "./agentcore-harness": {
+      "types": "./dist/src/agentcore-harness/index.d.ts",
+      "default": "./dist/src/agentcore-harness/index.js"
+    },
     "./a2a": {
       "types": "./dist/src/a2a/index.d.ts",
       "default": "./dist/src/a2a/index.js"
@@ -189,6 +193,8 @@
     "@aws-sdk/client-bedrock": "^3.1078.0",
     "@aws-sdk/client-bedrock-agent": "^3.1078.0",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+    "@aws-sdk/client-bedrock-agentcore": "^3.1078.0",
+    "@aws-sdk/client-bedrock-agentcore-control": "^3.1078.0",
     "@aws-sdk/client-s3": "^3.1078.0",
     "@aws-sdk/client-secrets-manager": "^3.1078.0",
     "@aws-sdk/client-ssm": "^3.1078.0",
@@ -246,6 +252,8 @@
     "@anthropic-ai/sdk": "^0.109.1",
     "@aws-sdk/client-bedrock-agent": "^3.1078.0",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+    "@aws-sdk/client-bedrock-agentcore": "^3.1078.0",
+    "@aws-sdk/client-bedrock-agentcore-control": "^3.1078.0",
     "@aws-sdk/client-s3": "^3.1078.0",
     "@aws/bedrock-token-generator": "^1.1.0",
     "@cedar-policy/cedar-wasm": "^4.0.0",
@@ -287,6 +295,12 @@
       "optional": true
     },
     "@aws-sdk/client-bedrock-agent-runtime": {
+      "optional": true
+    },
+    "@aws-sdk/client-bedrock-agentcore": {
+      "optional": true
+    },
+    "@aws-sdk/client-bedrock-agentcore-control": {
       "optional": true
     },
     "@aws-sdk/client-s3": {

--- a/strands-ts/src/__tests__/errors.test.ts
+++ b/strands-ts/src/__tests__/errors.test.ts
@@ -68,6 +68,15 @@ describe('ContextWindowOverflowError', () => {
       expect(error).toBeInstanceOf(ModelError)
     })
   })
+
+  describe('when instantiated with a cause', () => {
+    it('stores the cause error', () => {
+      const cause = new Error('original error')
+      const error = new ContextWindowOverflowError('context window overflow', { cause })
+
+      expect(error.cause).toBe(cause)
+    })
+  })
 })
 
 describe('MaxTokensError', () => {

--- a/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-agent.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-agent.test.ts
@@ -1,0 +1,878 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { BedrockAgentCoreClient, InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import { z } from 'zod'
+import { AgentCoreHarnessAgent, type AgentCoreHarnessAgentConfig } from '../agentcore-harness-agent.js'
+import { AgentCoreHarnessStreamUpdateEvent, AgentCoreHarnessResultEvent } from '../events.js'
+import { tool } from '../../tools/tool-factory.js'
+import { Message, TextBlock } from '../../types/messages.js'
+import { ImageBlock } from '../../types/media.js'
+import { AgentResult } from '../../types/agent.js'
+import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
+import {
+  ConcurrentInvocationError,
+  ContextWindowOverflowError,
+  MaxTokensError,
+  ModelError,
+  ModelThrottledError,
+} from '../../errors.js'
+import {
+  HARNESS_ARN,
+  SESSION_ID,
+  chunk,
+  harnessStream,
+  mockClient,
+  mockControlClient,
+} from './harness-test-fixtures.js'
+
+describe('AgentCoreHarnessAgent', () => {
+  describe('identity and validation', () => {
+    it('defaults id to the harness ARN', () => {
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID })
+      expect(agent.id).toBe('arn:harness')
+    })
+
+    it('uses provided id, name, and description', () => {
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        id: 'custom',
+        name: 'My Agent',
+        description: 'Does things',
+      })
+      expect(agent.id).toBe('custom')
+      expect(agent.name).toBe('My Agent')
+      expect(agent.description).toBe('Does things')
+    })
+
+    it('has undefined name and description when not provided', () => {
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID })
+      expect(agent.name).toBeUndefined()
+      expect(agent.description).toBeUndefined()
+    })
+
+    it.each([
+      ['an empty string', ''],
+      ['an empty array', []],
+      ['only empty text blocks', [new TextBlock('')]],
+    ] as [string, string | TextBlock[]][])('rejects a systemPrompt containing %s', (_description, systemPrompt) => {
+      expect(
+        () => new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, systemPrompt })
+      ).toThrow(TypeError)
+    })
+
+    it.each([
+      { desc: 'too short', id: 'short' },
+      { desc: 'too long', id: 'x'.repeat(101) },
+    ])('rejects a runtimeSessionId that is $desc', ({ id }) => {
+      expect(() => new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: id })).toThrow(
+        /33.*100 characters/
+      )
+    })
+
+    it.each([
+      { desc: 'starts with a hyphen', id: `-${'a'.repeat(32)}` },
+      { desc: 'starts with an underscore', id: `_${'a'.repeat(32)}` },
+      { desc: 'contains a period', id: `${'a'.repeat(32)}.` },
+      { desc: 'contains a space', id: `${'a'.repeat(32)} ` },
+    ])('rejects a runtimeSessionId that $desc', ({ id }) => {
+      expect(() => new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: id })).toThrow(
+        /must start with an alphanumeric character/
+      )
+    })
+
+    it('accepts hyphens and underscores after the first character', () => {
+      const runtimeSessionId = `a${'-_'.repeat(16)}`
+
+      expect(new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId }).runtimeSessionId).toBe(
+        runtimeSessionId
+      )
+    })
+
+    it.each(['concurrent', 'sequential'] as const)("accepts toolExecutor '%s'", (toolExecutor) => {
+      expect(
+        () => new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, toolExecutor })
+      ).not.toThrow()
+    })
+
+    it.each(['parallel', '', null])('rejects invalid runtime toolExecutor %#', (toolExecutor) => {
+      expect(
+        () =>
+          new AgentCoreHarnessAgent({
+            harnessArn: 'arn:harness',
+            runtimeSessionId: SESSION_ID,
+            toolExecutor: toolExecutor as never,
+          })
+      ).toThrow(`toolExecutor must be 'concurrent' or 'sequential', got '${String(toolExecutor)}'`)
+    })
+
+    it('rejects duplicate host tool names', () => {
+      const first = tool({
+        name: 'duplicate',
+        description: 'first',
+        inputSchema: z.object({}),
+        callback: () => 'first',
+      })
+      const second = tool({
+        name: 'duplicate',
+        description: 'second',
+        inputSchema: z.object({}),
+        callback: () => 'second',
+      })
+
+      expect(
+        () =>
+          new AgentCoreHarnessAgent({
+            harnessArn: 'arn:harness',
+            runtimeSessionId: SESSION_ID,
+            tools: [first, second],
+          })
+      ).toThrow("Tool with name 'duplicate' already registered")
+    })
+
+    it.each(['builtin', 'shell', 'file_operations'])("rejects reserved host tool name '%s'", (name) => {
+      const hostTool = tool({
+        name,
+        description: 'reserved name',
+        inputSchema: z.object({}),
+        callback: () => 'result',
+      })
+
+      expect(
+        () =>
+          new AgentCoreHarnessAgent({
+            harnessArn: 'arn:harness',
+            runtimeSessionId: SESSION_ID,
+            tools: [hostTool],
+          })
+      ).toThrow(`Host tool name '${name}' is reserved by AgentCore Harness.`)
+    })
+
+    it.each([
+      ['all tools', ['*']],
+      ['the inline-function namespace', ['@get_weather']],
+      ['the fully qualified inline function', ['@get_weather/get_weather']],
+      ['a matching namespace and tool glob', ['@get_*/get_w?ather']],
+    ])('accepts a host tool allowed by %s', (_description, allowedTools) => {
+      const hostTool = tool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: z.object({}),
+        callback: () => 'sunny',
+      })
+
+      expect(
+        () =>
+          new AgentCoreHarnessAgent({
+            harnessArn: HARNESS_ARN,
+            runtimeSessionId: SESSION_ID,
+            tools: [hostTool],
+            allowedTools,
+          })
+      ).not.toThrow()
+    })
+
+    it.each([
+      ['an empty list', []],
+      ['an unqualified name', ['get_weather']],
+      ['another namespace', ['@other']],
+      ['another tool in the namespace', ['@get_weather/get_forecast']],
+    ])('rejects a host tool excluded by %s', (_description, allowedTools) => {
+      const hostTool = tool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: z.object({}),
+        callback: () => 'sunny',
+      })
+
+      expect(
+        () =>
+          new AgentCoreHarnessAgent({
+            harnessArn: HARNESS_ARN,
+            runtimeSessionId: SESSION_ID,
+            tools: [hostTool],
+            allowedTools,
+          })
+      ).toThrow(
+        "Host tool 'get_weather' is excluded by effective allowedTools. Add '@get_weather', '@get_weather/get_weather', a matching namespace glob, or '*' to allowedTools."
+      )
+    })
+  })
+
+  describe('invoke', () => {
+    it('returns an AgentResult with the assembled text and endTurn stop reason', async () => {
+      const { client } = mockClient(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.textDelta('Hello '),
+          chunk.textDelta('world'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('end_turn')
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const result = await agent.invoke('Hi')
+
+      expect(result).toStrictEqual(
+        new AgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [new TextBlock('Hello world')],
+            trackingId: result.lastMessage.trackingId,
+          }),
+          invocationState: {},
+        })
+      )
+    })
+
+    it.each([
+      { name: 'turns', limits: { turns: 1 } },
+      { name: 'output tokens', limits: { outputTokens: 100 } },
+      { name: 'total tokens', limits: { totalTokens: 100 } },
+      { name: 'an empty object', limits: {} },
+    ])('rejects unsupported $name limits before invoking the harness', async ({ limits }) => {
+      const { client, send } = mockClient()
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke('Hi', { limits })).rejects.toThrow(
+        'InvokeOptions.limits is not supported by AgentCoreHarnessAgent. Configure Harness-side maxIterations, maxTokens, or timeoutSeconds when constructing the agent.'
+      )
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      { name: 'an empty content array', args: [] },
+      { name: 'an empty string', args: '' },
+      {
+        name: 'mixed text and unsupported media',
+        args: [
+          new TextBlock('Do not send only this text'),
+          new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1]) } }),
+        ],
+      },
+    ])('rejects $name before invoking the harness', async ({ args }) => {
+      const { client, send } = mockClient()
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke(args as never)).rejects.toThrow()
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('forwards modelConfig and systemPrompt overrides', async () => {
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        modelConfig: { bedrockModelConfig: { modelId: 'anthropic.claude' } },
+        systemPrompt: 'Be concise.',
+      })
+
+      await agent.invoke('Hi')
+
+      // modelConfig is sent on the wire under the InvokeHarness `model` field.
+      expect(send.mock.calls[0]![0].input).toStrictEqual({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'Hi' }] }],
+        model: { bedrockModelConfig: { modelId: 'anthropic.claude' } },
+        systemPrompt: [{ text: 'Be concise.' }],
+      })
+    })
+
+    it('forwards optional request fields verbatim to the wire request', async () => {
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const skills = [{ path: '/skills/researcher' }]
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        skills,
+        allowedTools: ['shell', 'browser'],
+        maxIterations: 10,
+        maxTokens: 4096,
+        timeoutSeconds: 300,
+        qualifier: 'prod',
+        runtimeUserId: 'user-42',
+        actorId: 'actor-7',
+      })
+
+      await agent.invoke('Hi')
+
+      expect(send.mock.calls[0]![0].input).toStrictEqual({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'Hi' }] }],
+        skills,
+        allowedTools: ['shell', 'browser'],
+        maxIterations: 10,
+        maxTokens: 4096,
+        timeoutSeconds: 300,
+        qualifier: 'prod',
+        runtimeUserId: 'user-42',
+        actorId: 'actor-7',
+      })
+    })
+
+    it('snapshots request overrides and isolates later invocations from command mutation', async () => {
+      const modelConfig: NonNullable<AgentCoreHarnessAgentConfig['modelConfig']> = {
+        bedrockModelConfig: {
+          modelId: 'original-model',
+          additionalParams: { nested: { value: 'original' } },
+        },
+      }
+      const systemPrompt = [new TextBlock('Original system prompt')]
+      const skills: NonNullable<AgentCoreHarnessAgentConfig['skills']> = [
+        {
+          git: {
+            url: 'https://example.com/original.git',
+            path: 'skills/original',
+            auth: { credentialArn: 'arn:original', username: 'original-user' },
+          },
+        },
+      ]
+      const allowedTools = ['shell']
+      const { client, send } = mockClient(
+        harnessStream(chunk.messageStop('end_turn')),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const config: AgentCoreHarnessAgentConfig = {
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        modelConfig,
+        systemPrompt,
+        skills,
+        allowedTools,
+        maxIterations: 10,
+        maxTokens: 1000,
+        timeoutSeconds: 60,
+        qualifier: 'original-endpoint',
+        runtimeUserId: 'original-user',
+        actorId: 'original-actor',
+      }
+      const agent = new AgentCoreHarnessAgent(config)
+
+      modelConfig.bedrockModelConfig.modelId = 'mutated-model'
+      ;(modelConfig.bedrockModelConfig.additionalParams as { nested: { value: string } }).nested.value = 'mutated'
+      systemPrompt.push(new TextBlock('Mutated prompt'))
+      skills[0]!.git!.url = 'https://example.com/mutated.git'
+      skills[0]!.git!.auth!.credentialArn = 'arn:mutated'
+      allowedTools[0] = 'browser'
+      config.modelConfig = { bedrockModelConfig: { modelId: 'replacement-model' } }
+      config.systemPrompt = 'Replacement prompt'
+      config.skills = [{ path: '/replacement' }]
+      config.allowedTools = ['file_operations']
+      config.maxIterations = 99
+      config.maxTokens = 99
+      config.timeoutSeconds = 99
+      config.qualifier = 'replacement-endpoint'
+      config.runtimeUserId = 'replacement-user'
+      config.actorId = 'replacement-actor'
+
+      await agent.invoke('First')
+
+      expect(send.mock.calls[0]![0].input).toStrictEqual({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'First' }] }],
+        model: {
+          bedrockModelConfig: {
+            modelId: 'original-model',
+            additionalParams: { nested: { value: 'original' } },
+          },
+        },
+        systemPrompt: [{ text: 'Original system prompt' }],
+        skills: [
+          {
+            git: {
+              url: 'https://example.com/original.git',
+              path: 'skills/original',
+              auth: { credentialArn: 'arn:original', username: 'original-user' },
+            },
+          },
+        ],
+        allowedTools: ['shell'],
+        maxIterations: 10,
+        maxTokens: 1000,
+        timeoutSeconds: 60,
+        qualifier: 'original-endpoint',
+        runtimeUserId: 'original-user',
+        actorId: 'original-actor',
+      })
+
+      const firstInput = send.mock.calls[0]![0].input
+      firstInput.model!.bedrockModelConfig!.modelId = 'client-mutated-model'
+      firstInput.systemPrompt![0]!.text = 'Client-mutated prompt'
+      firstInput.skills![0]!.git!.url = 'https://example.com/client-mutated.git'
+      firstInput.allowedTools![0] = 'client-mutated-tool'
+
+      await agent.invoke('Second')
+
+      expect(send.mock.calls[1]![0].input).toStrictEqual({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'Second' }] }],
+        model: {
+          bedrockModelConfig: {
+            modelId: 'original-model',
+            additionalParams: { nested: { value: 'original' } },
+          },
+        },
+        systemPrompt: [{ text: 'Original system prompt' }],
+        skills: [
+          {
+            git: {
+              url: 'https://example.com/original.git',
+              path: 'skills/original',
+              auth: { credentialArn: 'arn:original', username: 'original-user' },
+            },
+          },
+        ],
+        allowedTools: ['shell'],
+        maxIterations: 10,
+        maxTokens: 1000,
+        timeoutSeconds: 60,
+        qualifier: 'original-endpoint',
+        runtimeUserId: 'original-user',
+        actorId: 'original-actor',
+      })
+    })
+
+    it('forwards an explicit zero rather than dropping it as falsy', async () => {
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        maxTokens: 0,
+      })
+
+      await agent.invoke('Hi')
+
+      expect(send.mock.calls[0]![0].input).toStrictEqual({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'Hi' }] }],
+        maxTokens: 0,
+      })
+    })
+
+    it('forwards an empty allowedTools override rather than treating it as omitted', async () => {
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        allowedTools: [],
+      })
+
+      await agent.invoke('Hi')
+
+      expect(send.mock.calls[0]![0].input).toStrictEqual({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'Hi' }] }],
+        allowedTools: [],
+      })
+    })
+
+    it('omits optional request fields that are not configured', async () => {
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await agent.invoke('Hi')
+
+      expect(send.mock.calls[0]![0].input).toStrictEqual({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'Hi' }] }],
+      })
+    })
+  })
+
+  describe('concurrency', () => {
+    it('rejects a parallel invocation and allows another after the active invocation completes', async () => {
+      let releaseFirstRequest: () => void
+      const firstRequestGate = new Promise<void>((resolve) => {
+        releaseFirstRequest = resolve
+      })
+      const send = vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          await firstRequestGate
+          return { stream: harnessStream(chunk.messageStop('end_turn')) }
+        })
+        .mockResolvedValueOnce({ stream: harnessStream(chunk.messageStop('end_turn')) })
+      const client = { send } as unknown as BedrockAgentCoreClient
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const firstInvocation = agent.invoke('First')
+      await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+
+      await expect(agent.invoke('Second')).rejects.toBeInstanceOf(ConcurrentInvocationError)
+
+      releaseFirstRequest!()
+      await expect(firstInvocation).resolves.toMatchObject({ stopReason: 'endTurn' })
+      await expect(agent.invoke('Third')).resolves.toMatchObject({ stopReason: 'endTurn' })
+      expect(send).toHaveBeenCalledTimes(2)
+    })
+
+    it('releases the invocation lock after an error', async () => {
+      const originalError = new Error('request failed')
+      const send = vi
+        .fn()
+        .mockRejectedValueOnce(originalError)
+        .mockResolvedValueOnce({ stream: harnessStream(chunk.messageStop('end_turn')) })
+      const client = { send } as unknown as BedrockAgentCoreClient
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke('First')).rejects.toMatchObject({ constructor: ModelError, cause: originalError })
+      await expect(agent.invoke('Second')).resolves.toMatchObject({ stopReason: 'endTurn' })
+      expect(send).toHaveBeenCalledTimes(2)
+    })
+
+    it('releases the invocation lock when a stream is closed early', async () => {
+      const { client, send } = mockClient(
+        harnessStream(chunk.messageStart(), chunk.messageStop('end_turn')),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+      const firstStream = agent.stream('First')
+
+      await expect(firstStream.next()).resolves.toMatchObject({ done: false })
+      await expect(agent.invoke('Second')).rejects.toBeInstanceOf(ConcurrentInvocationError)
+
+      await firstStream.return(undefined as never)
+      await expect(agent.invoke('Third')).resolves.toMatchObject({ stopReason: 'endTurn' })
+      expect(send).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('stream', () => {
+    it('yields an update event per chunk and a final result event', async () => {
+      const messageStart = chunk.messageStart()
+      const textDelta = chunk.textDelta('Hi')
+      const messageStop = chunk.messageStop('end_turn')
+      const { client } = mockClient(harnessStream(messageStart, textDelta, messageStop))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const { items: events, result } = await collectGenerator(agent.stream('Hi'))
+
+      expect(result).toStrictEqual(
+        new AgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [new TextBlock('Hi')],
+            trackingId: result.lastMessage.trackingId,
+          }),
+          invocationState: {},
+        })
+      )
+      expect(events).toStrictEqual([
+        new AgentCoreHarnessStreamUpdateEvent(messageStart),
+        new AgentCoreHarnessStreamUpdateEvent(textDelta),
+        new AgentCoreHarnessStreamUpdateEvent(messageStop),
+        new AgentCoreHarnessResultEvent({ result }),
+      ])
+    })
+
+    it('throws MaxTokensError when the turn stops for max tokens', async () => {
+      const { client } = mockClient(
+        harnessStream(chunk.messageStart(), chunk.textDelta('partial'), chunk.messageStop('max_tokens'))
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke('Hi')).rejects.toBeInstanceOf(MaxTokensError)
+    })
+
+    it.each(['malformed_model_output', 'malformed_tool_use'])(
+      'throws ModelError when the turn stops for %s',
+      async (stopReason) => {
+        const { client } = mockClient(
+          harnessStream(chunk.messageStart(), chunk.textDelta('partial'), chunk.messageStop(stopReason))
+        )
+        const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+        await expect(agent.invoke('Hi')).rejects.toBeInstanceOf(ModelError)
+      }
+    )
+
+    it('throws ModelError when a tool-use input is not valid JSON', async () => {
+      const { client } = mockClient(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.toolUseStart('tu-1', 'get_weather'),
+          chunk.toolUseDelta('{"city":'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('tool_use')
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: ModelError,
+        cause: expect.any(SyntaxError),
+      })
+    })
+  })
+
+  describe('metrics', () => {
+    it('surfaces token usage and latency from the terminal metadata event', async () => {
+      const { client } = mockClient(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.textDelta('done'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('end_turn'),
+          chunk.metadata({ inputTokens: 100, outputTokens: 20, totalTokens: 120 }, 1500)
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const result = await agent.invoke('Hi')
+
+      expect(result.metrics?.accumulatedUsage).toStrictEqual({ inputTokens: 100, outputTokens: 20, totalTokens: 120 })
+      expect(result.metrics?.accumulatedMetrics).toStrictEqual({ latencyMs: 1500 })
+      expect(result.metrics?.latestContextSize).toBe(100)
+      expect(result.metrics?.projectedContextSize).toBe(120)
+      expect(result.metrics?.cycleCount).toBe(1)
+      expect(result.metrics?.totalDuration).toBeGreaterThanOrEqual(0)
+    })
+
+    it('passes cache-token counts through when the harness reports them', async () => {
+      const { client } = mockClient(
+        harnessStream(
+          chunk.messageStop('end_turn'),
+          chunk.metadata({
+            inputTokens: 100,
+            outputTokens: 20,
+            totalTokens: 120,
+            cacheReadInputTokens: 40,
+            cacheWriteInputTokens: 10,
+          })
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const result = await agent.invoke('Hi')
+
+      expect(result.metrics?.accumulatedUsage).toStrictEqual({
+        inputTokens: 100,
+        outputTokens: 20,
+        totalTokens: 120,
+        cacheReadInputTokens: 40,
+        cacheWriteInputTokens: 10,
+      })
+    })
+
+    it('accumulates multiple metadata events from one Harness call', async () => {
+      const { client } = mockClient(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.messageStop('tool_use'),
+          chunk.metadata({ inputTokens: 50, outputTokens: 5, totalTokens: 55 }, 100),
+          chunk.messageStart('user'),
+          chunk.messageStop('tool_result'),
+          chunk.messageStart(),
+          chunk.textDelta('done'),
+          chunk.messageStop('end_turn'),
+          chunk.metadata({ inputTokens: 200, outputTokens: 30, totalTokens: 230 }, 900)
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const result = await agent.invoke('Hi')
+
+      expect(result.metrics?.accumulatedUsage).toStrictEqual({ inputTokens: 250, outputTokens: 35, totalTokens: 285 })
+      expect(result.metrics?.accumulatedMetrics.latencyMs).toBe(1000)
+      expect(result.metrics?.latestContextSize).toBe(200)
+      expect(result.metrics?.projectedContextSize).toBe(230)
+      expect(result.metrics?.cycleCount).toBe(2)
+    })
+
+    it('omits metrics when the harness reports no usage', async () => {
+      const { client } = mockClient(harnessStream(chunk.messageStart(), chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const result = await agent.invoke('Hi')
+
+      expect(result.metrics).toBeUndefined()
+    })
+
+    it('counts only the terminal turn usage across a host-tool bounce', async () => {
+      // The tool_use turn carries no metadata event (matching the live harness); only the terminal
+      // turn reports usage, so the accumulated total is that single terminal turn's counts.
+      const bounced = tool({ name: 'ping', description: 'ping', inputSchema: z.object({}), callback: () => 'pong' })
+      const { client } = mockClient(
+        harnessStream(chunk.toolUseStart('tu-1', 'ping'), chunk.contentBlockStop(), chunk.messageStop('tool_use')),
+        harnessStream(
+          chunk.messageStart(),
+          chunk.textDelta('ok'),
+          chunk.messageStop('end_turn'),
+          chunk.metadata({ inputTokens: 200, outputTokens: 30, totalTokens: 230 }, 900)
+        )
+      )
+      const { controlClient } = mockControlClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [bounced],
+      })
+
+      const result = await agent.invoke('go')
+
+      expect(result.metrics?.accumulatedUsage).toStrictEqual({ inputTokens: 200, outputTokens: 30, totalTokens: 230 })
+      expect(result.metrics?.accumulatedMetrics.latencyMs).toBe(900)
+      expect(result.metrics?.cycleCount).toBe(2)
+    })
+
+    it('sums usage across turns when multiple terminal turns report it', async () => {
+      // Defends the accumulation logic: if the harness ever reports usage on more than one turn of a
+      // single invocation, the counts add up rather than overwrite.
+      const bounced = tool({ name: 'ping', description: 'ping', inputSchema: z.object({}), callback: () => 'pong' })
+      const { client } = mockClient(
+        harnessStream(
+          chunk.toolUseStart('tu-1', 'ping'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('tool_use'),
+          chunk.metadata({ inputTokens: 50, outputTokens: 5, totalTokens: 55 }, 100)
+        ),
+        harnessStream(
+          chunk.messageStop('end_turn'),
+          chunk.metadata({ inputTokens: 200, outputTokens: 30, totalTokens: 230 }, 900)
+        )
+      )
+      const { controlClient } = mockControlClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [bounced],
+      })
+
+      const result = await agent.invoke('go')
+
+      expect(result.metrics?.accumulatedUsage).toStrictEqual({ inputTokens: 250, outputTokens: 35, totalTokens: 285 })
+      expect(result.metrics?.accumulatedMetrics.latencyMs).toBe(1000)
+      // latest/projected describe the last reporting turn (200/30), not the accumulated total (250/35).
+      expect(result.metrics?.latestContextSize).toBe(200)
+      expect(result.metrics?.projectedContextSize).toBe(230)
+      expect(result.metrics?.cycleCount).toBe(2)
+    })
+  })
+
+  describe('cancellation', () => {
+    it('does not call the harness when the signal is already aborted', async () => {
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const result = await agent.invoke('Hi', { cancelSignal: AbortSignal.abort() })
+
+      expect(send).not.toHaveBeenCalled()
+      expect(result.stopReason).toBe('cancelled')
+    })
+
+    it('returns cancelled without throwing when aborted mid-stream', async () => {
+      const controller = new AbortController()
+      const send = vi.fn().mockImplementation(() => {
+        controller.abort()
+        return Promise.reject(new Error('aborted'))
+      })
+      const client = { send } as unknown as BedrockAgentCoreClient
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const result = await agent.invoke('Hi', { cancelSignal: controller.signal })
+      expect(result.stopReason).toBe('cancelled')
+    })
+  })
+
+  describe('errors', () => {
+    it.each(['ThrottlingException', 'ThrottledException'])(
+      'maps a %s from send() to ModelThrottledError',
+      async (name) => {
+        const send = vi.fn().mockRejectedValue(Object.assign(new Error('slow down'), { name }))
+        const client = { send } as unknown as BedrockAgentCoreClient
+        const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+        await expect(agent.invoke('Hi')).rejects.toBeInstanceOf(ModelThrottledError)
+      }
+    )
+
+    it('maps a context-window overflow thrown from send() to ContextWindowOverflowError', async () => {
+      const original = new Error('Input is too long for requested model.')
+      const send = vi.fn().mockRejectedValue(original)
+      const client = { send } as unknown as BedrockAgentCoreClient
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: ContextWindowOverflowError,
+        cause: original,
+      })
+    })
+
+    it('wraps a non-typed send() error in ModelError, preserving the cause', async () => {
+      const original = new Error('unexpected')
+      const send = vi.fn().mockRejectedValue(original)
+      const client = { send } as unknown as BedrockAgentCoreClient
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({ constructor: ModelError, cause: original })
+    })
+
+    it('throws a ModelError when the stream carries a validationException', async () => {
+      const original = { message: 'bad input' }
+      const { client } = mockClient(harnessStream({ validationException: original } as InvokeHarnessStreamOutput))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: ModelError,
+        message: 'bad input',
+        cause: original,
+      })
+    })
+
+    it('maps a context-window overflow in a validationException to ContextWindowOverflowError', async () => {
+      const original = { message: 'prompt is too long' }
+      const { client } = mockClient(harnessStream({ validationException: original } as InvokeHarnessStreamOutput))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      try {
+        await agent.invoke('Hi')
+        expect.fail('Expected error to be thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ContextWindowOverflowError)
+        expect((error as ContextWindowOverflowError).cause).toBe(original)
+      }
+    })
+
+    it('throws a ModelError when the stream carries an internalServerException', async () => {
+      const original = { message: 'boom' }
+      const { client } = mockClient(harnessStream({ internalServerException: original } as InvokeHarnessStreamOutput))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: ModelError,
+        message: 'boom',
+        cause: original,
+      })
+    })
+
+    it('throws a ModelError when the stream carries a runtimeClientError', async () => {
+      const original = { message: 'runtime failed' }
+      const { client } = mockClient(harnessStream({ runtimeClientError: original } as InvokeHarnessStreamOutput))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: ModelError,
+        message: 'runtime failed',
+        cause: original,
+      })
+    })
+  })
+})

--- a/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-cancellation.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-cancellation.test.ts
@@ -1,0 +1,297 @@
+import type { InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import type { BedrockAgentCoreControlClient } from '@aws-sdk/client-bedrock-agentcore-control'
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { ModelError } from '../../errors.js'
+import { tool } from '../../tools/tool-factory.js'
+import { TextBlock } from '../../types/messages.js'
+import { AgentCoreHarnessAgent } from '../agentcore-harness-agent.js'
+import { SESSION_ID, chunk, harnessStream, mockClient, mockControlClient } from './harness-test-fixtures.js'
+
+describe('AgentCoreHarnessAgent host-tool cancellation', () => {
+  it('commits sequential results, drains later tool requests, and allows reuse after cancellation', async () => {
+    const controller = new AbortController()
+    const firstCallback = vi.fn(() => {
+      controller.abort()
+      return 'first result'
+    })
+    const secondCallback = vi.fn(() => 'second result')
+    const first = tool({
+      name: 'first',
+      description: 'First tool',
+      inputSchema: z.object({}),
+      callback: firstCallback,
+    })
+    const second = tool({
+      name: 'second',
+      description: 'Second tool',
+      inputSchema: z.object({}),
+      callback: secondCallback,
+    })
+    const { client, send } = mockClient(
+      harnessStream(
+        chunk.messageStart(),
+        chunk.toolUseStart('tu-1', 'first'),
+        chunk.contentBlockStop(),
+        chunk.toolUseStart('tu-2', 'second'),
+        chunk.contentBlockStop(),
+        chunk.messageStop('tool_use')
+      ),
+      harnessStream(
+        chunk.messageStart(),
+        chunk.toolUseStart('tu-3', 'second'),
+        chunk.contentBlockStop(),
+        chunk.messageStop('tool_use')
+      ),
+      harnessStream(chunk.messageStart(), chunk.textDelta('Cancellation committed.'), chunk.messageStop('max_tokens')),
+      harnessStream(chunk.messageStart(), chunk.textDelta('Ready again.'), chunk.messageStop('end_turn'))
+    )
+    const { controlClient } = mockControlClient()
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: 'arn:harness',
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [first, second],
+      toolExecutor: 'sequential',
+    })
+
+    const cancelledResult = await agent.invoke('Hi', { cancelSignal: controller.signal })
+    const nextResult = await agent.invoke('Continue')
+
+    expect(cancelledResult.stopReason).toBe('cancelled')
+    expect(nextResult.stopReason).toBe('endTurn')
+    expect(nextResult.lastMessage.content).toStrictEqual([new TextBlock('Ready again.')])
+    expect(firstCallback).toHaveBeenCalledOnce()
+    expect(secondCallback).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledTimes(4)
+    expect(send.mock.calls.map((call) => call[1])).toStrictEqual([{ abortSignal: controller.signal }, {}, {}, {}])
+    expect(send.mock.calls[1]![0].input.messages[1]).toStrictEqual({
+      role: 'user',
+      content: [
+        {
+          toolResult: {
+            toolUseId: 'tu-1',
+            content: [{ text: 'first result' }],
+            status: 'success',
+            type: 'tool_use',
+          },
+        },
+        {
+          toolResult: {
+            toolUseId: 'tu-2',
+            content: [{ text: 'Tool execution cancelled' }],
+            status: 'error',
+            type: 'tool_use',
+          },
+        },
+      ],
+    })
+    expect(send.mock.calls[2]![0].input.messages[1]).toStrictEqual({
+      role: 'user',
+      content: [
+        {
+          toolResult: {
+            toolUseId: 'tu-3',
+            content: [{ text: 'Tool execution cancelled' }],
+            status: 'error',
+            type: 'tool_use',
+          },
+        },
+      ],
+    })
+  })
+
+  it('does not launch concurrent host tools when cancellation precedes execution', async () => {
+    const controller = new AbortController()
+    const firstCallback = vi.fn(() => 'first result')
+    const secondCallback = vi.fn(() => 'second result')
+    const first = tool({
+      name: 'first',
+      description: 'First tool',
+      inputSchema: z.object({}),
+      callback: firstCallback,
+    })
+    const second = tool({
+      name: 'second',
+      description: 'Second tool',
+      inputSchema: z.object({}),
+      callback: secondCallback,
+    })
+    async function* toolRequestThenCancel(): AsyncGenerator<InvokeHarnessStreamOutput> {
+      yield chunk.messageStart()
+      yield chunk.toolUseStart('tu-1', 'first')
+      yield chunk.contentBlockStop()
+      yield chunk.toolUseStart('tu-2', 'second')
+      yield chunk.contentBlockStop()
+      yield chunk.messageStop('tool_use')
+      controller.abort()
+    }
+    const { client, send } = mockClient(
+      toolRequestThenCancel(),
+      harnessStream(chunk.messageStart(), chunk.messageStop('end_turn'))
+    )
+    const { controlClient } = mockControlClient()
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: 'arn:harness',
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [first, second],
+    })
+
+    const result = await agent.invoke('Hi', { cancelSignal: controller.signal })
+
+    expect(result.stopReason).toBe('cancelled')
+    expect(firstCallback).not.toHaveBeenCalled()
+    expect(secondCallback).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send.mock.calls[1]![0].input.messages[1].content).toStrictEqual([
+      {
+        toolResult: {
+          toolUseId: 'tu-1',
+          content: [{ text: 'Tool execution cancelled' }],
+          status: 'error',
+          type: 'tool_use',
+        },
+      },
+      {
+        toolResult: {
+          toolUseId: 'tu-2',
+          content: [{ text: 'Tool execution cancelled' }],
+          status: 'error',
+          type: 'tool_use',
+        },
+      },
+    ])
+  })
+
+  it('finishes every concurrent host tool that started before cancellation', async () => {
+    const controller = new AbortController()
+    const firstCallback = vi.fn(() => {
+      controller.abort()
+      return 'first result'
+    })
+    const secondCallback = vi.fn(() => 'second result')
+    const first = tool({
+      name: 'first',
+      description: 'First tool',
+      inputSchema: z.object({}),
+      callback: firstCallback,
+    })
+    const second = tool({
+      name: 'second',
+      description: 'Second tool',
+      inputSchema: z.object({}),
+      callback: secondCallback,
+    })
+    const { client, send } = mockClient(
+      harnessStream(
+        chunk.messageStart(),
+        chunk.toolUseStart('tu-1', 'first'),
+        chunk.contentBlockStop(),
+        chunk.toolUseStart('tu-2', 'second'),
+        chunk.contentBlockStop(),
+        chunk.messageStop('tool_use')
+      ),
+      harnessStream(chunk.messageStart(), chunk.messageStop('end_turn'))
+    )
+    const { controlClient } = mockControlClient()
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: 'arn:harness',
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [first, second],
+    })
+
+    const result = await agent.invoke('Hi', { cancelSignal: controller.signal })
+
+    expect(result.stopReason).toBe('cancelled')
+    expect(firstCallback).toHaveBeenCalledOnce()
+    expect(secondCallback).toHaveBeenCalledOnce()
+    expect(send.mock.calls[1]![0].input.messages[1].content).toStrictEqual([
+      {
+        toolResult: {
+          toolUseId: 'tu-1',
+          content: [{ text: 'first result' }],
+          status: 'success',
+          type: 'tool_use',
+        },
+      },
+      {
+        toolResult: {
+          toolUseId: 'tu-2',
+          content: [{ text: 'second result' }],
+          status: 'success',
+          type: 'tool_use',
+        },
+      },
+    ])
+  })
+
+  it('throws when a mandatory host-result continuation fails after cancellation', async () => {
+    const controller = new AbortController()
+    const original = new Error('commit status unknown')
+    const hostTool = tool({
+      name: 'host',
+      description: 'Host tool',
+      inputSchema: z.object({}),
+      callback: () => {
+        controller.abort()
+        return 'completed result'
+      },
+    })
+    const { client, send } = mockClient(
+      harnessStream(
+        chunk.messageStart(),
+        chunk.toolUseStart('tu-1', 'host'),
+        chunk.contentBlockStop(),
+        chunk.messageStop('tool_use')
+      )
+    )
+    send.mockRejectedValueOnce(original)
+    const { controlClient } = mockControlClient()
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: 'arn:harness',
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [hostTool],
+    })
+
+    await expect(agent.invoke('Hi', { cancelSignal: controller.signal })).rejects.toMatchObject({
+      constructor: ModelError,
+      message: 'commit status unknown',
+      cause: original,
+    })
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send.mock.calls[1]![1]).toStrictEqual({})
+  })
+
+  it('returns cancelled without invoking the harness when aborted during tool resolution', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const controller = new AbortController()
+    const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+    const controlSend = vi.fn().mockImplementation(() => {
+      controller.abort()
+      return Promise.reject(new Error('aborted'))
+    })
+    const controlClient = { send: controlSend } as unknown as BedrockAgentCoreControlClient
+    const hostTool = tool({ name: 'host', description: 'Host tool', inputSchema: z.object({}), callback: () => 'ok' })
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: 'arn:harness',
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [hostTool],
+    })
+
+    const result = await agent.invoke('Hi', { cancelSignal: controller.signal })
+
+    expect(result.stopReason).toBe('cancelled')
+    expect(send).not.toHaveBeenCalled()
+    expect(warning).not.toHaveBeenCalled()
+    warning.mockRestore()
+  })
+})

--- a/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-client.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-client.test.ts
@@ -1,0 +1,115 @@
+import { BedrockAgentCoreClient, type BedrockAgentCoreClientConfig } from '@aws-sdk/client-bedrock-agentcore'
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { ModelError } from '../../errors.js'
+import { tool } from '../../tools/tool-factory.js'
+import { AgentCoreHarnessAgent } from '../agentcore-harness-agent.js'
+import { createHarnessClient, createHarnessControlClient } from '../clients.js'
+import {
+  HARNESS_ARN,
+  SESSION_ID,
+  chunk,
+  harnessStream,
+  mockClient,
+  mockControlClient,
+} from './harness-test-fixtures.js'
+
+describe('AgentCoreHarnessAgent clients', () => {
+  it('reuses an injected client across host-tool turns', async () => {
+    const { client, send } = mockClient(
+      harnessStream(chunk.toolUseStart('tu-1', 'noop'), chunk.contentBlockStop(), chunk.messageStop('tool_use')),
+      harnessStream(chunk.messageStop('end_turn'))
+    )
+    const noop = tool({ name: 'noop', description: 'noop', inputSchema: z.object({}), callback: () => 'ok' })
+    const { controlClient } = mockControlClient()
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [noop],
+    })
+
+    await agent.invoke('Hi')
+
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+
+  it('constructs clients with the intended region and retry ownership', async () => {
+    const defaultClient = createHarnessClient({}, 'us-east-1')
+    const configuredClient = createHarnessClient({ region: 'us-west-2', maxAttempts: 2 }, 'us-east-1')
+    const controlClient = createHarnessControlClient({ maxAttempts: 4 }, 'us-east-1')
+    const injectedClient = new BedrockAgentCoreClient({ region: 'us-east-1', maxAttempts: 3 })
+
+    expect(await defaultClient.config.maxAttempts()).toBe(1)
+    expect(await configuredClient.config.region()).toBe('us-east-1')
+    expect(await configuredClient.config.maxAttempts()).toBe(2)
+    expect(await controlClient.config.maxAttempts()).toBe(4)
+    expect(await injectedClient.config.maxAttempts()).toBe(3)
+  })
+
+  it('retries retryable pre-stream failures only when clientConfig opts in', async () => {
+    const credentials = { accessKeyId: 'test', secretAccessKey: 'test' }
+    const cases = [
+      {
+        name: 'retryable HTTP 500',
+        fail: () => ({
+          response: {
+            statusCode: 500,
+            headers: {
+              'content-type': 'application/json',
+              'x-amzn-errortype': 'InternalServerException',
+            },
+            body: new TextEncoder().encode(JSON.stringify({ message: 'server failed' })),
+          },
+        }),
+      },
+      {
+        name: 'ambiguous timeout',
+        fail: () => {
+          throw Object.assign(new Error('socket timed out'), { name: 'TimeoutError' })
+        },
+      },
+    ]
+
+    for (const testCase of cases) {
+      for (const expectedAttempts of [1, 2]) {
+        const handle = vi.fn().mockImplementation(testCase.fail)
+        const clientConfig: BedrockAgentCoreClientConfig = {
+          credentials,
+          requestHandler: { handle },
+          ...(expectedAttempts === 2 && { maxAttempts: 2 }),
+        }
+        const agent = new AgentCoreHarnessAgent({
+          harnessArn: HARNESS_ARN,
+          runtimeSessionId: SESSION_ID,
+          region: 'us-east-1',
+          clientConfig,
+        })
+
+        await expect(agent.invoke('Hi')).rejects.toBeDefined()
+        expect(handle, `${testCase.name} with ${expectedAttempts} attempt(s)`).toHaveBeenCalledTimes(expectedAttempts)
+      }
+    }
+  })
+
+  it('does not replay a request after response streaming begins', async () => {
+    const send = vi.fn().mockResolvedValue({
+      stream: (async function* () {
+        yield chunk.textDelta('partial')
+        throw new Error('stream failed')
+      })(),
+    })
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: SESSION_ID,
+      client: { send } as unknown as BedrockAgentCoreClient,
+    })
+
+    await expect(agent.invoke('Hi')).rejects.toMatchObject({
+      constructor: ModelError,
+      message: 'stream failed',
+    })
+    expect(send).toHaveBeenCalledOnce()
+  })
+})

--- a/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-composition.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-composition.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { Graph } from '../../multiagent/graph.js'
+import { Status } from '../../multiagent/state.js'
+import { Swarm } from '../../multiagent/swarm.js'
+import { tool } from '../../tools/tool-factory.js'
+import { AgentCoreHarnessAgent } from '../agentcore-harness-agent.js'
+import {
+  HARNESS_ARN,
+  SESSION_ID,
+  chunk,
+  harnessStream,
+  mockClient,
+  mockControlClient,
+} from './harness-test-fixtures.js'
+
+describe('AgentCoreHarnessAgent composition', () => {
+  it('rejects structured output before resolving tools or invoking the harness', async () => {
+    const hostTool = tool({
+      name: 'get_weather',
+      description: 'Get weather',
+      inputSchema: z.object({}),
+      callback: vi.fn(() => 'sunny'),
+    })
+    const { client, send } = mockClient()
+    const { controlClient, send: controlSend } = mockControlClient()
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [hostTool],
+      allowedTools: ['@get_weather'],
+    })
+
+    await expect(
+      agent.invoke('Hi', {
+        structuredOutputSchema: z.object({ answer: z.string() }),
+      })
+    ).rejects.toThrow(
+      'InvokeOptions.structuredOutputSchema is not supported by AgentCoreHarnessAgent. AgentCoreHarnessAgent cannot be used as a Swarm node.'
+    )
+    expect(controlSend).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('runs as a Graph node and reuses its configured remote session across Graph invocations', async () => {
+    const { client, send } = mockClient(
+      harnessStream(chunk.messageStop('end_turn')),
+      harnessStream(chunk.messageStop('end_turn'))
+    )
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: SESSION_ID,
+      client,
+    })
+    const graph = new Graph({ nodes: [agent], edges: [], maxSteps: 2 })
+
+    const first = await graph.invoke('First')
+    const second = await graph.invoke('Second')
+
+    expect(first.status).toBe(Status.COMPLETED)
+    expect(second.status).toBe(Status.COMPLETED)
+    expect(
+      send.mock.calls.map((call) => ({
+        runtimeSessionId: call[0].input.runtimeSessionId,
+        messages: call[0].input.messages,
+      }))
+    ).toStrictEqual([
+      { runtimeSessionId: SESSION_ID, messages: [{ role: 'user', content: [{ text: 'First' }] }] },
+      { runtimeSessionId: SESSION_ID, messages: [{ role: 'user', content: [{ text: 'Second' }] }] },
+    ])
+  })
+
+  it('fails a Swarm node without making a Harness request', async () => {
+    const { client, send } = mockClient()
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: SESSION_ID,
+      client,
+    })
+    const swarm = new Swarm({ nodes: [agent], start: agent.id, maxSteps: 1 })
+
+    const result = await swarm.invoke('Hi')
+
+    expect(result.status).toBe(Status.FAILED)
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0]).toMatchObject({
+      nodeId: agent.id,
+      status: Status.FAILED,
+      error: {
+        message:
+          'InvokeOptions.structuredOutputSchema is not supported by AgentCoreHarnessAgent. AgentCoreHarnessAgent cannot be used as a Swarm node.',
+      },
+    })
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-host-tools.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-host-tools.test.ts
@@ -1,0 +1,966 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { HarnessTool } from '@aws-sdk/client-bedrock-agentcore'
+import {
+  AccessDeniedException,
+  type BedrockAgentCoreControlClient,
+  GetHarnessCommand,
+  GetHarnessEndpointCommand,
+  ResourceNotFoundException,
+  ValidationException,
+} from '@aws-sdk/client-bedrock-agentcore-control'
+import { z } from 'zod'
+import { AgentCoreHarnessAgent } from '../agentcore-harness-agent.js'
+import { ModelError, ModelThrottledError, ToolValidationError } from '../../errors.js'
+import { tool } from '../../tools/tool-factory.js'
+import { Tool, type ToolStreamGenerator } from '../../tools/tool.js'
+import { TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { DocumentBlock, ImageBlock, VideoBlock } from '../../types/media.js'
+import {
+  HARNESS_ARN,
+  HARNESS_ID,
+  SESSION_ID,
+  chunk,
+  harnessStream,
+  mockClient,
+  mockControlClient,
+} from './harness-test-fixtures.js'
+
+describe('AgentCoreHarnessAgent host tools', () => {
+  describe('tool configuration', () => {
+    it('does not call GetHarness or override tools when no host tools are configured', async () => {
+      const deployedTool: HarnessTool = { type: 'agentcore_browser', name: 'browser' }
+      const { controlClient, send: controlSend } = mockControlClient([deployedTool])
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+      })
+
+      await agent.invoke('Hi')
+
+      expect(controlSend).not.toHaveBeenCalled()
+      expect(send.mock.calls[0]![0].input).not.toHaveProperty('tools')
+    })
+
+    it('rejects invalid invocation content before loading deployed tool configuration', async () => {
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: z.object({}),
+        callback: () => 'sunny',
+      })
+      const { controlClient, send: controlSend } = mockControlClient()
+      const { client, send } = mockClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [getWeather],
+      })
+
+      await expect(
+        agent.invoke([
+          new TextBlock('Do not send only this text'),
+          new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1]) } }),
+        ])
+      ).rejects.toThrow("unsupported type 'imageBlock'")
+      expect(controlSend).not.toHaveBeenCalled()
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('refreshes the default Harness configuration before every invocation', async () => {
+      const deployedTool: HarnessTool = { type: 'agentcore_browser', name: 'browser' }
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+        callback: () => 'sunny',
+      })
+      const { controlClient, send: controlSend } = mockControlClient([deployedTool], ['@get_weather'])
+      const { client, send } = mockClient(
+        harnessStream(chunk.messageStop('end_turn')),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [getWeather],
+      })
+
+      await agent.invoke('First')
+      await agent.invoke('Second')
+
+      expect(controlSend).toHaveBeenCalledTimes(2)
+      expect(controlSend.mock.calls.map((call) => call[0].input)).toStrictEqual([
+        { harnessId: HARNESS_ID },
+        { harnessId: HARNESS_ID },
+      ])
+      expect(
+        send.mock.calls.map((call) => ({
+          tools: call[0].input.tools?.map((harnessTool: HarnessTool) => harnessTool.name),
+          allowedTools: call[0].input.allowedTools,
+        }))
+      ).toStrictEqual([
+        { tools: ['browser', 'get_weather'], allowedTools: ['@get_weather'] },
+        { tools: ['browser', 'get_weather'], allowedTools: ['@get_weather'] },
+      ])
+      expect(send.mock.calls[0]![0].input.tools[0]).toStrictEqual(deployedTool)
+      expect(send.mock.calls[0]![0].input.tools[0]).not.toBe(deployedTool)
+    })
+
+    it('refreshes an explicit DEFAULT qualifier without reading a named endpoint', async () => {
+      const hostTool = tool({
+        name: 'host',
+        description: 'Host tool',
+        inputSchema: z.object({}),
+        callback: () => 'host result',
+      })
+      const { controlClient, send: controlSend } = mockControlClient()
+      const { client } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [hostTool],
+        qualifier: 'DEFAULT',
+      })
+
+      await agent.invoke('Hi')
+
+      expect(controlSend).toHaveBeenCalledOnce()
+      expect(controlSend.mock.calls[0]![0]).toBeInstanceOf(GetHarnessCommand)
+      expect(controlSend.mock.calls[0]![0].input).toStrictEqual({ harnessId: HARNESS_ID })
+    })
+
+    it('tracks a named endpoint live version and caches only that version configuration', async () => {
+      const v1Tool: HarnessTool = { type: 'agentcore_browser', name: 'browser-v1' }
+      const v2Tool: HarnessTool = { type: 'agentcore_browser', name: 'browser-v2' }
+      const hostTool = tool({
+        name: 'host',
+        description: 'Host tool',
+        inputSchema: z.object({}),
+        callback: () => 'host result',
+      })
+      const liveVersions = ['1', '1', '2', '1']
+      let endpointRead = 0
+      const controlSend = vi.fn((command: GetHarnessCommand | GetHarnessEndpointCommand) => {
+        if (command instanceof GetHarnessEndpointCommand) {
+          return Promise.resolve({ endpoint: { liveVersion: liveVersions[endpointRead++] } })
+        }
+        if (command instanceof GetHarnessCommand) {
+          const version = command.input.harnessVersion
+          return Promise.resolve({
+            harness: {
+              harnessVersion: version,
+              tools: version === '1' ? [v1Tool] : [v2Tool],
+            },
+          })
+        }
+        throw new Error('unexpected control-plane command')
+      })
+      const controlClient = { send: controlSend } as unknown as BedrockAgentCoreControlClient
+      const { client, send } = mockClient(
+        harnessStream(chunk.messageStop('end_turn')),
+        harnessStream(chunk.messageStop('end_turn')),
+        harnessStream(chunk.messageStop('end_turn')),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [hostTool],
+        qualifier: 'prod',
+      })
+
+      await agent.invoke('First')
+      await agent.invoke('Second')
+      await agent.invoke('Third')
+      await agent.invoke('Fourth')
+
+      expect(
+        controlSend.mock.calls.map((call) => ({
+          command: call[0].constructor.name,
+          input: call[0].input,
+        }))
+      ).toStrictEqual([
+        {
+          command: 'GetHarnessEndpointCommand',
+          input: { harnessId: HARNESS_ID, endpointName: 'prod' },
+        },
+        {
+          command: 'GetHarnessCommand',
+          input: { harnessId: HARNESS_ID, harnessVersion: '1' },
+        },
+        {
+          command: 'GetHarnessEndpointCommand',
+          input: { harnessId: HARNESS_ID, endpointName: 'prod' },
+        },
+        {
+          command: 'GetHarnessEndpointCommand',
+          input: { harnessId: HARNESS_ID, endpointName: 'prod' },
+        },
+        {
+          command: 'GetHarnessCommand',
+          input: { harnessId: HARNESS_ID, harnessVersion: '2' },
+        },
+        {
+          command: 'GetHarnessEndpointCommand',
+          input: { harnessId: HARNESS_ID, endpointName: 'prod' },
+        },
+        {
+          command: 'GetHarnessCommand',
+          input: { harnessId: HARNESS_ID, harnessVersion: '1' },
+        },
+      ])
+      expect(
+        send.mock.calls.map((call) => call[0].input.tools.map((harnessTool: HarnessTool) => harnessTool.name))
+      ).toStrictEqual([
+        ['browser-v1', 'host'],
+        ['browser-v1', 'host'],
+        ['browser-v2', 'host'],
+        ['browser-v1', 'host'],
+      ])
+    })
+
+    it('rejects a named endpoint without a live version before InvokeHarness', async () => {
+      const hostTool = tool({
+        name: 'host',
+        description: 'Host tool',
+        inputSchema: z.object({}),
+        callback: () => 'host result',
+      })
+      const controlSend = vi.fn().mockResolvedValue({ endpoint: {} })
+      const controlClient = { send: controlSend } as unknown as BedrockAgentCoreControlClient
+      const { client, send } = mockClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [hostTool],
+        qualifier: 'prod',
+      })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: Error,
+        message: "Harness endpoint 'prod' has no live version",
+      })
+      expect(controlSend).toHaveBeenCalledOnce()
+      expect(controlSend.mock.calls[0]![0]).toBeInstanceOf(GetHarnessEndpointCommand)
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('rejects an empty GetHarness response instead of replacing unknown deployed tools', async () => {
+      const hostTool = tool({
+        name: 'host',
+        description: 'Host tool',
+        inputSchema: z.object({}),
+        callback: () => 'host result',
+      })
+      const controlSend = vi.fn().mockResolvedValue({})
+      const controlClient = { send: controlSend } as unknown as BedrockAgentCoreControlClient
+      const { client, send } = mockClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [hostTool],
+      })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: Error,
+        message: 'GetHarness returned no Harness configuration',
+      })
+      expect(controlSend).toHaveBeenCalledOnce()
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('rejects pending DEFAULT configuration while the data plane still serves the previous version', async () => {
+      const hostTool = tool({
+        name: 'host',
+        description: 'Host tool',
+        inputSchema: z.object({}),
+        callback: () => 'host result',
+      })
+      const controlSend = vi.fn().mockResolvedValue({
+        harness: {
+          status: 'UPDATING',
+          tools: [{ type: 'agentcore_browser', name: 'pending-browser' }],
+        },
+      })
+      const controlClient = { send: controlSend } as unknown as BedrockAgentCoreControlClient
+      const { client, send } = mockClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [hostTool],
+      })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: Error,
+        message:
+          'Default Harness configuration cannot be resolved safely while the Harness is UPDATING. Retry after the update completes or use a named endpoint.',
+      })
+      expect(controlSend).toHaveBeenCalledOnce()
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('uses an explicit allowedTools override instead of the deployed list', async () => {
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+        callback: () => 'sunny',
+      })
+      const { controlClient } = mockControlClient([], [])
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [getWeather],
+        allowedTools: ['@get_weather'],
+      })
+
+      await agent.invoke('Hi')
+
+      expect(send.mock.calls[0]![0].input.allowedTools).toStrictEqual(['@get_weather'])
+    })
+
+    it('rejects a host tool excluded by the deployed allowlist before InvokeHarness', async () => {
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+        callback: () => 'sunny',
+      })
+      const { controlClient, send: controlSend } = mockControlClient([], [])
+      const { client, send } = mockClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [getWeather],
+      })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: ToolValidationError,
+        message:
+          "Host tool 'get_weather' is excluded by effective allowedTools. Add '@get_weather', '@get_weather/get_weather', a matching namespace glob, or '*' to allowedTools.",
+      })
+      expect(controlSend).toHaveBeenCalledOnce()
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('preserves non-throttling control-plane errors and retries the next invocation', async () => {
+      const originals = [
+        new AccessDeniedException({ $metadata: {}, message: 'access denied' }),
+        new ResourceNotFoundException({ $metadata: {}, message: 'not found' }),
+        new ValidationException({ $metadata: {}, message: 'invalid request', reason: undefined }),
+        new Error('control plane unavailable'),
+      ]
+      const deployedTool: HarnessTool = { type: 'agentcore_browser', name: 'browser' }
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+        callback: () => 'sunny',
+      })
+      const controlSend = vi
+        .fn()
+        .mockRejectedValueOnce(originals[0])
+        .mockRejectedValueOnce(originals[1])
+        .mockRejectedValueOnce(originals[2])
+        .mockRejectedValueOnce(originals[3])
+        .mockResolvedValueOnce({ harness: { tools: [deployedTool] } })
+      const controlClient = { send: controlSend } as unknown as BedrockAgentCoreControlClient
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [getWeather],
+      })
+
+      for (const original of originals) {
+        await expect(agent.invoke('First')).rejects.toBe(original)
+      }
+      expect(send).not.toHaveBeenCalled()
+
+      await agent.invoke('Second')
+
+      expect(controlSend).toHaveBeenCalledTimes(5)
+      expect(send).toHaveBeenCalledOnce()
+      expect(send.mock.calls[0]![0].input.tools.map((tool: HarnessTool) => tool.name)).toStrictEqual([
+        'browser',
+        'get_weather',
+      ])
+    })
+
+    it.each(['ThrottlingException', 'ThrottledException'])(
+      'maps a GetHarness %s to ModelThrottledError and preserves the cause',
+      async (name) => {
+        const original = Object.assign(new Error('slow down'), { name })
+        const controlSend = vi.fn().mockRejectedValue(original)
+        const controlClient = { send: controlSend } as unknown as BedrockAgentCoreControlClient
+        const { client, send } = mockClient()
+        const hostTool = tool({
+          name: 'get_weather',
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+          callback: () => 'sunny',
+        })
+        const agent = new AgentCoreHarnessAgent({
+          harnessArn: HARNESS_ARN,
+          runtimeSessionId: SESSION_ID,
+          client,
+          controlClient,
+          tools: [hostTool],
+        })
+
+        await expect(agent.invoke('Hi')).rejects.toMatchObject({
+          constructor: ModelThrottledError,
+          message: 'slow down',
+          cause: original,
+        })
+        expect(controlSend).toHaveBeenCalledOnce()
+        expect(send).not.toHaveBeenCalled()
+      }
+    )
+
+    it('rejects a host tool name that conflicts with a deployed harness tool', async () => {
+      const deployedTool: HarnessTool = { type: 'agentcore_browser', name: 'duplicate' }
+      const hostTool = tool({
+        name: 'duplicate',
+        description: 'duplicate',
+        inputSchema: z.object({}),
+        callback: () => 'host result',
+      })
+      const { controlClient, send: controlSend } = mockControlClient([deployedTool])
+      const { client, send } = mockClient(harnessStream(chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [hostTool],
+      })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: ToolValidationError,
+        message:
+          "Host tool 'duplicate' conflicts with deployed tool type 'agentcore_browser'. A local handler can bind only to a deployed inline_function.",
+      })
+      expect(controlSend).toHaveBeenCalledTimes(1)
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('rejects a stream-only host tool during construction', () => {
+      const streamOnlyTool = new (class extends Tool {
+        name = 'streamer'
+        description = 'stream only'
+        toolSpec = {
+          name: 'streamer',
+          description: 'stream only',
+          inputSchema: { type: 'object' as const, properties: {} },
+        }
+        // eslint-disable-next-line require-yield
+        async *stream(): ToolStreamGenerator {
+          return new ToolResultBlock({ toolUseId: 'x', status: 'success', content: [] })
+        }
+      })()
+
+      expect(
+        () =>
+          new AgentCoreHarnessAgent({
+            harnessArn: HARNESS_ARN,
+            runtimeSessionId: SESSION_ID,
+            tools: [streamOnlyTool as never],
+          })
+      ).toThrowError(
+        expect.objectContaining({
+          name: 'ToolValidationError',
+          message:
+            "Host tool 'streamer' must implement invoke(). AgentCoreHarnessAgent does not support stream-only tools.",
+        })
+      )
+    })
+  })
+
+  describe('host tool bounce', () => {
+    it('runs a host tool and resumes with a second InvokeHarness call carrying toolUse and toolResult', async () => {
+      const callback = vi.fn().mockResolvedValue('72F, sunny')
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+        callback,
+      })
+
+      // First call streams a tool_use; second call streams the final answer.
+      const { client, send } = mockClient(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.toolUseStart('tu-1', 'get_weather'),
+          chunk.toolUseDelta('{"city":"Seattle"}'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('tool_use')
+        ),
+        harnessStream(chunk.messageStart(), chunk.textDelta('It is 72F.'), chunk.messageStop('end_turn'))
+      )
+      const { controlClient, send: controlSend } = mockControlClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [getWeather],
+      })
+
+      const result = await agent.invoke('weather in Seattle?')
+
+      // The callback ran on the host with the parsed input.
+      expect(callback.mock.calls[0]![0]).toStrictEqual({ city: 'Seattle' })
+
+      // Two InvokeHarness calls were made.
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(controlSend).toHaveBeenCalledTimes(2)
+      expect(
+        send.mock.calls.map((call) => call[0].input.tools?.map((harnessTool: HarnessTool) => harnessTool.name))
+      ).toStrictEqual([['get_weather'], ['get_weather']])
+      expect(send.mock.calls.map((call) => call[0].input.allowedTools)).toStrictEqual([undefined, undefined])
+
+      // The resume call carries the assistant toolUse followed by the user toolResult.
+      const resumeMessages = send.mock.calls[1]![0].input.messages
+      expect(resumeMessages).toStrictEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'tu-1',
+                name: 'get_weather',
+                input: { city: 'Seattle' },
+                type: 'tool_use',
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'tu-1',
+                content: [{ text: '72F, sunny' }],
+                status: 'success',
+                type: 'tool_use',
+              },
+            },
+          ],
+        },
+      ])
+
+      expect(result.stopReason).toBe('endTurn')
+      expect((result.lastMessage.content[0] as TextBlock).text).toBe('It is 72F.')
+    })
+
+    it('uses the previous snapshot when a continuation refresh fails after a host side effect', async () => {
+      const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const callback = vi.fn(() => 'completed side effect')
+      const hostTool = tool({
+        name: 'host',
+        description: 'Host tool',
+        inputSchema: z.object({}),
+        callback,
+      })
+      const controlSend = vi
+        .fn()
+        .mockResolvedValueOnce({ harness: { tools: [] } })
+        .mockRejectedValueOnce(new Error('control plane unavailable'))
+      const controlClient = { send: controlSend } as unknown as BedrockAgentCoreControlClient
+      const { client, send } = mockClient(
+        harnessStream(chunk.toolUseStart('tu-1', 'host'), chunk.contentBlockStop(), chunk.messageStop('tool_use')),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [hostTool],
+      })
+
+      const result = await agent.invoke('Run host')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(callback).toHaveBeenCalledOnce()
+      expect(controlSend).toHaveBeenCalledTimes(2)
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(send.mock.calls[1]![0].input.tools.map((harnessTool: HarnessTool) => harnessTool.name)).toStrictEqual([
+        'host',
+      ])
+      expect(warning).toHaveBeenCalledWith(
+        `harness_arn=<${HARNESS_ARN}>, qualifier=<DEFAULT>, error=<control plane unavailable> | unable to refresh harness tool configuration, using previous snapshot for mandatory host result continuation`
+      )
+      warning.mockRestore()
+    })
+
+    it('runs multiple host tools in one bounce concurrently by default', async () => {
+      // beta resolves the gate alpha awaits, so alpha can only finish if beta starts first — which
+      // requires concurrent execution. Sequential execution would deadlock (alpha never returns).
+      let releaseAlpha: () => void = () => {}
+      const betaStarted = new Promise<void>((resolve) => {
+        releaseAlpha = resolve
+      })
+      const alpha = tool({
+        name: 'alpha',
+        description: 'Waits for beta to start',
+        inputSchema: z.object({}),
+        callback: async () => {
+          await betaStarted
+          return 'alpha'
+        },
+      })
+      const beta = tool({
+        name: 'beta',
+        description: 'Releases alpha',
+        inputSchema: z.object({}),
+        callback: () => {
+          releaseAlpha()
+          return 'beta'
+        },
+      })
+      const { client, send } = mockClient(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.toolUseStart('tu-1', 'alpha'),
+          chunk.contentBlockStop(),
+          chunk.toolUseStart('tu-2', 'beta'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('tool_use')
+        ),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const { controlClient } = mockControlClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [alpha, beta],
+      })
+
+      const result = await agent.invoke('run both')
+
+      expect(result.stopReason).toBe('endTurn')
+      // Results resume in input order regardless of completion order.
+      expect(send.mock.calls[1]![0].input.messages[1]).toStrictEqual({
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'tu-1',
+              content: [{ text: 'alpha' }],
+              status: 'success',
+              type: 'tool_use',
+            },
+          },
+          {
+            toolResult: {
+              toolUseId: 'tu-2',
+              content: [{ text: 'beta' }],
+              status: 'success',
+              type: 'tool_use',
+            },
+          },
+        ],
+      })
+    })
+
+    it('runs multiple host tools one at a time when toolExecutor is sequential', async () => {
+      const order: string[] = []
+      const alpha = tool({
+        name: 'alpha',
+        description: 'First',
+        inputSchema: z.object({}),
+        callback: async () => {
+          order.push('alpha:start')
+          await new Promise((resolve) => setTimeout(resolve, 0))
+          order.push('alpha:end')
+          return 'alpha'
+        },
+      })
+      const beta = tool({
+        name: 'beta',
+        description: 'Second',
+        inputSchema: z.object({}),
+        callback: () => {
+          order.push('beta:start')
+          return 'beta'
+        },
+      })
+      const { client } = mockClient(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.toolUseStart('tu-1', 'alpha'),
+          chunk.contentBlockStop(),
+          chunk.toolUseStart('tu-2', 'beta'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('tool_use')
+        ),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const { controlClient } = mockControlClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [alpha, beta],
+        toolExecutor: 'sequential',
+      })
+
+      await agent.invoke('run both')
+
+      // alpha fully completes before beta starts; concurrent execution would interleave them.
+      expect(order).toStrictEqual(['alpha:start', 'alpha:end', 'beta:start'])
+    })
+
+    it('preserves an empty string returned by a host tool', async () => {
+      const empty = tool({
+        name: 'empty',
+        description: 'Returns an empty string',
+        inputSchema: z.object({}),
+        callback: () => '',
+      })
+      const { client, send } = mockClient(
+        harnessStream(chunk.toolUseStart('tu-1', 'empty'), chunk.contentBlockStop(), chunk.messageStop('tool_use')),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const { controlClient } = mockControlClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [empty],
+      })
+
+      await agent.invoke('run empty')
+
+      expect(send.mock.calls[1]![0].input.messages[1]).toStrictEqual({
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'tu-1',
+              content: [{ text: '""' }],
+              status: 'success',
+              type: 'tool_use',
+            },
+          },
+        ],
+      })
+    })
+
+    it('encodes a JSON-compatible host tool value as JSON text', async () => {
+      const json = tool({
+        name: 'json',
+        description: 'Returns structured data',
+        inputSchema: z.object({}),
+        callback: () => ({ weather: 'sunny', temperature: 72 }),
+      })
+      const { client, send } = mockClient(
+        harnessStream(chunk.toolUseStart('tu-1', 'json'), chunk.contentBlockStop(), chunk.messageStop('tool_use')),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const { controlClient } = mockControlClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [json],
+      })
+
+      await agent.invoke('run json')
+
+      expect(send.mock.calls[1]![0].input.messages[1]).toStrictEqual({
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'tu-1',
+              content: [{ text: '{"weather":"sunny","temperature":72}' }],
+              status: 'success',
+              type: 'tool_use',
+            },
+          },
+        ],
+      })
+    })
+
+    it.each([
+      {
+        description: 'image',
+        value: new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1]) } }),
+      },
+      {
+        description: 'video',
+        value: new VideoBlock({ format: 'mp4', source: { bytes: new Uint8Array([2]) } }),
+      },
+      {
+        description: 'document',
+        value: new DocumentBlock({ name: 'notes', format: 'txt', source: { text: 'hello' } }),
+      },
+    ])('commits an error result when a host tool returns unsupported $description content', async ({ value }) => {
+      const media = tool({
+        name: 'media',
+        description: 'Returns unsupported media',
+        inputSchema: z.object({}),
+        callback: () => value,
+      })
+      const { client, send } = mockClient(
+        harnessStream(chunk.toolUseStart('tu-1', 'media'), chunk.contentBlockStop(), chunk.messageStop('tool_use')),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const { controlClient } = mockControlClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [media],
+      })
+
+      await agent.invoke('run media')
+
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(send.mock.calls[1]![0].input.messages[1]).toStrictEqual({
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'tu-1',
+              content: [
+                {
+                  text: `Error: Tool-result content at block index 0, item index 0 has unsupported type '${value.type}'. AgentCore Harness host tools can return only text or JSON-compatible values.`,
+                },
+              ],
+              status: 'error',
+              type: 'tool_use',
+            },
+          },
+        ],
+      })
+    })
+
+    it('returns an error tool result when a host tool throws, then resumes', async () => {
+      const failing = tool({
+        name: 'boom',
+        description: 'Fails',
+        inputSchema: z.object({}),
+        callback: () => {
+          throw new Error('kaboom')
+        },
+      })
+      const { client, send } = mockClient(
+        harnessStream(chunk.toolUseStart('tu-1', 'boom'), chunk.contentBlockStop(), chunk.messageStop('tool_use')),
+        harnessStream(chunk.messageStop('end_turn'))
+      )
+      const { controlClient } = mockControlClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: 'arn:harness',
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [failing],
+      })
+
+      await agent.invoke('run boom')
+
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(send.mock.calls[1]![0].input.messages[1]).toStrictEqual({
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'tu-1',
+              content: [{ text: 'Error: kaboom' }],
+              status: 'error',
+              type: 'tool_use',
+            },
+          },
+        ],
+      })
+    })
+
+    it('does not bounce for a tool the agent does not own', async () => {
+      const { client, send } = mockClient(
+        harnessStream(
+          chunk.toolUseStart('tu-1', 'vended_tool'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('tool_use')
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: 'arn:harness', runtimeSessionId: SESSION_ID, client })
+
+      const result = await agent.invoke('Hi')
+
+      // Unknown (vended) tool use is terminal; no resume call.
+      expect(send).toHaveBeenCalledTimes(1)
+      expect(result.stopReason).toBe('toolUse')
+    })
+
+    it('rejects an unexpected stream request for a registered host tool excluded by effective allowedTools', async () => {
+      const callback = vi.fn(() => 'sunny')
+      const getWeather = tool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: z.object({}),
+        callback,
+      })
+      const { client, send } = mockClient(
+        harnessStream(
+          chunk.toolUseStart('tu-1', 'get_weather'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('tool_use')
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        tools: [getWeather],
+      })
+      ;(
+        agent as unknown as {
+          _resolveToolConfiguration(): Promise<{ tools: HarnessTool[]; allowedTools?: string[] }>
+        }
+      )._resolveToolConfiguration = vi.fn().mockResolvedValue({ tools: [], allowedTools: [] })
+
+      await expect(agent.invoke('Hi')).rejects.toMatchObject({
+        constructor: ModelError,
+        message:
+          "Harness requested host tool 'get_weather' even though it is excluded by effective allowedTools. The callback was not executed.",
+      })
+      expect(callback).not.toHaveBeenCalled()
+      expect(send).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-inline-binding.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-inline-binding.test.ts
@@ -1,0 +1,259 @@
+import type { HarnessInlineFunctionConfig, HarnessTool } from '@aws-sdk/client-bedrock-agentcore'
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { AgentCoreHarnessAgent } from '../agentcore-harness-agent.js'
+import { ToolValidationError } from '../../errors.js'
+import { tool } from '../../tools/tool-factory.js'
+import {
+  HARNESS_ARN,
+  SESSION_ID,
+  chunk,
+  harnessStream,
+  mockClient,
+  mockControlClient,
+} from './harness-test-fixtures.js'
+
+describe('AgentCoreHarnessAgent deployed inline-function binding', () => {
+  it('binds a compatible local handler without duplicating the deployed declaration', async () => {
+    const deployedTool = inlineFunction({
+      description: 'Request approval',
+      inputSchema: {
+        required: ['requestId'],
+        properties: { requestId: { type: 'string' } },
+        additionalProperties: false,
+        type: 'object',
+      },
+    })
+    const callback = vi.fn().mockResolvedValue({ approved: true })
+    const localTool = tool({
+      name: 'approval',
+      description: 'Request approval',
+      inputSchema: z.object({ requestId: z.string() }),
+      callback,
+    })
+    const { controlClient } = mockControlClient([deployedTool], ['@approval'])
+    const { client, send } = mockClient(
+      harnessStream(
+        chunk.messageStart(),
+        chunk.toolUseStart('approval-1', 'approval'),
+        chunk.toolUseDelta('{"requestId":"req-1"}'),
+        chunk.contentBlockStop(),
+        chunk.messageStop('tool_use')
+      ),
+      harnessStream(chunk.messageStart(), chunk.textDelta('Approved.'), chunk.messageStop('end_turn'))
+    )
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [localTool],
+    })
+
+    const result = await agent.invoke('Approve request req-1')
+
+    expect(callback.mock.calls).toStrictEqual([[{ requestId: 'req-1' }, undefined]])
+    expect(
+      send.mock.calls.map((call) => ({
+        tools: call[0].input.tools,
+        allowedTools: call[0].input.allowedTools,
+      }))
+    ).toStrictEqual([
+      { tools: [deployedTool], allowedTools: ['@approval'] },
+      { tools: [deployedTool], allowedTools: ['@approval'] },
+    ])
+    expect(result.stopReason).toBe('endTurn')
+  })
+
+  it.each([
+    {
+      mismatch: 'description',
+      deployedTool: inlineFunction({
+        description: 'Approve a payment',
+        inputSchema: {
+          type: 'object',
+          properties: { requestId: { type: 'string' } },
+          required: ['requestId'],
+          additionalProperties: false,
+        },
+      }),
+      message:
+        "Host tool 'approval' cannot bind to the deployed inline function because its description differs. Make the local tool definition match the deployed inline function.",
+    },
+    {
+      mismatch: 'input schema',
+      deployedTool: inlineFunction({
+        description: 'Request approval',
+        inputSchema: {
+          type: 'object',
+          properties: { paymentId: { type: 'string' } },
+          required: ['paymentId'],
+          additionalProperties: false,
+        },
+      }),
+      message:
+        "Host tool 'approval' cannot bind to the deployed inline function because its input schema differs. Make the local tool definition match the deployed inline function.",
+    },
+  ])('rejects a same-name inline function with a different $mismatch', async ({ deployedTool, message }) => {
+    const localTool = tool({
+      name: 'approval',
+      description: 'Request approval',
+      inputSchema: z.object({ requestId: z.string() }),
+      callback: () => ({ approved: true }),
+    })
+    const { controlClient, send: controlSend } = mockControlClient([deployedTool], ['@approval'])
+    const { client, send } = mockClient()
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [localTool],
+    })
+
+    await expect(agent.invoke('Approve request req-1')).rejects.toMatchObject({
+      constructor: ToolValidationError,
+      message,
+    })
+    expect(controlSend).toHaveBeenCalledOnce()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('returns a deployed inline-function request when no local handler is configured', async () => {
+    const { controlClient, send: controlSend } = mockControlClient()
+    const { client, send } = mockClient(
+      harnessStream(
+        chunk.messageStart(),
+        chunk.toolUseStart('approval-1', 'approval'),
+        chunk.toolUseDelta('{"requestId":"req-1"}'),
+        chunk.contentBlockStop(),
+        chunk.messageStop('tool_use')
+      )
+    )
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+    })
+
+    const result = await agent.invoke('Approve request req-1')
+
+    expect(controlSend).not.toHaveBeenCalled()
+    expect(send.mock.calls[0]![0].input).not.toHaveProperty('tools')
+    expect({
+      stopReason: result.stopReason,
+      content: result.lastMessage.content.map((block) => block.toJSON()),
+    }).toStrictEqual({
+      stopReason: 'toolUse',
+      content: [
+        {
+          toolUse: {
+            toolUseId: 'approval-1',
+            name: 'approval',
+            input: { requestId: 'req-1' },
+          },
+        },
+      ],
+    })
+  })
+
+  it.each([
+    ['remote_mcp', 'mcp_1'],
+    ['agentcore_gateway', 'gateway_1'],
+    ['agentcore_browser', 'browser_1'],
+    ['agentcore_code_interpreter', 'code_interpreter_1'],
+    ['inline_function', 'inline_function_1'],
+  ] as const)(
+    'rejects a host tool that conflicts with an unnamed %s tool runtime name',
+    async (deployedToolType, generatedName) => {
+      const deployedTool: HarnessTool =
+        deployedToolType === 'inline_function'
+          ? {
+              type: deployedToolType,
+              config: {
+                inlineFunction: {
+                  description: 'Generated-name collision',
+                  inputSchema: {
+                    type: 'object',
+                    properties: {},
+                    additionalProperties: false,
+                  },
+                },
+              },
+            }
+          : { type: deployedToolType }
+      const localTool = tool({
+        name: generatedName,
+        description: 'Generated-name collision',
+        inputSchema: z.object({}),
+        callback: () => 'host result',
+      })
+      const { controlClient, send: controlSend } = mockControlClient([
+        { type: 'agentcore_gateway', name: 'existing' },
+        deployedTool,
+      ])
+      const { client, send } = mockClient()
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        controlClient,
+        tools: [localTool],
+      })
+
+      await expect(agent.invoke('Run the tool')).rejects.toMatchObject({
+        constructor: ToolValidationError,
+        message: `Host tool '${generatedName}' conflicts with the runtime-generated name of the unnamed deployed tool at index 1 (type '${deployedToolType}'). Assign the deployed tool an explicit unique name or rename the host tool.`,
+      })
+      expect(controlSend).toHaveBeenCalledOnce()
+      expect(send).not.toHaveBeenCalled()
+    }
+  )
+
+  it('rejects collisions between explicit and inferred deployed tool names', async () => {
+    const deployedTools: HarnessTool[] = [{ type: 'remote_mcp' }, { type: 'agentcore_gateway', name: 'mcp_0' }]
+    const unrelatedHostTool = tool({
+      name: 'approval',
+      description: 'Request approval',
+      inputSchema: z.object({}),
+      callback: () => 'host result',
+    })
+    const { controlClient, send: controlSend } = mockControlClient(deployedTools)
+    const { client, send } = mockClient()
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: SESSION_ID,
+      client,
+      controlClient,
+      tools: [unrelatedHostTool],
+    })
+
+    await expect(agent.invoke('Run the tool')).rejects.toMatchObject({
+      constructor: ToolValidationError,
+      message:
+        "Deployed harness tools at indexes 0 and 1 resolve to runtime name 'mcp_0'. Assign explicit unique names to the unnamed deployed tools.",
+    })
+    expect(controlSend).toHaveBeenCalledOnce()
+    expect(send).not.toHaveBeenCalled()
+  })
+})
+
+function inlineFunction({
+  description,
+  inputSchema,
+}: {
+  description: string
+  inputSchema: Record<string, unknown>
+}): HarnessTool {
+  return {
+    type: 'inline_function',
+    name: 'approval',
+    config: {
+      inlineFunction: {
+        description,
+        inputSchema: inputSchema as HarnessInlineFunctionConfig['inputSchema'],
+      },
+    },
+  }
+}

--- a/strands-ts/src/agentcore-harness/__tests__/events.test-d.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/events.test-d.ts
@@ -1,0 +1,16 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type { InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import type { AgentCoreHarnessEventData, AgentCoreHarnessStreamUpdateEvent } from '../events.js'
+
+describe('AgentCoreHarnessEventData', () => {
+  it('includes non-error stream events', () => {
+    expectTypeOf<InvokeHarnessStreamOutput.MessageStartMember>().toExtend<AgentCoreHarnessEventData>()
+    expectTypeOf<AgentCoreHarnessStreamUpdateEvent['event']>().toEqualTypeOf<AgentCoreHarnessEventData>()
+  })
+
+  it('excludes harness error events', () => {
+    expectTypeOf<InvokeHarnessStreamOutput.InternalServerExceptionMember>().not.toExtend<AgentCoreHarnessEventData>()
+    expectTypeOf<InvokeHarnessStreamOutput.ValidationExceptionMember>().not.toExtend<AgentCoreHarnessEventData>()
+    expectTypeOf<InvokeHarnessStreamOutput.RuntimeClientErrorMember>().not.toExtend<AgentCoreHarnessEventData>()
+  })
+})

--- a/strands-ts/src/agentcore-harness/__tests__/events.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/events.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { AgentCoreHarnessStreamUpdateEvent, AgentCoreHarnessResultEvent } from '../events.js'
+import { AgentResult } from '../../types/agent.js'
+import { Message, TextBlock } from '../../types/messages.js'
+import { AgentMetrics } from '../../telemetry/meter.js'
+import { anyTrackingId } from '../../__fixtures__/message-helpers.js'
+import type { AgentCoreHarnessEventData } from '../events.js'
+
+describe('AgentCoreHarnessStreamUpdateEvent', () => {
+  const chunk = { messageStart: { role: 'assistant' } } as AgentCoreHarnessEventData
+
+  it('creates instance with correct properties', () => {
+    const event = new AgentCoreHarnessStreamUpdateEvent(chunk)
+
+    expect(event.type).toBe('agentCoreHarnessStreamUpdateEvent')
+    expect(event.event).toBe(chunk)
+  })
+
+  describe('toJSON', () => {
+    const event = new AgentCoreHarnessStreamUpdateEvent(chunk)
+
+    it('serializes', () => {
+      expect(JSON.parse(JSON.stringify(event))).toStrictEqual({
+        type: 'agentCoreHarnessStreamUpdateEvent',
+        event: { messageStart: { role: 'assistant' } },
+      })
+    })
+
+    it('only excludes expected fields', () => {
+      const json = event.toJSON()
+      expect(Object.keys(event).filter((key) => !(key in json))).toStrictEqual([])
+    })
+  })
+})
+
+describe('AgentCoreHarnessResultEvent', () => {
+  const result = new AgentResult({
+    stopReason: 'endTurn',
+    lastMessage: new Message({ role: 'assistant', content: [new TextBlock('Done')] }),
+    metrics: new AgentMetrics(),
+    invocationState: {},
+  })
+
+  it('creates instance with correct properties', () => {
+    const event = new AgentCoreHarnessResultEvent({ result })
+
+    expect(event.type).toBe('agentCoreHarnessResultEvent')
+    expect(event.result).toBe(result)
+  })
+
+  describe('toJSON', () => {
+    const event = new AgentCoreHarnessResultEvent({ result })
+
+    it('serializes', () => {
+      expect(JSON.parse(JSON.stringify(event))).toStrictEqual({
+        type: 'agentCoreHarnessResultEvent',
+        result: {
+          type: 'agentResult',
+          stopReason: 'endTurn',
+          lastMessage: { role: 'assistant', content: [{ text: 'Done' }], trackingId: anyTrackingId },
+        },
+      })
+    })
+
+    it('only excludes expected fields', () => {
+      const json = event.toJSON()
+      expect(Object.keys(event).filter((key) => !(key in json))).toStrictEqual([])
+    })
+  })
+})

--- a/strands-ts/src/agentcore-harness/__tests__/harness-test-fixtures.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/harness-test-fixtures.ts
@@ -1,0 +1,59 @@
+import type { BedrockAgentCoreClient, HarnessTool, InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import type { BedrockAgentCoreControlClient } from '@aws-sdk/client-bedrock-agentcore-control'
+import { vi } from 'vitest'
+import type { AgentCoreHarnessEventData } from '../events.js'
+
+// A session id at the minimum valid length (33 chars).
+export const SESSION_ID = 'session-id-padded-to-thirty-three'
+export const HARNESS_ID = 'TestHarness-abcdefghij'
+export const HARNESS_ARN = `arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/${HARNESS_ID}`
+
+/** Builds a fake InvokeHarness stream from chunk objects. */
+export async function* harnessStream(
+  ...chunks: InvokeHarnessStreamOutput[]
+): AsyncGenerator<InvokeHarnessStreamOutput> {
+  for (const chunk of chunks) {
+    yield chunk
+  }
+}
+
+/** Chunk builders mirroring the InvokeHarness wire shapes. */
+export const chunk = {
+  messageStart: (role: 'assistant' | 'user' = 'assistant'): AgentCoreHarnessEventData =>
+    ({ messageStart: { role } }) as AgentCoreHarnessEventData,
+  textDelta: (text: string): AgentCoreHarnessEventData =>
+    ({ contentBlockDelta: { delta: { text } } }) as AgentCoreHarnessEventData,
+  toolUseStart: (toolUseId: string, name: string): AgentCoreHarnessEventData =>
+    ({ contentBlockStart: { start: { toolUse: { toolUseId, name } } } }) as AgentCoreHarnessEventData,
+  toolUseDelta: (input: string): AgentCoreHarnessEventData =>
+    ({ contentBlockDelta: { delta: { toolUse: { input } } } }) as AgentCoreHarnessEventData,
+  contentBlockStop: (): AgentCoreHarnessEventData => ({ contentBlockStop: {} }) as AgentCoreHarnessEventData,
+  messageStop: (stopReason: string): AgentCoreHarnessEventData =>
+    ({ messageStop: { stopReason } }) as AgentCoreHarnessEventData,
+  metadata: (usage: Record<string, number>, latencyMs?: number): AgentCoreHarnessEventData =>
+    ({ metadata: { usage, ...(latencyMs !== undefined && { metrics: { latencyMs } }) } }) as AgentCoreHarnessEventData,
+}
+
+/** A mock client whose `send` returns the queued streams in order. */
+export function mockClient(...streams: AsyncGenerator<InvokeHarnessStreamOutput>[]): {
+  client: BedrockAgentCoreClient
+  send: ReturnType<typeof vi.fn>
+} {
+  const send = vi.fn()
+  streams.forEach((stream) => send.mockResolvedValueOnce({ stream }))
+  return { client: { send } as unknown as BedrockAgentCoreClient, send }
+}
+
+/** A mock control client that returns the supplied deployed harness tool configuration. */
+export function mockControlClient(
+  deployedTools: HarnessTool[] = [],
+  allowedTools?: string[]
+): {
+  controlClient: BedrockAgentCoreControlClient
+  send: ReturnType<typeof vi.fn>
+} {
+  const send = vi.fn().mockResolvedValue({
+    harness: { tools: deployedTools, ...(allowedTools !== undefined && { allowedTools }) },
+  })
+  return { controlClient: { send } as unknown as BedrockAgentCoreControlClient, send }
+}

--- a/strands-ts/src/agentcore-harness/__tests__/request-formatting.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/request-formatting.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { tool } from '../../tools/tool-factory.js'
+import {
+  CachePointBlock,
+  GuardContentBlock,
+  JsonBlock,
+  Message,
+  ReasoningBlock,
+  TextBlock,
+  ToolResultBlock,
+  ToolUseBlock,
+} from '../../types/messages.js'
+import { DocumentBlock, ImageBlock, VideoBlock } from '../../types/media.js'
+import { CitationsBlock } from '../../types/citations.js'
+import { CheckpointError } from '../../errors.js'
+import { formatHarnessInput, formatHarnessSystemPrompt, formatHarnessTools } from '../request-formatting.js'
+import type { InvokeArgs } from '../../types/agent.js'
+import type { ContentBlock, ToolResultContent } from '../../types/messages.js'
+
+describe('formatHarnessInput', () => {
+  it.each([
+    { desc: 'string', args: 'Hello', expected: [{ text: 'Hello' }] },
+    { desc: 'ContentBlock[]', args: [new TextBlock('From block')], expected: [{ text: 'From block' }] },
+    { desc: 'ContentBlockData[]', args: [{ text: 'From data' }], expected: [{ text: 'From data' }] },
+    {
+      desc: 'Message[]',
+      args: [new Message({ role: 'user', content: [new TextBlock('From message')] })],
+      expected: [{ text: 'From message' }],
+    },
+    {
+      desc: 'MessageData[]',
+      args: [{ role: 'user', content: [{ text: 'From message data' }] }],
+      expected: [{ text: 'From message data' }],
+    },
+  ])('normalizes $desc input into Harness messages', ({ args, expected }) => {
+    expect(formatHarnessInput(args as InvokeArgs)).toStrictEqual([{ role: 'user', content: expected }])
+  })
+
+  it.each([
+    ['an empty content array', []],
+    ['an empty string', ''],
+    ['an empty message', [new Message({ role: 'user', content: [] })]],
+    ['an empty text block', [new TextBlock('')]],
+  ])('rejects %s', (_description, args) => {
+    expect(() => formatHarnessInput(args as InvokeArgs)).toThrow()
+  })
+
+  it('rejects interrupt-response input', () => {
+    expect(() => formatHarnessInput([{ interruptResponse: { interruptId: 'i1', response: 'ok' } }])).toThrow(
+      /interrupt-response/
+    )
+  })
+
+  it('rejects checkpoint-resume input', () => {
+    expect(() =>
+      formatHarnessInput({
+        checkpointResume: {
+          checkpoint: { position: 'afterModel', cycleIndex: 0, schemaVersion: '1.0' },
+        },
+      })
+    ).toThrow(
+      new CheckpointError('Received a checkpointResume block but AgentCoreHarnessAgent does not support checkpointing.')
+    )
+  })
+
+  it('formats every supported message content variant', () => {
+    const redactedContent = new Uint8Array([1, 2, 3])
+
+    expect(
+      formatHarnessInput([
+        new TextBlock('hello'),
+        new ToolUseBlock({ toolUseId: 'tu-1', name: 'lookup', input: { query: 'weather' } }),
+        new ToolResultBlock({
+          toolUseId: 'tu-1',
+          status: 'success',
+          content: [new TextBlock('sunny'), new JsonBlock({ json: { temperature: 72 } })],
+        }),
+        new ReasoningBlock({ text: 'thinking', signature: 'sig-1' }),
+        new ReasoningBlock({ redactedContent }),
+      ])
+    ).toStrictEqual([
+      {
+        role: 'user',
+        content: [
+          { text: 'hello' },
+          {
+            toolUse: {
+              toolUseId: 'tu-1',
+              name: 'lookup',
+              input: { query: 'weather' },
+              type: 'tool_use',
+            },
+          },
+          {
+            toolResult: {
+              toolUseId: 'tu-1',
+              content: [{ text: 'sunny' }, { text: '{"temperature":72}' }],
+              status: 'success',
+              type: 'tool_use',
+            },
+          },
+          { reasoningContent: { reasoningText: { text: 'thinking', signature: 'sig-1' } } },
+          { reasoningContent: { redactedContent } },
+        ],
+      },
+    ])
+  })
+
+  const unsupportedContentBlocks: { description: string; block: ContentBlock }[] = [
+    {
+      description: 'cache point',
+      block: new CachePointBlock({ cacheType: 'default' }),
+    },
+    {
+      description: 'guard content',
+      block: new GuardContentBlock({ text: { text: 'guard this', qualifiers: ['guard_content'] } }),
+    },
+    {
+      description: 'image',
+      block: new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1]) } }),
+    },
+    {
+      description: 'video',
+      block: new VideoBlock({ format: 'mp4', source: { bytes: new Uint8Array([2]) } }),
+    },
+    {
+      description: 'document',
+      block: new DocumentBlock({ name: 'notes', format: 'txt', source: { text: 'hello' } }),
+    },
+    {
+      description: 'citations',
+      block: new CitationsBlock({ citations: [], content: [{ text: 'cited answer' }] }),
+    },
+  ]
+
+  it.each(unsupportedContentBlocks)('rejects unsupported $description content without dropping it', ({ block }) => {
+    expect(() => formatHarnessInput([new TextBlock('keep me'), block])).toThrow(
+      `Content block at index 1 has unsupported type '${block.type}'.`
+    )
+  })
+
+  it('rejects an unknown runtime content block type', () => {
+    expect(() => formatHarnessInput([{ type: 'futureBlock' } as never])).toThrow(
+      "Content block at index 0 has unknown type 'futureBlock'."
+    )
+  })
+
+  it.each([
+    {
+      description: 'no content',
+      block: new ReasoningBlock({}),
+      message: 'must contain text, a signature, or redacted content',
+    },
+    {
+      description: 'empty text',
+      block: new ReasoningBlock({ text: '' }),
+      message: 'contains empty reasoning text',
+    },
+    {
+      description: 'text and redacted content',
+      block: new ReasoningBlock({ text: 'thinking', redactedContent: new Uint8Array([1]) }),
+      message: 'contains both reasoning text and redacted content',
+    },
+  ])('rejects reasoning content with $description', ({ block, message }) => {
+    expect(() => formatHarnessInput([block])).toThrow(message)
+  })
+
+  it('rejects a tool-use reasoning signature that the Harness cannot represent', () => {
+    expect(() =>
+      formatHarnessInput([
+        new ToolUseBlock({
+          toolUseId: 'tu-1',
+          name: 'lookup',
+          input: {},
+          reasoningSignature: 'signature',
+        }),
+      ])
+    ).toThrow('has a reasoningSignature, which AgentCore Harness cannot represent')
+  })
+
+  const unsupportedToolResultContent: { description: string; content: ToolResultContent }[] = [
+    {
+      description: 'image',
+      content: new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1]) } }),
+    },
+    {
+      description: 'video',
+      content: new VideoBlock({ format: 'mp4', source: { bytes: new Uint8Array([2]) } }),
+    },
+    {
+      description: 'document',
+      content: new DocumentBlock({ name: 'notes', format: 'txt', source: { text: 'hello' } }),
+    },
+  ]
+
+  it.each(unsupportedToolResultContent)('rejects unsupported $description tool-result content', ({ content }) => {
+    expect(() =>
+      formatHarnessInput([
+        new ToolResultBlock({
+          toolUseId: 'tu-1',
+          status: 'success',
+          content: [new TextBlock('keep me'), content],
+        }),
+      ])
+    ).toThrow(`item index 1 has unsupported type '${content.type}'`)
+  })
+
+  it('rejects an empty tool result', () => {
+    expect(() =>
+      formatHarnessInput([new ToolResultBlock({ toolUseId: 'tu-1', status: 'success', content: [] })])
+    ).toThrow('must contain at least one result item')
+  })
+
+  it('rejects an unknown runtime tool-result content type', () => {
+    expect(() =>
+      formatHarnessInput([
+        new ToolResultBlock({
+          toolUseId: 'tu-1',
+          status: 'success',
+          content: [{ type: 'futureToolResult' } as never],
+        }),
+      ])
+    ).toThrow("item index 0 has unknown type 'futureToolResult'")
+  })
+
+  it('serializes tool-result content to non-empty text', () => {
+    expect(
+      formatHarnessInput([
+        new ToolResultBlock({
+          toolUseId: 'tu-1',
+          status: 'success',
+          content: [new TextBlock(''), new JsonBlock({ json: { a: 1 } })],
+        }),
+      ])
+    ).toStrictEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'tu-1',
+              content: [{ text: '""' }, { text: '{"a":1}' }],
+              status: 'success',
+              type: 'tool_use',
+            },
+          },
+        ],
+      },
+    ])
+  })
+})
+
+describe('formatHarnessTools', () => {
+  it('formats host tools as inline functions', () => {
+    const hostTool = tool({
+      name: 'get_weather',
+      description: 'Get weather',
+      inputSchema: z.object({ city: z.string() }),
+      callback: () => 'sunny',
+    })
+
+    expect(formatHarnessTools([hostTool])).toStrictEqual([
+      {
+        type: 'inline_function',
+        name: 'get_weather',
+        config: {
+          inlineFunction: {
+            description: 'Get weather',
+            inputSchema: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+              additionalProperties: false,
+            },
+          },
+        },
+      },
+    ])
+  })
+})
+
+describe('formatHarnessSystemPrompt', () => {
+  it('formats strings and non-empty text blocks', () => {
+    expect(formatHarnessSystemPrompt('Be concise.')).toStrictEqual([{ text: 'Be concise.' }])
+    expect(formatHarnessSystemPrompt([new TextBlock('Be concise.'), new TextBlock('Be terse.')])).toStrictEqual([
+      { text: 'Be concise.' },
+      { text: 'Be terse.' },
+    ])
+  })
+
+  it.each(['', []])('rejects an empty prompt %#', (prompt) => {
+    expect(() => formatHarnessSystemPrompt(prompt as string | TextBlock[])).toThrow(
+      'systemPrompt must contain non-empty text when provided'
+    )
+  })
+
+  it('rejects an empty block instead of partially sending a mixed prompt', () => {
+    expect(() => formatHarnessSystemPrompt([new TextBlock('Keep me'), new TextBlock('')])).toThrow(
+      'systemPrompt block at index 1 must contain non-empty text'
+    )
+  })
+})

--- a/strands-ts/src/agentcore-harness/__tests__/stream-decoder.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/stream-decoder.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it, vi } from 'vitest'
+import { JsonBlock, ReasoningBlock, TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
+import { ModelError } from '../../errors.js'
+import { HarnessStreamDecoder } from '../stream-decoder.js'
+import type { AgentCoreHarnessEventData } from '../events.js'
+import type { DecodedHarnessTurn } from '../stream-decoder.js'
+
+/** Builds non-error Harness events used by decoder tests. */
+const event = {
+  messageStart: (role: 'assistant' | 'user' = 'assistant'): AgentCoreHarnessEventData =>
+    ({ messageStart: { role } }) as AgentCoreHarnessEventData,
+  textDelta: (text: string): AgentCoreHarnessEventData =>
+    ({ contentBlockDelta: { delta: { text } } }) as AgentCoreHarnessEventData,
+  toolUseStart: (toolUseId: string, name: string): AgentCoreHarnessEventData =>
+    ({ contentBlockStart: { start: { toolUse: { toolUseId, name } } } }) as AgentCoreHarnessEventData,
+  toolUseDelta: (input: string): AgentCoreHarnessEventData =>
+    ({ contentBlockDelta: { delta: { toolUse: { input } } } }) as AgentCoreHarnessEventData,
+  toolResultStart: (toolUseId: string, status: 'success' | 'error'): AgentCoreHarnessEventData =>
+    ({ contentBlockStart: { start: { toolResult: { toolUseId, status } } } }) as AgentCoreHarnessEventData,
+  toolResultTextDelta: (text: string): AgentCoreHarnessEventData =>
+    ({ contentBlockDelta: { delta: { toolResult: [{ text }] } } }) as AgentCoreHarnessEventData,
+  toolResultJsonDelta: (json: unknown): AgentCoreHarnessEventData =>
+    ({ contentBlockDelta: { delta: { toolResult: [{ json }] } } }) as AgentCoreHarnessEventData,
+  reasoningTextDelta: (text: string): AgentCoreHarnessEventData =>
+    ({ contentBlockDelta: { delta: { reasoningContent: { text } } } }) as AgentCoreHarnessEventData,
+  reasoningSignatureDelta: (signature: string): AgentCoreHarnessEventData =>
+    ({ contentBlockDelta: { delta: { reasoningContent: { signature } } } }) as AgentCoreHarnessEventData,
+  reasoningRedactedDelta: (redactedContent: Uint8Array): AgentCoreHarnessEventData =>
+    ({ contentBlockDelta: { delta: { reasoningContent: { redactedContent } } } }) as AgentCoreHarnessEventData,
+  bareContentBlockStart: (): AgentCoreHarnessEventData =>
+    ({ contentBlockStart: { start: undefined } }) as AgentCoreHarnessEventData,
+  contentBlockStop: (): AgentCoreHarnessEventData => ({ contentBlockStop: {} }) as AgentCoreHarnessEventData,
+  messageStop: (stopReason?: string): AgentCoreHarnessEventData =>
+    ({ messageStop: { stopReason } }) as AgentCoreHarnessEventData,
+  metadata: (inputTokens = 100, outputTokens = 20, latencyMs = 1500): AgentCoreHarnessEventData =>
+    ({
+      metadata: {
+        usage: { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens },
+        metrics: { latencyMs },
+      },
+    }) as AgentCoreHarnessEventData,
+}
+
+/** Decodes a complete sequence of Harness events. */
+function decode(...events: AgentCoreHarnessEventData[]): DecodedHarnessTurn {
+  const decoder = new HarnessStreamDecoder()
+  events.forEach((streamEvent) => decoder.accept(streamEvent))
+  return decoder.complete()
+}
+
+describe('HarnessStreamDecoder', () => {
+  describe('complete', () => {
+    it.each([
+      ['end_turn', 'endTurn'],
+      ['tool_use', 'toolUse'],
+      ['tool_result', 'toolResult'],
+      ['stop_sequence', 'stopSequence'],
+      ['content_filtered', 'contentFiltered'],
+      ['model_context_window_exceeded', 'modelContextWindowExceeded'],
+      ['max_iterations_exceeded', 'limitTurns'],
+      ['max_output_tokens_exceeded', 'limitOutputTokens'],
+      ['timeout_exceeded', 'timeoutExceeded'],
+      ['interrupted', 'interrupt'],
+      ['partial_turn', 'pauseTurn'],
+    ])('maps Harness stop reason %s to %s', (harnessStopReason, expectedStopReason) => {
+      expect(decode(event.messageStop(harnessStopReason)).stopReason).toBe(expectedStopReason)
+    })
+
+    it('preserves an unknown Harness stop reason in SDK casing', () => {
+      const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(decode(event.messageStop('future_stop_reason')).stopReason).toBe('futureStopReason')
+      expect(warning).toHaveBeenCalledWith(
+        'stop_reason=<future_stop_reason>, fallback=<futureStopReason> | unknown stop reason, converting to camelCase'
+      )
+
+      warning.mockRestore()
+    })
+
+    it.each([undefined, '', '   '])('rejects a missing or empty Harness stop reason %#', (stopReason) => {
+      expect(() => decode(event.messageStop(stopReason))).toThrow(
+        new ModelError('Harness messageStop event is missing a non-empty stopReason')
+      )
+    })
+
+    it('rejects a stream without a completed message', () => {
+      const decoder = new HarnessStreamDecoder()
+      decoder.accept(event.messageStart())
+      decoder.accept(event.textDelta('partial'))
+
+      expect(() => decoder.complete()).toThrow(new ModelError('Stream ended without completing a message'))
+    })
+
+    it('rejects an incomplete final message in a multi-message stream', () => {
+      const decoder = new HarnessStreamDecoder()
+      ;[
+        event.messageStart(),
+        event.messageStop('tool_result'),
+        event.messageStart(),
+        event.textDelta('partial'),
+      ].forEach((streamEvent) => decoder.accept(streamEvent))
+
+      expect(() => decoder.complete()).toThrow(new ModelError('Stream ended without completing a message'))
+    })
+
+    it('accumulates text and reasoning blocks', () => {
+      const result = decode(
+        event.messageStart(),
+        event.bareContentBlockStart(),
+        event.reasoningTextDelta('Let me think. '),
+        event.reasoningTextDelta('The answer is 4.'),
+        event.reasoningSignatureDelta('sig-'),
+        event.reasoningSignatureDelta('abc'),
+        event.reasoningRedactedDelta(new Uint8Array([1, 2])),
+        event.reasoningRedactedDelta(new Uint8Array([3, 4])),
+        event.contentBlockStop(),
+        event.textDelta('4'),
+        event.contentBlockStop(),
+        event.messageStop('end_turn')
+      )
+
+      expect(result.message.content).toStrictEqual([
+        new ReasoningBlock({
+          text: 'Let me think. The answer is 4.',
+          signature: 'sig-abc',
+          redactedContent: new Uint8Array([1, 2, 3, 4]),
+        }),
+        new TextBlock('4'),
+      ])
+    })
+
+    it('accumulates text and JSON tool-result content', () => {
+      const textResult = decode(
+        event.messageStart(),
+        event.toolResultStart('tu-1', 'success'),
+        event.toolResultTextDelta('{"stdout":"ok"}'),
+        event.contentBlockStop(),
+        event.messageStop('tool_result')
+      )
+      const jsonResult = decode(
+        event.messageStart(),
+        event.toolResultStart('tu-2', 'success'),
+        event.toolResultJsonDelta({ stdout: 'ok' }),
+        event.contentBlockStop(),
+        event.messageStop('tool_result')
+      )
+
+      expect([textResult.message.content, jsonResult.message.content]).toStrictEqual([
+        [
+          new ToolResultBlock({
+            toolUseId: 'tu-1',
+            status: 'success',
+            content: [new TextBlock('{"stdout":"ok"}')],
+          }),
+        ],
+        [
+          new ToolResultBlock({
+            toolUseId: 'tu-2',
+            status: 'success',
+            content: [new JsonBlock({ json: { stdout: 'ok' } })],
+          }),
+        ],
+      ])
+    })
+
+    it('keeps only the final message from a multi-message stream', () => {
+      const result = decode(
+        event.messageStart(),
+        event.toolUseStart('tu-1', 'vended_shell'),
+        event.contentBlockStop(),
+        event.messageStop('tool_use'),
+        event.messageStart(),
+        event.textDelta('Here is the summary.'),
+        event.contentBlockStop(),
+        event.messageStop('end_turn')
+      )
+
+      expect(result).toMatchObject({
+        message: { role: 'assistant', content: [new TextBlock('Here is the summary.')] },
+        stopReason: 'endTurn',
+        assistantMessageCount: 2,
+      })
+    })
+
+    it('counts only completed assistant messages', () => {
+      expect(
+        decode(
+          event.messageStart(),
+          event.messageStop('tool_use'),
+          event.messageStart('user'),
+          event.messageStop('tool_result'),
+          event.messageStart(),
+          event.messageStop('end_turn')
+        ).assistantMessageCount
+      ).toBe(2)
+    })
+
+    it.each([
+      [
+        'message role',
+        { messageStart: { role: undefined } },
+        "Harness messageStart event has invalid role 'undefined'",
+      ],
+      [
+        'tool-use ID',
+        { contentBlockStart: { start: { toolUse: { toolUseId: undefined, name: 'weather' } } } },
+        'Harness tool-use start event is missing a non-empty toolUseId',
+      ],
+      [
+        'tool-use name',
+        { contentBlockStart: { start: { toolUse: { toolUseId: 'tu-1', name: '' } } } },
+        'Harness tool-use start event is missing a non-empty name',
+      ],
+      [
+        'tool-result ID',
+        { contentBlockStart: { start: { toolResult: { toolUseId: undefined, status: 'success' } } } },
+        'Harness tool-result start event is missing a non-empty toolUseId',
+      ],
+    ])('rejects a malformed %s at the stream boundary', (_field, malformedEvent, message) => {
+      const decoder = new HarnessStreamDecoder()
+      expect(() => decoder.accept(malformedEvent as AgentCoreHarnessEventData)).toThrow(new ModelError(message))
+    })
+
+    it('scopes tool-input parse failures to the retained message', () => {
+      const recovered = decode(
+        event.messageStart(),
+        event.toolUseStart('tu-1', 'vended_tool'),
+        event.toolUseDelta('{"partial":'),
+        event.contentBlockStop(),
+        event.messageStop('tool_use'),
+        event.messageStart(),
+        event.textDelta('Recovered.'),
+        event.contentBlockStop(),
+        event.messageStop('end_turn')
+      )
+      const malformed = decode(
+        event.messageStart(),
+        event.toolUseStart('tu-2', 'vended_tool'),
+        event.toolUseDelta('{"partial":'),
+        event.contentBlockStop(),
+        event.messageStop('tool_use')
+      )
+
+      expect(recovered).not.toHaveProperty('toolInputParseError')
+      expect(malformed).toMatchObject({
+        message: {
+          content: [new ToolUseBlock({ toolUseId: 'tu-2', name: 'vended_tool', input: {} })],
+        },
+        toolInputParseError: expect.any(SyntaxError),
+      })
+    })
+
+    it('captures usage and latency metadata', () => {
+      expect(decode(event.messageStop('end_turn'), event.metadata())).toMatchObject({
+        stopReason: 'endTurn',
+        usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+        latestUsage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+        latencyMs: 1500,
+      })
+    })
+
+    it('accumulates metadata while retaining the latest model-turn usage', () => {
+      expect(
+        decode(event.messageStop('end_turn'), event.metadata(50, 5, 100), event.metadata(200, 30, 900))
+      ).toMatchObject({
+        usage: { inputTokens: 250, outputTokens: 35, totalTokens: 285 },
+        latestUsage: { inputTokens: 200, outputTokens: 30, totalTokens: 230 },
+        latencyMs: 1000,
+      })
+    })
+  })
+
+  describe('partialMessage', () => {
+    it('returns content accumulated before cancellation', () => {
+      const decoder = new HarnessStreamDecoder()
+      decoder.accept(event.messageStart())
+      decoder.accept(event.textDelta('partial'))
+
+      expect(decoder.partialMessage().content).toStrictEqual([new TextBlock('partial')])
+    })
+  })
+})

--- a/strands-ts/src/agentcore-harness/__tests__/tool-configuration.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/tool-configuration.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { isHostToolAllowed } from '../tool-configuration.js'
+
+describe('isHostToolAllowed', () => {
+  it.each([
+    ['c', '[!][c-a]', true],
+    ['c', '[c-a]', false],
+    [']', '[]]', true],
+    ['a', '[!a]', false],
+    ['b', '[!a]', true],
+    ['-', '[-]', true],
+    ['a', '[a-]', true],
+    ['-', '[a-]', true],
+    ['[', '[', true],
+    ['a', '[abc', false],
+    ['get_weather', 'get_*', true],
+    ['get_weather', 'get_?eather', true],
+    ['get_weather', 'GET_*', false],
+    ['abc', 'a**c', true],
+    ['abc', 'a[!d]c', true],
+    ['abc', 'a[^d]c', false],
+    ['abc', 'a[!b]c', false],
+  ] as const)('matches Python fnmatchcase(%j, %j) as %j', (value, pattern, expected) => {
+    expect(isHostToolAllowed(value, [`@${pattern}`])).toBe(expected)
+  })
+})

--- a/strands-ts/src/agentcore-harness/agentcore-harness-agent.ts
+++ b/strands-ts/src/agentcore-harness/agentcore-harness-agent.ts
@@ -1,0 +1,758 @@
+/** InvokableAgent wrapper for the AgentCore Harness API. */
+
+import {
+  type BedrockAgentCoreClient,
+  type BedrockAgentCoreClientConfig,
+  InvokeHarnessCommand,
+  type InvokeHarnessCommandInput,
+  type HarnessModelConfiguration,
+  type HarnessSkill,
+  type HarnessMessage,
+  type HarnessTool,
+  type InvokeHarnessStreamOutput,
+} from '@aws-sdk/client-bedrock-agentcore'
+import {
+  type BedrockAgentCoreControlClient,
+  type BedrockAgentCoreControlClientConfig,
+  GetHarnessCommand,
+  GetHarnessEndpointCommand,
+} from '@aws-sdk/client-bedrock-agentcore-control'
+import type { InvokableAgent, InvokeArgs, InvokeOptions } from '../types/agent.js'
+import { AgentResult } from '../types/agent.js'
+import type { ToolExecutorStrategy } from '../agent/agent.js'
+import { AgentMetrics } from '../telemetry/meter.js'
+import { accumulateUsage, createEmptyUsage, type Usage } from '../models/streaming.js'
+import { Message, TextBlock, ToolResultBlock, type StopReason } from '../types/messages.js'
+import { createErrorResult, createSuccessResult, type InvokableTool, type Tool } from '../tools/tool.js'
+import type { ToolUse } from '../tools/types.js'
+import {
+  ConcurrentInvocationError,
+  ContextWindowOverflowError,
+  MaxTokensError,
+  ModelError,
+  ModelThrottledError,
+  ToolValidationError,
+  normalizeError,
+} from '../errors.js'
+import { logger } from '../logging/logger.js'
+import { ToolRegistry } from '../registry/tool-registry.js'
+import {
+  AgentCoreHarnessResultEvent,
+  AgentCoreHarnessStreamUpdateEvent,
+  type AgentCoreHarnessEventData,
+  type AgentCoreHarnessStreamEvent,
+} from './events.js'
+import {
+  formatHarnessInput,
+  formatHarnessMessage,
+  formatHarnessSystemPrompt,
+  formatHarnessTools,
+} from './request-formatting.js'
+import { HarnessStreamDecoder } from './stream-decoder.js'
+import { assertHostToolsAllowed, isHostToolAllowed, mergeHarnessTools } from './tool-configuration.js'
+import { createHarnessClient, createHarnessControlClient } from './clients.js'
+
+/** Provider messages that the harness surfaces for context-window overflows. */
+const CONTEXT_WINDOW_OVERFLOW_ERRORS = [
+  'input is too long for requested model',
+  'input length and `max_tokens` exceed context limit',
+  'too many total text bytes',
+  'prompt is too long',
+]
+
+const RUNTIME_SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/
+
+const DEFAULT_HARNESS_QUALIFIER = 'DEFAULT'
+
+// Always-on harness tools and the namespace that contains them.
+const RESERVED_HARNESS_TOOL_NAMES = new Set(['builtin', 'shell', 'file_operations'])
+
+const THROTTLING_ERROR_NAMES = new Set(['ThrottlingException', 'ThrottledException'])
+
+interface ResolvedToolConfiguration {
+  tools: HarnessTool[]
+  allowedTools?: string[]
+}
+
+interface CachedVersionedToolConfiguration {
+  harnessVersion: string
+  toolConfiguration: ResolvedToolConfiguration
+}
+
+type HarnessRequestConfiguration = Pick<
+  InvokeHarnessCommandInput,
+  | 'model'
+  | 'systemPrompt'
+  | 'skills'
+  | 'allowedTools'
+  | 'maxIterations'
+  | 'maxTokens'
+  | 'timeoutSeconds'
+  | 'qualifier'
+  | 'runtimeUserId'
+  | 'actorId'
+>
+
+/**
+ * Configuration for {@link AgentCoreHarnessAgent}.
+ *
+ * Harness request overrides are snapshotted during construction and apply to every invocation.
+ * Create another agent instance when a conversation needs different request configuration.
+ */
+export interface AgentCoreHarnessAgentConfig {
+  /** ARN of the harness to invoke. */
+  harnessArn: string
+  /**
+   * Conversation session ID. Must be 33-100 characters and match `[A-Za-z0-9][A-Za-z0-9_-]*`.
+   * Reuse it to continue a conversation; a UUID is valid.
+   */
+  runtimeSessionId: string
+  /**
+   * Local tools exposed to the harness as inline functions. Only {@link InvokableTool} is supported,
+   * and tools run without a `ToolContext` or the local tool lifecycle. They cannot use invocation
+   * state, hooks, interventions, middleware, progress, local tracing or metrics, observe
+   * cancellation, or use local agent, sandbox, and app state. Requires
+   * `bedrock-agentcore:GetHarness` so deployed tools can be preserved. Named endpoints also require
+   * `bedrock-agentcore:GetHarnessEndpoint` on the Harness and endpoint. A local tool binds to a
+   * same-name deployed inline function only when its description and input schema match.
+   */
+  tools?: InvokableTool<unknown, unknown>[]
+  /**
+   * Host tool execution strategy. Defaults to `'concurrent'`; use `'sequential'` for tools with
+   * ordering dependencies or shared side effects.
+   */
+  toolExecutor?: ToolExecutorStrategy
+  /**
+   * Harness model override. This is wire configuration, not a local Strands `Model`.
+   */
+  modelConfig?: HarnessModelConfiguration
+  /** Text-only system prompt override. Omit to use the harness's default. */
+  systemPrompt?: string | TextBlock[]
+  /** Skills override. Omit to use the harness's configured skills. */
+  skills?: HarnessSkill[]
+  /**
+   * Tool allowlist override. Omit to preserve the deployed allowlist; an empty array disables all
+   * tools. Host inline functions use the Harness namespace syntax: for a tool named `get_weather`,
+   * use `@get_weather`, `@get_weather/get_weather`, a matching namespace glob, or `*`.
+   */
+  allowedTools?: string[]
+  /** Maximum server-side loop iterations. */
+  maxIterations?: number
+  /** Maximum model output tokens per server-side iteration. */
+  maxTokens?: number
+  /** Maximum server-side loop duration in seconds. */
+  timeoutSeconds?: number
+  /**
+   * Harness endpoint alias. Omit or use `DEFAULT` for the current Harness. Named endpoints allow
+   * host-tool configuration to be bound to their serving version.
+   */
+  qualifier?: string
+  /** End-user identity passed through to the runtime container. Omit if not needed. */
+  runtimeUserId?: string
+  /** Actor ID override for harness memory operations. */
+  actorId?: string
+  /** AWS region for constructed clients. Takes precedence over client-specific configuration. */
+  region?: string
+  /**
+   * Data-plane client configuration. Constructed clients default to `maxAttempts: 1` because
+   * `InvokeHarness` is stateful and has no idempotency token. Set `maxAttempts` to opt into retries.
+   */
+  clientConfig?: BedrockAgentCoreClientConfig
+  /** Injected data-plane client, used with its existing retry configuration. */
+  client?: BedrockAgentCoreClient
+  /** Control-plane client configuration used when host tools are present. Reads retain AWS SDK retries. */
+  controlClientConfig?: BedrockAgentCoreControlClientConfig
+  /** Injected control-plane client. */
+  controlClient?: BedrockAgentCoreControlClient
+  /** Optional unique identifier. Defaults to the harness ARN. */
+  id?: string
+  /** Optional name. */
+  name?: string
+  /** Optional description. */
+  description?: string
+}
+
+/**
+ * Wraps a managed AgentCore Harness as an {@link InvokableAgent}.
+ *
+ * The harness owns the agent loop, model, memory, and deployed tools. Custom tools can run locally
+ * through the Harness return-of-control flow.
+ *
+ * @example
+ * ```typescript
+ * import { randomUUID } from 'node:crypto'
+ * import { AgentCoreHarnessAgent } from '@strands-agents/sdk/agentcore-harness'
+ *
+ * const harnessArn = process.env.AGENTCORE_HARNESS_ARN
+ * if (!harnessArn) throw new Error('Set AGENTCORE_HARNESS_ARN')
+ *
+ * const agent = new AgentCoreHarnessAgent({
+ *   harnessArn,
+ *   runtimeSessionId: randomUUID(),
+ * })
+ * const result = await agent.invoke('Summarize the tools available in this harness.')
+ * ```
+ */
+export class AgentCoreHarnessAgent implements InvokableAgent {
+  private readonly _requestConfig: HarnessRequestConfiguration
+  private readonly _region: string | undefined
+  private readonly _clientConfig: BedrockAgentCoreClientConfig | undefined
+  private readonly _controlClientConfig: BedrockAgentCoreControlClientConfig | undefined
+  private _client: BedrockAgentCoreClient | undefined
+  private _controlClient: BedrockAgentCoreControlClient | undefined
+  private readonly _hostToolRegistry: ToolRegistry
+  private readonly _toolExecutor: ToolExecutorStrategy
+  private _isInvoking = false
+  private _cachedVersionedToolConfiguration: CachedVersionedToolConfiguration | undefined
+
+  /** The resource ARN for the managed harness. */
+  readonly harnessArn: string
+
+  /** The runtime session ID identifying the conversation. */
+  readonly runtimeSessionId: string
+
+  /** The unique identifier of the agent instance. */
+  readonly id: string
+
+  /** The name of the agent. */
+  readonly name?: string
+
+  /** Optional description of what the agent does. */
+  readonly description?: string
+
+  /**
+   * Creates an agent for a managed harness.
+   *
+   * Later mutation of `config` or its nested request values does not change this agent.
+   *
+   * @param config - Harness, session, request, client, and host-tool configuration
+   * @throws {@link ToolValidationError} If a host tool is invalid, duplicated, reserved, or explicitly disallowed
+   * @throws TypeError If a request override is invalid or cannot be snapshotted
+   * @throws Error If the runtime session ID does not satisfy the Harness contract
+   */
+  constructor(config: AgentCoreHarnessAgentConfig) {
+    if (config.runtimeSessionId.length < 33 || config.runtimeSessionId.length > 100) {
+      throw new Error(
+        `runtimeSessionId must be 33-100 characters, got ${config.runtimeSessionId.length}. The harness requires this length to identify a session.`
+      )
+    }
+    if (!RUNTIME_SESSION_ID_PATTERN.test(config.runtimeSessionId)) {
+      throw new Error(
+        'runtimeSessionId must start with an alphanumeric character and contain only alphanumeric characters, hyphens, and underscores.'
+      )
+    }
+    this._toolExecutor = resolveToolExecutor(config.toolExecutor)
+    this._requestConfig = snapshotRequestConfiguration(config)
+    this._region = config.region
+    this._clientConfig = config.clientConfig === undefined ? undefined : { ...config.clientConfig }
+    this._controlClientConfig = config.controlClientConfig === undefined ? undefined : { ...config.controlClientConfig }
+    this._client = config.client
+    this._controlClient = config.controlClient
+    this.harnessArn = config.harnessArn
+    this.runtimeSessionId = config.runtimeSessionId
+    this.id = config.id ?? config.harnessArn
+    if (config.name !== undefined) this.name = config.name
+    if (config.description !== undefined) this.description = config.description
+    for (const hostTool of config.tools ?? []) {
+      if (!isInvokableTool(hostTool)) {
+        throw new ToolValidationError(
+          `Host tool '${hostTool.name}' must implement invoke(). AgentCoreHarnessAgent does not support stream-only tools.`
+        )
+      }
+    }
+    this._hostToolRegistry = new ToolRegistry(config.tools)
+    const reservedHostTool = this._hostToolRegistry
+      .list()
+      .find((hostTool) => RESERVED_HARNESS_TOOL_NAMES.has(hostTool.name))
+    if (reservedHostTool !== undefined) {
+      throw new ToolValidationError(`Host tool name '${reservedHostTool.name}' is reserved by AgentCore Harness.`)
+    }
+    assertHostToolsAllowed(this._hostToolRegistry.list(), this._requestConfig.allowedTools)
+  }
+
+  /**
+   * Invokes the harness and returns the final result.
+   * See {@link stream} for supported options and event behavior.
+   *
+   * @param args - New input for the Harness-owned conversation
+   * @param options - Cancellation, invocation state, and other shared invocation options
+   * @returns The final Harness response and metrics reported for this invocation
+   * @throws {@link ConcurrentInvocationError} If this instance is already processing an invocation
+   * @throws TypeError If the input or invocation options are unsupported
+   * @throws {@link ToolValidationError} If deployed and host tool configuration is incompatible
+   * @throws {@link ModelThrottledError} If the data or control plane reports throttling
+   * @throws {@link ModelError} If the data plane, model, or Harness stream fails
+   * @throws Error If a non-throttling control-plane read fails
+   */
+  async invoke(args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
+    const gen = this.stream(args, options)
+    let next = await gen.next()
+    while (!next.done) {
+      next = await gen.next()
+    }
+    return next.value
+  }
+
+  /**
+   * Streams raw Harness events followed by a final {@link AgentCoreHarnessResultEvent}.
+   *
+   * Host tool calls run locally and resume the Harness with their results. `cancelSignal` and
+   * `invocationState` are supported. `limits` is rejected because the managed Harness cannot
+   * preserve the shared {@link InvokeOptions} budget semantics. Structured output options are not
+   * supported.
+   *
+   * Cancellation before host tool execution prevents the tools from starting. After host work
+   * starts, running tools finish and unstarted tools receive cancellation results. The agent sends
+   * every result to the Harness before returning with `stopReason: 'cancelled'`.
+   *
+   * Input supports non-empty text, tool-use, tool-result, and reasoning content. Empty input and
+   * unsupported content such as images, video, documents, cache points, guard content, and
+   * citations are rejected before any AWS request; mixed content is never partially sent.
+   *
+   * When the Harness reports usage, `cycleCount` counts completed assistant messages rather than
+   * HTTP requests or metadata records. User tool-result messages do not count. `totalDuration`
+   * measures client-observed invocation time. Usage may omit host-tool turns without metadata.
+   *
+   * @param args - New input for the Harness-owned conversation
+   * @param options - Cancellation, invocation state, and other shared invocation options
+   * @returns Raw Harness events, followed by the final result event and generator return value
+   * @throws {@link ConcurrentInvocationError} If this instance is already processing an invocation
+   * @throws TypeError If the input or invocation options are unsupported
+   * @throws {@link ToolValidationError} If deployed and host tool configuration is incompatible
+   * @throws {@link ModelThrottledError} If the data or control plane reports throttling
+   * @throws {@link ModelError} If the data plane, model, or Harness stream fails
+   * @throws Error If a non-throttling control-plane read fails
+   */
+  async *stream(
+    args: InvokeArgs,
+    options?: InvokeOptions
+  ): AsyncGenerator<AgentCoreHarnessStreamEvent, AgentResult, undefined> {
+    this._acquireLock()
+    try {
+      return yield* this._stream(args, options)
+    } finally {
+      this._isInvoking = false
+    }
+  }
+
+  private async *_stream(
+    args: InvokeArgs,
+    options?: InvokeOptions
+  ): AsyncGenerator<AgentCoreHarnessStreamEvent, AgentResult, undefined> {
+    if (options?.structuredOutputSchema !== undefined) {
+      throw new TypeError(
+        'InvokeOptions.structuredOutputSchema is not supported by AgentCoreHarnessAgent. AgentCoreHarnessAgent cannot be used as a Swarm node.'
+      )
+    }
+    if (options?.limits !== undefined) {
+      throw new TypeError(
+        'InvokeOptions.limits is not supported by AgentCoreHarnessAgent. Configure Harness-side maxIterations, maxTokens, or timeoutSeconds when constructing the agent.'
+      )
+    }
+
+    const invocationState = options?.invocationState ?? {}
+    const cancelSignal = options?.cancelSignal
+
+    // The harness owns conversation history by session, so the first request carries only the new
+    // turn; a follow-up request carries the assistant tool-use plus the host tool result.
+    let messages: HarnessMessage[] = formatHarnessInput(args)
+    const client = this._getClient()
+    let toolConfiguration: ResolvedToolConfiguration | undefined
+    let lastMessage = new Message({ role: 'assistant', content: [] })
+    let stopReason: StopReason
+    let mustCommitHostResults = false
+    const accumulatedUsage = createEmptyUsage()
+    let accumulatedLatencyMs = 0
+    let remoteCycleCount = 0
+    const invocationStartedAt = Date.now()
+    // Context-size fields describe the most recent reporting model turn, not the invocation total.
+    let lastUsage: Usage | undefined
+
+    while (true) {
+      const isHostResultContinuation = mustCommitHostResults
+
+      if (!isHostResultContinuation && cancelSignal?.aborted) {
+        stopReason = 'cancelled'
+        break
+      }
+
+      toolConfiguration = await this._resolveToolConfiguration(
+        isHostResultContinuation ? undefined : cancelSignal,
+        isHostResultContinuation ? toolConfiguration : undefined
+      )
+      if (!isHostResultContinuation && cancelSignal?.aborted) {
+        stopReason = 'cancelled'
+        break
+      }
+      const request = this._buildRequest(messages, toolConfiguration)
+      const decoder = new HarnessStreamDecoder()
+
+      try {
+        const response = await client.send(
+          new InvokeHarnessCommand(request),
+          cancelSignal && !isHostResultContinuation ? { abortSignal: cancelSignal } : {}
+        )
+        if (response.stream) {
+          for await (const chunk of response.stream) {
+            const event = this._streamEventOrThrow(chunk)
+            yield new AgentCoreHarnessStreamUpdateEvent(event)
+            decoder.accept(event)
+          }
+        }
+      } catch (unknownError) {
+        // Cancellation returns the partial result with stopReason 'cancelled' rather than throwing.
+        if (!isHostResultContinuation && cancelSignal?.aborted) {
+          lastMessage = decoder.partialMessage()
+          stopReason = 'cancelled'
+          break
+        }
+        throw this._normalizeError(unknownError)
+      }
+
+      const turnResult = decoder.complete()
+      remoteCycleCount += turnResult.assistantMessageCount
+      if (turnResult.usage !== undefined) {
+        accumulateUsage(accumulatedUsage, turnResult.usage)
+        accumulatedLatencyMs += turnResult.latencyMs ?? 0
+        lastUsage = turnResult.latestUsage ?? turnResult.usage
+      }
+
+      lastMessage = turnResult.message
+      stopReason = turnResult.stopReason
+
+      const hostToolUses = this._hostToolUses(lastMessage)
+      const cancellationRequested = cancelSignal?.aborted ?? false
+      if (stopReason !== 'toolUse' || hostToolUses.length === 0) {
+        if (cancellationRequested) {
+          stopReason = 'cancelled'
+        } else if (stopReason === 'maxTokens') {
+          throw new MaxTokensError(
+            'Model reached maximum token limit. This is an unrecoverable state that requires intervention.',
+            lastMessage
+          )
+        } else if (stopReason === 'malformedModelOutput' || stopReason === 'malformedToolUse') {
+          throw new ModelError(`Harness ended the turn with an unrecoverable stop reason: ${stopReason}`)
+        } else if (turnResult.toolInputParseError) {
+          throw new ModelError('unable to parse tool input JSON', { cause: turnResult.toolInputParseError })
+        }
+        break
+      }
+      if (turnResult.toolInputParseError && !cancellationRequested) {
+        throw new ModelError('unable to parse tool input JSON', { cause: turnResult.toolInputParseError })
+      }
+
+      const toolResults = await this._runHostTools(hostToolUses, toolConfiguration.allowedTools, cancelSignal)
+      messages = [
+        formatHarnessMessage(lastMessage),
+        formatHarnessMessage(new Message({ role: 'user', content: toolResults })),
+      ]
+      mustCommitHostResults = true
+    }
+
+    const result = new AgentResult({
+      stopReason,
+      lastMessage,
+      invocationState,
+      ...(lastUsage !== undefined && {
+        metrics: new AgentMetrics({
+          cycleCount: remoteCycleCount,
+          accumulatedUsage,
+          accumulatedMetrics: { latencyMs: accumulatedLatencyMs },
+          latestContextSize: lastUsage.inputTokens,
+          projectedContextSize: lastUsage.inputTokens + lastUsage.outputTokens,
+          totalDuration: Date.now() - invocationStartedAt,
+        }),
+      }),
+    })
+    yield new AgentCoreHarnessResultEvent({ result })
+    return result
+  }
+
+  private _acquireLock(): void {
+    if (this._isInvoking) {
+      throw new ConcurrentInvocationError(
+        'AgentCoreHarnessAgent is already processing an invocation. Wait for the current invoke() or stream() call to complete before invoking again.'
+      )
+    }
+    this._isInvoking = true
+  }
+
+  private _getClient(): BedrockAgentCoreClient {
+    this._client ??= createHarnessClient(this._clientConfig, this._region)
+    return this._client
+  }
+
+  private _getControlClient(): BedrockAgentCoreControlClient {
+    this._controlClient ??= createHarnessControlClient(this._controlClientConfig, this._region)
+    return this._controlClient
+  }
+
+  private async _resolveToolConfiguration(
+    cancelSignal?: AbortSignal,
+    continuationFallback?: ResolvedToolConfiguration
+  ): Promise<ResolvedToolConfiguration> {
+    if (this._hostToolRegistry.list().length === 0) {
+      return {
+        tools: [],
+        ...(this._requestConfig.allowedTools !== undefined && {
+          allowedTools: [...this._requestConfig.allowedTools],
+        }),
+      }
+    }
+
+    const hostTools = formatHarnessTools(this._hostToolRegistry.list())
+    try {
+      return await this._loadMergedToolConfiguration(hostTools, cancelSignal)
+    } catch (error) {
+      if (continuationFallback !== undefined) {
+        logger.warn(
+          `harness_arn=<${this.harnessArn}>, qualifier=<${this._requestConfig.qualifier ?? DEFAULT_HARNESS_QUALIFIER}>, error=<${normalizeError(error).message}> | unable to refresh harness tool configuration, using previous snapshot for mandatory host result continuation`
+        )
+        return continuationFallback
+      }
+      // The caller observes cancellation as a result; _stream checks the signal before invoking.
+      if (cancelSignal?.aborted) {
+        return {
+          tools: hostTools,
+          ...(this._requestConfig.allowedTools !== undefined && {
+            allowedTools: [...this._requestConfig.allowedTools],
+          }),
+        }
+      }
+      if (error instanceof ToolValidationError) throw error
+      const normalizedError = normalizeError(error)
+      if (normalizedError instanceof ModelThrottledError) throw normalizedError
+      if (THROTTLING_ERROR_NAMES.has(normalizedError.name)) {
+        throw new ModelThrottledError(normalizedError.message, { cause: error })
+      }
+      throw normalizedError
+    }
+  }
+
+  private async _loadMergedToolConfiguration(
+    hostTools: HarnessTool[],
+    cancelSignal?: AbortSignal
+  ): Promise<ResolvedToolConfiguration> {
+    const harnessId = harnessIdFromArn(this.harnessArn)
+    const qualifier = this._requestConfig.qualifier
+    const requestOptions = cancelSignal ? { abortSignal: cancelSignal } : {}
+
+    if (qualifier !== undefined && qualifier !== '' && qualifier !== DEFAULT_HARNESS_QUALIFIER) {
+      const endpointResponse = await this._getControlClient().send(
+        new GetHarnessEndpointCommand({ harnessId, endpointName: qualifier }),
+        requestOptions
+      )
+      const harnessVersion = endpointResponse.endpoint?.liveVersion
+      if (!harnessVersion) {
+        throw new Error(`Harness endpoint '${qualifier}' has no live version`)
+      }
+      if (this._cachedVersionedToolConfiguration?.harnessVersion === harnessVersion) {
+        return this._cachedVersionedToolConfiguration.toolConfiguration
+      }
+
+      const response = await this._getControlClient().send(
+        new GetHarnessCommand({ harnessId, harnessVersion }),
+        requestOptions
+      )
+      const toolConfiguration = this._mergeToolConfiguration(response.harness, hostTools)
+      this._cachedVersionedToolConfiguration = { harnessVersion, toolConfiguration }
+      return toolConfiguration
+    }
+
+    const response = await this._getControlClient().send(new GetHarnessCommand({ harnessId }), requestOptions)
+    if (response.harness?.status === 'UPDATING') {
+      throw new Error(
+        'Default Harness configuration cannot be resolved safely while the Harness is UPDATING. Retry after the update completes or use a named endpoint.'
+      )
+    }
+    return this._mergeToolConfiguration(response.harness, hostTools)
+  }
+
+  private _mergeToolConfiguration(
+    deployedHarness:
+      | {
+          tools?: HarnessTool[] | undefined
+          allowedTools?: string[] | undefined
+        }
+      | undefined,
+    hostTools: HarnessTool[]
+  ): ResolvedToolConfiguration {
+    if (deployedHarness === undefined) {
+      throw new Error('GetHarness returned no Harness configuration')
+    }
+    const deployedTools = deployedHarness.tools ?? []
+    const allowedTools = this._requestConfig.allowedTools ?? deployedHarness.allowedTools
+    assertHostToolsAllowed(this._hostToolRegistry.list(), allowedTools)
+    return {
+      tools: mergeHarnessTools(deployedTools, hostTools),
+      ...(allowedTools !== undefined && { allowedTools: [...allowedTools] }),
+    }
+  }
+
+  private _buildRequest(
+    messages: HarnessMessage[],
+    toolConfiguration: ResolvedToolConfiguration
+  ): InvokeHarnessCommandInput {
+    const { tools, allowedTools } = toolConfiguration
+    const requestConfiguration = cloneRequestValue(this._requestConfig, 'request configuration')
+    delete requestConfiguration.allowedTools
+    return {
+      harnessArn: this.harnessArn,
+      runtimeSessionId: this.runtimeSessionId,
+      messages,
+      ...requestConfiguration,
+      ...(tools.length > 0 && { tools: cloneRequestValue(tools, 'tools') }),
+      ...(allowedTools !== undefined && { allowedTools: [...allowedTools] }),
+    }
+  }
+
+  private _hostToolUses(message: Message): ToolUse[] {
+    const toolUses: ToolUse[] = []
+    for (const block of message.content) {
+      if (block.type === 'toolUseBlock' && this._hostToolRegistry.get(block.name) !== undefined) {
+        toolUses.push({ name: block.name, toolUseId: block.toolUseId, input: block.input })
+      }
+    }
+    return toolUses
+  }
+
+  private async _runHostTools(
+    toolUses: ToolUse[],
+    allowedTools: string[] | undefined,
+    cancelSignal?: AbortSignal
+  ): Promise<ToolResultBlock[]> {
+    switch (this._toolExecutor) {
+      case 'sequential': {
+        const results: ToolResultBlock[] = []
+        for (const toolUse of toolUses) {
+          results.push(
+            cancelSignal?.aborted
+              ? this._createCancelledHostToolResult(toolUse)
+              : await this._runHostTool(toolUse, allowedTools)
+          )
+        }
+        return results
+      }
+      case 'concurrent': {
+        if (cancelSignal?.aborted) {
+          return toolUses.map((toolUse) => this._createCancelledHostToolResult(toolUse))
+        }
+        return Promise.all(toolUses.map((toolUse) => this._runHostTool(toolUse, allowedTools)))
+      }
+      default: {
+        const _exhaustive: never = this._toolExecutor
+        throw new TypeError(`Unknown toolExecutor: ${_exhaustive as string}`)
+      }
+    }
+  }
+
+  private async _runHostTool(toolUse: ToolUse, allowedTools: string[] | undefined): Promise<ToolResultBlock> {
+    if (!isHostToolAllowed(toolUse.name, allowedTools)) {
+      throw new ModelError(
+        `Harness requested host tool '${toolUse.name}' even though it is excluded by effective allowedTools. The callback was not executed.`
+      )
+    }
+    // The constructor accepts only invokable tools, and the registry is immutable after construction.
+    const tool = this._hostToolRegistry.get(toolUse.name) as InvokableTool<unknown, unknown>
+    try {
+      const value = await tool.invoke(toolUse.input)
+      const result = createSuccessResult(value, toolUse.toolUseId)
+      // Validate inside the tool boundary so an unsupported return becomes a committed error result.
+      formatHarnessMessage(new Message({ role: 'user', content: [result] }))
+      return result
+    } catch (error) {
+      logger.warn(`tool=<${toolUse.name}>, tool_use_id=<${toolUse.toolUseId}> | host tool execution failed`)
+      return createErrorResult(error, toolUse.toolUseId)
+    }
+  }
+
+  private _createCancelledHostToolResult(toolUse: ToolUse): ToolResultBlock {
+    return new ToolResultBlock({
+      toolUseId: toolUse.toolUseId,
+      status: 'error',
+      content: [new TextBlock('Tool execution cancelled')],
+    })
+  }
+
+  private _streamEventOrThrow(chunk: InvokeHarnessStreamOutput): AgentCoreHarnessEventData {
+    if ('internalServerException' in chunk && chunk.internalServerException) {
+      throw new ModelError(chunk.internalServerException.message ?? 'AgentCore Harness internal server error', {
+        cause: chunk.internalServerException,
+      })
+    }
+    if ('validationException' in chunk && chunk.validationException) {
+      const message = chunk.validationException.message ?? 'AgentCore Harness validation error'
+      if (CONTEXT_WINDOW_OVERFLOW_ERRORS.some((phrase) => message.toLowerCase().includes(phrase))) {
+        throw new ContextWindowOverflowError(message, { cause: chunk.validationException })
+      }
+      throw new ModelError(message, { cause: chunk.validationException })
+    }
+    if ('runtimeClientError' in chunk && chunk.runtimeClientError) {
+      throw new ModelError(chunk.runtimeClientError.message ?? 'AgentCore Harness runtime client error', {
+        cause: chunk.runtimeClientError,
+      })
+    }
+    return chunk as AgentCoreHarnessEventData
+  }
+
+  private _normalizeError(unknownError: unknown): Error {
+    if (unknownError instanceof ModelError) return unknownError
+
+    const error = normalizeError(unknownError)
+    if (THROTTLING_ERROR_NAMES.has(error.name)) {
+      return new ModelThrottledError(error.message, { cause: unknownError })
+    }
+    if (CONTEXT_WINDOW_OVERFLOW_ERRORS.some((phrase) => error.message.toLowerCase().includes(phrase))) {
+      return new ContextWindowOverflowError(error.message, { cause: unknownError })
+    }
+    // Never let a raw vendor error escape the provider boundary.
+    return new ModelError(error.message, { cause: unknownError })
+  }
+}
+
+function isInvokableTool(tool: Tool): boolean {
+  return typeof (tool as Partial<InvokableTool<unknown, unknown>>).invoke === 'function'
+}
+
+function snapshotRequestConfiguration(config: AgentCoreHarnessAgentConfig): HarnessRequestConfiguration {
+  const systemPrompt = formatHarnessSystemPrompt(config.systemPrompt)
+  return cloneRequestValue(
+    {
+      ...(config.modelConfig !== undefined && { model: config.modelConfig }),
+      ...(systemPrompt !== undefined && { systemPrompt }),
+      ...(config.skills !== undefined && { skills: config.skills }),
+      ...(config.allowedTools !== undefined && { allowedTools: config.allowedTools }),
+      ...(config.maxIterations !== undefined && { maxIterations: config.maxIterations }),
+      ...(config.maxTokens !== undefined && { maxTokens: config.maxTokens }),
+      ...(config.timeoutSeconds !== undefined && { timeoutSeconds: config.timeoutSeconds }),
+      ...(config.qualifier !== undefined && { qualifier: config.qualifier }),
+      ...(config.runtimeUserId !== undefined && { runtimeUserId: config.runtimeUserId }),
+      ...(config.actorId !== undefined && { actorId: config.actorId }),
+    },
+    'request configuration'
+  )
+}
+
+function cloneRequestValue<T>(value: T, name: string): T {
+  try {
+    return globalThis.structuredClone(value)
+  } catch (error) {
+    throw new TypeError(`AgentCoreHarnessAgent ${name} must be structured-cloneable.`, { cause: error })
+  }
+}
+
+function resolveToolExecutor(toolExecutor: unknown): ToolExecutorStrategy {
+  switch (toolExecutor) {
+    case undefined:
+    case 'concurrent':
+      return 'concurrent'
+    case 'sequential':
+      return 'sequential'
+    default:
+      throw new TypeError(`toolExecutor must be 'concurrent' or 'sequential', got '${String(toolExecutor)}'`)
+  }
+}
+
+function harnessIdFromArn(harnessArn: string): string {
+  return harnessArn.slice(harnessArn.lastIndexOf('/') + 1)
+}

--- a/strands-ts/src/agentcore-harness/clients.ts
+++ b/strands-ts/src/agentcore-harness/clients.ts
@@ -1,0 +1,36 @@
+import { BedrockAgentCoreClient, type BedrockAgentCoreClientConfig } from '@aws-sdk/client-bedrock-agentcore'
+import {
+  BedrockAgentCoreControlClient,
+  type BedrockAgentCoreControlClientConfig,
+} from '@aws-sdk/client-bedrock-agentcore-control'
+
+/**
+ * Creates the Harness data-plane client owned by an AgentCoreHarnessAgent.
+ *
+ * @internal
+ */
+export function createHarnessClient(
+  config: BedrockAgentCoreClientConfig | undefined,
+  region: string | undefined
+): BedrockAgentCoreClient {
+  return new BedrockAgentCoreClient({
+    ...config,
+    maxAttempts: config?.maxAttempts ?? 1,
+    ...(region !== undefined && { region }),
+  })
+}
+
+/**
+ * Creates the Harness control-plane client owned by an AgentCoreHarnessAgent.
+ *
+ * @internal
+ */
+export function createHarnessControlClient(
+  config: BedrockAgentCoreControlClientConfig | undefined,
+  region: string | undefined
+): BedrockAgentCoreControlClient {
+  return new BedrockAgentCoreControlClient({
+    ...config,
+    ...(region !== undefined && { region }),
+  })
+}

--- a/strands-ts/src/agentcore-harness/events.ts
+++ b/strands-ts/src/agentcore-harness/events.ts
@@ -1,0 +1,86 @@
+/**
+ * AgentCore Harness-specific stream events yielded by AgentCoreHarnessAgent.stream().
+ */
+
+import type { InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import { StreamEvent } from '../hooks/events.js'
+import type { AgentResultEvent } from '../hooks/events.js'
+
+/**
+ * Union of non-error events received from an AgentCore Harness invocation.
+ *
+ * Harness error events are raised as exceptions instead of being yielded from the agent stream.
+ */
+export type AgentCoreHarnessEventData = Exclude<
+  InvokeHarnessStreamOutput,
+  | InvokeHarnessStreamOutput.InternalServerExceptionMember
+  | InvokeHarnessStreamOutput.ValidationExceptionMember
+  | InvokeHarnessStreamOutput.RuntimeClientErrorMember
+>
+
+/**
+ * Event wrapping a raw InvokeHarness streaming event.
+ *
+ * Yielded by `AgentCoreHarnessAgent.stream()` for each non-error event received from the remote agent.
+ * Harness error events are raised as exceptions instead.
+ * The `event` property is the raw InvokeHarness streaming event.
+ */
+export class AgentCoreHarnessStreamUpdateEvent extends StreamEvent {
+  readonly type = 'agentCoreHarnessStreamUpdateEvent' as const
+  readonly event: AgentCoreHarnessEventData
+
+  /**
+   * Creates a stream update event.
+   *
+   * @param event - Raw non-error event received from InvokeHarness
+   */
+  constructor(event: AgentCoreHarnessEventData) {
+    super()
+    this.event = event
+  }
+
+  /**
+   * Serializes the event.
+   *
+   * @returns The event type and raw Harness event
+   */
+  toJSON(): Pick<AgentCoreHarnessStreamUpdateEvent, 'type' | 'event'> {
+    return { type: this.type, event: this.event }
+  }
+}
+
+/**
+ * Event triggered as the final event in the AgentCore Harness agent stream.
+ * Wraps the agent result containing the stop reason and last message.
+ */
+export class AgentCoreHarnessResultEvent extends StreamEvent {
+  readonly type = 'agentCoreHarnessResultEvent' as const
+  readonly result: AgentResultEvent['result']
+
+  /**
+   * Creates the final result event.
+   *
+   * @param data - Final result from the Harness invocation
+   */
+  constructor(data: Pick<AgentResultEvent, 'result'>) {
+    super()
+    this.result = data.result
+  }
+
+  /**
+   * Serializes the event.
+   *
+   * @returns The event type and final result
+   */
+  toJSON(): Pick<AgentCoreHarnessResultEvent, 'type' | 'result'> {
+    return { type: this.type, result: this.result }
+  }
+}
+
+/**
+ * Union of all events yielded by `AgentCoreHarnessAgent.stream()`.
+ *
+ * Includes raw streaming events ({@link AgentCoreHarnessStreamUpdateEvent}) and the final
+ * result event ({@link AgentCoreHarnessResultEvent}).
+ */
+export type AgentCoreHarnessStreamEvent = AgentCoreHarnessStreamUpdateEvent | AgentCoreHarnessResultEvent

--- a/strands-ts/src/agentcore-harness/index.ts
+++ b/strands-ts/src/agentcore-harness/index.ts
@@ -1,0 +1,15 @@
+/**
+ * AgentCore Harness support for the Strands Agents SDK.
+ *
+ * Provides {@link AgentCoreHarnessAgent}, an {@link InvokableAgent} that runs its agent loop in a
+ * managed AgentCore Harness microVM via the `InvokeHarness` API, while executing host-side (custom)
+ * tools on the client.
+ */
+
+export { AgentCoreHarnessAgent, type AgentCoreHarnessAgentConfig } from './agentcore-harness-agent.js'
+export {
+  AgentCoreHarnessStreamUpdateEvent,
+  AgentCoreHarnessResultEvent,
+  type AgentCoreHarnessEventData,
+  type AgentCoreHarnessStreamEvent,
+} from './events.js'

--- a/strands-ts/src/agentcore-harness/request-formatting.ts
+++ b/strands-ts/src/agentcore-harness/request-formatting.ts
@@ -1,0 +1,224 @@
+import type {
+  HarnessContentBlock,
+  HarnessInlineFunctionConfig,
+  HarnessMessage,
+  HarnessSystemContentBlock,
+  HarnessTool,
+  HarnessToolResultContentBlock,
+} from '@aws-sdk/client-bedrock-agentcore'
+import { CheckpointError } from '../errors.js'
+import { isInterruptResponseContent } from '../types/interrupt.js'
+import { Message, TextBlock } from '../types/messages.js'
+import type { InvokeArgs } from '../types/agent.js'
+import type { ContentBlock, ContentBlockData, MessageData, ToolResultContent } from '../types/messages.js'
+import type { Tool } from '../tools/tool.js'
+
+/**
+ * Converts invocation input into Harness messages.
+ *
+ * @internal
+ * @param args - Arguments supplied to the agent invocation
+ * @returns Harness messages suitable for an InvokeHarness request
+ */
+export function formatHarnessInput(args: InvokeArgs): HarnessMessage[] {
+  const messages = normalizeArgs(args)
+  if (messages.length === 0) {
+    throw new TypeError('AgentCoreHarnessAgent input must contain at least one message.')
+  }
+  return messages.map((message) => formatHarnessMessage(message))
+}
+
+/**
+ * Converts a Strands message into a Harness message.
+ *
+ * @internal
+ * @param message - Strands message to convert
+ * @returns Harness wire message
+ */
+export function formatHarnessMessage(message: Message): HarnessMessage {
+  if (message.content.length === 0) {
+    throw new TypeError(`AgentCore Harness ${message.role} messages must contain at least one content block.`)
+  }
+  const content = message.content.map((block, index) => formatContentBlock(block, index))
+  return { role: message.role, content }
+}
+
+/**
+ * Converts host tools into Harness inline-function definitions.
+ *
+ * @internal
+ * @param tools - Host tools to expose to the Harness
+ * @returns Harness tool definitions
+ */
+export function formatHarnessTools(tools: Tool[]): HarnessTool[] {
+  return tools.map((tool): HarnessTool => {
+    const inlineFunction: HarnessInlineFunctionConfig = {
+      description: tool.toolSpec.description,
+      // Strands input schemas are JSON Schema, a valid AWS document value at runtime. The smithy
+      // DocumentType is recursive and JSONSchema7 does not match it structurally, so bridge via unknown.
+      inputSchema: (tool.toolSpec.inputSchema ?? {
+        type: 'object',
+        properties: {},
+      }) as unknown as HarnessInlineFunctionConfig['inputSchema'],
+    }
+    return { type: 'inline_function', name: tool.name, config: { inlineFunction } }
+  })
+}
+
+/**
+ * Converts a system prompt override into Harness system content blocks.
+ *
+ * @internal
+ * @param systemPrompt - System prompt override
+ * @returns Harness system content blocks, or undefined when omitted
+ */
+export function formatHarnessSystemPrompt(
+  systemPrompt: string | TextBlock[] | undefined
+): HarnessSystemContentBlock[] | undefined {
+  if (systemPrompt === undefined) return undefined
+  if (typeof systemPrompt === 'string') {
+    if (systemPrompt.length === 0) {
+      throw new TypeError('systemPrompt must contain non-empty text when provided')
+    }
+    return [{ text: systemPrompt }]
+  }
+  if (systemPrompt.length === 0) {
+    throw new TypeError('systemPrompt must contain non-empty text when provided')
+  }
+  return systemPrompt.map((block, index) => {
+    if (block.text.length === 0) {
+      throw new TypeError(`systemPrompt block at index ${index} must contain non-empty text`)
+    }
+    return { text: block.text }
+  })
+}
+
+/** Normalizes invocation arguments into Strands messages. */
+function normalizeArgs(args: InvokeArgs): Message[] {
+  if (typeof args === 'string') {
+    return [new Message({ role: 'user', content: [new TextBlock(args)] })]
+  }
+  if (typeof args === 'object' && args !== null && !Array.isArray(args) && 'checkpointResume' in args) {
+    throw new CheckpointError(
+      'Received a checkpointResume block but AgentCoreHarnessAgent does not support checkpointing.'
+    )
+  }
+  if (!Array.isArray(args) || args.length === 0) {
+    return []
+  }
+  const first = args[0]!
+  // Interrupt responses resume a local Agent's paused loop; the Harness runs its own loop and
+  // has no resume-from-interrupt concept. Host callbacks provide the Harness's approval path.
+  if (isInterruptResponseContent(first)) {
+    throw new Error(
+      'AgentCoreHarnessAgent does not support interrupt-response inputs. For human-in-the-loop, pass a custom tool whose callback performs the approval; the harness pauses on the tool call and resumes with the result.'
+    )
+  }
+  if (typeof first === 'object' && 'role' in first) {
+    return (args as (Message | MessageData)[]).map((message) =>
+      message instanceof Message ? message : Message.fromMessageData(message)
+    )
+  }
+  if (typeof first === 'object' && 'type' in first) {
+    return [new Message({ role: 'user', content: args as ContentBlock[] })]
+  }
+  return [Message.fromMessageData({ role: 'user', content: args as ContentBlockData[] })]
+}
+
+/** Converts a Strands content block into a Harness content block. */
+function formatContentBlock(block: ContentBlock, index: number): HarnessContentBlock {
+  switch (block.type) {
+    case 'textBlock':
+      if (block.text.length === 0) {
+        throw new TypeError(`Content block at index ${index} contains empty text, which AgentCore Harness rejects.`)
+      }
+      return { text: block.text }
+    case 'toolUseBlock':
+      if (block.reasoningSignature !== undefined) {
+        throw new TypeError(
+          `Tool-use content block at index ${index} has a reasoningSignature, which AgentCore Harness cannot represent.`
+        )
+      }
+      return { toolUse: { toolUseId: block.toolUseId, name: block.name, input: block.input, type: 'tool_use' } }
+    case 'toolResultBlock': {
+      if (block.content.length === 0) {
+        throw new TypeError(`Tool-result content block at index ${index} must contain at least one result item.`)
+      }
+      return {
+        toolResult: {
+          toolUseId: block.toolUseId,
+          content: block.content.map((content, contentIndex) => formatToolResultContent(content, index, contentIndex)),
+          status: block.status,
+          type: 'tool_use',
+        },
+      }
+    }
+    case 'reasoningBlock': {
+      const hasReasoningText = block.text !== undefined || block.signature !== undefined
+      const hasRedactedContent = block.redactedContent !== undefined
+      if (hasReasoningText && hasRedactedContent) {
+        throw new TypeError(
+          `Reasoning content block at index ${index} contains both reasoning text and redacted content, which AgentCore Harness cannot represent together.`
+        )
+      }
+      if (hasReasoningText) {
+        if (block.text === '' && block.signature === undefined) {
+          throw new TypeError(`Reasoning content block at index ${index} contains empty reasoning text.`)
+        }
+        return {
+          reasoningContent: {
+            reasoningText: {
+              text: block.text ?? '',
+              ...(block.signature !== undefined && { signature: block.signature }),
+            },
+          },
+        }
+      }
+      if (hasRedactedContent) {
+        return { reasoningContent: { redactedContent: block.redactedContent } }
+      }
+      throw new TypeError(
+        `Reasoning content block at index ${index} must contain text, a signature, or redacted content.`
+      )
+    }
+    case 'cachePointBlock':
+    case 'guardContentBlock':
+    case 'imageBlock':
+    case 'videoBlock':
+    case 'documentBlock':
+    case 'citationsBlock':
+      throw new TypeError(
+        `Content block at index ${index} has unsupported type '${block.type}'. AgentCore Harness supports only text, tool-use, tool-result, and reasoning content.`
+      )
+    default:
+      throw new TypeError(
+        `Content block at index ${index} has unknown type '${String((block as { type?: unknown }).type)}'.`
+      )
+  }
+}
+
+/** Converts tool-result content into its Harness request representation. */
+function formatToolResultContent(
+  content: ToolResultContent,
+  blockIndex: number,
+  contentIndex: number
+): HarnessToolResultContentBlock {
+  switch (content.type) {
+    case 'textBlock':
+      // Harness text must be non-empty; JSON string syntax preserves an empty string value.
+      return { text: content.text.length > 0 ? content.text : '""' }
+    case 'jsonBlock':
+      // The live Harness request path rejects JSON results despite the generated union member.
+      return { text: JSON.stringify(content.json) }
+    case 'imageBlock':
+    case 'videoBlock':
+    case 'documentBlock':
+      throw new TypeError(
+        `Tool-result content at block index ${blockIndex}, item index ${contentIndex} has unsupported type '${content.type}'. AgentCore Harness host tools can return only text or JSON-compatible values.`
+      )
+    default:
+      throw new TypeError(
+        `Tool-result content at block index ${blockIndex}, item index ${contentIndex} has unknown type '${String((content as { type?: unknown }).type)}'.`
+      )
+  }
+}

--- a/strands-ts/src/agentcore-harness/stream-decoder.ts
+++ b/strands-ts/src/agentcore-harness/stream-decoder.ts
@@ -1,0 +1,324 @@
+import type {
+  HarnessContentBlockDelta,
+  HarnessContentBlockStart,
+  HarnessStopReason,
+  HarnessToolResultContentBlock,
+} from '@aws-sdk/client-bedrock-agentcore'
+import { ModelError } from '../errors.js'
+import { logger } from '../logging/logger.js'
+import { accumulateUsage, type Usage } from '../models/streaming.js'
+import { JsonBlock, Message, ReasoningBlock, TextBlock, ToolResultBlock, ToolUseBlock } from '../types/messages.js'
+import type { JSONValue } from '../types/json.js'
+import type { ContentBlock, Role, StopReason, ToolResultContent } from '../types/messages.js'
+import type { ToolResultStatus } from '../tools/types.js'
+import type { AgentCoreHarnessEventData } from './events.js'
+
+/** Maps Harness wire stop reasons onto Strands stop reasons. */
+const STOP_REASON_MAP = {
+  end_turn: 'endTurn',
+  tool_use: 'toolUse',
+  tool_result: 'toolResult',
+  max_tokens: 'maxTokens',
+  stop_sequence: 'stopSequence',
+  content_filtered: 'contentFiltered',
+  model_context_window_exceeded: 'modelContextWindowExceeded',
+  max_iterations_exceeded: 'limitTurns',
+  max_output_tokens_exceeded: 'limitOutputTokens',
+  timeout_exceeded: 'timeoutExceeded',
+  interrupted: 'interrupt',
+  partial_turn: 'pauseTurn',
+  malformed_model_output: 'malformedModelOutput',
+  malformed_tool_use: 'malformedToolUse',
+} satisfies Record<HarnessStopReason, StopReason>
+
+/**
+ * A completed turn reconstructed from a Harness event stream.
+ *
+ * @internal
+ */
+export interface DecodedHarnessTurn {
+  /** Most recent message completed by the Harness call. */
+  message: Message
+  /** Reason the most recent message stopped. */
+  stopReason: StopReason
+  /** Token usage accumulated across the Harness call. */
+  usage?: Usage
+  /** Most recent token usage reported during the Harness call. */
+  latestUsage?: Usage
+  /** Latency accumulated across the Harness call in milliseconds. */
+  latencyMs?: number
+  /** Tool-input parse error associated with the retained message. */
+  toolInputParseError?: SyntaxError
+  /** Number of assistant messages completed during this Harness call. */
+  assistantMessageCount: number
+}
+
+/**
+ * Reconstructs the most recent message and metadata from one InvokeHarness event stream.
+ *
+ * @internal
+ */
+export class HarnessStreamDecoder {
+  private readonly _state = createStreamState()
+
+  /**
+   * Folds one non-error Harness stream event into the current turn.
+   *
+   * @param event - Harness event to process
+   */
+  accept(event: AgentCoreHarnessEventData): void {
+    accumulate(this._state, event)
+  }
+
+  /**
+   * Completes the turn after the Harness stream ends.
+   *
+   * @returns Reconstructed message, stop reason, usage, latency, and any deferred parse error
+   * @throws \{ModelError\} When the stream did not complete a message
+   */
+  complete(): DecodedHarnessTurn {
+    if (this._state.stopReason === undefined) {
+      throw new ModelError('Stream ended without completing a message')
+    }
+    return {
+      message: toMessage(this._state),
+      stopReason: this._state.stopReason,
+      ...(this._state.usage !== undefined && { usage: this._state.usage }),
+      ...(this._state.latestUsage !== undefined && { latestUsage: this._state.latestUsage }),
+      ...(this._state.latencyMs !== undefined && { latencyMs: this._state.latencyMs }),
+      ...(this._state.toolInputParseError !== undefined && {
+        toolInputParseError: this._state.toolInputParseError,
+      }),
+      assistantMessageCount: this._state.assistantMessageCount,
+    }
+  }
+
+  /**
+   * Returns the message assembled before a cancelled stream ended.
+   *
+   * @returns Partially reconstructed message
+   */
+  partialMessage(): Message {
+    return toMessage(this._state)
+  }
+}
+
+/** The content block currently being assembled from stream events. */
+type PendingBlock =
+  | { kind: 'text'; text: string }
+  | { kind: 'toolUse'; toolUseId: string; name: string; input: string }
+  | { kind: 'toolResult'; toolUseId: string; status: ToolResultStatus; content: ToolResultContent[] }
+  | { kind: 'reasoning'; text: string; signature?: string; redactedContent?: Uint8Array }
+
+/** Accumulated state for one InvokeHarness event stream. */
+interface StreamState {
+  role: Role
+  content: ContentBlock[]
+  pending: PendingBlock | undefined
+  stopReason: StopReason | undefined
+  toolInputParseError: SyntaxError | undefined
+  usage: Usage | undefined
+  latestUsage: Usage | undefined
+  latencyMs: number | undefined
+  assistantMessageCount: number
+}
+
+/** Creates fresh accumulation state for a single InvokeHarness turn. */
+function createStreamState(): StreamState {
+  return {
+    role: 'assistant',
+    content: [],
+    pending: undefined,
+    stopReason: undefined,
+    toolInputParseError: undefined,
+    usage: undefined,
+    latestUsage: undefined,
+    latencyMs: undefined,
+    assistantMessageCount: 0,
+  }
+}
+
+/** Folds one stream event into the accumulation state. */
+function accumulate(state: StreamState, event: AgentCoreHarnessEventData): void {
+  if ('messageStart' in event && event.messageStart) {
+    // A single InvokeHarness call can stream multiple messages. Retain only the most recent message.
+    flushPending(state)
+    state.content.length = 0
+    state.stopReason = undefined
+    state.toolInputParseError = undefined
+    state.role = roleFromHarness(event.messageStart.role)
+  }
+  if ('contentBlockStart' in event && event.contentBlockStart) {
+    flushPending(state)
+    state.pending = startBlock(event.contentBlockStart.start)
+  }
+  if ('contentBlockDelta' in event && event.contentBlockDelta) {
+    applyDelta(state, event.contentBlockDelta.delta)
+  }
+  if ('contentBlockStop' in event && event.contentBlockStop) {
+    flushPending(state)
+  }
+  if ('messageStop' in event && event.messageStop) {
+    state.stopReason = stopReasonFromHarness(event.messageStop.stopReason)
+    if (state.role === 'assistant') state.assistantMessageCount++
+  }
+  if ('metadata' in event && event.metadata) {
+    const usage = event.metadata.usage
+    if (usage) {
+      const reportedUsage: Usage = {
+        inputTokens: usage.inputTokens ?? 0,
+        outputTokens: usage.outputTokens ?? 0,
+        totalTokens: usage.totalTokens ?? 0,
+        ...(usage.cacheReadInputTokens !== undefined && { cacheReadInputTokens: usage.cacheReadInputTokens }),
+        ...(usage.cacheWriteInputTokens !== undefined && { cacheWriteInputTokens: usage.cacheWriteInputTokens }),
+      }
+      if (state.usage === undefined) state.usage = { ...reportedUsage }
+      else accumulateUsage(state.usage, reportedUsage)
+      state.latestUsage = reportedUsage
+    }
+    if (event.metadata.metrics?.latencyMs !== undefined) {
+      state.latencyMs = (state.latencyMs ?? 0) + event.metadata.metrics.latencyMs
+    }
+  }
+}
+
+/** Finalizes the accumulated state into a message. */
+function toMessage(state: StreamState): Message {
+  flushPending(state)
+  return new Message({ role: state.role, content: state.content })
+}
+
+/** Maps a Harness stop reason to SDK casing, preserving unknown future values. */
+function stopReasonFromHarness(stopReason: string | undefined): StopReason {
+  if (stopReason === undefined || stopReason.trim().length === 0) {
+    throw new ModelError('Harness messageStop event is missing a non-empty stopReason')
+  }
+  const mappedStopReason = STOP_REASON_MAP[stopReason as HarnessStopReason]
+  if (mappedStopReason !== undefined) return mappedStopReason
+
+  const fallback = stopReason.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase())
+  logger.warn(`stop_reason=<${stopReason}>, fallback=<${fallback}> | unknown stop reason, converting to camelCase`)
+  return fallback
+}
+
+/** Opens a pending block when a content-block start identifies its type. */
+function startBlock(start: HarnessContentBlockStart | undefined): PendingBlock | undefined {
+  if (start && 'toolUse' in start && start.toolUse) {
+    return {
+      kind: 'toolUse',
+      toolUseId: requiredWireString(start.toolUse.toolUseId, 'tool-use start', 'toolUseId'),
+      name: requiredWireString(start.toolUse.name, 'tool-use start', 'name'),
+      input: '',
+    }
+  }
+  if (start && 'toolResult' in start && start.toolResult) {
+    return {
+      kind: 'toolResult',
+      toolUseId: requiredWireString(start.toolResult.toolUseId, 'tool-result start', 'toolUseId'),
+      status: start.toolResult.status === 'error' ? 'error' : 'success',
+      content: [],
+    }
+  }
+  return undefined
+}
+
+/** Validates the message role carried by a stream event. */
+function roleFromHarness(role: string | undefined): Role {
+  if (role === 'assistant' || role === 'user') return role
+  throw new ModelError(`Harness messageStart event has invalid role '${String(role)}'`)
+}
+
+/** Narrows optional Smithy strings that are required for a valid stream. */
+function requiredWireString(value: string | undefined, event: string, field: string): string {
+  if (value !== undefined && value.length > 0) return value
+  throw new ModelError(`Harness ${event} event is missing a non-empty ${field}`)
+}
+
+/** Appends a delta to the pending block, matched to its kind. */
+function applyDelta(state: StreamState, delta: HarnessContentBlockDelta | undefined): void {
+  if (!delta) return
+  const pending = state.pending
+  if ('text' in delta && delta.text !== undefined) {
+    if (pending?.kind === 'text') pending.text += delta.text
+    else if (pending?.kind === 'reasoning') pending.text += delta.text
+    else state.pending = { kind: 'text', text: delta.text }
+  } else if ('toolUse' in delta && delta.toolUse && pending?.kind === 'toolUse') {
+    pending.input += delta.toolUse.input ?? ''
+  } else if ('toolResult' in delta && delta.toolResult && pending?.kind === 'toolResult') {
+    for (const item of delta.toolResult) {
+      pending.content.push(toolResultContentFromHarness(item))
+    }
+  } else if ('reasoningContent' in delta && delta.reasoningContent && pending?.kind === 'reasoning') {
+    const reasoning = delta.reasoningContent
+    if ('text' in reasoning && reasoning.text !== undefined) pending.text += reasoning.text
+    if ('signature' in reasoning && reasoning.signature !== undefined) {
+      pending.signature = (pending.signature ?? '') + reasoning.signature
+    }
+    if ('redactedContent' in reasoning && reasoning.redactedContent !== undefined) {
+      pending.redactedContent = concatBytes(pending.redactedContent, reasoning.redactedContent)
+    }
+  } else if ('reasoningContent' in delta && delta.reasoningContent && pending === undefined) {
+    const reasoning = delta.reasoningContent
+    state.pending = {
+      kind: 'reasoning',
+      text: 'text' in reasoning && reasoning.text ? reasoning.text : '',
+      ...('signature' in reasoning && reasoning.signature !== undefined && { signature: reasoning.signature }),
+      ...('redactedContent' in reasoning &&
+        reasoning.redactedContent !== undefined && { redactedContent: reasoning.redactedContent }),
+    }
+  }
+}
+
+/** Concatenates streamed binary reasoning content. */
+function concatBytes(current: Uint8Array | undefined, chunk: Uint8Array): Uint8Array {
+  if (current === undefined) return chunk
+  const combined = new Uint8Array(current.length + chunk.length)
+  combined.set(current)
+  combined.set(chunk, current.length)
+  return combined
+}
+
+/** Pushes the pending block onto the content list and clears it. */
+function flushPending(state: StreamState): void {
+  const pending = state.pending
+  if (!pending) return
+  switch (pending.kind) {
+    case 'text':
+      if (pending.text) state.content.push(new TextBlock(pending.text))
+      break
+    case 'toolUse': {
+      let input: JSONValue = {}
+      if (pending.input) {
+        try {
+          input = JSON.parse(pending.input) as JSONValue
+        } catch (error) {
+          if (error instanceof SyntaxError && !state.toolInputParseError) state.toolInputParseError = error
+        }
+      }
+      state.content.push(new ToolUseBlock({ toolUseId: pending.toolUseId, name: pending.name, input }))
+      break
+    }
+    case 'toolResult':
+      state.content.push(
+        new ToolResultBlock({ toolUseId: pending.toolUseId, status: pending.status, content: pending.content })
+      )
+      break
+    case 'reasoning':
+      state.content.push(
+        new ReasoningBlock({
+          ...(pending.text && { text: pending.text }),
+          ...(pending.signature !== undefined && { signature: pending.signature }),
+          ...(pending.redactedContent !== undefined && { redactedContent: pending.redactedContent }),
+        })
+      )
+      break
+  }
+  state.pending = undefined
+}
+
+/** Converts Harness tool-result content into a Strands tool-result content block. */
+function toolResultContentFromHarness(item: HarnessToolResultContentBlock): ToolResultContent {
+  if ('json' in item && item.json !== undefined) return new JsonBlock({ json: item.json as JSONValue })
+  if ('text' in item && item.text !== undefined) return new TextBlock(item.text)
+  return new TextBlock(JSON.stringify(item))
+}

--- a/strands-ts/src/agentcore-harness/tool-configuration.ts
+++ b/strands-ts/src/agentcore-harness/tool-configuration.ts
@@ -1,0 +1,320 @@
+import type { HarnessTool } from '@aws-sdk/client-bedrock-agentcore'
+import { ToolValidationError } from '../errors.js'
+import type { Tool } from '../tools/tool.js'
+
+/**
+ * Merges deployed Harness tools with local host-tool declarations.
+ *
+ * A local host tool can bind to a same-name deployed inline function when its description and
+ * input schema match. The deployed declaration remains authoritative and is emitted only once.
+ *
+ * @internal
+ * @param deployedTools - Tools configured on the deployed Harness
+ * @param hostTools - Inline-function declarations generated for local host tools
+ * @returns The tool list to send with InvokeHarness
+ * @throws {@link ToolValidationError} If deployed and local tool declarations conflict
+ */
+export function mergeHarnessTools(deployedTools: HarnessTool[], hostTools: HarnessTool[]): HarnessTool[] {
+  const deployedToolsByName = new Map<string, { index: number; inferred: boolean }>()
+  const namedDeployedTools = deployedTools.map((tool, index) => {
+    const resolvedName = resolveDeployedToolName(tool, index)
+    const existing = deployedToolsByName.get(resolvedName.name)
+    if (existing !== undefined) {
+      if (!existing.inferred && !resolvedName.inferred) {
+        throw new ToolValidationError(
+          `Deployed harness contains duplicate tool name '${resolvedName.name}'. Tool names must be unique.`
+        )
+      }
+      throw new ToolValidationError(
+        `Deployed harness tools at indexes ${existing.index} and ${index} resolve to runtime name '${resolvedName.name}'. Assign explicit unique names to the unnamed deployed tools.`
+      )
+    }
+    deployedToolsByName.set(resolvedName.name, { index, inferred: resolvedName.inferred })
+    return { tool, index, ...resolvedName }
+  })
+
+  const hostToolsByName = new Map(
+    hostTools
+      .filter((hostTool): hostTool is HarnessTool & { name: string } => hostTool.name !== undefined)
+      .map((hostTool) => [hostTool.name, hostTool])
+  )
+  const boundHostToolNames = new Set<string>()
+
+  for (const deployedTool of namedDeployedTools) {
+    const hostTool = hostToolsByName.get(deployedTool.name)
+    if (hostTool === undefined) continue
+
+    if (deployedTool.inferred) {
+      throw new ToolValidationError(
+        `Host tool '${hostTool.name}' conflicts with the runtime-generated name of the unnamed deployed tool at index ${deployedTool.index} (type '${String(deployedTool.tool.type)}'). Assign the deployed tool an explicit unique name or rename the host tool.`
+      )
+    }
+    assertCompatibleInlineFunction(deployedTool.tool, hostTool)
+    boundHostToolNames.add(deployedTool.name)
+  }
+
+  return [...deployedTools, ...hostTools.filter((hostTool) => !boundHostToolNames.has(hostTool.name ?? ''))]
+}
+
+/** Resolves the name used as the Harness runtime tool-map key. */
+function resolveDeployedToolName(
+  tool: HarnessTool,
+  index: number
+): {
+  name: string
+  inferred: boolean
+} {
+  if (tool.name) return { name: tool.name, inferred: false }
+
+  const prefix = ((): string => {
+    switch (tool.type) {
+      case 'remote_mcp':
+        return 'mcp'
+      case 'agentcore_gateway':
+        return 'gateway'
+      case 'agentcore_browser':
+        return 'browser'
+      case 'agentcore_code_interpreter':
+        return 'code_interpreter'
+      case 'inline_function':
+        return 'inline_function'
+      default:
+        throw new ToolValidationError(
+          `Unnamed deployed tool at index ${index} has unsupported type '${String(tool.type)}'; its runtime name cannot be determined safely.`
+        )
+    }
+  })()
+  return { name: `${prefix}_${index}`, inferred: true }
+}
+
+/**
+ * Verifies that every local host tool is admitted by an effective Harness allowlist.
+ *
+ * @internal
+ * @param hostTools - Local host tools
+ * @param allowedTools - Effective Harness allowlist, or undefined for unrestricted access
+ * @throws {@link ToolValidationError} If the allowlist excludes a local host tool
+ */
+export function assertHostToolsAllowed(hostTools: Tool[], allowedTools: string[] | undefined): void {
+  const excludedToolNames = hostTools
+    .map((hostTool) => hostTool.name)
+    .filter((hostToolName) => !isHostToolAllowed(hostToolName, allowedTools))
+  if (excludedToolNames.length === 0) return
+
+  const names = excludedToolNames.map((name) => `'${name}'`).join(', ')
+  const subject = excludedToolNames.length === 1 ? `Host tool ${names} is` : `Host tools ${names} are`
+  const example = excludedToolNames[0]!
+  throw new ToolValidationError(
+    `${subject} excluded by effective allowedTools. Add '@${example}', '@${example}/${example}', a matching namespace glob, or '*' to allowedTools.`
+  )
+}
+
+/**
+ * Tests a host tool name against the Harness allowlist namespace rules.
+ *
+ * @internal
+ * @param hostToolName - Local host tool name
+ * @param allowedTools - Effective Harness allowlist, or undefined for unrestricted access
+ * @returns Whether the host tool is admitted
+ */
+export function isHostToolAllowed(hostToolName: string, allowedTools: string[] | undefined): boolean {
+  if (allowedTools === undefined || allowedTools.includes('*')) return true
+
+  return allowedTools.some((pattern) => {
+    const separatorIndex = pattern.indexOf('/')
+    const isNamespaced = pattern.startsWith('@')
+    const namespacePattern = isNamespaced
+      ? pattern.slice(1, separatorIndex === -1 ? undefined : separatorIndex)
+      : 'builtin'
+    const toolPattern = isNamespaced ? (separatorIndex === -1 ? '*' : pattern.slice(separatorIndex + 1)) : pattern
+    return matchesFnmatchcase(hostToolName, namespacePattern) && matchesFnmatchcase(hostToolName, toolPattern)
+  })
+}
+
+/** Verifies that a local handler implements the contract of a deployed inline function. */
+function assertCompatibleInlineFunction(deployedTool: HarnessTool, hostTool: HarnessTool & { name: string }): void {
+  const name = hostTool.name
+  if (deployedTool.type !== 'inline_function') {
+    throw new ToolValidationError(
+      `Host tool '${name}' conflicts with deployed tool type '${String(deployedTool.type)}'. A local handler can bind only to a deployed inline_function.`
+    )
+  }
+
+  const deployedConfig = getInlineFunctionConfig(deployedTool)
+  const hostConfig = getInlineFunctionConfig(hostTool)
+  if (deployedConfig === undefined) {
+    throw new ToolValidationError(`Deployed inline function '${name}' has no inline-function configuration.`)
+  }
+  if (hostConfig === undefined) {
+    throw new ToolValidationError(`Host tool '${name}' has no inline-function configuration.`)
+  }
+
+  const mismatches: string[] = []
+  if (deployedConfig.description !== hostConfig.description) mismatches.push('description')
+  if (!areStructurallyEqual(deployedConfig.inputSchema, hostConfig.inputSchema)) mismatches.push('input schema')
+  if (mismatches.length === 0) return
+
+  const difference = mismatches.length === 1 ? `its ${mismatches[0]} differs` : `its ${mismatches.join(' and ')} differ`
+  throw new ToolValidationError(
+    `Host tool '${name}' cannot bind to the deployed inline function because ${difference}. Make the local tool definition match the deployed inline function.`
+  )
+}
+
+/** Extracts the inline-function member from a Harness tool configuration union. */
+function getInlineFunctionConfig(tool: HarnessTool):
+  | {
+      description: string | undefined
+      inputSchema: unknown
+    }
+  | undefined {
+  if (tool.config === undefined || !('inlineFunction' in tool.config)) return undefined
+  return tool.config.inlineFunction
+}
+
+/** Compares JSON-like values while ignoring object-property order. */
+function areStructurallyEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => areStructurallyEqual(value, right[index]))
+    )
+  }
+  if (!isRecord(left) || !isRecord(right)) return false
+
+  const leftKeys = Object.keys(left).sort()
+  const rightKeys = Object.keys(right).sort()
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key, index) => key === rightKeys[index] && areStructurallyEqual(left[key], right[key]))
+  )
+}
+
+/** Narrows plain JSON objects used by Harness input schemas. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Implements Python fnmatchcase semantics used by the Harness runtime. */
+function matchesFnmatchcase(value: string, pattern: string): boolean {
+  const tokens = tokenizeFnmatchPattern(pattern)
+  let reachable = new Set([0])
+
+  for (const character of value) {
+    reachable = starClosure(reachable, tokens)
+    const next = new Set<number>()
+    for (const tokenIndex of reachable) {
+      const token = tokens[tokenIndex]
+      if (token?.kind === 'star') {
+        next.add(tokenIndex)
+      } else if (token !== undefined && tokenMatches(token, character)) {
+        next.add(tokenIndex + 1)
+      }
+    }
+    reachable = next
+  }
+
+  return starClosure(reachable, tokens).has(tokens.length)
+}
+
+type FnmatchToken =
+  | { kind: 'star' }
+  | { kind: 'any' }
+  | { kind: 'literal'; value: string }
+  | { kind: 'class'; negated: boolean; literals: Set<string>; ranges: [string, string][] }
+  | { kind: 'never' }
+
+/** Converts a Python-style shell pattern into linear matching tokens. */
+function tokenizeFnmatchPattern(pattern: string): FnmatchToken[] {
+  const tokens: FnmatchToken[] = []
+  for (let index = 0; index < pattern.length; index++) {
+    const character = pattern[index]!
+    if (character === '*') {
+      if (tokens.at(-1)?.kind !== 'star') tokens.push({ kind: 'star' })
+      continue
+    }
+    if (character === '?') {
+      tokens.push({ kind: 'any' })
+      continue
+    }
+    if (character !== '[') {
+      tokens.push({ kind: 'literal', value: character })
+      continue
+    }
+
+    const parsed = parseCharacterClass(pattern, index)
+    if (parsed === undefined) {
+      tokens.push({ kind: 'literal', value: '[' })
+    } else {
+      tokens.push(parsed.token)
+      index = parsed.endIndex
+    }
+  }
+  return tokens
+}
+
+/** Parses the bracket expressions accepted by Python fnmatchcase. */
+function parseCharacterClass(
+  pattern: string,
+  startIndex: number
+): { token: FnmatchToken; endIndex: number } | undefined {
+  let endIndex = startIndex + 1
+  if (pattern[endIndex] === '!') endIndex++
+  if (pattern[endIndex] === ']') endIndex++
+  while (endIndex < pattern.length && pattern[endIndex] !== ']') endIndex++
+  if (endIndex >= pattern.length) return undefined
+
+  let content = pattern.slice(startIndex + 1, endIndex)
+  const negated = content.startsWith('!')
+  if (negated) content = content.slice(1)
+  if (content.length === 0) {
+    return { token: negated ? { kind: 'any' } : { kind: 'never' }, endIndex }
+  }
+
+  const literals = new Set<string>()
+  const ranges: [string, string][] = []
+  for (let index = 0; index < content.length; index++) {
+    const character = content[index]!
+    if (index + 2 < content.length && content[index + 1] === '-') {
+      const rangeEnd = content[index + 2]!
+      if (character <= rangeEnd) ranges.push([character, rangeEnd])
+      index += 2
+    } else {
+      literals.add(character)
+    }
+  }
+
+  if (literals.size === 0 && ranges.length === 0) {
+    return { token: negated ? { kind: 'any' } : { kind: 'never' }, endIndex }
+  }
+  return { token: { kind: 'class', negated, literals, ranges }, endIndex }
+}
+
+/** Expands pattern positions reachable through zero-length star matches. */
+function starClosure(indexes: Set<number>, tokens: FnmatchToken[]): Set<number> {
+  const result = new Set(indexes)
+  for (const index of result) {
+    if (tokens[index]?.kind === 'star') result.add(index + 1)
+  }
+  return result
+}
+
+/** Tests one non-star token against one input character. */
+function tokenMatches(token: Exclude<FnmatchToken, { kind: 'star' }>, character: string): boolean {
+  switch (token.kind) {
+    case 'any':
+      return true
+    case 'literal':
+      return token.value === character
+    case 'class': {
+      const included =
+        token.literals.has(character) ||
+        token.ranges.some(([rangeStart, rangeEnd]) => rangeStart <= character && character <= rangeEnd)
+      return token.negated ? !included : included
+    }
+    case 'never':
+      return false
+  }
+}

--- a/strands-ts/src/errors.ts
+++ b/strands-ts/src/errors.ts
@@ -41,9 +41,10 @@ export class ContextWindowOverflowError extends ModelError {
    * Creates a new ContextWindowOverflowError.
    *
    * @param message - Error message describing the context overflow
+   * @param options - Optional error options including the cause
    */
-  constructor(message: string) {
-    super(message)
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
     this.name = 'ContextWindowOverflowError'
   }
 }

--- a/strands-ts/src/tools/__tests__/tool.test.ts
+++ b/strands-ts/src/tools/__tests__/tool.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { FunctionTool } from '../function-tool.js'
-import { Tool, ToolStreamEvent, isValidToolName } from '../tool.js'
+import { Tool, ToolStreamEvent, createSuccessResult, isValidToolName } from '../tool.js'
+import { JsonBlock, TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { DocumentBlock, ImageBlock, VideoBlock } from '../../types/media.js'
+import { createMockContext } from '../../__fixtures__/tool-helpers.js'
+import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import type { ToolContext } from '../tool.js'
 import type { JSONValue } from '../../types/json.js'
-import { createMockContext } from '../../__fixtures__/tool-helpers.js'
-
-import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 
 describe('isValidToolName', () => {
   it.each([
@@ -29,6 +30,68 @@ describe('isValidToolName', () => {
     ['emoji🚀', 'non-ascii'],
   ])('rejects %s (%s)', (name) => {
     expect(isValidToolName(name)).toBe(false)
+  })
+})
+
+describe('createSuccessResult', () => {
+  it('converts plain serialized content blocks', () => {
+    expect([
+      createSuccessResult({ text: 'hello' }, 'text-id'),
+      createSuccessResult({ json: { answer: 42 } }, 'json-id'),
+    ]).toEqual([
+      new ToolResultBlock({
+        toolUseId: 'text-id',
+        status: 'success',
+        content: [new TextBlock('hello')],
+      }),
+      new ToolResultBlock({
+        toolUseId: 'json-id',
+        status: 'success',
+        content: [new JsonBlock({ json: { answer: 42 } })],
+      }),
+    ])
+  })
+
+  it('preserves media block instances', () => {
+    const mediaBlocks = [
+      new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1]) } }),
+      new VideoBlock({ format: 'mp4', source: { bytes: new Uint8Array([2]) } }),
+      new DocumentBlock({ name: 'notes', format: 'txt', source: { text: 'hello' } }),
+    ]
+
+    const results = mediaBlocks.map((block, index) => createSuccessResult(block, `media-${index}`))
+
+    expect(results).toEqual([
+      new ToolResultBlock({ toolUseId: 'media-0', status: 'success', content: [mediaBlocks[0]!] }),
+      new ToolResultBlock({ toolUseId: 'media-1', status: 'success', content: [mediaBlocks[1]!] }),
+      new ToolResultBlock({ toolUseId: 'media-2', status: 'success', content: [mediaBlocks[2]!] }),
+    ])
+    expect(results.map((result, index) => result.content[0] === mediaBlocks[index])).toEqual([true, true, true])
+  })
+
+  it('uses arrays of content blocks directly as result content', () => {
+    const text = new TextBlock('hello')
+    const image = new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1]) } })
+
+    const result = createSuccessResult([text, image], 'content-array')
+
+    expect(result).toEqual(
+      new ToolResultBlock({
+        toolUseId: 'content-array',
+        status: 'success',
+        content: [text, image],
+      })
+    )
+  })
+
+  it('wraps an empty array as JSON content', () => {
+    expect(createSuccessResult([], 'empty-array')).toEqual(
+      new ToolResultBlock({
+        toolUseId: 'empty-array',
+        status: 'success',
+        content: [new JsonBlock({ json: { $value: [] } })],
+      })
+    )
   })
 })
 

--- a/strands-ts/src/tools/function-tool.ts
+++ b/strands-ts/src/tools/function-tool.ts
@@ -1,18 +1,9 @@
-import { createErrorResult, Tool } from './tool.js'
+import { createErrorResult, createSuccessResult, Tool } from './tool.js'
 import type { InvokableTool, ToolContext } from './tool.js'
 import { ToolStreamEvent } from './tool.js'
 import type { ToolSpec } from './types.js'
 import type { JSONSchema, JSONValue } from '../types/json.js'
-import { deepCopy } from '../types/json.js'
-import {
-  JsonBlock,
-  TextBlock,
-  ToolResultBlock,
-  toolResultContentFromData,
-  type ToolResultContent,
-  type ToolResultContentData,
-} from '../types/messages.js'
-import { DocumentBlock, ImageBlock, VideoBlock } from '../types/media.js'
+import { ToolResultBlock } from '../types/messages.js'
 import { InterruptError } from '../interrupt.js'
 
 /**
@@ -195,14 +186,14 @@ export class FunctionTool extends Tool implements InvokableTool<unknown, JSONVal
         }
 
         // The generator's return value (when done = true) is wrapped in ToolResultBlock
-        return this._wrapInToolResult(iterResult.value, toolUse.toolUseId)
+        return createSuccessResult(iterResult.value, toolUse.toolUseId)
       } else if (result instanceof Promise) {
         // Handle promise: await and wrap in ToolResultBlock
         const value = await result
-        return this._wrapInToolResult(value, toolUse.toolUseId)
+        return createSuccessResult(value, toolUse.toolUseId)
       } else {
         // Handle synchronous value: wrap in ToolResultBlock
-        return this._wrapInToolResult(result, toolUse.toolUseId)
+        return createSuccessResult(result, toolUse.toolUseId)
       }
     } catch (error) {
       // Re-throw InterruptError to allow interrupt handling in agent loop
@@ -239,129 +230,5 @@ export class FunctionTool extends Tool implements InvokableTool<unknown, JSONVal
     }
 
     return (await result) as JSONValue
-  }
-
-  /**
-   * Wraps a value in a ToolResultBlock with success status.
-   *
-   * Due to AWS Bedrock limitations (only accepts objects as JSON content), the following
-   * rules are applied:
-   * - Content blocks (TextBlock, JsonBlock, ImageBlock, VideoBlock, DocumentBlock) → passed through directly
-   * - Arrays of content blocks → used directly as content array
-   * - Strings → TextBlock
-   * - Numbers, Booleans → TextBlock (converted to string)
-   * - null, undefined → TextBlock containing the literal "null"
-   * - Objects → JsonBlock (with deep copy)
-   * - Arrays (non-content blocks) → JsonBlock wrapped in \{ $value: array \} (with deep copy)
-   *
-   * @param value - The value to wrap (can be any type)
-   * @param toolUseId - The tool use ID for the ToolResultBlock
-   * @returns A ToolResultBlock containing the value
-   */
-  private _wrapInToolResult(value: unknown, toolUseId: string): ToolResultBlock {
-    try {
-      // Handle media blocks - pass through directly
-      if (value instanceof DocumentBlock || value instanceof ImageBlock || value instanceof VideoBlock) {
-        return new ToolResultBlock({
-          toolUseId,
-          status: 'success',
-          content: [value],
-        })
-      }
-
-      // Represent null/undefined as the JSON literal "null" for parity with the Python SDK
-      if (value === null || value === undefined) {
-        return new ToolResultBlock({
-          toolUseId,
-          status: 'success',
-          content: [new TextBlock('null')],
-        })
-      }
-
-      // Handle content blocks - class instances or plain data objects
-      const contentBlock = this._asToolResultContent(value)
-      if (contentBlock) {
-        return new ToolResultBlock({
-          toolUseId,
-          status: 'success',
-          content: [contentBlock],
-        })
-      }
-
-      // Handle primitives (strings, numbers, booleans) as text content
-      // Bedrock doesn't accept primitives as JSON content, so we convert all to strings
-      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        return new ToolResultBlock({
-          toolUseId,
-          status: 'success',
-          content: [new TextBlock(String(value))],
-        })
-      }
-
-      // Handle arrays
-      if (Array.isArray(value)) {
-        // Check if array contains only content blocks (class instances or plain data objects)
-        if (value.length > 0) {
-          const converted = value.map((item) => this._asToolResultContent(item))
-          if (converted.every((item): item is ToolResultContent => item !== undefined)) {
-            return new ToolResultBlock({
-              toolUseId,
-              status: 'success',
-              content: converted,
-            })
-          }
-        }
-
-        // Otherwise wrap in object { $value: array }
-        const copiedValue = deepCopy(value)
-        return new ToolResultBlock({
-          toolUseId,
-          status: 'success',
-          content: [new JsonBlock({ json: { $value: copiedValue } })],
-        })
-      }
-
-      // Handle objects as JSON content with deep copy
-      const copiedValue = deepCopy(value)
-      return new ToolResultBlock({
-        toolUseId,
-        status: 'success',
-        content: [new JsonBlock({ json: copiedValue })],
-      })
-    } catch (error) {
-      // If deep copy fails (circular references, non-serializable values), return error result
-      return createErrorResult(error, toolUseId)
-    }
-  }
-
-  /**
-   * Converts a value to a ToolResultContent instance if it matches a known content type.
-   * Accepts both class instances and plain data objects.
-   *
-   * @param value - Value to check and convert
-   * @returns ToolResultContent instance, or undefined if not a recognized content type
-   */
-  private _asToolResultContent(value: unknown): ToolResultContent | undefined {
-    if (typeof value !== 'object') return undefined
-
-    // Class instances — pass through
-    if (
-      value instanceof TextBlock ||
-      value instanceof JsonBlock ||
-      value instanceof ImageBlock ||
-      value instanceof VideoBlock ||
-      value instanceof DocumentBlock
-    ) {
-      return value
-    }
-
-    // Plain data objects — require exactly one key to match the discriminated
-    // union shape; multi-key objects fall through to JsonBlock instead.
-    try {
-      if (Object.keys(value as object).length !== 1) return undefined
-      return toolResultContentFromData(value as ToolResultContentData)
-    } catch {
-      return undefined
-    }
   }
 }

--- a/strands-ts/src/tools/tool.ts
+++ b/strands-ts/src/tools/tool.ts
@@ -1,6 +1,15 @@
 import type { ToolSpec, ToolUse } from './types.js'
-import { TextBlock, ToolResultBlock } from '../types/messages.js'
+import {
+  JsonBlock,
+  TextBlock,
+  ToolResultBlock,
+  toolResultContentFromData,
+  type ToolResultContent,
+  type ToolResultContentData,
+} from '../types/messages.js'
+import { DocumentBlock, ImageBlock, VideoBlock } from '../types/media.js'
 import type { InvocationState, LocalAgent } from '../types/agent.js'
+import { deepCopy } from '../types/json.js'
 import { normalizeError } from '../errors.js'
 import type { Interruptible } from '../interrupt.js'
 
@@ -201,6 +210,90 @@ export function createErrorResult(error: unknown, toolUseId: string): ToolResult
     content: [new TextBlock(`Error: ${errorObject.message}`)],
     error: errorObject,
   })
+}
+
+/**
+ * Creates a ToolResultBlock from a successful raw tool return value.
+ * Applies FunctionTool's established value-to-content conversion rules.
+ * Returns an error ToolResultBlock if the value cannot be serialized.
+ *
+ * @internal
+ * @param value - The raw tool return value
+ * @param toolUseId - The associated tool use ID
+ * @returns The converted ToolResultBlock
+ */
+export function createSuccessResult(value: unknown, toolUseId: string): ToolResultBlock {
+  try {
+    // Represent null/undefined as the JSON literal "null" for parity with the Python SDK
+    if (value === null || value === undefined) {
+      return new ToolResultBlock({ toolUseId, status: 'success', content: [new TextBlock('null')] })
+    }
+
+    // Content blocks — class instances or plain data objects
+    const contentBlock = asToolResultContent(value)
+    if (contentBlock) {
+      return new ToolResultBlock({ toolUseId, status: 'success', content: [contentBlock] })
+    }
+
+    // Not all providers accept primitive JSON tool-result content, so represent primitives as text.
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      return new ToolResultBlock({ toolUseId, status: 'success', content: [new TextBlock(String(value))] })
+    }
+
+    // Arrays
+    if (Array.isArray(value)) {
+      // Arrays of content blocks are used directly as the content array
+      if (value.length > 0) {
+        const converted = value.map((item) => asToolResultContent(item))
+        if (converted.every((item): item is ToolResultContent => item !== undefined)) {
+          return new ToolResultBlock({ toolUseId, status: 'success', content: converted })
+        }
+      }
+      // Otherwise wrap in an object { $value: array }
+      return new ToolResultBlock({
+        toolUseId,
+        status: 'success',
+        content: [new JsonBlock({ json: { $value: deepCopy(value) } })],
+      })
+    }
+
+    // Objects as JSON content with deep copy
+    return new ToolResultBlock({ toolUseId, status: 'success', content: [new JsonBlock({ json: deepCopy(value) })] })
+  } catch (error) {
+    // If deep copy fails (circular references, non-serializable values), return an error result
+    return createErrorResult(error, toolUseId)
+  }
+}
+
+/**
+ * Converts a value to a ToolResultContent instance if it matches a known content type,
+ * accepting both class instances and single-key plain data objects.
+ *
+ * @param value - Value to check and convert
+ * @returns ToolResultContent instance, or undefined if not a recognized content type
+ */
+function asToolResultContent(value: unknown): ToolResultContent | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+
+  // Class instances — pass through
+  if (
+    value instanceof TextBlock ||
+    value instanceof JsonBlock ||
+    value instanceof ImageBlock ||
+    value instanceof VideoBlock ||
+    value instanceof DocumentBlock
+  ) {
+    return value
+  }
+
+  // Plain data objects — require exactly one key to match the discriminated union shape;
+  // multi-key objects fall through to JsonBlock instead.
+  try {
+    if (Object.keys(value as object).length !== 1) return undefined
+    return toolResultContentFromData(value as ToolResultContentData)
+  } catch {
+    return undefined
+  }
 }
 
 const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -121,8 +121,8 @@ function decodeStoredContent(content: Uint8Array, contentType: string, reference
     }
   }
   // Return native content blocks for binary types so the agent sees the actual content.
-  // FunctionTool._wrapInToolResult passes ImageBlock/VideoBlock/DocumentBlock through as-is
-  // at runtime, even though the callback type signature only accepts JSONValue.
+  // createSuccessResult passes ImageBlock/VideoBlock/DocumentBlock through as-is at runtime,
+  // even though the callback type signature only accepts JSONValue.
   if (contentType.startsWith('image/')) {
     const format = contentType.split('/').pop()!
     return new ImageBlock({

--- a/strands-ts/test/integ/agentcore-harness.test.node.ts
+++ b/strands-ts/test/integ/agentcore-harness.test.node.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { collectGenerator } from '$/sdk/__fixtures__/model-test-helpers.js'
+import {
+  AgentCoreHarnessAgent,
+  AgentCoreHarnessStreamUpdateEvent,
+  type AgentCoreHarnessStreamEvent,
+} from '$/sdk/agentcore-harness/index.js'
+import { ModelError } from '$/sdk/errors.js'
+import { tool } from '$/sdk/index.js'
+
+const harnessArn = process.env.AGENTCORE_HARNESS_ARN
+const region = process.env.AGENTCORE_HARNESS_REGION ?? process.env.AWS_REGION ?? 'us-east-1'
+const qualifier = process.env.AGENTCORE_HARNESS_QUALIFIER
+const reasoningModelId = process.env.AGENTCORE_HARNESS_REASONING_MODEL_ID
+
+function requiredHarnessArn(): string {
+  if (!harnessArn) throw new Error('AGENTCORE_HARNESS_ARN is required')
+  return harnessArn
+}
+
+function sessionId(label: string): string {
+  return `strands-integ-${label}-${randomUUID()}`.slice(0, 100)
+}
+
+function completedMessageRoles(events: AgentCoreHarnessStreamEvent[]): string[] {
+  const roles: string[] = []
+  let currentRole = 'assistant'
+  for (const event of events) {
+    if (!(event instanceof AgentCoreHarnessStreamUpdateEvent)) continue
+    const chunk = event.event
+    if ('messageStart' in chunk && chunk.messageStart?.role) currentRole = chunk.messageStart.role
+    if ('messageStop' in chunk && chunk.messageStop) roles.push(currentRole)
+  }
+  return roles
+}
+
+describe.skipIf(!harnessArn)('AgentCoreHarnessAgent integration', () => {
+  it('continues a session and reports stream cycles independently of request metadata', async () => {
+    const runtimeSessionId = sessionId('memory')
+    const memoryToken = `cobalt-${randomUUID().slice(0, 8)}`
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: requiredHarnessArn(),
+      runtimeSessionId,
+      region,
+      ...(qualifier && { qualifier }),
+      systemPrompt: 'Follow the user instructions exactly and answer concisely.',
+    })
+
+    await agent.invoke(`Remember the exact token ${memoryToken}. Reply only with ACK.`)
+    const { items, result } = await collectGenerator(
+      agent.stream('Return the exact token I asked you to remember. Include nothing else.')
+    )
+    const completedRoles = completedMessageRoles(items)
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(result.toString()).toContain(memoryToken)
+    expect(completedRoles).toContain('assistant')
+    expect(result.metrics).toBeDefined()
+    expect(result.metrics!.cycleCount).toBe(completedRoles.filter((role) => role === 'assistant').length)
+    expect(result.metrics!.totalDuration).toBeGreaterThan(0)
+  }, 120_000)
+
+  it('runs an allowed host tool and commits its result before completing', async () => {
+    const receipt = `receipt-${randomUUID().slice(0, 8)}`
+    let observedSku: string | undefined
+    let callCount = 0
+    const lookupInventory = tool({
+      name: 'lookup_inventory',
+      description: 'Look up the available quantity and receipt for a product SKU',
+      inputSchema: z.object({ sku: z.string() }),
+      callback: ({ sku }) => {
+        observedSku = sku
+        callCount++
+        return { sku, availableQuantity: 7, receipt }
+      },
+    })
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: requiredHarnessArn(),
+      runtimeSessionId: sessionId('host-tool'),
+      region,
+      ...(qualifier && { qualifier }),
+      tools: [lookupInventory],
+      allowedTools: ['@lookup_inventory'],
+      systemPrompt:
+        'For inventory questions, call lookup_inventory exactly once and include its receipt unchanged in the answer.',
+    })
+
+    const { items, result } = await collectGenerator(agent.stream('Check inventory for SKU-1234.'))
+    const completedRoles = completedMessageRoles(items)
+
+    expect(observedSku).toBe('SKU-1234')
+    expect(callCount).toBe(1)
+    expect(result.stopReason).toBe('endTurn')
+    expect(result.toString()).toContain(receipt)
+    expect(completedRoles.filter((role) => role === 'assistant').length).toBeGreaterThanOrEqual(2)
+    expect(result.metrics).toBeDefined()
+    expect(result.metrics!.cycleCount).toBe(completedRoles.filter((role) => role === 'assistant').length)
+  }, 120_000)
+
+  it.skipIf(!reasoningModelId)(
+    'preserves reasoning text and its signature',
+    async () => {
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: requiredHarnessArn(),
+        runtimeSessionId: sessionId('reasoning'),
+        region,
+        ...(qualifier && { qualifier }),
+        modelConfig: {
+          bedrockModelConfig: {
+            modelId: reasoningModelId!,
+            apiFormat: 'converse_stream',
+            maxTokens: 2_000,
+            additionalParams: {
+              additionalModelRequestFields: {
+                thinking: { type: 'enabled', budget_tokens: 1_024 },
+              },
+            },
+          },
+        },
+      })
+
+      const { items, result } = await collectGenerator(agent.stream('What is 17 multiplied by 19?'))
+      const rawEvents = items
+        .filter(
+          (event): event is AgentCoreHarnessStreamUpdateEvent => event instanceof AgentCoreHarnessStreamUpdateEvent
+        )
+        .map((event) => event.event)
+      const reasoningDeltas = rawEvents.filter(
+        (event) =>
+          'contentBlockDelta' in event &&
+          event.contentBlockDelta?.delta &&
+          'reasoningContent' in event.contentBlockDelta.delta
+      )
+
+      expect(reasoningDeltas.length).toBeGreaterThan(0)
+      expect(
+        reasoningDeltas.some(
+          (event) =>
+            'contentBlockDelta' in event &&
+            event.contentBlockDelta?.delta &&
+            'reasoningContent' in event.contentBlockDelta.delta &&
+            event.contentBlockDelta.delta.reasoningContent?.signature
+        )
+      ).toBe(true)
+      expect(
+        result.lastMessage.content.some((block) => block.type === 'reasoningBlock' && block.text && block.signature)
+      ).toBe(true)
+    },
+    120_000
+  )
+
+  it('preserves a non-throttling control-plane error', async () => {
+    const hostTool = tool({
+      name: 'lookup_inventory',
+      description: 'Look up inventory for a product SKU',
+      inputSchema: z.object({ sku: z.string() }),
+      callback: () => 'unused',
+    })
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: requiredHarnessArn(),
+      runtimeSessionId: sessionId('missing-endpoint'),
+      region,
+      qualifier: `missing-${randomUUID().slice(0, 8)}`,
+      tools: [hostTool],
+    })
+
+    try {
+      await agent.invoke('Check inventory.')
+      expect.unreachable('Expected the missing endpoint lookup to fail')
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error)
+      expect(error).not.toBeInstanceOf(ModelError)
+      expect((error as Error).name).toMatch(/Exception$/)
+      expect(error).toHaveProperty('$metadata.httpStatusCode', 400)
+    }
+  })
+})


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

We introduce `AgentCoreHarnessAgent`, a new `InvokableAgent` implementation allowing developers to interface with and integrate a [AgentCore Harness agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) into their agentic applications just as easily as a typical Strands agent today.

The agent loop and memory remain under the control of the Harness, running on managed production-grade infrastructure. And now, developers can pass custom tools to run client-side (HITL or automatic), along with the ability to override the managed agent's system prompt and model per invocation.

### Developer Experience

A normal Strands Agent, today:

```typescript
import { Agent } from '@strands-agents/sdk'

const agent = new Agent({
  systemPrompt: 'You are AGI',
  tools: [myCustomTool]
})

await agent.invoke('List your tools')
```

(new) Initializing an `AgentCoreHarnessAgent` requires just two extra parameters:

```typescript
import { AgentCoreHarnessAgent } from '@strands-agents/sdk/agentcore-harness'

const agent = new AgentCoreHarnessAgent({
  harnessArn: '...',
  runtimeSessionId: '...',
  systemPrompt: 'You are AGI',
  tools: [myCustomTool]                  // passed custom tools still run client side
})

await agent.invoke('List your tools')
```

## Unlocks

- TLDR: `AgentCoreHarnessAgent` is a Strands Agent running on production-grade managed infrastructure
- Seamless composition of multi-agent graphs / swarms comprised of `AgentCoreHarnessAgent` instances

## Related Issues

<!-- Link to related issues using #issue-number format -->

Will link updated design doc

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

Will link, separate PR

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
