### PR TITLE
feat(mcp): refresh Python tools on list changes

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
@@ -100,6 +100,12 @@ Tools can also be listed explicitly if needed:
 </Tab>
 </Tabs>
 
+### Dynamic Tool Lists
+
+When an MCP client is passed directly to an agent, both SDKs listen for the server's tool-list change notifications. Notifications are debounced, the complete tool list is fetched again, and the agent's registry is updated before its next invocation. Configured Python tool filters and name prefixes are reapplied during every refresh.
+
+Tools obtained by calling `list_tools_sync()` or `listTools()` and then passed to an agent are a snapshot. Pass the client itself to the agent when runtime tool-list updates should be applied automatically.
+
 ## Transport Options
 
 Both Python and TypeScript support multiple transport mechanisms for connecting to MCP servers.

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -43,7 +43,9 @@ from mcp.types import (
     ListResourcesResult,
     ListResourceTemplatesResult,
     ReadResourceResult,
+    ServerNotification,
     TextResourceContents,
+    ToolListChangedNotification,
 )
 from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import EmbeddedResource as MCPEmbeddedResource
@@ -136,6 +138,8 @@ _NON_FATAL_ERROR_PATTERNS = [
     # See: https://github.com/modelcontextprotocol/python-sdk/blob/c51936f61f35a15f0b1f8fb6887963e5baee1506/src/mcp/shared/session.py#L421
     "unknown request id",
 ]
+
+_TOOLS_CHANGED_DEBOUNCE_SECONDS = 0.3
 
 
 class MCPClient(ToolProvider):
@@ -274,6 +278,9 @@ class MCPClient(ToolProvider):
         self._tool_provider_started = False
         self.server_instructions: str | None = None
         self._consumers: set[Any] = set()
+        self._tools_changed_callbacks: dict[Any, Callable[[list[str], Sequence[AgentTool]], None]] = {}
+        self._tools_change_generation = 0
+        self._tools_refresh_task: asyncio.Task[None] | None = None
 
         # Task support configuration and caching
         self._tasks_config = tasks_config
@@ -440,6 +447,14 @@ class MCPClient(ToolProvider):
         self._consumers.add(consumer_id)
         logger.debug("added provider consumer, count=%d", len(self._consumers))
 
+    def set_tools_changed_callback(
+        self,
+        consumer_id: Any,
+        callback: Callable[[list[str], Sequence[AgentTool]], None],
+    ) -> None:
+        """Register a consumer callback for MCP tool-list changes."""
+        self._tools_changed_callbacks[consumer_id] = callback
+
     def remove_consumer(self, consumer_id: Any, **kwargs: Any) -> None:
         """Remove a consumer from this tool provider.
 
@@ -450,6 +465,7 @@ class MCPClient(ToolProvider):
         Uses existing synchronous stop() method for safe cleanup.
         """
         self._consumers.discard(consumer_id)
+        self._tools_changed_callbacks.pop(consumer_id, None)
         logger.debug("removed provider consumer, count=%d", len(self._consumers))
 
         # A swallowed continue_on_error failure leaves _tool_provider_started False but still needs
@@ -538,6 +554,9 @@ class MCPClient(ToolProvider):
         self._tool_provider_started = False
         self._connection_failed = False
         self._consumers = set()
+        self._tools_changed_callbacks = {}
+        self._tools_change_generation = 0
+        self._tools_refresh_task = None
         self._server_task_capable = None
         self._tool_task_support_cache = {}
 
@@ -580,6 +599,15 @@ class MCPClient(ToolProvider):
         list_tools_response: ListToolsResult = self._invoke_on_background_thread(_list_tools_async()).result()
         self._log_debug_with_thread("received %d tools from MCP server", len(list_tools_response.tools))
 
+        return self._adapt_tools_response(list_tools_response, effective_prefix, effective_filters)
+
+    def _adapt_tools_response(
+        self,
+        list_tools_response: ListToolsResult,
+        prefix: str | None,
+        tool_filters: ToolFilters | None,
+    ) -> PaginatedList[MCPAgentTool]:
+        """Adapt one MCP tool-list page and apply configured naming and filtering."""
         mcp_tools = []
         for tool in list_tools_response.tools:
             if self._is_tasks_enabled():
