### PR TITLE
fix(python): surface Responses stream failures

### DIFF
--- a/strands-py/src/strands/models/_openai_errors.py
+++ b/strands-py/src/strands/models/_openai_errors.py
@@ -1,0 +1,38 @@
+"""Shared error classification for OpenAI model providers."""
+
+from typing import Literal
+
+OpenAIErrorKind = Literal["context_overflow", "throttling"]
+
+# Union of overflow phrases observed across OpenAI-compatible providers. Keep these lowercased so
+# classification only normalizes each provider message once.
+_CONTEXT_WINDOW_OVERFLOW_PATTERNS = (
+    "maximum context length",
+    "context_length_exceeded",
+    "too many tokens",
+    "context length",
+    "input is too long for requested model",
+    "input length and `max_tokens` exceed context limit",
+    "too many total text bytes",
+    "exceed customer model maximum",
+)
+_RATE_LIMIT_PATTERNS = ("rate_limit_exceeded", "rate limit", "too many requests")
+
+
+def classify_openai_error(error: BaseException) -> OpenAIErrorKind | None:
+    """Classify an error from an OpenAI or OpenAI-compatible provider."""
+    message = str(error).lower()
+    raw_code = getattr(error, "code", None)
+    code = raw_code.lower() if isinstance(raw_code, str) else ""
+
+    if (
+        getattr(error, "status_code", None) == 429
+        or code == "rate_limit_exceeded"
+        or any(pattern in message for pattern in _RATE_LIMIT_PATTERNS)
+    ):
+        return "throttling"
+
+    if code == "context_length_exceeded" or any(pattern in message for pattern in _CONTEXT_WINDOW_OVERFLOW_PATTERNS):
+        return "context_overflow"
+
+    return None

--- a/strands-py/src/strands/models/_openai_errors.py
+++ b/strands-py/src/strands/models/_openai_errors.py
@@ -15,6 +15,7 @@ _CONTEXT_WINDOW_OVERFLOW_PATTERNS = (
     "input length and `max_tokens` exceed context limit",
     "too many total text bytes",
     "exceed customer model maximum",
+    "exceeds the max_model_len",
 )
 _RATE_LIMIT_PATTERNS = ("rate_limit_exceeded", "rate limit", "too many requests")
 

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -23,21 +23,13 @@ from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._defaults import resolve_config_metadata
 from ._openai_bedrock import BedrockMantleConfig, resolve_bedrock_client_args
+from ._openai_errors import classify_openai_error
 from ._validation import _has_location_source, validate_config_keys
 from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
-
-# Alternative context overflow error messages
-# These are commonly returned by OpenAI-compatible endpoints wrapping other providers
-# (e.g., Databricks serving Bedrock models)
-_CONTEXT_OVERFLOW_MESSAGES = [
-    "Input is too long for requested model",
-    "input length and `max_tokens` exceed context limit",
-    "too many total text bytes",
-]
 
 
 class Client(Protocol):
@@ -716,95 +708,87 @@ class OpenAIModel(Model):
         async with self._get_client() as client:
             try:
                 response = await client.chat.completions.create(**request)
-            except openai.BadRequestError as e:
-                # Check if this is a context length exceeded error
-                if hasattr(e, "code") and e.code == "context_length_exceeded":
+
+                if not request["stream"]:
+                    for chunk in self._format_non_streaming_response(response):
+                        yield chunk
+                    return
+
+                logger.debug("got response from model")
+                yield self.format_chunk({"chunk_type": "message_start"})
+                tool_calls: dict[int, list[Any]] = {}
+                data_type = None
+                finish_reason = None  # Store finish_reason for later use
+                event = None  # Initialize for scope safety
+
+                async for event in response:
+                    # Defensive: skip events with empty or missing choices
+                    if not getattr(event, "choices", None):
+                        continue
+                    choice = event.choices[0]
+
+                    reasoning_content = getattr(choice.delta, "reasoning_content", None)
+                    if not isinstance(reasoning_content, str) or not reasoning_content:
+                        reasoning_content = getattr(choice.delta, "reasoning", None)
+
+                    if isinstance(reasoning_content, str) and reasoning_content:
+                        chunks, data_type = self._stream_switch_content("reasoning_content", data_type)
+                        for chunk in chunks:
+                            yield chunk
+                        yield self.format_chunk(
+                            {
+                                "chunk_type": "content_delta",
+                                "data_type": data_type,
+                                "data": reasoning_content,
+                            }
+                        )
+
+                    if choice.delta.content:
+                        chunks, data_type = self._stream_switch_content("text", data_type)
+                        for chunk in chunks:
+                            yield chunk
+                        yield self.format_chunk(
+                            {"chunk_type": "content_delta", "data_type": data_type, "data": choice.delta.content}
+                        )
+
+                    for tool_call in choice.delta.tool_calls or []:
+                        tool_calls.setdefault(tool_call.index, []).append(tool_call)
+
+                    if choice.finish_reason:
+                        finish_reason = choice.finish_reason  # Store for use outside loop
+                        if data_type:
+                            yield self.format_chunk({"chunk_type": "content_stop", "data_type": data_type})
+                        break
+
+                for tool_deltas in tool_calls.values():
+                    yield self.format_chunk(
+                        {"chunk_type": "content_start", "data_type": "tool", "data": tool_deltas[0]}
+                    )
+
+                    for tool_delta in tool_deltas:
+                        yield self.format_chunk(
+                            {"chunk_type": "content_delta", "data_type": "tool", "data": tool_delta}
+                        )
+
+                    yield self.format_chunk({"chunk_type": "content_stop", "data_type": "tool"})
+
+                yield self.format_chunk({"chunk_type": "message_stop", "data": finish_reason or "end_turn"})
+
+                # Skip remaining events as we don't have use for anything except the final usage payload
+                async for event in response:
+                    _ = event
+
+                if event and hasattr(event, "usage") and event.usage:
+                    yield self.format_chunk({"chunk_type": "metadata", "data": event.usage})
+            except openai.APIError as error:
+                error_kind = classify_openai_error(error)
+                if error_kind == "throttling":
+                    logger.warning("OpenAI threw rate limit error")
+                    raise ModelThrottledException(str(error)) from error
+                if error_kind == "context_overflow":
                     logger.warning("OpenAI threw context window overflow error")
