### PR TITLE
fix(mcp): deduplicate inverted-index postings

### DIFF
--- a/strands-mcp/src/strands_mcp_server/utils/indexer.py
+++ b/strands-mcp/src/strands_mcp_server/utils/indexer.py
@@ -107,8 +107,8 @@ class IndexSearch:
         haystack = " ".join(part for part in haystack_parts if part)
 
         for tok in _TOKEN.findall(haystack):
-            self.doc_indices.setdefault(tok, []).append(idx)
             if tok not in seen:
+                self.doc_indices.setdefault(tok, []).append(idx)
                 self.doc_frequency[tok] = self.doc_frequency.get(tok, 0) + 1
                 seen.add(tok)
 

--- a/strands-mcp/tests/test_indexer.py
+++ b/strands-mcp/tests/test_indexer.py
@@ -1,0 +1,26 @@
+"""Tests ensuring IndexSearch stores one posting per token and document.
+
+Regression coverage for https://github.com/strands-agents/harness-sdk/issues/3325.
+"""
+
+from strands_mcp_server.utils.indexer import Doc, IndexSearch
+
+
+def test_add_deduplicates_postings_per_document():
+    index = IndexSearch()
+    index.add(Doc(uri="first", display_title="First", content="agent agent", index_title="agent"))
+    index.add(Doc(uri="second", display_title="Second", content="agent", index_title=""))
+
+    exp_postings = [0, 1]
+    assert index.doc_indices["agent"] == exp_postings
+    assert index.doc_frequency["agent"] == 2
+
+
+def test_search_scores_each_posting_once():
+    index = IndexSearch()
+    index.add(Doc(uri="doc", display_title="Doc", content="agent agent agent", index_title=""))
+
+    tru_results = index.search("agent")
+
+    assert len(tru_results) == 1
+    assert tru_results[0][0] == 3.0


### PR DESCRIPTION
## Description

Repeated tokens currently add the same document to an inverted-index posting list multiple times, so searches recompute and accumulate the document's full term score for every occurrence. Keep posting-list membership aligned with document frequency by adding each token's document index only once.

## Related Issues

Resolves #3325

## Documentation PR

Not required; this is an internal bug fix with no public API changes.

## Type of Change

Bug fix

## Testing

The `strands-mcp` format check, lint, and full unit suite pass locally (49 tests). The repository's `hatch run prepare` script is not defined for this subproject.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
