### PR TITLE
fix(session): persist message strategy after invocation

### DIFF
--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -388,6 +388,21 @@ describe('SessionManager', () => {
       expect(snapshot).not.toBeNull()
     })
 
+    it('saves snapshot_latest when saveLatestOn is message', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: storage },
+        saveLatestOn: 'message',
+      })
+
+      await initPluginAndInvokeHook(sessionManager, new AfterInvocationEvent(createMockEvent(mockAgent)))
+
+      const snapshot = await storage.loadSnapshot({
+        location: { sessionId: 'test-session', scope: 'agent', scopeId: 'test-agent' },
+      })
+      expect(snapshot).not.toBeNull()
+    })
+
     it('does not save snapshot_latest when saveLatestOn is trigger', async () => {
       sessionManager = new SessionManager({
         sessionId: 'test-session',

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -36,7 +36,8 @@ import type { Swarm } from '../multiagent/swarm.js'
  *
  * `SaveLatestStrategy` controls how frequently `snapshot_latest` is updated:
  * - `'invocation'`: after every agent invocation completes (default; balances durability and I/O)
- * - `'message'`: after every message added (most durable, highest I/O)
+ * - `'message'`: after every message added and when an invocation completes
+ *   (most durable, highest I/O)
  * - `'trigger'`: only when a `snapshotTrigger` fires (or manually via `saveSnapshot`)
  *
  * Under `'invocation'` and `'message'`, guardrail redactions are persisted immediately so
@@ -245,9 +246,9 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     }
   }
 
-  /** Saves latest on invocation and fires the snapshot trigger if configured. */
+  /** Saves latest for auto-save strategies and fires the snapshot trigger if configured. */
   private async _onAfterAgentInvocation(event: AfterInvocationEvent): Promise<void> {
-    if (this._saveLatestOn === 'invocation') {
+    if (this._saveLatestOn !== 'trigger') {
       await this.saveSnapshot({ target: event.agent, isLatest: true })
     }
 


### PR DESCRIPTION
## Description

`saveLatestOn: 'message'` persisted message events but skipped the final invocation boundary. Interrupts and other invocation state can change without adding a message, so a process restart could restore a snapshot that did not contain the state needed to resume.

This change saves `snapshot_latest` from `AfterInvocationEvent` for both automatic strategies (`message` and `invocation`) while preserving `trigger` as an explicit opt-out. It also updates the strategy documentation and adds a regression test for the message strategy.

### Compatibility / Risk

No public types or method signatures change. Message-based sessions perform one additional latest-snapshot write at the end of each invocation; trigger-only sessions retain their existing behavior.

## Related Issues

Fixes #2474

## Documentation PR

The public `SaveLatestStrategy` documentation is updated inline. No separate site documentation is required.

## Type of Change

Bug fix

## Testing

- `vitest run --project unit-node src/session/__tests__/session-manager.test.ts` — 51 passed
- `vitest run --project unit-node` — 140 files, 3868 tests passed; no type errors
- `tsc --noEmit --project src/tsconfig.json` — passed
- `eslint src/session/session-manager.ts src/session/__tests__/session-manager.test.ts` — passed
- `prettier --check src/session/session-manager.ts src/session/__tests__/session-manager.test.ts` — passed

- [ ] I ran `hatch run prepare` (this is a TypeScript-only change; the equivalent unit, type, lint, and format checks were run directly)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