-                    raise ContextWindowOverflowException(str(e)) from e
-                # Re-raise other BadRequestError exceptions
+                    raise ContextWindowOverflowException(str(error)) from error
                 raise
-            except openai.RateLimitError as e:
-                # All rate limit errors should be treated as throttling, not context overflow
-                # Rate limits (including TPM) require waiting/retrying, not context reduction
-                logger.warning("OpenAI threw rate limit error")
-                raise ModelThrottledException(str(e)) from e
-            except openai.APIError as e:
-                # Check for alternative context overflow error messages
-                error_message = str(e)
-                if any(overflow_msg in error_message for overflow_msg in _CONTEXT_OVERFLOW_MESSAGES):
-                    logger.warning("context window overflow error detected")
-                    raise ContextWindowOverflowException(error_message) from e
-                # Re-raise other APIError exceptions
-                raise
-
-            if not request["stream"]:
-                for chunk in self._format_non_streaming_response(response):
-                    yield chunk
-                return
-
-            logger.debug("got response from model")
-            yield self.format_chunk({"chunk_type": "message_start"})
-            tool_calls: dict[int, list[Any]] = {}
-            data_type = None
-            finish_reason = None  # Store finish_reason for later use
-            event = None  # Initialize for scope safety
-
-            async for event in response:
-                # Defensive: skip events with empty or missing choices
-                if not getattr(event, "choices", None):
-                    continue
-                choice = event.choices[0]
-
-                reasoning_content = getattr(choice.delta, "reasoning_content", None)
-                if not isinstance(reasoning_content, str) or not reasoning_content:
-                    reasoning_content = getattr(choice.delta, "reasoning", None)
-
-                if isinstance(reasoning_content, str) and reasoning_content:
-                    chunks, data_type = self._stream_switch_content("reasoning_content", data_type)
-                    for chunk in chunks:
-                        yield chunk
-                    yield self.format_chunk(
-                        {
-                            "chunk_type": "content_delta",
-                            "data_type": data_type,
-                            "data": reasoning_content,
-                        }
-                    )
-
-                if choice.delta.content:
-                    chunks, data_type = self._stream_switch_content("text", data_type)
-                    for chunk in chunks:
-                        yield chunk
-                    yield self.format_chunk(
-                        {"chunk_type": "content_delta", "data_type": data_type, "data": choice.delta.content}
-                    )
-
-                for tool_call in choice.delta.tool_calls or []:
-                    tool_calls.setdefault(tool_call.index, []).append(tool_call)
-
-                if choice.finish_reason:
-                    finish_reason = choice.finish_reason  # Store for use outside loop
-                    if data_type:
-                        yield self.format_chunk({"chunk_type": "content_stop", "data_type": data_type})
-                    break
-
-            for tool_deltas in tool_calls.values():
-                yield self.format_chunk({"chunk_type": "content_start", "data_type": "tool", "data": tool_deltas[0]})
-
-                for tool_delta in tool_deltas:
-                    yield self.format_chunk({"chunk_type": "content_delta", "data_type": "tool", "data": tool_delta})
-
-                yield self.format_chunk({"chunk_type": "content_stop", "data_type": "tool"})
-
-            yield self.format_chunk({"chunk_type": "message_stop", "data": finish_reason or "end_turn"})
-
-            # Skip remaining events as we don't have use for anything except the final usage payload
-            async for event in response:
-                _ = event
-
-            if event and hasattr(event, "usage") and event.usage:
-                yield self.format_chunk({"chunk_type": "metadata", "data": event.usage})
-
         logger.debug("finished streaming response from model")
 
     def _stream_switch_content(self, data_type: str, prev_data_type: str | None) -> tuple[list[StreamEvent], str]:
@@ -858,25 +842,14 @@ class OpenAIModel(Model):
                 response: ParsedChatCompletion = await client.beta.chat.completions.parse(
                     **request, response_format=output_model
                 )
-            except openai.BadRequestError as e:
-                # Check if this is a context length exceeded error
-                if hasattr(e, "code") and e.code == "context_length_exceeded":
+            except openai.APIError as error:
+                error_kind = classify_openai_error(error)
+                if error_kind == "throttling":
+                    logger.warning("OpenAI threw rate limit error")
+                    raise ModelThrottledException(str(error)) from error
+                if error_kind == "context_overflow":
                     logger.warning("OpenAI threw context window overflow error")
