### PR TITLE
ci(release): enforce single-increment versions and verify publish on the registry

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -105,6 +105,13 @@ jobs:
           fi
           # Require a single-step increment (major, minor, or patch) so a typo
           # like 1.48.0 -> 1.84.0 fails here instead of relying on the approver.
+          # Validate the baseline first: a malformed previous tag (prerelease
+          # suffix, non-numeric part) must fail with a clear message, not a
+          # cryptic arithmetic error under set -e.
+          if ! [[ "$PREV_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::previous tag version '$PREV_VERSION' is not bare semver -- cannot compute the increment baseline."
+            exit 1
+          fi
           IFS=. read -r P_MAJ P_MIN P_PAT <<< "$PREV_VERSION"
           VALID="$((P_MAJ+1)).0.0 ${P_MAJ}.$((P_MIN+1)).0 ${P_MAJ}.${P_MIN}.$((P_PAT+1))"
           case " $VALID " in
@@ -471,7 +478,7 @@ jobs:
   # doesn't show the version within the timeout.
   verify-published:
     name: Verify version on PyPI
-    needs: [scan-commits, publish-pypi]
+    needs: [publish-pypi]
     if: inputs.dry_run != true
     runs-on: ubuntu-latest
     permissions: {}
@@ -482,7 +489,10 @@ jobs:
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do
-            if curl -sf "https://pypi.org/pypi/strands-agents/$VERSION/json" >/dev/null; then
+            # Cache-buster: registry CDNs cache negative (404) responses; a poll
+            # that lands before propagation must not pin a stale 404 for the
+            # rest of the window.
+            if curl -sf "https://pypi.org/pypi/strands-agents/$VERSION/json?t=$(date +%s)" >/dev/null; then
               echo "strands-agents $VERSION is live on PyPI."
               exit 0
             fi

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -103,6 +103,16 @@ jobs:
             echo "::error::version $NEW_VERSION is not greater than previous $PREV_VERSION."
             exit 1
           fi
+          # Require a single-step increment (major, minor, or patch) so a typo
+          # like 1.48.0 -> 1.84.0 fails here instead of relying on the approver.
+          IFS=. read -r P_MAJ P_MIN P_PAT <<< "$PREV_VERSION"
+          VALID="$((P_MAJ+1)).0.0 ${P_MAJ}.$((P_MIN+1)).0 ${P_MAJ}.${P_MIN}.$((P_PAT+1))"
+          case " $VALID " in
+            *" $NEW_VERSION "*) ;;
+            *)
+              echo "::error::version $NEW_VERSION is not a single increment of $PREV_VERSION (expected one of: $VALID)."
+              exit 1;;
+          esac
           if git rev-parse --verify "refs/tags/$NEW_TAG" >/dev/null 2>&1; then
             echo "::error::tag $NEW_TAG already exists."
             exit 1
@@ -454,3 +464,30 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  # ── Post-publish smoke check ───────────────────────────────────────────
+  # Poll PyPI until the new version is visible, replacing the manual
+  # "check the package page" verification. Fails loudly if the registry
+  # doesn't show the version within the timeout.
+  verify-published:
+    name: Verify version on PyPI
+    needs: [scan-commits, publish-pypi]
+    if: inputs.dry_run != true
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Poll PyPI for the new version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if curl -sf "https://pypi.org/pypi/strands-agents/$VERSION/json" >/dev/null; then
+              echo "strands-agents $VERSION is live on PyPI."
+              exit 0
+            fi
+            echo "attempt $i/30: not visible yet, retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::strands-agents $VERSION not visible on PyPI after 5 minutes."
+          exit 1

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -103,6 +103,16 @@ jobs:
             echo "::error::version $NEW_VERSION is not greater than previous $PREV_VERSION."
             exit 1
           fi
+          # Require a single-step increment (major, minor, or patch) so a typo
+          # like 1.48.0 -> 1.84.0 fails here instead of relying on the approver.
+          IFS=. read -r P_MAJ P_MIN P_PAT <<< "$PREV_VERSION"
+          VALID="$((P_MAJ+1)).0.0 ${P_MAJ}.$((P_MIN+1)).0 ${P_MAJ}.${P_MIN}.$((P_PAT+1))"
+          case " $VALID " in
+            *" $NEW_VERSION "*) ;;
+            *)
+              echo "::error::version $NEW_VERSION is not a single increment of $PREV_VERSION (expected one of: $VALID)."
+              exit 1;;
+          esac
           if git rev-parse --verify "refs/tags/$NEW_TAG" >/dev/null 2>&1; then
             echo "::error::tag $NEW_TAG already exists."
             exit 1
