### PR TITLE
fix(site): make sidebar badge spacing consistent across entry types

### DIFF
--- a/site/src/components/overrides/SidebarSublist.astro
+++ b/site/src/components/overrides/SidebarSublist.astro
@@ -179,16 +179,17 @@ function getFirstLink(entries: any[]): string | null {
       color: var(--sl-color-text-invert);
     }
     
-    a > *:not(:last-child), .group-label > *:not(:last-child) { margin-inline-end: 0.25em; }
-    
     @media (min-width: 50rem) { 
       .top-level > li + li { margin-top: 0.5rem; } 
       .large { font-size: var(--sl-text-base); } 
       a:not(.group-link) { font-size: var(--sl-text-sm); }
     }
 
+    /* Badge carries its own leading gap so spacing is identical for links,
+       section headers, and group labels, regardless of label whitespace */
     .sl-badge {
       font-size: .75em !important;
+      margin-inline-start: 0.375em;
     }
   }
 </style>


### PR DESCRIPTION
## Description

The "New" badges in the docs sidebar had inconsistent spacing: badges on leaf links (from page frontmatter) had a gap after the label, while badges on collapsible groups (from `navigation.yml`, e.g. Memory, Sandbox, Interventions) sat flush against the label text.

The gap was applied by a `*:not(:last-child)` sibling margin rule in `SidebarSublist.astro`, which only matches when the label is wrapped in an element and the badge isn't the last child — true for leaf links but not for group labels, where the label is a bare text node.

Fixed by moving the spacing onto the badge itself (`margin-inline-start` on `.sl-badge`) and removing the sibling margin rule, so all badges get the same gap regardless of entry type or label markup.

## Related Issues

N/A

## Documentation PR

N/A — CSS-only change to the docs site sidebar component.

## Type of Change

Bug fix

## Testing

Ran the site dev server and visually verified the sidebar: badge spacing is now identical for frontmatter badges (Context Management) and navigation.yml group badges (Memory, Sandbox, Interventions), including the current-page highlighted state. `npm run typecheck` passes.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