-                    raise ContextWindowOverflowException(str(e)) from e
-                # Re-raise other BadRequestError exceptions
-                raise
-            except openai.RateLimitError as e:
-                # All rate limit errors should be treated as throttling, not context overflow
-                # Rate limits (including TPM) require waiting/retrying, not context reduction
-                logger.warning("OpenAI threw rate limit error")
-                raise ModelThrottledException(str(e)) from e
-            except openai.APIError as e:
-                # Check for alternative context overflow error messages
-                error_message = str(e)
-                if any(overflow_msg in error_message for overflow_msg in _CONTEXT_OVERFLOW_MESSAGES):
-                    logger.warning("context window overflow error detected")
-                    raise ContextWindowOverflowException(error_message) from e
-                # Re-raise other APIError exceptions
+                    raise ContextWindowOverflowException(str(error)) from error
                 raise
 
         parsed: T | None = None

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -74,7 +74,17 @@ _MAX_MEDIA_SIZE_LABEL = "20MB"
 _DEFAULT_MIME_TYPE = "application/octet-stream"
 _CONTEXT_WINDOW_OVERFLOW_MSG = "OpenAI Responses API threw context window overflow error"
 _RATE_LIMIT_MSG = "OpenAI Responses API threw rate limit error"
-_CONTEXT_WINDOW_OVERFLOW_PATTERNS = ("exceed customer model maximum",)
+_CONTEXT_WINDOW_OVERFLOW_PATTERNS = (
+    "maximum context length",
+    "context_length_exceeded",
+    "too many tokens",
+    "context length",
+    "input is too long for requested model",
+    "input length and `max_tokens` exceed context limit",
+    "too many total text bytes",
+    "exceed customer model maximum",
+)
+_RATE_LIMIT_PATTERNS = ("rate_limit_exceeded", "rate limit", "too many requests")
 
 
 class _OpenAIResponsesStreamError(RuntimeError):
@@ -451,14 +461,19 @@ class OpenAIResponsesModel(Model):
                 error_message = str(e)
                 error_code = getattr(e, "code", None)
                 normalized_code = error_code.lower() if isinstance(error_code, str) else ""
+                normalized_message = error_message.lower()
+                if (
+                    isinstance(e, openai.RateLimitError)
+                    or normalized_code == "rate_limit_exceeded"
+                    or any(pattern in normalized_message for pattern in _RATE_LIMIT_PATTERNS)
+                ):
+                    logger.warning(_RATE_LIMIT_MSG)
+                    raise ModelThrottledException(error_message) from e
                 if normalized_code == "context_length_exceeded" or any(
-                    pattern in error_message.lower() for pattern in _CONTEXT_WINDOW_OVERFLOW_PATTERNS
+                    pattern in normalized_message for pattern in _CONTEXT_WINDOW_OVERFLOW_PATTERNS
                 ):
                     logger.warning(_CONTEXT_WINDOW_OVERFLOW_MSG)
                     raise ContextWindowOverflowException(error_message) from e
-                if isinstance(e, openai.RateLimitError) or normalized_code == "rate_limit_exceeded":
-                    logger.warning(_RATE_LIMIT_MSG)
-                    raise ModelThrottledException(error_message) from e
                 raise
 
             # Close current content block if we had any

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -61,6 +61,7 @@ from ..types.streaming import StreamEvent  # noqa: E402
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse  # noqa: E402
 from ._defaults import resolve_config_metadata  # noqa: E402
 from ._openai_bedrock import BedrockMantleConfig, resolve_bedrock_client_args  # noqa: E402
+from ._openai_errors import classify_openai_error  # noqa: E402
 from ._validation import validate_config_keys  # noqa: E402
 from .model import BaseModelConfig, Model  # noqa: E402
 
@@ -74,17 +75,6 @@ _MAX_MEDIA_SIZE_LABEL = "20MB"
 _DEFAULT_MIME_TYPE = "application/octet-stream"
 _CONTEXT_WINDOW_OVERFLOW_MSG = "OpenAI Responses API threw context window overflow error"
 _RATE_LIMIT_MSG = "OpenAI Responses API threw rate limit error"
-_CONTEXT_WINDOW_OVERFLOW_PATTERNS = (
-    "maximum context length",
-    "context_length_exceeded",
-    "too many tokens",
-    "context length",
-    "input is too long for requested model",
-    "input length and `max_tokens` exceed context limit",
-    "too many total text bytes",
-    "exceed customer model maximum",
-)
-_RATE_LIMIT_PATTERNS = ("rate_limit_exceeded", "rate limit", "too many requests")
 
 
 class _OpenAIResponsesStreamError(RuntimeError):
@@ -457,24 +447,14 @@ class OpenAIResponsesModel(Model):
                             if hasattr(event, "response") and hasattr(event.response, "usage"):
                                 final_usage = event.response.usage
                             break
-            except (openai.APIError, _OpenAIResponsesStreamError) as e:
-                error_message = str(e)
-                error_code = getattr(e, "code", None)
-                normalized_code = error_code.lower() if isinstance(error_code, str) else ""
-                normalized_message = error_message.lower()
-                if (
-                    isinstance(e, openai.RateLimitError)
-                    or getattr(e, "status_code", None) == 429
-                    or normalized_code == "rate_limit_exceeded"
-                    or any(pattern in normalized_message for pattern in _RATE_LIMIT_PATTERNS)
-                ):
+            except (openai.APIError, _OpenAIResponsesStreamError) as error:
+                error_kind = classify_openai_error(error)
+                if error_kind == "throttling":
                     logger.warning(_RATE_LIMIT_MSG)
-                    raise ModelThrottledException(error_message) from e
-                if normalized_code == "context_length_exceeded" or any(
-                    pattern in normalized_message for pattern in _CONTEXT_WINDOW_OVERFLOW_PATTERNS
-                ):
+                    raise ModelThrottledException(str(error)) from error
+                if error_kind == "context_overflow":
                     logger.warning(_CONTEXT_WINDOW_OVERFLOW_MSG)