@@ -590,19 +618,66 @@ class MCPClient(ToolProvider):
                 self._tool_task_support_cache[tool.name] = task_support or "forbidden"
 
             # Apply prefix if specified
-            if effective_prefix:
-                prefixed_name = f"{effective_prefix}_{tool.name}"
+            if prefix:
+                prefixed_name = f"{prefix}_{tool.name}"
                 mcp_tool = MCPAgentTool(tool, self, name_override=prefixed_name)
                 logger.debug("tool_rename=<%s->%s> | renamed tool", tool.name, prefixed_name)
             else:
                 mcp_tool = MCPAgentTool(tool, self)
 
             # Apply filters if specified
-            if self._should_include_tool_with_filters(mcp_tool, effective_filters):
+            if self._should_include_tool_with_filters(mcp_tool, tool_filters):
                 mcp_tools.append(mcp_tool)
 
         self._log_debug_with_thread("successfully adapted %d MCP tools", len(mcp_tools))
         return PaginatedList[MCPAgentTool](mcp_tools, token=list_tools_response.nextCursor)
+
+    async def _refresh_tools(self) -> None:
+        """Refresh cached provider tools on the MCP client's background event loop."""
+        session = cast(ClientSession, self._background_thread_session)
+        old_tool_names = [tool.tool_name for tool in self._loaded_tools or []]
+        refreshed_tools: list[MCPAgentTool] = []
+        pagination_token = None
+
+        if self._is_tasks_enabled():
+            self._tool_task_support_cache.clear()
+
+        while True:
+            response = await session.list_tools(cursor=pagination_token)
+            page = self._adapt_tools_response(response, self._prefix, self._tool_filters)
+            refreshed_tools.extend(page)
+            pagination_token = page.pagination_token
+            if pagination_token is None:
+                break
+
+        self._loaded_tools = refreshed_tools
+        for callback in list(self._tools_changed_callbacks.values()):
+            try:
+                callback(old_tool_names, refreshed_tools)
+            except Exception as error:
+                logger.warning("error=<%s> | MCP tools-changed callback failed", error, exc_info=True)
+
+    def _schedule_tools_refresh(self) -> None:
+        """Coalesce tool-list notifications into a debounced refresh task."""
+        self._tools_change_generation += 1
+        if self._tools_refresh_task is None or self._tools_refresh_task.done():
+            self._tools_refresh_task = asyncio.create_task(self._run_tools_refreshes())
+
+    async def _run_tools_refreshes(self) -> None:
+        """Run debounced refreshes until no newer notification is pending."""
+        while True:
+            generation = self._tools_change_generation
+            await asyncio.sleep(_TOOLS_CHANGED_DEBOUNCE_SECONDS)
+            if generation != self._tools_change_generation:
+                continue
+
+            try:
+                await self._refresh_tools()
+            except Exception as error:
+                logger.warning("error=<%s> | failed to refresh MCP tools after list-changed notification", error)
+
+            if generation == self._tools_change_generation:
+                return
 
     def list_prompts_sync(self, pagination_token: str | None = None) -> ListPromptsResult:
         """Synchronously retrieves the list of available prompts from the MCP server.
@@ -992,6 +1067,10 @@ class MCPClient(ToolProvider):
                     # Thread is not blocked as this a future
                     await self._close_future
 
+                    if self._tools_refresh_task is not None and not self._tools_refresh_task.done():
+                        self._tools_refresh_task.cancel()
+                        await asyncio.gather(self._tools_refresh_task, return_exceptions=True)
+
                     self._log_debug_with_thread("close signal received")
         except Exception as e:
             # If we encounter an exception and the future is still running,
@@ -1012,6 +1091,11 @@ class MCPClient(ToolProvider):
     # Raise an exception if the underlying client raises an exception in a message
     # This happens when the underlying client has an http timeout error
     async def _handle_error_message(self, message: Exception | Any) -> None:
+        if isinstance(message, ServerNotification) and isinstance(message.root, ToolListChangedNotification):
+            self._schedule_tools_refresh()
+            await anyio.lowlevel.checkpoint()
+            return
+
         if isinstance(message, Exception):
             error_msg = str(message).lower()
             if any(pattern in error_msg for pattern in _NON_FATAL_ERROR_PATTERNS):

--- a/strands-py/src/strands/tools/registry.py
+++ b/strands-py/src/strands/tools/registry.py
@@ -131,6 +131,7 @@ class ToolRegistry:
                 elif isinstance(tool, ToolProvider):
                     self._tool_providers.append(tool)
                     tool.add_consumer(self._registry_id)
+                    tool.set_tools_changed_callback(self._registry_id, self._replace_provider_tools)
 
                     async def get_tools() -> Sequence[AgentTool]:
                         return await tool.load_tools()
@@ -157,6 +158,25 @@ class ToolRegistry:
         for tool in tools:
             add_tool(tool)
         return tool_names
+
+    def _replace_provider_tools(self, old_tool_names: list[str], new_tools: Sequence[AgentTool]) -> None:
+        """Replace a provider's registered tools after its remote catalog changes."""
+        updated_registry = self.registry.copy()
+        updated_dynamic_tools = self.dynamic_tools.copy()
+
+        for tool_name in old_tool_names:
+            updated_registry.pop(tool_name, None)
+            updated_dynamic_tools.pop(tool_name, None)
+
+        for new_tool in new_tools:
+            updated_registry[new_tool.tool_name] = new_tool
+            if new_tool.is_dynamic:
+                updated_dynamic_tools[new_tool.tool_name] = new_tool
+            else:
+                updated_dynamic_tools.pop(new_tool.tool_name, None)
+
+        self.registry = updated_registry
+        self.dynamic_tools = updated_dynamic_tools
 
     def load_tool_from_filepath(self, tool_name: str, tool_path: str) -> None:
         """DEPRECATED: Load a tool from a file path.

--- a/strands-py/src/strands/tools/tool_provider.py
+++ b/strands-py/src/strands/tools/tool_provider.py
@@ -1,7 +1,7 @@
 """Tool provider interface."""
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -51,3 +51,18 @@ class ToolProvider(ABC):
             **kwargs: Additional arguments for future compatibility.
         """
         pass
