### PR TITLE
fix(openai): replay assistant text history as valid string-content input in Responses adapters

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -634,12 +634,25 @@ class OpenAIResponsesModel(Model):
             ]
 
             if formatted_contents:
-                formatted_messages.append(
-                    {
-                        "role": role,  # "user" | "assistant"
-                        "content": formatted_contents,
-                    }
-                )
+                if role == "assistant":
+                    # Only the string EasyInputMessage form is a valid assistant *input* shape
+                    # without the full output-item metadata (id/status/annotations) that has
+                    # already been discarded by this point. Replaying verbatim output items is
+                    # tracked in https://github.com/strands-agents/harness-sdk/issues/3389.
+                    if any(part.get("type") != "output_text" for part in formatted_contents):
+                        logger.warning(
+                            "non-text assistant history content has no valid Responses API input shape | dropping"
+                        )
+                    text = "\n".join(part["text"] for part in formatted_contents if part.get("type") == "output_text")
+                    if text:
+                        formatted_messages.append({"role": "assistant", "content": text})
+                else:
+                    formatted_messages.append(
+                        {
+                            "role": role,  # "user"
+                            "content": formatted_contents,
+                        }
+                    )
 
             formatted_messages.extend(formatted_tool_calls)
             formatted_messages.extend(formatted_tool_messages)

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -639,9 +639,14 @@ class OpenAIResponsesModel(Model):
                     # without the full output-item metadata (id/status/annotations) that has
                     # already been discarded by this point. Replaying verbatim output items is
                     # tracked in https://github.com/strands-agents/harness-sdk/issues/3389.