-                    raise ContextWindowOverflowException(error_message) from e
+                    raise ContextWindowOverflowException(str(error)) from error
                 raise
 
             # Close current content block if we had any
@@ -535,14 +515,15 @@ class OpenAIResponsesModel(Model):
                 request = self._format_request(prompt, system_prompt=system_prompt)
                 request.pop("stream", None)
                 response = await client.responses.parse(**request, text_format=output_model)
-            except openai.BadRequestError as e:
-                if hasattr(e, "code") and e.code == "context_length_exceeded":
+            except openai.APIError as error:
+                error_kind = classify_openai_error(error)
+                if error_kind == "throttling":
+                    logger.warning(_RATE_LIMIT_MSG)
+                    raise ModelThrottledException(str(error)) from error
+                if error_kind == "context_overflow":
                     logger.warning(_CONTEXT_WINDOW_OVERFLOW_MSG)
-                    raise ContextWindowOverflowException(str(e)) from e
+                    raise ContextWindowOverflowException(str(error)) from error
                 raise
-            except openai.RateLimitError as e:
-                logger.warning(_RATE_LIMIT_MSG)
-                raise ModelThrottledException(str(e)) from e
 
         if response.output_parsed:
             yield {"output": response.output_parsed}

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -74,6 +74,15 @@ _MAX_MEDIA_SIZE_LABEL = "20MB"
 _DEFAULT_MIME_TYPE = "application/octet-stream"
 _CONTEXT_WINDOW_OVERFLOW_MSG = "OpenAI Responses API threw context window overflow error"
 _RATE_LIMIT_MSG = "OpenAI Responses API threw rate limit error"
+_CONTEXT_WINDOW_OVERFLOW_PATTERNS = ("exceed customer model maximum",)
+
+
+class _OpenAIResponsesStreamError(RuntimeError):
+    """Error reported by a terminal OpenAI Responses API stream event."""
+
+    def __init__(self, message: str | None, code: str | None) -> None:
+        super().__init__(message or "OpenAI Responses API response failed")
+        self.code = code
 
 
 def _encode_media_to_data_url(data: bytes, format_ext: str, media_type: str = "image") -> str:
@@ -407,6 +416,17 @@ class OpenAIResponsesModel(Model):
                                         call_info["arguments"] = event.arguments
                                         break
 
+                        elif event.type == "response.failed":
+                            error = getattr(event.response, "error", None)
+                            raise _OpenAIResponsesStreamError(
+                                getattr(error, "message", None), getattr(error, "code", None)
+                            )
+
+                        elif event.type == "error":
+                            raise _OpenAIResponsesStreamError(
+                                getattr(event, "message", None), getattr(event, "code", None)
+                            )
+
                         elif event.type == "response.incomplete":
                             # Response stopped early (e.g., max tokens reached)
                             if hasattr(event, "response"):
@@ -427,13 +447,18 @@ class OpenAIResponsesModel(Model):
                             if hasattr(event, "response") and hasattr(event.response, "usage"):
                                 final_usage = event.response.usage
                             break
-            except openai.APIError as e:
-                if hasattr(e, "code") and e.code == "context_length_exceeded":
+            except (openai.APIError, _OpenAIResponsesStreamError) as e:
+                error_message = str(e)
+                error_code = getattr(e, "code", None)
+                normalized_code = error_code.lower() if isinstance(error_code, str) else ""
+                if normalized_code == "context_length_exceeded" or any(
+                    pattern in error_message.lower() for pattern in _CONTEXT_WINDOW_OVERFLOW_PATTERNS
+                ):
                     logger.warning(_CONTEXT_WINDOW_OVERFLOW_MSG)
-                    raise ContextWindowOverflowException(str(e)) from e
-                if isinstance(e, openai.RateLimitError):
+                    raise ContextWindowOverflowException(error_message) from e
+                if isinstance(e, openai.RateLimitError) or normalized_code == "rate_limit_exceeded":
                     logger.warning(_RATE_LIMIT_MSG)
-                    raise ModelThrottledException(str(e)) from e
+                    raise ModelThrottledException(error_message) from e
                 raise
 
             # Close current content block if we had any

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -464,6 +464,7 @@ class OpenAIResponsesModel(Model):
                 normalized_message = error_message.lower()
                 if (
                     isinstance(e, openai.RateLimitError)
+                    or getattr(e, "status_code", None) == 429
                     or normalized_code == "rate_limit_exceeded"
                     or any(pattern in normalized_message for pattern in _RATE_LIMIT_PATTERNS)
                 ):

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -2,6 +2,7 @@ import logging
 import os
 import unittest.mock
 
+import httpx
 import openai
 import pydantic
 import pytest
@@ -1422,6 +1423,8 @@ async def test_stream_context_overflow_exception(openai_client, model, messages)
         "Input is too long for requested model",
         "input length and `max_tokens` exceed context limit",
         "too many total text bytes",
+        "prompt tokens exceed customer model maximum",
+        "MAXIMUM CONTEXT LENGTH EXCEEDED",
     ],
 )
 async def test_stream_alternative_context_overflow_messages(openai_client, model, messages, error_message):