+
+    def set_tools_changed_callback(
+        self,
+        consumer_id: Any,
+        callback: Callable[[list[str], Sequence["AgentTool"]], None],
+    ) -> None:
+        """Set a callback for replacing tools when this provider's catalog changes.
+
+        Providers with a static catalog can keep the default no-op implementation.
+
+        Args:
+            consumer_id: Unique identifier for the consumer.
+            callback: Function receiving old tool names and the provider's refreshed tools.
+        """
+        return None

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tool_provider.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tool_provider.py
@@ -1,9 +1,11 @@
 """Unit tests for MCPClient ToolProvider functionality."""
 
 import re
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from mcp import ListToolsResult
+from mcp.types import ServerNotification, ToolListChangedNotification
 from mcp.types import Tool as MCPTool
 
 from strands.tools.mcp import MCPClient
@@ -82,6 +84,64 @@ def test_continue_on_error_and_connection_failed_accessors(mock_transport):
 
     lenient_client._connection_failed = True
     assert lenient_client.connection_failed is True
+
+
+@pytest.mark.asyncio
+async def test_tools_changed_notification_schedules_refresh(mock_transport):
+    client = MCPClient(mock_transport)
+
+    with patch.object(client, "_schedule_tools_refresh") as schedule_refresh:
+        await client._handle_error_message(ServerNotification(ToolListChangedNotification()))
+
+    schedule_refresh.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_tools_changed_notifications_are_coalesced(mock_transport):
+    client = MCPClient(mock_transport)
+
+    with (
+        patch("strands.tools.mcp.mcp_client._TOOLS_CHANGED_DEBOUNCE_SECONDS", 0),
+        patch.object(client, "_refresh_tools", new_callable=AsyncMock) as refresh_tools,
+    ):
+        client._schedule_tools_refresh()
+        client._schedule_tools_refresh()
+        client._schedule_tools_refresh()
+        await client._tools_refresh_task
+
+    refresh_tools.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_refresh_tools_reapplies_prefix_filters_and_pagination(mock_transport):
+    client = MCPClient(mock_transport, prefix="remote", tool_filters={"allowed": ["new_tool"]})
+    client._loaded_tools = [create_mock_tool("remote_old_tool", "old_tool")]
+    session = MagicMock()
+    session.list_tools = AsyncMock(
+        side_effect=[
+            ListToolsResult(
+                tools=[
+                    MCPTool(name="new_tool", inputSchema={"type": "object"}),
+                    MCPTool(name="filtered_tool", inputSchema={"type": "object"}),
+                ],
+                nextCursor="next",
+            ),
+            ListToolsResult(tools=[]),
+        ]
+    )
+    client._background_thread_session = session
+    callback = MagicMock()
+    client._tools_changed_callbacks["agent"] = callback
+
+    await client._refresh_tools()
+
+    assert [tool.tool_name for tool in client._loaded_tools] == ["remote_new_tool"]
+    assert session.list_tools.await_args_list[0].kwargs == {"cursor": None}
+    assert session.list_tools.await_args_list[1].kwargs == {"cursor": "next"}
+    callback.assert_called_once()
+    tru_old_names, tru_new_tools = callback.call_args.args
+    assert tru_old_names == ["remote_old_tool"]
+    assert [tool.tool_name for tool in tru_new_tools] == ["remote_new_tool"]
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/tools/test_registry.py
+++ b/strands-py/tests/strands/tools/test_registry.py
@@ -379,6 +379,9 @@ def test_tool_registry_process_tools_exception_after_add_consumer():
 
     # Verify add_consumer was called before the failure
     mock_provider.add_consumer.assert_called_once_with(registry._registry_id)
