### PR TITLE
feat(ts): add AgentCore Harness agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -327,6 +327,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-bedrock-agentcore": {
+      "version": "3.1091.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore/-/client-bedrock-agentcore-3.1091.0.tgz",
+      "integrity": "sha512-yen46opMFlQbv78obYoUuH4R1uGsj51eTTd0Yn19WIFZIWYAdmunuzufcyraXz2lzAcev+0VJQnHDtSDsp8JLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1078.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1078.0.tgz",
@@ -455,17 +475,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
-      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -491,15 +511,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
-      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -507,17 +527,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
-      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -525,23 +545,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
-      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-login": "^3.972.63",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -549,16 +569,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
-      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -566,21 +586,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
-      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-ini": "^3.973.1",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -588,15 +608,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
-      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -604,17 +624,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
-      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/token-providers": "3.1083.0",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -622,16 +642,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1083.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
-      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -639,16 +659,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
-      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -751,18 +771,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
-      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -770,14 +790,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -802,12 +822,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -842,12 +862,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2343,12 +2363,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.2.tgz",
-      "integrity": "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==",
+      "version": "3.29.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.6.tgz",
+      "integrity": "sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2356,13 +2376,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.7.tgz",
-      "integrity": "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.11.tgz",
+      "integrity": "sha512-6CUvZwS0tCcVCrcvh2TpwTXxmAkuY6JGNPeKODYRLjHtUUhFLGS3dNkNdRvT/ttJyqimqnhFMTS2nqp4pDZ7oQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2384,13 +2404,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.4.tgz",
-      "integrity": "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==",
+      "version": "5.6.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.8.tgz",
+      "integrity": "sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2453,13 +2473,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.4.tgz",
-      "integrity": "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==",
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.8.tgz",
+      "integrity": "sha512-ArSSIN4t1wLutcIkHzaL6N11J7xpZK7W3T0pFz9cep9zIpEr9x5+lhJRcVUgObGI3OIMbnROq7w8bwzx+Nkf8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2481,13 +2501,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.3.tgz",
-      "integrity": "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.7.tgz",
+      "integrity": "sha512-32PmEsuZV9lz7SZk3gJcm+EfIAoIVu83AJyEzgALpwmSqLvuacdAu0fvCVNMbDbegyk1S0lHUDrMWIfR47Micw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2495,9 +2515,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.0.tgz",
-      "integrity": "sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6751,6 +6771,7 @@
         "@aws-sdk/client-bedrock": "^3.1078.0",
         "@aws-sdk/client-bedrock-agent": "^3.1078.0",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+        "@aws-sdk/client-bedrock-agentcore": "^3.1078.0",
         "@aws-sdk/client-s3": "^3.1078.0",
         "@aws-sdk/client-secrets-manager": "^3.1078.0",
         "@aws-sdk/client-ssm": "^3.1078.0",
@@ -6794,6 +6815,7 @@
         "@anthropic-ai/sdk": "^0.109.1",
         "@aws-sdk/client-bedrock-agent": "^3.1078.0",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+        "@aws-sdk/client-bedrock-agentcore": "^3.1078.0",
         "@aws-sdk/client-s3": "^3.1078.0",
         "@aws/bedrock-token-generator": "^1.1.0",
         "@cedar-policy/cedar-wasm": "^4.0.0",
@@ -6826,6 +6848,9 @@
           "optional": true
         },
         "@aws-sdk/client-bedrock-agent-runtime": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agentcore": {
           "optional": true
         },
         "@aws-sdk/client-s3": {

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -24,6 +24,10 @@
       "node": "./dist/src/index.node.js",
       "default": "./dist/src/index.js"
     },
+    "./agentcore-harness": {
+      "types": "./dist/src/agentcore-harness/index.d.ts",
+      "default": "./dist/src/agentcore-harness/index.js"
+    },
     "./models/anthropic": {
       "types": "./dist/src/models/anthropic.d.ts",
       "default": "./dist/src/models/anthropic.js"
@@ -189,6 +193,7 @@
     "@aws-sdk/client-bedrock": "^3.1078.0",
     "@aws-sdk/client-bedrock-agent": "^3.1078.0",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+    "@aws-sdk/client-bedrock-agentcore": "^3.1078.0",
     "@aws-sdk/client-s3": "^3.1078.0",
     "@aws-sdk/client-secrets-manager": "^3.1078.0",
     "@aws-sdk/client-ssm": "^3.1078.0",
@@ -246,6 +251,7 @@
     "@anthropic-ai/sdk": "^0.109.1",
     "@aws-sdk/client-bedrock-agent": "^3.1078.0",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+    "@aws-sdk/client-bedrock-agentcore": "^3.1078.0",
     "@aws-sdk/client-s3": "^3.1078.0",
     "@aws/bedrock-token-generator": "^1.1.0",
     "@cedar-policy/cedar-wasm": "^4.0.0",
@@ -287,6 +293,9 @@
       "optional": true
     },
     "@aws-sdk/client-bedrock-agent-runtime": {
+      "optional": true
+    },
+    "@aws-sdk/client-bedrock-agentcore": {
       "optional": true
     },
     "@aws-sdk/client-s3": {

--- a/strands-ts/src/__tests__/errors.test.ts
+++ b/strands-ts/src/__tests__/errors.test.ts
@@ -68,6 +68,14 @@ describe('ContextWindowOverflowError', () => {
       expect(error).toBeInstanceOf(ModelError)
     })
   })