@@ -1453,6 +1456,8 @@ async def test_stream_alternative_context_overflow_messages(openai_client, model
         "Input is too long for requested model",
         "input length and `max_tokens` exceed context limit",
         "too many total text bytes",
+        "prompt tokens exceed customer model maximum",
+        "MAXIMUM CONTEXT LENGTH EXCEEDED",
     ],
 )
 async def test_structured_output_alternative_context_overflow_messages(
@@ -1522,6 +1527,75 @@ async def test_stream_other_bad_request_errors_passthrough(openai_client, model,
 
     # Verify the original exception is raised, not ContextWindowOverflowException
     assert exc_info.value == mock_error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mock_error", "expected_exception"),
+    [
+        (
+            openai.APIStatusError(
+                "opaque provider failure",
+                response=httpx.Response(
+                    429,
+                    request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+                ),
+                body=None,
+            ),
+            ModelThrottledException,
+        ),
+        (
+            openai.APIError(
+                message="prompt tokens exceed customer model maximum",
+                request=unittest.mock.MagicMock(),
+                body=None,
+            ),
+            ContextWindowOverflowException,
+        ),
+    ],
+)
+async def test_stream_classifies_error_during_iteration(openai_client, model, messages, mock_error, expected_exception):
+    async def error_generator():
+        yield unittest.mock.Mock(choices=[])
+        raise mock_error
+
+    openai_client.chat.completions.create = unittest.mock.AsyncMock(return_value=error_generator())
+
+    with pytest.raises(expected_exception) as exc_info:
+        async for _ in model.stream(messages):
+            pass
+
+    assert exc_info.value.__cause__ is mock_error
+
+
+@pytest.mark.asyncio
+async def test_stream_http_429_as_throttle(openai_client, model, messages):
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(429, request=request)
+    mock_error = openai.APIStatusError("opaque provider failure", response=response, body=None)
+    openai_client.chat.completions.create.side_effect = mock_error
+
+    with pytest.raises(ModelThrottledException, match="opaque provider failure") as exc_info:
+        async for _ in model.stream(messages):
+            pass
+
+    assert exc_info.value.__cause__ is mock_error
+
+
+@pytest.mark.asyncio
+async def test_structured_output_rate_limit_message(openai_client, model, messages, test_output_model_cls):
+    mock_error = openai.APIError(
+        message="Too many requests from provider",
+        request=unittest.mock.MagicMock(),
+        body={"error": {"message": "Too many requests from provider"}},
+    )
+    openai_client.beta.chat.completions.parse.side_effect = mock_error
+
+    with pytest.raises(ModelThrottledException, match="Too many requests") as exc_info:
+        async for _ in model.structured_output(test_output_model_cls, messages):
+            pass
+
+    assert exc_info.value.__cause__ is mock_error
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_openai_errors.py
+++ b/strands-py/tests/strands/models/test_openai_errors.py
@@ -21,6 +21,7 @@ class OpenAICompatibleError(Exception):
         "input length and `max_tokens` exceed context limit",
         "too many total text bytes",
         "exceed customer model maximum",
+        "the engine prompt length exceeds the max_model_len",
     ],
 )
 def test_classify_openai_error_context_overflow_message(message):

--- a/strands-py/tests/strands/models/test_openai_errors.py
+++ b/strands-py/tests/strands/models/test_openai_errors.py
@@ -1,0 +1,70 @@
+import pytest
+
+from strands.models._openai_errors import classify_openai_error
+
+
+class OpenAICompatibleError(Exception):
+    def __init__(self, message: str, *, code: object = None, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "maximum context length",
+        "context_length_exceeded",
+        "too many tokens",
+        "context length",
+        "input is too long for requested model",
+        "input length and `max_tokens` exceed context limit",
+        "too many total text bytes",
+        "exceed customer model maximum",
+    ],
+)
+def test_classify_openai_error_context_overflow_message(message):
+    assert classify_openai_error(OpenAICompatibleError(message)) == "context_overflow"
+
+
+def test_classify_openai_error_message_case_insensitive():
+    assert classify_openai_error(OpenAICompatibleError("MAXIMUM CONTEXT LENGTH EXCEEDED")) == "context_overflow"
+
+
+def test_classify_openai_error_context_overflow_code():
+    error = OpenAICompatibleError("provider failure", code="CONTEXT_LENGTH_EXCEEDED")
+
+    assert classify_openai_error(error) == "context_overflow"
+
+
+@pytest.mark.parametrize("message", ["rate_limit_exceeded", "rate limit", "too many requests"])
+def test_classify_openai_error_throttling_message(message):
+    assert classify_openai_error(OpenAICompatibleError(message)) == "throttling"
+
+
+def test_classify_openai_error_throttling_code():
+    error = OpenAICompatibleError("provider failure", code="RATE_LIMIT_EXCEEDED")
+
+    assert classify_openai_error(error) == "throttling"
+
+
+def test_classify_openai_error_http_429():
+    error = OpenAICompatibleError("provider failure", status_code=429)
+
+    assert classify_openai_error(error) == "throttling"
+
+
+def test_classify_openai_error_throttling_precedes_context_overflow():
+    error = OpenAICompatibleError("exceed customer model maximum", code="rate_limit_exceeded")
+
+    assert classify_openai_error(error) == "throttling"
+
+
+def test_classify_openai_error_unknown():
+    assert classify_openai_error(OpenAICompatibleError("unrelated failure")) is None
+
+
+def test_classify_openai_error_non_string_code():
+    error = OpenAICompatibleError("unrelated failure", code=400)
+
+    assert classify_openai_error(error) is None

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -2,6 +2,7 @@ import logging
 import os
 import unittest.mock
 
+import httpx
 import openai
 import pydantic
 import pytest
