### PR TITLE
ci(changelog): run the sync backstop every 2 hours

### DIFF
--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -4,7 +4,11 @@ on:
   release:
     types: [published]
   schedule:
-    - cron: '17 7 * * *'   # daily backstop for missed release events
+    # Backstop for missed release events, and the only same-day path for evals
+    # releases (evals cannot dispatch cross-repo with its GITHUB_TOKEN, and the
+    # bot PAT has no write here). skip-existing makes a no-op run nearly free,
+    # so a 2-hourly cadence costs little and caps changelog lag at ~2h.
+    - cron: '17 */2 * * *'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Description

Same-day changelog for evals. The daily cron is the only automatic path for evals releases: evals' `GITHUB_TOKEN` cannot dispatch a workflow in this repo (cross-repo dispatch needs `actions: write` here), and the changelog bot PAT deliberately has no write on this repo -- so an evals release waited up to 24h to appear.

Rather than minting a new cross-repo credential, this raises the backstop cron from daily to every 2 hours. `skip-existing` makes a no-op run nearly free (existing files are detected before any PR-API spend), so the added 11 runs/day cost almost nothing. Caps evals changelog lag at ~2h and tightens the missed-harness-release safety net at the same time.

Alternatives considered: a cross-repo dispatch from evals' release workflow needs a new secret with `actions: write` on this repo (another credential to scope, document, and rotate -- see how that went with the fork PAT); a GitHub App is the cleanest same-minute option but heavier setup than a 2h lag justifies today.

## Testing

- YAML validates; cron expression `17 */2 * * *` = minute 17 of every 2nd hour.
- The no-op cheapness this relies on is existing, tested behavior (`skip-existing` checks files before enrichment -- covered by `run.test.ts`).