-                    if any(part.get("type") != "output_text" for part in formatted_contents):
+                    dropped_types = [
+                        part.get("type", "unknown") for part in formatted_contents if part.get("type") != "output_text"
+                    ]
+                    if dropped_types:
                         logger.warning(
-                            "non-text assistant history content has no valid Responses API input shape | dropping"
+                            "content_type=<%s> | non-text assistant history content has no valid "
+                            "Responses API input shape | dropping",
+                            ", ".join(dropped_types),
                         )
                     text = "\n".join(part["text"] for part in formatted_contents if part.get("type") == "output_text")
                     if text:

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -300,7 +300,7 @@ def test_format_request_messages(system_prompt):
         },
         {
             "role": "assistant",
-            "content": [{"type": "output_text", "text": "call tool"}],
+            "content": "call tool",
         },
         {
             "type": "function_call",
@@ -317,12 +317,14 @@ def test_format_request_messages(system_prompt):
     assert tru_result == exp_result
 
 
-def test_format_request_messages_assistant_text_uses_output_text():
-    """Assistant text content must use output_text, not input_text.
+def test_format_request_messages_assistant_text_uses_string_content():
+    """Assistant history must use the string EasyInputMessage form.
 
-    Regression test for multi-turn conversations failing because the OpenAI
-    Responses API rejects input_text in assistant messages.
-    See: https://github.com/strands-agents/harness-sdk/issues/1850
+    A bare ``{"role": "assistant", "content": [{"type": "output_text", ...}]}``
+    is not a valid Responses API input item (it is neither a string-content
+    EasyInputMessage nor a complete ResponseOutputMessage) and is rejected by
+    strict backends such as Bedrock Mantle.
+    See: https://github.com/strands-agents/harness-sdk/issues/3388
     """
     messages = [
         {
@@ -347,12 +349,61 @@ def test_format_request_messages_assistant_text_uses_output_text():
     }
     assert result[1] == {
         "role": "assistant",
-        "content": [{"type": "output_text", "text": "Hello!"}],
+        "content": "Hello!",
     }
     assert result[2] == {
         "role": "user",
         "content": [{"type": "input_text", "text": "Say goodbye"}],
     }
+
+
+def test_format_request_messages_assistant_multiple_text_blocks_join_with_newline():
+    """Multiple assistant text blocks collapse into one newline-joined string."""
+    messages = [
+        {
+            "content": [{"text": "First."}, {"text": "Second."}],
+            "role": "assistant",
+        },
+    ]
+
+    result = OpenAIResponsesModel._format_request_messages(messages)
+
+    assert result == [{"role": "assistant", "content": "First.\nSecond."}]
+
+
+def test_format_request_messages_assistant_non_text_content_dropped():
+    """Assistant media has no valid Responses input shape and is dropped with a warning."""
+    messages = [
+        {
+            "content": [
+                {"text": "Here is the image."},
+                {"image": {"format": "png", "source": {"bytes": b"fake-image-data"}}},
+            ],
+            "role": "assistant",
+        },
+    ]
+
+    result = OpenAIResponsesModel._format_request_messages(messages)
+
+    assert result == [{"role": "assistant", "content": "Here is the image."}]
+
+
+def test_format_request_messages_assistant_history_items_are_valid_input_items():
+    """Formatted assistant history validates against the OpenAI input item schema."""
+    import openai
+
+    messages = [
+        {"content": [{"text": "What is 2+2?"}], "role": "user"},
+        {"content": [{"text": "4"}], "role": "assistant"},
+        {"content": [{"text": "What about 3+3?"}], "role": "user"},
+    ]
+
+    result = OpenAIResponsesModel._format_request_messages(messages)
+
+    assistant_item = result[1]
+    easy_message_fields = set(openai.types.responses.EasyInputMessageParam.__annotations__)
+    assert set(assistant_item) <= easy_message_fields
+    assert isinstance(assistant_item["content"], str)
 
 
 def test_format_request_message_content_role_assistant():
@@ -624,9 +675,7 @@ async def test_stream(openai_client, model_id, model, agenerator, alist):
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -737,9 +786,7 @@ async def test_stream_with_tool_calls(openai_client, model, agenerator, alist):
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -774,9 +821,7 @@ async def test_stream_with_tool_calls_done_event(openai_client, model, agenerato
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -835,9 +880,7 @@ async def test_stream_reasoning_content(openai_client, model, agenerator, alist,
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=20, total_tokens=30, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=20, total_tokens=30, input_tokens_details=None)
         ),
     )
 
@@ -883,9 +926,7 @@ async def test_stream_citation_annotations(openai_client, model, agenerator, ali
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -923,9 +964,7 @@ async def test_stream_unsupported_annotation_type(openai_client, model, agenerat
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -1311,7 +1350,7 @@ def test_format_request_messages_with_citations_content():
     assistant_msg = [m for m in formatted if m.get("role") == "assistant"][0]
     assert assistant_msg == {
         "role": "assistant",
-        "content": [{"type": "output_text", "text": "The answer with citations."}],
+        "content": "The answer with citations.",
     }
 
 
@@ -1462,7 +1501,7 @@ def test_format_request_messages_excludes_reasoning_content(caplog):
 
     assert result == [
         {"role": "user", "content": [{"type": "input_text", "text": "Hello"}]},
-        {"role": "assistant", "content": [{"type": "output_text", "text": "The answer is 42"}]},
+        {"role": "assistant", "content": "The answer is 42"},
         {"role": "user", "content": [{"type": "input_text", "text": "Thanks"}]},
     ]
     assert "reasoningContent is not yet supported" in caplog.text

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import unittest.mock
 
@@ -371,7 +372,7 @@ def test_format_request_messages_assistant_multiple_text_blocks_join_with_newlin
     assert result == [{"role": "assistant", "content": "First.\nSecond."}]
 
 
-def test_format_request_messages_assistant_non_text_content_dropped():
+def test_format_request_messages_assistant_non_text_content_dropped(caplog):
     """Assistant media has no valid Responses input shape and is dropped with a warning."""
     messages = [
         {
@@ -383,9 +384,27 @@ def test_format_request_messages_assistant_non_text_content_dropped():
         },
     ]
 
-    result = OpenAIResponsesModel._format_request_messages(messages)
+    with caplog.at_level(logging.WARNING, logger="strands.models.openai_responses"):
+        result = OpenAIResponsesModel._format_request_messages(messages)
 
     assert result == [{"role": "assistant", "content": "Here is the image."}]
+    assert "content_type=<input_image>" in caplog.text
+
+
+def test_format_request_messages_assistant_only_non_text_content_dropped_entirely(caplog):
+    """An assistant turn with only non-text content collapses to nothing and is omitted."""
+    messages = [
+        {
+            "content": [{"image": {"format": "png", "source": {"bytes": b"fake-image-data"}}}],
+            "role": "assistant",
+        },
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="strands.models.openai_responses"):
+        result = OpenAIResponsesModel._format_request_messages(messages)
+
+    assert result == []
+    assert "content_type=<input_image>" in caplog.text
 
 
 def test_format_request_messages_assistant_history_items_are_valid_input_items():

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -386,6 +386,50 @@ describe("OpenAIModel (api: 'responses')", () => {
       expect(typeof out.output).toBe('string')
       expect(out.output).toBe('pong')
     })
+
+    it('serializes assistant history as a string EasyInputMessage', async () => {
+      // A bare `{ role: 'assistant', content: [output_text] }` is not a valid
+      // Responses input item and is rejected by strict backends (Bedrock Mantle).
+      // See https://github.com/strands-agents/harness-sdk/issues/3388
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('What is 2+2?')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('4')] }),
+        new Message({ role: 'user', content: [new TextBlock('What about 3+3?')] }),
+      ]
+      const req = await runOnce({}, messages)
+      expect(req.input[1]).toEqual({ role: 'assistant', content: '4' })
+      expect(req.input[0]).toEqual({ role: 'user', content: [{ type: 'input_text', text: 'What is 2+2?' }] })
+      expect(req.input[2]).toEqual({ role: 'user', content: [{ type: 'input_text', text: 'What about 3+3?' }] })
+    })
+
+    it('joins multiple assistant text blocks with newlines', async () => {
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('list two words')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('First.'), new TextBlock('Second.')] }),
+        new Message({ role: 'user', content: [new TextBlock('thanks')] }),
+      ]
+      const req = await runOnce({}, messages)
+      expect(req.input[1]).toEqual({ role: 'assistant', content: 'First.\nSecond.' })
+    })
+
+    it('drops non-text assistant history content with a warning', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn')
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('draw something')] }),
+        new Message({
+          role: 'assistant',
+          content: [
+            new TextBlock('Here it is.'),
+            new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1, 2, 3]) } }),
+          ],
+        }),
+        new Message({ role: 'user', content: [new TextBlock('nice')] }),
+      ]
+      const req = await runOnce({}, messages)
+      expect(req.input[1]).toEqual({ role: 'assistant', content: 'Here it is.' })
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no valid responses api input shape'))
+      warnSpy.mockRestore()
+    })
   })
 
   describe('stream event mapping', () => {

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -6,6 +6,7 @@ import { ContextWindowOverflowError, ModelThrottledError } from '../../../errors
 import { collectIterator } from '../../../__fixtures__/model-test-helpers.js'
 import { Message, TextBlock, ToolUseBlock, ToolResultBlock } from '../../../types/messages.js'
 import { ImageBlock, DocumentBlock } from '../../../types/media.js'
+import { CitationsBlock } from '../../../types/citations.js'
 import { StateStore } from '../../../state-store.js'
 import { logger } from '../../../logging/logger.js'
 
@@ -428,7 +429,47 @@ describe("OpenAIModel (api: 'responses')", () => {
       const req = await runOnce({}, messages)
       expect(req.input[1]).toEqual({ role: 'assistant', content: 'Here it is.' })
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no valid responses api input shape'))
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('content_type=<input_image>'))
       warnSpy.mockRestore()
+    })
+
+    it('omits an assistant history turn whose content is entirely non-text', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn')
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('draw something')] }),
+        new Message({
+          role: 'assistant',
+          content: [new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1, 2, 3]) } })],
+        }),
+        new Message({ role: 'user', content: [new TextBlock('nice')] }),
+      ]
+      const req = await runOnce({}, messages)
+      expect(req.input.filter((i: any) => i.role === 'assistant')).toEqual([])
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('content_type=<input_image>'))
+      warnSpy.mockRestore()
+    })
+
+    it('serializes user-role citations content as input_text', async () => {
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new CitationsBlock({
+              citations: [
+                {
+                  location: { type: 'documentChar', documentIndex: 0, start: 0, end: 10 },
+                  source: 'doc-0',
+                  sourceContent: [{ text: 'source' }],
+                  title: 'Test',
+                },
+              ],
+              content: [{ text: 'quoted passage' }],
+            }),
+          ],
+        }),
+      ]
+      const req = await runOnce({}, messages)
+      expect(req.input[0]).toEqual({ role: 'user', content: [{ type: 'input_text', text: 'quoted passage' }] })
     })
   })
 

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -221,8 +221,11 @@ function formatResponsesMessages(messages: Message[]): ResponseInputItem[] {
         // which has already been discarded by this point. Non-text assistant history
         // has no valid input shape either. Replaying verbatim output items is
         // tracked in https://github.com/strands-agents/harness-sdk/issues/3389.
-        if (contentItems.some((item) => item.type !== 'output_text')) {
-          logger.warn('non-text assistant history content has no valid responses api input shape | dropping')
+        const droppedTypes = contentItems.filter((item) => item.type !== 'output_text').map((item) => item.type)
+        if (droppedTypes.length > 0) {
+          logger.warn(
+            `content_type=<${droppedTypes.join(', ')}> | non-text assistant history content has no valid responses api input shape | dropping`
+          )
         }
         const text = contentItems
           .filter((item) => item.type === 'output_text')

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -171,7 +171,7 @@ function formatResponsesMessages(messages: Message[]): ResponseInputItem[] {
         case 'citationsBlock': {
           const citBlock = block as { content: Array<{ text: string }> }
           for (const c of citBlock.content) {
-            contentItems.push({ type: 'output_text', text: c.text })
+            contentItems.push({ type: role === 'user' ? 'input_text' : 'output_text', text: c.text })
           }
           break
         }
@@ -214,15 +214,30 @@ function formatResponsesMessages(messages: Message[]): ResponseInputItem[] {
       }
     }
 
-    // Cast is needed because assistant messages here use `output_text` content
-    // blocks, which the SDK's input types model as `ResponseOutputMessage` —
-    // a response-shaped type that requires `id`/`status`/`annotations`. The API
-    // accepts these fields as omitted on input, but the SDK types don't reflect that.
     if (contentItems.length > 0) {
-      input.push({
-        role,
-        content: contentItems,
-      } as unknown as ResponseInputItem)
+      if (role === 'assistant') {
+        // Only the string EasyInputMessage form is a valid assistant *input* shape
+        // without the full ResponseOutputMessage metadata (id/status/annotations),
+        // which has already been discarded by this point. Non-text assistant history
+        // has no valid input shape either. Replaying verbatim output items is
+        // tracked in https://github.com/strands-agents/harness-sdk/issues/3389.
+        if (contentItems.some((item) => item.type !== 'output_text')) {
+          logger.warn('non-text assistant history content has no valid responses api input shape | dropping')
+        }
+        const text = contentItems
+          .filter((item) => item.type === 'output_text')
+          .map((item) => item.text as string)
+          .join('\n')
+        if (text) input.push({ role: 'assistant', content: text })
+      } else {
+        // Cast is needed only because `contentItems` is built as a loosely-typed
+        // record array; the user-role items themselves (`input_text`/`input_image`/
+        // `input_file`) are valid `EasyInputMessage` content.
+        input.push({
+          role,
+          content: contentItems,
+        } as unknown as ResponseInputItem)
+      }
     }
 
     input.push(...toolCallItems)


### PR DESCRIPTION
## Description

Fixes the OpenAI Responses adapters (TS `OpenAIModel` in Responses mode and Python `OpenAIResponsesModel`) sending an invalid assistant history shape when replaying multi-turn conversations without server-side state.

### The bug

Assistant turns were serialized as:

```json
{ "role": "assistant", "content": [{ "type": "output_text", "text": "..." }] }
```

This matches **no** valid OpenAI `input` item shape:
- `EasyInputMessage` requires string content for assistant text (`input_text` in assistant messages is rejected — that was #1850, which this shape was the workaround for)
- `ResponseOutputMessage` requires `type: "message"`, `id`, `status`, and `annotations` — all missing

OpenAI-hosted silently tolerated the malformed item, but Bedrock Mantle's strict Responses schema rejects it (`SubmitRequestFailure: code=-32602, msg=220 validation errors for ResponsesRequest`). The TS code even force-cast it away with `as unknown as ResponseInputItem`.

### The fix

Text-only assistant history (including citation text) is now collapsed to the documented string-content `EasyInputMessage` — the only assistant *input* shape that is valid without the output-item metadata (`id`/`status`/`annotations`) the adapters have already discarded:

```json
{ "role": "assistant", "content": "..." }
```

- **TS** (`strands-ts/src/models/openai/responses-adapter.ts`): assistant content items are collapsed into a single string message at assembly time; the `as unknown as` force-cast on the assistant path is gone (the item now typechecks as a real `EasyInputMessage`, so `tsc` guards this shape again). Non-text assistant content (never a valid input shape) is warn-dropped. Drive-by: the `citationsBlock` case emitted `output_text` even for **user**-role messages — it is now role-aware (`input_text` for user), matching the Python side.
- **Python** (`strands-py/src/strands/models/openai_responses.py`): same collapse in `_format_request_messages`; `_format_request_message_content` keeps producing the `output_text` intermediate, which is now joined into the string form at final assembly. Non-text assistant content is warn-dropped.
- Multiple text blocks in one assistant message are joined with `\n` (same convention as text-only tool-result outputs).

Reasoning content is still dropped as before — proper verbatim output-item round-tripping (incl. `encrypted_content`) is tracked in #3389.

### Verification

**Unit / static:**
- Python: **104/104** tests in `test_openai_responses.py` pass (updated 4 tests that asserted the buggy shape; added 4 regression tests incl. one that validates the assistant item against the official `openai` SDK `EasyInputMessageParam` field contract). `ruff check` + `ruff format` clean.
- TS: **50/50** tests in `responses.test.ts` pass (3 new regression tests: string form, newline joining, non-text warn-drop); all 580 unit tests under `src/models/` pass; `tsc --noEmit` clean with the cast removed; `eslint`/`prettier` clean; full pre-commit hook (unit suite + coverage) passed.
- Schema strictness proxy for Mantle: validating the items against the official `openai` Python SDK `ResponseInputItemParam` union — **old shape: 115 validation errors** (mirrors Mantle's `220 validation errors for ResponsesRequest`); **new shape: valid**.

**Live E2E (OpenAI-hosted, real API key):**
- **Python**: two-turn `Agent` conversation via `OpenAIResponsesModel` (`gpt-4o-mini`); wire capture of the second request confirms the assistant history item is exactly `{"role": "assistant", "content": "2 + 2 equals 4."}`; both turns complete correctly.
- **TS**: same two-turn flow via `OpenAIModel` (Responses mode) with a request-capturing client; second request carries `{"role":"assistant","content":"2+2 equals 4."}`; both turns complete.
- **TS reasoning multi-turn** (mirrors the Mantle integ repro): `gpt-5-mini` with `reasoning: { effort: 'low' }`, two turns — second turn completes with `stopReason: endTurn` despite reasoning blocks in history.
- Raw-wire baseline check: OpenAI-hosted **accepts both** the old and new shapes, empirically confirming the issue's claim that the bug was invisible there and only surfaces on strict backends (Mantle).

**Not run locally:** the live Mantle integ test (`test/integ/models/openai/mantle.test.node.ts > handles reasoning content across multi-turn conversations`) — my credentials are denied `bedrock-mantle:CreateInference`, so the run failed with 401 access_denied before reaching the model. This is exactly what PR CI runs with team credentials; would appreciate confirmation from that run.

## Related Issues

Fixes #3388

## Type of Change

Bug fix

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
