### PR TITLE
docs(mcp): correct search tool contracts

### DIFF
--- a/strands-mcp/README.md
+++ b/strands-mcp/README.md
@@ -33,16 +33,23 @@
   </p>
 </div>
 
-This MCP server provides curated documentation access to your GenAI tools via llms.txt files, enabling AI coding assistants to search and retrieve relevant documentation with intelligent ranking.
+This MCP server provides curated documentation access to your GenAI tools via llms.txt files, enabling AI coding assistants to find pages by title and retrieve their contents.
 
 ## Features
 
-- **Smart Document Search**: TF-IDF based search with Markdown-aware scoring that prioritizes titles, headers, and code blocks
+- **Title-Based Document Search**: Weighted TF-IDF ranking over the curated document titles
 - **Section-Based Browsing**: Browse document structure via table of contents, then fetch only the section you need - more token-efficient than retrieving full pages
 - **Curated Content**: Indexes documentation from llms.txt files with clean, human-readable titles
 - **On-Demand Fetching**: Lazy-loads full document content only when needed for optimal performance
-- **Snippet Generation**: Provides contextual snippets with relevance scoring for quick overview
+- **Snippet Generation**: Hydrates the top-ranked pages to provide contextual previews
 - **Real URL Support**: Works with actual HTTPS URLs while maintaining backward compatibility
+
+### Tool behavior
+
+- `search_docs(query, k)` searches document titles. Use title-like keywords, then call `fetch_doc` to inspect a result's contents.
+- Search scores are unbounded weighted TF-IDF values. They are useful only for ordering results from the same query; they are not probabilities and should not be compared across queries.
+- `search_docs` returns an empty list when no title matches. If a matched page cannot be fetched for its snippet, the result still includes the URL and title.
+- `fetch_doc` returns `{"error": "...", "url": "..."}` for unsupported URLs, failed page fetches, and unknown section IDs.
 
 ## Prerequisites
 

--- a/strands-mcp/README.md
+++ b/strands-mcp/README.md
@@ -49,7 +49,9 @@ This MCP server provides curated documentation access to your GenAI tools via ll
 - `search_docs(query, k)` searches document titles. Use title-like keywords, then call `fetch_doc` to inspect a result's contents.
 - Search scores are unbounded weighted TF-IDF values. They are useful only for ordering results from the same query; they are not probabilities and should not be compared across queries.
 - `search_docs` returns an empty list when no title matches. If a matched page cannot be fetched for its snippet, the result still includes the URL and title.
-- `fetch_doc` returns `{"error": "...", "url": "..."}` for unsupported URLs, failed page fetches, and unknown section IDs.
+- `fetch_doc` returns `{"error": "...", "url": "..."}` for unsupported URLs and failed page fetches. For
+  sectioned documents, unknown section IDs also return an error; `section` is ignored when the full document is
+  returned automatically.
 
 ## Prerequisites
 

--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -22,27 +22,15 @@ mcp = FastMCP(APP_NAME)
 
 @mcp.tool()
 def search_docs(query: str, k: int = 5) -> List[Dict[str, Any]]:
-    """Search curated documentation and return ranked results with snippets.
+    """Search the curated documentation catalog by title.
 
-    This tool provides access to the complete Strands Agents documentation including:
+    The catalog contains Strands Agents user guides, API reference pages, and
+    examples. Search ranking uses document titles, so use title-like keywords
+    such as "bedrock model", "structured output", or "MCP tools". The top
+    results are fetched on demand to provide content snippets, but page content
+    does not affect ranking.
 
-    **User Guide Topics:**
-    - Agent concepts (agent loop, conversation management, hooks, prompts, state)
-    - Model providers (Amazon Bedrock, Anthropic, Cohere, LiteLLM, LlamaAPI,
-            MistralAI, Ollama, OpenAI, SageMaker, Writer, Gemini)
-    - Multi-agent patterns (Agent2Agent, Agents as Tools, Graph, Swarm, Workflow)
-    - Tools (Python tools, MCP tools, community tools, executors)
-    - Deployment guides (EC2, EKS, Fargate, Lambda, Bedrock AgentCore)
-    - Observability & evaluation (logs, metrics, traces, evaluation)
-    - Safety & security (guardrails, PII redaction, responsible AI)
-
-    **API Reference:**
-    - Complete API documentation for Agent, Models, Tools, Handlers, etc.
-
-    **Examples:**
-    - Code samples and implementation examples
-
-    Use this to find relevant Strands Agents documentation for any development question.
+    Call fetch_doc with a result URL to read the page or one of its sections.
 
     Args:
         query: Search query string (e.g., "bedrock model", "tell me about a2a", "how to use MCP tools")
@@ -52,8 +40,13 @@ def search_docs(query: str, k: int = 5) -> List[Dict[str, Any]]:
         List of dictionaries containing:
         - url: Document URL
         - title: Display title
-        - score: Relevance score (0-1, higher is better)
+        - score: Unbounded weighted TF-IDF score. Higher is better within this
+          result set; do not interpret it as a probability or compare it across
+          different queries.
         - snippet: Contextual content preview
+
+        Returns an empty list when no document title matches. If a result page
+        cannot be fetched, its title is used as the snippet.
 
     """
     cache.ensure_ready()
@@ -131,6 +124,9 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
         On error:
         - error: Error description
         - url: Requested URL
+
+        Errors are returned for unsupported URLs, failed page fetches, and
+        unknown section IDs.
 
     """
     cache.ensure_ready()

--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -125,8 +125,9 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
         - error: Error description
         - url: Requested URL
 
-        Errors are returned for unsupported URLs, failed page fetches, and
-        unknown section IDs.
+        Errors are returned for unsupported URLs and failed page fetches. For
+        sectioned documents, unknown section IDs also return an error; `section`
+        is ignored when the full document is returned automatically.
 
     """
     cache.ensure_ready()


### PR DESCRIPTION
## Motivation

The Strands MCP server tells consuming models that `search_docs` searches full
document contents and returns a normalized 0–1 relevance score. The current
implementation indexes document titles only and returns unbounded weighted
TF-IDF scores, so those claims lead callers to misinterpret empty results and
score magnitudes.

Fixes #3324

## Changes

- describe `search_docs` as title-based catalog search and recommend title-like
  keywords
- document that page hydration supplies snippets but does not affect ranking
- define scores as query-local, unbounded weighted TF-IDF values
- document empty-search and snippet-fetch fallback behavior
- document the `fetch_doc` error object and its error cases
- align the README feature list and add a concise tool behavior reference

## Documentation PR

This is a documentation-only correction to the MCP tool descriptions and
package README. It does not change runtime behavior.

## Type of Change

Documentation

## Testing

- `strands-mcp` unit suite: 47 passed
- Ruff lint and format checks passed for the changed Python file
- Python `compileall` passed
- Parsed tool docstrings to verify the corrected contracts are present

- [ ] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