+    mock_provider.set_tools_changed_callback.assert_called_once_with(
+        registry._registry_id, registry._replace_provider_tools
+    )
 
     # Cleanup should still work
     registry.cleanup()
@@ -414,6 +417,22 @@ def test_tool_registry_add_consumer_before_load_tools():
 
     # Verify add_consumer was called with the registry ID
     mock_provider.add_consumer.assert_called_once_with(registry._registry_id)
+    mock_provider.set_tools_changed_callback.assert_called_once_with(
+        registry._registry_id, registry._replace_provider_tools
+    )
+
+
+def test_tool_registry_replaces_provider_tools_as_one_snapshot():
+    registry = ToolRegistry()
+    local_tool = PythonAgentTool(tool_name="local", tool_spec=MagicMock(), tool_func=lambda: None)
+    old_tool = PythonAgentTool(tool_name="old", tool_spec=MagicMock(), tool_func=lambda: None)
+    new_tool = PythonAgentTool(tool_name="new", tool_spec=MagicMock(), tool_func=lambda: None)
+    registry.register_tool(local_tool)
+    registry.register_tool(old_tool)
+
+    registry._replace_provider_tools(["old"], [new_tool])
+
+    assert registry.registry == {"local": local_tool, "new": new_tool}
 
 
 def test_validate_tool_spec_with_anyof_property():


### PR DESCRIPTION
## Motivation

Python agents currently cache MCP tools at initialization and silently discard
the server's tool-list change notification. Long-lived agents therefore keep
stale tools after a server adds, removes, or changes its catalog.

This handles the current MCP notification in an isolated subscription layer,
coalesces bursts with a 300 ms debounce on the client's background event loop,
refreshes every page, and atomically swaps each consuming registry's provider
tools. Refreshes reuse the configured filters and prefix.

Fixes #3272

## Public API Changes

`ToolProvider` now has a backward-compatible, default no-op
`set_tools_changed_callback()` hook. Dynamic providers can use it to publish a
replacement snapshot without requiring changes from static provider
implementations.

```python
provider.set_tools_changed_callback(
    consumer_id,
    lambda old_names, new_tools: ...,
)
```

## Documentation PR

The MCP guide now explains automatic dynamic-list refresh behavior and clarifies
that manually listed tools are a static snapshot.

## Type of Change

New feature

## Testing

- Targeted MCP provider and registry tests: 80 passed
- Full Python suite: 4,647 passed
- Ruff formatting and lint checks passed for changed files
- mypy passed for changed source files
- Documentation and snippet type-checks passed
- Site build: 857 pages, 856 HTML files, no broken links

- [ ] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
