### PR TITLE
docs(community): add Redis session manager

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -350,6 +350,7 @@ sidebar:
       - label: Session Managers
         items:
           - docs/community/session-managers/agentcore-memory
+          - docs/community/session-managers/strands-redis-session-manager
           - docs/community/session-managers/strands-valkey-session-manager
       - label: Tool Protocols
         items:

--- a/site/src/content/docs/community/session-managers/strands-redis-session-manager.mdx
+++ b/site/src/content/docs/community/session-managers/strands-redis-session-manager.mdx
@@ -1,0 +1,84 @@
+---
+project:
+  pypi: https://pypi.org/project/strands-redis-session-manager/
+  github: https://github.com/lekhnath/strands-redis-session-manager
+  maintainer: lekhnath
+title: Strands Redis Session Manager
+community: true
+description: >-
+  Persist Strands agent sessions in Redis with configurable key namespaces and
+  optional rolling expiration for distributed applications.
+integrationType: session-manager
+languages: Python
+sidebar:
+  label: "Redis"
+---
+
+
+[Strands Redis Session
+Manager](https://github.com/lekhnath/strands-redis-session-manager) stores agent
+sessions, state, and messages in Redis. Use it to share session data across application
+instances or to preserve conversations across process restarts.
+
+The package can expire all keys for a session after a configurable interval. It also
+supports rolling expiration on writes and optional expiration refreshes on reads.
+
+## Installation
+
+```bash
+pip install strands-redis-session-manager
+```
+
+The session manager requires Python 3.12 or later, Strands Agents 1.16 or later, and
+Redis 7.0.1 or later.
+
+## Usage
+
+Create a Redis client, then pass a `RedisSessionManager` to the agent:
+
+```python
+import os
+
+import redis
+from redis_session_manager import RedisSessionManager
+from strands import Agent
+
+redis_client = redis.Redis.from_url(
+    os.environ["REDIS_URL"],
+    decode_responses=True,
+)
+session_manager = RedisSessionManager(
+    session_id="customer-123",
+    redis_client=redis_client,
+    ttl_seconds=3600,
+)
+agent = Agent(session_manager=session_manager)
+
+agent("Remember that I prefer concise answers.")
+```
+
+Set `REDIS_URL` to a Redis connection string, for example:
+
+```bash
+export REDIS_URL="redis://localhost:6379/0"
+```
+
+Create another manager with the same session ID and Redis database to resume the
+stored conversation.
+
+## Configuration
+
+`RedisSessionManager` accepts these storage options:
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `namespace` | `strands:session` | Prefix for keys created by the session manager |
+| `ttl_seconds` | `None` | Expiration time for all keys in a session |
+| `rolling_ttl` | `True` | Refresh the session expiration when data changes |
+| `touch_on_read` | `False` | Refresh the session expiration when data is read |
+
+## References
+
+- [PyPI package](https://pypi.org/project/strands-redis-session-manager/)
+- [GitHub repository](https://github.com/lekhnath/strands-redis-session-manager)
+- [Issue tracker](https://github.com/lekhnath/strands-redis-session-manager/issues)


### PR DESCRIPTION
## Description

Adds a community integration page for
[`strands-redis-session-manager`](https://github.com/lekhnath/strands-redis-session-manager)
and includes it in the Session Managers navigation.

The documented package name, import path, constructor options, Python and Strands
requirements, TTL behavior, and example usage were verified against the current
v0.1.0 package source.

This is a documentation-only change and does not affect SDK compatibility.

## Related issues

Fixes #2580

## Testing

- `npm run typecheck`
- `npm run typecheck:snippets`
- `npm run build` (858 pages, 857 HTML pages, no broken links)
- Verified the generated detail page and Community Catalog entry

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/strands-agents/harness-sdk/blob/main/CONTRIBUTING.md) guide.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have run `hatch run prepare`.

`hatch run prepare` is not applicable to this documentation-only site change.
