### PR TITLE
feat(mcp): normalize search token inflections

### DIFF
--- a/strands-mcp/src/strands_mcp_server/utils/indexer.py
+++ b/strands-mcp/src/strands_mcp_server/utils/indexer.py
@@ -13,6 +13,35 @@ _MD_INLINE_CODE = re.compile(r"`([^`]+)`")
 _MD_LINK_TEXT = re.compile(r"\[([^\]]+)\]\([^)]+\)")
 
 
+def _normalize_token(token: str) -> str:
+    """Normalize common English inflections for search matching."""
+    token = token.lower()
+    if len(token) > 5 and token.endswith("ing"):
+        stem = token[:-3]
+        if len(stem) > 2 and stem[-1] == stem[-2] and stem[-1] not in "aeioulsz":
+            stem = stem[:-1]
+        return stem
+    if len(token) > 4 and token.endswith("ied"):
+        return f"{token[:-3]}y"
+    if len(token) > 4 and token.endswith("ed"):
+        stem = token[:-2]
+        if len(stem) > 2 and stem[-1] == stem[-2] and stem[-1] not in "aeioulsz":
+            stem = stem[:-1]
+        return stem
+    if len(token) > 4 and token.endswith("ies"):
+        return f"{token[:-3]}y"
+    if len(token) > 4 and token.endswith(("sses", "shes", "ches", "xes", "zes")):
+        return token[:-2]
+    if len(token) > 3 and token.endswith("s") and not token.endswith(("ss", "us", "is")):
+        return token[:-1]
+    return token
+
+
+def _count_token(text: str, token: str) -> int:
+    """Count normalized token occurrences in text."""
+    return sum(_normalize_token(raw_token) == token for raw_token in _TOKEN.findall(text))
+
+
 @dataclass(slots=True)
 class Doc:
     """A single indexed document with display and search metadata.
@@ -106,7 +135,8 @@ class IndexSearch:
 
         haystack = " ".join(part for part in haystack_parts if part)
 
-        for tok in _TOKEN.findall(haystack):
+        for raw_token in _TOKEN.findall(haystack):
+            tok = _normalize_token(raw_token)
             self.doc_indices.setdefault(tok, []).append(idx)
             if tok not in seen:
                 self.doc_frequency[tok] = self.doc_frequency.get(tok, 0) + 1
@@ -164,33 +194,30 @@ class IndexSearch:
                 - Link text matches: 2x weight
                 - Body text: 1x weight (base)
             """
-            content_lower = doc.content.lower()
-            title_lower = doc.index_title.lower()
-
             # Base content frequency
-            content_tf = content_lower.count(token)
+            content_tf = _count_token(doc.content, token)
 
             # Title matches (highest weight)
-            title_tf = title_lower.count(token) * _title_boost_for(doc)
+            title_tf = _count_token(doc.index_title, token) * _title_boost_for(doc)
 
             # Header matches (high weight)
             header_tf = 0
             for header in _MD_HEADER.findall(doc.content):
-                header_tf += header.lower().count(token) * 4
+                header_tf += _count_token(header, token) * 4
 
             # Code block matches (medium weight for tech docs)
             code_tf = 0
             for code in _MD_CODE_BLOCK.findall(doc.content):
-                code_tf += code.lower().count(token) * 2
+                code_tf += _count_token(code, token) * 2
 
             # Link text matches (medium weight)
             link_tf = 0
             for link in _MD_LINK_TEXT.findall(doc.content):
-                link_tf += link.lower().count(token) * 2
+                link_tf += _count_token(link, token) * 2
 
             return float(content_tf + title_tf + header_tf + code_tf + link_tf)
 
-        q_tokens = [t.lower() for t in _TOKEN.findall(query)]
+        q_tokens = [_normalize_token(token) for token in _TOKEN.findall(query)]
         scores: Dict[int, float] = {}
         N = max(len(self.docs), 1)
 

--- a/strands-mcp/tests/test_indexer.py
+++ b/strands-mcp/tests/test_indexer.py
@@ -1,0 +1,37 @@
+"""Tests for documentation search indexing."""
+
+import pytest
+
+from strands_mcp_server.utils.indexer import Doc, IndexSearch
+
+
+@pytest.mark.parametrize(
+    ("indexed_title", "query"),
+    [
+        ("Streaming guide", "stream"),
+        ("Stream guide", "streaming"),
+        ("Guardrails guide", "guardrail"),
+        ("Guardrail guide", "guardrails"),
+        ("Running agents", "run"),
+        ("Run agents", "running"),
+        ("Policies", "policy"),
+        ("Policy", "policies"),
+        ("Processed events", "process"),
+        ("Process events", "processed"),
+        ("Boxes", "box"),
+        ("Box", "boxes"),
+        ("Classes", "class"),
+        ("Class", "classes"),
+    ],
+)
+def test_search_matches_common_word_forms(indexed_title: str, query: str) -> None:
+    """Search matches common inflections in either direction (#3322)."""
+    index = IndexSearch()
+    doc = Doc(uri="https://strandsagents.com/guide", display_title=indexed_title, content="", index_title=indexed_title)
+    index.add(doc)
+
+    tru_results = index.search(query)
+    tru_docs = [result_doc for _, result_doc in tru_results]
+
+    assert tru_docs == [doc]
+    assert tru_results[0][0] > 0


### PR DESCRIPTION
## Description

Documentation search required exact token matches, so common variants such as `stream`/`streaming` and `guardrail`/`guardrails` produced false empty results. This change applies the same lightweight, dependency-free normalization to indexed text, queries, and relevance scoring.

Fixes #3322

### Compatibility / Risk

The tool API and response schema are unchanged. Normalization is intentionally limited to common English `-s`, `-es`, `-ies`, `-ed`, and `-ing` forms, with guards for words ending in `-ss`, `-us`, and `-is`.

## Related Issues

Fixes #3322

## Documentation PR

No documentation change is needed because this corrects existing search behavior without changing the tool interface.

## Type of Change

New feature

## Testing

- `.venv/bin/pytest tests/test_indexer.py -q` — 14 passed
- `.venv/bin/pytest tests/ -q` — 61 passed
- `hatch fmt --formatter` — passed
- `hatch fmt --linter` — passed

- [ ] I ran `hatch run prepare` (the MCP package does not define a `prepare` script; its formatter, linter, and full unit suite were run directly)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
