### PR TITLE
feat(python): add per-call MCP tool cancellation

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -114,12 +114,13 @@ The `agent.cancel()` method provides a way to stop the loop from outside, such a
 <Tabs>
   <Tab label="Python">
 
-  The agent checks for cancellation at two checkpoints:
+  The agent checks for cancellation at three checkpoints:
 
   | Checkpoint | Behavior | Note |
   |---|---|---|
   | Model response streaming | Partial output is discarded | Usage metrics may be inaccurate since the stream is closed before the model sends its final metadata event |
   | Before tool execution | Tool calls are skipped with error results added to maintain valid conversation state | |
+  | During MCP tool execution | The in-flight MCP request is cancelled without closing the shared MCP session | Remote cancellation is best-effort; the agent stops locally even if the server does not acknowledge cancellation |
 
   The agent returns a result with `stop_reason="cancelled"`. `cancel()` is thread-safe and idempotent. Calling it multiple times or from different threads is safe.
 
@@ -148,6 +149,41 @@ The `agent.cancel()` method provides a way to stop the loop from outside, such a
   if result.stop_reason == "cancelled":
       print("Agent was cancelled due to timeout")
   ```
+
+  #### Per-call MCP cancellation
+
+  `MCPClient.call_tool_sync()` and `MCPClient.call_tool_async()` also accept a caller-owned
+  `threading.Event` through the keyword-only `cancel_signal` parameter. Setting the event cancels
+  only that call; the MCP session remains available for later calls. A locally observed cancellation
+  returns an error result with `cancelled=True`. This marker does not guarantee that remote execution
+  stopped, because protocol cancellation is best-effort.
+
+  ```python
+  import asyncio
+  import threading
+
+  from strands.tools.mcp import MCPClient
+
+  cancel_signal = threading.Event()
+
+  # Inside an active MCPClient context:
+  sync_result = client.call_tool_sync(
+      tool_use_id="sync-call",
+      name="long_running_tool",
+      arguments={},
+      cancel_signal=cancel_signal,
+  )
+
+  async_result = await client.call_tool_async(
+      tool_use_id="async-call",
+      name="long_running_tool",
+      arguments={},
+      cancel_signal=cancel_signal,
+  )
+  ```
+
+  The event is not cleared by `MCPClient`; clear it before reusing it for another call. Cancelling the
+  outer asyncio task is separate from setting `cancel_signal` and raises `asyncio.CancelledError`.
 
   Cancellation differs from [interrupts](../interrupts.mdx) in that it stops the agent entirely rather than pausing for human input. Interrupts allow the agent to resume from where it left off; cancellation does not.
   </Tab>

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -151,66 +151,6 @@ The `agent.cancel()` method provides a way to stop the loop from outside, such a
       print("Agent was cancelled due to timeout")
   ```
 
-  #### Per-call MCP cancellation
-
-  `MCPClient.call_tool_sync()` and `MCPClient.call_tool_async()` also accept a caller-owned
-  `threading.Event` through the keyword-only `cancel_signal` parameter. Setting the event cancels
-  only that call; the MCP session remains available for later calls. A locally observed cancellation
-  returns an error result with `cancelled=True`. This marker does not guarantee that remote execution
-  stopped, because protocol cancellation is best-effort.
-
-  Synchronous call:
-
-  ```python
-  import threading
-
-  from strands.tools.mcp import MCPClient
-
-
-  def call_tool(client: MCPClient) -> None:
-      """Cancel a tool after one second while the client context is active."""
-      cancel_signal = threading.Event()
-      timer = threading.Timer(1, cancel_signal.set)
-      timer.start()
-      try:
-          result = client.call_tool_sync(
-              tool_use_id="sync-call",
-              name="long_running_tool",
-              arguments={},
-              cancel_signal=cancel_signal,
-          )
-      finally:
-          timer.cancel()
-  ```
-
-  Asynchronous call:
-
-  ```python
-  import asyncio
-  import threading
-
-  from strands.tools.mcp import MCPClient
-
-
-  async def call_tool(client: MCPClient) -> None:
-      """Cancel a tool after one second while the client context is active."""
-      cancel_signal = threading.Event()
-      loop = asyncio.get_running_loop()
-      timer = loop.call_later(1, cancel_signal.set)
-      try:
-          result = await client.call_tool_async(
-              tool_use_id="async-call",
-              name="long_running_tool",
-              arguments={},
-              cancel_signal=cancel_signal,
-          )
-      finally:
-          timer.cancel()
-  ```
-
-  The event is not cleared by `MCPClient`; clear it before reusing it for another call. Cancelling the
-  outer asyncio task is separate from setting `cancel_signal` and raises `asyncio.CancelledError`.
-
   Cancellation differs from [interrupts](../interrupts.mdx) in that it stops the agent entirely rather than pausing for human input. Interrupts allow the agent to resume from where it left off; cancellation does not.
   </Tab>
   <Tab label="TypeScript">

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -158,28 +158,42 @@ The `agent.cancel()` method provides a way to stop the loop from outside, such a
   returns an error result with `cancelled=True`. This marker does not guarantee that remote execution
   stopped, because protocol cancellation is best-effort.
 
+  Synchronous call:
+
   ```python
-  import asyncio
   import threading
 
   from strands.tools.mcp import MCPClient
 
-  cancel_signal = threading.Event()
 
-  # Inside an active MCPClient context:
-  sync_result = client.call_tool_sync(
-      tool_use_id="sync-call",
-      name="long_running_tool",
-      arguments={},
-      cancel_signal=cancel_signal,
-  )
+  def call_tool(client: MCPClient) -> None:
+      """Call a tool while the client context is active."""
+      cancel_signal = threading.Event()
+      result = client.call_tool_sync(
+          tool_use_id="sync-call",
+          name="long_running_tool",
+          arguments={},
+          cancel_signal=cancel_signal,
+      )
+  ```
 
-  async_result = await client.call_tool_async(
-      tool_use_id="async-call",
-      name="long_running_tool",
-      arguments={},
-      cancel_signal=cancel_signal,
-  )
+  Asynchronous call:
+
+  ```python
+  import threading
+
+  from strands.tools.mcp import MCPClient
+
+
+  async def call_tool(client: MCPClient) -> None:
+      """Call a tool while the client context is active."""
+      cancel_signal = threading.Event()
+      result = await client.call_tool_async(
+          tool_use_id="async-call",
+          name="long_running_tool",
+          arguments={},
+          cancel_signal=cancel_signal,
+      )
   ```
 
   The event is not cleared by `MCPClient`; clear it before reusing it for another call. Cancelling the

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -114,13 +114,14 @@ The `agent.cancel()` method provides a way to stop the loop from outside, such a
 <Tabs>
   <Tab label="Python">
 
-  The agent checks for cancellation at three checkpoints:
+  The agent checks for cancellation at four checkpoints:
 
   | Checkpoint | Behavior | Note |
   |---|---|---|
   | Model response streaming | Partial output is discarded | Usage metrics may be inaccurate since the stream is closed before the model sends its final metadata event |
   | Before tool execution | Tool calls are skipped with error results added to maintain valid conversation state | |
   | During MCP tool execution | The in-flight MCP request is cancelled without closing the shared MCP session | Remote cancellation is best-effort; the agent stops locally even if the server does not acknowledge cancellation |
+  | After tool execution | The agent stops before the next model call | Non-MCP tools finish before cancellation is observed |
 
   The agent returns a result with `stop_reason="cancelled"`. `cancel()` is thread-safe and idempotent. Calling it multiple times or from different threads is safe.
 
@@ -167,33 +168,44 @@ The `agent.cancel()` method provides a way to stop the loop from outside, such a
 
 
   def call_tool(client: MCPClient) -> None:
-      """Call a tool while the client context is active."""
+      """Cancel a tool after one second while the client context is active."""
       cancel_signal = threading.Event()
-      result = client.call_tool_sync(
-          tool_use_id="sync-call",
-          name="long_running_tool",
-          arguments={},
-          cancel_signal=cancel_signal,
-      )
+      timer = threading.Timer(1, cancel_signal.set)
+      timer.start()
+      try:
+          result = client.call_tool_sync(
+              tool_use_id="sync-call",
+              name="long_running_tool",
+              arguments={},
+              cancel_signal=cancel_signal,
+          )
+      finally:
+          timer.cancel()
   ```
 
   Asynchronous call:
 
   ```python
+  import asyncio
   import threading
 
   from strands.tools.mcp import MCPClient
 
 
   async def call_tool(client: MCPClient) -> None:
-      """Call a tool while the client context is active."""
+      """Cancel a tool after one second while the client context is active."""
       cancel_signal = threading.Event()
