### PR TITLE
Docs: clarify local metrics and telemetry export

### DIFF
--- a/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
@@ -17,7 +17,7 @@ The Strands Agents SDK automatically tracks key metrics during agent execution:
 - **Tool usage**: Call counts, success rates, and execution times for each tool
 - **Event loop cycles**: Number of reasoning cycles and their durations
 
-All these metrics are accessible through the [`AgentResult`](@api/python/strands.agent.agent_result#AgentResult) object that's returned whenever you invoke an agent:
+All these metrics are accessible through the [`AgentResult`](@api/python/strands.agent.agent_result#AgentResult) object that's returned whenever you invoke an agent. They are available for local analysis. To export them to an observability backend, configure Strands telemetry as described in the [Traces](./traces.md) documentation:
 
 ```python
 from strands import Agent


### PR DESCRIPTION
## Description
This PR clarifies that metrics accessed through `AgentResult` are available for local analysis, but can also be exported to an observability backend. It also adds a cross-reference to the Traces documentation, where telemetry configuration is explained.

This addresses a documentation gap by distinguishing local metric access from telemetry export. It also aligns the metrics section with the **Local Execution Traces** section, which already references OpenTelemetry export, improving consistency and reducing potential confusion.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Documentation update


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
