### PR TITLE
fix: reset reasoning signature state when a content block ends

### DIFF
--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -338,8 +338,9 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
             }
         }
 
-        if "signature" in state:
-            content_block["reasoningContent"]["reasoningText"]["signature"] = state["signature"]
+        # Consume the signature so it cannot leak into the next reasoning block
+        if (signature := state.pop("signature", None)) is not None:
+            content_block["reasoningContent"]["reasoningText"]["signature"] = signature
 
         content.append(content_block)
         state["reasoningText"] = ""

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -475,7 +475,6 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, event_type, s
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
-                "signature": "123",
                 "citationsContent": [],
                 "redactedContent": b"",
             },
@@ -515,7 +514,6 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, event_type, s
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
-                "signature": "123",
                 "citationsContent": [],
                 "redactedContent": b"",
             },
@@ -1153,6 +1151,59 @@ async def test_process_stream_with_signature(agenerator, alist):
 
     assert message["content"][0]["reasoningContent"]["reasoningText"]["signature"] == "test-signature"
     assert message["content"][1]["text"] == "Sure! Let’s do it"
+
+
+@pytest.mark.asyncio
+async def test_process_stream_with_multiple_signed_reasoning_blocks(agenerator, alist):
+    """Each reasoning block keeps its own signature — no cross-block leakage.
+
+    Providers verify thinking signatures byte-identical per block when the
+    conversation is sent back (e.g. Anthropic extended thinking across tool
+    loops). A leaked signature accumulator turns the second block's signature
+    into "SIG1SIG2" and the follow-up request is rejected with a 400.
+    """
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "contentBlockDelta": {
+                "delta": {"reasoningContent": {"text": "first thought"}},
+                "contentBlockIndex": 0,
+            }
+        },
+        {
+            "contentBlockDelta": {
+                "delta": {"reasoningContent": {"signature": "SIG1"}},
+                "contentBlockIndex": 0,
+            }
+        },
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {
+            "contentBlockDelta": {
+                "delta": {"reasoningContent": {"text": "second thought"}},
+                "contentBlockIndex": 1,
+            }
+        },
+        {
+            "contentBlockDelta": {
+                "delta": {"reasoningContent": {"signature": "SIG2"}},
+                "contentBlockIndex": 1,
+            }
+        },
+        {"contentBlockStop": {"contentBlockIndex": 1}},
+        {"contentBlockDelta": {"delta": {"text": "answer"}, "contentBlockIndex": 2}},
+        {"contentBlockStop": {"contentBlockIndex": 2}},
+        {"messageStop": {"stopReason": "end_turn"}},
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+
+    last_event = cast(ModelStopReason, (await alist(stream))[-1])
+
+    message = _get_message_from_event(last_event)
+
+    assert message["content"][0]["reasoningContent"]["reasoningText"]["signature"] == "SIG1"
+    assert message["content"][1]["reasoningContent"]["reasoningText"]["signature"] == "SIG2"
+    assert message["content"][2]["text"] == "answer"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`handle_content_block_stop` finalizes a reasoning block but left `state["signature"]` in place, while every other accumulator (`text`, `reasoningText`, `redactedContent`, `current_tool_use`) is cleared there. With multiple signed reasoning blocks in one assistant message (e.g. Anthropic adaptive/interleaved thinking across tool loops), every block after the first was stored with the concatenation of all signatures so far (`SIG1`, `SIG1SIG2`, …). Providers verify thinking signatures byte-identical per block when the conversation is sent back, so any follow-up request failed with `400 invalid_request_error` ("…`thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified…").

This PR consumes the signature when the block is finalized (`state.pop("signature", None)`). That restores per-block signatures and also keeps the `"signature" in state` guard truthful, so a leftover signature can no longer turn later empty blocks into spurious reasoning blocks.

## Related Issues

Fixes #3425

## Documentation PR

No documentation changes needed.

## Type of Change

Bug fix

## Testing

- New regression test `test_process_stream_with_multiple_signed_reasoning_blocks`: two signed reasoning blocks in one message must come out as `SIG1` / `SIG2` — before the fix they come out as `SIG1` / `SIG1SIG2`.
- Two existing parametrized `test_handle_content_block_stop` cases asserted the leaking `signature` state and were updated to the consumed-signature expectation.
- `tests/strands/event_loop/` passes completely (133 passed); `ruff check` and `ruff format --check` clean on the changed files.

- [ ] I ran `hatch run prepare` — fails in my environment on building the optional `cedarpy` dependency (unrelated to this change); ran the targeted equivalent above instead.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (no docs affected)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.