### PR TITLE
feat(vended-tools): add sleep tool

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
@@ -36,6 +36,16 @@ import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:combined_import]
 
+// --8<-- [start:sleep_import]
+import { Agent } from '@strands-agents/sdk'
+import { sleep } from '@strands-agents/sdk/vended-tools/sleep'
+// --8<-- [end:sleep_import]
+
+// --8<-- [start:sleep_custom_import]
+import { Agent } from '@strands-agents/sdk'
+import { makeSleep } from '@strands-agents/sdk/vended-tools/sleep'
+// --8<-- [end:sleep_custom_import]
+
 // --8<-- [start:stop_import]
 import { Agent } from '@strands-agents/sdk'
 import { stop } from '@strands-agents/sdk/vended-tools/stop'

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,8 +10,10 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-ts/src/vended-tools/sleep/sleep.ts
   - path: strands-ts/src/vended-tools/stop/stop.ts
   - path: strands-py/src/strands/vended_tools/http_request/http_request.py
+  - path: strands-py/src/strands/vended_tools/sleep/sleep.py
   - path: strands-py/src/strands/vended_tools/stop/stop.py
 ---
 
@@ -37,6 +39,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | Python, TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
+| [Sleep](#sleep) | Pause execution for a bounded, cancellable duration | Python, TypeScript (Node.js, browsers) |
 | [Stop](#stop) | Gracefully end the agent loop when the task is complete | Python, TypeScript (Node.js, browsers) |
 
 ### File Editor
@@ -197,6 +200,72 @@ agent("List all Python files in the current directory and count them")
 ```
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
+
+---
+
+### Sleep
+
+Pauses the agent for a bounded number of seconds. Cancelling the enclosing
+invocation aborts the sleep immediately rather than waiting for the full
+duration, so a long timer never ties up a session the caller has moved on from.
+
+_Supported in: Node.js, modern browsers (TypeScript); all platforms (Python)._
+
+The maximum duration is configurable at construction (default: 60 seconds) and
+cannot be raised by the model. Negative, `NaN`, infinite, non-numeric, and
+boolean durations are rejected at the tool boundary.
+
+**Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:sleep_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:sleep_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import sleep
+
+agent = Agent(tools=[sleep])
+agent("Pause for two seconds, then continue.")
+```
+
+</Tab>
+</Tabs>
+
+**Custom maximum:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:sleep_custom_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:sleep_custom_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import make_sleep
+
+short_sleep = make_sleep(max_duration=5)
+agent = Agent(tools=[short_sleep])
+```
+
+</Tab>
+</Tabs>
+
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/sleep/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
@@ -6,6 +6,8 @@ import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:basic_import]
 import { SessionManager, FileStorage } from '@strands-agents/sdk'
+import { sleep, makeSleep } from '@strands-agents/sdk/vended-tools/sleep'
+import { stop } from '@strands-agents/sdk/vended-tools/stop'
 
 // Agent with vended tools example
 async function agentWithVendedToolsExample() {
@@ -132,7 +134,23 @@ async function combinedToolsExample() {
   // --8<-- [end:combined_tools_example]
 }
 
-import { stop } from '@strands-agents/sdk/vended-tools/stop'
+// Sleep tool example
+async function sleepExample() {
+  // --8<-- [start:sleep_example]
+  const agent = new Agent({
+    tools: [sleep],
+  })
+  await agent.invoke('Pause for two seconds, then continue.')
+  // --8<-- [end:sleep_example]
+}
+
+// Sleep tool custom maximum
+async function sleepCustomExample() {
+  // --8<-- [start:sleep_custom_example]
+  const shortSleep = makeSleep({ maxDuration: 5 })
+  const agent = new Agent({ tools: [shortSleep] })
+  // --8<-- [end:sleep_custom_example]
+}
 
 // Stop tool example
 async function stopExample() {

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,10 +1,11 @@
-"""Built-in tools for executing commands, editing files, making HTTP requests, and controlling the agent loop.
+"""Built-in tools for commands, files, HTTP, pausing, and agent-loop control.
 
 The :data:`bash` tool runs a
 persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
 factories produce sandbox-routed tools that either bind to a
 :class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
 sandboxes do when vending tools) or read the sandbox from the agent at call time.
+The :data:`sleep` tool pauses execution for a bounded, cancellable duration.
 The :data:`stop` tool signals the event loop to end the current invocation
 gracefully.
 
@@ -16,15 +17,16 @@ controls when needed.
 Example Usage:
     ```python
     from strands import Agent
-    from strands.vended_tools import bash, file_editor, http_request, stop
+    from strands.vended_tools import bash, file_editor, http_request, sleep, stop
 
-    agent = Agent(tools=[bash, file_editor, http_request, stop])
+    agent = Agent(tools=[bash, file_editor, http_request, sleep, stop])
     ```
 """
 
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
 from .http_request import http_request, make_http_request
+from .sleep import make_sleep, sleep
 from .stop import make_stop, stop
 
 __all__ = [
@@ -34,6 +36,8 @@ __all__ = [
     "make_bash",
     "make_file_editor",
     "make_http_request",
+    "make_sleep",
     "make_stop",
+    "sleep",
     "stop",
 ]

--- a/strands-py/src/strands/vended_tools/sleep/__init__.py
+++ b/strands-py/src/strands/vended_tools/sleep/__init__.py
@@ -1,0 +1,17 @@
+"""Sleep tool for pausing agent execution for a bounded, cooperative duration.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import sleep
+
+    agent = Agent(tools=[sleep])
+    ```
+"""
+
+from .sleep import make_sleep, sleep
+
+__all__ = [
+    "make_sleep",
+    "sleep",
+]

--- a/strands-py/src/strands/vended_tools/sleep/sleep.py
+++ b/strands-py/src/strands/vended_tools/sleep/sleep.py
@@ -1,0 +1,90 @@
+"""Sleep tool: pause execution for a bounded, cooperative duration.
+
+Provides :func:`make_sleep` (a factory that lets the caller configure the
+maximum permitted duration) and :data:`sleep` (a default instance with a 60-second
+cap). Sleeps are implemented with :func:`asyncio.sleep`, which unblocks
+immediately when the surrounding task is cancelled. When the tool is invoked
+through the standard :class:`DecoratedFunctionTool` path, the raised
+:class:`asyncio.CancelledError` is caught by the tool executor and surfaced as
+a tool-error result; direct callers awaiting the underlying coroutine observe
+the cancellation directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from typing import TYPE_CHECKING
+
+from ...tools.decorator import tool
+from .types import DEFAULT_MAX_DURATION, sleep_description
+
+if TYPE_CHECKING:
+    from ...tools.decorator import DecoratedFunctionTool
+
+
+def make_sleep(
+    *,
+    max_duration: float = DEFAULT_MAX_DURATION,
+    name: str = "sleep",
+    description: str | None = None,
+) -> DecoratedFunctionTool:
+    """Create a sleep tool with a configurable maximum duration.
+
+    The returned tool pauses execution for ``duration`` seconds via
+    :func:`asyncio.sleep`. Cancelling the surrounding task unblocks the sleep
+    immediately rather than waiting for the full duration; the resulting
+    :class:`asyncio.CancelledError` is caught by the standard tool executor
+    when the tool is invoked through :class:`DecoratedFunctionTool` and
+    surfaced as a tool-error result to the model.
+
+    Args:
+        max_duration: Upper bound on ``duration`` in seconds. Must be a finite,
+            positive number. Defaults to :data:`DEFAULT_MAX_DURATION` (60 s).
+        name: Tool name. Defaults to ``"sleep"``.
+        description: Tool description shown to the model.
+
+    Returns:
+        A decorated tool that pauses execution for the requested duration.
+
+    Raises:
+        ValueError: If ``max_duration`` is not a positive, finite number.
+    """
+    if not isinstance(max_duration, (int, float)) or isinstance(max_duration, bool):
+        raise ValueError(f"max_duration must be a number, got {type(max_duration).__name__}")
+    if not math.isfinite(max_duration) or max_duration <= 0:
+        raise ValueError(f"max_duration must be positive and finite, got {max_duration!r}")
+
+    resolved_max = float(max_duration)
+    resolved_description = description if description is not None else sleep_description(resolved_max)
+
+    @tool(name=name, description=resolved_description)
+    async def sleep_tool(duration: float) -> str:
+        """Pauses execution for the given number of seconds.
+
+        The sleep is cooperative: it uses :func:`asyncio.sleep` and aborts
+        immediately if the enclosing task is cancelled. Negative, non-finite,
+        non-numeric, or oversized durations are rejected before the sleep begins.
+
+        Args:
+            duration: Seconds to pause. Must be a finite, non-negative number
+                no larger than the tool's configured maximum.
+        """
+        if isinstance(duration, bool) or not isinstance(duration, (int, float)):
+            raise ValueError(f"duration must be a number, got {type(duration).__name__}")
+        seconds = float(duration)
+        if not math.isfinite(seconds):
+            raise ValueError(f"duration must be a finite number, got {duration!r}")
+        if seconds < 0:
+            raise ValueError(f"duration must be non-negative, got {seconds}")
+        if seconds > resolved_max:
+            raise ValueError(f"duration {seconds} exceeds maximum of {resolved_max} seconds")
+
+        await asyncio.sleep(seconds)
+        return f"Slept for {duration} seconds"
+
+    return sleep_tool
+
+
+sleep = make_sleep()
+"""Default sleep tool with a 60-second maximum duration."""

--- a/strands-py/src/strands/vended_tools/sleep/types.py
+++ b/strands-py/src/strands/vended_tools/sleep/types.py
@@ -1,0 +1,18 @@
+"""Shared types and constants for the sleep tool."""
+
+DEFAULT_MAX_DURATION = 60.0
+"""Default upper bound on ``duration`` (seconds) accepted by :func:`make_sleep`."""
+
+
+def sleep_description(max_duration: float) -> str:
+    """Build the model-facing description with the configured max interpolated."""
+    return (
+        f"Pauses execution for a specified number of seconds (max {max_duration}). "
+        "Cooperative and cancellable: the sleep aborts immediately when the agent "
+        "invocation is cancelled. Rejects negative, NaN, infinite, or non-numeric "
+        f"durations, and durations above {max_duration}."
+    )
+
+
+SLEEP_DESCRIPTION = sleep_description(DEFAULT_MAX_DURATION)
+"""Description for the default sleep tool (60-second cap)."""

--- a/strands-py/tests/strands/vended_tools/test_sleep.py
+++ b/strands-py/tests/strands/vended_tools/test_sleep.py
@@ -1,0 +1,169 @@
+"""Tests for the sleep tool.
+
+The sleep tool pauses execution via :func:`asyncio.sleep`. Tests use tiny
+durations (single-digit millisecond values or less) and patch
+:func:`asyncio.sleep` where the assertion is about the argument rather than
+the delay itself, so the suite never actually blocks for a second. Coverage
+spans input validation, the configurable cap, and cooperative cancellation.
+"""
+
+import asyncio
+import importlib
+import math
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from strands.vended_tools.sleep import make_sleep, sleep
+from strands.vended_tools.sleep.types import DEFAULT_MAX_DURATION
+
+# The parent package rebinds ``sleep`` to the tool object, which shadows the
+# submodule attribute. On Python 3.10 ``unittest.mock.patch`` walks a dotted
+# target with ``getattr`` and stops at that tool, raising AttributeError; 3.11+
+# resolves the longest importable prefix first. Reach the submodule via
+# ``importlib`` so tests behave identically across supported Python versions.
+_sleep_module = importlib.import_module("strands.vended_tools.sleep.sleep")
+
+
+class TestInputValidation:
+    """Boundary validation on the ``duration`` input."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_negative_duration(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            await sleep(duration=-0.1)
+
+    @pytest.mark.asyncio
+    async def test_rejects_nan_duration(self):
+        with pytest.raises(ValueError, match="finite"):
+            await sleep(duration=math.nan)
+
+    @pytest.mark.asyncio
+    async def test_rejects_positive_infinity(self):
+        with pytest.raises(ValueError, match="finite"):
+            await sleep(duration=math.inf)
+
+    @pytest.mark.asyncio
+    async def test_rejects_negative_infinity(self):
+        with pytest.raises(ValueError, match="finite"):
+            await sleep(duration=-math.inf)
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_numeric_duration(self):
+        with pytest.raises(ValueError, match="number"):
+            await sleep(duration="1.0")  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_rejects_boolean_duration(self):
+        with pytest.raises(ValueError, match="number"):
+            await sleep(duration=True)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_rejects_duration_above_max(self):
+        capped = make_sleep(max_duration=0.5)
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            await capped(duration=0.6)
+
+    @pytest.mark.asyncio
+    async def test_rejects_duration_above_default_max(self):
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            await sleep(duration=DEFAULT_MAX_DURATION + 1)
+
+
+class TestFactoryValidation:
+    """The factory itself rejects bad ``max_duration`` values."""
+
+    def test_rejects_zero_max(self):
+        with pytest.raises(ValueError, match="positive"):
+            make_sleep(max_duration=0)
+
+    def test_rejects_negative_max(self):
+        with pytest.raises(ValueError, match="positive"):
+            make_sleep(max_duration=-1)
+
+    def test_rejects_nan_max(self):
+        with pytest.raises(ValueError, match="positive"):
+            make_sleep(max_duration=math.nan)
+
+    def test_rejects_infinite_max(self):
+        with pytest.raises(ValueError, match="positive"):
+            make_sleep(max_duration=math.inf)
+
+    def test_rejects_non_numeric_max(self):
+        with pytest.raises(ValueError, match="number"):
+            make_sleep(max_duration="60")  # type: ignore[arg-type]
+
+
+class TestCooperativeCancellation:
+    """The sleep must abort promptly when the enclosing task is cancelled."""
+
+    @pytest.mark.asyncio
+    async def test_cancellation_propagates_before_full_duration(self):
+        capped = make_sleep(max_duration=10)
+
+        task = asyncio.create_task(capped(duration=5))
+        # Let the coroutine reach the ``await asyncio.sleep`` point.
+        await asyncio.sleep(0)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_cancellation_does_not_wait_for_full_duration(self):
+        """Cancelling should return in far less time than the requested sleep."""
+        capped = make_sleep(max_duration=10)
+
+        task = asyncio.create_task(capped(duration=5))
+        await asyncio.sleep(0)
+
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        elapsed = loop.time() - started
+        # A cooperative cancel should return well under a second; the requested
+        # sleep was 5 s.
+        assert elapsed < 1.0
+
+
+class TestHappyPath:
+    """Successful sleeps return a completion message."""
+
+    @pytest.mark.asyncio
+    async def test_zero_duration_returns_immediately(self):
+        result = await sleep(duration=0)
+        assert result == "Slept for 0 seconds"
+
+    @pytest.mark.asyncio
+    async def test_small_duration_returns_expected_message(self):
+        result = await sleep(duration=0.01)
+        assert result == "Slept for 0.01 seconds"
+
+    @pytest.mark.asyncio
+    async def test_calls_asyncio_sleep_with_requested_duration(self):
+        # A fake asyncio.sleep proves we hand the requested value straight through
+        # to the primitive, without waiting a real second. Patch the module's
+        # ``asyncio`` binding rather than ``asyncio.sleep`` itself so we don't
+        # break other tests that concurrently use the real primitive.
+        fake_sleep = AsyncMock()
+        fake_asyncio = types.SimpleNamespace(sleep=fake_sleep)
+        with patch.object(_sleep_module, "asyncio", fake_asyncio):
+            result = await sleep(duration=1.5)
+
+        fake_sleep.assert_awaited_once_with(1.5)
+        assert result == "Slept for 1.5 seconds"
+
+    @pytest.mark.asyncio
+    async def test_integer_duration_is_accepted(self):
+        fake_sleep = AsyncMock()
+        fake_asyncio = types.SimpleNamespace(sleep=fake_sleep)
+        with patch.object(_sleep_module, "asyncio", fake_asyncio):
+            result = await sleep(duration=2)
+
+        fake_sleep.assert_awaited_once_with(2.0)
+        assert result == "Slept for 2 seconds"
+
+

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/src/vended-tools/bash/index.d.ts",
       "default": "./dist/src/vended-tools/bash/index.js"
     },
+    "./vended-tools/sleep": {
+      "types": "./dist/src/vended-tools/sleep/index.d.ts",
+      "default": "./dist/src/vended-tools/sleep/index.js"
+    },
     "./vended-tools/stop": {
       "types": "./dist/src/vended-tools/stop/index.d.ts",
       "default": "./dist/src/vended-tools/stop/index.js"

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -3,7 +3,7 @@
  *
  * Provides a single import path for consumers who want all built-in tools:
  * ```typescript
- * import { bash, fileEditor, httpRequest, notebook } from '@strands-agents/sdk/vended-tools'
+ * import { bash, fileEditor, httpRequest, notebook, sleep, stop } from '@strands-agents/sdk/vended-tools'
  * ```
  *
  * Note: This module requires a Node.js environment because the `bash` tool
@@ -15,4 +15,5 @@ export * from './bash/index.js'
 export * from './file-editor/index.js'
 export * from './http-request/index.js'
 export * from './notebook/index.js'
+export * from './sleep/index.js'
 export * from './stop/index.js'

--- a/strands-ts/src/vended-tools/sleep/README.md
+++ b/strands-ts/src/vended-tools/sleep/README.md
@@ -1,0 +1,57 @@
+# Sleep Tool
+
+Pauses agent execution for a bounded, cooperative duration.
+
+The tool takes a `duration` in seconds. It attaches a one-shot listener to `context.agent.cancelSignal`, so cancelling the agent aborts the sleep immediately rather than waiting for the full duration. A configurable maximum (default: 60 s) rejects oversized requests before the sleep starts, and negative, `NaN`, `Infinity`, and non-numeric inputs are rejected at the tool boundary.
+
+## Usage
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { sleep } from '@strands-agents/sdk/vended-tools/sleep'
+
+const agent = new Agent({ tools: [sleep] })
+await agent.invoke('Pause for two seconds, then continue.')
+```
+
+Direct invocation:
+
+```typescript
+const result = await sleep.invoke({ duration: 0.5 })
+// "Slept for 0.5 seconds"
+```
+
+Custom maximum:
+
+```typescript
+import { makeSleep } from '@strands-agents/sdk/vended-tools/sleep'
+
+const shortSleep = makeSleep({ maxDuration: 5 })
+const agent = new Agent({ tools: [shortSleep] })
+```
+
+## API
+
+### `sleep`
+
+The default tool, produced by `makeSleep()` with `maxDuration = 60`.
+
+### `makeSleep(options?)`
+
+| Option        | Type     | Default    | Description                                                         |
+| ------------- | -------- | ---------- | ------------------------------------------------------------------- |
+| `maxDuration` | `number` | `60`       | Upper bound on `duration`, in seconds. Must be finite and positive. |
+| `name`        | `string` | `sleep`    | Tool name.                                                          |
+| `description` | `string` | (built-in) | Description shown to the model.                                     |
+
+Throws if `maxDuration` is not a positive, finite number.
+
+### Input
+
+| Property   | Type     | Required | Description                                                           |
+| ---------- | -------- | -------- | --------------------------------------------------------------------- |
+| `duration` | `number` | Yes      | Seconds to pause. Must be finite, non-negative, and `<= maxDuration`. |
+
+### Output
+
+Returns a string of the form `"Slept for <duration> seconds"`.

--- a/strands-ts/src/vended-tools/sleep/__tests__/sleep.test.ts
+++ b/strands-ts/src/vended-tools/sleep/__tests__/sleep.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { sleep, makeSleep, DEFAULT_MAX_DURATION } from '../index.js'
+import type { ToolContext } from '../../../index.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+
+/**
+ * Build a fresh ToolContext, optionally wiring an AbortController's signal
+ * onto the mock agent for cancellation testing.
+ */
+function createContext(controller?: AbortController): ToolContext {
+  const agent = createMockAgent()
+  if (controller) {
+    // Override the mock's default (unaborted) signal with the test's controller.
+    Object.defineProperty(agent, 'cancelSignal', { value: controller.signal, configurable: true })
+  }
+  return {
+    toolUse: { name: 'sleep', toolUseId: 'test-id', input: {} },
+    agent,
+    invocationState: {},
+    interrupt: () => {
+      throw new Error('interrupt not available in mock context')
+    },
+  }
+}
+
+describe('sleep tool', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('input validation', () => {
+    it('rejects negative durations', async () => {
+      await expect(sleep.invoke({ duration: -0.1 }, createContext())).rejects.toThrow(/non-negative/)
+    })
+
+    it('rejects NaN durations', async () => {
+      await expect(sleep.invoke({ duration: Number.NaN }, createContext())).rejects.toThrow()
+    })
+
+    it('rejects positive infinity', async () => {
+      await expect(sleep.invoke({ duration: Number.POSITIVE_INFINITY }, createContext())).rejects.toThrow()
+    })
+
+    it('rejects negative infinity', async () => {
+      await expect(sleep.invoke({ duration: Number.NEGATIVE_INFINITY }, createContext())).rejects.toThrow()
+    })
+
+    it('rejects non-numeric input via schema', async () => {
+      await expect(sleep.invoke({ duration: 'one' as unknown as number }, createContext())).rejects.toThrow()
+    })
+
+    it('rejects boolean input via schema', async () => {
+      await expect(sleep.invoke({ duration: true as unknown as number }, createContext())).rejects.toThrow()
+      await expect(sleep.invoke({ duration: false as unknown as number }, createContext())).rejects.toThrow()
+    })
+
+    it('rejects duration above default maximum', async () => {
+      await expect(sleep.invoke({ duration: DEFAULT_MAX_DURATION + 1 }, createContext())).rejects.toThrow(
+        /exceeds maximum/
+      )
+    })
+
+    it('rejects duration above configured maximum', async () => {
+      const capped = makeSleep({ maxDuration: 0.5 })
+      await expect(capped.invoke({ duration: 0.6 }, createContext())).rejects.toThrow(/exceeds maximum/)
+    })
+  })
+
+  describe('factory validation', () => {
+    it('rejects zero maxDuration', () => {
+      expect(() => makeSleep({ maxDuration: 0 })).toThrow(/positive/)
+    })
+
+    it('rejects negative maxDuration', () => {
+      expect(() => makeSleep({ maxDuration: -1 })).toThrow(/positive/)
+    })
+
+    it('rejects NaN maxDuration', () => {
+      expect(() => makeSleep({ maxDuration: Number.NaN })).toThrow(/positive/)
+    })
+
+    it('rejects Infinity maxDuration', () => {
+      expect(() => makeSleep({ maxDuration: Number.POSITIVE_INFINITY })).toThrow(/positive/)
+    })
+
+    it('rejects non-numeric maxDuration', () => {
+      expect(() => makeSleep({ maxDuration: '10' as unknown as number })).toThrow(/positive/)
+    })
+  })
+
+  describe('cancellation', () => {
+    it('aborts immediately when cancelSignal fires mid-sleep', async () => {
+      const controller = new AbortController()
+      const context = createContext(controller)
+
+      const invocation = sleep.invoke({ duration: 5 }, context)
+      globalThis.setTimeout(() => controller.abort(), 10)
+
+      const started = Date.now()
+      const error = await invocation.catch((cause: unknown) => cause)
+      const elapsed = Date.now() - started
+      // Cooperative cancel: should return in far less than the requested 5 s.
+      expect(elapsed).toBeLessThan(1000)
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).name).toBe('AbortError')
+    })
+
+    it('rejects synchronously when the signal is already aborted', async () => {
+      const controller = new AbortController()
+      controller.abort()
+      const context = createContext(controller)
+
+      const error = await sleep.invoke({ duration: 1 }, context).catch((cause: unknown) => cause)
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).name).toBe('AbortError')
+    })
+  })
+
+  describe('happy path', () => {
+    it('returns the expected message after a real short sleep', async () => {
+      const started = Date.now()
+      const result = await sleep.invoke({ duration: 0.05 }, createContext())
+      const elapsed = Date.now() - started
+      expect(result).toBe('Slept for 0.05 seconds')
+      // Most of the requested duration should have elapsed.
+      expect(elapsed).toBeGreaterThanOrEqual(40)
+    })
+
+    it('accepts zero duration', async () => {
+      const result = await sleep.invoke({ duration: 0 }, createContext())
+      expect(result).toBe('Slept for 0 seconds')
+    })
+
+    it('works without a context by skipping the cancel wiring', async () => {
+      const result = await sleep.invoke({ duration: 0.01 })
+      expect(result).toBe('Slept for 0.01 seconds')
+    })
+  })
+
+  describe('timing (fake timers)', () => {
+    // Isolate fake-timer usage so any leakage cannot poison the real-timer tests.
+    it('drives setTimeout with the requested duration in ms', async () => {
+      vi.useFakeTimers()
+      try {
+        const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+
+        const promise = sleep.invoke({ duration: 2 }, createContext())
+        // Let the promise executor schedule its timer.
+        await Promise.resolve()
+
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000)
+
+        await vi.advanceTimersByTimeAsync(2000)
+        await expect(promise).resolves.toBe('Slept for 2 seconds')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/sleep/index.ts
+++ b/strands-ts/src/vended-tools/sleep/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Sleep tool for pausing agent execution for a bounded, cooperative duration.
+ */
+
+export { sleep } from './sleep.js'
+export { makeSleep } from './make-sleep.js'
+export type { MakeSleepOptions } from './make-sleep.js'
+export { DEFAULT_MAX_DURATION, SLEEP_DESCRIPTION } from './types.js'
+export type { SleepInput } from './types.js'

--- a/strands-ts/src/vended-tools/sleep/make-sleep.ts
+++ b/strands-ts/src/vended-tools/sleep/make-sleep.ts
@@ -1,0 +1,111 @@
+/**
+ * Sleep tool factory: pauses execution for a bounded, cooperative duration.
+ *
+ * The returned tool honors the invocation's `AbortSignal` (from
+ * `context.agent.cancelSignal`), so cancelling the agent aborts the sleep
+ * immediately rather than waiting for the full duration.
+ */
+
+import type { InvokableTool } from '../../tools/tool.js'
+import { tool } from '../../tools/tool-factory.js'
+import { z } from 'zod'
+import type { JSONValue } from '../../types/json.js'
+import type { SleepInput } from './types.js'
+import { DEFAULT_MAX_DURATION, sleepDescription } from './types.js'
+
+/**
+ * Options for {@link makeSleep}.
+ */
+export interface MakeSleepOptions {
+  /**
+   * Upper bound on the `duration` input, in seconds. Must be a finite, positive
+   * number. Defaults to {@link DEFAULT_MAX_DURATION} (60 s).
+   */
+  maxDuration?: number
+  /**
+   * Tool name. Defaults to `"sleep"`.
+   */
+  name?: string
+  /**
+   * Tool description shown to the model.
+   */
+  description?: string
+}
+
+/**
+ * Creates a sleep tool with a configurable maximum duration.
+ *
+ * The returned tool pauses for the requested number of seconds. It attaches a
+ * one-shot listener to `context.agent.cancelSignal` so that cancellation of
+ * the enclosing agent invocation immediately aborts the sleep with an
+ * `AbortError`.
+ *
+ * @param options - Configuration options.
+ * @returns A tool that pauses execution for the requested duration.
+ * @throws Error if `maxDuration` is not a finite, positive number.
+ *
+ * @example
+ * ```typescript
+ * const shortSleep = makeSleep({ maxDuration: 5 })
+ * const agent = new Agent({ tools: [shortSleep] })
+ * ```
+ */
+export function makeSleep(options: MakeSleepOptions = {}): InvokableTool<SleepInput, JSONValue> {
+  const maxDuration = options.maxDuration ?? DEFAULT_MAX_DURATION
+  if (typeof maxDuration !== 'number' || !Number.isFinite(maxDuration) || maxDuration <= 0) {
+    throw new Error(`maxDuration must be a positive, finite number, got ${String(maxDuration)}`)
+  }
+
+  const inputSchema = z.object({
+    duration: z
+      .number()
+      .finite('duration must be a finite number')
+      .nonnegative('duration must be non-negative')
+      .max(maxDuration, `duration exceeds maximum of ${maxDuration} seconds`)
+      .describe(`Seconds to pause. Must be finite, non-negative, and no larger than ${maxDuration}.`),
+  })
+
+  return tool({
+    name: options.name ?? 'sleep',
+    description: options.description ?? sleepDescription(maxDuration),
+    inputSchema,
+    callback: async (input, context) => {
+      const { duration } = input
+
+      const cancelSignal = context?.agent.cancelSignal
+      if (cancelSignal?.aborted) {
+        throw cancelSignal.reason ?? new DOMException('Sleep cancelled before it started', 'AbortError')
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        function cleanup(): void {
+          if (cancelSignal) {
+            cancelSignal.removeEventListener('abort', onAbort)
+          }
+        }
+        function onAbort(): void {
+          globalThis.clearTimeout(timer)
+          cleanup()
+          reject(cancelSignal?.reason ?? new DOMException('Sleep cancelled', 'AbortError'))
+        }
+
+        const timer = globalThis.setTimeout(() => {
+          cleanup()
+          resolve()
+        }, duration * 1000)
+
+        if (cancelSignal) {
+          cancelSignal.addEventListener('abort', onAbort, { once: true })
+          // Re-check after attaching: the signal may have aborted between the
+          // pre-flight check and here, and abort listeners do not fire for
+          // events dispatched before they were added.
+          if (cancelSignal.aborted) {
+            onAbort()
+          }
+        }
+      })
+
+      return `Slept for ${duration} seconds`
+    },
+  })
+}

--- a/strands-ts/src/vended-tools/sleep/sleep.ts
+++ b/strands-ts/src/vended-tools/sleep/sleep.ts
@@ -1,0 +1,21 @@
+/**
+ * Default sleep tool with the built-in maximum duration.
+ */
+
+import { makeSleep } from './make-sleep.js'
+
+/**
+ * Default sleep tool. Pauses execution for up to 60 seconds and aborts
+ * immediately when the agent invocation is cancelled.
+ *
+ * @example
+ * ```typescript
+ * // With an agent
+ * const agent = new Agent({ tools: [sleep] })
+ * await agent.invoke('Wait 2 seconds, then continue')
+ *
+ * // Direct usage
+ * await sleep.invoke({ duration: 0.5 })
+ * ```
+ */
+export const sleep = makeSleep()

--- a/strands-ts/src/vended-tools/sleep/types.ts
+++ b/strands-ts/src/vended-tools/sleep/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Type definitions and constants for the sleep tool.
+ */
+
+/**
+ * Default upper bound on `duration` (seconds) accepted by `makeSleep`.
+ */
+export const DEFAULT_MAX_DURATION = 60
+
+/**
+ * Build the model-facing description with the configured maximum interpolated
+ * so the model knows the exact ceiling.
+ */
+export function sleepDescription(maxDuration: number): string {
+  return (
+    `Pauses execution for a specified number of seconds (max ${maxDuration}). ` +
+    'Cooperative and cancellable: the sleep aborts immediately when the agent ' +
+    'invocation is cancelled. Rejects negative, NaN, infinite, or non-numeric ' +
+    `durations, and durations above ${maxDuration}.`
+  )
+}
+
+/**
+ * Description for the default sleep tool (60-second cap).
+ */
+export const SLEEP_DESCRIPTION = sleepDescription(DEFAULT_MAX_DURATION)
+
+/**
+ * Input parameters accepted by the sleep tool.
+ *
+ * The Zod schema in `make-sleep.ts` is the single source of truth for the
+ * validated input shape (it also enforces the configured maximum); this type
+ * describes the pre-refinement shape callers can pass directly.
+ */
+export interface SleepInput {
+  /**
+   * Seconds to pause. Must be a finite, non-negative number and no larger than
+   * the tool's configured maximum.
+   */
+  duration: number
+}


### PR DESCRIPTION
Closes #3241.

Vended sleep tool in both SDKs. Pauses agent execution for a requested number of seconds and cooperates with the SDK's cancellation primitive so cancelling the enclosing invocation aborts the sleep immediately rather than waiting out the full duration. Python shims onto asyncio.sleep, TypeScript onto setTimeout plus the invocation's AbortSignal.

Both expose a factory with a configurable duration cap, defaulting to sixty seconds. The cap is set at construction and cannot be raised by the model. Requests above the cap are rejected at the tool boundary before the sleep starts. Negative, NaN, positive and negative infinity, non-numeric, and boolean durations are also rejected. Stdlib only, no new deps.

Tests exercise the boundary rejections, the factory-level cap checks, and a real five-second cancel that returns in well under a second. The TypeScript suite also covers the short-circuit path for an already-aborted signal and asserts, via a fake timer, that the underlying timer receives the requested duration converted to milliseconds.
