### PR TITLE
feat(vended-tools): reconcile editor commands into file_editor

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -7,6 +7,7 @@ languages: [python, typescript]
 tags: [tool-authoring]
 sourceLinks:
   - path: strands-ts/src/vended-tools/file-editor/file-editor.ts
+  - path: strands-py/src/strands/vended_tools/file_editor/file_editor.py
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
@@ -37,7 +38,11 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 
 ### File Editor
 
-Gives your agent the ability to read and modify files on disk — useful for coding agents, config management, or any workflow where the agent needs to inspect output and make targeted edits.
+Gives your agent the ability to read and modify files on disk — useful for coding agents, config management, or any workflow where the agent needs to inspect output and make targeted edits. Commands: `view`, `create`, `str_replace`, `insert`, `pattern_replace` (regex), `find_line`, and `undo_edit` (single-step, in-memory).
+
+Ambiguous `str_replace` and `pattern_replace` matches are rejected unless the caller opts in with `replace_all: true`, so the model can't silently rewrite an entire file. Binary files and files above the configurable size cap (default 1 MB) are rejected with a clean error. Pass `root` to `makeFileEditor` / `make_file_editor` to confine every operation to a single directory — the resolver applies both string-level and (when the local filesystem sees the target) `realpath`-based symlink checks.
+
+The two SDKs guard `pattern_replace` against catastrophic regex differently. The Python side runs the match and substitution on a worker thread with a configurable wall-clock timeout (`pattern_replace_timeout`, default five seconds). The TypeScript side cannot replicate that — V8 has no in-exec regex timeout and JavaScript has no way to cancel a running `.exec()` call — so it statically rejects the classic ReDoS shapes (`(a+)+`, `(a*)*`, and so on) before compiling. A pattern accepted by Python may be refused by TypeScript.
 
 :::caution[Security Warning]
 This tool reads and writes files at arbitrary absolute paths with the full permissions of the process. Only use with trusted input and consider running in a [sandboxed environment](../sandbox/index.mdx) for production.

--- a/strands-py/src/strands/vended_tools/file_editor/file_editor.py
+++ b/strands-py/src/strands/vended_tools/file_editor/file_editor.py
@@ -1,17 +1,20 @@
 """Sandbox-routed file editor tool.
 
 Provides
-``view`` (with line ranges), ``create``, ``str_replace``, and ``insert``
-operations, all routed through a :class:`~strands.sandbox.base.Sandbox`: either
-one bound at creation (as the built-in Docker/SSH sandboxes do when vending
-tools) or the agent's configured sandbox read from ``tool_context.agent.sandbox``
-at call time.
+``view`` (with line ranges), ``create``, ``str_replace``, ``insert``,
+``pattern_replace``, ``find_line``, and ``undo_edit`` operations, all routed
+through a :class:`~strands.sandbox.base.Sandbox`: either one bound at creation
+(as the built-in Docker/SSH sandboxes do when vending tools) or the agent's
+configured sandbox read from ``tool_context.agent.sandbox`` at call time.
 """
 
 from __future__ import annotations
 
+import asyncio
+import os
 import posixpath
 import re
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Literal
 
 from ...sandbox.errors import SandboxPathNotFoundError
@@ -23,13 +26,30 @@ if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
 
 _SNIPPET_LINES = 4
-_DEFAULT_MAX_FILE_SIZE = 1048576  # 1MB
+_DEFAULT_MAX_FILE_SIZE = 1 * 1024 * 1024  # 1 MB
 _MAX_DIRECTORY_DEPTH = 2
+_MAX_PATTERN_LENGTH = 1000
+_MAX_PATTERN_MATCHES = 10_000
+_PATTERN_REPLACE_TIMEOUT_SEC = 5.0
+_DEFAULT_MAX_UNDO_ENTRIES = 32
+_DEFAULT_MAX_UNDO_BYTES = 32 * 1024 * 1024  # 32 MB
 
 DEFAULT_FILE_EDITOR_DESCRIPTION = (
-    "Filesystem editor tool for viewing, creating, and editing files. Supports view "
-    "(with line ranges), create, str_replace, and insert operations. Files must use absolute paths."
+    "Filesystem editor for viewing, creating, and editing files. Supports view (with "
+    "line ranges), create, str_replace (exact match; ambiguous matches must opt in via "
+    "replace_all), insert, pattern_replace (regex), find_line, and undo_edit. Files "
+    "must use absolute paths."
 )
