### PR TITLE
feat(site): add Storage category to community catalog

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -346,6 +346,9 @@ sidebar:
           - docs/community/memory-stores/overview
           - docs/community/memory-stores/agentcore-memory-store
           - docs/community/memory-stores/strands-dakera
+      - label: Storage
+        items:
+          - docs/community/storage/overview
       - label: Session Managers
         items:
           - docs/community/session-managers/agentcore-memory

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -147,7 +147,7 @@ export const collections = {
         // Category for TypeScript API docs (classes, interfaces, type-aliases, functions)
         category: z.string().optional(),
         // Integration type for filtering (e.g., 'model-provider' for model providers)
-        integrationType: z.enum(['model-provider', 'tool', 'session-manager', 'memory-store', 'integration', 'plugin', 'agent-extension', 'intervention']).optional(),
+        integrationType: z.enum(['model-provider', 'tool', 'session-manager', 'memory-store', 'storage', 'integration', 'plugin', 'agent-extension', 'intervention']).optional(),
         // Short description for catalog listings
         description: z.string().optional(),
         // Array of slugs that should redirect to this page (e.g., old URLs)

--- a/site/src/content/docs/community/community-packages.mdx
+++ b/site/src/content/docs/community/community-packages.mdx
@@ -17,6 +17,7 @@ export const communitySessionManagers = getIntegrationEntries(allDocs, 'session-
 export const communityMemoryStores = getIntegrationEntries(allDocs, 'memory-store', true)
 export const communityTools = getIntegrationEntries(allDocs, 'tool', true)
 export const communityAgentExtensions = getIntegrationEntries(allDocs, 'agent-extension', true)
+export const communityStorage = getIntegrationEntries(allDocs, 'storage', true)
 export const communityInterventions = getIntegrationEntries(allDocs, 'intervention', true)
 
 export const packageColumns = [
@@ -78,6 +79,14 @@ Session managers provide alternative storage backends for conversation history. 
 Memory stores are backends that give agents long-term memory across sessions. Each implements the `MemoryStore` interface and plugs into an agent through a `MemoryManager`. See the [Memory Stores overview](./memory-stores/overview.md) for how they fit together.
 
 <SimpleTable data={communityMemoryStores} columns={packageColumns}>
+  {renderCell}
+</SimpleTable>
+
+## Storage
+
+Storage backends let agents and SDK subsystems persist raw bytes under string keys. Each implements the `Storage` interface and can be passed to session managers, context offloaders, or any construct that needs durable persistence. See the [Storage overview](./storage/overview.md) for how they fit together.
+
+<SimpleTable data={communityStorage} columns={packageColumns}>
   {renderCell}
 </SimpleTable>
 

--- a/site/src/content/docs/community/get-featured.mdx
+++ b/site/src/content/docs/community/get-featured.mdx
@@ -14,6 +14,7 @@ We feature **reusable packages** that extend Strands Agents capabilities:
 - **Tools** — packaged tools that solve common problems (API integrations, utilities, etc.)
 - **Session Managers** — custom storage backends for conversation history
 - **Memory Stores** — `MemoryStore` implementations giving agents long-term knowledge across sessions
+- **Storage** — `Storage` implementations for persisting raw bytes (DynamoDB, Redis, custom backends)
 - **Plugins** — extend or modify agent behavior during lifecycle events
 - **Integrations** — protocol implementations, framework bridges, etc.
 - **Agent Extensions** — specialized agent subclasses that change how agents reason and act
@@ -42,6 +43,7 @@ Place your documentation in the right spot:
 | Tools | `community/tools/` | `strands-deepgram.mdx` |
 | Session Managers | `community/session-managers/` | `agentcore-memory.mdx` |
 | Memory Stores | `community/memory-stores/` | `my-store.mdx` |
+| Storage | `community/storage/` | `my-storage.mdx` |
 | Plugins | `community/plugins/` | `my-plugin.mdx` |
 | Integrations | `community/integrations/` | `ag-ui.mdx` |
 | Agent Extensions | `community/agent-extensions/` | `strands-code-agent.mdx` |
@@ -83,7 +85,7 @@ Links to your repo, PyPI, official docs, etc.
 
 Every community page needs frontmatter with catalog fields so it appears in the [community catalog](./community-packages.md). Without `community: true`, `integrationType`, `description`, and `languages`, your page won't show up in the catalog tables.
 
-Here's the full frontmatter for a **Tool** (adapt `integrationType` for your package type — `tool`, `model-provider`, `session-manager`, `memory-store`, `plugin`, `integration`, `agent-extension`, or `intervention`):
+Here's the full frontmatter for a **Tool** (adapt `integrationType` for your package type — `tool`, `model-provider`, `session-manager`, `memory-store`, `storage`, `plugin`, `integration`, `agent-extension`, or `intervention`):
 
 ```yaml
 ---
@@ -107,7 +109,7 @@ service:
 | Field | Required | Notes |
 |-------|----------|-------|
 | `community` | ✅ | Must be `true` |
-| `integrationType` | ✅ | `tool`, `model-provider`, `session-manager`, `memory-store`, `plugin`, `integration`, `agent-extension`, or `intervention` |
+| `integrationType` | ✅ | `tool`, `model-provider`, `session-manager`, `memory-store`, `storage`, `plugin`, `integration`, `agent-extension`, or `intervention` |
 | `description` | ✅ | Shown in the catalog table |
 | `languages` | ✅ | `Python`, `TypeScript`, or omit for both |
 | `project` | Recommended | PyPI/npm link, GitHub repo, maintainer |

--- a/site/src/content/docs/community/storage/overview.mdx
+++ b/site/src/content/docs/community/storage/overview.mdx
@@ -1,0 +1,39 @@
+---
+title: Community Storage Backends
+description: Community-built storage backends for persisting raw bytes under string keys.
+tags: [storage]
+sidebar:
+  label: "Overview"
+---
+
+A **storage backend** persists raw bytes under `/`-separated string
+keys. The SDK uses the `Storage` interface internally for session
+snapshots, context offloading, and any construct that needs durable
+key-value persistence. Any class that implements the four-method
+`Storage` protocol (`write`, `read`, `delete`, `list`) can plug in.
+
+The SDK ships reference backends:
+[`InMemoryStorage`](../../user-guide/concepts/plugins/context-offloader.md),
+[`LocalFileStorage`](../../user-guide/concepts/agents/session-management.md),
+and
+[`S3Storage`](../../user-guide/concepts/agents/session-management.md).
+The packages below are **community-built** storage backends you can
+install and use wherever a `Storage` instance is accepted.
+
+:::note[Community maintained]
+These packages are maintained by their authors, not the Strands team.
+Review packages before using them in production. Quality and support
+may vary.
+:::
+
+## Browse the catalog
+
+See the [Storage section of the community catalog](../community-packages.md#storage)
+for the current list, with language support and links to each package.
+
+## Add your storage backend
+
+Built a `Storage` implementation? See the
+[Get Featured guide](../get-featured.md) to list it here, and the
+[Extensions guide](../../contribute/contributing/extensions.md) for
+how to build and publish a package.

--- a/site/src/content/docs/community/storage/overview.mdx
+++ b/site/src/content/docs/community/storage/overview.mdx
@@ -12,10 +12,10 @@ key-value persistence. Any class that implements the four-method
 `Storage` protocol (`write`, `read`, `delete`, `list`) can plug in.
 
 The SDK ships reference backends:
-[`InMemoryStorage`](../../user-guide/concepts/storage.mdx),
-[`LocalFileStorage`](../../user-guide/concepts/storage.mdx),
+[`InMemoryStorage`](../../user-guide/concepts/storage.mdx#inmemorystorage),
+[`LocalFileStorage`](../../user-guide/concepts/storage.mdx#localfilestorage),
 and
-[`S3Storage`](../../user-guide/concepts/storage.mdx).
+[`S3Storage`](../../user-guide/concepts/storage.mdx#s3storage).
 The packages below are **community-built** storage backends you can
 install and use wherever a `Storage` instance is accepted.
 

--- a/site/src/content/docs/community/storage/overview.mdx
+++ b/site/src/content/docs/community/storage/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Community Storage Backends
 description: Community-built storage backends for persisting raw bytes under string keys.
-tags: [storage]
 sidebar:
   label: "Overview"
 ---
@@ -13,10 +12,10 @@ key-value persistence. Any class that implements the four-method
 `Storage` protocol (`write`, `read`, `delete`, `list`) can plug in.
 
 The SDK ships reference backends:
-[`InMemoryStorage`](../../user-guide/concepts/plugins/context-offloader.md),
-[`LocalFileStorage`](../../user-guide/concepts/agents/session-management.md),
+[`InMemoryStorage`](../../user-guide/concepts/storage.mdx),
+[`LocalFileStorage`](../../user-guide/concepts/storage.mdx),
 and
-[`S3Storage`](../../user-guide/concepts/agents/session-management.md).
+[`S3Storage`](../../user-guide/concepts/storage.mdx).
 The packages below are **community-built** storage backends you can
 install and use wherever a `Storage` instance is accepted.
 

--- a/site/src/content/docs/contribute/contributing/extensions.mdx
+++ b/site/src/content/docs/contribute/contributing/extensions.mdx
@@ -28,6 +28,7 @@ Strands has several extension points. Each serves a different purpose in the age
 | **Interventions** | Add composable control handlers for authorization, guardrails, and steering with typed actions | [Interventions](../../user-guide/concepts/agents/interventions/index.md) |
 | **Session managers** | Persist conversations to external storage for resumption or sharing | [Session management](../../user-guide/concepts/agents/session-management.md) |
 | **Conversation managers** | Control how message history grows—trim old messages or summarize context | [Conversation management](../../user-guide/concepts/agents/conversation-management.md) |
+| **Storage** | Persist raw bytes under string keys for session snapshots, context offloading, and other durable data | [Storage backends](../../user-guide/concepts/plugins/context-offloader.md#storage-backends) |
 
 Tools are the most common extension type. They let agents interact with specific services like Slack, databases, or internal APIs.
 
@@ -36,7 +37,7 @@ Tools are the most common extension type. They let agents interact with specific
 The fastest way to create a publishable extension is the [extension template](https://github.com/strands-agents/extension-template). It gives you a ready-made project structure with skeleton implementations for Python and TypeScript, testing setup, and GitHub Actions workflows for publishing.
 
 1. Click "Use this template" on GitHub to create your repository
-2. Run the setup script to customize the project — pick a package name, select which components you need (tool, model provider, plugin, intervention, session manager, conversation manager), and fill in your author info
+2. Run the setup script to customize the project — pick a package name, select which components you need (tool, model provider, plugin, intervention, session manager, conversation manager, memory store, storage), and fill in your author info
 3. Install dependencies and run checks
 4. Implement your component logic in the generated files
 

--- a/site/src/util/integration-content.ts
+++ b/site/src/util/integration-content.ts
@@ -15,6 +15,7 @@ export type IntegrationType =
   | 'tool'
   | 'session-manager'
   | 'memory-store'
+  | 'storage'
   | 'integration'
   | 'plugin'
   | 'agent-extension'


### PR DESCRIPTION
## Description

Add Storage as a new extension type in the community ecosystem. Storage backends implement the `Storage` interface to persist raw bytes under string keys, used by session managers, context offloaders, and other SDK constructs.

- Add `storage` to `integrationType` enum and TypeScript type
- Add Storage section to community catalog page
- Create `community/storage/overview.mdx` page with deep-links to the shipped [Storage concept page](https://strandsagents.com/docs/user-guide/concepts/storage/) (#3408)
- Add Storage to navigation sidebar
- Update extensions docs and get-featured guide

## Related Issues

Builds on #3408 (storage concept docs, now shipped).

## Type of Change

Documentation update

## Testing

- [x] `npm run build` passes with no broken links
- [x] Storage overview page renders correctly with anchor links to InMemoryStorage, LocalFileStorage, and S3Storage sections

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.