-      result = await client.call_tool_async(
-          tool_use_id="async-call",
-          name="long_running_tool",
-          arguments={},
-          cancel_signal=cancel_signal,
-      )
+      loop = asyncio.get_running_loop()
+      timer = loop.call_later(1, cancel_signal.set)
+      try:
+          result = await client.call_tool_async(
+              tool_use_id="async-call",
+              name="long_running_tool",
+              arguments={},
+              cancel_signal=cancel_signal,
+          )
+      finally:
+          timer.cancel()
   ```
 
   The event is not cleared by `MCPClient`; clear it before reusing it for another call. Cancelling the

--- a/strands-py/AGENTS.md
+++ b/strands-py/AGENTS.md
@@ -206,7 +206,7 @@ class XModel(Model):
 - **Never buffer a stream into a list before yielding.** Consume upstream async iterables with `async for` and yield as you go.
 - **Async-first with thin sync facades.** Public APIs come in async form (`invoke_async`, `stream_async`) plus thin sync wrappers (`__call__`, `invoke`) that delegate via `_async.run_async`. Never block the event loop — wrap blocking or third-party-sync calls in `asyncio.to_thread` (see `bedrock.py`).
 - **The floor is Python 3.10.** Do not use `asyncio.TaskGroup` or `asyncio.timeout` (3.11+) without a `sys.version_info` gate and a 3.10 fallback (see `multiagent/swarm.py`); for concurrent work use `asyncio.create_task` and clean up in `finally` with `task.cancel()` then `await asyncio.gather(*tasks, return_exceptions=True)`.
-- **Cancellation is cooperative.** `agent.cancel()` sets an internal `threading.Event` checked at model/tool boundaries and forwarded into in-flight MCP calls (see `agent/_concurrency.py` and `tools/mcp/mcp_agent_tool.py`). Direct MCP calls also accept a caller-owned `threading.Event` through `cancel_signal`; remote cancellation is best-effort. *(The TypeScript SDK uses `AbortSignal` instead — see its AGENTS.md.)*
+- **Cancellation is cooperative.** Long-running integrations must propagate and observe the agent cancellation signal rather than blocking the event loop. *(The TypeScript SDK uses `AbortSignal` instead — see its AGENTS.md.)*
 
 ## MCP Tasks (Experimental)
 

--- a/strands-py/AGENTS.md
+++ b/strands-py/AGENTS.md
@@ -206,7 +206,7 @@ class XModel(Model):
 - **Never buffer a stream into a list before yielding.** Consume upstream async iterables with `async for` and yield as you go.
 - **Async-first with thin sync facades.** Public APIs come in async form (`invoke_async`, `stream_async`) plus thin sync wrappers (`__call__`, `invoke`) that delegate via `_async.run_async`. Never block the event loop — wrap blocking or third-party-sync calls in `asyncio.to_thread` (see `bedrock.py`).
 - **The floor is Python 3.10.** Do not use `asyncio.TaskGroup` or `asyncio.timeout` (3.11+) without a `sys.version_info` gate and a 3.10 fallback (see `multiagent/swarm.py`); for concurrent work use `asyncio.create_task` and clean up in `finally` with `task.cancel()` then `await asyncio.gather(*tasks, return_exceptions=True)`.
-- **Cancellation is cooperative.** It uses an internal `threading.Event` set by `agent.cancel()` and checked at turn/tool boundaries (see `agent/_concurrency.py`); the SDK does not accept an external cancel token. *(The TypeScript SDK uses `AbortSignal` instead — see its AGENTS.md.)*
+- **Cancellation is cooperative.** `agent.cancel()` sets an internal `threading.Event` checked at model/tool boundaries and forwarded into in-flight MCP calls (see `agent/_concurrency.py` and `tools/mcp/mcp_agent_tool.py`). Direct MCP calls also accept a caller-owned `threading.Event` through `cancel_signal`; remote cancellation is best-effort. *(The TypeScript SDK uses `AbortSignal` instead — see its AGENTS.md.)*
 
 ## MCP Tasks (Experimental)
 

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -596,6 +596,7 @@ class Agent(AgentBase):
         - During model response streaming
         - Before tool execution
         - During MCP tool execution
+        - After tool execution, before the next model call
 
         The agent will return a result with stop_reason="cancelled".
 

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -595,6 +595,7 @@ class Agent(AgentBase):
         The agent will stop gracefully at the next cancellation-safe point:
         - During model response streaming
         - Before tool execution
+        - During MCP tool execution
 
         The agent will return a result with stop_reason="cancelled".
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -559,8 +559,7 @@ async def _handle_model_execution(
 
             if last_event is None:
                 raise RuntimeError(
-                    "Middleware chain did not yield a result event. "
-                    "Ensure middleware forwards events from next()."
+                    "Middleware chain did not yield a result event. Ensure middleware forwards events from next()."
                 )
 
             # Write the post-stream model state back to the agent. Skipped on error
@@ -849,9 +848,18 @@ async def _handle_tool_execution(
         )
         return
 
+    if agent._cancel_signal.is_set():
+        yield EventLoopStopEvent(
+            "cancelled",
+            message,
+            agent.event_loop_metrics,
+            invocation_state["request_state"],
+        )
+        return
+
     # Emit after_tools checkpoint. Only fires on tool_use cycles: a model that
     # returns end_turn first never reaches this branch.
-    if agent._checkpointing and not agent._cancel_signal.is_set():
+    if agent._checkpointing:
         cycle_index = agent._checkpoint_cycle_index
         agent._checkpoint_cycle_index = cycle_index + 1
         yield _build_checkpoint_stop_event(
@@ -860,17 +868,6 @@ async def _handle_tool_execution(
             cycle_index=cycle_index,
             message=message,
             request_state=invocation_state["request_state"],
-        )
-        return
-
-    # If checkpointing is on and cancel suppressed the checkpoint above, emit
-    # "cancelled" now to avoid an extra model call.
-    if agent._checkpointing and agent._cancel_signal.is_set():
-        yield EventLoopStopEvent(
-            "cancelled",
-            message,
-            agent.event_loop_metrics,
-            invocation_state["request_state"],
         )
         return
 

--- a/strands-py/src/strands/tools/executors/_executor.py
+++ b/strands-py/src/strands/tools/executors/_executor.py
@@ -93,6 +93,19 @@ class ToolExecutor(abc.ABC):
         return await agent.hooks.invoke_callbacks_async(event)
 
     @staticmethod
+    def _should_retry(agent: "Agent | BidiAgent", after_event: AfterToolCallEvent | BidiAfterToolCallEvent) -> bool:
+        """Return whether a hook-requested retry should run.
+
+        Cancellation is terminal: retrying a locally cancelled tool can spin indefinitely
+        while delaying the caller's requested agent stop.
+        """
+        if not getattr(after_event, "retry", False):
+            return False
+        if cast(dict[str, Any], after_event.result).get("cancelled") is True:
+            return False
+        return not (ToolExecutor._is_agent(agent) and agent._cancel_signal.is_set())
+
+    @staticmethod
     async def _stream(
         agent: "Agent | BidiAgent",
         tool_use: ToolUse,
@@ -265,8 +278,7 @@ class ToolExecutor(abc.ABC):
                     agent, selected_tool, tool_use, invocation_state, result, exception=exception
                 )
 
-                # Check if retry requested (getattr for BidiAfterToolCallEvent compatibility)
-                if getattr(after_event, "retry", False):
+                if ToolExecutor._should_retry(agent, after_event):
                     logger.debug("tool_name=<%s> | retry requested, retrying tool call", tool_name)
                     continue
 
@@ -296,8 +308,7 @@ class ToolExecutor(abc.ABC):
                 after_event, _ = await ToolExecutor._invoke_after_tool_call_hook(
                     agent, selected_tool, tool_use, invocation_state, error_result, exception=e
                 )
-                # Check if retry requested (getattr for BidiAfterToolCallEvent compatibility)
-                if getattr(after_event, "retry", False):
+                if ToolExecutor._should_retry(agent, after_event):
                     logger.debug("tool_name=<%s> | retry requested after exception, retrying tool call", tool_name)
                     continue
                 yield ToolResultEvent(after_event.result, exception=after_event.exception)

--- a/strands-py/src/strands/tools/executors/sequential.py
+++ b/strands-py/src/strands/tools/executors/sequential.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 from ...telemetry.metrics import Trace
-from ...types._events import ToolInterruptEvent, TypedEvent
+from ...types._events import ToolInterruptEvent, ToolResultEvent, TypedEvent
 from ...types.tools import ToolResult, ToolUse
 from ._executor import ToolExecutor
 
@@ -48,6 +48,16 @@ class SequentialToolExecutor(ToolExecutor):
         interrupted = False
 
         for tool_use in tool_uses:
+            if agent._cancel_signal.is_set():
+                cancel_result: ToolResult = {
+                    "toolUseId": str(tool_use.get("toolUseId")),
+                    "status": "error",
+                    "content": [{"text": "Tool execution cancelled"}],
+                }
+                tool_results.append(cancel_result)
+                yield ToolResultEvent(cancel_result)
+                continue
+
             events = ToolExecutor._stream_with_trace(
                 agent, tool_use, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context
             )

--- a/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
@@ -115,6 +115,6 @@ class MCPAgentTool(AgentTool):
             name=self.mcp_tool.name,  # Use original MCP name for server communication
             arguments=tool_use["input"],
             read_timeout_seconds=self.timeout,
-            cancel_signal=invocation_state["agent"]._cancel_signal,
+            cancel_signal=getattr(invocation_state["agent"], "_cancel_signal", None),
         )
         yield ToolResultEvent(result)

--- a/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
@@ -115,6 +115,6 @@ class MCPAgentTool(AgentTool):
             name=self.mcp_tool.name,  # Use original MCP name for server communication
             arguments=tool_use["input"],
             read_timeout_seconds=self.timeout,
-            cancel_signal=getattr(invocation_state["agent"], "_cancel_signal", None),
+            cancel_signal=getattr(invocation_state.get("agent"), "_cancel_signal", None),
         )
         yield ToolResultEvent(result)

--- a/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
@@ -115,5 +115,6 @@ class MCPAgentTool(AgentTool):
             name=self.mcp_tool.name,  # Use original MCP name for server communication
             arguments=tool_use["input"],
             read_timeout_seconds=self.timeout,
+            cancel_signal=invocation_state["agent"]._cancel_signal,
         )
         yield ToolResultEvent(result)

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -1338,7 +1338,7 @@ class MCPClient(ToolProvider):
                 else:
                     pending = {invoke_event} if not invoke_event.done() else set()
                 if pending:
-                    invoke_event.add_done_callback(lambda task: task.exception() if not task.cancelled() else None)
+                    self._track_background_cleanup_task(invoke_event)
                 if cancel_event is not None and not cancel_event.done():
                     cancel_event.cancel()
                     await asyncio.gather(cancel_event, return_exceptions=True)

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -1188,7 +1188,11 @@ class MCPClient(ToolProvider):
                 )
             else:
                 return
-            await asyncio.wait_for(cancellation, timeout=1)
+            cancellation_task = asyncio.create_task(cancellation)
+            _, pending = await asyncio.wait({cancellation_task}, timeout=1)
+            if pending:
+                cancellation_task.cancel()
+                cancellation_task.add_done_callback(lambda task: task.exception() if not task.cancelled() else None)
         except Exception as error:
             self._log_debug_with_thread("error=<%s> | failed to notify MCP server of cancellation", str(error))
 
@@ -1214,6 +1218,7 @@ class MCPClient(ToolProvider):
                 raise RuntimeError("Tool execution cancelled")
 
             invoke_event = asyncio.create_task(coro)
+            invoke_cancel_requested = False
             cancel_event: asyncio.Task[None] | None = None
 
             if cancel_signal is not None:
@@ -1233,6 +1238,7 @@ class MCPClient(ToolProvider):
 
                 if cancel_signal is not None and cancel_signal.is_set():
                     self._log_debug_with_thread("cancellation detected during MCP invocation")
+                    invoke_cancel_requested = True
                     invoke_event.cancel()
                     _, pending = await asyncio.wait({invoke_event}, timeout=1)
                     if pending:
@@ -1248,13 +1254,15 @@ class MCPClient(ToolProvider):
                 await asyncio.wait({invoke_event}, timeout=1)
                 raise RuntimeError("Connection to the MCP server was closed")
             finally:
-                if not invoke_event.done():
+                if not invoke_event.done() and not invoke_cancel_requested:
                     invoke_event.cancel()
                     _, pending = await asyncio.wait({invoke_event}, timeout=1)
-                    if pending:
-                        invoke_event.add_done_callback(lambda task: task.exception() if not task.cancelled() else None)
                     if cancellation_state is not None:
                         await self._cancel_tool_call(cancellation_state)
+                else:
+                    pending = {invoke_event} if not invoke_event.done() else set()
+                if pending:
+                    invoke_event.add_done_callback(lambda task: task.exception() if not task.cancelled() else None)
                 if cancel_event is not None and not cancel_event.done():
                     cancel_event.cancel()
                     await asyncio.gather(cancel_event, return_exceptions=True)
@@ -1448,13 +1456,25 @@ class MCPClient(ToolProvider):
         try:
             create_result = await asyncio.shield(create_task)
         except asyncio.CancelledError:
-            try:
-                create_result = await asyncio.wait_for(asyncio.shield(create_task), timeout=1)
+            done, _ = await asyncio.wait({create_task}, timeout=1)
+            if done:
+                create_result = create_task.result()
                 if cancellation_state is not None:
                     cancellation_state["task_id"] = create_result.task.taskId
-            except asyncio.TimeoutError:
-                create_task.cancel()
-                await asyncio.gather(create_task, return_exceptions=True)
+            else:
+
+                def cancel_delayed_task(task: asyncio.Task[Any]) -> None:
+                    if task.cancelled():
+                        return
+                    try:
+                        result = task.result()
+                    except Exception:
+                        return
+                    if cancellation_state is not None:
+                        cancellation_state["task_id"] = result.task.taskId
+                        asyncio.create_task(self._cancel_tool_call(cancellation_state))
+
+                create_task.add_done_callback(cancel_delayed_task)
             raise
         task_id = create_result.task.taskId
         if cancellation_state is not None:

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -1298,8 +1298,9 @@ class MCPClient(ToolProvider):
             if cancel_signal is not None:
 
                 async def wait_for_cancel() -> None:
-                    # Polling avoids blocking the loop. Running Event.wait() in an executor would
-                    # leave its worker thread blocked when this watcher is cancelled after success.
+                    # threading.Event has no async notification hook. Poll on this loop rather than
+                    # running Event.wait() in an executor: cancelling that await cannot stop a worker
+                    # already blocked in Event.wait(), so successful calls could strand worker threads.
                     while not cancel_signal.is_set():
                         await asyncio.sleep(0.05)
 
@@ -1332,7 +1333,11 @@ class MCPClient(ToolProvider):
             finally:
                 if not invoke_event.done() and not invoke_cancel_requested:
                     invoke_event.cancel()
+                    # asyncio.wait reports expiration through pending; it does not raise TimeoutError.
+                    # The original caller cancellation or exception continues after this bounded cleanup.
                     _, pending = await asyncio.wait({invoke_event}, timeout=1)
+                    if pending:
+                        self._log_debug_with_thread("MCP invocation did not finish within bounded cancellation cleanup")
                     if cancellation_state is not None:
                         await self._cancel_tool_call(cancellation_state)
                 else:

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -70,6 +70,10 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+class _MCPCallCancelledError(RuntimeError):
+    """Raised internally when a per-call MCP cancellation signal is observed."""
+
+
 class _ToolFilterCallback(Protocol):
     def __call__(self, tool: AgentTool, **kwargs: Any) -> bool: ...
 
@@ -93,6 +97,7 @@ class _CallCancellationState(TypedDict, total=False):
     session: ClientSession
     request_id: int
     task_id: str
+    notification_sent: bool
 
 
 class MCPServerConfig(TypedDict, total=False):
@@ -808,6 +813,7 @@ class MCPClient(ToolProvider):
         read_timeout_seconds: timedelta | None = None,
         meta: dict[str, Any] | None = None,
         progress_callback: ProgressFnT | None = None,
+        *,
         cancel_signal: threading.Event | None = None,
     ) -> MCPToolResult:
         """Synchronously calls a tool on the MCP server.
@@ -823,10 +829,16 @@ class MCPClient(ToolProvider):
             meta: Optional metadata to pass to the tool call per MCP spec (_meta)
             progress_callback: Optional callback to receive progress notifications for this
                 call. Overrides the instance-level callback set at construction time.
-            cancel_signal: Optional thread-safe event that cancels only this in-flight call when set.
+            cancel_signal: Optional caller-owned, thread-safe event for this call. A pre-set event
+                cancels before the MCP request starts. If set while the request is in flight,
+                cancellation wins over a concurrently arriving result. The returned error result has
+                ``cancelled=True``. Remote cancellation is best-effort and bounded; the shared MCP
+                session remains reusable. Clear the event before reusing it for another call.
 
         Returns:
-            MCPToolResult: The result of the tool call
+            MCPToolResult: The tool result. Locally observed cancellation returns an error result with
+                ``cancelled=True`` rather than raising. Cancelling the outer asyncio task is separate
+                and still raises ``asyncio.CancelledError`` for ``call_tool_async``.
         """
         self._log_debug_with_thread("calling MCP tool '%s' synchronously with tool_use_id=%s", name, tool_use_id)
         if not self._is_session_active():
@@ -858,6 +870,7 @@ class MCPClient(ToolProvider):
         read_timeout_seconds: timedelta | None = None,
         meta: dict[str, Any] | None = None,
         progress_callback: ProgressFnT | None = None,
+        *,
         cancel_signal: threading.Event | None = None,
     ) -> MCPToolResult:
         """Asynchronously calls a tool on the MCP server.
@@ -873,10 +886,16 @@ class MCPClient(ToolProvider):
             meta: Optional metadata to pass to the tool call per MCP spec (_meta)
             progress_callback: Optional callback to receive progress notifications for this
                 call. Overrides the instance-level callback set at construction time.
-            cancel_signal: Optional thread-safe event that cancels only this in-flight call when set.
+            cancel_signal: Optional caller-owned, thread-safe event for this call. A pre-set event
+                cancels before the MCP request starts. If set while the request is in flight,
+                cancellation wins over a concurrently arriving result. The returned error result has
+                ``cancelled=True``. Remote cancellation is best-effort and bounded; the shared MCP
+                session remains reusable. Clear the event before reusing it for another call.
 
         Returns:
-            MCPToolResult: The result of the tool call
+            MCPToolResult: The tool result. Locally observed cancellation returns an error result with
+                ``cancelled=True`` rather than raising. Cancelling the outer asyncio task is separate
+                and still raises ``asyncio.CancelledError`` for ``call_tool_async``.
         """
         self._log_debug_with_thread("calling MCP tool '%s' asynchronously with tool_use_id=%s", name, tool_use_id)
         if not self._is_session_active():
@@ -927,11 +946,14 @@ class MCPClient(ToolProvider):
             except Exception:
                 logger.debug("Failed to parse ElicitationRequiredErrorData from -32042 error", exc_info=True)
 
-        return MCPToolResult(
+        result = MCPToolResult(
             status="error",
             toolUseId=tool_use_id,
             content=[{"text": f"Tool execution failed: {str(exception)}"}],
         )
+        if isinstance(exception, _MCPCallCancelledError):
+            result["cancelled"] = True
+        return result
 
     def _handle_tool_result(self, tool_use_id: str, call_tool_result: MCPCallToolResult) -> MCPToolResult:
         """Maps MCP tool result to the agent's MCPToolResult format.
@@ -1169,7 +1191,7 @@ class MCPClient(ToolProvider):
     async def _cancel_tool_call(self, cancellation_state: _CallCancellationState) -> None:
         """Cancel the exact MCP task or request represented by the per-call state."""
         session = cancellation_state.get("session")
-        if session is None:
+        if session is None or cancellation_state.get("notification_sent"):
             return
 
         try:
@@ -1188,6 +1210,7 @@ class MCPClient(ToolProvider):
                 )
             else:
                 return
+            cancellation_state["notification_sent"] = True
             cancellation_task = asyncio.create_task(cancellation)
             _, pending = await asyncio.wait({cancellation_task}, timeout=1)
             if pending:
@@ -1215,7 +1238,7 @@ class MCPClient(ToolProvider):
         async def run_async() -> T:
             if cancel_signal is not None and cancel_signal.is_set():
                 coro.close()
-                raise RuntimeError("Tool execution cancelled")
+                raise _MCPCallCancelledError("Tool execution cancelled")
 
             invoke_event = asyncio.create_task(coro)
             invoke_cancel_requested = False
@@ -1245,7 +1268,7 @@ class MCPClient(ToolProvider):
                         self._log_debug_with_thread("timed out cleaning up cancelled MCP invocation")
                     if cancellation_state is not None:
                         await self._cancel_tool_call(cancellation_state)
-                    raise RuntimeError("Tool execution cancelled")
+                    raise _MCPCallCancelledError("Tool execution cancelled")
                 if invoke_event in done:
                     return await invoke_event
 
@@ -1461,6 +1484,7 @@ class MCPClient(ToolProvider):
                 create_result = create_task.result()
                 if cancellation_state is not None:
                     cancellation_state["task_id"] = create_result.task.taskId
+                    await self._cancel_tool_call(cancellation_state)
             else:
 
                 def cancel_delayed_task(task: asyncio.Task[Any]) -> None:

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -36,6 +36,9 @@ from mcp.shared.exceptions import McpError
 from mcp.shared.session import ProgressFnT
 from mcp.types import (
     BlobResourceContents,
+    CancelledNotification,
+    CancelledNotificationParams,
+    ClientNotification,
     ElicitationRequiredErrorData,
     GetPromptResult,
     Implementation,
@@ -84,6 +87,12 @@ class ToolFilters(TypedDict, total=False):
 
     allowed: list[_ToolMatcher]
     rejected: list[_ToolMatcher]
+
+
+class _CallCancellationState(TypedDict, total=False):
+    session: ClientSession
+    request_id: int
+    task_id: str
 
 
 class MCPServerConfig(TypedDict, total=False):
@@ -735,6 +744,7 @@ class MCPClient(ToolProvider):
         read_timeout_seconds: timedelta | None,
         meta: dict[str, Any] | None = None,
         progress_callback: ProgressFnT | None = None,
+        cancellation_state: _CallCancellationState | None = None,
     ) -> Coroutine[Any, Any, MCPCallToolResult]:
         """Create the appropriate coroutine for calling a tool.
 
@@ -748,6 +758,7 @@ class MCPClient(ToolProvider):
             meta: Optional metadata to pass to the tool call per MCP spec (_meta).
             progress_callback: Optional callback to receive progress notifications.
                 If None, falls back to the instance-level callback set at construction time.
+            cancellation_state: Internal state used to cancel the exact MCP request or task.
 
         Returns:
             A coroutine that will execute the tool call.
@@ -767,7 +778,11 @@ class MCPClient(ToolProvider):
                 # When task-augmented execution is used, use the read_timeout_seconds parameter
                 # (which is a timedelta) for the polling timeout.
                 return await self._call_tool_as_task_and_poll_async(
-                    name, arguments, poll_timeout=read_timeout_seconds, meta=meta
+                    name,
+                    arguments,
+                    poll_timeout=read_timeout_seconds,
+                    meta=meta,
+                    cancellation_state=cancellation_state,
                 )
 
             return _call_as_task()
@@ -775,7 +790,11 @@ class MCPClient(ToolProvider):
             self._log_debug_with_thread("tool=<%s> | using direct call_tool", name)
 
             async def _call_tool_direct() -> MCPCallToolResult:
-                return await cast(ClientSession, self._background_thread_session).call_tool(
+                session = cast(ClientSession, self._background_thread_session)
+                if cancellation_state is not None:
+                    cancellation_state["session"] = session
+                    cancellation_state["request_id"] = session._request_id
+                return await session.call_tool(
                     name, arguments, read_timeout_seconds, progress_callback=effective_callback, meta=meta
                 )
 
@@ -814,11 +833,17 @@ class MCPClient(ToolProvider):
             raise MCPClientInitializationError(CLIENT_SESSION_NOT_RUNNING_ERROR_MESSAGE)
 
         try:
+            cancellation_state = _CallCancellationState()
             coro = self._create_call_tool_coroutine(
-                name, arguments, read_timeout_seconds, meta=meta, progress_callback=progress_callback
+                name,
+                arguments,
+                read_timeout_seconds,
+                meta=meta,
+                progress_callback=progress_callback,
+                cancellation_state=cancellation_state,
             )
             call_tool_result: MCPCallToolResult = self._invoke_on_background_thread(
-                coro, cancel_signal=cancel_signal
+                coro, cancel_signal=cancel_signal, cancellation_state=cancellation_state
             ).result()
             return self._handle_tool_result(tool_use_id, call_tool_result)
         except Exception as e:
@@ -858,10 +883,18 @@ class MCPClient(ToolProvider):
             raise MCPClientInitializationError(CLIENT_SESSION_NOT_RUNNING_ERROR_MESSAGE)
 
         try:
+            cancellation_state = _CallCancellationState()
             coro = self._create_call_tool_coroutine(
-                name, arguments, read_timeout_seconds, meta=meta, progress_callback=progress_callback
+                name,
+                arguments,
+                read_timeout_seconds,
+                meta=meta,
+                progress_callback=progress_callback,
+                cancellation_state=cancellation_state,
             )
-            future = self._invoke_on_background_thread(coro, cancel_signal=cancel_signal)
+            future = self._invoke_on_background_thread(
+                coro, cancel_signal=cancel_signal, cancellation_state=cancellation_state
+            )
             call_tool_result: MCPCallToolResult = await asyncio.wrap_future(future)
             return self._handle_tool_result(tool_use_id, call_tool_result)
         except Exception as e:
@@ -1133,8 +1166,33 @@ class MCPClient(ToolProvider):
             "[Thread: %s, Session: %s] %s", threading.current_thread().name, self._session_id, formatted_msg, **kwargs
         )
 
+    async def _cancel_tool_call(self, cancellation_state: _CallCancellationState) -> None:
+        """Cancel the exact MCP task or request represented by the per-call state."""
+        session = cancellation_state.get("session")
+        if session is None:
+            return
+
+        try:
+            if task_id := cancellation_state.get("task_id"):
+                await session.experimental.cancel_task(task_id)
+            elif (request_id := cancellation_state.get("request_id")) is not None:
+                await session.send_notification(
+                    ClientNotification(
+                        CancelledNotification(
+                            params=CancelledNotificationParams(
+                                requestId=request_id, reason="Strands agent invocation cancelled"
+                            )
+                        )
+                    )
+                )
+        except Exception as error:
+            self._log_debug_with_thread("error=<%s> | failed to notify MCP server of cancellation", str(error))
+
     def _invoke_on_background_thread(
-        self, coro: Coroutine[Any, Any, T], cancel_signal: threading.Event | None = None
+        self,
+        coro: Coroutine[Any, Any, T],
+        cancel_signal: threading.Event | None = None,
+        cancellation_state: _CallCancellationState | None = None,
     ) -> futures.Future[T]:
         # save a reference to this so that even if it's reset we have the original
         close_future = self._close_future
@@ -1169,13 +1227,15 @@ class MCPClient(ToolProvider):
             try:
                 done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
-                if invoke_event in done:
-                    return await invoke_event
-                if cancel_event is not None and cancel_event in done:
+                if cancel_signal is not None and cancel_signal.is_set():
                     self._log_debug_with_thread("cancellation detected during MCP invocation")
+                    if cancellation_state is not None:
+                        await self._cancel_tool_call(cancellation_state)
                     invoke_event.cancel()
                     await asyncio.gather(invoke_event, return_exceptions=True)
                     raise RuntimeError("Tool execution cancelled")
+                if invoke_event in done:
+                    return await invoke_event
 
                 self._log_debug_with_thread("event loop for the server closed before the invoke completed")
                 invoke_event.cancel()
@@ -1330,6 +1390,7 @@ class MCPClient(ToolProvider):
         ttl: timedelta | None = None,
         poll_timeout: timedelta | None = None,
         meta: dict[str, Any] | None = None,
+        cancellation_state: _CallCancellationState | None = None,
     ) -> MCPCallToolResult:
         """Call a tool using task-augmented execution and poll until completion.
 
@@ -1344,6 +1405,7 @@ class MCPClient(ToolProvider):
             ttl: Task time-to-live. Uses configured value if not specified.
             poll_timeout: Timeout for polling. Uses configured value if not specified.
             meta: Optional metadata to pass to the tool call per MCP spec (_meta).
+            cancellation_state: Internal state used to cancel the exact MCP request or task.
 
         Returns:
             MCPCallToolResult: The final tool result after task completion.
@@ -1360,6 +1422,9 @@ class MCPClient(ToolProvider):
 
         # Step 1: Create the task
         self._log_debug_with_thread("tool=<%s> | calling tool as task with ttl=%d ms", name, ttl_ms)
+        if cancellation_state is not None:
+            cancellation_state["session"] = session
+            cancellation_state["request_id"] = session._request_id
         create_result = await session.experimental.call_tool_as_task(
             name=name,
             arguments=arguments,
@@ -1367,6 +1432,8 @@ class MCPClient(ToolProvider):
             meta=meta,
         )
         task_id = create_result.task.taskId
+        if cancellation_state is not None:
+            cancellation_state["task_id"] = task_id
         self._log_debug_with_thread("tool=<%s>, task_id=<%s> | task created", name, task_id)
 
         # Step 2: Poll until terminal status (with timeout protection)

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -1234,9 +1234,8 @@ class MCPClient(ToolProvider):
                 if cancel_signal is not None and cancel_signal.is_set():
                     self._log_debug_with_thread("cancellation detected during MCP invocation")
                     invoke_event.cancel()
-                    try:
-                        await asyncio.wait_for(asyncio.gather(invoke_event, return_exceptions=True), timeout=1)
-                    except asyncio.TimeoutError:
+                    _, pending = await asyncio.wait({invoke_event}, timeout=1)
+                    if pending:
                         self._log_debug_with_thread("timed out cleaning up cancelled MCP invocation")
                     if cancellation_state is not None:
                         await self._cancel_tool_call(cancellation_state)
@@ -1246,12 +1245,14 @@ class MCPClient(ToolProvider):
 
                 self._log_debug_with_thread("event loop for the server closed before the invoke completed")
                 invoke_event.cancel()
-                await asyncio.gather(invoke_event, return_exceptions=True)
+                await asyncio.wait({invoke_event}, timeout=1)
                 raise RuntimeError("Connection to the MCP server was closed")
             finally:
                 if not invoke_event.done():
                     invoke_event.cancel()
-                    await asyncio.gather(invoke_event, return_exceptions=True)
+                    _, pending = await asyncio.wait({invoke_event}, timeout=1)
+                    if pending:
+                        invoke_event.add_done_callback(lambda task: task.exception() if not task.cancelled() else None)
                     if cancellation_state is not None:
                         await self._cancel_tool_call(cancellation_state)
                 if cancel_event is not None and not cancel_event.done():
@@ -1436,7 +1437,6 @@ class MCPClient(ToolProvider):
         self._log_debug_with_thread("tool=<%s> | calling tool as task with ttl=%d ms", name, ttl_ms)
         if cancellation_state is not None:
             cancellation_state["session"] = session
-            cancellation_state["request_id"] = session._request_id
         create_task = asyncio.create_task(
             session.experimental.call_tool_as_task(
                 name=name,

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -554,6 +554,7 @@ class MCPClient(ToolProvider):
         self._tool_provider_started = False
         self._connection_failed = False
         self._consumers = set()
+        self._background_cleanup_tasks.clear()
         self._server_task_capable = None
         self._tool_task_support_cache = {}
 
@@ -1067,6 +1068,7 @@ class MCPClient(ToolProvider):
                     await self._close_future
 
                     self._log_debug_with_thread("close signal received")
+                    await self._drain_background_cleanup_tasks()
         except Exception as e:
             # If we encounter an exception and the future is still running,
             # it means it was encountered during the initialization phase.
@@ -1201,6 +1203,20 @@ class MCPClient(ToolProvider):
             "[Thread: %s, Session: %s] %s", threading.current_thread().name, self._session_id, formatted_msg, **kwargs
         )
 
+    async def _drain_background_cleanup_tasks(self) -> None:
+        """Give detached MCP cancellation cleanup a bounded window before session shutdown."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 1
+        while self._background_cleanup_tasks and loop.time() < deadline:
+            timeout = max(0, deadline - loop.time())
+            await asyncio.wait(set(self._background_cleanup_tasks), timeout=timeout)
+
+        pending = set(self._background_cleanup_tasks)
+        self._background_cleanup_tasks.clear()
+        for task in pending:
+            task.cancel()
+            task.add_done_callback(lambda done: done.exception() if not done.cancelled() else None)
+
     async def _cancel_tool_call(self, cancellation_state: _CallCancellationState) -> None:
         """Cancel the exact MCP task or request represented by the per-call state."""
         session = cancellation_state.get("session")
@@ -1225,8 +1241,10 @@ class MCPClient(ToolProvider):
                 return
             cancellation_state["notification_sent"] = True
             cancellation_task = asyncio.create_task(cancellation)
-            _, pending = await asyncio.wait({cancellation_task}, timeout=1)
-            if pending:
+            done, pending = await asyncio.wait({cancellation_task}, timeout=1)
+            if done:
+                await cancellation_task
+            else:
                 cancellation_task.cancel()
                 cancellation_task.add_done_callback(lambda task: task.exception() if not task.cancelled() else None)
         except Exception as error:
@@ -1515,7 +1533,9 @@ class MCPClient(ToolProvider):
                         self._background_cleanup_tasks.add(cleanup_task)
                         cleanup_task.add_done_callback(self._background_cleanup_tasks.discard)
 
+                self._background_cleanup_tasks.add(create_task)
                 create_task.add_done_callback(cancel_delayed_task)
+                create_task.add_done_callback(self._background_cleanup_tasks.discard)
             raise
         task_id = create_result.task.taskId
         if cancellation_state is not None:

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -288,6 +288,8 @@ class MCPClient(ToolProvider):
         self._tool_provider_started = False
         self.server_instructions: str | None = None
         self._consumers: set[Any] = set()
+        # Keep detached cleanup tasks alive until they finish; asyncio only retains weak references.
+        self._background_cleanup_tasks: set[asyncio.Task[Any]] = set()
 
         # Task support configuration and caching
         self._tasks_config = tasks_config
@@ -798,7 +800,12 @@ class MCPClient(ToolProvider):
                 session = cast(ClientSession, self._background_thread_session)
                 if cancellation_state is not None:
                     cancellation_state["session"] = session
-                    cancellation_state["request_id"] = session._request_id
+                    # MCP assigns the captured private ID synchronously at the start of
+                    # send_request(). If that invariant changes, omit remote notification rather
+                    # than risk cancelling a different request; local cancellation still works.
+                    request_id = getattr(session, "_request_id", None)
+                    if isinstance(request_id, int):
+                        cancellation_state["request_id"] = request_id
                 return await session.call_tool(
                     name, arguments, read_timeout_seconds, progress_callback=effective_callback, meta=meta
                 )
@@ -946,13 +953,19 @@ class MCPClient(ToolProvider):
             except Exception:
                 logger.debug("Failed to parse ElicitationRequiredErrorData from -32042 error", exc_info=True)
 
-        result = MCPToolResult(
-            status="error",
-            toolUseId=tool_use_id,
-            content=[{"text": f"Tool execution failed: {str(exception)}"}],
-        )
         if isinstance(exception, _MCPCallCancelledError):
-            result["cancelled"] = True
+            result = MCPToolResult(
+                status="error",
+                toolUseId=tool_use_id,
+                content=[{"text": "Tool execution cancelled locally; remote execution may have continued"}],
+                cancelled=True,
+            )
+        else:
+            result = MCPToolResult(
+                status="error",
+                toolUseId=tool_use_id,
+                content=[{"text": f"Tool execution failed: {str(exception)}"}],
+            )
         return result
 
     def _handle_tool_result(self, tool_use_id: str, call_tool_result: MCPCallToolResult) -> MCPToolResult:
@@ -1247,6 +1260,8 @@ class MCPClient(ToolProvider):
             if cancel_signal is not None:
 
                 async def wait_for_cancel() -> None:
+                    # Polling avoids blocking the loop. Running Event.wait() in an executor would
+                    # leave its worker thread blocked when this watcher is cancelled after success.
                     while not cancel_signal.is_set():
                         await asyncio.sleep(0.05)
 
@@ -1496,7 +1511,9 @@ class MCPClient(ToolProvider):
                         return
                     if cancellation_state is not None:
                         cancellation_state["task_id"] = result.task.taskId
-                        asyncio.create_task(self._cancel_tool_call(cancellation_state))
+                        cleanup_task = asyncio.create_task(self._cancel_tool_call(cancellation_state))
+                        self._background_cleanup_tasks.add(cleanup_task)
+                        cleanup_task.add_done_callback(self._background_cleanup_tasks.discard)
 
                 create_task.add_done_callback(cancel_delayed_task)
             raise

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -290,6 +290,7 @@ class MCPClient(ToolProvider):
         self._consumers: set[Any] = set()
         # Keep detached cleanup tasks alive until they finish; asyncio only retains weak references.
         self._background_cleanup_tasks: set[asyncio.Task[Any]] = set()
+        self._accept_background_cleanup_tasks = True
 
         # Task support configuration and caching
         self._tasks_config = tasks_config
@@ -334,6 +335,7 @@ class MCPClient(ToolProvider):
             raise MCPClientInitializationError("the client session is currently running")
 
         self._log_debug_with_thread("entering MCPClient context")
+        self._accept_background_cleanup_tasks = True
         # Copy context vars to propagate to the background thread
         # This ensures that context set in the main thread is accessible in the background thread
         # See: https://github.com/strands-agents/harness-sdk/issues/1440
@@ -1203,6 +1205,15 @@ class MCPClient(ToolProvider):
             "[Thread: %s, Session: %s] %s", threading.current_thread().name, self._session_id, formatted_msg, **kwargs
         )
 
+    def _track_background_cleanup_task(self, task: asyncio.Task[Any]) -> None:
+        """Retain a detached cleanup task while the MCP session can still service it."""
+        if not self._accept_background_cleanup_tasks:
+            task.cancel()
+            task.add_done_callback(lambda done: done.exception() if not done.cancelled() else None)
+            return
+        self._background_cleanup_tasks.add(task)
+        task.add_done_callback(self._background_cleanup_tasks.discard)
+
     async def _drain_background_cleanup_tasks(self) -> None:
         """Give detached MCP cancellation cleanup a bounded window before session shutdown."""
         loop = asyncio.get_running_loop()
@@ -1211,11 +1222,19 @@ class MCPClient(ToolProvider):
             timeout = max(0, deadline - loop.time())
             await asyncio.wait(set(self._background_cleanup_tasks), timeout=timeout)
 
+        # Stop delayed callbacks from enqueueing work after the session has started closing.
+        self._accept_background_cleanup_tasks = False
         pending = set(self._background_cleanup_tasks)
-        self._background_cleanup_tasks.clear()
         for task in pending:
             task.cancel()
-            task.add_done_callback(lambda done: done.exception() if not done.cancelled() else None)
+        if pending:
+            done, still_pending = await asyncio.wait(pending, timeout=0.1)
+            for task in done:
+                if not task.cancelled():
+                    task.exception()
+            for task in still_pending:
+                task.add_done_callback(lambda done: done.exception() if not done.cancelled() else None)
+        self._background_cleanup_tasks.clear()
 
     async def _cancel_tool_call(self, cancellation_state: _CallCancellationState) -> None:
         """Cancel the exact MCP task or request represented by the per-call state."""
@@ -1241,6 +1260,7 @@ class MCPClient(ToolProvider):
                 return
             cancellation_state["notification_sent"] = True
             cancellation_task = asyncio.create_task(cancellation)
+            self._track_background_cleanup_task(cancellation_task)
             done, pending = await asyncio.wait({cancellation_task}, timeout=1)
             if done:
                 await cancellation_task
@@ -1530,12 +1550,10 @@ class MCPClient(ToolProvider):
                     if cancellation_state is not None:
                         cancellation_state["task_id"] = result.task.taskId
                         cleanup_task = asyncio.create_task(self._cancel_tool_call(cancellation_state))
-                        self._background_cleanup_tasks.add(cleanup_task)
-                        cleanup_task.add_done_callback(self._background_cleanup_tasks.discard)
+                        self._track_background_cleanup_task(cleanup_task)
 
-                self._background_cleanup_tasks.add(create_task)
+                self._track_background_cleanup_task(create_task)
                 create_task.add_done_callback(cancel_delayed_task)
-                create_task.add_done_callback(self._background_cleanup_tasks.discard)
             raise
         task_id = create_result.task.taskId
         if cancellation_state is not None:

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -789,6 +789,7 @@ class MCPClient(ToolProvider):
         read_timeout_seconds: timedelta | None = None,
         meta: dict[str, Any] | None = None,
         progress_callback: ProgressFnT | None = None,
+        cancel_signal: threading.Event | None = None,
     ) -> MCPToolResult:
         """Synchronously calls a tool on the MCP server.
 
@@ -803,6 +804,7 @@ class MCPClient(ToolProvider):
             meta: Optional metadata to pass to the tool call per MCP spec (_meta)
             progress_callback: Optional callback to receive progress notifications for this
                 call. Overrides the instance-level callback set at construction time.
+            cancel_signal: Optional thread-safe event that cancels only this in-flight call when set.
 
         Returns:
             MCPToolResult: The result of the tool call
@@ -815,7 +817,9 @@ class MCPClient(ToolProvider):
             coro = self._create_call_tool_coroutine(
                 name, arguments, read_timeout_seconds, meta=meta, progress_callback=progress_callback
             )
-            call_tool_result: MCPCallToolResult = self._invoke_on_background_thread(coro).result()
+            call_tool_result: MCPCallToolResult = self._invoke_on_background_thread(
+                coro, cancel_signal=cancel_signal
+            ).result()
             return self._handle_tool_result(tool_use_id, call_tool_result)
         except Exception as e:
             logger.exception("tool execution failed")
@@ -829,6 +833,7 @@ class MCPClient(ToolProvider):
         read_timeout_seconds: timedelta | None = None,
         meta: dict[str, Any] | None = None,
         progress_callback: ProgressFnT | None = None,
+        cancel_signal: threading.Event | None = None,
     ) -> MCPToolResult:
         """Asynchronously calls a tool on the MCP server.
 
@@ -843,6 +848,7 @@ class MCPClient(ToolProvider):
             meta: Optional metadata to pass to the tool call per MCP spec (_meta)
             progress_callback: Optional callback to receive progress notifications for this
                 call. Overrides the instance-level callback set at construction time.
+            cancel_signal: Optional thread-safe event that cancels only this in-flight call when set.
 
         Returns:
             MCPToolResult: The result of the tool call
@@ -855,7 +861,7 @@ class MCPClient(ToolProvider):
             coro = self._create_call_tool_coroutine(
                 name, arguments, read_timeout_seconds, meta=meta, progress_callback=progress_callback
             )
-            future = self._invoke_on_background_thread(coro)
+            future = self._invoke_on_background_thread(coro, cancel_signal=cancel_signal)
             call_tool_result: MCPCallToolResult = await asyncio.wrap_future(future)
             return self._handle_tool_result(tool_use_id, call_tool_result)
         except Exception as e:
@@ -1127,7 +1133,9 @@ class MCPClient(ToolProvider):
             "[Thread: %s, Session: %s] %s", threading.current_thread().name, self._session_id, formatted_msg, **kwargs
         )
 
-    def _invoke_on_background_thread(self, coro: Coroutine[Any, Any, T]) -> futures.Future[T]:
+    def _invoke_on_background_thread(
+        self, coro: Coroutine[Any, Any, T], cancel_signal: threading.Event | None = None
+    ) -> futures.Future[T]:
         # save a reference to this so that even if it's reset we have the original
         close_future = self._close_future
 
@@ -1139,20 +1147,44 @@ class MCPClient(ToolProvider):
             raise MCPClientInitializationError("the client session was not initialized")
 
         async def run_async() -> T:
-            # Fix for strands-agents/harness-sdk/issues/995 - cancel all pending invocations if/when the session closes
+            if cancel_signal is not None and cancel_signal.is_set():
+                coro.close()
+                raise RuntimeError("Tool execution cancelled")
+
             invoke_event = asyncio.create_task(coro)
-            tasks: list[asyncio.Task | asyncio.Future] = [
-                invoke_event,
-                close_future,
-            ]
+            cancel_event: asyncio.Task[None] | None = None
 
-            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            if cancel_signal is not None:
 
-            if done.pop() == close_future:
+                async def wait_for_cancel() -> None:
+                    while not cancel_signal.is_set():
+                        await asyncio.sleep(0.05)
+
+                cancel_event = asyncio.create_task(wait_for_cancel())
+
+            tasks: list[asyncio.Task[Any] | asyncio.Future[Any]] = [invoke_event, close_future]
+            if cancel_event is not None:
+                tasks.append(cancel_event)
+
+            try:
+                done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+                if invoke_event in done:
+                    return await invoke_event
+                if cancel_event is not None and cancel_event in done:
+                    self._log_debug_with_thread("cancellation detected during MCP invocation")
+                    invoke_event.cancel()
+                    await asyncio.gather(invoke_event, return_exceptions=True)
+                    raise RuntimeError("Tool execution cancelled")
+
                 self._log_debug_with_thread("event loop for the server closed before the invoke completed")
+                invoke_event.cancel()
+                await asyncio.gather(invoke_event, return_exceptions=True)
                 raise RuntimeError("Connection to the MCP server was closed")
-            else:
-                return await invoke_event
+            finally:
+                if cancel_event is not None and not cancel_event.done():
+                    cancel_event.cancel()
+                    await asyncio.gather(cancel_event, return_exceptions=True)
 
         invoke_future = asyncio.run_coroutine_threadsafe(coro=run_async(), loop=self._background_thread_event_loop)
         return invoke_future

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -1173,10 +1173,11 @@ class MCPClient(ToolProvider):
             return
 
         try:
+            cancellation: Coroutine[Any, Any, Any]
             if task_id := cancellation_state.get("task_id"):
-                await session.experimental.cancel_task(task_id)
+                cancellation = session.experimental.cancel_task(task_id)
             elif (request_id := cancellation_state.get("request_id")) is not None:
-                await session.send_notification(
+                cancellation = session.send_notification(
                     ClientNotification(
                         CancelledNotification(
                             params=CancelledNotificationParams(
@@ -1185,6 +1186,9 @@ class MCPClient(ToolProvider):
                         )
                     )
                 )
+            else:
+                return
+            await asyncio.wait_for(cancellation, timeout=1)
         except Exception as error:
             self._log_debug_with_thread("error=<%s> | failed to notify MCP server of cancellation", str(error))
 
@@ -1229,10 +1233,13 @@ class MCPClient(ToolProvider):
 
                 if cancel_signal is not None and cancel_signal.is_set():
                     self._log_debug_with_thread("cancellation detected during MCP invocation")
+                    invoke_event.cancel()
+                    try:
+                        await asyncio.wait_for(asyncio.gather(invoke_event, return_exceptions=True), timeout=1)
+                    except asyncio.TimeoutError:
+                        self._log_debug_with_thread("timed out cleaning up cancelled MCP invocation")
                     if cancellation_state is not None:
                         await self._cancel_tool_call(cancellation_state)
-                    invoke_event.cancel()
-                    await asyncio.gather(invoke_event, return_exceptions=True)
                     raise RuntimeError("Tool execution cancelled")
                 if invoke_event in done:
                     return await invoke_event
@@ -1242,6 +1249,11 @@ class MCPClient(ToolProvider):
                 await asyncio.gather(invoke_event, return_exceptions=True)
                 raise RuntimeError("Connection to the MCP server was closed")
             finally:
+                if not invoke_event.done():
+                    invoke_event.cancel()
+                    await asyncio.gather(invoke_event, return_exceptions=True)
+                    if cancellation_state is not None:
+                        await self._cancel_tool_call(cancellation_state)
                 if cancel_event is not None and not cancel_event.done():
                     cancel_event.cancel()
                     await asyncio.gather(cancel_event, return_exceptions=True)
@@ -1425,12 +1437,25 @@ class MCPClient(ToolProvider):
         if cancellation_state is not None:
             cancellation_state["session"] = session
             cancellation_state["request_id"] = session._request_id
-        create_result = await session.experimental.call_tool_as_task(
-            name=name,
-            arguments=arguments,
-            ttl=ttl_ms,
-            meta=meta,
+        create_task = asyncio.create_task(
+            session.experimental.call_tool_as_task(
+                name=name,
+                arguments=arguments,
+                ttl=ttl_ms,
+                meta=meta,
+            )
         )
+        try:
+            create_result = await asyncio.shield(create_task)
+        except asyncio.CancelledError:
+            try:
+                create_result = await asyncio.wait_for(asyncio.shield(create_task), timeout=1)
+                if cancellation_state is not None:
+                    cancellation_state["task_id"] = create_result.task.taskId
+            except asyncio.TimeoutError:
+                create_task.cancel()
+                await asyncio.gather(create_task, return_exceptions=True)
+            raise
         task_id = create_result.task.taskId
         if cancellation_state is not None:
             cancellation_state["task_id"] = task_id

--- a/strands-py/src/strands/tools/mcp/mcp_types.py
+++ b/strands-py/src/strands/tools/mcp/mcp_types.py
@@ -1,7 +1,7 @@
 """Type definitions for MCP integration."""
 
 from contextlib import AbstractAsyncContextManager
-from typing import Any
+from typing import Any, Literal
 
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.client.streamable_http import GetSessionIdCallback
@@ -66,8 +66,11 @@ class MCPToolResult(ToolResult):
             returned a failure. Absent when the tool succeeded or when the error was a
             protocol/client exception rather than a tool-reported failure, letting
             callers distinguish application errors from transport/protocol errors.
+        cancelled: ``True`` when the local per-call cancellation signal was observed.
+            This confirms local cancellation, not that remote execution stopped.
     """
 
     structuredContent: NotRequired[dict[str, Any]]
     metadata: NotRequired[dict[str, Any]]
     isError: NotRequired[bool]
+    cancelled: NotRequired[Literal[True]]

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -1584,3 +1584,35 @@ async def test_event_loop_cycle_cancel_mid_cycle_beats_after_tools_checkpoint(
 
     assert tru_stop_reason == "cancelled"
     assert tru_checkpoint is None
+
+
+@pytest.mark.asyncio
+async def test_event_loop_cycle_cancel_after_tools_stops_without_checkpointing(
+    agent,
+    model,
+    tool,
+    tool_stream,
+    agenerator,
+    alist,
+):
+    """Cancel set during tool execution stops the invocation before another model call."""
+    original_execute = agent.tool_executor._execute
+
+    def execute_then_cancel(*args, **kwargs):
+        stream = original_execute(*args, **kwargs)
+
+        async def wrapped():
+            async for event in stream:
+                yield event
+            agent._cancel_signal.set()
+
+        return wrapped()
+
+    model.stream.return_value = agenerator(tool_stream)
+
+    with unittest.mock.patch.object(agent.tool_executor, "_execute", side_effect=execute_then_cancel):
+        stream = strands.event_loop.event_loop.event_loop_cycle(agent=agent, invocation_state={})
+        events = await alist(stream)
+
+    assert events[-1]["stop"][0] == "cancelled"
+    assert model.stream.call_count == 1

--- a/strands-py/tests/strands/tools/executors/conftest.py
+++ b/strands-py/tests/strands/tools/executors/conftest.py
@@ -120,6 +120,7 @@ def agent(tool_registry, hook_registry):
     mock_agent.tool_registry = tool_registry
     mock_agent.hooks = hook_registry
     mock_agent._interrupt_state = _InterruptState()
+    mock_agent._cancel_signal = threading.Event()
     mock_agent._middleware_registry = MiddlewareRegistry()
     mock_agent.trace_attributes = {}
     return mock_agent

--- a/strands-py/tests/strands/tools/executors/test_executor.py
+++ b/strands-py/tests/strands/tools/executors/test_executor.py
@@ -713,6 +713,43 @@ async def test_executor_stream_retry_true(executor, agent, tool_results, invocat
     assert tool_results[0] == {"toolUseId": "1", "status": "success", "content": [{"text": "attempt_2"}]}
 
 
+@pytest.mark.parametrize("cancel_agent", [False, True])
+@pytest.mark.asyncio
+async def test_executor_stream_does_not_retry_cancelled_tool_result(
+    cancel_agent, executor, agent, tool_results, invocation_state, alist
+):
+    """Test cancellation remains terminal when an after hook requests retry."""
+    call_count = 0
+
+    @strands.tool(name="cancelled_tool")
+    def cancelled_tool():
+        nonlocal call_count
+        call_count += 1
+        if cancel_agent:
+            agent._cancel_signal.set()
+        return {
+            "status": "error",
+            "content": [{"text": "cancelled"}],
+            **({} if cancel_agent else {"cancelled": True}),
+        }
+
+    def retry_on_error(event):
+        if isinstance(event, AfterToolCallEvent) and event.result["status"] == "error":
+            event.retry = True
+        return event
+
+    agent.tool_registry.register_tool(cancelled_tool)
+    agent.hooks.add_callback(AfterToolCallEvent, retry_on_error)
+    tool_use: ToolUse = {"name": "cancelled_tool", "toolUseId": "1", "input": {}}
+
+    tru_events = await alist(executor._stream(agent, tool_use, tool_results, invocation_state))
+
+    assert call_count == 1
+    assert len(tru_events) == 1
+    assert tru_events[0].tool_result["status"] == "error"
+    assert len(tool_results) == 1
+
+
 @pytest.mark.asyncio
 async def test_executor_stream_retry_true_emits_events_from_both_attempts(
     executor, agent, tool_results, invocation_state, alist

--- a/strands-py/tests/strands/tools/executors/test_sequential.py
+++ b/strands-py/tests/strands/tools/executors/test_sequential.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import BaseModel
 
-from strands.hooks import BeforeToolCallEvent
+from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
 from strands.interrupt import Interrupt
 from strands.tools.decorator import tool
 from strands.tools.executors import SequentialToolExecutor
@@ -73,6 +73,34 @@ async def test_sequential_executor_execute(
     tru_results = tool_results
     exp_results = [exp_events[0].tool_result, exp_events[1].tool_result]
     assert tru_results == exp_results
+
+
+@pytest.mark.asyncio
+async def test_sequential_executor_cancellation_skips_remaining_tools(
+    executor, agent, tool_results, cycle_trace, cycle_span, invocation_state, alist, weather_tool
+):
+    """Test cancellation after one tool prevents later tools from running."""
+
+    def cancel_after_first_tool(event):
+        if isinstance(event, AfterToolCallEvent) and event.tool_use["toolUseId"] == "1":
+            agent._cancel_signal.set()
+
+    agent.hooks.add_callback(AfterToolCallEvent, cancel_after_first_tool)
+    tool_uses = [
+        {"name": "weather_tool", "toolUseId": "1", "input": {}},
+        {"name": "temperature_tool", "toolUseId": "2", "input": {}},
+    ]
+
+    tru_events = await alist(
+        executor._execute(agent, tool_uses, tool_results, cycle_trace, cycle_span, invocation_state)
+    )
+
+    exp_events = [
+        ToolResultEvent({"toolUseId": "1", "status": "success", "content": [{"text": "sunny"}]}),
+        ToolResultEvent({"toolUseId": "2", "status": "error", "content": [{"text": "Tool execution cancelled"}]}),
+    ]
+    assert tru_events == exp_events
+    assert tool_results == [event.tool_result for event in exp_events]
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -130,3 +130,19 @@ async def test_stream_with_timeout(mock_mcp_tool, mock_mcp_client, alist):
         read_timeout_seconds=timeout,
         cancel_signal=cancel_signal,
     )
+
+
+@pytest.mark.asyncio
+async def test_stream_without_agent_cancel_signal(mcp_agent_tool, mock_mcp_client, alist):
+    """Test MCP tools remain compatible with agent implementations without cancellation."""
+    tool_use = {"toolUseId": "test-789", "name": "test_tool", "input": {}}
+
+    await alist(mcp_agent_tool.stream(tool_use, {"agent": MagicMock(spec=[])}))
+
+    mock_mcp_client.call_tool_async.assert_called_once_with(
+        tool_use_id="test-789",
+        name="test_tool",
+        arguments={},
+        read_timeout_seconds=None,
+        cancel_signal=None,
+    )

--- a/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -137,7 +137,7 @@ async def test_stream_without_agent_cancel_signal(mcp_agent_tool, mock_mcp_clien
     """Test MCP tools remain compatible with agent implementations without cancellation."""
     tool_use = {"toolUseId": "test-789", "name": "test_tool", "input": {}}
 
-    await alist(mcp_agent_tool.stream(tool_use, {"agent": MagicMock(spec=[])}))
+    await alist(mcp_agent_tool.stream(tool_use, {}))
 
     mock_mcp_client.call_tool_async.assert_called_once_with(
         tool_use_id="test-789",

--- a/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -1,3 +1,4 @@
+import threading
 from datetime import timedelta
 from unittest.mock import MagicMock
 
@@ -83,13 +84,19 @@ def test_tool_spec_without_output_schema(mock_mcp_tool, mock_mcp_client):
 @pytest.mark.asyncio
 async def test_stream(mcp_agent_tool, mock_mcp_client, alist):
     tool_use = {"toolUseId": "test-123", "name": "test_tool", "input": {"param": "value"}}
+    cancel_signal = threading.Event()
+    invocation_state = {"agent": MagicMock(_cancel_signal=cancel_signal)}
 
-    tru_events = await alist(mcp_agent_tool.stream(tool_use, {}))
+    tru_events = await alist(mcp_agent_tool.stream(tool_use, invocation_state))
     exp_events = [ToolResultEvent(mock_mcp_client.call_tool_async.return_value)]
 
     assert tru_events == exp_events
     mock_mcp_client.call_tool_async.assert_called_once_with(
-        tool_use_id="test-123", name="test_tool", arguments={"param": "value"}, read_timeout_seconds=None
+        tool_use_id="test-123",
+        name="test_tool",
+        arguments={"param": "value"},
+        read_timeout_seconds=None,
+        cancel_signal=cancel_signal,
     )
 
 
@@ -109,11 +116,17 @@ async def test_stream_with_timeout(mock_mcp_tool, mock_mcp_client, alist):
     timeout = timedelta(seconds=45)
     agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client, timeout=timeout)
     tool_use = {"toolUseId": "test-456", "name": "test_tool", "input": {"param": "value"}}
+    cancel_signal = threading.Event()
+    invocation_state = {"agent": MagicMock(_cancel_signal=cancel_signal)}
 
-    tru_events = await alist(agent_tool.stream(tool_use, {}))
+    tru_events = await alist(agent_tool.stream(tool_use, invocation_state))
     exp_events = [ToolResultEvent(mock_mcp_client.call_tool_async.return_value)]
 
     assert tru_events == exp_events
     mock_mcp_client.call_tool_async.assert_called_once_with(
-        tool_use_id="test-456", name="test_tool", arguments={"param": "value"}, read_timeout_seconds=timeout
+        tool_use_id="test-456",
+        name="test_tool",
+        arguments={"param": "value"},
+        read_timeout_seconds=timeout,
+        cancel_signal=cancel_signal,
     )

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -523,6 +523,56 @@ async def test_call_tool_async_caller_cancellation_cleans_up_background_call(moc
 
 
 @pytest.mark.asyncio
+async def test_call_tool_async_caller_cancellation_timeout_preserves_cancelled_error(
+    mock_transport, mock_session, caplog
+):
+    """Test bounded cleanup retains resistant work without replacing caller cancellation."""
+    call_started = threading.Event()
+    call_cancelled = threading.Event()
+    release_call = threading.Event()
+    mock_session._request_id = 0
+
+    async def resistant_call(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        call_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            call_cancelled.set()
+            while not release_call.is_set():
+                await asyncio.sleep(0.01)
+        return MCPCallToolResult(isError=False, content=[MCPTextContent(type="text", text="late")])
+
+    mock_session.call_tool.side_effect = resistant_call
+
+    try:
+        with MCPClient(mock_transport["transport_callable"]) as client:
+            caller = asyncio.create_task(
+                client.call_tool_async(tool_use_id="cancelled", name="slow_tool", arguments={})
+            )
+            assert await asyncio.to_thread(call_started.wait, 1)
+            caller.cancel()
+            with caplog.at_level("DEBUG", logger="strands.tools.mcp.mcp_client"):
+                with pytest.raises(asyncio.CancelledError):
+                    await caller
+                assert await asyncio.to_thread(call_cancelled.wait, 1)
+                for _ in range(150):
+                    if "did not finish within bounded cancellation cleanup" in caplog.text:
+                        break
+                    await asyncio.sleep(0.01)
+
+            assert "did not finish within bounded cancellation cleanup" in caplog.text
+            assert client._background_cleanup_tasks
+            release_call.set()
+            for _ in range(100):
+                if not client._background_cleanup_tasks:
+                    break
+                await asyncio.sleep(0.01)
+            assert not client._background_cleanup_tasks
+    finally:
+        release_call.set()
+
+
+@pytest.mark.asyncio
 async def test_call_tool_async_forwards_meta(mock_transport, mock_session):
     """Test that call_tool_async forwards meta to ClientSession.call_tool."""
     mock_content = MCPTextContent(type="text", text="Test message")

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -1,4 +1,6 @@
+import asyncio
 import base64
+import threading
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -241,6 +243,87 @@ def test_call_tool_sync_no_progress_callback_by_default(mock_transport, mock_ses
         client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={})
 
         mock_session.call_tool.assert_called_once_with("test_tool", {}, None, progress_callback=None, meta=None)
+
+
+def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport, mock_session):
+    """Test cancellation stops one call without closing the MCP session."""
+    first_call_started = threading.Event()
+    first_call_cancelled = threading.Event()
+    cancel_signal = threading.Event()
+    mock_content = MCPTextContent(type="text", text="done")
+
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        if name == "slow_tool":
+            first_call_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                first_call_cancelled.set()
+                raise
+        return MCPCallToolResult(isError=False, content=[mock_content])
+
+    mock_session.call_tool.side_effect = call_tool
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        cancellation_thread = threading.Thread(target=lambda: (first_call_started.wait(timeout=1), cancel_signal.set()))
+        cancellation_thread.start()
+        cancelled_result = client.call_tool_sync(
+            tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal
+        )
+        cancellation_thread.join(timeout=1)
+
+        second_result = client.call_tool_sync(tool_use_id="completed", name="fast_tool", arguments={})
+
+    assert cancelled_result == {
+        "status": "error",
+        "toolUseId": "cancelled",
+        "content": [{"text": "Tool execution failed: Tool execution cancelled"}],
+    }
+    assert first_call_cancelled.wait(timeout=1)
+    assert second_result["status"] == "success"
+    assert mock_session.call_tool.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_transport, mock_session):
+    """Test each concurrent call observes only its own cancellation signal."""
+    slow_call_started = asyncio.Event()
+    slow_call_cancelled = asyncio.Event()
+    cancel_signal = threading.Event()
+    other_signal = threading.Event()
+    mock_content = MCPTextContent(type="text", text="done")
+
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        if name == "slow_tool":
+            slow_call_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                slow_call_cancelled.set()
+                raise
+        return MCPCallToolResult(isError=False, content=[mock_content])
+
+    mock_session.call_tool.side_effect = call_tool
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        cancelled_call = asyncio.create_task(
+            client.call_tool_async(tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal)
+        )
+        completed_call = asyncio.create_task(
+            client.call_tool_async(tool_use_id="completed", name="fast_tool", arguments={}, cancel_signal=other_signal)
+        )
+
+        await asyncio.wait_for(slow_call_started.wait(), timeout=1)
+        cancel_signal.set()
+        cancelled_result, completed_result = await asyncio.wait_for(
+            asyncio.gather(cancelled_call, completed_call), timeout=1
+        )
+
+    assert cancelled_result["status"] == "error"
+    assert cancelled_result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+    assert slow_call_cancelled.is_set()
+    assert completed_result["status"] == "success"
+    assert not other_signal.is_set()
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -245,6 +245,26 @@ def test_call_tool_sync_no_progress_callback_by_default(mock_transport, mock_ses
         mock_session.call_tool.assert_called_once_with("test_tool", {}, None, progress_callback=None, meta=None)
 
 
+def test_call_tool_sync_pre_set_cancel_signal_skips_request(mock_transport, mock_session):
+    """Test a pre-set cancellation signal short-circuits before sending a request."""
+    cancel_signal = threading.Event()
+    cancel_signal.set()
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(
+            tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal
+        )
+
+    assert result == {
+        "status": "error",
+        "toolUseId": "cancelled",
+        "content": [{"text": "Tool execution cancelled locally; remote execution may have continued"}],
+        "cancelled": True,
+    }
+    mock_session.call_tool.assert_not_awaited()
+    mock_session.send_notification.assert_not_awaited()
+
+
 def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport, mock_session):
     """Test cancellation stops one call without closing the MCP session."""
     first_call_started = threading.Event()
@@ -278,7 +298,7 @@ def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport
     assert cancelled_result == {
         "status": "error",
         "toolUseId": "cancelled",
-        "content": [{"text": "Tool execution failed: Tool execution cancelled"}],
+        "content": [{"text": "Tool execution cancelled locally; remote execution may have continued"}],
         "cancelled": True,
     }
     assert first_call_cancelled.wait(timeout=1)
@@ -299,7 +319,12 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
     other_signal = threading.Event()
     mock_content = MCPTextContent(type="text", text="done")
 
+    assigned_request_ids = {}
+
     async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        request_id = mock_session._request_id
+        mock_session._request_id += 1
+        assigned_request_ids[name] = request_id
         if name == "slow_tool":
             slow_call_started.set()
             try:
@@ -327,15 +352,43 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
         )
 
     assert cancelled_result["status"] == "error"
-    assert cancelled_result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+    assert cancelled_result["content"] == [
+        {"text": "Tool execution cancelled locally; remote execution may have continued"}
+    ]
     assert cancelled_result["cancelled"] is True
     assert slow_call_cancelled.is_set()
     mock_session.send_notification.assert_awaited_once()
     notification = mock_session.send_notification.await_args.args[0].root
     assert notification.method == "notifications/cancelled"
-    assert notification.params.requestId == 0
+    assert notification.params.requestId == assigned_request_ids["slow_tool"]
+    assert assigned_request_ids["slow_tool"] != assigned_request_ids["fast_tool"]
     assert completed_result["status"] == "success"
     assert not other_signal.is_set()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_async_cancel_without_sdk_request_id_still_cancels_locally(mock_transport, mock_session):
+    """Test an MCP SDK private-field change degrades to local-only cancellation."""
+    call_started = asyncio.Event()
+    cancel_signal = threading.Event()
+    del mock_session._request_id
+
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        call_started.set()
+        await asyncio.Event().wait()
+
+    mock_session.call_tool.side_effect = call_tool
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        call = asyncio.create_task(
+            client.call_tool_async(tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal)
+        )
+        await asyncio.wait_for(call_started.wait(), timeout=1)
+        cancel_signal.set()
+        result = await asyncio.wait_for(call, timeout=1)
+
+    assert result["cancelled"] is True
+    mock_session.send_notification.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -356,7 +409,7 @@ async def test_call_tool_async_cancel_wins_when_result_and_signal_are_ready(mock
         )
 
     assert result["status"] == "error"
-    assert result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+    assert result["content"] == [{"text": "Tool execution cancelled locally; remote execution may have continued"}]
     assert result["cancelled"] is True
 
 

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -313,6 +313,7 @@ def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport
 @pytest.mark.asyncio
 async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_transport, mock_session):
     """Test each concurrent call observes only its own cancellation signal."""
+    first_call_started = asyncio.Event()
     slow_call_started = asyncio.Event()
     slow_call_cancelled = asyncio.Event()
     cancel_signal = threading.Event()
@@ -325,6 +326,9 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
         request_id = mock_session._request_id
         mock_session._request_id += 1
         assigned_request_ids[name] = request_id
+        if name == "first_tool":
+            first_call_started.set()
+            await asyncio.Event().wait()
         if name == "slow_tool":
             slow_call_started.set()
             try:
@@ -338,6 +342,10 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
     mock_session._request_id = 41
 
     with MCPClient(mock_transport["transport_callable"]) as client:
+        first_call = asyncio.create_task(
+            client.call_tool_async(tool_use_id="first", name="first_tool", arguments={}, cancel_signal=other_signal)
+        )
+        await asyncio.wait_for(first_call_started.wait(), timeout=1)
         cancelled_call = asyncio.create_task(
             client.call_tool_async(tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal)
         )
@@ -350,6 +358,9 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
         cancelled_result, completed_result = await asyncio.wait_for(
             asyncio.gather(cancelled_call, completed_call), timeout=1
         )
+        first_call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_call
 
     assert cancelled_result["status"] == "error"
     assert cancelled_result["content"] == [
@@ -357,11 +368,11 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
     ]
     assert cancelled_result["cancelled"] is True
     assert slow_call_cancelled.is_set()
-    mock_session.send_notification.assert_awaited_once()
-    notification = mock_session.send_notification.await_args.args[0].root
-    assert notification.method == "notifications/cancelled"
-    assert notification.params.requestId == assigned_request_ids["slow_tool"]
-    assert notification.params.requestId >= 41
+    notifications = [call.args[0].root for call in mock_session.send_notification.await_args_list]
+    assert all(notification.method == "notifications/cancelled" for notification in notifications)
+    cancelled_request_ids = {notification.params.requestId for notification in notifications}
+    assert assigned_request_ids["slow_tool"] in cancelled_request_ids
+    assert assigned_request_ids["slow_tool"] > assigned_request_ids["first_tool"]
     assert assigned_request_ids["slow_tool"] != assigned_request_ids["fast_tool"]
     assert completed_result["status"] == "success"
     assert not other_signal.is_set()

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -279,6 +279,7 @@ def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport
         "status": "error",
         "toolUseId": "cancelled",
         "content": [{"text": "Tool execution failed: Tool execution cancelled"}],
+        "cancelled": True,
     }
     assert first_call_cancelled.wait(timeout=1)
     mock_session.send_notification.assert_awaited_once()
@@ -327,6 +328,7 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
 
     assert cancelled_result["status"] == "error"
     assert cancelled_result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+    assert cancelled_result["cancelled"] is True
     assert slow_call_cancelled.is_set()
     mock_session.send_notification.assert_awaited_once()
     notification = mock_session.send_notification.await_args.args[0].root
@@ -355,6 +357,7 @@ async def test_call_tool_async_cancel_wins_when_result_and_signal_are_ready(mock
 
     assert result["status"] == "error"
     assert result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+    assert result["cancelled"] is True
 
 
 @pytest.mark.asyncio
@@ -618,6 +621,11 @@ def test_mcp_tool_result_type():
         status="error", toolUseId="test-789", content=[{"text": "Tool failed"}], isError=True
     )
     assert result_with_is_error["isError"] is True
+
+    result_with_cancelled = MCPToolResult(
+        status="error", toolUseId="test-789", content=[{"text": "cancelled"}], cancelled=True
+    )
+    assert result_with_cancelled["cancelled"] is True
 
 
 def test_call_tool_sync_without_structured_content(mock_transport, mock_session):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -335,7 +335,7 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
         return MCPCallToolResult(isError=False, content=[mock_content])
 
     mock_session.call_tool.side_effect = call_tool
-    mock_session._request_id = 0
+    mock_session._request_id = 41
 
     with MCPClient(mock_transport["transport_callable"]) as client:
         cancelled_call = asyncio.create_task(
@@ -361,6 +361,7 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
     notification = mock_session.send_notification.await_args.args[0].root
     assert notification.method == "notifications/cancelled"
     assert notification.params.requestId == assigned_request_ids["slow_tool"]
+    assert notification.params.requestId >= 41
     assert assigned_request_ids["slow_tool"] != assigned_request_ids["fast_tool"]
     assert completed_result["status"] == "success"
     assert not other_signal.is_set()
@@ -389,6 +390,33 @@ async def test_call_tool_async_cancel_without_sdk_request_id_still_cancels_local
 
     assert result["cancelled"] is True
     mock_session.send_notification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_async_logs_remote_cancellation_failure(mock_transport, mock_session, caplog):
+    """Test an immediate remote notification failure is observed and logged."""
+    call_started = asyncio.Event()
+    cancel_signal = threading.Event()
+    mock_session._request_id = 7
+    mock_session.send_notification.side_effect = RuntimeError("notification failed")
+
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        call_started.set()
+        await asyncio.Event().wait()
+
+    mock_session.call_tool.side_effect = call_tool
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        call = asyncio.create_task(
+            client.call_tool_async(tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal)
+        )
+        await asyncio.wait_for(call_started.wait(), timeout=1)
+        cancel_signal.set()
+        with caplog.at_level("DEBUG", logger="strands.tools.mcp.mcp_client"):
+            result = await asyncio.wait_for(call, timeout=1)
+
+    assert result["cancelled"] is True
+    assert "failed to notify MCP server of cancellation" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -453,6 +453,41 @@ async def test_call_tool_async_cancel_wins_when_result_and_signal_are_ready(mock
 
 
 @pytest.mark.asyncio
+async def test_call_tool_async_tracks_cancellation_resistant_invocation(mock_transport, mock_session):
+    """Test a resistant invocation remains owned until bounded session shutdown."""
+    call_started = asyncio.Event()
+    release_call = threading.Event()
+    cancel_signal = threading.Event()
+    mock_session._request_id = 0
+
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        call_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            while not release_call.is_set():
+                await asyncio.sleep(0.01)
+        return MCPCallToolResult(isError=False, content=[MCPTextContent(type="text", text="late")])
+
+    mock_session.call_tool.side_effect = call_tool
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        call = asyncio.create_task(
+            client.call_tool_async(tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal)
+        )
+        await asyncio.wait_for(call_started.wait(), timeout=1)
+        cancel_signal.set()
+        result = await asyncio.wait_for(call, timeout=2)
+        assert client._background_cleanup_tasks
+        release_timer = threading.Timer(0.1, release_call.set)
+        release_timer.start()
+
+    release_timer.join(timeout=1)
+    assert result["cancelled"] is True
+    assert not client._background_cleanup_tasks
+
+
+@pytest.mark.asyncio
 async def test_call_tool_async_caller_cancellation_cleans_up_background_call(mock_transport, mock_session):
     """Test cancelling the caller also cancels the background invocation."""
     call_started = asyncio.Event()

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -358,6 +358,41 @@ async def test_call_tool_async_cancel_wins_when_result_and_signal_are_ready(mock
 
 
 @pytest.mark.asyncio
+async def test_call_tool_async_caller_cancellation_cleans_up_background_call(mock_transport, mock_session):
+    """Test cancelling the caller also cancels the background invocation."""
+    call_started = asyncio.Event()
+    call_cancelled = asyncio.Event()
+    mock_session._request_id = 0
+
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        call_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            call_cancelled.set()
+            raise
+
+    mock_session.call_tool.side_effect = call_tool
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        caller = asyncio.create_task(client.call_tool_async(tool_use_id="cancelled", name="slow_tool", arguments={}))
+        await asyncio.wait_for(call_started.wait(), timeout=1)
+        caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+
+        mock_session.call_tool.side_effect = None
+        mock_session.call_tool.return_value = MCPCallToolResult(
+            isError=False, content=[MCPTextContent(type="text", text="done")]
+        )
+        second_result = await client.call_tool_async(tool_use_id="completed", name="fast_tool", arguments={})
+
+    assert call_cancelled.is_set()
+    mock_session.send_notification.assert_awaited_once()
+    assert second_result["status"] == "success"
+
+
+@pytest.mark.asyncio
 async def test_call_tool_async_forwards_meta(mock_transport, mock_session):
     """Test that call_tool_async forwards meta to ClientSession.call_tool."""
     mock_content = MCPTextContent(type="text", text="Test message")

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -263,6 +263,7 @@ def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport
         return MCPCallToolResult(isError=False, content=[mock_content])
 
     mock_session.call_tool.side_effect = call_tool
+    mock_session._request_id = 0
 
     with MCPClient(mock_transport["transport_callable"]) as client:
         cancellation_thread = threading.Thread(target=lambda: (first_call_started.wait(timeout=1), cancel_signal.set()))
@@ -280,6 +281,10 @@ def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport
         "content": [{"text": "Tool execution failed: Tool execution cancelled"}],
     }
     assert first_call_cancelled.wait(timeout=1)
+    mock_session.send_notification.assert_awaited_once()
+    notification = mock_session.send_notification.await_args.args[0].root
+    assert notification.method == "notifications/cancelled"
+    assert notification.params.requestId == 0
     assert second_result["status"] == "success"
     assert mock_session.call_tool.call_count == 2
 
@@ -304,6 +309,7 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
         return MCPCallToolResult(isError=False, content=[mock_content])
 
     mock_session.call_tool.side_effect = call_tool
+    mock_session._request_id = 0
 
     with MCPClient(mock_transport["transport_callable"]) as client:
         cancelled_call = asyncio.create_task(
@@ -322,8 +328,33 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
     assert cancelled_result["status"] == "error"
     assert cancelled_result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
     assert slow_call_cancelled.is_set()
+    mock_session.send_notification.assert_awaited_once()
+    notification = mock_session.send_notification.await_args.args[0].root
+    assert notification.method == "notifications/cancelled"
+    assert notification.params.requestId == 0
     assert completed_result["status"] == "success"
     assert not other_signal.is_set()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_async_cancel_wins_when_result_and_signal_are_ready(mock_transport, mock_session):
+    """Test a set cancellation signal takes precedence over a concurrently ready result."""
+    cancel_signal = threading.Event()
+    mock_content = MCPTextContent(type="text", text="late result")
+
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        cancel_signal.set()
+        return MCPCallToolResult(isError=False, content=[mock_content])
+
+    mock_session.call_tool.side_effect = call_tool
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = await client.call_tool_async(
+            tool_use_id="cancelled", name="racing_tool", arguments={}, cancel_signal=cancel_signal
+        )
+
+    assert result["status"] == "error"
+    assert result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -341,7 +341,7 @@ class TestTaskExecution:
             result = await asyncio.wait_for(call, timeout=2)
             release_response.set()
             assert await asyncio.to_thread(cancellation_started.wait, 1)
-            assert len(client._background_cleanup_tasks) == 1
+            assert len(client._background_cleanup_tasks) >= 1
             release_cancellation.set()
             await asyncio.sleep(0.1)
             assert not client._background_cleanup_tasks

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -251,7 +251,9 @@ class TestTaskExecution:
             second_result = await client.call_tool_async(tool_use_id="completed", name="fast_tool", arguments={})
 
         assert cancelled_result["status"] == "error"
-        assert cancelled_result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+        assert cancelled_result["content"] == [
+            {"text": "Tool execution cancelled locally; remote execution may have continued"}
+        ]
         assert cancelled_result["cancelled"] is True
         mock_session.experimental.cancel_task.assert_awaited_once_with("test-task-id")
         assert second_result["status"] == "success"
@@ -303,6 +305,8 @@ class TestTaskExecution:
         self._setup_task_tool(mock_session, "slow_tool")
         creation_started = threading.Event()
         release_response = threading.Event()
+        cancellation_started = threading.Event()
+        release_cancellation = threading.Event()
         cancel_signal = threading.Event()
         create_result = MagicMock()
         create_result.task.taskId = "late-task-id"
@@ -317,8 +321,13 @@ class TestTaskExecution:
                     await asyncio.sleep(0.01)
             return create_result
 
+        async def resistant_cancellation(task_id):
+            cancellation_started.set()
+            while not release_cancellation.is_set():
+                await asyncio.sleep(0.01)
+
         mock_session.experimental.call_tool_as_task = resistant_creation
-        mock_session.experimental.cancel_task = AsyncMock()
+        mock_session.experimental.cancel_task = resistant_cancellation
 
         with MCPClient(mock_transport["transport_callable"], tasks_config=TasksConfig()) as client:
             client.list_tools_sync()
@@ -331,10 +340,13 @@ class TestTaskExecution:
             cancel_signal.set()
             result = await asyncio.wait_for(call, timeout=2)
             release_response.set()
+            assert await asyncio.to_thread(cancellation_started.wait, 1)
+            assert len(client._background_cleanup_tasks) == 1
+            release_cancellation.set()
             await asyncio.sleep(0.1)
+            assert not client._background_cleanup_tasks
 
         assert result["status"] == "error"
-        mock_session.experimental.cancel_task.assert_awaited_once_with("late-task-id")
 
     @pytest.mark.asyncio
     async def test_task_creation_cancellation_does_not_guess_shared_request_id(self, mock_transport, mock_session):
@@ -404,7 +416,7 @@ class TestTaskExecution:
             result = await asyncio.wait_for(call, timeout=2)
 
         assert result["status"] == "error"
-        assert result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+        assert result["content"] == [{"text": "Tool execution cancelled locally; remote execution may have continued"}]
         assert result["cancelled"] is True
 
     def test_logs_warning_when_task_execution_ignores_progress_callback(self, mock_transport, mock_session, caplog):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -215,6 +215,46 @@ class TestTaskExecution:
             assert result["status"] == "success"
             assert "Done" in result["content"][0].get("text", "")
 
+    @pytest.mark.asyncio
+    async def test_cancellation_cancels_remote_task_and_preserves_session(self, mock_transport, mock_session):
+        """Test per-call cancellation stops the remote task without closing the session."""
+        import threading
+
+        self._setup_task_tool(mock_session, "slow_tool")
+        poll_started = asyncio.Event()
+        cancel_signal = threading.Event()
+
+        async def infinite_poll(task_id):
+            poll_started.set()
+            while True:
+                await asyncio.sleep(1)
+                yield MagicMock(status="running")
+
+        mock_session.experimental.poll_task = infinite_poll
+        mock_session.experimental.cancel_task = AsyncMock()
+
+        with MCPClient(mock_transport["transport_callable"], tasks_config=TasksConfig()) as client:
+            client.list_tools_sync()
+            cancelled_call = asyncio.create_task(
+                client.call_tool_async(
+                    tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal
+                )
+            )
+            await asyncio.wait_for(poll_started.wait(), timeout=1)
+            cancel_signal.set()
+            cancelled_result = await asyncio.wait_for(cancelled_call, timeout=1)
+
+            client._tool_task_support_cache["fast_tool"] = None
+            mock_session.call_tool.return_value = MCPCallToolResult(
+                isError=False, content=[MCPTextContent(type="text", text="done")]
+            )
+            second_result = await client.call_tool_async(tool_use_id="completed", name="fast_tool", arguments={})
+
+        assert cancelled_result["status"] == "error"
+        assert cancelled_result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+        mock_session.experimental.cancel_task.assert_awaited_once_with("test-task-id")
+        assert second_result["status"] == "success"
+
     def test_logs_warning_when_task_execution_ignores_progress_callback(self, mock_transport, mock_session, caplog):
         """Test warning is logged when task execution ignores progress callbacks."""
         self._setup_task_tool(mock_session, "task_tool")

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -255,6 +255,78 @@ class TestTaskExecution:
         mock_session.experimental.cancel_task.assert_awaited_once_with("test-task-id")
         assert second_result["status"] == "success"
 
+    @pytest.mark.asyncio
+    async def test_cancellation_reconciles_delayed_task_creation_response(self, mock_transport, mock_session):
+        """Test cancellation discovers and stops a task whose creation response is delayed."""
+        import threading
+
+        self._setup_task_tool(mock_session, "slow_tool")
+        creation_started = threading.Event()
+        release_response = threading.Event()
+        cancel_signal = threading.Event()
+        create_result = MagicMock()
+        create_result.task.taskId = "delayed-task-id"
+
+        async def delayed_creation(**kwargs):
+            creation_started.set()
+            while not release_response.is_set():
+                await asyncio.sleep(0.01)
+            return create_result
+
+        mock_session.experimental.call_tool_as_task = delayed_creation
+        mock_session.experimental.cancel_task = AsyncMock()
+
+        with MCPClient(mock_transport["transport_callable"], tasks_config=TasksConfig()) as client:
+            client.list_tools_sync()
+            call = asyncio.create_task(
+                client.call_tool_async(
+                    tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal
+                )
+            )
+            assert await asyncio.to_thread(creation_started.wait, 1)
+            cancel_signal.set()
+            await asyncio.sleep(0.1)
+            release_response.set()
+            result = await asyncio.wait_for(call, timeout=2)
+
+        assert result["status"] == "error"
+        mock_session.experimental.cancel_task.assert_awaited_once_with("delayed-task-id")
+
+    @pytest.mark.asyncio
+    async def test_remote_task_cancellation_timeout_does_not_block_local_result(self, mock_transport, mock_session):
+        """Test an unresponsive tasks/cancel request cannot hang local cancellation."""
+        import threading
+
+        self._setup_task_tool(mock_session, "slow_tool")
+        poll_started = asyncio.Event()
+        cancel_signal = threading.Event()
+
+        async def infinite_poll(task_id):
+            poll_started.set()
+            while True:
+                await asyncio.sleep(1)
+                yield MagicMock(status="running")
+
+        async def hanging_cancel(task_id):
+            await asyncio.Event().wait()
+
+        mock_session.experimental.poll_task = infinite_poll
+        mock_session.experimental.cancel_task = hanging_cancel
+
+        with MCPClient(mock_transport["transport_callable"], tasks_config=TasksConfig()) as client:
+            client.list_tools_sync()
+            call = asyncio.create_task(
+                client.call_tool_async(
+                    tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal
+                )
+            )
+            await asyncio.wait_for(poll_started.wait(), timeout=1)
+            cancel_signal.set()
+            result = await asyncio.wait_for(call, timeout=2)
+
+        assert result["status"] == "error"
+        assert result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+
     def test_logs_warning_when_task_execution_ignores_progress_callback(self, mock_transport, mock_session, caplog):
         """Test warning is logged when task execution ignores progress callbacks."""
         self._setup_task_tool(mock_session, "task_tool")

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -349,6 +349,49 @@ class TestTaskExecution:
         assert result["status"] == "error"
 
     @pytest.mark.asyncio
+    async def test_context_exit_drains_delayed_task_cancellation(self, mock_transport, mock_session):
+        """Test session shutdown waits for delayed task creation and remote cancellation."""
+        import threading
+
+        self._setup_task_tool(mock_session, "slow_tool")
+        creation_started = threading.Event()
+        release_response = threading.Event()
+        cancel_signal = threading.Event()
+        create_result = MagicMock()
+        create_result.task.taskId = "shutdown-task-id"
+
+        async def resistant_creation(**kwargs):
+            creation_started.set()
+            try:
+                while not release_response.is_set():
+                    await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                while not release_response.is_set():
+                    await asyncio.sleep(0.01)
+            return create_result
+
+        mock_session.experimental.call_tool_as_task = resistant_creation
+        mock_session.experimental.cancel_task = AsyncMock()
+
+        with MCPClient(mock_transport["transport_callable"], tasks_config=TasksConfig()) as client:
+            client.list_tools_sync()
+            call = asyncio.create_task(
+                client.call_tool_async(
+                    tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal
+                )
+            )
+            assert await asyncio.to_thread(creation_started.wait, 1)
+            cancel_signal.set()
+            result = await asyncio.wait_for(call, timeout=2)
+            release_timer = threading.Timer(0.1, release_response.set)
+            release_timer.start()
+
+        release_timer.join(timeout=1)
+        assert result["status"] == "error"
+        mock_session.experimental.cancel_task.assert_awaited_once_with("shutdown-task-id")
+        assert not client._background_cleanup_tasks
+
+    @pytest.mark.asyncio
     async def test_task_creation_cancellation_does_not_guess_shared_request_id(self, mock_transport, mock_session):
         """Test task creation cancellation waits for the task ID instead of guessing a request ID."""
         import threading

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -293,6 +293,38 @@ class TestTaskExecution:
         mock_session.experimental.cancel_task.assert_awaited_once_with("delayed-task-id")
 
     @pytest.mark.asyncio
+    async def test_task_creation_cancellation_does_not_guess_shared_request_id(self, mock_transport, mock_session):
+        """Test task creation cancellation waits for the task ID instead of guessing a request ID."""
+        import threading
+
+        self._setup_task_tool(mock_session, "slow_tool")
+        creation_started = threading.Event()
+        cancel_signal = threading.Event()
+
+        async def blocked_creation(**kwargs):
+            creation_started.set()
+            await asyncio.Event().wait()
+
+        mock_session.experimental.call_tool_as_task = blocked_creation
+        mock_session.experimental.cancel_task = AsyncMock()
+        mock_session._request_id = 42
+
+        with MCPClient(mock_transport["transport_callable"], tasks_config=TasksConfig()) as client:
+            client.list_tools_sync()
+            call = asyncio.create_task(
+                client.call_tool_async(
+                    tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal
+                )
+            )
+            assert await asyncio.to_thread(creation_started.wait, 1)
+            cancel_signal.set()
+            result = await asyncio.wait_for(call, timeout=2)
+
+        assert result["status"] == "error"
+        mock_session.send_notification.assert_not_awaited()
+        mock_session.experimental.cancel_task.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_remote_task_cancellation_timeout_does_not_block_local_result(self, mock_transport, mock_session):
         """Test an unresponsive tasks/cancel request cannot hang local cancellation."""
         import threading

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -293,6 +293,49 @@ class TestTaskExecution:
         mock_session.experimental.cancel_task.assert_awaited_once_with("delayed-task-id")
 
     @pytest.mark.asyncio
+    async def test_cancellation_detaches_resistant_task_creation_and_cancels_late_task(
+        self, mock_transport, mock_session
+    ):
+        """Test a cancellation-resistant creation call cannot block the local result."""
+        import threading
+
+        self._setup_task_tool(mock_session, "slow_tool")
+        creation_started = threading.Event()
+        release_response = threading.Event()
+        cancel_signal = threading.Event()
+        create_result = MagicMock()
+        create_result.task.taskId = "late-task-id"
+
+        async def resistant_creation(**kwargs):
+            creation_started.set()
+            try:
+                while not release_response.is_set():
+                    await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                while not release_response.is_set():
+                    await asyncio.sleep(0.01)
+            return create_result
+
+        mock_session.experimental.call_tool_as_task = resistant_creation
+        mock_session.experimental.cancel_task = AsyncMock()
+
+        with MCPClient(mock_transport["transport_callable"], tasks_config=TasksConfig()) as client:
+            client.list_tools_sync()
+            call = asyncio.create_task(
+                client.call_tool_async(
+                    tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal
+                )
+            )
+            assert await asyncio.to_thread(creation_started.wait, 1)
+            cancel_signal.set()
+            result = await asyncio.wait_for(call, timeout=2)
+            release_response.set()
+            await asyncio.sleep(0.1)
+
+        assert result["status"] == "error"
+        mock_session.experimental.cancel_task.assert_awaited_once_with("late-task-id")
+
+    @pytest.mark.asyncio
     async def test_task_creation_cancellation_does_not_guess_shared_request_id(self, mock_transport, mock_session):
         """Test task creation cancellation waits for the task ID instead of guessing a request ID."""
         import threading
@@ -340,7 +383,10 @@ class TestTaskExecution:
                 yield MagicMock(status="running")
 
         async def hanging_cancel(task_id):
-            await asyncio.Event().wait()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                await asyncio.Event().wait()
 
         mock_session.experimental.poll_task = infinite_poll
         mock_session.experimental.cancel_task = hanging_cancel

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -252,6 +252,7 @@ class TestTaskExecution:
 
         assert cancelled_result["status"] == "error"
         assert cancelled_result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+        assert cancelled_result["cancelled"] is True
         mock_session.experimental.cancel_task.assert_awaited_once_with("test-task-id")
         assert second_result["status"] == "success"
 
@@ -404,6 +405,7 @@ class TestTaskExecution:
 
         assert result["status"] == "error"
         assert result["content"] == [{"text": "Tool execution failed: Tool execution cancelled"}]
+        assert result["cancelled"] is True
 
     def test_logs_warning_when_task_execution_ignores_progress_callback(self, mock_transport, mock_session, caplog):
         """Test warning is logged when task execution ignores progress callbacks."""

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -500,6 +500,67 @@ describe('Agent Hooks Integration', () => {
       expect(hookCallCount).toBe(2)
     })
 
+    it('does not retry a tool call after agent cancellation', async () => {
+      let toolCallCount = 0
+      const tool = createMockTool('cancelledTool', () => {
+        toolCallCount++
+        return new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'error',
+          content: [new TextBlock('Cancelled locally')],
+        })
+      })
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'cancelledTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Should not reach' })
+
+      const agent = new Agent({ model, tools: [tool] })
+      let hookCallCount = 0
+      agent.addHook(AfterToolCallEvent, (event: AfterToolCallEvent) => {
+        hookCallCount++
+        if (hookCallCount === 1) {
+          agent.cancel()
+          event.retry = true
+        }
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(toolCallCount).toBe(1)
+      expect(hookCallCount).toBe(1)
+    })
+
+    it('does not retry a hook-cancelled tool after agent cancellation', async () => {
+      let toolCallCount = 0
+      const tool = createMockTool('cancelledTool', () => {
+        toolCallCount++
+        return new ToolResultBlock({ toolUseId: 'tool-1', status: 'success', content: [new TextBlock('Success')] })
+      })
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'cancelledTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Should not reach' })
+
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(BeforeToolCallEvent, (event: BeforeToolCallEvent) => {
+        event.cancel = true
+      })
+      let hookCallCount = 0
+      agent.addHook(AfterToolCallEvent, (event: AfterToolCallEvent) => {
+        hookCallCount++
+        agent.cancel()
+        event.retry = true
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(toolCallCount).toBe(0)
+      expect(hookCallCount).toBe(1)
+    })
+
     it('does not retry tool call when retry is not set', async () => {
       let toolCallCount = 0
       const tool = createMockTool('failingTool', () => {

--- a/strands-ts/src/tools/executors/executor.ts
+++ b/strands-ts/src/tools/executors/executor.ts
@@ -122,7 +122,7 @@ export abstract class ToolExecutor {
           invocationState,
         })
         yield afterToolCallEvent
-        if (afterToolCallEvent.retry) {
+        if (this._shouldRetry(options.agent, afterToolCallEvent)) {
           continue
         }
         return this._normalizeToolResultId(afterToolCallEvent.result, toolUseBlock.toolUseId)
@@ -143,7 +143,7 @@ export abstract class ToolExecutor {
       })
       yield afterToolCallEvent
 
-      if (afterToolCallEvent.retry) {
+      if (this._shouldRetry(options.agent, afterToolCallEvent)) {
         continue
       }
 
@@ -151,6 +151,10 @@ export abstract class ToolExecutor {
       // observe the same value.
       return this._normalizeToolResultId(afterToolCallEvent.result, toolUseBlock.toolUseId)
     }
+  }
+
+  private _shouldRetry(agent: Agent, afterToolCallEvent: AfterToolCallEvent): boolean {
+    return afterToolCallEvent.retry === true && !agent.cancelSignal.aborted
   }
 
   private _normalizeToolResultId(result: ToolResultBlock, toolUseId: string): ToolResultBlock {


### PR DESCRIPTION
## Description

Ports TypeScript per-call MCP tool cancellation to Python and keeps cancellation-vs-retry behavior aligned in both SDKs.

- adds keyword-only `cancel_signal: threading.Event | None` to Python sync and async MCP calls
- forwards `agent.cancel()` into active MCP calls and stops before later sequential tools/model turns
- sends request-scoped `notifications/cancelled` or `tasks/cancel`
- bounds and owns delayed/cancellation-resistant cleanup through session shutdown
- returns `cancelled=True` with explicit local-vs-remote semantics
- makes hook-requested tool retry terminal after cancellation in both Python and TypeScript

### Latest review-driven revision (`7d88f3f8`)

- removed the direct per-call MCP section from the agent-loop guide because it exposed implementation detail
- generalized the `strands-py/AGENTS.md` cancellation rule instead of documenting this feature specifically
- clarified why the Python bridge polls `threading.Event`: it has no async notification hook, while executor-based `Event.wait()` cannot be interrupted and can strand workers after successful calls
- clarified that bounded `asyncio.wait(..., timeout=1)` returns unfinished work in `pending` and does not raise `TimeoutError`; the original caller cancellation or exception continues
- added a cancellation-resistant invocation regression proving `CancelledError` still bubbles while cleanup is retained and later drained

## Related Issues

Resolves #3276
Related: #537

## Documentation PR

Included at `site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx`.

## Type of Change

New feature

## Port evidence

<details><summary>Cross-SDK behavior</summary>

| Behavior | Coverage | Result |
|---|---|---|
| Direct Python MCP cancellation | pre-set/in-flight/racing signals, exact request ID, concurrent isolation, missing-private-ID fallback, session reuse | PASS |
| Python MCP task cancellation | delayed/resistant creation, remote cancellation timeout/failure, shutdown drain, session reuse | PASS |
| Python agent cancellation | adapter forwarding, no retry, no later sequential tool, no extra model turn | PASS |
| TypeScript cancellation-vs-retry parity | executed-tool and hook-cancel paths stop retrying when `cancelSignal.aborted`; ordinary retries remain covered | PASS |
| Cancellation-resistant Python cleanup | caller still receives `CancelledError`; unfinished invocation is retained and later drained | PASS |

</details>

### Dependency / capability delta

- **New dependencies/version changes:** none; existing `mcp>=1.23.0,<2.0.0` range is unchanged.
- **New capability:** direct Python sync/async MCP calls accept caller-owned per-call cancellation; agent cancellation reaches active MCP calls.
- **Protocol delta:** direct calls may emit `notifications/cancelled`; task calls may issue `tasks/cancel`.
- **Credential/filesystem/subprocess/deserialization delta:** none.

### Open questions

None.

## Independent review ledger

- Python round 1: 5 findings (cleanup lifecycle, cancellation errors/request IDs, checkpoint/docs examples) — fixed and regression-tested.
- Python round 2: 3 findings (remaining sequential tools, cleanup ownership, stronger request-ID proof) — fixed and regression-tested.
- Python round 3: 1 finding (retain cancellation-resistant direct invocation during shutdown) — fixed and regression-tested.
- TypeScript parity revision at `57a5b6ff`: fresh review **APPROVE**, no findings.
- Murat-driven revision at `7d88f3f8`: fresh review **APPROVE**, no findings; polling rationale, timeout propagation, resistant cleanup, and documentation scope were checked.

## Testing

Python at `7d88f3f840350a555cd8727f863330bc046dbd4c`:

```console
$ hatch test -q
4507 passed, 38 warnings in 58.38s

$ hatch run hatch-static-analysis:lint-check
All checks passed!
Success: no issues found in 223 source files
```

TypeScript at `7d88f3f840350a555cd8727f863330bc046dbd4c`:

```console
$ npm test
138 test files passed
3808 tests passed

$ npm run build && npm run type-check
# passed
$ npm run lint
# passed
$ npm run format:check
All matched files use Prettier code style!
```

`git diff --check` passed. The Python warnings are existing resource warnings in the test suite. CI is running on the latest head.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added tests proving the fix/feature works
- [x] I have updated documentation and examples
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.