+
+  describe('when instantiated with a cause', () => {
+    it('preserves the cause', () => {
+      const cause = new Error('original error')
+
+      expect(new ContextWindowOverflowError('context window overflow', { cause }).cause).toBe(cause)
+    })
+  })
 })
 
 describe('MaxTokensError', () => {

--- a/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-agent.test.ts
+++ b/strands-ts/src/agentcore-harness/__tests__/agentcore-harness-agent.test.ts
@@ -1,0 +1,593 @@
+import {
+  BedrockAgentCoreClient,
+  InvokeHarnessCommand,
+  type InvokeHarnessStreamOutput,
+} from '@aws-sdk/client-bedrock-agentcore'
+import type { AgentExecutionEvent, ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server'
+import type { TaskArtifactUpdateEvent } from '@a2a-js/sdk'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createCancellableAgent } from '../../__fixtures__/agent-helpers.js'
+import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
+import { A2AExecutor } from '../../a2a/executor.js'
+import {
+  ConcurrentInvocationError,
+  ContextWindowOverflowError,
+  MaxTokensError,
+  ModelError,
+  ModelThrottledError,
+} from '../../errors.js'
+import { logger } from '../../logging/logger.js'
+import { Graph } from '../../multiagent/graph.js'
+import { Status } from '../../multiagent/state.js'
+import { AgentResult } from '../../types/agent.js'
+import { Message, ReasoningBlock, TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
+import { AgentCoreHarnessAgent } from '../agentcore-harness-agent.js'
+import {
+  AgentCoreHarnessResultEvent,
+  AgentCoreHarnessStreamUpdateEvent,
+  type AgentCoreHarnessEventData,
+} from '../events.js'
+
+const HARNESS_ARN = 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/TestHarness-abcdefghij'
+const SESSION_ID = 'session-id-padded-to-thirty-three'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('AgentCoreHarnessAgent', () => {
+  describe('constructor', () => {
+    it('derives identity from the Harness session and accepts an override', () => {
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+      const identifiedAgent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        id: 'research-harness',
+      })
+
+      expect(agent).toMatchObject({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        id: `${HARNESS_ARN}:${SESSION_ID}`,
+      })
+      expect(identifiedAgent).toMatchObject({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        id: 'research-harness',
+      })
+    })
+
+    it('uses standard AWS region resolution and defaults to one attempt', async () => {
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        clientConfig: { region: 'us-east-2' },
+      })
+      const client = clientFrom(agent)
+
+      await expect(client.config.region()).resolves.toBe('us-east-2')
+      await expect(client.config.maxAttempts()).resolves.toBe(1)
+    })
+
+    it('forwards client configuration including explicit retry settings', async () => {
+      const credentials = vi.fn().mockResolvedValue({
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret-key',
+      })
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        clientConfig: { credentials, maxAttempts: 4, region: 'eu-west-1' },
+      })
+      const client = clientFrom(agent)
+
+      await expect(client.config.region()).resolves.toBe('eu-west-1')
+      await expect(client.config.maxAttempts()).resolves.toBe(4)
+      await expect(client.config.credentials()).resolves.toMatchObject({ accessKeyId: 'test-access-key' })
+      expect(credentials).toHaveBeenCalledOnce()
+    })
+
+    it('uses an injected client without replacing its configuration', async () => {
+      const client = new BedrockAgentCoreClient({ region: 'eu-west-1', maxAttempts: 6 })
+      const send = vi.spyOn(client, 'send').mockResolvedValueOnce({
+        stream: harnessStream(chunk.messageStart(), chunk.messageStop('end_turn')),
+      } as never)
+      const agent = new AgentCoreHarnessAgent({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        client,
+        clientConfig: { maxAttempts: 2, region: 'ap-southeast-2' },
+      })
+
+      await agent.invoke('Run it.')
+
+      expect(send).toHaveBeenCalledOnce()
+      await expect(client.config.region()).resolves.toBe('eu-west-1')
+      await expect(client.config.maxAttempts()).resolves.toBe(6)
+    })
+
+    it('defers Harness identifier validation to AgentCore', () => {
+      const harnessArn = 'validated-by-service'
+      const runtimeSessionId = 'validated-by-service'
+
+      expect(
+        new AgentCoreHarnessAgent({ harnessArn, runtimeSessionId, clientConfig: { region: 'us-east-1' } })
+      ).toMatchObject({
+        harnessArn,
+        runtimeSessionId,
+      })
+    })
+  })
+
+  describe('stream', () => {
+    it('sends one text request and translates the complete Harness stream', async () => {
+      const metadata = chunk.metadata(
+        { inputTokens: 10, outputTokens: 4, totalTokens: 14 },
+        25
+      ) as AgentCoreHarnessEventData
+      const send = mockHarness(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.textDelta('working'),
+          chunk.messageStop('tool_use'),
+          chunk.messageStart('user'),
+          chunk.messageStop('tool_result'),
+          chunk.messageStart(),
+          chunk.reasoningDelta({ text: 'considering' }),
+          chunk.reasoningDelta({ signature: 'signed' }),
+          chunk.contentBlockStop(),
+          chunk.textDelta('Complete.'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('end_turn'),
+          metadata
+        )
+      )
+      const invocationState = { requestId: 'request-1' }
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      const { items, result } = await collectGenerator(agent.stream('Run it.', { invocationState }))
+
+      expect(send).toHaveBeenCalledOnce()
+      expect(send.mock.calls[0]![0]).toBeInstanceOf(InvokeHarnessCommand)
+      expect(send.mock.calls[0]![0].input).toStrictEqual({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'Run it.' }] }],
+      })
+      expect(send.mock.calls[0]![1]).toStrictEqual({})
+      expect(result).toEqual(
+        new AgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [new ReasoningBlock({ text: 'considering', signature: 'signed' }), new TextBlock('Complete.')],
+            trackingId: result.lastMessage.trackingId,
+          }),
+          invocationState,
+        })
+      )
+      expect(items.at(-1)).toBeInstanceOf(AgentCoreHarnessResultEvent)
+      expect(items.slice(0, -1)).toHaveLength(13)
+      expect(items[0]).toBeInstanceOf(AgentCoreHarnessStreamUpdateEvent)
+      expect(items.at(-2)).toEqual(new AgentCoreHarnessStreamUpdateEvent(metadata))
+    })
+
+    it('preserves a pending tool block before implicit text content', async () => {
+      mockHarness(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.toolUseStart('tool-1', 'lookup'),
+          chunk.toolUseDelta('{"city":"Boston"}'),
+          chunk.textDelta('Done.'),
+          chunk.messageStop('end_turn')
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      const result = await agent.invoke('Run it.')
+
+      expect(result).toEqual(
+        new AgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [
+              new ToolUseBlock({ toolUseId: 'tool-1', name: 'lookup', input: { city: 'Boston' } }),
+              new TextBlock('Done.'),
+            ],
+            trackingId: result.lastMessage.trackingId,
+          }),
+          invocationState: {},
+        })
+      )
+    })
+
+    it('warns when converting unknown tool-result content to text', async () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      mockHarness(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.toolResultStart('tool-1'),
+          chunk.toolResultDelta([{ futureContent: { value: 1 } }]),
+          chunk.contentBlockStop(),
+          chunk.messageStop('tool_result')
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      const result = await agent.invoke('Run it.')
+
+      expect(result).toEqual(
+        new AgentResult({
+          stopReason: 'toolResult',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [
+              new ToolResultBlock({
+                toolUseId: 'tool-1',
+                status: 'success',
+                content: [new TextBlock('{"futureContent":{"value":1}}')],
+              }),
+            ],
+            trackingId: result.lastMessage.trackingId,
+          }),
+          invocationState: {},
+        })
+      )
+      expect(warn).toHaveBeenCalledOnce()
+      expect(warn).toHaveBeenCalledWith('fields=<futureContent> | unknown tool-result content, converting to JSON text')
+    })
+
+    it.each([
+      { termination: 'throws', throwsAfterAbort: true },
+      { termination: 'closes normally', throwsAfterAbort: false },
+    ])('returns only pre-abort content when an aborted stream $termination', async ({ throwsAfterAbort }) => {
+      const controller = new AbortController()
+      const send = mockHarness(cancelledStream(controller, throwsAfterAbort))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      const { items, result } = await collectGenerator(agent.stream('Run it.', { cancelSignal: controller.signal }))
+
+      expect({ ...result.toJSON(), lastMessage: result.lastMessage.toJSON() }).toEqual({
+        type: 'agentResult',
+        stopReason: 'cancelled',
+        lastMessage: {
+          role: 'assistant',
+          content: [{ text: 'partial' }],
+          trackingId: expect.any(String),
+        },
+      })
+      expect(result.invocationState).toEqual({})
+      expect(items).toEqual([
+        new AgentCoreHarnessStreamUpdateEvent(chunk.messageStart() as AgentCoreHarnessEventData),
+        new AgentCoreHarnessStreamUpdateEvent(chunk.textDelta('partial') as AgentCoreHarnessEventData),
+        new AgentCoreHarnessResultEvent({ result }),
+      ])
+      expect(send.mock.calls[0]![1]).toStrictEqual({ abortSignal: controller.signal })
+    })
+
+    it('does not make a request when already cancelled', async () => {
+      const send = mockHarness(harnessStream())
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      const result = await agent.invoke('Run it.', { cancelSignal: AbortSignal.abort() })
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      {
+        chunk: {
+          internalServerException: { message: 'internal failure' },
+        } as InvokeHarnessStreamOutput,
+        error: ModelError,
+        message: 'internal failure',
+      },
+      {
+        chunk: {
+          validationException: { message: 'Prompt is too long' },
+        } as InvokeHarnessStreamOutput,
+        error: ContextWindowOverflowError,
+        message: 'Prompt is too long',
+      },
+      {
+        chunk: {
+          runtimeClientError: { message: 'runtime failure' },
+        } as InvokeHarnessStreamOutput,
+        error: ModelError,
+        message: 'runtime failure',
+      },
+    ])('translates a streamed service error', async ({ chunk: errorChunk, error, message }) => {
+      mockHarness(harnessStream(errorChunk))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      await expect(agent.invoke('Run it.')).rejects.toMatchObject({ constructor: error, message })
+    })
+
+    it('rejects malformed tool input before returning a tool-use result', async () => {
+      mockHarness(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.toolUseStart('tool-1', 'deployed_inline'),
+          chunk.toolUseDelta('{'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('tool_use')
+        )
+      )
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      await expect(agent.invoke('Run it.')).rejects.toMatchObject({
+        constructor: ModelError,
+        message: 'Unable to parse Harness tool input JSON.',
+      })
+    })
+
+    it('surfaces max-token termination as MaxTokensError', async () => {
+      mockHarness(harnessStream(chunk.messageStart(), chunk.textDelta('partial'), chunk.messageStop('max_tokens')))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      await expect(agent.invoke('Run it.')).rejects.toBeInstanceOf(MaxTokensError)
+    })
+
+    it('rejects an interrupted Harness turn as non-resumable', async () => {
+      mockHarness(harnessStream(chunk.messageStart(), chunk.textDelta('partial'), chunk.messageStop('interrupted')))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      await expect(agent.invoke('Run it.')).rejects.toMatchObject({
+        constructor: ModelError,
+        message: 'Harness ended the turn with an unrecoverable stop reason: interrupted',
+      })
+    })
+
+    it('rejects a concurrent invocation and releases the instance afterward', async () => {
+      let release: (response: { stream: AsyncGenerator<InvokeHarnessStreamOutput> }) => void
+      const pending = new Promise<{ stream: AsyncGenerator<InvokeHarnessStreamOutput> }>((resolve) => {
+        release = resolve
+      })
+      const send = vi.spyOn(BedrockAgentCoreClient.prototype, 'send').mockReturnValueOnce(pending as never)
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      const first = agent.invoke('First')
+      await expect(agent.invoke('Second')).rejects.toBeInstanceOf(ConcurrentInvocationError)
+      release!({ stream: harnessStream(chunk.messageStart(), chunk.messageStop('end_turn')) })
+      await first
+
+      send.mockResolvedValueOnce({
+        stream: harnessStream(chunk.messageStart(), chunk.messageStop('end_turn')),
+      } as never)
+      await expect(agent.invoke('Third')).resolves.toMatchObject({ stopReason: 'endTurn' })
+    })
+  })
+
+  describe('validation', () => {
+    it.each([
+      {
+        args: [new TextBlock('Line one'), new TextBlock('Line two')],
+        expected: 'Line one\nLine two',
+      },
+      {
+        args: [{ text: 'Data one' }, { text: 'Data two' }],
+        expected: 'Data one\nData two',
+      },
+      {
+        args: [
+          new Message({ role: 'user', content: [new TextBlock('Earlier')] }),
+          new Message({ role: 'assistant', content: [new TextBlock('Reply')] }),
+          new Message({ role: 'user', content: [new TextBlock('Latest'), new TextBlock('request')] }),
+        ],
+        expected: 'Latest\nrequest',
+      },
+      {
+        args: [
+          { role: 'user' as const, content: [{ text: 'Serialized earlier' }] },
+          { role: 'user' as const, content: [{ text: 'Serialized latest' }] },
+        ],
+        expected: 'Serialized latest',
+      },
+    ])('normalizes supported text input before calling AgentCore', async ({ args, expected }) => {
+      const send = mockHarness(harnessStream(chunk.messageStart(), chunk.messageStop('end_turn')))
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      await agent.invoke(args)
+
+      expect(send.mock.calls[0]![0].input.messages).toStrictEqual([{ role: 'user', content: [{ text: expected }] }])
+    })
+
+    it.each([
+      { args: '', options: undefined, message: 'input must contain non-empty text' },
+      { args: [], options: undefined, message: 'input must contain non-empty text' },
+      {
+        args: [new ReasoningBlock({ text: 'private reasoning' })],
+        options: undefined,
+        message: 'accepts only text content blocks; received reasoningBlock',
+      },
+      {
+        args: [new Message({ role: 'assistant', content: [new TextBlock('No user message')] })],
+        options: undefined,
+        message: 'must include at least one user message',
+      },
+      {
+        args: [{ interruptResponse: { interruptId: 'interrupt-1', response: 'continue' } }],
+        options: undefined,
+        message: 'does not support interrupt response input',
+      },
+      {
+        args: { checkpointResume: { checkpoint: { position: 'afterModel' } } },
+        options: undefined,
+        message: 'does not support checkpoint resume input',
+      },
+      {
+        args: 'Hi',
+        options: { structuredOutputSchema: { _output: undefined } },
+        message: 'structuredOutputSchema is not supported',
+      },
+      { args: 'Hi', options: { limits: { turns: 1 } }, message: 'limits is not supported' },
+    ])('rejects unsupported input and options before calling AgentCore', async ({ args, options, message }) => {
+      const send = mockHarness(harnessStream())
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      await expect(agent.invoke(args as never, options as never)).rejects.toThrow(message)
+      expect(send).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('composition', () => {
+    it('accepts dependency output from a Graph predecessor', async () => {
+      const send = mockHarness(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.textDelta('Harness graph result'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('end_turn')
+        )
+      )
+      const source = createCancellableAgent('source', 0, { message: 'Source result' })
+      const harness = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+      const graph = new Graph({
+        nodes: [source, harness],
+        edges: [[source.id, harness.id]],
+        maxSteps: 2,
+      })
+
+      const result = await graph.invoke('Original task')
+
+      expect(result.status).toBe(Status.COMPLETED)
+      expect(result.content).toStrictEqual([new TextBlock('Harness graph result')])
+      expect(send.mock.calls[0]![0].input.messages).toStrictEqual([
+        { role: 'user', content: [{ text: 'Original task\n[node: source]\nSource result' }] },
+      ])
+    })
+
+    it('returns final Harness text through A2A execution', async () => {
+      const send = mockHarness(
+        harnessStream(
+          chunk.messageStart(),
+          chunk.textDelta('Harness A2A result'),
+          chunk.contentBlockStop(),
+          chunk.messageStop('end_turn')
+        )
+      )
+      const harness = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+      const executor = new A2AExecutor({ agentFactory: () => harness })
+      const eventBus = createMockEventBus()
+      const context = createRequestContext('A2A request')
+
+      await executor.execute(context, eventBus)
+
+      const artifactEvents = eventBus.events.filter(
+        (event): event is TaskArtifactUpdateEvent => event.kind === 'artifact-update'
+      )
+      expect(artifactEvents).toStrictEqual([
+        {
+          kind: 'artifact-update',
+          taskId: 'task-1',
+          contextId: 'context-1',
+          artifact: {
+            artifactId: expect.any(String),
+            parts: [{ kind: 'text', text: 'Harness A2A result' }],
+          },
+          append: false,
+          lastChunk: true,
+        },
+      ])
+      expect(send.mock.calls[0]![0].input.messages).toStrictEqual([
+        { role: 'user', content: [{ text: 'A2A request' }] },
+      ])
+    })
+  })
+
+  describe('errors', () => {
+    it.each([
+      { name: 'ThrottlingException', error: ModelThrottledError },
+      { name: 'OtherException', error: ModelError },
+    ])('normalizes a rejected AgentCore request', async ({ name, error }) => {
+      const original = Object.assign(new Error('request failed'), { name })
+      vi.spyOn(BedrockAgentCoreClient.prototype, 'send').mockRejectedValueOnce(original)
+      const agent = new AgentCoreHarnessAgent({ harnessArn: HARNESS_ARN, runtimeSessionId: SESSION_ID })
+
+      await expect(agent.invoke('Run it.')).rejects.toMatchObject({
+        constructor: error,
+        message: 'request failed',
+        cause: original,
+      })
+    })
+  })
+})
+
+function clientFrom(agent: AgentCoreHarnessAgent): BedrockAgentCoreClient {
+  return (agent as unknown as { _client: BedrockAgentCoreClient })._client
+}
+
+function mockHarness(stream: AsyncGenerator<InvokeHarnessStreamOutput>): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(BedrockAgentCoreClient.prototype, 'send').mockResolvedValueOnce({ stream } as never)
+}
+
+async function* harnessStream(...chunks: InvokeHarnessStreamOutput[]): AsyncGenerator<InvokeHarnessStreamOutput> {
+  yield* chunks
+}
+
+async function* cancelledStream(
+  controller: AbortController,
+  throwsAfterAbort: boolean
+): AsyncGenerator<InvokeHarnessStreamOutput> {
+  yield chunk.messageStart()
+  yield chunk.textDelta('partial')
+  controller.abort()
+  if (throwsAfterAbort) throw new Error('aborted')
+  yield chunk.textDelta(' buffered after abort')
+  yield chunk.contentBlockStop()
+  yield chunk.messageStop('end_turn')
+}
+
+function createMockEventBus(): ExecutionEventBus & { events: AgentExecutionEvent[] } {
+  const events: AgentExecutionEvent[] = []
+  return {
+    events,
+    publish: vi.fn((event) => {
+      events.push(event)
+    }),
+    on: vi.fn().mockReturnThis(),
+    off: vi.fn().mockReturnThis(),
+    once: vi.fn().mockReturnThis(),
+    removeAllListeners: vi.fn().mockReturnThis(),
+    finished: vi.fn(),
+  }
+}
+
+function createRequestContext(text: string): RequestContext {
+  return {
+    taskId: 'task-1',
+    contextId: 'context-1',
+    userMessage: {
+      kind: 'message',
+      messageId: 'message-1',
+      role: 'user',
+      parts: [{ kind: 'text', text }],
+    },
+  }
+}
+
+const chunk = {
+  messageStart: (role: 'assistant' | 'user' = 'assistant'): InvokeHarnessStreamOutput =>
+    ({ messageStart: { role } }) as InvokeHarnessStreamOutput,
+  textDelta: (text: string): InvokeHarnessStreamOutput =>
+    ({ contentBlockDelta: { delta: { text } } }) as InvokeHarnessStreamOutput,
+  reasoningDelta: (reasoningContent: { text?: string; signature?: string }): InvokeHarnessStreamOutput =>
+    ({ contentBlockDelta: { delta: { reasoningContent } } }) as InvokeHarnessStreamOutput,
+  toolUseStart: (toolUseId: string, name: string): InvokeHarnessStreamOutput =>
+    ({ contentBlockStart: { start: { toolUse: { toolUseId, name } } } }) as InvokeHarnessStreamOutput,
+  toolUseDelta: (input: string): InvokeHarnessStreamOutput =>
+    ({ contentBlockDelta: { delta: { toolUse: { input } } } }) as InvokeHarnessStreamOutput,
+  toolResultStart: (toolUseId: string): InvokeHarnessStreamOutput =>
+    ({
+      contentBlockStart: { start: { toolResult: { toolUseId, status: 'success' } } },
+    }) as InvokeHarnessStreamOutput,
+  toolResultDelta: (toolResult: Record<string, unknown>[]): InvokeHarnessStreamOutput =>
+    ({ contentBlockDelta: { delta: { toolResult } } }) as InvokeHarnessStreamOutput,
+  contentBlockStop: (): InvokeHarnessStreamOutput => ({ contentBlockStop: {} }) as InvokeHarnessStreamOutput,
+  messageStop: (stopReason: string): InvokeHarnessStreamOutput =>
+    ({ messageStop: { stopReason } }) as InvokeHarnessStreamOutput,
+  metadata: (usage: Record<string, number>, latencyMs: number): InvokeHarnessStreamOutput =>
+    ({ metadata: { usage, metrics: { latencyMs } } }) as InvokeHarnessStreamOutput,
+}

--- a/strands-ts/src/agentcore-harness/agentcore-harness-agent.ts
+++ b/strands-ts/src/agentcore-harness/agentcore-harness-agent.ts
@@ -1,0 +1,354 @@
+/** `InvokableAgent` adapter for the AgentCore `InvokeHarness` API. */
+
+import {
+  BedrockAgentCoreClient,
+  InvokeHarnessCommand,
+  type BedrockAgentCoreClientConfig,
+  type InvokeHarnessStreamOutput,
+} from '@aws-sdk/client-bedrock-agentcore'
+import type { InvokableAgent, InvokeArgs, InvokeOptions } from '../types/agent.js'
+import { AgentResult } from '../types/agent.js'
+import { Message, contentBlockFromData } from '../types/messages.js'
+import type { ContentBlock, ContentBlockData, MessageData, TextBlock } from '../types/messages.js'
+import { isInterruptResponseContent } from '../types/interrupt.js'
+import {
+  ConcurrentInvocationError,
+  ContextWindowOverflowError,
+  MaxTokensError,
+  ModelError,
+  ModelThrottledError,
+  normalizeError,
+} from '../errors.js'
+import {
+  AgentCoreHarnessResultEvent,
+  AgentCoreHarnessStreamUpdateEvent,
+  type AgentCoreHarnessEventData,
+  type AgentCoreHarnessStreamEvent,
+} from './events.js'
+import { HarnessStreamDecoder, type DecodedHarnessInvocation } from './stream-decoder.js'
+
+const THROTTLING_ERROR_NAMES = new Set(['ThrottlingException', 'ThrottledException'])
+const CONTEXT_WINDOW_OVERFLOW_ERRORS = [
+  'input is too long for requested model',
+  'input length and `max_tokens` exceed context limit',
+  'too many total text bytes',
+  'prompt is too long',
+]
+
+/**
+ * Configuration for {@link AgentCoreHarnessAgent}.
+ */
+export interface AgentCoreHarnessAgentConfig {
+  /** ARN of the deployed AgentCore Harness. */
+  harnessArn: string
+  /** Conversation session ID. Must be 33-100 Harness-compatible characters. */
+  runtimeSessionId: string
+  /** Optional unique identifier. Defaults to the Harness ARN and runtime session ID. */
+  id?: string
+  /** AgentCore client to use. Takes precedence over `clientConfig`. */
+  client?: BedrockAgentCoreClient
+  /** AgentCore client configuration. Uses standard AWS region resolution; `maxAttempts` defaults to 1. */
+  clientConfig?: BedrockAgentCoreClientConfig
+}
+
+/**
+ * Adapts one deployed AgentCore Harness to the Strands {@link InvokableAgent} interface.
+ *
+ * Each `invoke()` or `stream()` call sends one non-empty text message through `InvokeHarness`.
+ * Text blocks are joined with newlines. Message-history input uses the latest user message.
+ * Non-text content, interrupt responses, and checkpoint resumes are rejected before the request.
+ * The deployed Harness owns its model, prompt, tools, skills, limits, and agent loop.
+ * Tool execution and continuation must happen in the deployed Harness; this adapter does not
+ * execute or continue inline tool calls locally.
+ *
+ * @example
+ * ```typescript
+ * import { randomUUID } from 'node:crypto'
+ * import { AgentCoreHarnessAgent } from '@strands-agents/sdk/agentcore-harness'
+ *
+ * const agent = new AgentCoreHarnessAgent({
+ *   harnessArn: process.env.AGENTCORE_HARNESS_ARN!,
+ *   runtimeSessionId: randomUUID(),
+ * })
+ *
+ * const result = await agent.invoke('Summarize the worktree.')
+ * ```
+ */
+export class AgentCoreHarnessAgent implements InvokableAgent {
+  private readonly _client: BedrockAgentCoreClient
+  private _isInvoking = false
+
+  /** ARN of the deployed Harness. */
+  readonly harnessArn: string
+
+  /** Session ID used by the Harness-owned conversation. */
+  readonly runtimeSessionId: string
+
+  /** Identifier unique to this Harness session. */
+  readonly id: string
+
+  /**
+   * Creates a Harness adapter.
+   *
+   * @param config - Harness identity, session, and optional AgentCore client configuration
+   */
+  constructor(config: AgentCoreHarnessAgentConfig) {
+    this.harnessArn = config.harnessArn
+    this.runtimeSessionId = config.runtimeSessionId
+    this.id = config.id ?? `${config.harnessArn}:${config.runtimeSessionId}`
+    this._client =
+      config.client ??
+      new BedrockAgentCoreClient({
+        ...config.clientConfig,
+        maxAttempts: config.clientConfig?.maxAttempts ?? 1,
+      })
+  }
+
+  /**
+   * Invokes the deployed Harness and returns its final result.
+   *
+   * @param args - Non-empty text as a string, text blocks, or message history
+   * @param options - Cancellation and invocation state; other options are unsupported
+   * @returns Final Harness result
+   * @throws {@link ConcurrentInvocationError} If this instance is already processing an invocation
+   * @throws TypeError If input or invocation options are unsupported
+   * @throws {@link ModelThrottledError} If AgentCore reports throttling
+   * @throws {@link ModelError} If AgentCore or the Harness stream fails
+   */
+  async invoke(args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
+    const generator = this.stream(args, options)
+    let next = await generator.next()
+    while (!next.done) {
+      next = await generator.next()
+    }
+    return next.value
+  }
+
+  /**
+   * Streams one `InvokeHarness` request.
+   *
+   * @param args - Non-empty text as a string, text blocks, or message history
+   * @param options - Cancellation and invocation state; other options are unsupported
+   * @returns Raw Harness events followed by the final result event and generator return value
+   * @throws {@link ConcurrentInvocationError} If this instance is already processing an invocation
+   * @throws TypeError If input or invocation options are unsupported
+   * @throws {@link ModelThrottledError} If AgentCore reports throttling
+   * @throws {@link ModelError} If AgentCore or the Harness stream fails
+   */
+  async *stream(
+    args: InvokeArgs,
+    options?: InvokeOptions
+  ): AsyncGenerator<AgentCoreHarnessStreamEvent, AgentResult, undefined> {
+    this._acquireLock()
+    try {
+      return yield* this._stream(args, options)
+    } finally {
+      this._isInvoking = false
+    }
+  }
+
+  private async *_stream(
+    args: InvokeArgs,
+    options?: InvokeOptions
+  ): AsyncGenerator<AgentCoreHarnessStreamEvent, AgentResult, undefined> {
+    const text = textFromInvokeArgs(args)
+    assertSupportedOptions(options)
+
+    const invocationState = options?.invocationState ?? {}
+    const cancelSignal = options?.cancelSignal
+    const decoder = new HarnessStreamDecoder()
+
+    if (cancelSignal?.aborted) {
+      const result = createCancelledResult(decoder, invocationState)
+      yield new AgentCoreHarnessResultEvent({ result })
+      return result
+    }
+
+    try {
+      const response = await this._client.send(
+        new InvokeHarnessCommand({
+          harnessArn: this.harnessArn,
+          runtimeSessionId: this.runtimeSessionId,
+          messages: [{ role: 'user', content: [{ text }] }],
+        }),
+        cancelSignal ? { abortSignal: cancelSignal } : {}
+      )
+      if (response.stream) {
+        for await (const chunk of response.stream) {
+          if (cancelSignal?.aborted) break
+
+          const streamError = harnessStreamError(chunk)
+          if (streamError) throw streamError
+
+          const event = chunk as AgentCoreHarnessEventData
+          decoder.accept(event)
+          yield new AgentCoreHarnessStreamUpdateEvent(event)
+        }
+      }
+    } catch (error) {
+      if (cancelSignal?.aborted) {
+        const result = createCancelledResult(decoder, invocationState)
+        yield new AgentCoreHarnessResultEvent({ result })
+        return result
+      }
+      throw normalizeHarnessError(error)
+    }
+
+    if (cancelSignal?.aborted) {
+      const result = createCancelledResult(decoder, invocationState)
+      yield new AgentCoreHarnessResultEvent({ result })
+      return result
+    }
+
+    const decoded = decoder.complete()
+    throwIfUnrecoverable(decoded)
+    const result = new AgentResult({
+      stopReason: decoded.stopReason,
+      lastMessage: decoded.message,
+      invocationState,
+    })
+    yield new AgentCoreHarnessResultEvent({ result })
+    return result
+  }
+
+  private _acquireLock(): void {
+    if (this._isInvoking) {
+      throw new ConcurrentInvocationError(
+        'AgentCoreHarnessAgent is already processing an invocation. Wait for the current invoke() or stream() call to complete before invoking again.'
+      )
+    }
+    this._isInvoking = true
+  }
+}
+
+function textFromInvokeArgs(args: InvokeArgs): string {
+  if (typeof args === 'string') {
+    return requireNonEmptyText(args)
+  }
+
+  if (!Array.isArray(args)) {
+    throw new TypeError('AgentCoreHarnessAgent does not support checkpoint resume input.')
+  }
+  if (args.length === 0) {
+    throw new TypeError('AgentCoreHarnessAgent input must contain non-empty text.')
+  }
+
+  const first = args[0]!
+  if (isInterruptResponseContent(first)) {
+    throw new TypeError('AgentCoreHarnessAgent does not support interrupt response input.')
+  }
+
+  if ('role' in first) {
+    const messages = (args as (Message | MessageData)[]).map((message) =>
+      message instanceof Message ? message : Message.fromMessageData(message)
+    )
+    const latestUserMessage = messages
+      .slice()
+      .reverse()
+      .find((message) => message.role === 'user')
+    if (latestUserMessage === undefined) {
+      throw new TypeError('AgentCoreHarnessAgent message input must include at least one user message.')
+    }
+    return textFromContentBlocks(latestUserMessage.content)
+  }
+
+  const blocks = (args as (ContentBlock | ContentBlockData)[]).map((block) =>
+    'type' in block ? block : contentBlockFromData(block)
+  )
+  return textFromContentBlocks(blocks)
+}
+
+function textFromContentBlocks(blocks: ContentBlock[]): string {
+  const textBlocks = blocks.filter((block): block is TextBlock => block.type === 'textBlock')
+  const unsupportedTypes = blocks.filter((block) => block.type !== 'textBlock').map((block) => block.type)
+  if (unsupportedTypes.length > 0) {
+    throw new TypeError(
+      `AgentCoreHarnessAgent accepts only text content blocks; received ${unsupportedTypes.join(', ')}.`
+    )
+  }
+  return requireNonEmptyText(textBlocks.map((block) => block.text).join('\n'))
+}
+
+function requireNonEmptyText(text: string): string {
+  if (text.length === 0) {
+    throw new TypeError('AgentCoreHarnessAgent input must contain non-empty text.')
+  }
+  return text
+}
+
+function assertSupportedOptions(options: InvokeOptions | undefined): void {
+  if (options?.structuredOutputSchema !== undefined) {
+    throw new TypeError('InvokeOptions.structuredOutputSchema is not supported by AgentCoreHarnessAgent.')
+  }
+  if (options?.limits !== undefined) {
+    throw new TypeError('InvokeOptions.limits is not supported by AgentCoreHarnessAgent.')
+  }
+}
+
+function createCancelledResult(
+  decoder: HarnessStreamDecoder,
+  invocationState: NonNullable<InvokeOptions['invocationState']>
+): AgentResult {
+  return new AgentResult({
+    stopReason: 'cancelled',
+    lastMessage: decoder.partialMessage(),
+    invocationState,
+  })
+}
+
+function throwIfUnrecoverable(decoded: DecodedHarnessInvocation): void {
+  // A context-window stop reason is a completed Harness turn; request and stream failures are normalized separately.
+  switch (decoded.stopReason) {
+    case 'maxTokens':
+      throw new MaxTokensError(
+        'Model reached maximum token limit. This is an unrecoverable state that requires intervention.',
+        decoded.message
+      )
+    case 'interrupted':
+    case 'malformedModelOutput':
+    case 'malformedToolUse':
+      throw new ModelError(`Harness ended the turn with an unrecoverable stop reason: ${decoded.stopReason}`)
+  }
+  if (decoded.toolInputParseError) {
+    throw new ModelError('Unable to parse Harness tool input JSON.', { cause: decoded.toolInputParseError })
+  }
+}
+
+function harnessStreamError(chunk: InvokeHarnessStreamOutput): ModelError | undefined {
+  if ('internalServerException' in chunk && chunk.internalServerException) {
+    return new ModelError(chunk.internalServerException.message ?? 'AgentCore Harness internal server error', {
+      cause: chunk.internalServerException,
+    })
+  }
+  if ('validationException' in chunk && chunk.validationException) {
+    const message = chunk.validationException.message ?? 'AgentCore Harness validation error'
+    if (isContextWindowOverflow(message)) {
+      return new ContextWindowOverflowError(message, { cause: chunk.validationException })
+    }
+    return new ModelError(message, { cause: chunk.validationException })
+  }
+  if ('runtimeClientError' in chunk && chunk.runtimeClientError) {
+    return new ModelError(chunk.runtimeClientError.message ?? 'AgentCore Harness runtime client error', {
+      cause: chunk.runtimeClientError,
+    })
+  }
+  return undefined
+}
+
+function normalizeHarnessError(error: unknown): Error {
+  if (error instanceof ModelError) return error
+
+  const normalized = normalizeError(error)
+  if (THROTTLING_ERROR_NAMES.has(normalized.name)) {
+    return new ModelThrottledError(normalized.message, { cause: error })
+  }
+  if (isContextWindowOverflow(normalized.message)) {
+    return new ContextWindowOverflowError(normalized.message, { cause: error })
+  }
+  return new ModelError(normalized.message, { cause: error })
+}
+
+function isContextWindowOverflow(message: string): boolean {
+  const normalized = message.toLowerCase()
+  return CONTEXT_WINDOW_OVERFLOW_ERRORS.some((phrase) => normalized.includes(phrase))
+}

--- a/strands-ts/src/agentcore-harness/events.ts
+++ b/strands-ts/src/agentcore-harness/events.ts
@@ -1,0 +1,66 @@
+/** AgentCore Harness stream events yielded by {@link AgentCoreHarnessAgent}. */
+
+import type { InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import { StreamEvent } from '../hooks/events.js'
+import type { AgentResultEvent } from '../hooks/events.js'
+
+/** Non-error events received from an AgentCore Harness invocation. */
+export type AgentCoreHarnessEventData = Exclude<
+  InvokeHarnessStreamOutput,
+  | InvokeHarnessStreamOutput.InternalServerExceptionMember
+  | InvokeHarnessStreamOutput.ValidationExceptionMember
+  | InvokeHarnessStreamOutput.RuntimeClientErrorMember
+>
+
+/** Wraps one raw event from the `InvokeHarness` response stream. */
+export class AgentCoreHarnessStreamUpdateEvent extends StreamEvent {
+  readonly type = 'agentCoreHarnessStreamUpdateEvent' as const
+  readonly event: AgentCoreHarnessEventData
+
+  /**
+   * Creates a Harness stream update.
+   *
+   * @param event - Raw non-error event received from `InvokeHarness`
+   */
+  constructor(event: AgentCoreHarnessEventData) {
+    super()
+    this.event = event
+  }
+
+  /**
+   * Serializes the event.
+   *
+   * @returns Event type and raw Harness event
+   */
+  toJSON(): Pick<AgentCoreHarnessStreamUpdateEvent, 'type' | 'event'> {
+    return { type: this.type, event: this.event }
+  }
+}
+
+/** Wraps the final result yielded by an AgentCore Harness agent stream. */
+export class AgentCoreHarnessResultEvent extends StreamEvent {
+  readonly type = 'agentCoreHarnessResultEvent' as const
+  readonly result: AgentResultEvent['result']
+
+  /**
+   * Creates a final Harness result event.
+   *
+   * @param data - Completed agent result
+   */
+  constructor(data: Pick<AgentResultEvent, 'result'>) {
+    super()
+    this.result = data.result
+  }
+
+  /**
+   * Serializes the event.
+   *
+   * @returns Event type and completed result
+   */
+  toJSON(): Pick<AgentCoreHarnessResultEvent, 'type' | 'result'> {
+    return { type: this.type, result: this.result }
+  }
+}
+
+/** Events yielded by {@link AgentCoreHarnessAgent.stream}. */
+export type AgentCoreHarnessStreamEvent = AgentCoreHarnessStreamUpdateEvent | AgentCoreHarnessResultEvent

--- a/strands-ts/src/agentcore-harness/index.ts
+++ b/strands-ts/src/agentcore-harness/index.ts
@@ -1,0 +1,9 @@
+/** AgentCore Harness adapter. */
+
+export { AgentCoreHarnessAgent, type AgentCoreHarnessAgentConfig } from './agentcore-harness-agent.js'
+export {
+  AgentCoreHarnessResultEvent,
+  AgentCoreHarnessStreamUpdateEvent,
+  type AgentCoreHarnessEventData,
+  type AgentCoreHarnessStreamEvent,
+} from './events.js'

--- a/strands-ts/src/agentcore-harness/stream-decoder.ts
+++ b/strands-ts/src/agentcore-harness/stream-decoder.ts
@@ -1,0 +1,261 @@
+import type {
+  HarnessContentBlockDelta,
+  HarnessContentBlockStart,
+  HarnessStopReason,
+  HarnessToolResultContentBlock,
+} from '@aws-sdk/client-bedrock-agentcore'
+import { ModelError } from '../errors.js'
+import { logger } from '../logging/logger.js'
+import { JsonBlock, Message, ReasoningBlock, TextBlock, ToolResultBlock, ToolUseBlock } from '../types/messages.js'
+import type { JSONValue } from '../types/json.js'
+import type { ContentBlock, Role, StopReason, ToolResultContent } from '../types/messages.js'
+import type { ToolResultStatus } from '../tools/types.js'
+import type { AgentCoreHarnessEventData } from './events.js'
+
+const STOP_REASON_MAP = {
+  end_turn: 'endTurn',
+  tool_use: 'toolUse',
+  tool_result: 'toolResult',
+  max_tokens: 'maxTokens',
+  stop_sequence: 'stopSequence',
+  content_filtered: 'contentFiltered',
+  model_context_window_exceeded: 'modelContextWindowExceeded',
+  max_iterations_exceeded: 'limitTurns',
+  max_output_tokens_exceeded: 'limitOutputTokens',
+  timeout_exceeded: 'timeoutExceeded',
+  interrupted: 'interrupted',
+  partial_turn: 'pauseTurn',
+  malformed_model_output: 'malformedModelOutput',
+  malformed_tool_use: 'malformedToolUse',
+} satisfies Record<HarnessStopReason, StopReason>
+
+/** @internal */
+export interface DecodedHarnessInvocation {
+  /** Most recent message completed by the Harness. */
+  message: Message
+  /** Reason the most recent message stopped. */
+  stopReason: StopReason
+  /** Deferred parse failure for a streamed tool input. */
+  toolInputParseError?: SyntaxError
+}
+
+/** Reconstructs the final Strands message from an `InvokeHarness` stream. @internal */
+export class HarnessStreamDecoder {
+  private readonly _state: StreamState = {
+    role: 'assistant',
+    content: [],
+    pending: undefined,
+    stopReason: undefined,
+    toolInputParseError: undefined,
+  }
+
+  /**
+   * Folds one Harness stream event into the invocation.
+   *
+   * @param event - Harness event to process
+   */
+  accept(event: AgentCoreHarnessEventData): void {
+    accumulate(this._state, event)
+  }
+
+  /**
+   * Completes the invocation.
+   *
+   * @returns Final message and stop reason
+   * @throws {@link ModelError} When the stream did not complete a message
+   */
+  complete(): DecodedHarnessInvocation {
+    if (this._state.stopReason === undefined) {
+      throw new ModelError('AgentCore Harness stream ended without completing a message')
+    }
+    return {
+      message: toMessage(this._state),
+      stopReason: this._state.stopReason,
+      ...(this._state.toolInputParseError !== undefined && {
+        toolInputParseError: this._state.toolInputParseError,
+      }),
+    }
+  }
+
+  /**
+   * Returns the message assembled before a cancelled stream ended.
+   *
+   * @returns Partially reconstructed message
+   */
+  partialMessage(): Message {
+    return toMessage(this._state)
+  }
+}
+
+type PendingBlock =
+  | { kind: 'text'; text: string }
+  | { kind: 'toolUse'; toolUseId: string; name: string; input: string }
+  | { kind: 'toolResult'; toolUseId: string; status: ToolResultStatus; content: ToolResultContent[] }
+  | { kind: 'reasoning'; text: string; signature?: string; redactedContent?: Uint8Array }
+
+interface StreamState {
+  role: Role
+  content: ContentBlock[]
+  pending: PendingBlock | undefined
+  stopReason: StopReason | undefined
+  toolInputParseError: SyntaxError | undefined
+}
+
+function accumulate(state: StreamState, event: AgentCoreHarnessEventData): void {
+  if ('messageStart' in event && event.messageStart) {
+    flushPending(state)
+    state.content.length = 0
+    state.stopReason = undefined
+    state.toolInputParseError = undefined
+    state.role = roleFromHarness(event.messageStart.role)
+  }
+  if ('contentBlockStart' in event && event.contentBlockStart) {
+    flushPending(state)
+    state.pending = startBlock(event.contentBlockStart.start)
+  }
+  if ('contentBlockDelta' in event && event.contentBlockDelta) {
+    applyDelta(state, event.contentBlockDelta.delta)
+  }
+  if ('contentBlockStop' in event && event.contentBlockStop) {
+    flushPending(state)
+  }
+  if ('messageStop' in event && event.messageStop) {
+    state.stopReason = stopReasonFromHarness(event.messageStop.stopReason)
+  }
+}
+
+function toMessage(state: StreamState): Message {
+  flushPending(state)
+  return new Message({ role: state.role, content: state.content })
+}
+
+function stopReasonFromHarness(stopReason: string | undefined): StopReason {
+  if (stopReason === undefined || stopReason.trim().length === 0) {
+    throw new ModelError('AgentCore Harness messageStop event is missing a non-empty stopReason')
+  }
+  const mappedStopReason = STOP_REASON_MAP[stopReason as HarnessStopReason]
+  if (mappedStopReason !== undefined) return mappedStopReason
+
+  const fallback = stopReason.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase())
+  logger.warn(`stop_reason=<${stopReason}>, fallback=<${fallback}> | unknown stop reason, converting to camelCase`)
+  return fallback
+}
+
+function startBlock(start: HarnessContentBlockStart | undefined): PendingBlock | undefined {
+  if (start && 'toolUse' in start && start.toolUse) {
+    return {
+      kind: 'toolUse',
+      toolUseId: requiredWireString(start.toolUse.toolUseId, 'tool-use start', 'toolUseId'),
+      name: requiredWireString(start.toolUse.name, 'tool-use start', 'name'),
+      input: '',
+    }
+  }
+  if (start && 'toolResult' in start && start.toolResult) {
+    return {
+      kind: 'toolResult',
+      toolUseId: requiredWireString(start.toolResult.toolUseId, 'tool-result start', 'toolUseId'),
+      status: start.toolResult.status === 'error' ? 'error' : 'success',
+      content: [],
+    }
+  }
+  return undefined
+}
+
+function roleFromHarness(role: string | undefined): Role {
+  if (role === 'assistant' || role === 'user') return role
+  throw new ModelError(`AgentCore Harness messageStart event has invalid role '${String(role)}'`)
+}
+
+function requiredWireString(value: string | undefined, event: string, field: string): string {
+  if (value !== undefined && value.length > 0) return value
+  throw new ModelError(`AgentCore Harness ${event} event is missing a non-empty ${field}`)
+}
+
+function applyDelta(state: StreamState, delta: HarnessContentBlockDelta | undefined): void {
+  if (!delta) return
+  const pending = state.pending
+  if ('text' in delta && delta.text !== undefined) {
+    if (pending?.kind === 'text') pending.text += delta.text
+    else if (pending?.kind === 'reasoning') pending.text += delta.text
+    else {
+      flushPending(state)
+      state.pending = { kind: 'text', text: delta.text }
+    }
+  } else if ('toolUse' in delta && delta.toolUse && pending?.kind === 'toolUse') {
+    pending.input += delta.toolUse.input ?? ''
+  } else if ('toolResult' in delta && delta.toolResult && pending?.kind === 'toolResult') {
+    for (const item of delta.toolResult) {
+      pending.content.push(toolResultContentFromHarness(item))
+    }
+  } else if ('reasoningContent' in delta && delta.reasoningContent && pending?.kind === 'reasoning') {
+    const reasoning = delta.reasoningContent
+    if ('text' in reasoning && reasoning.text !== undefined) pending.text += reasoning.text
+    if ('signature' in reasoning && reasoning.signature !== undefined) {
+      pending.signature = (pending.signature ?? '') + reasoning.signature
+    }
+    if ('redactedContent' in reasoning && reasoning.redactedContent !== undefined) {
+      pending.redactedContent = concatBytes(pending.redactedContent, reasoning.redactedContent)
+    }
+  } else if ('reasoningContent' in delta && delta.reasoningContent && pending === undefined) {
+    const reasoning = delta.reasoningContent
+    state.pending = {
+      kind: 'reasoning',
+      text: 'text' in reasoning && reasoning.text ? reasoning.text : '',
+      ...('signature' in reasoning && reasoning.signature !== undefined && { signature: reasoning.signature }),
+      ...('redactedContent' in reasoning &&
+        reasoning.redactedContent !== undefined && { redactedContent: reasoning.redactedContent }),
+    }
+  }
+}
+
+function concatBytes(current: Uint8Array | undefined, chunk: Uint8Array): Uint8Array {
+  if (current === undefined) return chunk
+  const combined = new Uint8Array(current.length + chunk.length)
+  combined.set(current)
+  combined.set(chunk, current.length)
+  return combined
+}
+
+function flushPending(state: StreamState): void {
+  const pending = state.pending
+  if (!pending) return
+  switch (pending.kind) {
+    case 'text':
+      if (pending.text) state.content.push(new TextBlock(pending.text))
+      break
+    case 'toolUse': {
+      let input: JSONValue = {}
+      if (pending.input) {
+        try {
+          input = JSON.parse(pending.input) as JSONValue
+        } catch (error) {
+          if (error instanceof SyntaxError && !state.toolInputParseError) state.toolInputParseError = error
+        }
+      }
+      state.content.push(new ToolUseBlock({ toolUseId: pending.toolUseId, name: pending.name, input }))
+      break
+    }
+    case 'toolResult':
+      state.content.push(
+        new ToolResultBlock({ toolUseId: pending.toolUseId, status: pending.status, content: pending.content })
+      )
+      break
+    case 'reasoning':
+      state.content.push(
+        new ReasoningBlock({
+          ...(pending.text && { text: pending.text }),
+          ...(pending.signature !== undefined && { signature: pending.signature }),
+          ...(pending.redactedContent !== undefined && { redactedContent: pending.redactedContent }),
+        })
+      )
+      break
+  }
+  state.pending = undefined
+}
+
+function toolResultContentFromHarness(item: HarnessToolResultContentBlock): ToolResultContent {
+  if ('json' in item && item.json !== undefined) return new JsonBlock({ json: item.json as JSONValue })
+  if ('text' in item && item.text !== undefined) return new TextBlock(item.text)
+  logger.warn(`fields=<${Object.keys(item).join(',')}> | unknown tool-result content, converting to JSON text`)
+  return new TextBlock(JSON.stringify(item))
+}

--- a/strands-ts/src/errors.ts
+++ b/strands-ts/src/errors.ts
@@ -41,9 +41,10 @@ export class ContextWindowOverflowError extends ModelError {
    * Creates a new ContextWindowOverflowError.
    *
    * @param message - Error message describing the context overflow
+   * @param options - Optional error options including the cause
    */
-  constructor(message: string) {
-    super(message)
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
     this.name = 'ContextWindowOverflowError'
   }
 }

--- a/strands-ts/test/integ/agentcore-harness.test.node.ts
+++ b/strands-ts/test/integ/agentcore-harness.test.node.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { AgentCoreHarnessAgent } from '@strands-agents/sdk/agentcore-harness'
+
+const harnessArn = process.env.AGENTCORE_HARNESS_ARN
+
+describe.skipIf(!harnessArn)('AgentCoreHarnessAgent integration', () => {
+  it('invokes a deployed Harness and continues its session', async () => {
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: harnessArn!,
+      runtimeSessionId: randomUUID(),
+    })
+
+    const first = await agent.invoke('Reply with a short greeting.')
+    const second = await agent.invoke('Reply with a different short greeting.')
+
+    expect(first).toMatchObject({ stopReason: 'endTurn' })
+    expect(second).toMatchObject({ stopReason: 'endTurn' })
+    expect(first.toString().length).toBeGreaterThan(0)
+    expect(second.toString().length).toBeGreaterThan(0)
+  }, 120_000)
+})

