### PR TITLE
fix(models/llamacpp): send llama.cpp sampler params at the top level, not under extra_body

### DIFF
--- a/strands-py/src/strands/models/llamacpp.py
+++ b/strands-py/src/strands/models/llamacpp.py
@@ -389,9 +389,9 @@ class LlamaCppModel(Model):
             if "json_schema" in params:
                 request["json_schema"] = params["json_schema"]
 
-            # llama.cpp-specific parameters that must be passed via extra_body
-            # NOTE: grammar and json_schema are NOT in this set because llama.cpp server
-            # expects them directly in the request body for proper constraint application
+            # llama.cpp-specific sampling parameters. The llama.cpp server reads these
+            # from the top level of the request body, which is also where grammar and
+            # json_schema (handled above) are placed.
             llamacpp_specific_params = {
                 "repeat_penalty",
                 "top_k",
@@ -432,15 +432,15 @@ class LlamaCppModel(Model):
                 if param in openai_params:
                     request[param] = value
 
-            # Collect llama.cpp-specific parameters for extra_body
-            extra_body: dict[str, Any] = {}
+            # Add llama.cpp-specific parameters directly to the request body. This
+            # provider posts the request over raw httpx rather than the OpenAI SDK, so
+            # there is no client-side layer to flatten an "extra_body" object into the
+            # request; nesting these under "extra_body" would leave them unread by the
+            # server. Placing them at the top level matches how the SDK's extra_body is
+            # ultimately delivered, and how grammar/json_schema are already handled.
             for param, value in params.items():
                 if param in llamacpp_specific_params:
-                    extra_body[param] = value
-
-            # Add extra_body if we have llama.cpp-specific parameters
-            if extra_body:
-                request["extra_body"] = extra_body
+                    request[param] = value
 
         return request
 

--- a/strands-py/src/strands/models/llamacpp.py
+++ b/strands-py/src/strands/models/llamacpp.py
@@ -432,12 +432,7 @@ class LlamaCppModel(Model):
                 if param in openai_params:
                     request[param] = value
 
-            # Add llama.cpp-specific parameters directly to the request body. This
-            # provider posts the request over raw httpx rather than the OpenAI SDK, so
-            # there is no client-side layer to flatten an "extra_body" object into the
-            # request; nesting these under "extra_body" would leave them unread by the
-            # server. Placing them at the top level matches how the SDK's extra_body is
-            # ultimately delivered, and how grammar/json_schema are already handled.
+            # Add llama.cpp-specific parameters directly to the request body
             for param, value in params.items():
                 if param in llamacpp_specific_params:
                     request[param] = value

--- a/strands-py/tests/strands/models/test_llamacpp.py
+++ b/strands-py/tests/strands/models/test_llamacpp.py
@@ -98,11 +98,12 @@ def test_format_request_with_llamacpp_params() -> None:
     # Grammar and json_schema go directly in request for llama.cpp
     assert request["grammar"] == "root ::= 'yes' | 'no'"
 
-    # Other llama.cpp specific params should be in extra_body
-    assert "extra_body" in request
-    assert request["extra_body"]["repeat_penalty"] == 1.1
-    assert request["extra_body"]["top_k"] == 40
-    assert request["extra_body"]["min_p"] == 0.05
+    # Other llama.cpp specific params go directly in the request body (the server
+    # reads them at the top level; there is no OpenAI SDK to flatten extra_body).
+    assert "extra_body" not in request
+    assert request["repeat_penalty"] == 1.1
+    assert request["top_k"] == 40
+    assert request["min_p"] == 0.05
 
 
 def test_format_request_with_all_new_params() -> None:
@@ -150,26 +151,52 @@ def test_format_request_with_all_new_params() -> None:
     assert request["grammar"] == "root ::= answer"
     assert request["json_schema"] == {"type": "object"}
 
-    # Check all other llama.cpp params are in extra_body
-    assert "extra_body" in request
-    extra = request["extra_body"]
-    assert extra["repeat_penalty"] == 1.1
-    assert extra["top_k"] == 40
-    assert extra["min_p"] == 0.05
-    assert extra["typical_p"] == 0.95
-    assert extra["tfs_z"] == 0.97
-    assert extra["top_a"] == 0.1
-    assert extra["mirostat"] == 2
-    assert extra["mirostat_lr"] == 0.1
-    assert extra["mirostat_ent"] == 5.0
-    assert extra["penalty_last_n"] == 256
-    assert extra["n_probs"] == 5
-    assert extra["min_keep"] == 1
-    assert extra["ignore_eos"] is False
-    assert extra["logit_bias"] == {100: 5.0, 200: -5.0}
-    assert extra["cache_prompt"] is True
-    assert extra["slot_id"] == 1
-    assert extra["samplers"] == ["top_k", "tfs_z", "typical_p"]
+    # All other llama.cpp params go directly in the request body, not nested under
+    # an OpenAI-SDK-only extra_body object.
+    assert "extra_body" not in request
+    assert request["repeat_penalty"] == 1.1
+    assert request["top_k"] == 40
+    assert request["min_p"] == 0.05
+    assert request["typical_p"] == 0.95
+    assert request["tfs_z"] == 0.97
+    assert request["top_a"] == 0.1
+    assert request["mirostat"] == 2
+    assert request["mirostat_lr"] == 0.1
+    assert request["mirostat_ent"] == 5.0
+    assert request["penalty_last_n"] == 256
+    assert request["n_probs"] == 5
+    assert request["min_keep"] == 1
+    assert request["ignore_eos"] is False
+    assert request["logit_bias"] == {100: 5.0, 200: -5.0}
+    assert request["cache_prompt"] is True
+    assert request["slot_id"] == 1
+    assert request["samplers"] == ["top_k", "tfs_z", "typical_p"]
+
+
+def test_format_request_llamacpp_params_are_top_level_not_extra_body() -> None:
+    """llama.cpp sampling params must reach the server at the top level of the body.
+
+    The request is posted over raw httpx (see stream()/count_tokens), not the OpenAI
+    SDK, so an "extra_body" object is never flattened into the request; nesting the
+    params there leaves them unread by the llama.cpp server. This regression test
+    pins the params to the top level, where the server reads them.
+    """
+    model = LlamaCppModel(
+        params={
+            "top_k": 40,
+            "repeat_penalty": 1.1,
+            "mirostat": 2,
+            "samplers": ["top_k", "min_p"],
+        }
+    )
+
+    request = model._format_request([{"role": "user", "content": [{"text": "hi"}]}])
+
+    assert "extra_body" not in request
+    assert request["top_k"] == 40
+    assert request["repeat_penalty"] == 1.1
+    assert request["mirostat"] == 2
+    assert request["samplers"] == ["top_k", "min_p"]
 
 
 def test_format_tool_call_preserves_non_ascii() -> None:

--- a/strands-py/tests/strands/models/test_llamacpp.py
+++ b/strands-py/tests/strands/models/test_llamacpp.py
@@ -174,12 +174,8 @@ def test_format_request_with_all_new_params() -> None:
 
 
 def test_format_request_llamacpp_params_are_top_level_not_extra_body() -> None:
-    """llama.cpp sampling params must reach the server at the top level of the body.
-
-    The request is posted over raw httpx (see stream()/count_tokens), not the OpenAI
-    SDK, so an "extra_body" object is never flattened into the request; nesting the
-    params there leaves them unread by the llama.cpp server. This regression test
-    pins the params to the top level, where the server reads them.
+    """llama.cpp sampling params are placed at the top level of the request body,
+    not under extra_body. Regression test for #3422.
     """
     model = LlamaCppModel(
         params={


### PR DESCRIPTION
## Description

`LlamaCppModel._format_request` collected the llama.cpp-specific sampling parameters (`top_k`, `repeat_penalty`, `min_p`, `typical_p`, `tfs_z`, `top_a`, `mirostat*`, `penalty_last_n`, `n_probs`, `min_keep`, `ignore_eos`, `logit_bias`, `cache_prompt`, `slot_id`, `samplers`) into a nested `extra_body` object:

```python
if extra_body:
    request["extra_body"] = extra_body
```

**Root cause:** `extra_body` is an OpenAI Python SDK client-side convention. The SDK merges its contents into the top level of the request body before sending. This provider does not use the OpenAI SDK; it posts the request dict verbatim over raw httpx (`stream`, `count_tokens`):

```python
response = await self.client.post("/v1/chat/completions", json=request)
```

So the parameters are transmitted nested under a literal `"extra_body"` object rather than as top-level request fields. Every other request-level field this method sets is placed at the top level: the standard OpenAI params (`temperature`, `top_p`, `stop`) and, notably, `grammar`/`json_schema`, which are also llama.cpp-specific. The sampler params are the only ones nested under `extra_body`, so they do not arrive in the same top-level form as the fields the server is handed directly.

**Invariant:** llama.cpp-specific sampling params must reach the top level of the request body, the same place `grammar`/`json_schema` and the standard OpenAI params already go.

**Fix:** write the sampler params directly into `request` instead of nesting them under `extra_body`. This is exactly the wire format the OpenAI SDK's `extra_body` would have produced, so it restores the parameter delivery the code intended.

## Related Issues

Fixes #3422

## Type of Change

Bug fix

## Testing

Verified in a clean `python:3.12-slim` Docker container against `main` @ `81bccd84`, with `strands.models.llamacpp.__file__` printed on both sides to confirm provenance:

- Repro on unmodified `main`: `_format_request` with `{top_k, repeat_penalty, min_p, mirostat}` returns them nested under `request["extra_body"]`, while `temperature` lands at the top level.
- New regression test `test_format_request_llamacpp_params_are_top_level_not_extra_body` and the two updated tests fail on `main` (the params are under `extra_body`) and pass on this branch.
- `tests/strands/models/test_llamacpp.py`: 38 passed.
- `ruff check`, `ruff format --check`, and `mypy` on the changed source: clean.

I did not run a live llama.cpp server, so the server-side effect is not directly observed here: the verification covers the request the provider builds, not the server's handling of it. The fix restores the top-level wire format that this method already treats as correct for every other request field (and that the OpenAI SDK's `extra_body` produces after flattening).

I also did not run the full `hatch test --all` suite: the sandbox is missing optional provider/system dependencies (unrelated modules fail at import collection, identically on `main`). The change is confined to one pure method (`_format_request`); no other module imports it.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly (no documented behavior changes; the parameters were already advertised as supported)
- [x] My changes generate no new warnings
