### PR TITLE
feat(model-routing): thread per-call model through InvokeModelStage

### DIFF
--- a/strands-py/src/strands/_context_manager/modes/agentic/agentic_context.py
+++ b/strands-py/src/strands/_context_manager/modes/agentic/agentic_context.py
@@ -8,7 +8,7 @@ so it can decide when to compress.
 
 import logging
 from dataclasses import replace
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from ...._middleware.stages import InvokeModelContext
 from ...._middleware.types import MiddlewareInputHandler
@@ -25,9 +25,6 @@ from ....tools.decorator import tool
 from ....types.content import Message, _ensure_tracking_id
 from ....types.exceptions import ContextWindowOverflowException
 from ....types.tools import ToolContext
-
-if TYPE_CHECKING:
-    from ....models.model import Model
 
 logger = logging.getLogger(__name__)
 
@@ -286,15 +283,13 @@ def _matches_pin_filter(message: Message, filter: Literal["user", "assistant", "
     return True  # type: ignore[unreachable]
 
 
-def create_token_usage_middleware(model: "Model") -> MiddlewareInputHandler:
+def create_token_usage_middleware() -> MiddlewareInputHandler:
     """Create middleware that appends a ``<context-status>`` block to the last message.
 
-    The block reports projected input-token usage against the model's context window limit so the
-    model can decide when to compress. The original messages are not mutated; the last message is
-    copied and the status text appended to the copy.
-
-    Args:
-        model: The model whose context window limit is reported.
+    The block reports projected input-token usage against the context window limit of the
+    model that will actually handle the call (``context.model``), so guidance stays correct
+    even when middleware has redirected the call to a different model. The original messages
+    are not mutated; the last message is copied and the status text appended to the copy.
 
     Returns:
         An async ``MiddlewareInputHandler`` for the ``InvokeModelStage.Input`` phase.
@@ -305,7 +300,7 @@ def create_token_usage_middleware(model: "Model") -> MiddlewareInputHandler:
         if projected_input_tokens is None:
             return context
 
-        context_window_limit = model.context_window_limit or DEFAULT_CONTEXT_WINDOW_LIMIT
+        context_window_limit = context.model.context_window_limit or DEFAULT_CONTEXT_WINDOW_LIMIT
         remaining = max(0, context_window_limit - projected_input_tokens)
         percent_used = (projected_input_tokens / context_window_limit) * 100
 

--- a/strands-py/src/strands/_middleware/README.md
+++ b/strands-py/src/strands/_middleware/README.md
@@ -170,6 +170,13 @@ short-circuiting before the chain. `ExecuteToolContext.tool` is therefore `Agent
 
 Context fields (`messages`, `system_prompt`, `tool_specs`, `tool_choice`) are deep-copied when building the middleware context. `invocation_state` is shared by reference. `model_state` is excluded from the context entirely — middleware cannot access or modify it. The terminal reads it directly from the agent at invocation time.
 
+## Per-call model
+
+`InvokeModelContext.model` is the model the terminal invokes, initialized from `agent.model`. Middleware can point a single call at a different model via `replace()`, without mutating agent state; the terminal streams `context.model`, so the replacement also drives the trace span's `model_id`:
+```python
+modified = replace(context, model=other_model)
+```
+
 ## Context transformation
 
 Middleware creates modified contexts via `dataclasses.replace()`:

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -23,12 +23,11 @@ if TYPE_CHECKING:
 class InvokeModelContext:
     """Context passed to InvokeModelStage middleware.
 
-    All collection fields (messages, system_prompt, tool_specs, tool_choice) are
-    defensive copies — middleware cannot accidentally mutate agent state.
-    invocation_state is shared by reference (hooks and tools write to it during streaming).
-
-    ``model`` is the model this call invokes; it starts as ``agent.model`` and middleware
-    may replace it per call.
+    The collection fields (messages, system_prompt, tool_specs, tool_choice) are defensive
+    copies, so middleware cannot accidentally mutate agent state. ``invocation_state`` and
+    ``model`` are instead shared by reference: ``invocation_state`` is the live dict hooks and
+    tools write to during streaming, and ``model`` is the model this call invokes (it starts
+    as ``agent.model``; middleware may replace it per call).
     """
 
     agent: Agent

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -27,9 +27,8 @@ class InvokeModelContext:
     defensive copies — middleware cannot accidentally mutate agent state.
     invocation_state is shared by reference (hooks and tools write to it during streaming).
 
-    ``model`` is the concrete model the terminal will invoke. It defaults to
-    ``agent.model``; middleware (e.g. model routing) may replace it to redirect a single
-    call without mutating shared agent state.
+    ``model`` is the model this call invokes; it starts as ``agent.model`` and middleware
+    may replace it per call.
     """
 
     agent: Agent

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from ..agent.agent import Agent
     from ..experimental.bidi import BidiAgent
     from ..interrupt import _InterruptState
+    from ..models.model import Model
     from ..types._events import ModelStopReason, ToolResultEvent, TypedEvent
     from ..types.content import Messages, SystemPrompt
     from ..types.tools import AgentTool, ToolChoice, ToolSpec, ToolUse
@@ -25,6 +26,10 @@ class InvokeModelContext:
     All collection fields (messages, system_prompt, tool_specs, tool_choice) are
     defensive copies — middleware cannot accidentally mutate agent state.
     invocation_state is shared by reference (hooks and tools write to it during streaming).
+
+    ``model`` is the concrete model the terminal will invoke. It defaults to
+    ``agent.model``; middleware (e.g. model routing) may replace it to redirect a single
+    call without mutating shared agent state.
     """
 
     agent: Agent
@@ -33,6 +38,7 @@ class InvokeModelContext:
     tool_specs: list[ToolSpec]
     tool_choice: ToolChoice | None
     invocation_state: dict[str, Any]
+    model: Model
     projected_input_tokens: int | None = None
 
 

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -411,7 +411,7 @@ class Agent(AgentBase):
             from .._context_manager.modes.agentic.agentic_context import create_token_usage_middleware
             from .._middleware.stages import InvokeModelStage
 
-            self._middleware_registry.add_middleware(InvokeModelStage.Input, create_token_usage_middleware(self.model))
+            self._middleware_registry.add_middleware(InvokeModelStage.Input, create_token_usage_middleware())
 
         self._plugin_registry = _PluginRegistry(self)
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -537,6 +537,7 @@ async def _handle_model_execution(
                 tool_specs=copy.deepcopy(tool_specs),
                 tool_choice=copy.deepcopy(structured_output_context.tool_choice),
                 invocation_state=invocation_state,
+                model=agent.model,
                 projected_input_tokens=projected_input_tokens,
             )
 
@@ -559,8 +560,7 @@ async def _handle_model_execution(
 
             if last_event is None:
                 raise RuntimeError(
-                    "Middleware chain did not yield a result event. "
-                    "Ensure middleware forwards events from next()."
+                    "Middleware chain did not yield a result event. Ensure middleware forwards events from next()."
                 )
 
             # Write the post-stream model state back to the agent. Skipped on error
@@ -663,7 +663,7 @@ def _make_invoke_model_terminal(
     async def terminal(ctx: InvokeModelContext) -> AsyncGenerator[Any, None]:
         system_prompt_str, system_prompt_content = split_system_prompt(ctx.system_prompt)
 
-        model_id = agent.model.config.get("model_id") if hasattr(agent.model, "config") else None
+        model_id = ctx.model.config.get("model_id") if hasattr(ctx.model, "config") else None
         model_invoke_span = tracer.start_model_invoke_span(
             messages=ctx.messages,
             parent_span=cycle_span,
@@ -675,7 +675,7 @@ def _make_invoke_model_terminal(
         with trace_api.use_span(model_invoke_span, end_on_exit=False):
             try:
                 async for event in stream_messages(
-                    agent.model,
+                    ctx.model,
                     system_prompt_str,
                     ctx.messages,
                     ctx.tool_specs,

--- a/strands-py/tests/strands/agent/conversation_manager/test_token_usage_middleware.py
+++ b/strands-py/tests/strands/agent/conversation_manager/test_token_usage_middleware.py
@@ -25,6 +25,7 @@ def make_context(**overrides) -> InvokeModelContext:
         tool_specs=[],
         tool_choice=None,
         invocation_state={},
+        model=Mock(),
     )
     defaults.update(overrides)
     return InvokeModelContext(**defaults)

--- a/strands-py/tests/strands/agent/conversation_manager/test_token_usage_middleware.py
+++ b/strands-py/tests/strands/agent/conversation_manager/test_token_usage_middleware.py
@@ -25,7 +25,7 @@ def make_context(**overrides) -> InvokeModelContext:
         tool_specs=[],
         tool_choice=None,
         invocation_state={},
-        model=Mock(),
+        model=mock_model(200_000),
     )
     defaults.update(overrides)
     return InvokeModelContext(**defaults)
@@ -34,7 +34,7 @@ def make_context(**overrides) -> InvokeModelContext:
 @pytest.mark.asyncio
 class TestCreateTokenUsageMiddleware:
     async def test_returns_context_unchanged_when_projected_tokens_not_set(self):
-        middleware = create_token_usage_middleware(mock_model(200_000))
+        middleware = create_token_usage_middleware()
         context = make_context()
 
         result = await middleware(context)
@@ -42,7 +42,7 @@ class TestCreateTokenUsageMiddleware:
         assert result is context
 
     async def test_returns_context_unchanged_when_messages_are_empty(self):
-        middleware = create_token_usage_middleware(mock_model(200_000))
+        middleware = create_token_usage_middleware()
         context = make_context(messages=[], projected_input_tokens=50_000)
 
         result = await middleware(context)
@@ -50,8 +50,8 @@ class TestCreateTokenUsageMiddleware:
         assert result is context
 
     async def test_appends_context_status_to_last_message_content(self):
-        middleware = create_token_usage_middleware(mock_model(200_000))
-        context = make_context(projected_input_tokens=50_000)
+        middleware = create_token_usage_middleware()
+        context = make_context(model=mock_model(200_000), projected_input_tokens=50_000)
 
         result = await middleware(context)
 
@@ -64,8 +64,19 @@ class TestCreateTokenUsageMiddleware:
         assert "<remaining>" in status_text
         assert "</context-status>" in status_text
 
+    async def test_uses_the_effective_context_model_limit_not_a_captured_default(self):
+        # guards against reporting the agent's default-model window for a redirected call
+        middleware = create_token_usage_middleware()
+        context = make_context(model=mock_model(10_000), projected_input_tokens=8_000)
+
+        result = await middleware(context)
+
+        status_text = result.messages[0]["content"][1]["text"]
+        assert "8,000 / 10,000 tokens (80.0%)" in status_text
+        assert "<remaining>~2,000 tokens</remaining>" in status_text
+
     async def test_does_not_mutate_the_original_messages(self):
-        middleware = create_token_usage_middleware(mock_model(200_000))
+        middleware = create_token_usage_middleware()
         original_message: Message = {"role": "user", "content": [{"text": "hello"}]}
         context = make_context(messages=[original_message], projected_input_tokens=50_000)
 
@@ -75,8 +86,8 @@ class TestCreateTokenUsageMiddleware:
         assert len(original_message["content"]) == 1
 
     async def test_uses_default_context_window_limit_when_model_has_no_limit(self):
-        middleware = create_token_usage_middleware(mock_model(None))
-        context = make_context(projected_input_tokens=100_000)
+        middleware = create_token_usage_middleware()
+        context = make_context(model=mock_model(None), projected_input_tokens=100_000)
 
         result = await middleware(context)
 
@@ -86,7 +97,7 @@ class TestCreateTokenUsageMiddleware:
         assert "200,000" in status_text
 
     async def test_preserves_message_metadata(self):
-        middleware = create_token_usage_middleware(mock_model(200_000))
+        middleware = create_token_usage_middleware()
         metadata = {"usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15}}
         context = make_context(
             messages=[{"role": "user", "content": [{"text": "hello"}], "metadata": metadata}],
@@ -98,8 +109,8 @@ class TestCreateTokenUsageMiddleware:
         assert result.messages[0]["metadata"] == metadata
 
     async def test_reports_correct_remaining_tokens(self):
-        middleware = create_token_usage_middleware(mock_model(100_000))
-        context = make_context(projected_input_tokens=80_000)
+        middleware = create_token_usage_middleware()
+        context = make_context(model=mock_model(100_000), projected_input_tokens=80_000)
 
         result = await middleware(context)
 

--- a/strands-py/tests/strands/injection/test_message_injection.py
+++ b/strands-py/tests/strands/injection/test_message_injection.py
@@ -51,6 +51,7 @@ def invoke_ctx(messages: list[dict], agent: Any = None) -> InvokeModelContext:
         tool_specs=[],
         tool_choice=None,
         invocation_state={},
+        model=MagicMock(),
     )
 
 

--- a/strands-py/tests/strands/memory/test_memory_manager.py
+++ b/strands-py/tests/strands/memory/test_memory_manager.py
@@ -1192,6 +1192,7 @@ def _invoke_ctx(messages: list[dict], agent: Any) -> Any:
         tool_specs=[],
         tool_choice=None,
         invocation_state={},
+        model=getattr(agent, "model", None),
     )
 
 

--- a/strands-py/tests/strands/middleware/test_agent_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_middleware.py
@@ -720,3 +720,38 @@ def test_retry_on_error_use_case():
     result = agent("test")
     assert result.message["content"][0]["text"] == "Success!"
     assert call_count == 3
+
+
+# --- per-call model on context (routing plumbing) ---
+
+
+def test_invoke_model_context_exposes_agent_model(agent):
+    """InvokeModelContext.model defaults to agent.model."""
+    captured: list = []
+
+    async def capture(context, next_fn):
+        captured.append(context.model)
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, capture)
+    agent("test")
+
+    assert captured == [agent.model]
+
+
+def test_terminal_streams_context_model_override():
+    """The terminal streams the model set on the context, not agent.model."""
+    model_a = MockedModelProvider([{"role": "assistant", "content": [{"text": "A"}]}])
+    model_b = MockedModelProvider([{"role": "assistant", "content": [{"text": "B"}]}])
+    agent = Agent(model=model_a, callback_handler=None)
+    model_a.stream = AsyncMock(wraps=model_a.stream)
+
+    def route_to_b(context):
+        return replace(context, model=model_b)
+
+    agent._middleware_registry.add_middleware(InvokeModelStage.Input, route_to_b)
+    result = agent("test")
+
+    assert result.message["content"][0]["text"] == "B"
+    model_a.stream.assert_not_called()

--- a/strands-py/tests/strands/vended_plugins/context_injector/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_injector/test_plugin.py
@@ -40,6 +40,7 @@ def invoke_ctx(messages: list[dict], agent: Any) -> InvokeModelContext:
         tool_specs=[],
         tool_choice=None,
         invocation_state={},
+        model=MagicMock(),
     )
 
 


### PR DESCRIPTION
## Description

First slice of model routing (design in `team/designs/0016-model-routing.md`): the per-call model plumbing that later routing middleware builds on.

`InvokeModelStage`'s terminal previously read `agent.model` directly, so nothing could redirect an individual model call without mutating shared agent state (unsafe under concurrent invocations). This PR threads the model to invoke through the middleware context instead:

- `InvokeModelContext` gains a required `model: Model`, initialized from `agent.model`.
- The invoke-model terminal streams `ctx.model` (and reads its `model_id` for the span) rather than `agent.model`.

No behavior change for existing single-model agents. This is intentionally a standalone, inert seam; the `ModelRouter` type and strategies land in follow-up PRs.

## Related Issues

Refs #364

## Type of Change

New feature

## Public API note

`InvokeModelContext` (consumed by invoke-stage middleware authors) now carries the concrete model for the call, which middleware may replace to redirect a single invocation. The natural form is an Input-phase handler (a pure context transform):

```python
def route(context):
    return replace(context, model=my_other_model)  # this call streams my_other_model
```

The field is required, not optional: every model call has a concrete model, and the terminal relies on it, so an absent model is a construction-time error rather than a runtime `None` in the hot path.

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Added tests: the context exposes `agent.model` by default, and a middleware overriding `ctx.model` redirects the streamed model. Full Python unit suite passes locally; format and lint clean.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

> Draft: opening early for review of the routing seam before `ModelRouter` lands.
