### PR TITLE
feat(vended-tools): add http_request to strands-py

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,6 +10,7 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-py/src/strands/vended_tools/http_request/http_request.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -31,7 +32,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | Tool | Description | Supported in |
 |------|-------------|--------------|
 | [File Editor](#file-editor) | View, create, and edit files | Python, TypeScript (Node.js) |
-| [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
+| [HTTP Request](#http-request) | Make HTTP requests to external APIs | Python, TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
 
@@ -76,20 +77,53 @@ agent("Create a file at /tmp/hello.txt with the contents 'Hello, world!'")
 
 Lets your agent call external APIs and fetch web content. Supports all HTTP methods, custom headers, and request bodies. Default timeout is 30 seconds.
 
-_Supported in: Node.js 20+, modern browsers._
+_Supported in: Python; Node.js 20+, modern browsers (TypeScript)._
+
+The Python tool ships with a strict default posture that rejects non-public destinations (loopback, RFC1918, link-local, multicast, reserved, and known cloud-metadata endpoints), refuses non-http and non-https schemes, caps redirect chains, response bodies, and response headers, and rejects model-supplied Authorization, Cookie, and Proxy-Authorization headers unless the tool operator has opted the target host in. Redirects are re-validated at every hop and cross-origin hops strip credentials. Use the make_http_request factory to relax individual controls when the deployment requires it.
 
 :::caution[Security Warning]
-This tool makes HTTP requests to arbitrary URLs without restrictions on destination. Only use with trusted input and consider running in a [sandboxed environment](../sandbox/index.mdx) for production.
+Even with the default posture, this tool can call any public URL. Only use with trusted input and consider running in a [sandboxed environment](../sandbox/index.mdx) for production.
 :::
 
 **Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
 ```typescript
 --8<-- "user-guide/concepts/tools/vended-tools-imports.ts:http_request_import"
 
 --8<-- "user-guide/concepts/tools/vended-tools.ts:http_request_example"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/http-request/README.md)
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import http_request
+
+agent = Agent(tools=[http_request])
+agent("Get data from https://api.example.com/data")
+```
+
+Custom posture:
+
+```python
+from strands import Agent
+from strands.vended_tools import make_http_request
+
+tool = make_http_request(
+    allow_private_hosts=["metrics.internal.example.com"],
+    allow_auth_for_hosts=["api.example.com"],
+)
+agent = Agent(tools=[tool])
+```
+
+</Tab>
+</Tabs>
+
+📖 Full API Reference: [TypeScript](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/http-request/README.md) · [Python](https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/vended_tools/http_request/README.md)
 
 ---
 

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "boto3>=1.26.0,<2.0.0",
     "botocore>=1.29.0,<2.0.0",
     "docstring_parser>=0.15,<1.0",
+    "httpx>=0.28.1,<1.0.0",
     "jsonschema>=4.0.0,<5.0.0",
     "mcp>=1.23.0,<2.0.0",
     "pydantic>=2.4.0,<3.0.0",

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,4 +1,4 @@
-"""Built-in tools for executing commands and editing files.
+"""Built-in tools for executing commands, editing files, and making HTTP requests.
 
 The :data:`bash` tool runs a
 persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
@@ -6,21 +6,29 @@ factories produce sandbox-routed tools that either bind to a
 :class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
 sandboxes do when vending tools) or read the sandbox from the agent at call time.
 
+The :data:`http_request` tool makes raw HTTP calls with a strict default
+security posture (private-network denial, redirect and body-size caps,
+sensitive-header rejection); use :func:`make_http_request` to relax individual
+controls when needed.
+
 Example Usage:
     ```python
     from strands import Agent
-    from strands.vended_tools import bash, file_editor
+    from strands.vended_tools import bash, file_editor, http_request
 
-    agent = Agent(tools=[bash, file_editor])
+    agent = Agent(tools=[bash, file_editor, http_request])
     ```
 """
 
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
+from .http_request import http_request, make_http_request
 
 __all__ = [
     "bash",
     "file_editor",
+    "http_request",
     "make_bash",
     "make_file_editor",
+    "make_http_request",
 ]

--- a/strands-py/src/strands/vended_tools/http_request/README.md
+++ b/strands-py/src/strands/vended_tools/http_request/README.md
@@ -1,0 +1,47 @@
+# http_request
+
+Vended tool for making raw HTTP calls from an agent, with a strict-by-default posture. Thin shim over httpx.AsyncClient.
+
+## Usage
+
+```python
+from strands import Agent
+from strands.vended_tools import http_request
+
+agent = Agent(tools=[http_request])
+```
+
+Custom posture (operator opts specific hosts back in):
+
+```python
+from strands.vended_tools import make_http_request
+
+tool = make_http_request(
+    allow_private_hosts=["metrics.internal.example.com"],
+    allow_auth_for_hosts=["api.example.com"],
+    max_response_bytes=2 * 1024 * 1024,
+    max_redirects=3,
+    default_timeout_seconds=15.0,
+)
+agent = Agent(tools=[tool])
+```
+
+Model-facing inputs: `method`, `url`, `headers?`, `body?`, `timeout?`. Model-facing output: `status`, `status_text`, `headers`, `body`.
+
+## Defaults
+
+The tool operator sets every control at construction time; the model cannot loosen them.
+
+- Only http and https schemes are accepted.
+- Hostnames ending in `.internal`, `.local`, `.localhost`, `.corp`, `.home`, `.lan`, `.intranet`, `.private`, `.i2p`, or `.onion` are refused before DNS runs. A trailing dot on a rooted FQDN is stripped before matching.
+- Loopback, RFC1918, link-local, multicast, reserved, unspecified, CGNAT, and site-local ranges are refused. IPv4-mapped IPv6 addresses are unwrapped first so `is_global` on Python 3.10 and 3.11 cannot smuggle a private address through.
+- Cloud metadata endpoints (169.254.169.254, `fd00:ec2::254`, `metadata.google.internal`, `metadata`, 100.100.100.200, 192.0.0.192) are rejected before DNS.
+- Redirects are walked manually, every hop is re-validated, and cross-origin hops drop Authorization, Cookie, and Proxy-Authorization. Origin is compared as (scheme, host, port-or-default), so an HTTPS to HTTP downgrade or a port change on the same host also strips. A 303 response forces GET with an empty body. Chain length defaults to five; `max_redirects=0` raises if a 3xx is encountered.
+- Response body defaults to a ten-mebibyte cap; response headers default to a sixty-four-kibibyte cap. Oversize responses raise and the connection is aborted.
+- Model-supplied `timeout` must be positive and is capped at the operator-configured default (thirty seconds); a zero or negative value is rejected.
+- Authorization, Cookie, and Proxy-Authorization are rejected unless the target host is in `allow_auth_for_hosts`. Host and other hop-by-hop headers are rejected unconditionally.
+- The parent agent's cancel signal is read via the injected `ToolContext`. A set signal raises `asyncio.CancelledError` before the next redirect hop and between response-body chunks.
+
+## DNS rebinding
+
+The guard resolves the host up front via `getaddrinfo` and re-validates every redirect. Between check-time and connect-time, httpx performs its own resolve; an attacker-controlled name server can return a public address to the first call and a private one to the second. Pinning the resolved IP through httpx is impractical without reaching into httpcore, so the tool accepts this residual risk against dynamic DNS. The guard still protects against static DNS pointing at private space, and metadata endpoints are blocked by name before DNS runs.

--- a/strands-py/src/strands/vended_tools/http_request/__init__.py
+++ b/strands-py/src/strands/vended_tools/http_request/__init__.py
@@ -1,0 +1,42 @@
+"""HTTP request tool for making raw HTTP calls to external APIs.
+
+The tool ships with a strict default posture: it rejects requests to
+non-public destinations (loopback, RFC1918, link-local, multicast, reserved,
+cloud-metadata endpoints), refuses non-http(s) schemes, caps redirect chains
+and response body size, and rejects model-supplied ``Authorization`` /
+``Cookie`` / ``Proxy-Authorization`` headers unless the tool operator has
+opted the target host in. On a redirect that changes origin (scheme, host,
+or port), those same headers are also stripped so the credential never
+travels to the new origin.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import http_request
+
+    agent = Agent(tools=[http_request])
+    ```
+
+    Custom posture (e.g. allow a known internal host):
+    ```python
+    from strands.vended_tools import make_http_request
+
+    tool = make_http_request(
+        allow_private_hosts=["metrics.internal.example.com"],
+        allow_auth_for_hosts=["api.example.com"],
+    )
+    agent = Agent(tools=[tool])
+    ```
+"""
+
+from .http_request import HttpRequestConfig, HttpRequestError, http_request, make_http_request
+from .types import HttpMethod, HttpRequestOutput
+
+__all__ = [
+    "HttpMethod",
+    "HttpRequestConfig",
+    "HttpRequestError",
+    "HttpRequestOutput",
+    "http_request",
+    "make_http_request",
+]

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -1,0 +1,612 @@
+"""HTTP request tool for making raw HTTP calls to external APIs.
+
+Provides :func:`make_http_request` (a factory that lets the tool operator
+configure allowlists and limits) and :data:`http_request` (a default instance
+with the safe defaults applied).
+
+The tool is a thin shim over ``httpx.AsyncClient``. Its job is to guard the
+network boundary the model can reach:
+
+- reject non-http(s) schemes;
+- reject hostnames that end in the SSRF-spec denylist suffixes
+  (``.internal``, ``.local``, ``.corp``, ``.onion``, ...);
+- resolve the target host to an IP and refuse non-public destinations
+  (RFC1918, loopback, link-local, multicast, reserved, IPv4-mapped-private
+  IPv6, cloud-metadata addresses) unless the operator has explicitly
+  allowlisted the host at construction time;
+- re-validate every redirect hop against the same policy;
+- strip cross-origin auth (``Authorization`` / ``Cookie`` /
+  ``Proxy-Authorization``) on every redirect that changes origin -- a scheme
+  downgrade, a port change, or a host change all strip;
+- cap the total request time, the redirect count, the response body size,
+  and the total response-header size;
+- reject model-supplied ``Authorization`` / ``Cookie`` /
+  ``Proxy-Authorization`` headers unless the operator's config permits
+  them for the target host;
+- propagate the parent agent's cancel signal (``Agent._cancel_signal``) so an
+  in-flight fetch aborts when the agent is cancelled. Cancellation is
+  signalled with :class:`asyncio.CancelledError`, matching the
+  :func:`asyncio.sleep`-style vended-tool convention.
+
+DNS-rebinding note. The check-then-connect pattern here leaves a small TOCTOU
+window: an attacker-controlled name server can return a public address to
+``getaddrinfo`` and a private one to httpx's own resolve at connect time.
+Pinning the resolved IP through httpx's transport is impractical without
+reaching into httpcore internals; we accept this residual risk against
+dynamic DNS and rely on the guard for static DNS. The rest of the controls
+still hold: metadata addresses and non-http(s) schemes remain blocked, and
+redirects are re-validated.
+
+These controls are set by the tool operator at construction time and are
+never controllable by the model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+import threading
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+import httpx
+
+from ...tools.decorator import tool
+from ...types.tools import ToolContext
+from .types import DEFAULT_HTTP_REQUEST_DESCRIPTION, HttpMethod, HttpRequestOutput
+
+if TYPE_CHECKING:
+    from ...tools.decorator import DecoratedFunctionTool
+
+
+Resolver = Callable[[str], list[str]]
+"""Function that maps a hostname to a list of IP-address strings."""
+
+
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024
+_DEFAULT_MAX_REDIRECTS = 5
+_DEFAULT_MAX_RESPONSE_HEADERS_BYTES = 64 * 1024
+"""Cap on the total size of response headers returned to the model."""
+
+_DEFAULT_SCHEME_PORTS = {"http": 80, "https": 443}
+"""Default ports used when computing an origin tuple for redirect auth checks."""
+
+_DENYLIST_SUFFIXES = (
+    ".internal",
+    ".local",
+    ".localhost",
+    ".corp",
+    ".home",
+    ".lan",
+    ".intranet",
+    ".private",
+    ".i2p",
+    ".onion",
+)
+"""Hostname suffixes that must never resolve, per the shared SSRF spec (§4)."""
+
+_SENSITIVE_HEADER_NAMES = frozenset({"authorization", "cookie", "proxy-authorization"})
+"""Headers that the model may not set unless the operator opts the target host in."""
+
+_HOP_BY_HOP_HEADER_NAMES = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+        "host",
+    }
+)
+"""Hop-by-hop and forbidden headers the model must not set."""
+
+_CLOUD_METADATA_HOSTS = frozenset(
+    {
+        # AWS / Azure / OpenStack / DigitalOcean
+        "169.254.169.254",
+        # AWS IMDSv2 IPv6
+        "fd00:ec2::254",
+        # GCP metadata by DNS (bare label is checked before DNS)
+        "metadata.google.internal",
+        "metadata",
+        # Alibaba Cloud
+        "100.100.100.200",
+        # Oracle Cloud Infrastructure
+        "192.0.0.192",
+    }
+)
+"""Well-known metadata endpoints that must never be reachable by default."""
+
+
+class HttpRequestError(RuntimeError):
+    """Raised when a request is rejected or fails."""
+
+
+@dataclass(frozen=True)
+class HttpRequestConfig:
+    """Operator-controlled configuration for :func:`make_http_request`.
+
+    Every field is set by the tool operator at construction time. Nothing here
+    is under the model's control.
+
+    Attributes:
+        allow_private_hosts: Hostnames (case-insensitive) that are permitted to
+            resolve to a private-network IP. An entry ``"internal.example.com"``
+            allows exactly that host; there is no wildcard matching. Empty by
+            default -- private destinations are denied by default.
+        allow_auth_for_hosts: Hostnames for which the model may set
+            ``Authorization`` / ``Cookie`` / ``Proxy-Authorization`` headers.
+            Any request to a host not in this set is rejected outright if it
+            carries one of those headers; on a cross-origin redirect away
+            from an allowlisted host, the same headers are stripped so the
+            credential never travels to the new origin.
+        max_response_bytes: Hard cap on response body size in bytes.
+        max_response_headers_bytes: Hard cap on total response-header size in
+            bytes. Response headers are returned to the model, so this bounds
+            what an oversized ``Set-Cookie`` (or similar) can push through.
+        max_redirects: Hard cap on redirect chain length. A value of ``0``
+            raises ``HttpRequestError`` if a 3xx is encountered.
+        default_timeout_seconds: Timeout used when the model does not supply
+            one (also acts as an upper bound on any timeout the model asks
+            for).
+    """
+
+    allow_private_hosts: frozenset[str] = field(default_factory=frozenset)
+    allow_auth_for_hosts: frozenset[str] = field(default_factory=frozenset)
+    max_response_bytes: int = _DEFAULT_MAX_RESPONSE_BYTES
+    max_response_headers_bytes: int = _DEFAULT_MAX_RESPONSE_HEADERS_BYTES
+    max_redirects: int = _DEFAULT_MAX_REDIRECTS
+    default_timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
+
+
+def _default_resolver(host: str) -> list[str]:
+    """Resolve a hostname to a list of unique IP-address strings."""
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError as e:
+        raise HttpRequestError(f"DNS resolution failed for {host}: {e}") from e
+    seen: list[str] = []
+    for info in infos:
+        raw = info[4][0]
+        # IPv4 tuples return a str; IPv6 sockaddr can include a scope id. Only str
+        # addresses are interpretable here.
+        if not isinstance(raw, str):
+            continue
+        if raw not in seen:
+            seen.append(raw)
+    return seen
+
+
+def make_http_request(
+    *,
+    allow_private_hosts: Iterable[str] | None = None,
+    allow_auth_for_hosts: Iterable[str] | None = None,
+    max_response_bytes: int = _DEFAULT_MAX_RESPONSE_BYTES,
+    max_response_headers_bytes: int = _DEFAULT_MAX_RESPONSE_HEADERS_BYTES,
+    max_redirects: int = _DEFAULT_MAX_REDIRECTS,
+    default_timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    name: str = "http_request",
+    description: str = DEFAULT_HTTP_REQUEST_DESCRIPTION,
+    resolver: Resolver | None = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> DecoratedFunctionTool:
+    """Create an HTTP request tool configured for a given security posture.
+
+    The safe default posture (no arguments) denies every private-network
+    destination, denies model-supplied ``Authorization`` / ``Cookie``, caps
+    the response body at 10 MiB, follows at most five redirects, and times
+    out after 30 seconds.
+
+    Args:
+        allow_private_hosts: Hostnames whose DNS answers may point at private
+            IPs (loopback / RFC1918 / link-local / etc.). Use only for hosts
+            you fully trust the model to reach on the internal network.
+        allow_auth_for_hosts: Hostnames for which the model is allowed to set
+            ``Authorization`` / ``Cookie`` / ``Proxy-Authorization`` headers.
+        max_response_bytes: Hard cap on response body size.
+        max_response_headers_bytes: Hard cap on total response-header size
+            (default 64 KiB).
+        max_redirects: Hard cap on redirect chain length. ``0`` raises
+            ``HttpRequestError`` if a 3xx is encountered instead of following.
+        default_timeout_seconds: Default and upper-bound per-request timeout.
+        name: Tool name shown to the model.
+        description: Tool description shown to the model.
+        resolver: Injection point for the DNS resolver. Callers can pass a
+            custom resolver (e.g. to force a specific mode); tests pass a
+            stub. Defaults to a resolver backed by ``socket.getaddrinfo``.
+        transport: Injection point for the ``httpx`` transport. Callers can
+            pass a mock transport in tests. Defaults to the standard
+            connection-based transport.
+
+    Returns:
+        A decorated tool that makes HTTP requests within the configured policy.
+    """
+    config = HttpRequestConfig(
+        allow_private_hosts=frozenset(h.lower() for h in (allow_private_hosts or ())),
+        allow_auth_for_hosts=frozenset(h.lower() for h in (allow_auth_for_hosts or ())),
+        max_response_bytes=max_response_bytes,
+        max_response_headers_bytes=max_response_headers_bytes,
+        max_redirects=max_redirects,
+        default_timeout_seconds=default_timeout_seconds,
+    )
+    active_resolver: Resolver = resolver if resolver is not None else _default_resolver
+    active_transport = transport
+
+    @tool(name=name, description=description, context=True)
+    async def http_request_tool(
+        method: HttpMethod,
+        url: str,
+        headers: dict[str, str] | None = None,
+        body: str | None = None,
+        timeout: float | None = None,
+        tool_context: ToolContext | None = None,
+    ) -> HttpRequestOutput:
+        """Make an HTTP request to a URL and return the response.
+
+        Args:
+            method: HTTP method (``GET``, ``POST``, ``PUT``, ``DELETE``,
+                ``PATCH``, ``HEAD``, ``OPTIONS``).
+            url: Absolute ``http://`` or ``https://`` URL to request.
+            headers: Optional request headers.
+            body: Optional request body as a string.
+            timeout: Optional per-request timeout in seconds. Capped at the
+                tool's configured default.
+            tool_context: Framework-injected. Not model-visible. Carries the
+                agent so the tool can read its cancel signal mid-flight.
+        """
+        effective_timeout = _resolve_timeout(timeout, config.default_timeout_seconds)
+        sanitized_headers = _sanitize_headers(headers, url, config)
+        cancel_signal = _extract_cancel_signal(tool_context)
+
+        return await _perform_request(
+            method=method,
+            url=url,
+            headers=sanitized_headers,
+            body=body,
+            timeout=effective_timeout,
+            config=config,
+            resolver=active_resolver,
+            transport=active_transport,
+            cancel_signal=cancel_signal,
+        )
+
+    return http_request_tool
+
+
+http_request = make_http_request()
+"""Default HTTP request tool with the safe posture applied."""
+
+
+# ---- Internals ----
+
+
+def _resolve_timeout(model_timeout: float | None, default: float) -> float:
+    """Return the effective request timeout, bounded by the configured default."""
+    if model_timeout is None:
+        return default
+    if model_timeout <= 0:
+        raise HttpRequestError("timeout must be positive")
+    return min(float(model_timeout), default)
+
+
+def _format_number(value: float) -> str:
+    """Format a numeric value without a trailing ``.0`` for whole numbers.
+
+    Keeps error messages byte-identical to the TypeScript sibling, which
+    stringifies integers-as-numbers without the fractional part.
+    """
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _sanitize_headers(
+    headers: dict[str, str] | None,
+    url: str,
+    config: HttpRequestConfig,
+) -> dict[str, str]:
+    """Drop or reject headers the model must not set for this URL."""
+    if not headers:
+        return {}
+    host = (urlsplit(url).hostname or "").lower()
+    auth_allowed = host in config.allow_auth_for_hosts
+    result: dict[str, str] = {}
+    for key, value in headers.items():
+        lowered = key.lower()
+        if lowered in _HOP_BY_HOP_HEADER_NAMES:
+            raise HttpRequestError(f"Header not allowed: {key}")
+        if lowered in _SENSITIVE_HEADER_NAMES and not auth_allowed:
+            raise HttpRequestError(
+                f"Header {key} is not allowed for {host or 'this URL'}. "
+                "The tool operator has not opted this host into auth header passthrough."
+            )
+        result[key] = value
+    return result
+
+
+async def _validate_url(url: str, config: HttpRequestConfig, resolver: Resolver) -> str:
+    """Validate a URL against the security policy and return the resolved host.
+
+    - Only ``http`` and ``https`` schemes are allowed.
+    - The host must be present.
+    - Well-known cloud-metadata hosts are blocked outright.
+    - Hostnames on the SSRF-spec suffix denylist are refused before DNS runs;
+      the operator's ``allow_private_hosts`` does not override this because a
+      ``.internal`` or ``.corp`` host that the operator wants reachable should
+      have a real name outside the reserved namespace.
+    - The host must not resolve to a private/reserved IP unless allowlisted.
+
+    The resolver call is off-loaded to a worker thread with ``asyncio.to_thread``
+    so a slow or failing name server does not stall the event loop.
+    """
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        raise HttpRequestError(f"Only http and https URLs are allowed (got scheme {parts.scheme!r})")
+    if not parts.hostname:
+        raise HttpRequestError("URL has no host")
+    # `parts.port` raises ValueError on non-numeric ports (e.g. "example.com:bad"),
+    # which would otherwise propagate as an unhandled exception through _origin()
+    # on a redirect. Fail closed with the tool's own error type.
+    try:
+        _ = parts.port
+    except ValueError as error:
+        raise HttpRequestError(f"URL has an invalid port: {url!r}") from error
+    host = parts.hostname.lower()
+
+    if host in _CLOUD_METADATA_HOSTS:
+        raise HttpRequestError(f"Host {host} is a known cloud-metadata endpoint and is not allowed")
+
+    # DNS suffix denylist per SSRF spec §4. Applied before ``allow_private_hosts``
+    # so that opting in a single private IP cannot accidentally re-enable a
+    # reserved namespace like ``.internal`` or ``.corp``. Strip a single
+    # trailing dot (rooted FQDN) before matching so ``foo.internal.`` also
+    # resolves to the denylist.
+    denylist_host = host.rstrip(".")
+    for suffix in _DENYLIST_SUFFIXES:
+        if denylist_host == suffix.lstrip(".") or denylist_host.endswith(suffix):
+            raise HttpRequestError(f"Refusing to resolve {host}: hostname ends with denied suffix {suffix!r}")
+
+    if host in config.allow_private_hosts:
+        return host
+
+    # If the URL uses an IP literal, validate it directly -- do not consult the resolver.
+    literal_ip = _parse_ip_literal(parts.hostname)
+    if literal_ip is not None:
+        if not _is_public_ip(literal_ip):
+            raise HttpRequestError(f"Refusing to connect to non-public address {parts.hostname}")
+        return host
+
+    addresses = await asyncio.to_thread(resolver, host)
+    if not addresses:
+        raise HttpRequestError(f"DNS resolution returned no addresses for {host}")
+
+    for addr in addresses:
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError as e:
+            raise HttpRequestError(f"Could not parse resolved address {addr!r} for {host}") from e
+        if not _is_public_ip(ip):
+            raise HttpRequestError(f"Refusing to connect to {host}: resolves to non-public address {addr}")
+    return host
+
+
+def _parse_ip_literal(raw: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Return the IP address if ``raw`` is an IP literal, else ``None``.
+
+    ``urlsplit`` strips the ``[...]`` around an IPv6 literal, so ``raw`` is
+    already the bare address form here.
+    """
+    try:
+        return ipaddress.ip_address(raw)
+    except ValueError:
+        return None
+
+
+def _is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if the IP is safe to dial (globally routable, non-metadata).
+
+    Follows the shared SSRF spec's predicate set. IPv4-mapped IPv6 addresses
+    are unwrapped first so `is_global` on ``::ffff:10.0.0.1`` (which returns
+    True on Python 3.10/3.11) does not create a bypass.
+    """
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    if str(ip) in _CLOUD_METADATA_HOSTS:
+        return False
+    # `is_global` alone returns True for multicast on all supported Python
+    # versions, so we assert each predicate the spec calls out explicitly.
+    if ip.is_multicast or ip.is_reserved or ip.is_unspecified or ip.is_link_local:
+        return False
+    if getattr(ip, "is_site_local", False):
+        return False
+    return bool(ip.is_global)
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    """Return the ``(scheme, hostname, port)`` origin tuple for a URL.
+
+    ``port`` falls back to the default for the scheme (80/443) so a URL that
+    omits the port and one that spells it out compare equal. Scheme is
+    case-folded; hostname is already case-insensitive per RFC 3986.
+    """
+    parts = urlsplit(url)
+    scheme = (parts.scheme or "").lower()
+    host = (parts.hostname or "").lower()
+    port = parts.port if parts.port is not None else _DEFAULT_SCHEME_PORTS.get(scheme)
+    return scheme, host, port
+
+
+def _strip_cross_origin_auth(headers: dict[str, str], from_url: str, to_url: str) -> dict[str, str]:
+    """Drop credentialing headers when a redirect changes origin.
+
+    A 3xx to an attacker-controlled origin would otherwise forward whatever
+    ``Authorization`` / ``Cookie`` / ``Proxy-Authorization`` header the
+    operator opted the original host into. Only exact-origin redirects
+    (same scheme, host, and port) preserve the headers -- a scheme downgrade
+    (HTTPS -> HTTP), a port change, or a host change all strip.
+    """
+    if _origin(from_url) == _origin(to_url):
+        return headers
+    return {k: v for k, v in headers.items() if k.lower() not in _SENSITIVE_HEADER_NAMES}
+
+
+async def _perform_request(
+    *,
+    method: HttpMethod,
+    url: str,
+    headers: dict[str, str],
+    body: str | None,
+    timeout: float,
+    config: HttpRequestConfig,
+    resolver: Resolver,
+    transport: httpx.AsyncBaseTransport | None,
+    cancel_signal: threading.Event | None = None,
+) -> HttpRequestOutput:
+    """Perform the HTTP request, honouring the redirect and body-size caps.
+
+    Redirects are followed manually so every hop can be re-validated against
+    the resolver policy and cross-origin auth can be stripped before the
+    next request is built.
+    """
+    await _validate_url(url, config, resolver)
+
+    client_kwargs: dict[str, object] = {
+        "timeout": timeout,
+        "follow_redirects": False,
+    }
+    if transport is not None:
+        client_kwargs["transport"] = transport
+
+    current_method: str = method
+    current_url: str = url
+    current_body: str | None = body
+    current_headers: dict[str, str] = dict(headers)
+
+    async with httpx.AsyncClient(**client_kwargs) as client:  # type: ignore[arg-type]
+        for _ in range(config.max_redirects + 1):
+            _check_cancelled(cancel_signal)
+            try:
+                request = client.build_request(
+                    current_method,
+                    current_url,
+                    headers=current_headers or None,
+                    content=current_body,
+                )
+                response = await client.send(request, stream=True)
+            except httpx.TimeoutException as e:
+                raise HttpRequestError(f"Request timed out after {_format_number(timeout)} seconds") from e
+            except httpx.RequestError as e:
+                raise HttpRequestError(f"Request failed: {e}") from e
+
+            try:
+                if response.status_code in (301, 302, 303, 307, 308):
+                    location = response.headers.get("location")
+                    if location:
+                        next_url = str(response.url.join(location))
+                        await _validate_url(next_url, config, resolver)
+                        current_headers = _strip_cross_origin_auth(current_headers, current_url, next_url)
+                        # 303 semantics: force GET and drop body.
+                        if response.status_code == 303 and current_method.upper() != "HEAD":
+                            current_method = "GET"
+                            current_body = None
+                        current_url = next_url
+                        await response.aclose()
+                        continue
+
+                headers_out = _capped_response_headers(response, config.max_response_headers_bytes)
+                body_text = await _read_capped_body(response, config.max_response_bytes, cancel_signal=cancel_signal)
+            finally:
+                if not response.is_closed:
+                    await response.aclose()
+
+            return HttpRequestOutput(
+                status=response.status_code,
+                status_text=response.reason_phrase or "",
+                headers=headers_out,
+                body=body_text,
+            )
+
+    raise HttpRequestError(f"Too many redirects (limit {config.max_redirects})")
+
+
+async def _read_capped_body(
+    response: httpx.Response,
+    max_bytes: int,
+    *,
+    cancel_signal: threading.Event | None = None,
+) -> str:
+    """Read the response body streaming, aborting if it exceeds ``max_bytes``."""
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in response.aiter_bytes():
+        _check_cancelled(cancel_signal)
+        total += len(chunk)
+        if total > max_bytes:
+            raise HttpRequestError(f"Response body exceeded maximum size of {max_bytes} bytes")
+        chunks.append(chunk)
+    raw = b"".join(chunks)
+    encoding = response.encoding or "utf-8"
+    try:
+        return raw.decode(encoding, errors="replace")
+    except LookupError:
+        return raw.decode("utf-8", errors="replace")
+
+
+def _capped_response_headers(response: httpx.Response, max_bytes: int) -> dict[str, str]:
+    r"""Return response headers as a lower-cased dict, capped at ``max_bytes``.
+
+    Response headers are surfaced to the model, so an oversized ``Set-Cookie``
+    or debug header could shove megabytes back through. The cap is on the
+    summed size of the ``name: value`` pairs; we walk in order and refuse the
+    whole response if the running total goes over.
+
+    ``multi_items`` preserves every occurrence, so a response with two
+    ``Set-Cookie`` lines does not get comma-collapsed into an unparseable
+    single value (cookie values legitimately contain commas). Repeated
+    headers are joined with a newline separator, which mirrors the wire form
+    ``Set-Cookie: a=1\r\nSet-Cookie: b=2`` closely enough for a model to
+    split on.
+    """
+    result: dict[str, str] = {}
+    total = 0
+    for key, value in response.headers.multi_items():
+        # 2 bytes for ": " between name/value; a rough model of on-the-wire size.
+        total += len(key) + len(value) + 2
+        if total > max_bytes:
+            raise HttpRequestError(f"Response headers exceeded maximum size of {max_bytes} bytes")
+        lowered = key.lower()
+        existing = result.get(lowered)
+        result[lowered] = value if existing is None else f"{existing}\n{value}"
+    return result
+
+
+def _extract_cancel_signal(tool_context: ToolContext | None) -> threading.Event | None:
+    """Return the agent's cancellation event when available.
+
+    The event lives on ``Agent._cancel_signal``. It is a private attribute --
+    we access it defensively so the tool works with any object shape (mocks,
+    ``BidiAgent``, etc.) rather than crashing when the attribute is missing.
+    """
+    if tool_context is None:
+        return None
+    agent: Any = getattr(tool_context, "agent", None)
+    signal: Any = getattr(agent, "_cancel_signal", None)
+    return signal if isinstance(signal, threading.Event) else None
+
+
+def _check_cancelled(cancel_signal: threading.Event | None) -> None:
+    """Raise :class:`asyncio.CancelledError` if the agent's cancel signal has been set.
+
+    Cancellation is signalled with the same exception the surrounding
+    :func:`asyncio` task would raise, so callers can distinguish "cancelled"
+    from other request failures without pattern-matching on error text.
+    """
+    if cancel_signal is not None and cancel_signal.is_set():
+        raise asyncio.CancelledError("Request cancelled")

--- a/strands-py/src/strands/vended_tools/http_request/types.py
+++ b/strands-py/src/strands/vended_tools/http_request/types.py
@@ -1,0 +1,32 @@
+"""Shared types and constants for the http_request tool."""
+
+from typing import Literal, TypedDict
+
+HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+"""HTTP methods supported by the tool."""
+
+
+class HttpRequestOutput(TypedDict):
+    """Output of an HTTP request.
+
+    Attributes:
+        status: HTTP status code.
+        status_text: HTTP status reason phrase.
+        headers: Response headers as a plain dict (lower-cased keys).
+        body: Response body as text.
+    """
+
+    status: int
+    status_text: str
+    headers: dict[str, str]
+    body: str
+
+
+DEFAULT_HTTP_REQUEST_DESCRIPTION = (
+    "Makes HTTP requests to external APIs. Supports GET, POST, PUT, DELETE, PATCH, HEAD, "
+    "and OPTIONS methods. Returns response with status, headers, and body. "
+    "Requests to non-public destinations (loopback, RFC1918, link-local, multicast, "
+    "reserved, and cloud metadata endpoints) are rejected by default; the tool operator "
+    "can allowlist specific hosts."
+)
+"""Description for the http_request tool shown to the model."""

--- a/strands-py/tests/strands/vended_tools/test_http_request.py
+++ b/strands-py/tests/strands/vended_tools/test_http_request.py
@@ -1,0 +1,803 @@
+"""Tests for the http_request tool.
+
+The security surface -- URL scheme, private-network denial (literal and via
+DNS), redirect re-validation, and response-size cap -- comes first. Happy
+path GET/POST follows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from strands.types.tools import ToolContext, ToolUse
+from strands.vended_tools.http_request import (
+    HttpRequestError,
+    http_request,
+    make_http_request,
+)
+from strands.vended_tools.http_request.types import DEFAULT_HTTP_REQUEST_DESCRIPTION
+
+
+def _public_resolver(host: str) -> list[str]:
+    """Test resolver that resolves any host to a fixed public address."""
+    return ["93.184.216.34"]  # example.com; globally routable
+
+
+def _make_transport(handler):
+    """Build a mock httpx transport from a request handler callable."""
+    return httpx.MockTransport(handler)
+
+
+class TestSecuritySchemes:
+    """Only ``http`` and ``https`` are allowed."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("url", ["file:///etc/passwd", "ftp://example.com/", "javascript:alert(1)"])
+    async def test_rejects_non_http_scheme(self, url):
+        tool = make_http_request(resolver=_public_resolver)
+        with pytest.raises(HttpRequestError, match="http and https"):
+            await tool(method="GET", url=url)
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_port(self):
+        # A non-numeric port makes urlsplit(url).port raise ValueError at
+        # access time, which would otherwise leak through _origin() on a
+        # redirect. Verify the tool surfaces its own error type instead.
+        tool = make_http_request(resolver=_public_resolver)
+        with pytest.raises(HttpRequestError, match="invalid port"):
+            await tool(method="GET", url="https://example.com:bad/data")
+
+
+class TestSecurityPrivateNetworks:
+    """Private-network destinations are denied by default, whether by literal IP or DNS."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/",
+            "http://10.0.0.5/",
+            "http://192.168.1.1/",
+            "http://172.16.0.1/",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[::1]/",
+            "http://[fe80::1]/",
+            # Multicast: SSDP (v4), mDNS (v4), all-nodes (v6).
+            "http://239.255.255.250:1900/",
+            "http://224.0.0.251:5353/",
+            "http://[ff02::1]/",
+            # IPv4-mapped IPv6: `is_global` on ::ffff:10.0.0.1 returns True on
+            # Python 3.10/3.11. Unwrap must happen before the flag check.
+            "http://[::ffff:10.0.0.1]/",
+            "http://[::ffff:169.254.169.254]/",
+            # Reserved / unspecified / documentation.
+            "http://0.0.0.0/",
+            "http://192.0.2.1/",
+            "http://198.51.100.1/",
+            "http://203.0.113.1/",
+        ],
+    )
+    async def test_rejects_private_ip_literal(self, url):
+        tool = make_http_request(resolver=_public_resolver)
+        with pytest.raises(HttpRequestError):
+            await tool(method="GET", url=url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url,match",
+        [
+            ("http://metadata.google.internal/", "cloud-metadata"),
+            # Alibaba Cloud metadata.
+            ("http://100.100.100.200/", "cloud-metadata|non-public"),
+            # Oracle Cloud Infrastructure metadata.
+            ("http://192.0.0.192/", "cloud-metadata|non-public"),
+        ],
+    )
+    async def test_rejects_metadata_endpoint(self, url, match):
+        tool = make_http_request(resolver=_public_resolver)
+        with pytest.raises(HttpRequestError, match=match):
+            await tool(method="GET", url=url)
+
+    @pytest.mark.asyncio
+    async def test_rejects_host_that_resolves_to_private_ip(self):
+        # DNS-rebinding-style: public-looking hostname resolves to private IP.
+        def private_resolver(_host: str) -> list[str]:
+            return ["10.0.0.5"]
+
+        tool = make_http_request(resolver=private_resolver)
+        with pytest.raises(HttpRequestError, match="non-public"):
+            await tool(method="GET", url="https://sneaky.example.com/")
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_host_bypasses_private_check(self):
+        def private_resolver(_host: str) -> list[str]:
+            return ["10.0.0.5"]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.host == "internal.example.com"
+            return httpx.Response(200, text="ok")
+
+        tool = make_http_request(
+            allow_private_hosts=["internal.example.com"],
+            resolver=private_resolver,
+            transport=_make_transport(handler),
+        )
+        result = await tool(method="GET", url="https://internal.example.com/")
+        assert result["status"] == 200
+
+
+class TestSecurityHeaders:
+    """Sensitive headers are stripped unless the operator opts a host in."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_authorization_header_by_default(self):
+        tool = make_http_request(resolver=_public_resolver)
+        with pytest.raises(HttpRequestError, match="Authorization"):
+            await tool(
+                method="GET",
+                url="https://example.com/",
+                headers={"Authorization": "Bearer secret"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_cookie_header_by_default(self):
+        tool = make_http_request(resolver=_public_resolver)
+        with pytest.raises(HttpRequestError, match="Cookie"):
+            await tool(
+                method="GET",
+                url="https://example.com/",
+                headers={"Cookie": "session=abc"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_hop_by_hop_header(self):
+        tool = make_http_request(resolver=_public_resolver)
+        with pytest.raises(HttpRequestError, match="not allowed"):
+            await tool(
+                method="GET",
+                url="https://example.com/",
+                headers={"Host": "spoofed.example.com"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_allows_authorization_for_allowlisted_host(self):
+        received: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            received.update(request.headers)
+            return httpx.Response(200, text="ok")
+
+        tool = make_http_request(
+            allow_auth_for_hosts=["api.example.com"],
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        result = await tool(
+            method="GET",
+            url="https://api.example.com/",
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert result["status"] == 200
+        assert received["authorization"] == "Bearer secret"
+
+
+class TestSecurityRedirects:
+    """Redirects are followed, capped, and re-validated at every hop."""
+
+    @pytest.mark.asyncio
+    async def test_follows_redirect(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "/final"})
+            return httpx.Response(200, text="final body")
+
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        result = await tool(method="GET", url="https://example.com/start")
+        assert result["status"] == 200
+        assert result["body"] == "final body"
+
+    @pytest.mark.asyncio
+    async def test_caps_redirect_chain(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            # Every request redirects to a new path -- infinite chain.
+            next_path = "/next" + request.url.path
+            return httpx.Response(302, headers={"location": next_path})
+
+        tool = make_http_request(
+            max_redirects=3,
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        with pytest.raises(HttpRequestError, match="Too many redirects"):
+            await tool(method="GET", url="https://example.com/start")
+
+    @pytest.mark.asyncio
+    async def test_revalidates_redirect_target(self):
+        # First hop resolves public; the redirect points at a hostname
+        # that resolves private. The tool must refuse the second hop.
+        call_count = {"n": 0}
+
+        def rebinding_resolver(host: str) -> list[str]:
+            call_count["n"] += 1
+            if host == "start.example.com":
+                return ["93.184.216.34"]
+            return ["10.0.0.5"]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302, headers={"location": "https://internal.example.com/"})
+
+        tool = make_http_request(
+            resolver=rebinding_resolver,
+            transport=_make_transport(handler),
+        )
+        with pytest.raises(HttpRequestError, match="non-public"):
+            await tool(method="GET", url="https://start.example.com/start")
+        # Both hops resolved.
+        assert call_count["n"] >= 2
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_redirect_strips_auth(self):
+        # An operator-opted-in host redirects to a *different* host: the
+        # Authorization / Cookie headers must not follow.
+        seen_hops: list[tuple[str, dict[str, str]]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_hops.append((request.url.host, dict(request.headers)))
+            if request.url.host == "api.example.com":
+                return httpx.Response(302, headers={"location": "https://attacker.example/"})
+            return httpx.Response(200, text="ok")
+
+        tool = make_http_request(
+            allow_auth_for_hosts=["api.example.com"],
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        result = await tool(
+            method="GET",
+            url="https://api.example.com/",
+            headers={"Authorization": "Bearer secret", "Cookie": "s=1"},
+        )
+        assert result["status"] == 200
+        first_host, first_headers = seen_hops[0]
+        second_host, second_headers = seen_hops[1]
+        assert first_host == "api.example.com"
+        assert first_headers["authorization"] == "Bearer secret"
+        assert second_host == "attacker.example"
+        assert "authorization" not in second_headers
+        assert "cookie" not in second_headers
+
+    @pytest.mark.asyncio
+    async def test_same_host_redirect_preserves_auth(self):
+        seen_hops: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_hops.append(dict(request.headers))
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "/final"})
+            return httpx.Response(200, text="ok")
+
+        tool = make_http_request(
+            allow_auth_for_hosts=["api.example.com"],
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        result = await tool(
+            method="GET",
+            url="https://api.example.com/start",
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert result["status"] == 200
+        assert seen_hops[0]["authorization"] == "Bearer secret"
+        assert seen_hops[1]["authorization"] == "Bearer secret"
+
+    @pytest.mark.asyncio
+    async def test_303_forces_get_and_drops_body(self):
+        received = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/post":
+                assert request.method == "POST"
+                return httpx.Response(303, headers={"location": "/result"})
+            received["method"] = request.method
+            received["content"] = request.content
+            return httpx.Response(200, text="done")
+
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        result = await tool(
+            method="POST",
+            url="https://example.com/post",
+            body='{"x":1}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert result["status"] == 200
+        assert received["method"] == "GET"
+        assert received["content"] == b""
+
+
+class TestSecurityBodyCap:
+    """Response bodies larger than the cap are refused."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_response(self):
+        big = b"a" * 2048
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=big)
+
+        tool = make_http_request(
+            max_response_bytes=1024,
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        with pytest.raises(HttpRequestError, match="exceeded maximum size"):
+            await tool(method="GET", url="https://example.com/big")
+
+
+class TestHappyPath:
+    """Basic GET / POST flow works when the security policy is satisfied."""
+
+    @pytest.mark.asyncio
+    async def test_get_returns_body_and_headers(self):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/json", "x-custom": "value"},
+                text='{"ok":true}',
+            )
+
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        result = await tool(method="GET", url="https://example.com/data")
+        assert result["status"] == 200
+        assert result["status_text"] == "OK"
+        assert result["body"] == '{"ok":true}'
+        assert result["headers"]["content-type"].startswith("application/json")
+        assert result["headers"]["x-custom"] == "value"
+
+    @pytest.mark.asyncio
+    async def test_post_sends_body_and_custom_headers(self):
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["body"] = request.content
+            seen["ct"] = request.headers.get("content-type")
+            return httpx.Response(201, text='{"id":1}')
+
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        result = await tool(
+            method="POST",
+            url="https://example.com/users",
+            headers={"Content-Type": "application/json"},
+            body='{"name":"test"}',
+        )
+        assert result["status"] == 201
+        assert seen["method"] == "POST"
+        assert seen["body"] == b'{"name":"test"}'
+        assert seen["ct"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_status_is_returned_not_raised(self):
+        # The tool returns the response as-is; the model decides what to do.
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="not found")
+
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        result = await tool(method="GET", url="https://example.com/missing")
+        assert result["status"] == 404
+        assert result["body"] == "not found"
+
+
+class TestTimeoutBoundary:
+    """The model-supplied timeout is validated and bounded."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_positive_timeout(self):
+        tool = make_http_request(resolver=_public_resolver)
+        with pytest.raises(HttpRequestError, match="positive"):
+            await tool(method="GET", url="https://example.com/", timeout=0)
+
+    @pytest.mark.asyncio
+    async def test_model_timeout_is_capped_at_default(self):
+        # If the tool operator set default 5s and the model asks for 60s,
+        # the effective timeout is 5s. We verify by observing that a
+        # transport that never responds triggers a timeout.
+        async def slow_handler(_request: httpx.Request) -> httpx.Response:
+            raise httpx.TimeoutException("timed out")
+
+        transport = httpx.MockTransport(slow_handler)
+        tool = make_http_request(
+            default_timeout_seconds=5.0,
+            resolver=_public_resolver,
+            transport=transport,
+        )
+        with pytest.raises(HttpRequestError, match="timed out"):
+            await tool(method="GET", url="https://example.com/slow", timeout=60)
+
+
+class TestToolMetadata:
+    """Tool name, description, and input schema."""
+
+    def test_default_name(self):
+        assert http_request.tool_name == "http_request"
+
+    def test_default_description(self):
+        assert http_request.tool_spec["description"] == DEFAULT_HTTP_REQUEST_DESCRIPTION
+
+    def test_custom_name(self):
+        assert make_http_request(name="fetch").tool_name == "fetch"
+
+    def test_schema_exposes_expected_parameters(self):
+        # `tool_context` is a framework-injected special parameter and must
+        # never appear in the model-facing schema.
+        props = http_request.tool_spec["inputSchema"]["json"]["properties"]
+        assert set(props) == {"method", "url", "headers", "body", "timeout"}
+
+
+class TestSecurityCrossOriginAuth:
+    """Cross-origin redirects strip auth per origin tuple, not just hostname."""
+
+    @pytest.mark.asyncio
+    async def test_https_to_http_downgrade_strips_auth(self):
+        # HTTPS -> HTTP on the same host is still cross-origin: the credential
+        # would travel over plaintext. Hostname-only comparison would preserve
+        # it, so this test guards against the pre-round-3 predicate.
+        seen_hops: list[tuple[str, dict[str, str]]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_hops.append((str(request.url), dict(request.headers)))
+            if request.url.scheme == "https":
+                return httpx.Response(302, headers={"location": "http://api.example.com/final"})
+            return httpx.Response(200, text="ok")
+
+        tool = make_http_request(
+            allow_auth_for_hosts=["api.example.com"],
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        result = await tool(
+            method="GET",
+            url="https://api.example.com/",
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert result["status"] == 200
+        assert "authorization" in seen_hops[0][1]
+        assert "authorization" not in seen_hops[1][1]
+        assert "cookie" not in seen_hops[1][1]
+
+    @pytest.mark.asyncio
+    async def test_same_host_port_change_strips_auth(self):
+        # Same host + same scheme but a different port is a different origin.
+        seen_hops: list[tuple[str, dict[str, str]]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_hops.append((str(request.url), dict(request.headers)))
+            if request.url.port in (None, 443):
+                return httpx.Response(302, headers={"location": "https://api.example.com:8443/final"})
+            return httpx.Response(200, text="ok")
+
+        tool = make_http_request(
+            allow_auth_for_hosts=["api.example.com"],
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        result = await tool(
+            method="GET",
+            url="https://api.example.com/",
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert result["status"] == 200
+        assert "authorization" in seen_hops[0][1]
+        assert "authorization" not in seen_hops[1][1]
+
+    @pytest.mark.asyncio
+    async def test_same_origin_default_port_preserves_auth(self):
+        # `https://api.example.com/` and `https://api.example.com:443/final`
+        # are the same origin -- port default must resolve to 443.
+        seen_hops: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_hops.append(dict(request.headers))
+            if request.url.path == "/":
+                # Explicit port 443 = default; must still be same-origin.
+                return httpx.Response(302, headers={"location": "https://api.example.com:443/final"})
+            return httpx.Response(200, text="ok")
+
+        tool = make_http_request(
+            allow_auth_for_hosts=["api.example.com"],
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        result = await tool(
+            method="GET",
+            url="https://api.example.com/",
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert result["status"] == 200
+        assert seen_hops[0]["authorization"] == "Bearer secret"
+        assert seen_hops[1]["authorization"] == "Bearer secret"
+
+
+class TestSecurityDnsSuffixDenylist:
+    """Hostnames ending in denied suffixes are refused before DNS resolves."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://service.internal/",
+            "http://foo.corp/",
+            "http://bar.home/",
+            "http://baz.lan/",
+            "http://svc.intranet/",
+            "http://api.private/",
+            "http://mysite.i2p/",
+            "http://hidden.onion/",
+            # `.local` and `.localhost` are also denied.
+            "http://raspberrypi.local/",
+            "http://something.localhost/",
+            # Trailing dot on a rooted FQDN must not bypass the suffix match.
+            "http://service.internal./",
+            # Case-folded match.
+            "http://SERVICE.Internal/",
+        ],
+    )
+    async def test_rejects_denied_suffix_before_dns(self, url):
+        called = {"n": 0}
+
+        def resolver(_host: str) -> list[str]:
+            # If the guard let this through, we'd see a resolver call.
+            called["n"] += 1
+            return ["93.184.216.34"]
+
+        tool = make_http_request(resolver=resolver)
+        with pytest.raises(HttpRequestError, match="denied suffix"):
+            await tool(method="GET", url=url)
+        assert called["n"] == 0
+
+
+class TestSecurityResponseHeaderCap:
+    """Response headers are capped so an oversize response can't dump megabytes back."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_response_headers(self):
+        # 200 bytes of value * 6 headers = 1200 bytes -- over the 500-byte cap.
+        big_value = "x" * 200
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={f"x-blob-{i}": big_value for i in range(6)},
+                text="ok",
+            )
+
+        tool = make_http_request(
+            max_response_headers_bytes=500,
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        with pytest.raises(HttpRequestError, match="Response headers exceeded"):
+            await tool(method="GET", url="https://example.com/")
+
+    @pytest.mark.asyncio
+    async def test_within_cap_headers_returned(self):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, headers={"x-small": "value"}, text="ok")
+
+        tool = make_http_request(
+            max_response_headers_bytes=1024,
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        result = await tool(method="GET", url="https://example.com/")
+        assert result["headers"]["x-small"] == "value"
+
+
+class TestSecurityMaxRedirectsZero:
+    """`max_redirects=0` raises when a 3xx is encountered, per docstring."""
+
+    @pytest.mark.asyncio
+    async def test_max_redirects_zero_raises_on_3xx(self):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302, headers={"location": "/final"})
+
+        tool = make_http_request(
+            max_redirects=0,
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        with pytest.raises(HttpRequestError, match="Too many redirects"):
+            await tool(method="GET", url="https://example.com/")
+
+    @pytest.mark.asyncio
+    async def test_max_redirects_zero_still_returns_non_3xx(self):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="ok")
+
+        tool = make_http_request(
+            max_redirects=0,
+            resolver=_public_resolver,
+            transport=_make_transport(handler),
+        )
+        result = await tool(method="GET", url="https://example.com/")
+        assert result["status"] == 200
+
+
+class TestCancelSignal:
+    """The agent's cancel signal aborts an in-flight request."""
+
+    @staticmethod
+    def _tool_context_for(agent: object) -> ToolContext:
+        tool_use = ToolUse(toolUseId="http_1", name="http_request", input={})
+        return ToolContext(tool_use=tool_use, agent=agent, invocation_state={})
+
+    @pytest.mark.asyncio
+    async def test_pre_flight_cancel_short_circuits(self):
+        # Signal set before dispatch: the tool sees it before the first send.
+        # This alone is not enough to prove the mid-flight path works, so the
+        # next test also drives the between-chunks branch. Cancellation is
+        # signalled with ``asyncio.CancelledError`` so callers can distinguish
+        # it from other request failures without matching on error text.
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise AssertionError("transport should not be called if cancel is pre-set")
+
+        cancel = threading.Event()
+        cancel.set()
+        agent = SimpleNamespace(_cancel_signal=cancel)
+
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        with pytest.raises(asyncio.CancelledError):
+            await tool(
+                method="GET",
+                url="https://example.com/",
+                tool_context=self._tool_context_for(agent),
+            )
+
+    @pytest.mark.asyncio
+    async def test_mid_flight_cancel_between_chunks(self):
+        # The response starts fine; the cancel signal fires as the client
+        # reads its second chunk. The guard between chunks must catch this
+        # even though the first chunk arrived before the signal.
+        cancel = threading.Event()
+
+        async def streaming_body():
+            yield b"partial-"
+            cancel.set()
+            yield b"the-rest"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=streaming_body())
+
+        agent = SimpleNamespace(_cancel_signal=cancel)
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        with pytest.raises(asyncio.CancelledError):
+            await tool(
+                method="GET",
+                url="https://example.com/",
+                tool_context=self._tool_context_for(agent),
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_cancel_signal_no_op(self):
+        # Agent without a `_cancel_signal` attribute must not crash the tool.
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="ok")
+
+        agent = SimpleNamespace()  # no _cancel_signal at all
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        result = await tool(
+            method="GET",
+            url="https://example.com/",
+            tool_context=self._tool_context_for(agent),
+        )
+        assert result["status"] == 200
+
+
+class TestResponseHeaderMultiplicity:
+    """Repeated response headers (Set-Cookie) preserve every occurrence."""
+
+    @pytest.mark.asyncio
+    async def test_repeated_set_cookie_is_preserved(self):
+        # Two Set-Cookie lines must not be comma-collapsed. Cookie values
+        # legitimately contain commas (Expires=Wed, 09 Jun 2021 ...) so the
+        # model needs to see both values distinctly.
+        def handler(_request: httpx.Request) -> httpx.Response:
+            headers = [
+                ("set-cookie", "session=abc; Path=/"),
+                ("set-cookie", "tracking=xyz; Path=/"),
+            ]
+            return httpx.Response(200, headers=headers, text="ok")
+
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        result = await tool(method="GET", url="https://example.com/")
+        cookies = result["headers"]["set-cookie"].split("\n")
+        assert "session=abc; Path=/" in cookies
+        assert "tracking=xyz; Path=/" in cookies
+
+
+class TestURLValidation:
+    """Odd URL shapes that must fail closed."""
+
+    @pytest.mark.asyncio
+    async def test_url_with_no_host_is_rejected(self):
+        tool = make_http_request(resolver=_public_resolver)
+        with pytest.raises(HttpRequestError, match="URL has no host"):
+            await tool(method="GET", url="http:///path")
+
+    @pytest.mark.asyncio
+    async def test_resolver_returning_empty_list_is_rejected(self):
+        def empty_resolver(_host: str) -> list[str]:
+            return []
+
+        tool = make_http_request(resolver=empty_resolver)
+        with pytest.raises(HttpRequestError, match="no addresses"):
+            await tool(method="GET", url="https://example.com/")
+
+    @pytest.mark.asyncio
+    async def test_resolver_returning_unparseable_address_is_rejected(self):
+        def bad_resolver(_host: str) -> list[str]:
+            return ["not-an-ip"]
+
+        tool = make_http_request(resolver=bad_resolver)
+        with pytest.raises(HttpRequestError, match="Could not parse resolved address"):
+            await tool(method="GET", url="https://example.com/")
+
+    @pytest.mark.asyncio
+    async def test_denylist_suffix_precedes_allow_private_hosts(self):
+        # Opting a `.internal` host into allow_private_hosts must not
+        # re-enable the suffix-denylist namespace. The denylist runs first.
+        tool = make_http_request(
+            allow_private_hosts=["service.internal"],
+            resolver=_public_resolver,
+        )
+        with pytest.raises(HttpRequestError, match="denied suffix"):
+            await tool(method="GET", url="http://service.internal/")
+
+    @pytest.mark.asyncio
+    async def test_redirect_without_location_returns_response(self):
+        # A 302 without a Location header cannot be followed; the tool should
+        # return the response as-is rather than looping.
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302, text="see elsewhere maybe")
+
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        result = await tool(method="GET", url="https://example.com/")
+        assert result["status"] == 302
+        assert result["body"] == "see elsewhere maybe"
+
+    @pytest.mark.asyncio
+    async def test_request_error_is_wrapped(self):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom")
+
+        tool = make_http_request(resolver=_public_resolver, transport=_make_transport(handler))
+        with pytest.raises(HttpRequestError, match="Request failed"):
+            await tool(method="GET", url="https://example.com/")
+
+
+class TestDefaultResolver:
+    """The stdlib-backed default resolver returns unique addresses or raises."""
+
+    def test_default_resolver_returns_unique_public_addresses(self):
+        # localhost always resolves; every address returned should parse as
+        # an IP even though the guard would separately refuse to dial it.
+        from strands.vended_tools.http_request.http_request import _default_resolver
+
+        addresses = _default_resolver("localhost")
+        assert addresses
+        for addr in addresses:
+            # Just assert parseable; policy is applied elsewhere.
+            import ipaddress
+
+            ipaddress.ip_address(addr)
+
+    def test_default_resolver_raises_on_unresolvable_host(self):
+        from strands.vended_tools.http_request.http_request import _default_resolver
+
+        with pytest.raises(HttpRequestError, match="DNS resolution failed"):
+            # RFC 6761 reserved name: guaranteed not to resolve on the public DNS.
+            _default_resolver("invalid.test")


### PR DESCRIPTION
Closes #3238.

Ports the http_request vended tool to Python. Mirrors the TypeScript surface (method, url, optional headers, body, timeout in; status, status_text, headers, body out) as a thin shim over httpx.AsyncClient. The default tool carries a strict security posture; make_http_request lets the operator relax individual controls at construction. httpx is now a direct core dependency, aligned with the existing a2a-extra bound.

The model can point this tool at any URL, so the boundary is where enforcement lives. Non-http schemes are refused. Hostnames on the SSRF-spec suffix denylist are refused before DNS. Every remaining hostname resolves through getaddrinfo off-loaded to a worker thread, and each returned address is checked against ipaddress.is_global with IPv4-mapped IPv6 unwrapped first. Cloud-metadata endpoints are named explicitly. The operator can opt individual hosts back in.

Redirects are walked manually so every hop re-runs the same policy. Cross-origin hops drop Authorization, Cookie, and Proxy-Authorization. Response body, response headers, and redirect chain each have their own cap, defaulting to five hops, ten mebibytes, and sixty-four kibibytes. The model-supplied timeout is capped at the operator default of thirty seconds; zero and negative values are rejected. Non-2xx responses come back as data rather than raising, matching the sub-issue's request.