@@ -1169,6 +1170,20 @@ async def test_stream_context_overflow_exception_api_error_type(openai_client, m
 
     assert "maximum context length" in str(exc_info.value)
     assert exc_info.value.__cause__ == mock_error
+
+
+@pytest.mark.asyncio
+async def test_stream_http_429_as_throttle(openai_client, model, messages):
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    response = httpx.Response(429, request=request)
+    error = openai.APIStatusError("opaque provider failure", response=response, body=None)
+    openai_client.responses.create.side_effect = error
+
+    with pytest.raises(ModelThrottledException, match="opaque provider failure") as exc_info:
+        async for _ in model.stream(messages):
+            pass
+
+    assert exc_info.value.__cause__ is error
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1044,6 +1044,57 @@ async def test_structured_output_forwards_request_params(openai_client, model_id
 
 
 @pytest.mark.asyncio
+async def test_stream_response_failed_raises_provider_error(openai_client, model, messages, agenerator):
+    error = unittest.mock.Mock(message="The model failed while processing the request.", code="server_error")
+    failed_event = unittest.mock.Mock(type="response.failed", response=unittest.mock.Mock(error=error))
+    openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([failed_event]))
+
+    with pytest.raises(RuntimeError, match="The model failed while processing the request") as exc_info:
+        async for _ in model.stream(messages):
+            pass
+
+    assert exc_info.value.code == "server_error"
+
+
+@pytest.mark.asyncio
+async def test_stream_response_failed_context_overflow(openai_client, model, messages, agenerator):
+    message = "prompt tokens (320666) exceed customer model maximum (278528) for model-id"
+    error = unittest.mock.Mock(message=message, code="invalid_prompt")
+    failed_event = unittest.mock.Mock(type="response.failed", response=unittest.mock.Mock(error=error))
+    openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([failed_event]))
+
+    with pytest.raises(ContextWindowOverflowException, match="exceed customer model maximum") as exc_info:
+        async for _ in model.stream(messages):
+            pass
+
+    assert exc_info.value.__cause__.code == "invalid_prompt"
+
+
+@pytest.mark.asyncio
+async def test_stream_response_failed_without_error_details(openai_client, model, messages, agenerator):
+    failed_event = unittest.mock.Mock(type="response.failed", response=unittest.mock.Mock(error=None))
+    openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([failed_event]))
+
+    with pytest.raises(RuntimeError, match="OpenAI Responses API response failed"):
+        async for _ in model.stream(messages):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_stream_error_event_as_throttle(openai_client, model, messages, agenerator):
+    error_event = unittest.mock.Mock(
+        type="error", code="rate_limit_exceeded", message="Rate limit exceeded while streaming."
+    )
+    openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([error_event]))
+
+    with pytest.raises(ModelThrottledException, match="Rate limit exceeded while streaming") as exc_info:
+        async for _ in model.stream(messages):
+            pass
+
+    assert exc_info.value.__cause__.code == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
 async def test_stream_context_overflow_exception(openai_client, model, messages):
     """Test that OpenAI context overflow errors are properly converted to ContextWindowOverflowException."""
     mock_error = openai.BadRequestError(

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1291,6 +1291,39 @@ async def test_structured_output_context_overflow_exception(openai_client, model
 
 
 @pytest.mark.asyncio
+async def test_structured_output_context_overflow_message(openai_client, model, messages, test_output_model_cls):
+    message = "prompt tokens exceed customer model maximum"
+    mock_error = openai.APIError(
+        message=message,
+        request=unittest.mock.MagicMock(),
+        body={"error": {"message": message}},
+    )
+    openai_client.responses.parse.side_effect = mock_error
+
+    with pytest.raises(ContextWindowOverflowException, match="exceed customer model maximum") as exc_info:
+        async for _ in model.structured_output(test_output_model_cls, messages):
+            pass
+
+    assert exc_info.value.__cause__ is mock_error
+
+
+@pytest.mark.asyncio
+async def test_structured_output_rate_limit_message(openai_client, model, messages, test_output_model_cls):
+    mock_error = openai.APIError(
+        message="Too many requests from provider",
+        request=unittest.mock.MagicMock(),
+        body={"error": {"message": "Too many requests from provider"}},
+    )
+    openai_client.responses.parse.side_effect = mock_error
+
+    with pytest.raises(ModelThrottledException, match="Too many requests") as exc_info:
+        async for _ in model.structured_output(test_output_model_cls, messages):
+            pass
+
+    assert exc_info.value.__cause__ is mock_error
+
+
+@pytest.mark.asyncio
 async def test_structured_output_rate_limit_as_throttle(openai_client, model, messages, test_output_model_cls):
     """Test that structured output handles rate limit errors properly."""
     mock_error = openai.RateLimitError(

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -5,6 +5,8 @@ import unittest.mock
 import openai
 import pydantic
 import pytest
+from openai.types.responses import Response, ResponseErrorEvent, ResponseFailedEvent
+from openai.types.responses.response_error import ResponseError
 
 import strands
 from strands.models.openai_responses import _MAX_MEDIA_SIZE_BYTES, OpenAIResponsesModel
@@ -1045,8 +1047,10 @@ async def test_structured_output_forwards_request_params(openai_client, model_id
 
 @pytest.mark.asyncio
 async def test_stream_response_failed_raises_provider_error(openai_client, model, messages, agenerator):
-    error = unittest.mock.Mock(message="The model failed while processing the request.", code="server_error")
-    failed_event = unittest.mock.Mock(type="response.failed", response=unittest.mock.Mock(error=error))
+    error = ResponseError(message="The model failed while processing the request.", code="server_error")
+    failed_event = ResponseFailedEvent.model_construct(
+        type="response.failed", sequence_number=1, response=Response.model_construct(error=error)
+    )
     openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([failed_event]))
 
     with pytest.raises(RuntimeError, match="The model failed while processing the request") as exc_info:
@@ -1059,8 +1063,10 @@ async def test_stream_response_failed_raises_provider_error(openai_client, model
 @pytest.mark.asyncio
 async def test_stream_response_failed_context_overflow(openai_client, model, messages, agenerator):
     message = "prompt tokens (320666) exceed customer model maximum (278528) for model-id"
-    error = unittest.mock.Mock(message=message, code="invalid_prompt")
-    failed_event = unittest.mock.Mock(type="response.failed", response=unittest.mock.Mock(error=error))
+    error = ResponseError(message=message, code="invalid_prompt")
+    failed_event = ResponseFailedEvent.model_construct(
+        type="response.failed", sequence_number=1, response=Response.model_construct(error=error)
+    )
     openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([failed_event]))
 
     with pytest.raises(ContextWindowOverflowException, match="exceed customer model maximum") as exc_info:
@@ -1071,8 +1077,23 @@ async def test_stream_response_failed_context_overflow(openai_client, model, mes
 
 
 @pytest.mark.asyncio
+async def test_stream_response_failed_existing_context_pattern(openai_client, model, messages, agenerator):
+    error = ResponseError(message="This model's maximum context length is 4096 tokens.", code="invalid_prompt")
+    failed_event = ResponseFailedEvent.model_construct(
+        type="response.failed", sequence_number=1, response=Response.model_construct(error=error)
+    )
+    openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([failed_event]))
+
+    with pytest.raises(ContextWindowOverflowException, match="maximum context length"):
+        async for _ in model.stream(messages):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_stream_response_failed_without_error_details(openai_client, model, messages, agenerator):
-    failed_event = unittest.mock.Mock(type="response.failed", response=unittest.mock.Mock(error=None))
+    failed_event = ResponseFailedEvent.model_construct(
+        type="response.failed", sequence_number=1, response=Response.model_construct(error=None)
+    )
     openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([failed_event]))
 
     with pytest.raises(RuntimeError, match="OpenAI Responses API response failed"):
@@ -1081,9 +1102,10 @@ async def test_stream_response_failed_without_error_details(openai_client, model
 
 
 @pytest.mark.asyncio
-async def test_stream_error_event_as_throttle(openai_client, model, messages, agenerator):
-    error_event = unittest.mock.Mock(
-        type="error", code="rate_limit_exceeded", message="Rate limit exceeded while streaming."
+@pytest.mark.parametrize("code", ["rate_limit_exceeded", None])
+async def test_stream_error_event_as_throttle(openai_client, model, messages, agenerator, code):
+    error_event = ResponseErrorEvent(
+        type="error", sequence_number=1, code=code, message="Rate limit exceeded while streaming."
     )
     openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([error_event]))
 
@@ -1091,7 +1113,22 @@ async def test_stream_error_event_as_throttle(openai_client, model, messages, ag
         async for _ in model.stream(messages):
             pass
 
-    assert exc_info.value.__cause__.code == "rate_limit_exceeded"
+    assert exc_info.value.__cause__.code == code
+
+
+@pytest.mark.asyncio
+async def test_stream_throttle_precedes_context_overflow(openai_client, model, messages, agenerator):
+    error_event = ResponseErrorEvent(
+        type="error",
+        sequence_number=1,
+        code="rate_limit_exceeded",
+        message="prompt tokens exceed customer model maximum",
+    )
+    openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator([error_event]))
+
+    with pytest.raises(ModelThrottledException, match="exceed customer model maximum"):
+        async for _ in model.stream(messages):
+            pass
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests_integ/models/test_model_mantle.py
+++ b/strands-py/tests_integ/models/test_model_mantle.py
@@ -49,6 +49,30 @@ def test_agent_invoke(model):
     assert "4" in str(result) or "four" in str(result).lower()
 
 
+def test_responses_context_overflow_recovers(model):
+    """Agent context management recovers from a live Mantle Responses overflow."""
+    messages = [
+        {"role": "user", "content": [{"text": "test " * 150_000}]},
+        {"role": "assistant", "content": [{"text": "That was a long prompt."}]},
+        {"role": "user", "content": [{"text": "What is 2+2?"}]},
+    ]
+    events = []
+    agent = Agent(
+        model=model,
+        messages=messages,
+        system_prompt="Reply with only the number.",
+        callback_handler=lambda **event: events.append(event),
+    )
+
+    result = agent()
+
+    assert "4" in str(result)
+    assert len(agent.messages) == 2
+    chunks = [event["event"] for event in events if "event" in event]
+    assert sum("messageStart" in chunk for chunk in chunks) == 2
+    assert sum("messageStop" in chunk for chunk in chunks) == 1
+
+
 def test_responses_server_side_conversation(stateful_model):
     agent = Agent(model=stateful_model, system_prompt="Reply in one short sentence.", callback_handler=None)
 


### PR DESCRIPTION
TL;DR: Ports #3290 to Python so terminal Responses failures are surfaced and OpenAI error classification is shared across Chat Completions and Responses.

`response.failed` and `error` events now preserve provider messages/codes. A shared private classifier mirrors TS `errors.ts` and is used by both Python OpenAI models for streaming and structured output, including failures raised during chat stream iteration. A live Bedrock Mantle integration test now forces overflow and verifies Agent context reduction recovers.

<details><summary>Translation and validation evidence</summary>

## Source

- TypeScript source PR: #3290
- Merged source commit: `3c234b2feb5892a4568929662e87e6ba6cdda00d`
- Source test diff accounting: **5 test changes** — one new case in an existing parameterized classifier test and four new Responses tests. All five map below; **0 `missing-behavior` entries**.

## Behavior traceability

| Source test changed/added by #3290 | Target Python test | Result |
|---|---|---|
| `classifies overflow phrase %p as contextOverflow` — Mantle case added at [`errors.test.ts:5-16`](https://github.com/strands-agents/harness-sdk/blob/3c234b2feb5892a4568929662e87e6ba6cdda00d/strands-ts/src/models/openai/__tests__/errors.test.ts#L5-L16) | `test_classify_openai_error_context_overflow_message` — [`test_openai_errors.py:13-28`](https://github.com/strands-agents/harness-sdk/blob/9731b5f3ee6fed0b7db646242b53c12286445819/strands-py/tests/strands/models/test_openai_errors.py#L13-L28) | PASS |
| `throws response.failed instead of finalizing an empty successful response` — [`responses.test.ts:733-754`](https://github.com/strands-agents/harness-sdk/blob/3c234b2feb5892a4568929662e87e6ba6cdda00d/strands-ts/src/models/openai/__tests__/responses.test.ts#L733-L754) | `test_stream_response_failed_raises_provider_error` — [`test_openai_responses.py:1049-1061`](https://github.com/strands-agents/harness-sdk/blob/9731b5f3ee6fed0b7db646242b53c12286445819/strands-py/tests/strands/models/test_openai_responses.py#L1049-L1061) | PASS |
| `wraps a response.failed context limit as ContextWindowOverflowError` — [`responses.test.ts:756-773`](https://github.com/strands-agents/harness-sdk/blob/3c234b2feb5892a4568929662e87e6ba6cdda00d/strands-ts/src/models/openai/__tests__/responses.test.ts#L756-L773) | `test_stream_response_failed_context_overflow` — [`test_openai_responses.py:1064-1077`](https://github.com/strands-agents/harness-sdk/blob/9731b5f3ee6fed0b7db646242b53c12286445819/strands-py/tests/strands/models/test_openai_responses.py#L1064-L1077) | PASS |
| `throws the fallback message when response.failed has no error details` — [`responses.test.ts:775-787`](https://github.com/strands-agents/harness-sdk/blob/3c234b2feb5892a4568929662e87e6ba6cdda00d/strands-ts/src/models/openai/__tests__/responses.test.ts#L775-L787) | `test_stream_response_failed_without_error_details` — [`test_openai_responses.py:1093-1102`](https://github.com/strands-agents/harness-sdk/blob/9731b5f3ee6fed0b7db646242b53c12286445819/strands-py/tests/strands/models/test_openai_responses.py#L1093-L1102) | PASS |
| `maps a Responses error event through the existing error classifier` — [`responses.test.ts:789-802`](https://github.com/strands-agents/harness-sdk/blob/3c234b2feb5892a4568929662e87e6ba6cdda00d/strands-ts/src/models/openai/__tests__/responses.test.ts#L789-L802) | `test_stream_error_event_as_throttle` — [`test_openai_responses.py:1105-1117`](https://github.com/strands-agents/harness-sdk/blob/9731b5f3ee6fed0b7db646242b53c12286445819/strands-py/tests/strands/models/test_openai_responses.py#L1105-L1117) | PASS |

Additional parity coverage locks in case-insensitive matching, non-string codes, throttle-before-overflow precedence, generic HTTP 429, Chat stream-iteration failures, both structured-output paths, and unknown-error passthrough.

## Live regression test

[`test_responses_context_overflow_recovers`](https://github.com/strands-agents/harness-sdk/blob/9731b5f3ee6fed0b7db646242b53c12286445819/strands-py/tests_integ/models/test_model_mantle.py#L52-L73) calls live `openai.gpt-oss-120b` through Bedrock Mantle with an oversized Responses prompt. The current endpoint emits:

```text
The engine prompt length 150091 exceeds the max_model_len 131072. Please reduce prompt.
```

The test verifies that this terminal failure is classified as context overflow, the default conversation manager removes the oversized turn, the retry answers the retained `2+2` prompt, and the final history has exactly the retained user/assistant pair. The live wording required adding the provider-observed `exceeds the max_model_len` classifier phrase.

```text
tests_integ/models/test_model_mantle.py::test_responses_context_overflow_recovers PASSED
5 passed in 8.50s
```

No AWS resources were created.

## Structural map

- TS `models/openai/errors.ts` → Python `models/_openai_errors.py`
- TS `classifyOpenAIError` → Python `classify_openai_error`
- TS Responses terminal-event branches → Python `response.failed` / `error` branches
- Shared classifier consumers → Python Chat + Responses, stream + structured output

## Captured validation output

```text
252 passed in 2.44s
4635 passed, 38 warnings in 50.42s
5 live Mantle integration tests passed in 8.50s
All checks passed!
Success: no issues found in 227 source files
3 changed files already formatted
```

Independent port validator: **PASS**. Final independent reviewer: **approved, no findings**.

## Decision log

- Kept the Responses terminal-event exception private while preserving provider message/code.
- Matched source ordering: throttling before context overflow.
- Centralized patterns rather than adding another provider-local copy.
- Applied the shared helper to both structured-output paths, addressing the review's non-blocking consistency note.
- Expanded Chat's classifier boundary over async iteration to match TS stream behavior.
- Added a live recovery test rather than only asserting the exception type, proving context management retries successfully.

## Dependencies / sensitive surface

- No new dependencies.
- No new credential, filesystem, subprocess, deserialization, or network behavior outside the existing live Mantle integration suite.

## Open questions

None.

</details>