+
+_Command = Literal[
+    "view",
+    "create",
+    "str_replace",
+    "insert",
+    "pattern_replace",
+    "find_line",
+    "undo_edit",
+]
 
 
 def make_file_editor(
@@ -37,6 +57,11 @@ def make_file_editor(
     sandbox: Sandbox | None = None,
     name: str = "file_editor",
     description: str = DEFAULT_FILE_EDITOR_DESCRIPTION,
+    root: str | None = None,
+    max_file_size: int = _DEFAULT_MAX_FILE_SIZE,
+    max_undo_entries: int = _DEFAULT_MAX_UNDO_ENTRIES,
+    max_undo_bytes: int = _DEFAULT_MAX_UNDO_BYTES,
+    pattern_replace_timeout: float = _PATTERN_REPLACE_TIMEOUT_SEC,
 ) -> DecoratedFunctionTool:
     """Create a sandbox-routed file editor tool.
 
@@ -50,14 +75,43 @@ def make_file_editor(
             configured sandbox is used at call time.
         name: Tool name. Defaults to ``"file_editor"``.
         description: Tool description shown to the model.
+        root: Optional absolute directory that confines every operation. String-
+            level checks reject non-absolute paths and any ``..`` traversal on
+            the raw input; when the resolved target exists on the local host,
+            ``os.path.realpath`` is also applied and the resulting path must
+            still be inside ``root``. Confinement is enforced against the raw
+            (string-level) path input before I/O; concurrent rename attacks
+            between the confinement check and the read/write are the sandbox's
+            responsibility. When ``root`` is ``None``, only absolute-path and
+            ``..``-traversal checks apply; the underlying sandbox's symlink
+            policy governs escape.
+        max_file_size: Maximum file size (bytes) accepted by view/edit
+            commands. Defaults to 1 MB.
+        max_undo_entries: Maximum number of distinct paths retained in the
+            in-memory undo history. Oldest entry is evicted on overflow.
+            Defaults to 32.
+        max_undo_bytes: Approximate cap on total bytes of file content held in
+            the undo history (UTF-8). Oldest entries are evicted until the cap
+            is met. Defaults to 32 MB.
+        pattern_replace_timeout: Wall-clock seconds allowed for a single
+            ``pattern_replace`` invocation before the tool aborts with a
+            "possible catastrophic regex" error. Defaults to 5.0 seconds.
 
     Returns:
         A decorated tool that performs file operations through the sandbox.
     """
+    if root is not None and not posixpath.isabs(root):
+        raise ValueError(f"root must be an absolute path, got: {root}")
+    normalized_root: str | None = None if root is None else posixpath.normpath(root).rstrip("/") or "/"
+
+    # Bounded LRU: previous file content keyed by path. A second edit overwrites
+    # the snapshot for that path, matching the upstream editor's single-step
+    # undo semantics; older entries are evicted when either cap is exceeded.
+    undo_history: OrderedDict[str, str] = OrderedDict()
 
     @tool(name=name, description=description, context="tool_context")
     async def file_editor_tool(
-        command: Literal["view", "create", "str_replace", "insert"],
+        command: _Command,
         path: str,
         tool_context: ToolContext,
         file_text: str | None = None,
@@ -65,31 +119,82 @@ def make_file_editor(
         old_str: str | None = None,
         new_str: str | None = None,
         insert_line: int | None = None,
+        pattern: str | None = None,
+        search_text: str | None = None,
+        fuzzy: bool = False,
+        replace_all: bool = False,
     ) -> str:
         """Filesystem editor for viewing, creating, and editing files.
 
         Args:
-            command: The operation to perform: `view`, `create`, `str_replace`, `insert`.
+            command: The operation to perform: ``view``, ``create``,
+                ``str_replace``, ``insert``, ``pattern_replace``,
+                ``find_line``, or ``undo_edit``.
             path: Absolute path to the file or directory.
             tool_context: Injected by the framework. Not user-facing.
-            file_text: Content for new file (required for create command).
-            view_range: Line range to view [start, end]. 1-indexed. End can be -1 for end of file.
-            old_str: Exact string to find and replace (required for str_replace command).
-            new_str: Replacement string (for str_replace and insert commands).
-            insert_line: Line number where text should be inserted (0-indexed, required for insert command).
+            file_text: Content for new file (required for ``create``).
+            view_range: Line range to view ``[start, end]``. 1-indexed. End can
+                be ``-1`` for end of file.
+            old_str: Exact string to find and replace (required for
+                ``str_replace``). Must be unique unless ``replace_all=True``.
+            new_str: Replacement string (for ``str_replace``,
+                ``pattern_replace``, and ``insert``).
+            insert_line: Line number where text should be inserted (0-indexed,
+                required for ``insert``).
+            pattern: Regex pattern to match (required for ``pattern_replace``).
+            search_text: Text to search for (required for ``find_line``).
+            fuzzy: Enable whitespace-tolerant matching for ``find_line``.
+            replace_all: For ``str_replace`` / ``pattern_replace``, allow
+                replacing all occurrences. Defaults to ``False`` (unique match
+                required) to prevent silent broad edits.
         """
         active = sandbox if sandbox is not None else tool_context.agent.sandbox
-        # Strip trailing slashes from the path.
-        file_path = re.sub(r"[/\\]+$", "", path)
+        resolved = _resolve_path(path, normalized_root)
 
         if command == "view":
-            return await _handle_view(active, file_path, view_range)
+            return await _handle_view(active, resolved, view_range, max_file_size)
         if command == "create":
-            return await _handle_create(active, file_path, file_text)
+            return await _handle_create(active, resolved, file_text, undo_history, max_file_size)
         if command == "str_replace":
-            return await _handle_str_replace(active, file_path, old_str, new_str)
+            return await _handle_str_replace(
+                active,
+                resolved,
+                old_str,
+                new_str,
+                replace_all,
+                max_file_size,
+                undo_history,
+                max_undo_entries,
+                max_undo_bytes,
+            )
         if command == "insert":
-            return await _handle_insert(active, file_path, insert_line, new_str)
+            return await _handle_insert(
+                active,
+                resolved,
+                insert_line,
+                new_str,
+                max_file_size,
+                undo_history,
+                max_undo_entries,
+                max_undo_bytes,
+            )
+        if command == "pattern_replace":
+            return await _handle_pattern_replace(
+                active,
+                resolved,
+                pattern,
+                new_str,
+                replace_all,
+                max_file_size,
+                undo_history,
+                max_undo_entries,
+                max_undo_bytes,
+                pattern_replace_timeout,
+            )
+        if command == "find_line":
+            return await _handle_find_line(active, resolved, search_text, fuzzy, max_file_size)
+        if command == "undo_edit":
+            return await _handle_undo(active, resolved, undo_history)
         raise ValueError(f"Unknown command: {command}")
 
     return file_editor_tool
@@ -99,24 +204,81 @@ file_editor = make_file_editor()
 """Default sandbox-routed file editor tool. Reads the sandbox from the agent's context at call time."""
 
 
-def _validate_path(file_path: str) -> None:
-    """Validate that a path is absolute and contains no directory traversal.
+# ---- Path resolution and confinement ----
+
+
+def _resolve_path(file_path: str, root: str | None) -> str:
+    """Normalize a path, rejecting traversal and out-of-root inputs.
+
+    This is the single funnel every command routes through — it exists so path
+    validation cannot be bypassed by a new command forgetting to call it. When
+    ``root`` is set and the target (or its parent, for a not-yet-existing file)
+    exists locally, symlinks are also resolved via ``os.path.realpath`` and the
+    result must still be inside ``root`` — a symlink inside ``root`` pointing
+    at ``/etc/passwd`` is rejected.
 
     Args:
-        file_path: The path to validate.
+        file_path: The raw path from the tool input.
+        root: Optional absolute directory that confines the result.
+
+    Returns:
+        The normalized (trailing-slash-stripped, ``posixpath.normpath``)
+        absolute path.
 
     Raises:
-        ValueError: If the path is not absolute or contains a ``..`` segment.
+        ValueError: If the path is not absolute, contains a ``..`` segment, or
+            resolves (via ``realpath`` when applicable) outside ``root``.
     """
-    # Absolute means POSIX-absolute (leading "/"), matching the sandbox path model.
-    if not posixpath.isabs(file_path):
-        suggested = posixpath.abspath(file_path)
+    # Strip trailing slashes on the raw input (compat with pre-existing behavior).
+    stripped = re.sub(r"[/\\]+$", "", file_path) or file_path
+
+    if not posixpath.isabs(stripped):
+        suggested = posixpath.abspath(stripped)
         raise ValueError(
             f"The path {file_path} is not an absolute path, it should start with `/`. Maybe you meant {suggested}?"
         )
-    # Check for '..' segments on the raw input -- normalizing first would resolve them away.
-    if ".." in re.split(r"[/\\]", file_path):
+
+    # Reject '..' segments on the raw input -- normalize() would resolve them
+    # away and could silently permit escape past the root.
+    if ".." in re.split(r"[/\\]", stripped):
         raise ValueError("Invalid path: path traversal is not allowed")
+
+    normalized = posixpath.normpath(stripped)
+
+    if root is not None:
+        # String-level confinement: normalized must equal root or start with root + "/".
+        if normalized != root and not normalized.startswith(root.rstrip("/") + "/"):
+            raise ValueError(f"Invalid path: {file_path} is outside the configured root {root}")
+
+        # Symlink confinement is a best-effort, local-fs-only layer. If `root`
+        # itself does not exist on the local filesystem, the caller is running
+        # against a non-local sandbox (Docker, SSH, ...) whose paths do not map
+        # to this host — `os.path.realpath` would return the unchanged
+        # non-existent path and the check below would reject every operation
+        # (`realpath("/workspace-in-container")` != `realpath(root)`). In that
+        # case, the string-level check above is the whole policy; the sandbox
+        # owns its own symlink handling.
+        if not os.path.lexists(root):
+            return normalized
+
+        # Resolve the deepest existing ancestor via realpath and confirm it is
+        # still inside root. Catches a symlink `inside-root/link -> /etc/passwd`
+        # that the string-level check can't see.
+        probe = normalized
+        while probe and probe != "/" and not os.path.lexists(probe):
+            parent = posixpath.dirname(probe)
+            if parent == probe:
+                break
+            probe = parent
+        if probe and os.path.lexists(probe):
+            real = os.path.realpath(probe)
+            root_real = os.path.realpath(root)
+            if real != root_real and not real.startswith(root_real.rstrip("/") + "/"):
+                raise ValueError(
+                    f"Invalid path: {file_path} resolves via symlink to {real}, outside the configured root {root}"
+                )
+
+    return normalized
 
 
 def _apply_view_range(file_content: str, view_range: list[int] | None) -> tuple[str, int]:
@@ -159,41 +321,48 @@ def _apply_view_range(file_content: str, view_range: list[int] | None) -> tuple[
 
 
 def _build_str_replace_result(
-    original_content: str, old_str: str, new_str: str | None, file_path: str
-) -> tuple[str, str, int]:
-    """Perform a unique str_replace and return (new content, change snippet, 0-indexed snippet start).
+    original_content: str,
+    old_str: str,
+    new_str: str | None,
+    file_path: str,
+    replace_all: bool,
+) -> tuple[str, str, int, int]:
+    """Perform ``str_replace`` and return ``(new content, snippet, snippet start, count)``.
 
     Args:
         original_content: The current file content.
-        old_str: The exact string to replace (must appear exactly once).
+        old_str: The exact string to replace.
         new_str: The replacement string (``None`` deletes the match).
         file_path: The file path, for error messages.
-
-    Returns:
-        A tuple of (new content, snippet around the change, 0-indexed snippet start line).
+        replace_all: When ``True``, replace every occurrence; otherwise require
+            exactly one match.
 
     Raises:
-        ValueError: If ``old_str`` does not appear exactly once.
+        ValueError: If ``old_str`` does not appear, or appears more than once
+            without ``replace_all``.
     """
-    file_content = original_content.replace("\t", "        ")
-    expanded_old = old_str.replace("\t", "        ")
-    expanded_new = new_str.replace("\t", "        ") if new_str else ""
+    new_str_value = new_str or ""
 
-    occurrences = file_content.count(expanded_old)
+    occurrences = original_content.count(old_str)
     if occurrences == 0:
         raise ValueError(f"No replacement was performed, old_str `{old_str}` did not appear verbatim in {file_path}.")
-    if occurrences > 1:
-        lines = file_content.split("\n")
-        line_numbers = [i + 1 for i, line in enumerate(lines) if expanded_old in line]
+    if occurrences > 1 and not replace_all:
+        lines = original_content.split("\n")
+        line_numbers = [i + 1 for i, line in enumerate(lines) if old_str in line]
         raise ValueError(
             f"No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines "
-            f"{line_numbers}. Please ensure it is unique"
+            f"{line_numbers}. Pass replace_all=True to replace every occurrence, or make old_str unique."
         )
 
-    new_content = file_content.replace(expanded_old, expanded_new, 1)
-    replacement_line = len(file_content[: file_content.index(expanded_old)].split("\n")) - 1
-    inserted_lines = len(expanded_new.split("\n"))
-    original_lines = len(expanded_old.split("\n"))
+    count = occurrences if replace_all else 1
+    new_content = (
+        original_content.replace(old_str, new_str_value)
+        if replace_all
+        else original_content.replace(old_str, new_str_value, 1)
+    )
+    replacement_line = len(original_content[: original_content.index(old_str)].split("\n")) - 1
+    inserted_lines = len(new_str_value.split("\n"))
+    original_lines = len(old_str.split("\n"))
     line_difference = inserted_lines - original_lines
 
     new_lines = new_content.split("\n")
@@ -201,7 +370,7 @@ def _build_str_replace_result(
     end_line = min(len(new_lines), replacement_line + _SNIPPET_LINES + line_difference + 1)
     snippet = "\n".join(new_lines[start_line:end_line])
 
-    return new_content, snippet, start_line
+    return new_content, snippet, start_line, count
 
 
 def _build_insert_result(original_content: str, insert_line: int, new_str: str) -> tuple[str, str, int]:
@@ -218,10 +387,7 @@ def _build_insert_result(original_content: str, insert_line: int, new_str: str) 
     Raises:
         ValueError: If ``insert_line`` is out of bounds.
     """
-    file_text = original_content.replace("\t", "        ")
-    expanded_new = new_str.replace("\t", "        ")
-
-    file_text_lines = file_text.split("\n")
+    file_text_lines = original_content.split("\n")
     n_lines = len(file_text_lines)
 
     if insert_line < 0 or insert_line > n_lines:
@@ -230,10 +396,10 @@ def _build_insert_result(original_content: str, insert_line: int, new_str: str) 
             f"of the file: [0, {n_lines}]"
         )
 
-    new_str_lines = expanded_new.split("\n")
+    new_str_lines = new_str.split("\n")
     new_file_text_lines = (
         new_str_lines
-        if file_text == ""
+        if original_content == ""
         else [*file_text_lines[:insert_line], *new_str_lines, *file_text_lines[insert_line:]]
     )
 
@@ -259,6 +425,53 @@ def _make_output(file_content: str, file_descriptor: str, init_line: int = 1) ->
     expanded_content = file_content.replace("\t", "        ")
     numbered_lines = [f"{index + init_line:>6}  {line}" for index, line in enumerate(expanded_content.split("\n"))]
     return f"Here's the result of running `cat -n` on {file_descriptor}:\n" + "\n".join(numbered_lines) + "\n"
+
+
+def _find_line_number(content: str, search_text: str, fuzzy: bool) -> int:
+    """Return the 0-indexed line number where ``search_text`` first appears, else ``-1``.
+
+    When ``fuzzy=True``, whitespace between words is collapsed and matching is
+    case-insensitive.
+    """
+    lines = content.split("\n")
+    if fuzzy:
+        tokens = search_text.strip().split()
+        if not tokens:
+            return -1
+        pattern = re.compile(".*".join(re.escape(t) for t in tokens), re.IGNORECASE)
+        for i, line in enumerate(lines):
+            if pattern.search(line):
+                return i
+    else:
+        for i, line in enumerate(lines):
+            if search_text in line:
+                return i
+    return -1
+
+
+# ---- Undo history bookkeeping ----
+
+
+def _store_undo_snapshot(
+    undo_history: OrderedDict[str, str],
+    file_path: str,
+    content: str,
+    max_entries: int,
+    max_bytes: int,
+) -> None:
+    """Record a pre-edit snapshot in the LRU undo history, evicting oldest on overflow.
+
+    ``dict`` insertion order gives LRU semantics: a re-inserted key is moved to
+    the end, and eviction removes the oldest key when either the entry count or
+    the aggregate byte cap is exceeded.
+    """
+    if file_path in undo_history:
+        del undo_history[file_path]
+    undo_history[file_path] = content
+    total_bytes = sum(len(v.encode("utf-8")) for v in undo_history.values())
+    while undo_history and (len(undo_history) > max_entries or total_bytes > max_bytes):
+        _, evicted = undo_history.popitem(last=False)
+        total_bytes -= len(evicted.encode("utf-8"))
 
 
 # ---- Sandbox-routed I/O helpers ----
@@ -290,22 +503,26 @@ async def _probe_sandbox_path(sandbox: Sandbox, file_path: str) -> tuple[bool, b
     return True, entry.is_dir or False
 
 
-def _assert_within_size_limit(content: str, max_size: int = _DEFAULT_MAX_FILE_SIZE) -> None:
-    """Assert content is within the size limit.
+async def _read_text_or_reject_binary(sandbox: Sandbox, file_path: str, max_size: int) -> str:
+    """Read text through the sandbox, rejecting binary files and oversize inputs.
 
-    Checked after reading because ``list_files`` does not reliably report size
-    across sandbox backends.
-
-    Args:
-        content: The content to measure.
-        max_size: The maximum allowed size in bytes.
-
-    Raises:
-        ValueError: If the content exceeds ``max_size``.
+    Reads raw bytes first so the size cap and encoding detection run before UTF-8
+    decoding — a corrupted UTF-8 error message is worse than a clean rejection.
+    UTF-16 BOMs are detected up front so a valid UTF-16 file is reported as an
+    unsupported encoding rather than misclassified as binary. Otherwise the
+    classic NUL-in-first-8-KB heuristic identifies binary content.
     """
-    size = len(content.encode("utf-8"))
-    if size > max_size:
-        raise ValueError(f"File size ({size} bytes) exceeds maximum allowed size ({max_size} bytes)")
+    raw = await sandbox.read_file(file_path)
+    if len(raw) > max_size:
+        raise ValueError(f"File size ({len(raw)} bytes) exceeds maximum allowed size ({max_size} bytes)")
+    if raw.startswith(b"\xff\xfe") or raw.startswith(b"\xfe\xff"):
+        raise ValueError(f"Refusing to read non-UTF-8 file (detected UTF-16 BOM): {file_path}")
+    if b"\x00" in raw[:8192]:
+        raise ValueError(f"Refusing to read binary file: {file_path}")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as e:
+        raise ValueError(f"Refusing to read non-UTF-8 file: {file_path}") from e
 
 
 async def _list_directory(sandbox: Sandbox, dir_path: str) -> str:
@@ -342,10 +559,8 @@ async def _list_directory(sandbox: Sandbox, dir_path: str) -> str:
 # ---- Sandbox-path handlers ----
 
 
-async def _handle_view(sandbox: Sandbox, file_path: str, view_range: list[int] | None) -> str:
+async def _handle_view(sandbox: Sandbox, file_path: str, view_range: list[int] | None, max_size: int) -> str:
     """Handle the ``view`` command: render a file with line numbers or list a directory."""
-    _validate_path(file_path)
-
     exists, is_dir = await _probe_sandbox_path(sandbox, file_path)
     if not exists:
         raise ValueError(f"The path {file_path} does not exist. Please provide a valid path.")
@@ -355,34 +570,82 @@ async def _handle_view(sandbox: Sandbox, file_path: str, view_range: list[int] |
             raise ValueError("The `view_range` parameter is not allowed when `path` points to a directory.")
         return await _list_directory(sandbox, file_path)
 
-    file_content = await sandbox.read_text(file_path)
-    _assert_within_size_limit(file_content)
+    file_content = await _read_text_or_reject_binary(sandbox, file_path, max_size)
 
     content, init_line = _apply_view_range(file_content, view_range)
     return _make_output(content, file_path, init_line)
 
 
-async def _handle_create(sandbox: Sandbox, file_path: str, file_text: str | None) -> str:
+def _reject_oversize_replacement(text: str | None, max_size: int, label: str = "new_str") -> None:
+    """Reject a replacement payload whose UTF-8 encoding would exceed ``max_size``.
+
+    The read side already refuses to load files above the cap; this mirrors it
+    on the write side so a model can't ship an unbounded ``file_text`` or
+    ``new_str`` through the tool.
+    """
+    if text is None:
+        return
+    encoded = len(text.encode("utf-8"))
+    if encoded > max_size:
+        raise ValueError(f"{label} ({encoded} bytes) exceeds maximum allowed size ({max_size} bytes)")
+
+
+def _reject_oversize_result(content: str, max_size: int, file_path: str) -> None:
+    """Reject a post-edit buffer whose UTF-8 length would exceed ``max_size``.
+
+    Catches the case where the individual ``new_str`` fits but the resulting
+    file (after all substitutions) is larger than the read cap — a
+    ``replace_all`` that expands every match, for instance.
+    """
+    encoded = len(content.encode("utf-8"))
+    if encoded > max_size:
+        raise ValueError(
+            f"The edit would produce a {encoded}-byte file at {file_path}, "
+            f"exceeding the maximum allowed size of {max_size} bytes."
+        )
+
+
+async def _handle_create(
+    sandbox: Sandbox,
+    file_path: str,
+    file_text: str | None,
+    undo_history: OrderedDict[str, str],
+    max_size: int,
+) -> str:
     """Handle the ``create`` command: write a new file, refusing to overwrite."""
     if file_text is None:
         raise ValueError("Parameter `file_text` is required for command: create")
-
-    _validate_path(file_path)
+    _reject_oversize_replacement(file_text, max_size, label="file_text")
 
     exists, _ = await _probe_sandbox_path(sandbox, file_path)
     if exists:
         raise ValueError(f"File already exists at: {file_path}. Cannot overwrite files using command `create`.")
 
     await sandbox.write_text(file_path, file_text)
+    # ``create`` is intentionally not snapshotted for undo: rolling back a
+    # create means deleting the file, which is a different operation from
+    # "restore prior content" and is easy for the caller to do themselves.
+    undo_history.pop(file_path, None)
     return f"File created successfully at: {file_path}"
 
 
-async def _handle_str_replace(sandbox: Sandbox, file_path: str, old_str: str | None, new_str: str | None) -> str:
-    """Handle the ``str_replace`` command: replace a unique occurrence of ``old_str``."""
+async def _handle_str_replace(
+    sandbox: Sandbox,
+    file_path: str,
+    old_str: str | None,
+    new_str: str | None,
+    replace_all: bool,
+    max_size: int,
+    undo_history: OrderedDict[str, str],
+    max_undo_entries: int,
+    max_undo_bytes: int,
+) -> str:
+    """Handle the ``str_replace`` command: replace ``old_str`` (unique unless ``replace_all``)."""
     if old_str is None:
         raise ValueError("Parameter `old_str` is required for command: str_replace")
-
-    _validate_path(file_path)
+    if old_str == "":
+        raise ValueError("Parameter `old_str` must not be empty for command: str_replace")
+    _reject_oversize_replacement(new_str, max_size)
 
     exists, is_dir = await _probe_sandbox_path(sandbox, file_path)
     if not exists:
@@ -390,26 +653,38 @@ async def _handle_str_replace(sandbox: Sandbox, file_path: str, old_str: str | N
     if is_dir:
         raise ValueError(f"The path {file_path} is a directory and only the `view` command can be used on directories")
 
-    file_content = await sandbox.read_text(file_path)
-    _assert_within_size_limit(file_content)
+    file_content = await _read_text_or_reject_binary(sandbox, file_path, max_size)
 
-    new_content, snippet, start_line = _build_str_replace_result(file_content, old_str, new_str, file_path)
+    new_content, snippet, start_line, count = _build_str_replace_result(
+        file_content, old_str, new_str, file_path, replace_all
+    )
 
+    _reject_oversize_result(new_content, max_size, file_path)
+    _store_undo_snapshot(undo_history, file_path, file_content, max_undo_entries, max_undo_bytes)
     await sandbox.write_text(file_path, new_content)
 
+    suffix = f" ({count} occurrences replaced)" if replace_all and count > 1 else ""
     return (
-        f"The file {file_path} has been edited. "
+        f"The file {file_path} has been edited.{suffix} "
         f"{_make_output(snippet, f'a snippet of {file_path}', start_line + 1)}"
         "Review the changes and make sure they are as expected. Edit the file again if necessary."
     )
 
 
-async def _handle_insert(sandbox: Sandbox, file_path: str, insert_line: int | None, new_str: str | None) -> str:
+async def _handle_insert(
+    sandbox: Sandbox,
+    file_path: str,
+    insert_line: int | None,
+    new_str: str | None,
+    max_size: int,
+    undo_history: OrderedDict[str, str],
+    max_undo_entries: int,
+    max_undo_bytes: int,
+) -> str:
     """Handle the ``insert`` command: insert text at a 0-indexed line."""
     if insert_line is None or new_str is None:
         raise ValueError("Parameters `insert_line` and `new_str` are required for command: insert")
-
-    _validate_path(file_path)
+    _reject_oversize_replacement(new_str, max_size)
 
     exists, is_dir = await _probe_sandbox_path(sandbox, file_path)
     if not exists:
@@ -417,11 +692,12 @@ async def _handle_insert(sandbox: Sandbox, file_path: str, insert_line: int | No
     if is_dir:
         raise ValueError(f"The path {file_path} is a directory and only the `view` command can be used on directories")
 
-    file_text = await sandbox.read_text(file_path)
-    _assert_within_size_limit(file_text)
+    file_text = await _read_text_or_reject_binary(sandbox, file_path, max_size)
 
     new_content, snippet, start_line = _build_insert_result(file_text, insert_line, new_str)
 
+    _reject_oversize_result(new_content, max_size, file_path)
+    _store_undo_snapshot(undo_history, file_path, file_text, max_undo_entries, max_undo_bytes)
     await sandbox.write_text(file_path, new_content)
 
     return (
@@ -430,3 +706,165 @@ async def _handle_insert(sandbox: Sandbox, file_path: str, insert_line: int | No
         "Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). "
         "Edit the file again if necessary."
     )
+
+
+async def _handle_pattern_replace(
+    sandbox: Sandbox,
+    file_path: str,
+    pattern: str | None,
+    new_str: str | None,
+    replace_all: bool,
+    max_size: int,
+    undo_history: OrderedDict[str, str],
+    max_undo_entries: int,
+    max_undo_bytes: int,
+    timeout_sec: float,
+) -> str:
+    r"""Handle the ``pattern_replace`` command: regex-based replacement.
+
+    Uses Python ``re`` semantics for both pattern and replacement (backreferences
+    like ``\1`` in ``new_str`` are honored — this is the deliberate difference
+    from ``str_replace``, whose replacement is literal). Requires ``replace_all``
+    for more than one match, same as ``str_replace``.
+
+    The pattern length is capped, match count is capped, and the whole
+    match/substitution runs in a worker thread with a wall-clock timeout so a
+    catastrophic regex (``(a+)+b`` and friends) cannot hang the event loop.
+
+    Known limit: on timeout, ``asyncio.wait_for`` returns to the caller but the
+    underlying worker thread continues running the runaway regex (Python
+    threads cannot be cancelled). Concurrent catastrophic patterns will pin CPU
+    on the shared default thread pool until they complete.
+
+    Cross-SDK divergence: the TypeScript SDK cannot replicate this timeout — V8
+    has no in-exec regex timeout and JavaScript has no way to cancel a running
+    ``.exec()`` call. Instead it statically rejects the classic ReDoS shapes
+    (``(a+)+``, ``(a*)*``, ...) before compiling. A pattern accepted here under
+    ``pattern_replace_timeout`` may be refused by the TypeScript side.
+    """
+    if pattern is None:
+        raise ValueError("Parameter `pattern` is required for command: pattern_replace")
+    if pattern == "":
+        raise ValueError("Parameter `pattern` must not be empty for command: pattern_replace")
+    if new_str is None:
+        raise ValueError("Parameter `new_str` is required for command: pattern_replace")
+    _reject_oversize_replacement(new_str, max_size)
+    if len(pattern) > _MAX_PATTERN_LENGTH:
+        raise ValueError(f"Pattern is {len(pattern)} chars, exceeds maximum of {_MAX_PATTERN_LENGTH}.")
+
+    try:
+        regex = re.compile(pattern)
+    except re.error as e:
+        raise ValueError(f"Invalid regex pattern `{pattern}`: {e}") from e
+
+    exists, is_dir = await _probe_sandbox_path(sandbox, file_path)
+    if not exists:
+        raise ValueError(f"The path {file_path} does not exist. Please provide a valid path.")
+    if is_dir:
+        raise ValueError(f"The path {file_path} is a directory and only the `view` command can be used on directories")
+
+    file_content = await _read_text_or_reject_binary(sandbox, file_path, max_size)
+
+    def _run_regex() -> tuple[list[re.Match[str]], str, int]:
+        # Iterate rather than list(finditer) so a runaway match count can be
+        # aborted early. The substitution reuses the counted matches.
+        collected: list[re.Match[str]] = []
+        for m in regex.finditer(file_content):
+            collected.append(m)
+            if len(collected) > _MAX_PATTERN_MATCHES:
+                raise ValueError(
+                    f"Pattern `{pattern}` produced more than {_MAX_PATTERN_MATCHES} matches; refusing to continue."
+                )
+        if not collected:
+            return collected, file_content, 0
+        substituted = regex.sub(new_str, file_content, count=0 if replace_all else 1)
+        replaced = len(collected) if replace_all else 1
+        return collected, substituted, replaced
+
+    try:
+        matches, new_content, count = await asyncio.wait_for(asyncio.to_thread(_run_regex), timeout=timeout_sec)
+    except asyncio.TimeoutError as e:
+        raise ValueError(
+            f"Pattern `{pattern}` timed out after {timeout_sec}s; refusing to continue (possible catastrophic regex)."
+        ) from e
+    except re.error as e:
+        # `regex.sub` raises `re.error` at substitution time when `new_str`
+        # references a group that does not exist (e.g. `\9`) or contains
+        # malformed group syntax. Surface it as the same clean `ValueError` the
+        # compile step (above) uses for bad patterns.
+        raise ValueError(f"Invalid replacement `{new_str}` for pattern `{pattern}`: {e}") from e
+
+    if not matches:
+        raise ValueError(f"No replacement was performed, pattern `{pattern}` did not match in {file_path}.")
+    if len(matches) > 1 and not replace_all:
+        line_numbers = [file_content.count("\n", 0, m.start()) + 1 for m in matches]
+        raise ValueError(
+            f"No replacement was performed. Pattern `{pattern}` matched {len(matches)} times "
+            f"(lines {line_numbers}). Pass replace_all=True to replace every occurrence, or tighten the pattern."
+        )
+
+    _reject_oversize_result(new_content, max_size, file_path)
+    _store_undo_snapshot(undo_history, file_path, file_content, max_undo_entries, max_undo_bytes)
+    await sandbox.write_text(file_path, new_content)
+
+    replacement_line = file_content.count("\n", 0, matches[0].start())
+    new_lines = new_content.split("\n")
+    start = max(0, replacement_line - _SNIPPET_LINES)
+    end = min(len(new_lines), replacement_line + _SNIPPET_LINES + 1)
+    snippet = "\n".join(new_lines[start:end])
+
+    suffix = f" ({count} matches replaced)" if replace_all and count > 1 else ""
+    return (
+        f"The file {file_path} has been edited via pattern_replace.{suffix} "
+        f"{_make_output(snippet, f'a snippet of {file_path}', start + 1)}"
+        "Review the changes and make sure they are as expected. Edit the file again if necessary."
+    )
+
+
+async def _handle_find_line(
+    sandbox: Sandbox,
+    file_path: str,
+    search_text: str | None,
+    fuzzy: bool,
+    max_size: int,
+) -> str:
+    """Handle the ``find_line`` command: return the 1-indexed line and a context snippet."""
+    if search_text is None:
+        raise ValueError("Parameter `search_text` is required for command: find_line")
+
+    exists, is_dir = await _probe_sandbox_path(sandbox, file_path)
+    if not exists:
+        raise ValueError(f"The path {file_path} does not exist. Please provide a valid path.")
+    if is_dir:
+        raise ValueError(f"The path {file_path} is a directory and only the `view` command can be used on directories")
+
+    file_content = await _read_text_or_reject_binary(sandbox, file_path, max_size)
+
+    line_index = _find_line_number(file_content, search_text, fuzzy)
+    if line_index == -1:
+        raise ValueError(f"Could not find `{search_text}` in {file_path}.")
+
+    lines = file_content.split("\n")
+    start = max(0, line_index - _SNIPPET_LINES)
+    end = min(len(lines), line_index + _SNIPPET_LINES + 1)
+    snippet = "\n".join(lines[start:end])
+    return (
+        f"Found `{search_text}` at line {line_index + 1} of {file_path}.\n"
+        f"{_make_output(snippet, f'a snippet of {file_path}', start + 1)}"
+    )
+
+
+async def _handle_undo(sandbox: Sandbox, file_path: str, undo_history: OrderedDict[str, str]) -> str:
+    """Handle the ``undo_edit`` command: restore the last in-memory snapshot for ``file_path``.
+
+    The snapshot is unconditionally written back through the sandbox: if the
+    file was deleted (or moved) outside the tool since the snapshot was
+    captured, ``undo_edit`` will re-create it at that path. Undo tracks
+    content-per-path, not the file's presence.
+    """
+    if file_path not in undo_history:
+        raise ValueError(f"No undo history available for {file_path} in this session.")
+
+    previous_content = undo_history.pop(file_path)
+    await sandbox.write_text(file_path, previous_content)
+    return f"Reverted {file_path} to its previous in-memory snapshot."

--- a/strands-py/tests/strands/vended_tools/test_file_editor.py
+++ b/strands-py/tests/strands/vended_tools/test_file_editor.py
@@ -365,13 +365,25 @@ class TestInsert:
 
 
 class TestFileSizeLimit:
-    """The 1MB content size guard."""
+    """The configurable content size guard."""
 
     @pytest.mark.asyncio
-    async def test_view_exceeds_size_limit_raises(self, editor, ctx, tmp_path):
-        file_path = _write(tmp_path / "large.txt", "x" * 1048577)  # 1MB + 1 byte
+    async def test_view_exceeds_size_limit_raises(self, ctx, tmp_path):
+        # Use a low custom cap so the test doesn't need to allocate the default cap.
+        small_editor = make_file_editor(sandbox=NotASandboxLocalEnvironment(), max_file_size=1024)
+        file_path = _write(tmp_path / "large.txt", "x" * 2048)
         with pytest.raises(ValueError, match="exceeds"):
-            await editor(command="view", path=file_path, tool_context=ctx)
+            await small_editor(command="view", path=file_path, tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_default_cap_is_one_megabyte(self, editor, ctx, tmp_path):
+        # Default cap is 1 MB. A file just under it is accepted; a 2 MB file is rejected.
+        under = _write(tmp_path / "under.txt", "x" * (1 * 1024 * 1024 - 1))
+        result = await editor(command="view", path=under, tool_context=ctx)
+        assert "cat -n" in result
+        over = _write(tmp_path / "over.txt", "x" * (2 * 1024 * 1024))
+        with pytest.raises(ValueError, match="exceeds"):
+            await editor(command="view", path=over, tool_context=ctx)
 
 
 class TestEdgeCases:
@@ -438,3 +450,450 @@ class TestToolMetadata:
         assert "command" in props
         assert "path" in props
         assert "tool_context" not in props
+
+    def test_input_schema_advertises_new_commands(self):
+        # The literal-enum values must include the newly reconciled commands so
+        # models see them in the tool schema.
+        command_enum = file_editor.tool_spec["inputSchema"]["json"]["properties"]["command"]["enum"]
+        assert set(command_enum) == {
+            "view",
+            "create",
+            "str_replace",
+            "insert",
+            "pattern_replace",
+            "find_line",
+            "undo_edit",
+        }
+
+
+class TestConfinementRoot:
+    """When a ``root`` is configured, all paths must resolve inside it."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_absolute_path_outside_root(self, ctx, tmp_path):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        outside = tmp_path / "outside.txt"
+        _write(outside, "secret")
+        confined = make_file_editor(sandbox=NotASandboxLocalEnvironment(), root=str(root))
+        with pytest.raises(ValueError, match="outside the configured root"):
+            await confined(command="view", path=str(outside), tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_traversal_even_with_root(self, ctx, tmp_path):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        confined = make_file_editor(sandbox=NotASandboxLocalEnvironment(), root=str(root))
+        with pytest.raises(ValueError, match="path traversal"):
+            await confined(command="view", path=f"{root}/../outside.txt", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_sibling_that_shares_prefix(self, ctx, tmp_path):
+        root = tmp_path / "ws"
+        root.mkdir()
+        sibling = tmp_path / "ws-neighbor"
+        sibling.mkdir()
+        _write(sibling / "file.txt", "content")
+        confined = make_file_editor(sandbox=NotASandboxLocalEnvironment(), root=str(root))
+        with pytest.raises(ValueError, match="outside the configured root"):
+            await confined(command="view", path=str(sibling / "file.txt"), tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_allows_path_inside_root(self, ctx, tmp_path):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        target = _write(root / "ok.txt", "hello")
+        confined = make_file_editor(sandbox=NotASandboxLocalEnvironment(), root=str(root))
+        result = await confined(command="view", path=target, tool_context=ctx)
+        assert "hello" in result
+
+    def test_rejects_relative_root_at_construction(self):
+        with pytest.raises(ValueError, match="absolute path"):
+            make_file_editor(root="relative/root")
+
+    @pytest.mark.asyncio
+    async def test_symlink_pointing_outside_root_is_rejected(self, ctx, tmp_path):
+        # A symlink inside root that resolves to a file outside root must not
+        # slip past the string-level confinement check.
+        root = tmp_path / "workspace"
+        root.mkdir()
+        secret = tmp_path / "secret.txt"
+        _write(secret, "top secret")
+        link = root / "escape.txt"
+        link.symlink_to(secret)
+        confined = make_file_editor(sandbox=NotASandboxLocalEnvironment(), root=str(root))
+        with pytest.raises(ValueError, match="symlink|outside"):
+            await confined(command="view", path=str(link), tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_symlink_pointing_inside_root_is_allowed(self, ctx, tmp_path):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        target = _write(root / "real.txt", "inside content")
+        link = root / "alias.txt"
+        link.symlink_to(target)
+        confined = make_file_editor(sandbox=NotASandboxLocalEnvironment(), root=str(root))
+        result = await confined(command="view", path=str(link), tool_context=ctx)
+        assert "inside content" in result
+
+
+class TestWriteSizeCaps:
+    """The write side must also reject payloads above the configured cap."""
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_oversize_file_text(self, ctx, tmp_path):
+        e = make_file_editor(sandbox=NotASandboxLocalEnvironment(), max_file_size=1024)
+        with pytest.raises(ValueError, match="exceeds maximum allowed size"):
+            await e(
+                command="create",
+                path=str(tmp_path / "big.txt"),
+                tool_context=ctx,
+                file_text="x" * 2048,
+            )
+
+    @pytest.mark.asyncio
+    async def test_str_replace_rejects_oversize_new_str(self, ctx, tmp_path):
+        e = make_file_editor(sandbox=NotASandboxLocalEnvironment(), max_file_size=1024)
+        file_path = _write(tmp_path / "s.txt", "small")
+        with pytest.raises(ValueError, match="exceeds maximum allowed size"):
+            await e(
+                command="str_replace",
+                path=file_path,
+                tool_context=ctx,
+                old_str="small",
+                new_str="y" * 2048,
+            )
+
+
+class TestNonLocalRoot:
+    """A ``root`` that does not exist on the local host (e.g. Docker sandbox) must not
+    fail every op via ``realpath``. The realpath layer must be skipped; the string-
+    level confinement still applies."""
+
+    @pytest.mark.asyncio
+    async def test_confines_container_side_root(self, ctx):
+        # A container-side path with no local counterpart. The tool should
+        # accept an in-root path (and fail later at the sandbox with a
+        # not-found), and reject an out-of-root path at the string level.
+        container_root = "/workspace-in-container-does-not-exist-locally"
+        e = make_file_editor(sandbox=NotASandboxLocalEnvironment(), root=container_root)
+        with pytest.raises(ValueError, match="does not exist"):
+            await e(command="view", path=f"{container_root}/foo.txt", tool_context=ctx)
+        with pytest.raises(ValueError, match="outside the configured root"):
+            await e(command="view", path="/etc/passwd", tool_context=ctx)
+
+
+class TestPatternReplaceReDoSGuards:
+    """``pattern_replace`` must bound pattern length, match count, and wall-clock time."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_overlong_pattern(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "content")
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            await editor(
+                command="pattern_replace",
+                path=file_path,
+                tool_context=ctx,
+                pattern="a" * 1001,
+                new_str="x",
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_catastrophic_regex_via_timeout(self, ctx, tmp_path):
+        # (a+)+b against an all-a input is the canonical catastrophic
+        # backtracking example. Use a small input plus a short timeout so the
+        # test exercises the timeout path in ~0.1s instead of stalling pytest.
+        e = make_file_editor(sandbox=NotASandboxLocalEnvironment(), pattern_replace_timeout=0.05)
+        file_path = _write(tmp_path / "evil.txt", "a" * 24)
+        with pytest.raises(ValueError, match="timed out|catastrophic"):
+            await e(
+                command="pattern_replace",
+                path=file_path,
+                tool_context=ctx,
+                pattern=r"(a+)+b",
+                new_str="x",
+            )
+
+
+class TestUndoLRUEviction:
+    """The undo history is a bounded LRU: it must evict on overflow."""
+
+    @pytest.mark.asyncio
+    async def test_evicts_oldest_entry_past_entry_cap(self, ctx, tmp_path):
+        # Two-entry cap; three edits must evict the oldest.
+        e = make_file_editor(sandbox=NotASandboxLocalEnvironment(), max_undo_entries=2)
+        paths = [_write(tmp_path / f"f{i}.txt", f"orig{i}") for i in range(3)]
+        for i, p in enumerate(paths):
+            await e(command="str_replace", path=p, tool_context=ctx, old_str=f"orig{i}", new_str=f"new{i}")
+        # Oldest snapshot (f0) has been evicted.
+        with pytest.raises(ValueError, match="No undo history"):
+            await e(command="undo_edit", path=paths[0], tool_context=ctx)
+        # Two most recent still restore.
+        await e(command="undo_edit", path=paths[1], tool_context=ctx)
+        assert (tmp_path / "f1.txt").read_text() == "orig1"
+
+    @pytest.mark.asyncio
+    async def test_evicts_past_byte_cap(self, ctx, tmp_path):
+        # Byte cap of ~10 bytes; each snapshot is larger, so only one fits.
+        e = make_file_editor(sandbox=NotASandboxLocalEnvironment(), max_undo_bytes=10)
+        p1 = _write(tmp_path / "big1.txt", "x" * 100)
+        p2 = _write(tmp_path / "big2.txt", "y" * 100)
+        await e(command="str_replace", path=p1, tool_context=ctx, old_str="x", new_str="X", replace_all=True)
+        await e(command="str_replace", path=p2, tool_context=ctx, old_str="y", new_str="Y", replace_all=True)
+        with pytest.raises(ValueError, match="No undo history"):
+            await e(command="undo_edit", path=p1, tool_context=ctx)
+
+
+class TestBinaryRejection:
+    """Binary files must be rejected on view/edit rather than silently mangled."""
+
+    @pytest.mark.asyncio
+    async def test_view_rejects_binary_file(self, editor, ctx, tmp_path):
+        file_path = tmp_path / "binary.bin"
+        file_path.write_bytes(b"\x00\x01\x02BINARY\x00DATA")
+        with pytest.raises(ValueError, match="binary"):
+            await editor(command="view", path=str(file_path), tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_str_replace_rejects_binary_file(self, editor, ctx, tmp_path):
+        file_path = tmp_path / "binary.bin"
+        file_path.write_bytes(b"HEAD\x00TAIL")
+        with pytest.raises(ValueError, match="binary"):
+            await editor(command="str_replace", path=str(file_path), tool_context=ctx, old_str="HEAD", new_str="X")
+
+    @pytest.mark.asyncio
+    async def test_utf16_le_bom_rejected_as_unsupported_encoding(self, editor, ctx, tmp_path):
+        # UTF-16 text is a valid, decodable format but not UTF-8. Report it as
+        # an unsupported encoding rather than misclassifying as binary.
+        file_path = tmp_path / "utf16.txt"
+        file_path.write_bytes(b"\xff\xfe" + "hello world".encode("utf-16-le"))
+        with pytest.raises(ValueError, match="UTF-16"):
+            await editor(command="view", path=str(file_path), tool_context=ctx)
+
+
+class TestStrReplaceReplaceAll:
+    """``str_replace`` must refuse ambiguous matches without ``replace_all``."""
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_without_opt_in_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "DUP\nfoo\nDUP\nbar\nDUP\n")
+        with pytest.raises(ValueError, match="replace_all"):
+            await editor(command="str_replace", path=file_path, tool_context=ctx, old_str="DUP", new_str="X")
+
+    @pytest.mark.asyncio
+    async def test_replace_all_opt_in_replaces_every_occurrence(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "DUP\nfoo\nDUP\nbar\nDUP\n")
+        result = await editor(
+            command="str_replace",
+            path=file_path,
+            tool_context=ctx,
+            old_str="DUP",
+            new_str="X",
+            replace_all=True,
+        )
+        assert "3 occurrences replaced" in result
+        assert (tmp_path / "test.txt").read_text() == "X\nfoo\nX\nbar\nX\n"
+
+
+class TestPatternReplace:
+    """The ``pattern_replace`` regex command."""
+
+    @pytest.mark.asyncio
+    async def test_unique_match(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "hello world\ngoodbye")
+        await editor(
+            command="pattern_replace",
+            path=file_path,
+            tool_context=ctx,
+            pattern=r"hello (\w+)",
+            new_str=r"HI \1",
+        )
+        assert (tmp_path / "test.txt").read_text() == "HI world\ngoodbye"
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_without_replace_all_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "foo\nfoo\nfoo\n")
+        with pytest.raises(ValueError, match="replace_all"):
+            await editor(command="pattern_replace", path=file_path, tool_context=ctx, pattern="foo", new_str="bar")
+
+    @pytest.mark.asyncio
+    async def test_replace_all_opt_in(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "foo\nfoo\nfoo\n")
+        await editor(
+            command="pattern_replace",
+            path=file_path,
+            tool_context=ctx,
+            pattern="foo",
+            new_str="bar",
+            replace_all=True,
+        )
+        assert (tmp_path / "test.txt").read_text() == "bar\nbar\nbar\n"
+
+    @pytest.mark.asyncio
+    async def test_invalid_pattern_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "content")
+        with pytest.raises(ValueError, match="Invalid regex"):
+            await editor(command="pattern_replace", path=file_path, tool_context=ctx, pattern="[unclosed", new_str="x")
+
+    @pytest.mark.asyncio
+    async def test_no_match_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "content")
+        with pytest.raises(ValueError, match="did not match"):
+            await editor(command="pattern_replace", path=file_path, tool_context=ctx, pattern="MISSING", new_str="x")
+
+
+class TestFindLine:
+    """The ``find_line`` command."""
+
+    @pytest.mark.asyncio
+    async def test_finds_first_occurrence(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "alpha\nbeta\ngamma\nbeta again\n")
+        result = await editor(command="find_line", path=file_path, tool_context=ctx, search_text="beta")
+        assert "line 2" in result
+        assert "gamma" in result  # context snippet
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "alpha\n")
+        with pytest.raises(ValueError, match="Could not find"):
+            await editor(command="find_line", path=file_path, tool_context=ctx, search_text="MISSING")
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_matches_across_whitespace(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "def   my_function ( ):\n    pass\n")
+        result = await editor(
+            command="find_line", path=file_path, tool_context=ctx, search_text="def my_function", fuzzy=True
+        )
+        assert "line 1" in result
+
+
+class TestUndo:
+    """In-memory, per-tool-instance ``undo_edit``."""
+
+    @pytest.mark.asyncio
+    async def test_undo_str_replace(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "hello\n")
+        await editor(command="str_replace", path=file_path, tool_context=ctx, old_str="hello", new_str="goodbye")
+        assert (tmp_path / "test.txt").read_text() == "goodbye\n"
+        await editor(command="undo_edit", path=file_path, tool_context=ctx)
+        assert (tmp_path / "test.txt").read_text() == "hello\n"
+
+    @pytest.mark.asyncio
+    async def test_undo_insert(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "one\ntwo\n")
+        await editor(command="insert", path=file_path, tool_context=ctx, insert_line=1, new_str="between")
+        await editor(command="undo_edit", path=file_path, tool_context=ctx)
+        assert (tmp_path / "test.txt").read_text() == "one\ntwo\n"
+
+    @pytest.mark.asyncio
+    async def test_undo_pattern_replace(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "a\nb\nc\n")
+        await editor(command="pattern_replace", path=file_path, tool_context=ctx, pattern="a", new_str="A")
+        await editor(command="undo_edit", path=file_path, tool_context=ctx)
+        assert (tmp_path / "test.txt").read_text() == "a\nb\nc\n"
+
+    @pytest.mark.asyncio
+    async def test_undo_without_history_raises(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "content\n")
+        with pytest.raises(ValueError, match="No undo history"):
+            await editor(command="undo_edit", path=file_path, tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_undo_is_scoped_to_tool_instance(self, ctx, tmp_path):
+        # Two independent tool instances share no history.
+        file_path = _write(tmp_path / "test.txt", "original\n")
+        editor_a = make_file_editor(sandbox=NotASandboxLocalEnvironment())
+        editor_b = make_file_editor(sandbox=NotASandboxLocalEnvironment())
+        await editor_a(command="str_replace", path=file_path, tool_context=ctx, old_str="original", new_str="changed")
+        with pytest.raises(ValueError, match="No undo history"):
+            await editor_b(command="undo_edit", path=file_path, tool_context=ctx)
+
+
+class TestEmptyInputRejection:
+    """Empty ``old_str`` / ``pattern`` inputs produce confusing behavior and are rejected."""
+
+    @pytest.mark.asyncio
+    async def test_str_replace_empty_old_str_raises(self, editor, ctx, tmp_path):
+        # `"".count("")` returns `len + 1`; without an explicit guard the caller
+        # would see a confusing "multiple occurrences" error or, with
+        # replace_all, `new_str` inserted between every character.
+        file_path = _write(tmp_path / "test.txt", "hello\n")
+        with pytest.raises(ValueError, match="empty"):
+            await editor(command="str_replace", path=file_path, tool_context=ctx, old_str="", new_str="X")
+
+    @pytest.mark.asyncio
+    async def test_pattern_replace_empty_pattern_raises(self, editor, ctx, tmp_path):
+        # An empty pattern compiles to a zero-width regex that matches at every
+        # position — surprising, and almost certainly a caller error.
+        file_path = _write(tmp_path / "test.txt", "hello\n")
+        with pytest.raises(ValueError, match="empty"):
+            await editor(command="pattern_replace", path=file_path, tool_context=ctx, pattern="", new_str="x")
+
+
+class TestPatternReplaceBadBackreference:
+    """Bad ``new_str`` backreferences must surface as a clean ``ValueError``."""
+
+    @pytest.mark.asyncio
+    async def test_missing_group_backreference_raises_valueerror(self, editor, ctx, tmp_path):
+        # `re.sub` raises `re.error` at substitution time when new_str references
+        # a group that doesn't exist. The worker-thread wrapper must convert
+        # this into a caller-friendly ValueError rather than leaking as an
+        # internal exception.
+        file_path = _write(tmp_path / "test.txt", "hello world\n")
+        with pytest.raises(ValueError, match="Invalid replacement"):
+            await editor(
+                command="pattern_replace",
+                path=file_path,
+                tool_context=ctx,
+                pattern=r"hello",
+                new_str=r"\9",
+            )
+
+
+class TestOversizePostEdit:
+    """An edit whose *result* is larger than ``max_file_size`` is rejected before write."""
+
+    @pytest.mark.asyncio
+    async def test_str_replace_expansion_past_cap_rejected(self, ctx, tmp_path):
+        # Cap is 32 bytes. Original is 20 bytes. `replace_all` on "x" -> "XXX"
+        # produces 60 bytes, past the cap.
+        e = make_file_editor(sandbox=NotASandboxLocalEnvironment(), max_file_size=32)
+        file_path = _write(tmp_path / "grow.txt", "x" * 20)
+        with pytest.raises(ValueError, match="exceeding the maximum"):
+            await e(
+                command="str_replace",
+                path=file_path,
+                tool_context=ctx,
+                old_str="x",
+                new_str="XXX",
+                replace_all=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_insert_expansion_past_cap_rejected(self, ctx, tmp_path):
+        # Original is 30 bytes. `new_str` is 10 bytes. The result would be 41
+        # bytes ("\n" adds one on insert into non-empty content), past the cap.
+        e = make_file_editor(sandbox=NotASandboxLocalEnvironment(), max_file_size=32)
+        file_path = _write(tmp_path / "grow.txt", "x" * 30)
+        with pytest.raises(ValueError, match="exceeding the maximum"):
+            await e(
+                command="insert",
+                path=file_path,
+                tool_context=ctx,
+                insert_line=0,
+                new_str="y" * 10,
+            )
+
+    @pytest.mark.asyncio
+    async def test_pattern_replace_expansion_past_cap_rejected(self, ctx, tmp_path):
+        e = make_file_editor(sandbox=NotASandboxLocalEnvironment(), max_file_size=32)
+        file_path = _write(tmp_path / "grow.txt", "x" * 20)
+        with pytest.raises(ValueError, match="exceeding the maximum"):
+            await e(
+                command="pattern_replace",
+                path=file_path,
+                tool_context=ctx,
+                pattern="x",
+                new_str="XXX",
+                replace_all=True,
+            )

--- a/strands-ts/src/vended-tools/file-editor/README.md
+++ b/strands-ts/src/vended-tools/file-editor/README.md
@@ -1,26 +1,10 @@
 # File Editor Tool
 
-A filesystem editor tool for viewing, creating, and editing files programmatically. Provides string replacement, line insertion, and directory viewing with security validation.
+A filesystem editor for viewing, creating, and editing files. All I/O routes through the agent's configured `Sandbox`, so isolation is a property of the sandbox rather than the tool.
 
-## ⚠️ Security Warning
+The tool exposes seven commands: `view` (file contents with line numbers, or a two-level directory listing), `create` (refuses to overwrite), `str_replace` (exact-match; ambiguous matches require `replace_all: true`), `insert` (0-indexed line insertion), `pattern_replace` (regex; `new_str` honours `$&` / `$1` backreferences), `find_line` (first-occurrence line lookup with optional whitespace-tolerant `fuzzy` matching), and `undo_edit` (single-step, in-memory revert of the most recent edit for a path). Paths must be absolute and free of `..` segments. Binary files and files above the size cap are rejected with a clean error. `pattern_replace` bounds the pattern length, the match count, and rejects the classic `(...+)+` catastrophic-backtracking shape before compilation.
 
-**This tool reads and writes files at arbitrary absolute paths without sandboxing or workspace restrictions.**
-
-- Only use with trusted input
-- File operations execute with the full permissions of the Node.js process
-- For production deployments, consider running in a sandboxed environment (containers, VMs, etc.)
-- Never expose this tool to untrusted users or untrusted prompt input without additional security measures
-
-## Features
-
-- **View files** with line numbers and optional line range support
-- **Create files** with initial content
-- **String-based find and replace** with uniqueness validation
-- **Line-based text insertion** at any position
-- **Directory viewing** up to 2 levels deep (configurable)
-- **Configurable file size limits** (default 1MB)
-
-## Installation
+## Usage
 
 ```typescript
 import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
@@ -34,73 +18,18 @@ const agent = new Agent({
 await agent.invoke('Create a file /tmp/notes.txt with "# My Notes"')
 ```
 
-## Commands
+## Customization
 
-### `view`
+`makeFileEditor` accepts:
 
-View file contents with line numbers or list directory contents (up to 2 levels deep).
-
-**Parameters:**
-
-- `path` (string, required): Absolute path to file or directory
-- `view_range` (optional): `[start_line, end_line]` (1-indexed, end can be -1 for EOF)
-
-### `create`
-
-Create a new file with content. Creates parent directories if needed.
-
-**Parameters:**
-
-- `path` (string, required): Absolute path for new file
-- `file_text` (string, required): Initial content
-
-### `str_replace`
-
-Replace an exact string match in a file. The string must appear exactly once.
-
-**Parameters:**
-
-- `path` (string, required): Absolute path to file
-- `old_str` (string, required): Exact string to find
-- `new_str` (string, optional): Replacement string
-
-### `insert`
-
-Insert text at a specific line number (0-indexed).
-
-**Parameters:**
-
-- `path` (string, required): Absolute path to file
-- `insert_line` (number, required): Line number for insertion (0 = beginning)
-- `new_str` (string, required): Text to insert
-
-## Example Usage
+- `root` (string, optional): confines every operation to an absolute directory. Applies both a string-level check and, when the local filesystem sees the target, a `realpath`-based symlink check.
+- `maxFileSize` (number, optional): byte cap on files that can be read or written. Defaults to 1 MB.
+- `maxUndoEntries` (number, optional): maximum distinct paths retained in the in-memory undo history. Defaults to 32.
+- `maxUndoBytes` (number, optional): approximate byte cap on the undo history. Defaults to 32 MB.
+- `name`, `description`: override the tool's registered name and description.
 
 ```typescript
-import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
-import { Agent, BedrockModel } from '@strands-agents/sdk'
+import { makeFileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 
-const agent = new Agent({
-  model: new BedrockModel({ region: 'us-east-1' }),
-  tools: [fileEditor],
-})
-
-// Agent can use natural language
-await agent.invoke('Create /tmp/config.json with {"debug": false}')
-await agent.invoke('Replace "debug": false with "debug": true in /tmp/config.json')
-await agent.invoke('View lines 1-20 of /tmp/config.json')
+const editor = makeFileEditor({ root: '/workspace', maxFileSize: 5 * 1024 * 1024 })
 ```
-
-## Security
-
-- Requires absolute paths (must start with `/`)
-- Blocks directory traversal attempts (`..`)
-- File size limits (default 1MB)
-- Clear error messages
-
-## Limitations
-
-- Node.js only (uses filesystem APIs)
-- Text files only (UTF-8 encoded)
-- Exact string matching (no regex)
-- History is session-scoped

--- a/strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
+++ b/strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { fileEditor } from '../file-editor.js'
+import { fileEditor, makeFileEditor } from '../file-editor.js'
 import type { ToolContext } from '../../../index.js'
 import { StateStore } from '../../../state-store.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
@@ -7,6 +7,7 @@ import { TestSandbox } from '../../../__fixtures__/test-sandbox.node.js'
 import { promises as fs, mkdtempSync } from 'fs'
 import * as path from 'path'
 import { tmpdir } from 'os'
+import { Buffer } from 'buffer'
 
 describe('fileEditor tool', () => {
   let testDir: string
@@ -476,12 +477,402 @@ describe('fileEditor tool', () => {
   })
 
   describe('file size limits', () => {
-    it('throws when file exceeds default size limit', async () => {
-      // Create a file larger than 1MB
-      const largeContent = 'x'.repeat(1048577) // 1MB + 1 byte
-      const filePath = await createTestFile('large.txt', largeContent)
+    it('throws when file exceeds configured size limit', async () => {
+      const smallEditor = makeFileEditor({ maxFileSize: 1024 })
+      const filePath = await createTestFile('large.txt', 'x'.repeat(2048))
+      await expect(smallEditor.invoke({ command: 'view', path: filePath }, context)).rejects.toThrow('exceeds')
+    })
 
-      await expect(fileEditor.invoke({ command: 'view', path: filePath }, context)).rejects.toThrow('exceeds')
+    it('default cap is 1 MB: accepts a file just under and rejects a 2 MB file', async () => {
+      const under = await createTestFile('under.txt', 'x'.repeat(1 * 1024 * 1024 - 1))
+      const result = await fileEditor.invoke({ command: 'view', path: under }, context)
+      expect(result).toContain('cat -n')
+      const over = await createTestFile('over.txt', 'x'.repeat(2 * 1024 * 1024))
+      await expect(fileEditor.invoke({ command: 'view', path: over }, context)).rejects.toThrow('exceeds')
+    })
+  })
+
+  describe('binary rejection', () => {
+    it('rejects a binary file on view', async () => {
+      const filePath = path.join(testDir, 'binary.bin')
+      await fs.writeFile(filePath, Buffer.from([0x00, 0x01, 0x02, 0x66, 0x6f, 0x6f, 0x00]))
+      await expect(fileEditor.invoke({ command: 'view', path: filePath }, context)).rejects.toThrow('binary')
+    })
+
+    it('rejects a binary file on str_replace', async () => {
+      const filePath = path.join(testDir, 'binary.bin')
+      await fs.writeFile(filePath, Buffer.from([0x48, 0x45, 0x41, 0x44, 0x00, 0x54, 0x41, 0x49, 0x4c]))
+      await expect(
+        fileEditor.invoke({ command: 'str_replace', path: filePath, old_str: 'HEAD', new_str: 'X' }, context)
+      ).rejects.toThrow('binary')
+    })
+
+    it('rejects a UTF-16 file as unsupported encoding, not as binary', async () => {
+      const filePath = path.join(testDir, 'utf16.txt')
+      const bom = Buffer.from([0xff, 0xfe])
+      const body = Buffer.from('hello world', 'utf16le')
+      await fs.writeFile(filePath, Buffer.concat([bom, body]))
+      await expect(fileEditor.invoke({ command: 'view', path: filePath }, context)).rejects.toThrow('UTF-16')
+    })
+  })
+
+  describe('pattern_replace ReDoS guards', () => {
+    it('rejects an overlong pattern', async () => {
+      const filePath = await createTestFile('test.txt', 'content')
+      await expect(
+        fileEditor.invoke(
+          { command: 'pattern_replace', path: filePath, pattern: 'a'.repeat(1001), new_str: 'x' },
+          context
+        )
+      ).rejects.toThrow('exceeds maximum')
+    })
+
+    it('rejects a pattern that produces more than the match cap', async () => {
+      // A tiny pattern over a large-ish input can easily blow past the 10k cap.
+      const filePath = await createTestFile('many.txt', 'a'.repeat(20_000))
+      await expect(
+        fileEditor.invoke(
+          { command: 'pattern_replace', path: filePath, pattern: 'a', new_str: 'b', replace_all: true },
+          context
+        )
+      ).rejects.toThrow('more than')
+    })
+
+    it('rejects a nested-quantifier pattern before compilation', async () => {
+      // `(a+)+b` on all-a input hangs a single V8 exec call — the match-count
+      // cap can't catch it because catastrophic backtracking happens inside
+      // one exec, not between execs. The sync heuristic must reject it.
+      const filePath = await createTestFile('evil.txt', 'a'.repeat(24))
+      await expect(
+        fileEditor.invoke({ command: 'pattern_replace', path: filePath, pattern: '(a+)+b', new_str: 'x' }, context)
+      ).rejects.toThrow(/nested quantifier|catastrophic/i)
+    })
+  })
+
+  describe('write-side size caps', () => {
+    it('rejects a create whose file_text exceeds maxFileSize', async () => {
+      const editor = makeFileEditor({ maxFileSize: 1024 })
+      const filePath = path.join(testDir, 'big-create.txt')
+      await expect(
+        editor.invoke({ command: 'create', path: filePath, file_text: 'x'.repeat(2048) }, context)
+      ).rejects.toThrow('exceeds maximum allowed size')
+    })
+
+    it('rejects a str_replace whose new_str exceeds maxFileSize', async () => {
+      const editor = makeFileEditor({ maxFileSize: 1024 })
+      const filePath = await createTestFile('small.txt', 'small')
+      await expect(
+        editor.invoke({ command: 'str_replace', path: filePath, old_str: 'small', new_str: 'y'.repeat(2048) }, context)
+      ).rejects.toThrow('exceeds maximum allowed size')
+    })
+
+    it('rejects a str_replace whose result expands past the cap', async () => {
+      // Cap is 32 bytes. Original is 20 bytes. `replace_all` on 'x' -> 'XXX'
+      // produces 60 bytes, past the cap even though every individual new_str
+      // fits.
+      const editor = makeFileEditor({ maxFileSize: 32 })
+      const filePath = await createTestFile('grow.txt', 'x'.repeat(20))
+      await expect(
+        editor.invoke(
+          { command: 'str_replace', path: filePath, old_str: 'x', new_str: 'XXX', replace_all: true },
+          context
+        )
+      ).rejects.toThrow('exceeding the maximum')
+    })
+
+    it('rejects an insert whose result expands past the cap', async () => {
+      const editor = makeFileEditor({ maxFileSize: 32 })
+      const filePath = await createTestFile('grow.txt', 'x'.repeat(30))
+      await expect(
+        editor.invoke({ command: 'insert', path: filePath, insert_line: 0, new_str: 'y'.repeat(10) }, context)
+      ).rejects.toThrow('exceeding the maximum')
+    })
+
+    it('rejects a pattern_replace whose result expands past the cap', async () => {
+      const editor = makeFileEditor({ maxFileSize: 32 })
+      const filePath = await createTestFile('grow.txt', 'x'.repeat(20))
+      await expect(
+        editor.invoke(
+          { command: 'pattern_replace', path: filePath, pattern: 'x', new_str: 'XXX', replace_all: true },
+          context
+        )
+      ).rejects.toThrow('exceeding the maximum')
+    })
+  })
+
+  describe('empty input rejection', () => {
+    it('rejects an empty old_str on str_replace', async () => {
+      // `"".count("")` returns len + 1; without an explicit guard the caller
+      // would see a confusing "multiple occurrences" error or, with replace_all,
+      // new_str inserted between every character.
+      const filePath = await createTestFile('empty-old.txt', 'hello\n')
+      await expect(
+        fileEditor.invoke({ command: 'str_replace', path: filePath, old_str: '', new_str: 'X' }, context)
+      ).rejects.toThrow('must not be empty')
+    })
+
+    it('rejects an empty pattern on pattern_replace', async () => {
+      // An empty pattern is a zero-width regex that matches at every position.
+      const filePath = await createTestFile('empty-pattern.txt', 'hello\n')
+      await expect(
+        fileEditor.invoke({ command: 'pattern_replace', path: filePath, pattern: '', new_str: 'X' }, context)
+      ).rejects.toThrow('must not be empty')
+    })
+  })
+
+  describe('non-local root (docker-shaped)', () => {
+    it('confines against a container-side root that does not exist locally', async () => {
+      // Simulates a Docker sandbox whose paths are container-side: `root` does
+      // not map to any local path. The realpath layer must be skipped or every
+      // op would fail ENOENT. The string-level check still applies.
+      const containerRoot = '/workspace-in-container-does-not-exist-locally'
+      const editor = makeFileEditor({ root: containerRoot })
+      // A path inside the (non-local) root should pass path resolution and
+      // fail only when the sandbox tries to actually read it. Use the sandbox
+      // path-not-found error as the signal: resolution succeeded.
+      await expect(editor.invoke({ command: 'view', path: `${containerRoot}/foo.txt` }, context)).rejects.toThrow(
+        'does not exist'
+      )
+      // And a path outside root still fails cleanly at the string-level check.
+      await expect(editor.invoke({ command: 'view', path: '/etc/passwd' }, context)).rejects.toThrow(
+        'outside the configured root'
+      )
+    })
+  })
+
+  describe('undo LRU eviction', () => {
+    it('evicts the oldest entry when maxUndoEntries is exceeded', async () => {
+      const editor = makeFileEditor({ maxUndoEntries: 2 })
+      const paths: string[] = []
+      for (let i = 0; i < 3; i++) {
+        const p = await createTestFile(`f${i}.txt`, `orig${i}`)
+        paths.push(p)
+        await editor.invoke({ command: 'str_replace', path: p, old_str: `orig${i}`, new_str: `new${i}` }, context)
+      }
+      // Oldest (f0) has been evicted.
+      await expect(editor.invoke({ command: 'undo_edit', path: paths[0]! }, context)).rejects.toThrow('No undo history')
+      // Second-oldest still restores.
+      await editor.invoke({ command: 'undo_edit', path: paths[1]! }, context)
+      expect(await fs.readFile(paths[1]!, 'utf-8')).toBe('orig1')
+    })
+
+    it('evicts past the byte cap', async () => {
+      const editor = makeFileEditor({ maxUndoBytes: 10 })
+      const p1 = await createTestFile('big1.txt', 'x'.repeat(100))
+      const p2 = await createTestFile('big2.txt', 'y'.repeat(100))
+      await editor.invoke({ command: 'str_replace', path: p1, old_str: 'x', new_str: 'X', replace_all: true }, context)
+      await editor.invoke({ command: 'str_replace', path: p2, old_str: 'y', new_str: 'Y', replace_all: true }, context)
+      await expect(editor.invoke({ command: 'undo_edit', path: p1 }, context)).rejects.toThrow('No undo history')
+    })
+  })
+
+  describe('str_replace replace_all opt-in', () => {
+    it('rejects an ambiguous match without replace_all', async () => {
+      const filePath = await createTestFile('dup.txt', 'DUP\nfoo\nDUP\nbar\nDUP\n')
+      await expect(
+        fileEditor.invoke({ command: 'str_replace', path: filePath, old_str: 'DUP', new_str: 'X' }, context)
+      ).rejects.toThrow('replace_all')
+    })
+
+    it('replaces every occurrence when replace_all is true', async () => {
+      const filePath = await createTestFile('dup.txt', 'DUP\nfoo\nDUP\nbar\nDUP\n')
+      const result = await fileEditor.invoke(
+        { command: 'str_replace', path: filePath, old_str: 'DUP', new_str: 'X', replace_all: true },
+        context
+      )
+      expect(result).toContain('3 occurrences replaced')
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('X\nfoo\nX\nbar\nX\n')
+    })
+  })
+
+  describe('pattern_replace command', () => {
+    it('replaces a unique regex match with backreferences', async () => {
+      const filePath = await createTestFile('test.txt', 'hello world\ngoodbye')
+      await fileEditor.invoke(
+        { command: 'pattern_replace', path: filePath, pattern: 'hello (\\w+)', new_str: 'HI $1' },
+        context
+      )
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('HI world\ngoodbye')
+    })
+
+    it('rejects an ambiguous match without replace_all', async () => {
+      const filePath = await createTestFile('test.txt', 'foo\nfoo\nfoo\n')
+      await expect(
+        fileEditor.invoke({ command: 'pattern_replace', path: filePath, pattern: 'foo', new_str: 'bar' }, context)
+      ).rejects.toThrow('replace_all')
+    })
+
+    it('replaces every match when replace_all is true', async () => {
+      const filePath = await createTestFile('test.txt', 'foo\nfoo\nfoo\n')
+      await fileEditor.invoke(
+        { command: 'pattern_replace', path: filePath, pattern: 'foo', new_str: 'bar', replace_all: true },
+        context
+      )
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('bar\nbar\nbar\n')
+    })
+
+    it('throws on an invalid regex', async () => {
+      const filePath = await createTestFile('test.txt', 'content')
+      await expect(
+        fileEditor.invoke({ command: 'pattern_replace', path: filePath, pattern: '[unclosed', new_str: 'x' }, context)
+      ).rejects.toThrow('Invalid regex')
+    })
+
+    it('throws when the pattern does not match', async () => {
+      const filePath = await createTestFile('test.txt', 'content')
+      await expect(
+        fileEditor.invoke({ command: 'pattern_replace', path: filePath, pattern: 'MISSING', new_str: 'x' }, context)
+      ).rejects.toThrow('did not match')
+    })
+  })
+
+  describe('find_line command', () => {
+    it('finds the first occurrence and returns a context snippet', async () => {
+      const filePath = await createTestFile('test.txt', 'alpha\nbeta\ngamma\nbeta again\n')
+      const result = await fileEditor.invoke({ command: 'find_line', path: filePath, search_text: 'beta' }, context)
+      expect(result).toContain('line 2')
+      expect(result).toContain('gamma')
+    })
+
+    it('throws when not found', async () => {
+      const filePath = await createTestFile('test.txt', 'alpha\n')
+      await expect(
+        fileEditor.invoke({ command: 'find_line', path: filePath, search_text: 'MISSING' }, context)
+      ).rejects.toThrow('Could not find')
+    })
+
+    it('matches across whitespace when fuzzy is true', async () => {
+      const filePath = await createTestFile('test.txt', 'def   my_function ( ):\n    pass\n')
+      const result = await fileEditor.invoke(
+        { command: 'find_line', path: filePath, search_text: 'def my_function', fuzzy: true },
+        context
+      )
+      expect(result).toContain('line 1')
+    })
+  })
+
+  describe('undo_edit command', () => {
+    it('reverts a str_replace edit', async () => {
+      const editor = makeFileEditor()
+      const filePath = await createTestFile('test.txt', 'hello\n')
+      await editor.invoke({ command: 'str_replace', path: filePath, old_str: 'hello', new_str: 'goodbye' }, context)
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('goodbye\n')
+      await editor.invoke({ command: 'undo_edit', path: filePath }, context)
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('hello\n')
+    })
+
+    it('reverts an insert edit', async () => {
+      const editor = makeFileEditor()
+      const filePath = await createTestFile('test.txt', 'one\ntwo\n')
+      await editor.invoke({ command: 'insert', path: filePath, insert_line: 1, new_str: 'between' }, context)
+      await editor.invoke({ command: 'undo_edit', path: filePath }, context)
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('one\ntwo\n')
+    })
+
+    it('reverts a pattern_replace edit', async () => {
+      const editor = makeFileEditor()
+      const filePath = await createTestFile('test.txt', 'a\nb\nc\n')
+      await editor.invoke({ command: 'pattern_replace', path: filePath, pattern: 'a', new_str: 'A' }, context)
+      await editor.invoke({ command: 'undo_edit', path: filePath }, context)
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('a\nb\nc\n')
+    })
+
+    it('throws when no history exists', async () => {
+      const filePath = await createTestFile('test.txt', 'content\n')
+      await expect(fileEditor.invoke({ command: 'undo_edit', path: filePath }, context)).rejects.toThrow(
+        'No undo history'
+      )
+    })
+
+    it('scopes history to a single tool instance', async () => {
+      const filePath = await createTestFile('test.txt', 'original\n')
+      const editorA = makeFileEditor()
+      const editorB = makeFileEditor()
+      await editorA.invoke({ command: 'str_replace', path: filePath, old_str: 'original', new_str: 'changed' }, context)
+      await expect(editorB.invoke({ command: 'undo_edit', path: filePath }, context)).rejects.toThrow('No undo history')
+    })
+  })
+
+  describe('root confinement', () => {
+    it('rejects an absolute path outside the configured root', async () => {
+      const rootDir = path.join(testDir, 'workspace')
+      const outside = path.join(testDir, 'outside.txt')
+      await fs.mkdir(rootDir)
+      await fs.writeFile(outside, 'secret')
+      const confined = makeFileEditor({ root: rootDir })
+      await expect(confined.invoke({ command: 'view', path: outside }, context)).rejects.toThrow(
+        'outside the configured root'
+      )
+    })
+
+    it('still rejects `..` traversal even with a root', async () => {
+      const rootDir = path.join(testDir, 'workspace')
+      await fs.mkdir(rootDir)
+      const confined = makeFileEditor({ root: rootDir })
+      await expect(confined.invoke({ command: 'view', path: `${rootDir}/../outside.txt` }, context)).rejects.toThrow(
+        'path traversal'
+      )
+    })
+
+    it('rejects a sibling that shares the root prefix', async () => {
+      const rootDir = path.join(testDir, 'ws')
+      const sibling = path.join(testDir, 'ws-neighbor')
+      await fs.mkdir(rootDir)
+      await fs.mkdir(sibling)
+      await fs.writeFile(path.join(sibling, 'file.txt'), 'content')
+      const confined = makeFileEditor({ root: rootDir })
+      await expect(confined.invoke({ command: 'view', path: path.join(sibling, 'file.txt') }, context)).rejects.toThrow(
+        'outside the configured root'
+      )
+    })
+
+    it('allows a path inside the root', async () => {
+      const rootDir = path.join(testDir, 'workspace')
+      await fs.mkdir(rootDir)
+      const target = path.join(rootDir, 'ok.txt')
+      await fs.writeFile(target, 'hello')
+      const confined = makeFileEditor({ root: rootDir })
+      const result = await confined.invoke({ command: 'view', path: target }, context)
+      expect(result).toContain('hello')
+    })
+
+    it('throws at construction if root is not absolute', () => {
+      expect(() => makeFileEditor({ root: 'relative/root' })).toThrow('absolute path')
+    })
+
+    it('rejects a symlink inside root that points outside root', async () => {
+      const rootDir = path.join(testDir, 'workspace')
+      await fs.mkdir(rootDir)
+      const secret = path.join(testDir, 'secret.txt')
+      await fs.writeFile(secret, 'top secret')
+      const link = path.join(rootDir, 'escape.txt')
+      await fs.symlink(secret, link)
+      const confined = makeFileEditor({ root: rootDir })
+      await expect(confined.invoke({ command: 'view', path: link }, context)).rejects.toThrow(/symlink|outside/)
+    })
+
+    it('allows a symlink inside root that points to a file also inside root', async () => {
+      const rootDir = path.join(testDir, 'workspace')
+      await fs.mkdir(rootDir)
+      const target = path.join(rootDir, 'real.txt')
+      await fs.writeFile(target, 'inside content')
+      const link = path.join(rootDir, 'alias.txt')
+      await fs.symlink(target, link)
+      const confined = makeFileEditor({ root: rootDir })
+      const result = await confined.invoke({ command: 'view', path: link }, context)
+      expect(result).toContain('inside content')
+    })
+
+    it.skipIf(process.platform === 'win32')('allows a path when root is the filesystem root', async () => {
+      // POSIX-only: stripTrailingSep preserves `/`, so a naive `r + sep` check
+      // would produce `//` and reject every valid in-root path. Guard against
+      // regressing that edge case. Windows treats each drive letter as its
+      // own root; the analogous case there (`root: 'C:\\'`) is covered by the
+      // trailing-separator branch in isInsideRoot the same way.
+      const filePath = await createTestFile('at-fs-root.txt', 'content')
+      const confined = makeFileEditor({ root: '/' })
+      const result = await confined.invoke({ command: 'view', path: filePath }, context)
+      expect(result).toContain('content')
     })
   })
 

--- a/strands-ts/src/vended-tools/file-editor/file-editor.ts
+++ b/strands-ts/src/vended-tools/file-editor/file-editor.ts
@@ -1,40 +1,65 @@
 import { tool } from '../../tools/tool-factory.js'
 import { z } from 'zod'
-import { Buffer } from 'buffer'
 import { Sandbox } from '../../sandbox/base.js'
 import { SandboxPathNotFoundError } from '../../sandbox/errors.js'
 import * as path from 'path'
+import * as fs from 'fs'
+import { Buffer } from 'buffer'
 
 const SNIPPET_LINES = 4
-const DEFAULT_MAX_FILE_SIZE = 1048576 // 1MB
+const DEFAULT_MAX_FILE_SIZE = 1 * 1024 * 1024 // 1 MB
 const MAX_DIRECTORY_DEPTH = 2
+const MAX_PATTERN_LENGTH = 1000
+const MAX_PATTERN_MATCHES = 10_000
+const DEFAULT_MAX_UNDO_ENTRIES = 32
+const DEFAULT_MAX_UNDO_BYTES = 32 * 1024 * 1024 // 32 MB
 
 /**
  * Zod schema for file editor input validation.
  */
 const fileEditorInputSchema = z.object({
   command: z
-    .enum(['view', 'create', 'str_replace', 'insert'])
-    .describe('The operation to perform: `view`, `create`, `str_replace`, `insert`.'),
+    .enum(['view', 'create', 'str_replace', 'insert', 'pattern_replace', 'find_line', 'undo_edit'])
+    .describe(
+      'The operation to perform: `view`, `create`, `str_replace`, `insert`, `pattern_replace`, `find_line`, or `undo_edit`.'
+    ),
   path: z.string().describe('Absolute path to the file or directory.'),
   file_text: z.string().optional().describe('Content for new file (required for create command).'),
   view_range: z
     .tuple([z.number(), z.number()])
     .optional()
     .describe('Line range to view [start, end]. 1-indexed. End can be -1 for end of file.'),
-  old_str: z.string().optional().describe('Exact string to find and replace (required for str_replace command).'),
-  new_str: z.string().optional().describe('Replacement string (for str_replace and insert commands).'),
+  old_str: z
+    .string()
+    .optional()
+    .describe(
+      'Exact string to find and replace (required for str_replace). Must be unique unless replace_all is true.'
+    ),
+  new_str: z
+    .string()
+    .optional()
+    .describe('Replacement string (for str_replace, pattern_replace, and insert commands).'),
   insert_line: z
     .number()
     .optional()
     .describe('Line number where text should be inserted (0-indexed, required for insert command).'),
+  pattern: z.string().optional().describe('Regex pattern to match (required for pattern_replace command).'),
+  search_text: z.string().optional().describe('Text to search for (required for find_line command).'),
+  fuzzy: z.boolean().optional().describe('Enable whitespace-tolerant, case-insensitive matching for find_line.'),
+  replace_all: z
+    .boolean()
+    .optional()
+    .describe(
+      'For str_replace and pattern_replace, allow replacing every occurrence. Defaults to false; a match count > 1 is rejected without this flag to prevent silent broad edits.'
+    ),
 })
 
 /**
  * File editor tool for viewing, creating, and editing files programmatically.
  *
- * Provides commands for viewing files/directories, creating files, string replacement,
- * and line insertion. All I/O routes through the agent's configured sandbox.
+ * Provides commands for viewing files/directories, creating files, string and
+ * regex replacement, line insertion, search, and single-step undo. All I/O
+ * routes through the agent's configured sandbox.
  *
  * @example
  * ```typescript
@@ -52,11 +77,39 @@ const fileEditorInputSchema = z.object({
  * ```
  */
 export const DEFAULT_FILE_EDITOR_DESCRIPTION =
-  'Filesystem editor tool for viewing, creating, and editing files. Supports view (with line ranges), create, str_replace, and insert operations. Files must use absolute paths.'
+  'Filesystem editor for viewing, creating, and editing files. Supports view (with line ranges), create, str_replace (exact match; ambiguous matches must opt in via replace_all), insert, pattern_replace (regex), find_line, and undo_edit. Files must use absolute paths.'
 
 export interface MakeFileEditorOptions {
   name?: string
   description?: string
+  /**
+   * Optional absolute directory that confines every operation. String-level
+   * checks reject non-absolute paths and any `..` traversal on the raw input;
+   * when the resolved target exists on the local host, `fs.realpathSync` is
+   * also applied and the result must still be inside `root`. Confinement is
+   * enforced against the raw path input before I/O; concurrent rename attacks
+   * between the confinement check and the read/write are the sandbox's
+   * responsibility. When `undefined`, only absolute-path and `..`-traversal
+   * checks apply; the underlying sandbox's symlink policy governs escape.
+   */
+  root?: string
+  /**
+   * Maximum file size (bytes) accepted by view/edit commands. Defaults to
+   * 1 MB. Anything larger is rejected with a clean error rather than being
+   * loaded into memory.
+   */
+  maxFileSize?: number
+  /**
+   * Maximum number of distinct paths retained in the in-memory undo history.
+   * Oldest entry is evicted on overflow. Defaults to 32.
+   */
+  maxUndoEntries?: number
+  /**
+   * Approximate cap on total bytes of file content held in the undo history
+   * (measured as UTF-8 byte length, matching the Python side). Oldest entries
+   * are evicted until the cap is met. Defaults to 32 MB.
+   */
+  maxUndoBytes?: number
 }
 
 /**
@@ -72,6 +125,23 @@ export function makeFileEditor(
 ): ReturnType<typeof tool> {
   const boundSandbox = sandboxOrOptions instanceof Sandbox ? sandboxOrOptions : undefined
   const options = sandboxOrOptions instanceof Sandbox || maybeOptions ? (maybeOptions ?? {}) : (sandboxOrOptions ?? {})
+  const maxFileSize = options.maxFileSize ?? DEFAULT_MAX_FILE_SIZE
+  const maxUndoEntries = options.maxUndoEntries ?? DEFAULT_MAX_UNDO_ENTRIES
+  const maxUndoBytes = options.maxUndoBytes ?? DEFAULT_MAX_UNDO_BYTES
+
+  if (options.root !== undefined && !path.isAbsolute(options.root)) {
+    throw new Error(`root must be an absolute path, got: ${options.root}`)
+  }
+  // Use platform-native normalization so a Windows-style `root`
+  // (e.g. `C:\Users\...\workspace`) survives round-tripping. Trailing separators
+  // are stripped so subsequent `startsWith(root + sep)` checks work.
+  const normalizedRoot: string | undefined =
+    options.root === undefined ? undefined : stripTrailingSep(path.normalize(options.root))
+
+  // Bounded LRU: previous file content keyed by path. `Map` preserves insertion
+  // order, so re-inserting a key after `delete` gives LRU behavior; eviction
+  // removes the oldest key when either cap is exceeded.
+  const undoHistory = new Map<string, string>()
 
   return tool({
     name: options.name ?? 'fileEditor',
@@ -80,19 +150,54 @@ export function makeFileEditor(
     callback: async (input, context) => {
       if (!context) throw new Error('Tool context is required for fileEditor operations')
       const sandbox = boundSandbox ?? context.agent.sandbox
-      const filePath = input.path.replace(/[/\\]+$/, '')
+      const filePath = resolvePath(input.path, normalizedRoot)
 
       switch (input.command) {
         case 'view':
-          return handleView(sandbox, filePath, input.view_range)
+          return handleView(sandbox, filePath, input.view_range, maxFileSize)
         case 'create':
-          return handleCreate(sandbox, filePath, input.file_text!)
+          return handleCreate(sandbox, filePath, input.file_text!, undoHistory, maxFileSize)
         case 'str_replace':
-          return handleStrReplace(sandbox, filePath, input.old_str!, input.new_str)
+          return handleStrReplace(
+            sandbox,
+            filePath,
+            input.old_str!,
+            input.new_str,
+            input.replace_all === true,
+            maxFileSize,
+            undoHistory,
+            maxUndoEntries,
+            maxUndoBytes
+          )
         case 'insert':
-          return handleInsert(sandbox, filePath, input.insert_line!, input.new_str!)
+          return handleInsert(
+            sandbox,
+            filePath,
+            input.insert_line!,
+            input.new_str!,
+            maxFileSize,
+            undoHistory,
+            maxUndoEntries,
+            maxUndoBytes
+          )
+        case 'pattern_replace':
+          return handlePatternReplace(
+            sandbox,
+            filePath,
+            input.pattern!,
+            input.new_str,
+            input.replace_all === true,
+            maxFileSize,
+            undoHistory,
+            maxUndoEntries,
+            maxUndoBytes
+          )
+        case 'find_line':
+          return handleFindLine(sandbox, filePath, input.search_text!, input.fuzzy === true, maxFileSize)
+        case 'undo_edit':
+          return handleUndo(sandbox, filePath, undoHistory)
         default:
-          throw new Error(`Unknown command: ${input.command}`)
+          throw new Error(`Unknown command: ${(input as { command: string }).command}`)
       }
     },
   })
@@ -104,22 +209,159 @@ export function makeFileEditor(
 export const fileEditor = makeFileEditor()
 
 /**
- * Validates that a path is absolute and doesn't contain directory traversal.
+ * Normalize a path, rejecting traversal and out-of-root inputs.
+ *
+ * This is the single funnel every command routes through — it exists so path
+ * validation cannot be bypassed by a new command forgetting to call it. When
+ * `root` is set and the target (or its parent, for a not-yet-existing file)
+ * exists locally, symlinks are also resolved via `fs.realpathSync` and the
+ * result must still be inside `root` — a symlink inside `root` pointing at
+ * `/etc/passwd` is rejected. When `root` does not exist locally (e.g. a Docker
+ * sandbox whose paths are container-side), the realpath layer is skipped and
+ * the sandbox owns its own symlink policy — otherwise every operation would
+ * fail an ENOENT-on-realpath check.
  */
-function validatePath(filePath: string): void {
-  // Check if it's an absolute path
-  if (!path.isAbsolute(filePath)) {
-    const suggestedPath = path.resolve(filePath)
+function resolvePath(filePath: string, root: string | undefined): string {
+  // Strip trailing slashes on the raw input (compat with pre-existing
+  // behavior). Uses `stripTrailingSep` so a Windows drive root like `C:\` is
+  // preserved rather than collapsed to `C:` (which is not absolute).
+  const stripped = stripTrailingSep(filePath)
+
+  if (!path.isAbsolute(stripped)) {
+    const suggestedPath = path.resolve(stripped)
     throw new Error(
-      `The path ${filePath} is not an absolute path, it should start with \`/\`. Maybe you meant ${suggestedPath}?`
+      `The path ${filePath} is not an absolute path, it should start with \`/\` (or a drive letter on Windows). Maybe you meant ${suggestedPath}?`
     )
   }
 
-  // Check for '..' segments on the raw input — path.normalize resolves them away,
-  // so checking after normalize is ineffective.
-  if (filePath.split(/[/\\]/).includes('..')) {
+  // Reject `..` segments on the raw input — path.normalize resolves them away
+  // and could silently permit escape past the root.
+  if (stripped.split(/[/\\]/).includes('..')) {
     throw new Error(`Invalid path: path traversal is not allowed`)
   }
+
+  // Platform-native normalization so Windows drive-letter paths survive.
+  const normalized = stripTrailingSep(path.normalize(stripped))
+
+  if (root !== undefined) {
+    // String-level confinement: normalized must equal root or start with root
+    // + platform separator. Case-insensitive on Windows; case-sensitive on POSIX.
+    if (!isInsideRoot(normalized, root)) {
+      throw new Error(`Invalid path: ${filePath} is outside the configured root ${root}`)
+    }
+
+    // Symlink confinement is a best-effort, local-fs-only layer. If `root`
+    // itself does not exist on the local filesystem, the caller is running
+    // against a non-local sandbox (Docker, SSH, etc.) whose paths do not map
+    // to this host — realpath would ENOENT on every call and reject every
+    // operation. In that case the string-level check above is the whole
+    // policy; the sandbox owns its own symlink handling.
+    if (!fs.existsSync(root)) {
+      return normalized
+    }
+
+    // Resolve the deepest existing ancestor via realpath and confirm it is
+    // still inside root. This is what catches a symlink `inside-root/link ->
+    // /etc/passwd` — the string-level check above only sees `inside-root/link`.
+    let probe = normalized
+    while (probe && !existsSyncLstat(probe)) {
+      const parent = path.dirname(probe)
+      if (parent === probe) break
+      probe = parent
+    }
+    if (probe && existsSyncLstat(probe)) {
+      let real: string
+      let rootReal: string
+      try {
+        real = fs.realpathSync(probe)
+        rootReal = fs.realpathSync(root)
+      } catch {
+        // realpath can fail on a broken symlink; treat that as an escape.
+        throw new Error(`Invalid path: ${filePath} could not be resolved for symlink confinement.`)
+      }
+      if (!isInsideRoot(real, rootReal)) {
+        throw new Error(
+          `Invalid path: ${filePath} resolves via symlink to ${real}, outside the configured root ${root}`
+        )
+      }
+    }
+  }
+
+  return normalized
+}
+
+function stripTrailingSep(p: string): string {
+  // Preserve drive roots (`C:\`, `/`) but drop a trailing separator otherwise.
+  if (p.length <= 1) return p
+  if (process.platform === 'win32' && /^[A-Za-z]:[\\/]$/.test(p)) return p
+  return p.replace(/[\\/]+$/, '') || p
+}
+
+function isInsideRoot(target: string, root: string): boolean {
+  const t = process.platform === 'win32' ? target.toLowerCase() : target
+  const r = process.platform === 'win32' ? stripTrailingSep(root).toLowerCase() : stripTrailingSep(root)
+  if (t === r) return true
+  // Root can already end in a separator when it is the filesystem root (`/`)
+  // or a Windows drive root (`C:\`) — stripTrailingSep preserves those. In
+  // that case, concatenating another separator would produce `//` or `C:\\`
+  // and every valid in-root path would fail startsWith.
+  const rEndsWithSep = r.endsWith('/') || r.endsWith('\\')
+  if (rEndsWithSep) return t.startsWith(r)
+  // Otherwise, match either separator so a Windows normalized path
+  // (`C:\a\b`) matches a root that could be written with either style.
+  return t.startsWith(r + path.sep) || t.startsWith(r + '/')
+}
+
+/**
+ * Reject a replacement payload whose UTF-8 length would exceed `maxSize`. The
+ * read-side cap already protects against pulling a huge file into memory; this
+ * mirrors it on the write side so a model can't ship an unbounded `new_str`
+ * or `file_text` through the tool.
+ */
+function rejectOversizeReplacement(text: string | undefined, maxSize: number, label = 'new_str'): void {
+  if (text === undefined) return
+  const bytes = Buffer.byteLength(text, 'utf-8')
+  if (bytes > maxSize) {
+    throw new Error(`${label} (${bytes} bytes) exceeds maximum allowed size (${maxSize} bytes)`)
+  }
+}
+
+/**
+ * Reject a post-edit buffer whose UTF-8 length would exceed `maxSize`. The
+ * write-side cap catches the case where the individual `new_str` fits but the
+ * resulting file (after all substitutions) is larger than the read cap — a
+ * `replace_all` that expands every match, for instance.
+ */
+function rejectOversizeResult(content: string, maxSize: number, filePath: string): void {
+  const bytes = Buffer.byteLength(content, 'utf-8')
+  if (bytes > maxSize) {
+    throw new Error(
+      `The edit would produce a ${bytes}-byte file at ${filePath}, exceeding the maximum allowed size of ${maxSize} bytes.`
+    )
+  }
+}
+
+function existsSyncLstat(p: string): boolean {
+  try {
+    fs.lstatSync(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Approximate check that a pattern contains a nested quantifier (`(...+)+`,
+ * `(...*)*`, `(...+)*`, `(...*)+`). Catastrophic backtracking in JS regex
+ * (`(a+)+b` on all-a input) hangs a single `.exec()` call, and V8 has no
+ * regex timeout — the match-count cap only fires between exec calls, so this
+ * pre-compile heuristic is the only sync-time defense. False positives on
+ * legitimate patterns are acceptable — the caller can loosen the pattern.
+ */
+function looksLikeCatastrophicPattern(pattern: string): boolean {
+  // A quantified group whose interior also contains a quantifier is the
+  // classic ReDoS shape. `(a+)+`, `(a*)*`, `(a|a)*`, `(a+)*b`, etc.
+  return /\([^()]*[+*][^()]*\)[+*]/.test(pattern)
 }
 
 /**
@@ -159,38 +401,42 @@ function applyViewRange(
 }
 
 /**
- * Performs a unique str_replace transformation on file content. Validates that
- * `oldStr` appears exactly once. Returns the new content plus a snippet around
- * the change site (with 0-indexed `startLine`).
+ * Performs a str_replace transformation on file content. Requires exactly one
+ * match unless `replaceAll` is true. Returns the new content, a context
+ * snippet, the snippet's 0-indexed start line, and the number of substitutions
+ * performed.
  */
 function buildStrReplaceResult(
   originalContent: string,
   oldStr: string,
   newStr: string | undefined,
-  filePath: string
-): { newContent: string; snippet: string; startLine: number } {
-  const fileContent = originalContent.replace(/\t/g, '        ')
-  const expandedOldStr = oldStr.replace(/\t/g, '        ')
-  const expandedNewStr = newStr ? newStr.replace(/\t/g, '        ') : ''
+  filePath: string,
+  replaceAll: boolean
+): { newContent: string; snippet: string; startLine: number; count: number } {
+  const newStrValue = newStr ?? ''
 
-  const occurrences = (fileContent.match(new RegExp(escapeRegExp(expandedOldStr), 'g')) || []).length
+  const occurrences = (originalContent.match(new RegExp(escapeRegExp(oldStr), 'g')) || []).length
   if (occurrences === 0) {
     throw new Error(`No replacement was performed, old_str \`${oldStr}\` did not appear verbatim in ${filePath}.`)
   }
-  if (occurrences > 1) {
-    const lines = fileContent.split('\n')
-    const lineNumbers = lines
-      .map((line, index) => (line.includes(expandedOldStr) ? index + 1 : -1))
-      .filter((num) => num !== -1)
+  if (occurrences > 1 && !replaceAll) {
+    const lines = originalContent.split('\n')
+    const lineNumbers = lines.map((line, index) => (line.includes(oldStr) ? index + 1 : -1)).filter((num) => num !== -1)
     throw new Error(
-      `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines ${JSON.stringify(lineNumbers)}. Please ensure it is unique`
+      `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines ${JSON.stringify(lineNumbers)}. Pass replace_all=true to replace every occurrence, or make old_str unique.`
     )
   }
 
-  const newContent = fileContent.replace(expandedOldStr, () => expandedNewStr)
-  const replacementLine = fileContent.substring(0, fileContent.indexOf(expandedOldStr)).split('\n').length - 1
-  const insertedLines = expandedNewStr.split('\n').length
-  const originalLines = expandedOldStr.split('\n').length
+  const count = replaceAll ? occurrences : 1
+  // Single replacement uses a replacer function so `$&`/`$1`/`$$` in newStr
+  // survive verbatim (String.prototype.replace with a string would interpret
+  // them). replace_all is a plain split/join for the same reason.
+  const newContent = replaceAll
+    ? originalContent.split(oldStr).join(newStrValue)
+    : originalContent.replace(oldStr, () => newStrValue)
+  const replacementLine = originalContent.substring(0, originalContent.indexOf(oldStr)).split('\n').length - 1
+  const insertedLines = newStrValue.split('\n').length
+  const originalLines = oldStr.split('\n').length
   const lineDifference = insertedLines - originalLines
 
   const newLines = newContent.split('\n')
@@ -198,7 +444,7 @@ function buildStrReplaceResult(
   const endLine = Math.min(newLines.length, replacementLine + SNIPPET_LINES + lineDifference + 1)
   const snippet = newLines.slice(startLine, endLine).join('\n')
 
-  return { newContent, snippet, startLine }
+  return { newContent, snippet, startLine, count }
 }
 
 /**
@@ -211,10 +457,7 @@ function buildInsertResult(
   insertLine: number,
   newStr: string
 ): { newContent: string; snippet: string; startLine: number } {
-  const fileText = originalContent.replace(/\t/g, '        ')
-  const expandedNewStr = newStr.replace(/\t/g, '        ')
-
-  const fileTextLines = fileText.split('\n')
+  const fileTextLines = originalContent.split('\n')
   const nLines = fileTextLines.length
 
   if (insertLine < 0 || insertLine > nLines) {
@@ -223,9 +466,9 @@ function buildInsertResult(
     )
   }
 
-  const newStrLines = expandedNewStr.split('\n')
+  const newStrLines = newStr.split('\n')
   const newFileTextLines =
-    fileText === ''
+    originalContent === ''
       ? newStrLines
       : [...fileTextLines.slice(0, insertLine), ...newStrLines, ...fileTextLines.slice(insertLine)]
 
@@ -260,6 +503,59 @@ function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+/**
+ * Returns the 0-indexed line number where `searchText` first appears, else -1.
+ *
+ * When `fuzzy` is true, whitespace between tokens is collapsed and matching
+ * is case-insensitive.
+ */
+function findLineNumber(content: string, searchText: string, fuzzy: boolean): number {
+  const lines = content.split('\n')
+  if (fuzzy) {
+    const tokens = searchText.trim().split(/\s+/).filter(Boolean)
+    if (tokens.length === 0) return -1
+    const pattern = new RegExp(tokens.map(escapeRegExp).join('.*'), 'i')
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      if (line !== undefined && pattern.test(line)) return i
+    }
+  } else {
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      if (line !== undefined && line.includes(searchText)) return i
+    }
+  }
+  return -1
+}
+
+// ---- Undo history bookkeeping ----
+
+/**
+ * Record a pre-edit snapshot in the LRU undo history, evicting oldest on overflow.
+ *
+ * `Map` iteration follows insertion order; a re-inserted key after `delete` moves
+ * to the end. `keys().next()` therefore yields the oldest entry for eviction.
+ */
+function storeUndoSnapshot(
+  undoHistory: Map<string, string>,
+  filePath: string,
+  content: string,
+  maxEntries: number,
+  maxBytes: number
+): void {
+  if (undoHistory.has(filePath)) undoHistory.delete(filePath)
+  undoHistory.set(filePath, content)
+  let totalBytes = 0
+  for (const v of undoHistory.values()) totalBytes += Buffer.byteLength(v, 'utf-8')
+  while (undoHistory.size > 0 && (undoHistory.size > maxEntries || totalBytes > maxBytes)) {
+    const oldestKey = undoHistory.keys().next().value
+    if (oldestKey === undefined) break
+    const evicted = undoHistory.get(oldestKey)!
+    undoHistory.delete(oldestKey)
+    totalBytes -= Buffer.byteLength(evicted, 'utf-8')
+  }
+}
+
 // ---- Sandbox-routed I/O helpers ----
 
 /**
@@ -286,13 +582,33 @@ async function probeSandboxPath(sandbox: Sandbox, filePath: string): Promise<{ e
 }
 
 /**
- * Asserts content size is within the limit, checked after read since `listFiles`
- * does not reliably report size across sandbox backends.
+ * Read text through the sandbox, rejecting binary files and oversize inputs.
+ *
+ * Reads raw bytes first so the size cap and encoding detection run before
+ * UTF-8 decoding — a corrupted UTF-8 error is worse than a clean rejection.
+ * UTF-16 BOMs are detected up front so a valid UTF-16 file is reported as an
+ * unsupported encoding rather than misclassified as binary. Otherwise the
+ * classic NUL-in-first-8-KB heuristic identifies binary content.
  */
-function assertWithinSizeLimit(content: string, maxSize: number = DEFAULT_MAX_FILE_SIZE): void {
-  const size = Buffer.byteLength(content, 'utf-8')
-  if (size > maxSize) {
-    throw new Error(`File size (${size} bytes) exceeds maximum allowed size (${maxSize} bytes)`)
+async function readTextOrRejectBinary(sandbox: Sandbox, filePath: string, maxSize: number): Promise<string> {
+  const raw = await sandbox.readFile(filePath)
+  if (raw.byteLength > maxSize) {
+    throw new Error(`File size (${raw.byteLength} bytes) exceeds maximum allowed size (${maxSize} bytes)`)
+  }
+  if (raw.byteLength >= 2 && ((raw[0] === 0xff && raw[1] === 0xfe) || (raw[0] === 0xfe && raw[1] === 0xff))) {
+    throw new Error(`Refusing to read non-UTF-8 file (detected UTF-16 BOM): ${filePath}`)
+  }
+  const scanLen = Math.min(raw.byteLength, 8192)
+  for (let i = 0; i < scanLen; i++) {
+    if (raw[i] === 0) {
+      throw new Error(`Refusing to read binary file: ${filePath}`)
+    }
+  }
+  const decoder = new TextDecoder('utf-8', { fatal: true })
+  try {
+    return decoder.decode(raw)
+  } catch {
+    throw new Error(`Refusing to read non-UTF-8 file: ${filePath}`)
   }
 }
 
@@ -334,10 +650,9 @@ async function listDirectory(sandbox: Sandbox, dirPath: string): Promise<string>
 async function handleView(
   sandbox: Sandbox,
   filePath: string,
-  viewRange: [number, number] | undefined
+  viewRange: [number, number] | undefined,
+  maxSize: number
 ): Promise<string> {
-  validatePath(filePath)
-
   const { exists, isDir } = await probeSandboxPath(sandbox, filePath)
   if (!exists) {
     throw new Error(`The path ${filePath} does not exist. Please provide a valid path.`)
@@ -350,19 +665,25 @@ async function handleView(
     return listDirectory(sandbox, filePath)
   }
 
-  const fileContent = await sandbox.readText(filePath)
-  assertWithinSizeLimit(fileContent)
-
+  const fileContent = await readTextOrRejectBinary(sandbox, filePath, maxSize)
   const { content, initLine } = applyViewRange(fileContent, viewRange)
   return makeOutput(content, filePath, initLine)
 }
 
-async function handleCreate(sandbox: Sandbox, filePath: string, fileText: string): Promise<string> {
+async function handleCreate(
+  sandbox: Sandbox,
+  filePath: string,
+  fileText: string,
+  undoHistory: Map<string, string>,
+  maxSize: number
+): Promise<string> {
   if (fileText === undefined) {
     throw new Error('Parameter `file_text` is required for command: create')
   }
-
-  validatePath(filePath)
+  const writeBytes = Buffer.byteLength(fileText, 'utf-8')
+  if (writeBytes > maxSize) {
+    throw new Error(`file_text (${writeBytes} bytes) exceeds maximum allowed size (${maxSize} bytes)`)
+  }
 
   const { exists } = await probeSandboxPath(sandbox, filePath)
   if (exists) {
@@ -370,6 +691,10 @@ async function handleCreate(sandbox: Sandbox, filePath: string, fileText: string
   }
 
   await sandbox.writeText(filePath, fileText)
+  // `create` is intentionally not snapshotted for undo: rolling back a create
+  // means deleting the file, which is a different operation from "restore
+  // prior content" and is easy for the caller to do themselves.
+  undoHistory.delete(filePath)
   return `File created successfully at: ${filePath}`
 }
 
@@ -377,13 +702,20 @@ async function handleStrReplace(
   sandbox: Sandbox,
   filePath: string,
   oldStr: string,
-  newStr: string | undefined
+  newStr: string | undefined,
+  replaceAll: boolean,
+  maxSize: number,
+  undoHistory: Map<string, string>,
+  maxUndoEntries: number,
+  maxUndoBytes: number
 ): Promise<string> {
   if (oldStr === undefined) {
     throw new Error('Parameter `old_str` is required for command: str_replace')
   }
-
-  validatePath(filePath)
+  if (oldStr === '') {
+    throw new Error('Parameter `old_str` must not be empty for command: str_replace')
+  }
+  if (newStr !== undefined) rejectOversizeReplacement(newStr, maxSize, 'new_str')
 
   const { exists, isDir } = await probeSandboxPath(sandbox, filePath)
   if (!exists) {
@@ -393,22 +725,38 @@ async function handleStrReplace(
     throw new Error(`The path ${filePath} is a directory and only the \`view\` command can be used on directories`)
   }
 
-  const fileContent = await sandbox.readText(filePath)
-  assertWithinSizeLimit(fileContent)
+  const fileContent = await readTextOrRejectBinary(sandbox, filePath, maxSize)
 
-  const { newContent, snippet, startLine } = buildStrReplaceResult(fileContent, oldStr, newStr, filePath)
+  const { newContent, snippet, startLine, count } = buildStrReplaceResult(
+    fileContent,
+    oldStr,
+    newStr,
+    filePath,
+    replaceAll
+  )
 
+  rejectOversizeResult(newContent, maxSize, filePath)
+  storeUndoSnapshot(undoHistory, filePath, fileContent, maxUndoEntries, maxUndoBytes)
   await sandbox.writeText(filePath, newContent)
 
-  return `The file ${filePath} has been edited. ${makeOutput(snippet, `a snippet of ${filePath}`, startLine + 1)}Review the changes and make sure they are as expected. Edit the file again if necessary.`
+  const suffix = replaceAll && count > 1 ? ` (${count} occurrences replaced)` : ''
+  return `The file ${filePath} has been edited.${suffix} ${makeOutput(snippet, `a snippet of ${filePath}`, startLine + 1)}Review the changes and make sure they are as expected. Edit the file again if necessary.`
 }
 
-async function handleInsert(sandbox: Sandbox, filePath: string, insertLine: number, newStr: string): Promise<string> {
+async function handleInsert(
+  sandbox: Sandbox,
+  filePath: string,
+  insertLine: number,
+  newStr: string,
+  maxSize: number,
+  undoHistory: Map<string, string>,
+  maxUndoEntries: number,
+  maxUndoBytes: number
+): Promise<string> {
   if (insertLine === undefined || newStr === undefined) {
     throw new Error('Parameters `insert_line` and `new_str` are required for command: insert')
   }
-
-  validatePath(filePath)
+  rejectOversizeReplacement(newStr, maxSize, 'new_str')
 
   const { exists, isDir } = await probeSandboxPath(sandbox, filePath)
   if (!exists) {
@@ -418,12 +766,194 @@ async function handleInsert(sandbox: Sandbox, filePath: string, insertLine: numb
     throw new Error(`The path ${filePath} is a directory and only the \`view\` command can be used on directories`)
   }
 
-  const fileText = await sandbox.readText(filePath)
-  assertWithinSizeLimit(fileText)
+  const fileText = await readTextOrRejectBinary(sandbox, filePath, maxSize)
 
   const { newContent, snippet, startLine } = buildInsertResult(fileText, insertLine, newStr)
 
+  rejectOversizeResult(newContent, maxSize, filePath)
+  storeUndoSnapshot(undoHistory, filePath, fileText, maxUndoEntries, maxUndoBytes)
   await sandbox.writeText(filePath, newContent)
 
   return `The file ${filePath} has been edited. ${makeOutput(snippet, 'a snippet of the edited file', startLine + 1)}Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.`
+}
+
+async function handlePatternReplace(
+  sandbox: Sandbox,
+  filePath: string,
+  pattern: string,
+  newStr: string | undefined,
+  replaceAll: boolean,
+  maxSize: number,
+  undoHistory: Map<string, string>,
+  maxUndoEntries: number,
+  maxUndoBytes: number
+): Promise<string> {
+  if (pattern === undefined) {
+    throw new Error('Parameter `pattern` is required for command: pattern_replace')
+  }
+  if (pattern === '') {
+    throw new Error('Parameter `pattern` must not be empty for command: pattern_replace')
+  }
+  if (newStr === undefined) {
+    throw new Error('Parameter `new_str` is required for command: pattern_replace')
+  }
+  rejectOversizeReplacement(newStr, maxSize, 'new_str')
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    throw new Error(`Pattern is ${pattern.length} chars, exceeds maximum of ${MAX_PATTERN_LENGTH}.`)
+  }
+  if (looksLikeCatastrophicPattern(pattern)) {
+    // Deliberate cross-SDK divergence: V8 has no in-exec regex timeout and JS
+    // has no way to cancel a running .exec() call, so a catastrophic pattern
+    // would hang the event loop indefinitely. The Python side runs regexes on
+    // a worker thread under an asyncio.wait_for timeout; TypeScript cannot
+    // replicate that safely, so it statically rejects the classic ReDoS
+    // shapes ((...+)+, (...*)*, ...) before compiling. A pattern accepted by
+    // Python with `pattern_replace_timeout` may be refused here — see the
+    // vended-tools doc for the reasoning.
+    throw new Error(
+      `Pattern \`${pattern}\` contains a nested quantifier that risks catastrophic backtracking; refusing to compile. Rewrite without a quantified group whose interior also has a quantifier.`
+    )
+  }
+
+  // Compile once with the `g` flag; a shared `.exec()` loop drives both the
+  // ambiguity check (with a match cap so a runaway regex can't produce an
+  // unbounded array) and the eventual substitution. V8 has no timeout, so the
+  // pre-compile heuristic above plus the hard match cap below are the defense
+  // against catastrophic backtracking.
+  let regex: RegExp
+  try {
+    regex = new RegExp(pattern, 'g')
+  } catch (e) {
+    throw new Error(`Invalid regex pattern \`${pattern}\`: ${(e as Error).message}`, { cause: e })
+  }
+
+  const { exists, isDir } = await probeSandboxPath(sandbox, filePath)
+  if (!exists) {
+    throw new Error(`The path ${filePath} does not exist. Please provide a valid path.`)
+  }
+  if (isDir) {
+    throw new Error(`The path ${filePath} is a directory and only the \`view\` command can be used on directories`)
+  }
+
+  const fileContent = await readTextOrRejectBinary(sandbox, filePath, maxSize)
+
+  const matches: RegExpExecArray[] = []
+  regex.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = regex.exec(fileContent)) !== null) {
+    matches.push(m)
+    if (matches.length > MAX_PATTERN_MATCHES) {
+      throw new Error(`Pattern \`${pattern}\` produced more than ${MAX_PATTERN_MATCHES} matches; refusing to continue.`)
+    }
+    // Guard against a zero-width match causing an infinite loop.
+    if (m.index === regex.lastIndex) regex.lastIndex++
+  }
+
+  if (matches.length === 0) {
+    throw new Error(`No replacement was performed, pattern \`${pattern}\` did not match in ${filePath}.`)
+  }
+  if (matches.length > 1 && !replaceAll) {
+    const lineNumbers = matches.map((mm) => fileContent.substring(0, mm.index).split('\n').length)
+    throw new Error(
+      `No replacement was performed. Pattern \`${pattern}\` matched ${matches.length} times (lines ${JSON.stringify(lineNumbers)}). Pass replace_all=true to replace every occurrence, or tighten the pattern.`
+    )
+  }
+
+  // Build the replacement without recompiling the regex: substitute in reverse
+  // order using the captured match indices when we're replacing all; otherwise
+  // slice around the first match to avoid re-running the engine.
+  const first = matches[0]!
+  let newContent: string
+  if (replaceAll) {
+    newContent = ''
+    let cursor = 0
+    for (const mm of matches) {
+      newContent += fileContent.slice(cursor, mm.index) + expandBackreferences(newStr, mm)
+      cursor = mm.index + mm[0].length
+    }
+    newContent += fileContent.slice(cursor)
+  } else {
+    newContent =
+      fileContent.slice(0, first.index) +
+      expandBackreferences(newStr, first) +
+      fileContent.slice(first.index + first[0].length)
+  }
+
+  const count = replaceAll ? matches.length : 1
+
+  rejectOversizeResult(newContent, maxSize, filePath)
+  storeUndoSnapshot(undoHistory, filePath, fileContent, maxUndoEntries, maxUndoBytes)
+  await sandbox.writeText(filePath, newContent)
+
+  const replacementLine = fileContent.substring(0, first.index).split('\n').length - 1
+  const newLines = newContent.split('\n')
+  const startLine = Math.max(0, replacementLine - SNIPPET_LINES)
+  const endLine = Math.min(newLines.length, replacementLine + SNIPPET_LINES + 1)
+  const snippet = newLines.slice(startLine, endLine).join('\n')
+
+  const suffix = replaceAll && count > 1 ? ` (${count} matches replaced)` : ''
+  return `The file ${filePath} has been edited via pattern_replace.${suffix} ${makeOutput(snippet, `a snippet of ${filePath}`, startLine + 1)}Review the changes and make sure they are as expected. Edit the file again if necessary.`
+}
+
+/**
+ * Expand `$&`, `$$`, and `$1..$9` backreferences against a match, mirroring
+ * String.prototype.replace's replacement-string semantics. Used so a single
+ * compiled regex + captured matches drives both the ambiguity check and the
+ * substitution (no second `.replace()` call, no third regex compile).
+ */
+function expandBackreferences(replacement: string, match: RegExpExecArray): string {
+  return replacement.replace(/\$(\$|&|\d)/g, (_full, token: string) => {
+    if (token === '$') return '$'
+    if (token === '&') return match[0]
+    const idx = parseInt(token, 10)
+    return match[idx] ?? ''
+  })
+}
+
+async function handleFindLine(
+  sandbox: Sandbox,
+  filePath: string,
+  searchText: string,
+  fuzzy: boolean,
+  maxSize: number
+): Promise<string> {
+  if (searchText === undefined) {
+    throw new Error('Parameter `search_text` is required for command: find_line')
+  }
+
+  const { exists, isDir } = await probeSandboxPath(sandbox, filePath)
+  if (!exists) {
+    throw new Error(`The path ${filePath} does not exist. Please provide a valid path.`)
+  }
+  if (isDir) {
+    throw new Error(`The path ${filePath} is a directory and only the \`view\` command can be used on directories`)
+  }
+
+  const fileContent = await readTextOrRejectBinary(sandbox, filePath, maxSize)
+
+  const lineIndex = findLineNumber(fileContent, searchText, fuzzy)
+  if (lineIndex === -1) {
+    throw new Error(`Could not find \`${searchText}\` in ${filePath}.`)
+  }
+
+  const lines = fileContent.split('\n')
+  const startLine = Math.max(0, lineIndex - SNIPPET_LINES)
+  const endLine = Math.min(lines.length, lineIndex + SNIPPET_LINES + 1)
+  const snippet = lines.slice(startLine, endLine).join('\n')
+  return `Found \`${searchText}\` at line ${lineIndex + 1} of ${filePath}.\n${makeOutput(snippet, `a snippet of ${filePath}`, startLine + 1)}`
+}
+
+// Restores the last in-memory snapshot for `filePath`. The snapshot is
+// unconditionally written back through the sandbox: if the file was deleted
+// (or moved) outside the tool since the snapshot was captured, `undo_edit`
+// will re-create it at that path. Undo tracks content-per-path, not the
+// file's presence.
+async function handleUndo(sandbox: Sandbox, filePath: string, undoHistory: Map<string, string>): Promise<string> {
+  const previous = undoHistory.get(filePath)
+  if (previous === undefined) {
+    throw new Error(`No undo history available for ${filePath} in this session.`)
+  }
+  undoHistory.delete(filePath)
+  await sandbox.writeText(filePath, previous)
+  return `Reverted ${filePath} to its previous in-memory snapshot.`
 }

--- a/strands-ts/src/vended-tools/file-editor/types.ts
+++ b/strands-ts/src/vended-tools/file-editor/types.ts
@@ -3,10 +3,29 @@
  */
 export interface FileEditorOptions {
   /**
-   * Maximum file size in bytes that can be read (default: 1048576 / 1MB).
+   * Maximum file size in bytes that can be read (default: 1 * 1024 * 1024 / 1 MB).
    */
   maxFileSize?: number
+  /**
+   * Optional absolute directory that confines every operation.
+   */
+  root?: string
+  /**
+   * Maximum number of distinct paths retained in the in-memory undo history
+   * (default: 32).
+   */
+  maxUndoEntries?: number
+  /**
+   * Approximate byte cap on total undo history (default: 32 * 1024 * 1024 / 32 MB).
+   */
+  maxUndoBytes?: number
 }
+
+// The Zod schema in `file-editor.ts` (`fileEditorInputSchema`) is the single
+// source of truth for the validated input shape. These interfaces exist as a
+// discriminated union so consumers can narrow on `command` in TypeScript; when
+// you add or rename a field on the schema, update the matching interface here
+// too.
 
 /**
  * Input parameters for view operation.
@@ -34,6 +53,12 @@ export interface StrReplaceInput {
   path: string
   old_str: string
   new_str?: string
+  /**
+   * When true, replace every occurrence of `old_str`. Defaults to false; a
+   * match count \> 1 is rejected without this flag to prevent silent broad
+   * edits.
+   */
+  replace_all?: boolean
 }
 
 /**
@@ -47,9 +72,47 @@ export interface InsertInput {
 }
 
 /**
+ * Input parameters for pattern_replace (regex) operation.
+ */
+export interface PatternReplaceInput {
+  command: 'pattern_replace'
+  path: string
+  pattern: string
+  new_str: string
+  /**
+   * When true, replace every match. Defaults to false; a match count \> 1 is
+   * rejected without this flag to prevent silent broad edits.
+   */
+  replace_all?: boolean
+}
+
+/**
+ * Input parameters for find_line operation.
+ */
+export interface FindLineInput {
+  command: 'find_line'
+  path: string
+  search_text: string
+  /**
+   * When true, whitespace between tokens is collapsed and matching is
+   * case-insensitive.
+   */
+  fuzzy?: boolean
+}
+
+/**
+ * Input parameters for undo_edit operation.
+ */
+export interface UndoEditInput {
+  command: 'undo_edit'
+  path: string
+}
+
+/**
  * Union type of all valid file editor inputs.
  */
-export type FileEditorInput = ViewInput | CreateInput | StrReplaceInput | InsertInput
+export type FileEditorInput =
+  ViewInput | CreateInput | StrReplaceInput | InsertInput | PatternReplaceInput | FindLineInput | UndoEditInput
 
 /**
  * Interface for pluggable file readers.


### PR DESCRIPTION
Reconciles the strands-agents/tools editor command set into the existing file_editor vended tool in both SDKs. The tool now exposes seven commands: view, create, str_replace, insert, pattern_replace (regex), find_line, and undo_edit (single-step, in-memory), rather than the previous four. No new editor tool is introduced; the surface simply grows.

The wider win is that every command now routes through a single path resolver (_resolve_path in Python, resolvePath in TypeScript) with optional root confinement. Previously each handler had to remember to call _validate_path, so a future command could have silently skipped it. That funnel is enforced by construction now, and applies both a string-level check (absolute path, no .. segments, inside root) and, when the local filesystem sees the target, a realpath-based symlink check.

Notable calls: symlink confinement is deliberately best-effort at the string level and skipped when root is not visible locally, since a Docker or SSH sandbox's paths do not map to this host and a realpath check would ENOENT on every call. Binary and non-UTF-8 files are rejected up front to prevent mangled output and writes. The size cap defaults to one megabyte, configurable via max_file_size / maxFileSize. Ambiguous str_replace and pattern_replace matches are rejected unless the caller opts in with replace_all, so the model cannot silently rewrite an entire file from a fuzzy match. Undo is a per-tool-instance LRU of pre-edit content, capped by both entry count and byte size, never touching disk. The community-tools editor's syntax highlighting, rich console output, and .bak backup files are deliberately not ported: presentation belongs in SDK hooks, and disk backups do not survive a container restart.

The TypeScript input type is a hand-maintained discriminated union rather than a z.infer, so consumers can narrow on the command literal in a way z.infer would flatten. A comment marks the Zod schema as the single source of truth.

https://github.com/strands-agents/harness-sdk/issues/3235