--- a/strands-ts/test/packages/cjs-module/cjs.js
+++ b/strands-ts/test/packages/cjs-module/cjs.js
@@ -85,6 +85,16 @@ async function main() {
   }
   console.log('✓ Model subpath exports verified')
 
+  const { AgentCoreHarnessAgent } = await import('@strands-agents/sdk/agentcore-harness')
+  const harnessAgent = new AgentCoreHarnessAgent({
+    harnessArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/TestHarness-abcdefghij',
+    runtimeSessionId: 'session-id-padded-to-thirty-three',
+  })
+  if (typeof harnessAgent.invoke !== 'function') {
+    throw new Error('AgentCoreHarnessAgent subpath export is not constructible')
+  }
+  console.log('✓ AgentCore Harness subpath export verified')
+
   // Verify barrel exports match individual subpath exports
   if (
     barrelBash !== bash ||

--- a/strands-ts/test/packages/cjs-module/package.json
+++ b/strands-ts/test/packages/cjs-module/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "description": "Test package to verify SDK works with CSJ",
   "dependencies": {
+    "@aws-sdk/client-bedrock-agentcore": "^3.1078.0",
     "@strands-agents/sdk": "file:../../.."
   }
 }

--- a/strands-ts/test/packages/esm-module/esm.js
+++ b/strands-ts/test/packages/esm-module/esm.js
@@ -27,6 +27,9 @@ import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 import { GoogleModel } from '@strands-agents/sdk/models/google'
 