@@ -457,3 +467,30 @@ jobs:
           fi
           # ./ prefix: npm treats a bare "dir/file.tgz" as a git spec.
           npm publish "./${tgzs[0]}" --access public --tag latest
+
+  # ── Post-publish smoke check ───────────────────────────────────────────
+  # Poll npm until the new version is visible, replacing the manual
+  # "check the package page" verification. Fails loudly if the registry
+  # doesn't show the version within the timeout.
+  verify-published:
+    name: Verify version on npm
+    needs: [scan-commits, publish-npm]
+    if: inputs.dry_run != true
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Poll npm for the new version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if curl -sf "https://registry.npmjs.org/@strands-agents/sdk/$VERSION" >/dev/null; then
+              echo "@strands-agents/sdk $VERSION is live on npm."
+              exit 0
+            fi
+            echo "attempt $i/30: not visible yet, retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::@strands-agents/sdk $VERSION not visible on npm after 5 minutes."
+          exit 1

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -105,6 +105,13 @@ jobs:
           fi
           # Require a single-step increment (major, minor, or patch) so a typo
           # like 1.48.0 -> 1.84.0 fails here instead of relying on the approver.
+          # Validate the baseline first: a malformed previous tag (prerelease
+          # suffix, non-numeric part) must fail with a clear message, not a
+          # cryptic arithmetic error under set -e.
+          if ! [[ "$PREV_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::previous tag version '$PREV_VERSION' is not bare semver -- cannot compute the increment baseline."
+            exit 1
+          fi
           IFS=. read -r P_MAJ P_MIN P_PAT <<< "$PREV_VERSION"
           VALID="$((P_MAJ+1)).0.0 ${P_MAJ}.$((P_MIN+1)).0 ${P_MAJ}.${P_MIN}.$((P_PAT+1))"
           case " $VALID " in
@@ -474,7 +481,7 @@ jobs:
   # doesn't show the version within the timeout.
   verify-published:
     name: Verify version on npm
-    needs: [scan-commits, publish-npm]
+    needs: [publish-npm]
     if: inputs.dry_run != true
     runs-on: ubuntu-latest
     permissions: {}
@@ -485,7 +492,10 @@ jobs:
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do
-            if curl -sf "https://registry.npmjs.org/@strands-agents/sdk/$VERSION" >/dev/null; then
+            # Cache-buster: registry CDNs cache negative (404) responses; a poll
+            # that lands before propagation must not pin a stale 404 for the
+            # rest of the window.
+            if curl -sf "https://registry.npmjs.org/@strands-agents/sdk/$VERSION?t=$(date +%s)" >/dev/null; then
               echo "@strands-agents/sdk $VERSION is live on npm."
               exit 0
             fi


### PR DESCRIPTION
## Description

Two release-hardening items from the release SOP review, applied to both `release-python.yml` and `release-typescript.yml`:

**1. Strict single-increment version check (scan-commits).** The scan previously rejected only non-monotonic versions, so a typo like `1.48.0` -> `1.84.0` sailed through to the approver. Now the typed version must be exactly one of `MAJOR+1.0.0`, `MAJOR.MINOR+1.0`, or `MAJOR.MINOR.PATCH+1` relative to the previous tag, and anything else fails at scan with the three valid candidates in the error message. Deterministic; no behavior change for correct inputs.

**2. Post-publish smoke check (`verify-published`).** A final job that polls the registry (PyPI for python, npm for typescript) until the new version is visible, timing out loudly after 5 minutes. Replaces the manual "check the package page shows the new version" step in the SOP. Runs with an empty permissions block; skipped on dry runs like the other release-side jobs.

## Testing

- Both workflows validate as YAML.
- Increment guard verified by hand against the case table: prev `1.47.0` accepts `2.0.0`, `1.48.0`, `1.47.1`; rejects `1.84.0`, `1.49.0`, `3.0.0`, `1.47.2`.
- The poll loop uses the public registry JSON endpoints (`pypi.org/pypi/<pkg>/<ver>/json`, `registry.npmjs.org/<pkg>/<ver>`); both verified to return 200 for existing versions and 404 for missing ones.
- Full exercise requires a real release; both changes are scan-time or post-publish, so neither can affect the publish path itself.