### PR TITLE
perf(mcp): hydrate search snippets concurrently

### DIFF
--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List
 from urllib.parse import urlparse
 
@@ -61,13 +62,11 @@ def search_docs(query: str, k: int = 5) -> List[Dict[str, Any]]:
     results = index.search(query, k=k) if index else []
     url_cache = cache.get_url_cache()
 
-    # Collect top-k URLs that need hydration (no content yet)
-    # Simplified: Direct hydration in one pass
     top = results[: min(len(results), cache.SNIPPET_HYDRATE_MAX)]
-    for _, doc in top:
-        cached = url_cache.get(doc.uri)
-        if cached is None or not cached.content:
-            cache.ensure_page(doc.uri)
+    urls_to_hydrate = [doc.uri for _, doc in top if (page := url_cache.get(doc.uri)) is None or not page.content]
+    if urls_to_hydrate:
+        with ThreadPoolExecutor(max_workers=len(urls_to_hydrate)) as executor:
+            list(executor.map(cache.ensure_page, urls_to_hydrate))
 
     # Build response with real content snippets when available
     return_docs: List[Dict[str, Any]] = []

--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -63,7 +63,9 @@ def search_docs(query: str, k: int = 5) -> List[Dict[str, Any]]:
     url_cache = cache.get_url_cache()
 
     top = results[: min(len(results), cache.SNIPPET_HYDRATE_MAX)]
-    urls_to_hydrate = [doc.uri for _, doc in top if (page := url_cache.get(doc.uri)) is None or not page.content]
+    urls_to_hydrate = list(
+        dict.fromkeys(doc.uri for _, doc in top if (page := url_cache.get(doc.uri)) is None or not page.content)
+    )
     if urls_to_hydrate:
         with ThreadPoolExecutor(max_workers=len(urls_to_hydrate)) as executor:
             list(executor.map(cache.ensure_page, urls_to_hydrate))

--- a/strands-mcp/tests/test_server.py
+++ b/strands-mcp/tests/test_server.py
@@ -17,7 +17,8 @@ def test_search_docs_hydrates_pages_concurrently(mock_cache):
         Doc(uri=f"https://strandsagents.com/{index}.md", display_title=f"Doc {index}", content="", index_title="")
         for index in range(2)
     ]
-    mock_cache.get_index.return_value.search.return_value = [(1.0, doc) for doc in docs]
+    ranked_docs = [docs[0], docs[0], docs[1]]
+    mock_cache.get_index.return_value.search.return_value = [(1.0, doc) for doc in ranked_docs]
     mock_cache.get_url_cache.return_value = {doc.uri: None for doc in docs}
     mock_cache.SNIPPET_HYDRATE_MAX = 5
 
@@ -42,7 +43,9 @@ def test_search_docs_hydrates_pages_concurrently(mock_cache):
     tru_result = search_docs("agent")
 
     assert max_active_fetches == 2
-    assert [result["url"] for result in tru_result] == [doc.uri for doc in docs]
+    assert mock_cache.ensure_page.call_count == 2
+    assert {call.args[0] for call in mock_cache.ensure_page.call_args_list} == {doc.uri for doc in docs}
+    assert [result["url"] for result in tru_result] == [doc.uri for doc in ranked_docs]
 
 
 @patch("strands_mcp_server.server.cache")

--- a/strands-mcp/tests/test_server.py
+++ b/strands-mcp/tests/test_server.py
@@ -1,11 +1,48 @@
-"""Tests for fetch_doc MCP tool."""
+"""Tests for MCP server tools."""
 
+from threading import Event, Lock
 from unittest.mock import patch
 
 import pytest
 
-from strands_mcp_server.server import fetch_doc
+from strands_mcp_server.server import fetch_doc, search_docs
 from strands_mcp_server.utils.doc_fetcher import Page
+from strands_mcp_server.utils.indexer import Doc
+
+
+@patch("strands_mcp_server.server.cache")
+def test_search_docs_hydrates_pages_concurrently(mock_cache):
+    """Guard against serial snippet hydration (#3329)."""
+    docs = [
+        Doc(uri=f"https://strandsagents.com/{index}.md", display_title=f"Doc {index}", content="", index_title="")
+        for index in range(2)
+    ]
+    mock_cache.get_index.return_value.search.return_value = [(1.0, doc) for doc in docs]
+    mock_cache.get_url_cache.return_value = {doc.uri: None for doc in docs}
+    mock_cache.SNIPPET_HYDRATE_MAX = 5
+
+    fetch_lock = Lock()
+    both_fetches_started = Event()
+    active_fetches = 0
+    max_active_fetches = 0
+
+    def ensure_page(_url: str) -> None:
+        nonlocal active_fetches, max_active_fetches
+        with fetch_lock:
+            active_fetches += 1
+            max_active_fetches = max(max_active_fetches, active_fetches)
+            if active_fetches == len(docs):
+                both_fetches_started.set()
+        both_fetches_started.wait(timeout=0.5)
+        with fetch_lock:
+            active_fetches -= 1
+
+    mock_cache.ensure_page.side_effect = ensure_page
+
+    tru_result = search_docs("agent")
+
+    assert max_active_fetches == 2
+    assert [result["url"] for result in tru_result] == [doc.uri for doc in docs]
 
 
 @patch("strands_mcp_server.server.cache")


### PR DESCRIPTION
## Description

`search_docs` hydrated up to five uncached result pages serially, so first-search latency grew with every slow page. This change runs the existing bounded hydration set concurrently while preserving ranking and response construction order.

A synthetic five-page benchmark with 50 ms fixed fetch latency improved median hydration time from 269.5 ms to 56.3 ms across five runs.

Fixes #3329

### Compatibility / Risk

The response schema and ordering are unchanged. The executor is bounded by `SNIPPET_HYDRATE_MAX` (currently five), and cache writes remain delegated to the existing `ensure_page` path.

## Related Issues

Fixes #3329

## Documentation PR

No documentation change is needed because the tool API and response behavior are unchanged.

## Type of Change

Performance improvement

## Testing

- `hatch fmt --formatter` — passed
- `hatch fmt --linter` — passed
- `.venv/bin/pytest tests/test_server.py -q` — 16 passed
- `.venv/bin/pytest tests/ -q` — 48 passed
- Synthetic five-page, 50 ms/fetch benchmark — sequential median 269.5 ms; concurrent median 56.3 ms

- [ ] I ran `hatch run prepare` (the MCP package does not define a `prepare` script; the package lint and test commands above were run directly)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