+// Verify AgentCore Harness subpath export
+import { AgentCoreHarnessAgent } from '@strands-agents/sdk/agentcore-harness'
+
 import { z } from 'zod'
 
 console.log('✓ Import from main entry point successful')
@@ -126,6 +129,15 @@ if (BedrockFromSubpath !== BedrockModel) {
   throw new Error('BedrockModel from subpath should match main export')
 }
 console.log('✓ Model subpath exports verified')
+
+const harnessAgent = new AgentCoreHarnessAgent({
+  harnessArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/TestHarness-abcdefghij',
+  runtimeSessionId: 'session-id-padded-to-thirty-three',
+})
+if (typeof harnessAgent.invoke !== 'function') {
+  throw new Error('AgentCoreHarnessAgent subpath export is not constructible')
+}
+console.log('✓ AgentCore Harness subpath export verified')
 
 // Verify barrel exports match individual subpath exports
 if (

--- a/strands-ts/test/packages/esm-module/package.json
+++ b/strands-ts/test/packages/esm-module/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "description": "Test package to verify SDK works without bundler",
   "dependencies": {
+    "@aws-sdk/client-bedrock-agentcore": "^3.1078.0",
     "@strands-agents/sdk": "file:../../.."
   }
 }

--- a/strands-ts/test/packages/npm-pack/verify.ts
+++ b/strands-ts/test/packages/npm-pack/verify.ts
@@ -4,7 +4,7 @@
  * that transitively pulls an optional peer fails at module load.
  *
  * Subpaths deliberately NOT imported because they require optional peers:
- *   models/{anthropic,openai,google,vercel}, a2a, a2a/express,
+ *   agentcore-harness, models/{anthropic,openai,google,vercel}, a2a, a2a/express,
  *   session/s3-storage, telemetry. Those are covered by the sibling
  *   `../esm-module` and `../cjs-module` suites.
  */
@@ -135,7 +135,12 @@ if (!(ctxErr instanceof Error)) {
 void AgentResult
 console.log('[pack-test] Error + result types importable')
 
-if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+if (
+  barrelBash !== bash ||
+  barrelFileEditor !== fileEditor ||
+  barrelHttpRequest !== httpRequest ||
+  barrelNotebook !== notebook
+) {
   throw new Error('Barrel vended-tools exports do not match individual subpath exports')
 }
 if (


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

We introduce `AgentCoreHarnessAgent`, a new `InvokableAgent` implementation allowing developers to interface with and integrate a [AgentCore Harness agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) into their agentic applications just as easily as a typical Strands agent today.

```bash
npm install @strands-agents/sdk @aws-sdk/client-bedrock-agentcore
```

```typescript
import { AgentCoreHarnessAgent } from '@strands-agents/sdk/agentcore-harness'

const agent = new AgentCoreHarnessAgent({
  harnessArn: '...',
  runtimeSessionId: '...',
})

const result = await agent.invoke("Tell me about your local environment")
```

```mermaid
sequenceDiagram
    participant Client as Strands client
    participant Agent as AgentCoreHarnessAgent
    participant API as InvokeHarness API
    participant Harness as Deployed Harness

    Client->>Agent: invoke(input) or stream(input)
    Agent->>API: InvokeHarness(ARN, session ID, messages)
    API->>Harness: Run agent

    Note over Harness: Owns the model, prompt, tools, memory, limits, and agent loop

    Harness-->>API: Stream events and terminal result
    API-->>Agent: InvokeHarness event stream
    Agent-->>Client: AgentResult or streamed events
```

### Scope and roadmap

This PR establishes an intentionally narrow V0. Each subsequent version shifts a deliberate part of Harness ownership to the client.

| Version | Scope | Features and support introduced | Experience |
| --- | --- | --- | --- |
| **V0: Remote adapter** | Invoke and stream a deployed Harness through the `InvokableAgent` interface. | Text input, raw event streaming, cancellation, typed error translation, runtime session continuity, and Graph/A2A composition. | The Harness owns its model, prompt, tools, memory, and agent loop. The client supplies the Harness ARN, session ID, and input. |
| **V1: Client-side tool calling** | Pass custom tools to the harness agent to be run client-side, automatically or HITL, return tool results, and continue the Harness turn. | `inline_function` registration, automatic or HITL client-side tool execution, tool-result submission, and `partial_turn` continuation with merged streaming and metrics. | Above + Harness receives custom tools as `inline_functions`. |
| **V2: Harness overrides** | Support request-scoped overrides for Harness capabilities exposed by `InvokeHarness`, such as microVM-side tools, system prompt and more. | Request-scoped model, system prompt, Harness-side tool, skill, allowed-tool, execution-limit, timeout, and memory actor overrides. | Above + Harness receives additional parameters in the `InvokeHarness` request being constructed by the adapter. |

V0 intentionally excludes built-in client-side tool execution, continuation handling, and per-invocation Harness configuration overrides.

<details>
<summary><h3>🟦 Full API call flow (V0-V1-V2) 🟦</h3></summary>

```mermaid
sequenceDiagram
    participant Client as Strands client
    participant Agent as AgentCoreHarnessAgent
    participant API as InvokeHarness API
    participant Harness as Deployed Harness

    Note over Client,Harness: V0 - Remote invocation

    Client->>Agent: invoke(input)
    Agent->>API: InvokeHarness(session, messages)
    API->>Harness: Run agent
    Harness-->>API: Stream events
    API-->>Agent: Stream events

    opt V1 - Inline function
        Agent-->>Client: toolUse
        Client->>Client: Execute tool or complete HITL
        Client->>Agent: toolResult
        Agent->>API: Continue with toolUse and toolResult
        API->>Harness: Resume agent
    end

    Harness-->>API: Final response
    API-->>Agent: Final events
    Agent-->>Client: AgentResult

    Note over Agent,Harness: V2 optionally adds request-scoped Harness overrides
```
</details>


## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

New feature

## Testing

- [x] Ran the whole suite, added various tests

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate documentation example
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
