### PR TITLE
fix(streaming): consume reasoning signature per content block

### DIFF
--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -338,8 +338,9 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
             }
         }
 
-        if "signature" in state:
-            content_block["reasoningContent"]["reasoningText"]["signature"] = state["signature"]
+        # Consume the signature so it belongs to exactly this block and does not leak into the next one.
+        if (signature := state.pop("signature", None)) is not None:
+            content_block["reasoningContent"]["reasoningText"]["signature"] = signature
 
         content.append(content_block)
         state["reasoningText"] = ""

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -475,7 +475,6 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, event_type, s
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
-                "signature": "123",
                 "citationsContent": [],
                 "redactedContent": b"",
             },
@@ -515,7 +514,6 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, event_type, s
                 "current_tool_use": {},
                 "text": "",
                 "reasoningText": "",
-                "signature": "123",
                 "citationsContent": [],
                 "redactedContent": b"",
             },
@@ -1153,6 +1151,65 @@ async def test_process_stream_with_signature(agenerator, alist):
 
     assert message["content"][0]["reasoningContent"]["reasoningText"]["signature"] == "test-signature"
     assert message["content"][1]["text"] == "Sure! Let’s do it"
+
+
+@pytest.mark.asyncio
+async def test_process_stream_with_multiple_signed_reasoning_blocks(agenerator, alist):
+    """Each signed reasoning block keeps only its own signature.
+
+    Guards against https://github.com/strands-agents/harness-sdk/issues/3425: the signature accumulator
+    was never cleared when a reasoning block finalized, so later blocks carried a cumulative concatenation
+    ("SIG1", "SIG1SIG2", ...) that providers reject as a modified thinking signature on the next request.
+    """
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "first"}}, "contentBlockIndex": 0}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "SIG1"}}, "contentBlockIndex": 0}},
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "second"}}, "contentBlockIndex": 1}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "SIG2"}}, "contentBlockIndex": 1}},
+        {"contentBlockStop": {"contentBlockIndex": 1}},
+        {"messageStop": {"stopReason": "end_turn"}},
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+
+    last_event = cast(ModelStopReason, (await alist(stream))[-1])
+
+    message = _get_message_from_event(last_event)
+
+    tru_signatures = [block["reasoningContent"]["reasoningText"]["signature"] for block in message["content"]]
+    exp_signatures = ["SIG1", "SIG2"]
+    assert tru_signatures == exp_signatures
+
+
+@pytest.mark.asyncio
+async def test_process_stream_signature_does_not_leak_into_later_empty_block(agenerator, alist):
+    """A signed reasoning block does not turn a later empty content block into a spurious reasoning block.
+
+    Guards against the secondary effect of https://github.com/strands-agents/harness-sdk/issues/3425: a stale
+    signature left in state kept the ``"signature" in state`` guard true, so an otherwise-empty trailing block
+    was materialized as a reasoning block carrying the leaked signature.
+    """
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "thinking"}}, "contentBlockIndex": 0}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "SIG1"}}, "contentBlockIndex": 0}},
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {"contentBlockStart": {"start": {}, "contentBlockIndex": 1}},
+        {"contentBlockStop": {"contentBlockIndex": 1}},
+        {"messageStop": {"stopReason": "end_turn"}},
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+
+    last_event = cast(ModelStopReason, (await alist(stream))[-1])
+
+    message = _get_message_from_event(last_event)
+
+    tru_content = message["content"]
+    exp_content = [{"reasoningContent": {"reasoningText": {"text": "thinking", "signature": "SIG1"}}}]
+    assert tru_content == exp_content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`handle_content_block_delta` accumulates reasoning-signature deltas into `state["signature"]` (correct — signatures stream in chunks). But `handle_content_block_stop` read that value **without ever clearing it** when finalizing a reasoning block, unlike every other accumulator (`text`, `reasoningText`, `redactedContent`, `current_tool_use`).

As a result, a second signed thinking block in the same message inherited the first block's signature, producing a cumulative concatenation (`"SIG1"`, `"SIG1SIG2"`, …). Providers verify thinking signatures byte-identical per block when the conversation is sent back, so any follow-up request that re-sends the conversation (tool-loop continuation, a second invoke on the same agent) was rejected:

```
400 invalid_request_error: "…`thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified…"
```

This is triggered in practice by an Anthropic model with `thinking: adaptive` plus tool use, which produces assistant messages with multiple signed thinking blocks.

**Fix:** consume the signature when the block is finalized so it belongs to exactly that block and cannot leak into the next one:

```python
if (signature := state.pop("signature", None)) is not None:
    content_block["reasoningContent"]["reasoningText"]["signature"] = signature
```

Using `pop` also fixes the **secondary effect** documented in the issue: the stale `"signature"` key had kept the `elif reasoning_text or "signature" in state:` guard (introduced in #2150) truthy, so a later empty content block was materialized as a spurious reasoning block carrying the leaked signature.

This is Python-only — the TypeScript SDK's `streamAggregated` already resets its reasoning accumulator both on block start and after finalizing a block, so no parity change is needed.

## Related Issues

Fixes #3425. Related: #2150 (introduced the signature-in-state guard), #790 / #1698 (adjacent signature handling).

## Documentation PR

No documentation changes needed — this is an internal streaming-accumulator bug fix with no API surface change.

## Type of Change

Bug fix

## Testing

- `test_process_stream_with_multiple_signed_reasoning_blocks` — the exact repro from the issue; asserts each block keeps its own signature (`["SIG1", "SIG2"]`). Reproduces `["SIG1", "SIG1SIG2"]` without the fix.
- `test_process_stream_signature_does_not_leak_into_later_empty_block` — guards the secondary effect; without the fix an empty trailing block was materialized as a spurious reasoning block carrying the leaked signature.
- Updated the two `test_handle_content_block_stop` parametrized cases so the finalized state no longer retains the consumed `signature` key.

I confirmed both new tests **fail without the fix and pass with it**. Verified locally on Python 3.12:

- `tests/strands/event_loop/` — 134 passed
- anthropic/bedrock/litellm signature & reasoning tests — 13 passed
- `hatch fmt --linter --check` (ruff + mypy over 232 source files) — clean
- `streaming.py` / `test_streaming.py` pass `ruff format --check`

- [ ] I ran `hatch run prepare`

> Note: I ran the individual CI-gate steps (`hatch fmt --linter --check`, scoped `ruff format --check`, and the relevant `hatch test` subsets) rather than the full `hatch run prepare`, since the whole-repo formatter flags several pre-existing unrelated files this change does not touch.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
