### PR TITLE
fix(models): serialize assistant text history as valid Responses input shape

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -634,12 +634,27 @@ class OpenAIResponsesModel(Model):
             ]
 
             if formatted_contents:
-                formatted_messages.append(
-                    {
-                        "role": role,  # "user" | "assistant"
-                        "content": formatted_contents,
-                    }
-                )
+                if role == "assistant":
+                    # The string EasyInputMessage form is the only valid assistant *input*
+                    # shape without the full ResponseOutputMessage metadata
+                    # (id/status/annotations), which the adapter does not retain.
+                    # Non-text assistant history has no valid input shape either; verbatim
+                    # output-item round-tripping is tracked in
+                    # https://github.com/strands-agents/harness-sdk/issues/3389.
+                    if any(part.get("type") != "output_text" for part in formatted_contents):
+                        logger.warning(
+                            "non-text assistant history content has no valid responses api input shape | dropping"
+                        )
+                    text = "\n".join(part["text"] for part in formatted_contents if part.get("type") == "output_text")
+                    if text:
+                        formatted_messages.append({"role": "assistant", "content": text})
+                else:
+                    formatted_messages.append(
+                        {
+                            "role": role,
+                            "content": formatted_contents,
+                        }
+                    )
 
             formatted_messages.extend(formatted_tool_calls)
             formatted_messages.extend(formatted_tool_messages)

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -300,7 +300,7 @@ def test_format_request_messages(system_prompt):
         },
         {
             "role": "assistant",
-            "content": [{"type": "output_text", "text": "call tool"}],
+            "content": "call tool",
         },
         {
             "type": "function_call",
@@ -317,12 +317,14 @@ def test_format_request_messages(system_prompt):
     assert tru_result == exp_result
 
 
-def test_format_request_messages_assistant_text_uses_output_text():
-    """Assistant text content must use output_text, not input_text.
+def test_format_request_messages_assistant_text_uses_string_content():
+    """Assistant text history must serialize as the string EasyInputMessage form.
 
-    Regression test for multi-turn conversations failing because the OpenAI
-    Responses API rejects input_text in assistant messages.
-    See: https://github.com/strands-agents/harness-sdk/issues/1850
+    Regression test for strict Responses backends (Bedrock Mantle) rejecting
+    the bare ``{"role": "assistant", "content": [{"type": "output_text", ...}]}``
+    shape, which is not a valid input item (a full ResponseOutputMessage
+    requires id/status/annotations).
+    See: https://github.com/strands-agents/harness-sdk/issues/3388
     """
     messages = [
         {
@@ -347,12 +349,46 @@ def test_format_request_messages_assistant_text_uses_output_text():
     }
     assert result[1] == {
         "role": "assistant",
-        "content": [{"type": "output_text", "text": "Hello!"}],
+        "content": "Hello!",
     }
     assert result[2] == {
         "role": "user",
         "content": [{"type": "input_text", "text": "Say goodbye"}],
     }
+
+
+def test_format_request_messages_assistant_history_is_valid_input_item():
+    """Every formatted assistant history item validates against the OpenAI input schema.
+
+    Guards the wire shape: strict backends (Bedrock Mantle) validate request
+    items against the Responses schema and reject invalid ones.
+    See: https://github.com/strands-agents/harness-sdk/issues/3388
+    """
+    pydantic = pytest.importorskip("pydantic")
+    from openai.types.responses import ResponseInputItemParam
+
+    messages = [
+        {"content": [{"text": "What is 2+2?"}], "role": "user"},
+        {"content": [{"text": "4"}], "role": "assistant"},
+        {"content": [{"text": "What about 3+3?"}], "role": "user"},
+    ]
+
+    result = OpenAIResponsesModel._format_request_messages(messages)
+
+    adapter = pydantic.TypeAdapter(ResponseInputItemParam)
+    for item in result:
+        adapter.validate_python(item)
+
+
+def test_format_request_messages_assistant_multiple_text_blocks_joined():
+    """Multiple assistant text blocks join with newlines into one string."""
+    messages = [
+        {"content": [{"text": "first"}, {"text": "second"}], "role": "assistant"},
+    ]
+
+    result = OpenAIResponsesModel._format_request_messages(messages)
+
+    assert result == [{"role": "assistant", "content": "first\nsecond"}]
 
 
 def test_format_request_message_content_role_assistant():
@@ -624,9 +660,7 @@ async def test_stream(openai_client, model_id, model, agenerator, alist):
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -737,9 +771,7 @@ async def test_stream_with_tool_calls(openai_client, model, agenerator, alist):
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -774,9 +806,7 @@ async def test_stream_with_tool_calls_done_event(openai_client, model, agenerato
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -835,9 +865,7 @@ async def test_stream_reasoning_content(openai_client, model, agenerator, alist,
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=20, total_tokens=30, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=20, total_tokens=30, input_tokens_details=None)
         ),
     )
 
@@ -883,9 +911,7 @@ async def test_stream_citation_annotations(openai_client, model, agenerator, ali
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -923,9 +949,7 @@ async def test_stream_unsupported_annotation_type(openai_client, model, agenerat
     mock_complete_event = unittest.mock.Mock(
         type="response.completed",
         response=unittest.mock.Mock(
-            usage=unittest.mock.Mock(
-                input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None
-            )
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=5, total_tokens=15, input_tokens_details=None)
         ),
     )
 
@@ -1311,7 +1335,7 @@ def test_format_request_messages_with_citations_content():
     assistant_msg = [m for m in formatted if m.get("role") == "assistant"][0]
     assert assistant_msg == {
         "role": "assistant",
-        "content": [{"type": "output_text", "text": "The answer with citations."}],
+        "content": "The answer with citations.",
     }
 
 
@@ -1462,7 +1486,7 @@ def test_format_request_messages_excludes_reasoning_content(caplog):
 
     assert result == [
         {"role": "user", "content": [{"type": "input_text", "text": "Hello"}]},
-        {"role": "assistant", "content": [{"type": "output_text", "text": "The answer is 42"}]},
+        {"role": "assistant", "content": "The answer is 42"},
         {"role": "user", "content": [{"type": "input_text", "text": "Thanks"}]},
     ]
     assert "reasoningContent is not yet supported" in caplog.text

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -294,6 +294,35 @@ describe("OpenAIModel (api: 'responses')", () => {
       })
     })
 
+    it('serializes text-only assistant history as a string EasyInputMessage', async () => {
+      // Regression test: strict Responses backends (Bedrock Mantle) reject the
+      // bare `{ role: 'assistant', content: [{ type: 'output_text', ... }] }`
+      // shape, which is not a valid input item (a full ResponseOutputMessage
+      // requires id/status/annotations).
+      // See: https://github.com/strands-agents/harness-sdk/issues/3388
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('What is 2+2?')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('4')] }),
+        new Message({ role: 'user', content: [new TextBlock('What about 3+3?')] }),
+      ]
+      const req = await runOnce({}, messages)
+      expect(req.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'What is 2+2?' }] },
+        { role: 'assistant', content: '4' },
+        { role: 'user', content: [{ type: 'input_text', text: 'What about 3+3?' }] },
+      ])
+    })
+
+    it('joins multiple assistant text blocks with newlines', async () => {
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('hi')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('first'), new TextBlock('second')] }),
+        new Message({ role: 'user', content: [new TextBlock('go on')] }),
+      ]
+      const req = await runOnce({}, messages)
+      expect(req.input[1]).toEqual({ role: 'assistant', content: 'first\nsecond' })
+    })
+
     it('prefixes errored tool results with [ERROR]', async () => {
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('x')] }),

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -170,8 +170,9 @@ function formatResponsesMessages(messages: Message[]): ResponseInputItem[] {
 
         case 'citationsBlock': {
           const citBlock = block as { content: Array<{ text: string }> }
+          const textType = role === 'assistant' ? 'output_text' : 'input_text'
           for (const c of citBlock.content) {
-            contentItems.push({ type: 'output_text', text: c.text })
+            contentItems.push({ type: textType, text: c.text })
           }
           break
         }
@@ -214,15 +215,30 @@ function formatResponsesMessages(messages: Message[]): ResponseInputItem[] {
       }
     }
 
-    // Cast is needed because assistant messages here use `output_text` content
-    // blocks, which the SDK's input types model as `ResponseOutputMessage` —
-    // a response-shaped type that requires `id`/`status`/`annotations`. The API
-    // accepts these fields as omitted on input, but the SDK types don't reflect that.
     if (contentItems.length > 0) {
-      input.push({
-        role,
-        content: contentItems,
-      } as unknown as ResponseInputItem)
+      if (role === 'assistant') {
+        // The string `EasyInputMessage` form is the only valid assistant *input*
+        // shape without the full `ResponseOutputMessage` metadata
+        // (`id`/`status`/`annotations`), which the adapter does not retain.
+        // Non-text assistant history has no valid input shape either; verbatim
+        // output-item round-tripping is tracked in
+        // https://github.com/strands-agents/harness-sdk/issues/3389.
+        if (contentItems.some((item) => item.type !== 'output_text')) {
+          logger.warn('non-text assistant history content has no valid responses api input shape | dropping')
+        }
+        const text = contentItems
+          .filter((item) => item.type === 'output_text')
+          .map((item) => item.text as string)
+          .join('\n')
+        if (text) {
+          input.push({ role: 'assistant', content: text })
+        }
+      } else {
+        // Cast bridges the loosely-typed accumulator array; every user content
+        // item pushed above is a valid `ResponseInputContent` shape
+        // (input_text/input_image/input_file).
+        input.push({ role, content: contentItems } as unknown as ResponseInputItem)
+      }
     }
 
     input.push(...toolCallItems)


### PR DESCRIPTION
## Description

The OpenAI Responses adapters in **both SDKs** serialize assistant history into an invalid `input` item shape when replaying multi-turn conversations without server-side state (`stateful: false`, the default):

```json
{ "role": "assistant", "content": [{ "type": "output_text", "text": "..." }] }
```

This matches neither valid assistant *input* shape: it isn't a string-content `EasyInputMessage`, and it's missing the `id`/`status`/`annotations` a full `ResponseOutputMessage` requires. OpenAI-hosted silently tolerates it; strict backends like Bedrock Mantle reject the request (`code=-32602, 220 validation errors for ResponsesRequest`).

### Fix (parity change in both SDKs)

Text-only assistant history is now serialized as the string `EasyInputMessage` form — the only assistant input shape that is valid without the output-item metadata the adapters have already discarded:

```json
{ "role": "assistant", "content": "..." }
```

- Multiple assistant text blocks join with `\n` (consistent with text-only tool-result joining).
- Non-text assistant content is dropped with a warning — it has no valid input shape without fabricated metadata. Verbatim output-item round-tripping (which also preserves reasoning) is tracked in #3389; this minimal fix deliberately stays out of that scope.
- Tool-call/tool-result items are untouched (already valid separate items).
- **TS drive-by in the same function:** `citationsBlock` pushed `output_text` unconditionally, even for `role: 'user'` (invalid on the user path too). It is now role-aware, matching the Python side.
- **TS:** the `as unknown as ResponseInputItem` cast that existed solely to erase the invalid assistant shape is gone from that path; `tsc` now guards the assistant item shape again.

Files:
- `strands-ts/src/models/openai/responses-adapter.ts`
- `strands-py/src/strands/models/openai_responses.py`

## Related Issues

Fixes #3388
Related: #3389 (reasoning/output-item round-trip follow-up), surfaced by #3290

## Testing

**Unit (updated + new regression tests)**
- Python: `hatch run test` on `tests/strands/models/test_openai_responses.py` — 103/103 pass. Rewrote the fixtures that previously asserted the buggy shape; added a multi-block join test and a wire-shape guard that validates every formatted history item against the official `ResponseInputItemParam` schema (`pydantic.TypeAdapter`). Verified the guard rejects the old buggy shape and accepts the new one.
- TS: `responses.test.ts` — 49/49 pass, including a new two-turn regression test asserting the assistant turn serializes as `{ role: 'assistant', content: '4' }` and a multi-block join test. Full unit suite (3794 tests), lint, format, `type-check`, and build pass (pre-commit hook ran the full gate).

**E2E (live)**
- **OpenAI-hosted Responses API** (`gpt-4o-mini`): 3-turn stateless conversation (history replay each turn) and a tool-call-interleaved 2-turn conversation — both SDKs, all turns accepted. ✅
- **TS live integ suite** `test/integ/models/openai/responses.test.ts`: 12/12 pass against OpenAI-hosted. ✅
- **Bedrock Mantle**: could not exercise from this environment — the runner's IAM role is denied `bedrock-mantle:CreateInference`. The official-SDK schema validation above encodes the same contract Mantle enforces; the repo's Mantle integ tests (`test_model_mantle.py`, `mantle.test.node.ts`) will exercise it in CI with proper credentials.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
