### PR TITLE
fix(site): show language support on community pages

### DIFF
--- a/site/src/components/overrides/MarkdownContent.astro
+++ b/site/src/components/overrides/MarkdownContent.astro
@@ -12,9 +12,7 @@ const { languages, community, experimental } = starlightRoute.entry.data;
 <div class="sl-markdown-content">
   {experimental && <ExperimentalAside />}
   {community && <CommunityContributionAside />}
-  {/* Language support aside is omitted for community pages — the CommunityContributionAside already
-      contextualizes the page, and language support is listed in the community catalog table instead. */}
-  {languages && !community && <LanguageSupportAside languages={languages} />}
+  {languages && <LanguageSupportAside languages={languages} />}
   <slot />
   <PageTags />
 </div>


### PR DESCRIPTION
## Description

Community detail pages already declare supported SDK languages in frontmatter, but the shared Markdown layout deliberately suppressed the existing language-support notice whenever a page was community maintained. The catalog table exposed the information, while readers arriving directly on a detail page received no indication that changing the global language preference could not change the content.

This change renders the existing `LanguageSupportAside` on every page with `languages` metadata, including community pages. Community provenance and language availability remain separate notices with their existing styling.

### Compatibility / Risk

The change reuses existing metadata and an existing component. Pages without `languages` metadata are unchanged, and no routing or language-toggle behavior changes.

## Related Issues

Fixes #3334

## Documentation PR

This site UI fix applies to documentation pages directly.

## Type of Change

Bug fix

## Testing

- `npm run typecheck` in `site/` — passed
- `npm run typecheck:snippets` in `site/` — passed
- `npm run build` in `site/` — 857 pages built; 856 HTML pages checked with no broken links
- Generated HTML smoke checks — Python-only and TypeScript-only community pages both contain the `Language Support` notice with the correct language

- [ ] I ran `hatch run prepare` (this is a site-only change; site type checks and a full production build were run directly)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
