### PR TITLE
feat(a2a): support the interrupt round trip over A2A

### DIFF
--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -381,11 +381,13 @@ In single-agent mode the server reuses one agent across every context, swapping 
 
 ### Answering Interrupts
 
-When a tool or hook on the served agent raises an [interrupt](../interrupts.md), the task moves to the A2A `input_required` state and waits. The client answers it, and the task resumes the paused tool exactly where it stopped.
-
 :::note[Python only]
 This feature is currently available in the Python SDK only.
 :::
+
+When a tool or hook on the served agent raises an [interrupt](../interrupts.md), the task moves to the A2A `input_required` state and waits. The client answers it, and the task resumes the paused tool exactly where it stopped.
+
+Answering an interrupt is the one flow on this page that needs the raw [`a2a-sdk`](https://github.com/a2aproject/a2a-python) client rather than `A2AAgent`. `A2AAgent` speaks in text, so it raises `ValueError` if you pass it interrupt responses, and it drops the `DataPart` carrying the interrupt ids when it reads the reply. The examples below build A2A messages directly.
 
 Each interrupt has a server-generated id, and an answer is bound to the id of the interrupt that raised it. The server advertises the pending interrupts on the `input_required` status message as a `DataPart`, alongside the human-readable `TextPart`:
 
@@ -418,7 +420,7 @@ To answer, send a new message on the same `taskId` containing a `DataPart` that 
 }
 ```
 
-The `response` is any JSON value, and it becomes the return value of the `interrupt()` call that paused the tool. Answer several interrupts in one message by sending one `DataPart` for each.
+The `response` becomes the return value of the `interrupt()` call that paused the tool. It is any JSON value except `null`, which the server refuses — a null answer would leave the interrupt unsatisfied and re-raise it. `false` and `0` are fine. Answer several interrupts in one message by sending one `DataPart` for each.
 
 Reading the ids off the status message and answering them:
 
@@ -441,7 +443,15 @@ answers = [
 ]
 ```
 
-The server rejects an answer it cannot bind, before the agent runs, so a refused answer leaves the interrupt pending and the task still answerable. An answer is rejected when its `interruptId` does not match an interrupt the task is waiting on, when no interrupt is pending, when the same `interruptId` is answered twice in one message, when the payload is missing `interruptId` or `response`, or when it is sent alongside other content parts. A task with a pending interrupt also rejects an ordinary conversational message — answer the interrupt, or cancel the task.
+The server rejects an answer it cannot bind, before the agent runs, so a refused answer leaves the interrupt pending and the task still answerable. An answer is rejected when:
+
+- its `interruptId` does not match an interrupt the task is waiting on
+- no interrupt is pending
+- the same `interruptId` is answered twice in one message
+- the payload is missing `interruptId`, or its `response` is missing or `null`
+- it is sent alongside other content parts
+
+A task with a pending interrupt also rejects an ordinary conversational message — answer the interrupt, or cancel the task.
 
 A `DataPart` without an `interruptResponse` key is unaffected and continues to reach the agent as structured data.
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -379,6 +379,72 @@ Contexts are keyed on the client supplied `context_id`. A caller who knows anoth
 In single-agent mode the server reuses one agent across every context, swapping each context's saved state on and off the shared instance under a lock, which serializes all requests. A single `agent` with a configured `session_manager` is rejected, because the session manager would persist every context into one interleaved session. Prefer `agent_factory` for any deployment that serves more than one conversation.
 :::
 
+### Answering Interrupts
+
+When a tool or hook on the served agent raises an [interrupt](../interrupts.md), the task moves to the A2A `input_required` state and waits. The client answers it, and the task resumes the paused tool exactly where it stopped.
+
+:::note[Python only]
+This feature is currently available in the Python SDK only.
+:::
+
+Each interrupt has a server-generated id, and an answer is bound to the id of the interrupt that raised it. The server advertises the pending interrupts on the `input_required` status message as a `DataPart`, alongside the human-readable `TextPart`:
+
+```json
+{
+  "kind": "data",
+  "data": {
+    "interrupts": [
+      {
+        "interruptId": "v1:tool_call:tu-1:a71adb48-e65d-55fa-b155-0359c9cd3b66",
+        "name": "approve_campaign",
+        "reason": {"name": "spring-launch"}
+      }
+    ]
+  }
+}
+```
+
+To answer, send a new message on the same `taskId` containing a `DataPart` that echoes the `interruptId` back with the response:
+
+```json
+{
+  "kind": "data",
+  "data": {
+    "interruptResponse": {
+      "interruptId": "v1:tool_call:tu-1:a71adb48-e65d-55fa-b155-0359c9cd3b66",
+      "response": {"approved": true}
+    }
+  }
+}
+```
+
+The `response` is any JSON value, and it becomes the return value of the `interrupt()` call that paused the tool. Answer several interrupts in one message by sending one `DataPart` for each.
+
+Reading the ids off the status message and answering them:
+
+```python
+from a2a.types import DataPart, Part
+
+# The task parked in input_required; read the interrupts it is waiting on.
+pending = next(
+    part.root.data["interrupts"]
+    for part in task.status.message.parts
+    if isinstance(part.root, DataPart) and "interrupts" in part.root.data
+)
+
+# Answer each one on the same taskId.
+answers = [
+    Part(root=DataPart(data={
+        "interruptResponse": {"interruptId": item["interruptId"], "response": {"approved": True}}
+    }))
+    for item in pending
+]
+```
+
+The server rejects an answer it cannot bind, before the agent runs, so a refused answer leaves the interrupt pending and the task still answerable. An answer is rejected when its `interruptId` does not match an interrupt the task is waiting on, when no interrupt is pending, when the same `interruptId` is answered twice in one message, when the payload is missing `interruptId` or `response`, or when it is sent alongside other content parts. A task with a pending interrupt also rejects an ordinary conversational message — answer the interrupt, or cancel the task.
+
+A `DataPart` without an `interruptResponse` key is unaffected and continues to reach the agent as structured data.
+
 ### Server Configuration Options
 
 <Tabs>

--- a/strands-py/src/strands/multiagent/a2a/executor.py
+++ b/strands-py/src/strands/multiagent/a2a/executor.py
@@ -18,12 +18,21 @@ import warnings
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
-from a2a.types import DataPart, FilePart, InternalError, Part, TaskState, TextPart, UnsupportedOperationError
+from a2a.types import (
+    DataPart,
+    FilePart,
+    InternalError,
+    InvalidParamsError,
+    Part,
+    TaskState,
+    TextPart,
+    UnsupportedOperationError,
+)
 from a2a.utils import new_agent_text_message, new_task
 from a2a.utils.errors import ServerError
 
@@ -32,6 +41,7 @@ from ...agent.agent import AgentResult as SAAgentResult
 from ...session.session_manager import SessionManager
 from ...types._snapshot import Snapshot
 from ...types.content import ContentBlock
+from ...types.interrupt import InterruptResponse, InterruptResponseContent
 from ...types.media import (
     DocumentContent,
     DocumentSource,
@@ -45,6 +55,39 @@ logger = logging.getLogger(__name__)
 
 # A factory that builds a fresh Agent for a given A2A context_id.
 AgentFactory = Callable[[str], SAAgent]
+
+# Key identifying a DataPart that carries a Strands interrupt response. The A2A payload mirrors the
+# `InterruptResponseContent` type verbatim so the wire contract and the SDK type cannot drift.
+INTERRUPT_RESPONSE_KEY = "interruptResponse"
+
+# Key under which an `input_required` status message advertises the interrupts awaiting an answer.
+# Each entry carries the `interruptId` that the matching interrupt response must echo back.
+INTERRUPTS_KEY = "interrupts"
+
+# What this executor invokes the agent with: fresh conversational content, or interrupt responses
+# resuming a task parked in `input_required`. Deliberately narrower than the public `AgentInput`,
+# which also admits `str`, `Messages`, and `None` — an A2A message only ever converts to these two.
+# Each arm stays homogeneous because `_InterruptState.resume()` rejects a prompt whose contents are
+# not all interrupt responses.
+_AgentPrompt = list[ContentBlock] | list[InterruptResponseContent]
+
+
+def _is_interrupt_resume(prompt: _AgentPrompt) -> bool:
+    """Whether a prompt carries interrupt responses rather than conversational content."""
+    return bool(prompt) and INTERRUPT_RESPONSE_KEY in prompt[0]
+
+
+def _jsonable(value: Any) -> Any:
+    """Return a value unchanged when it can cross the JSON-RPC boundary, else its string form.
+
+    An interrupt reason is arbitrary user data. A value the transport cannot encode would otherwise
+    surface only while serializing the response, long after the interrupt details are assembled.
+    """
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return value
 
 
 @dataclass
@@ -194,7 +237,7 @@ class StrandsA2AExecutor(AgentExecutor):
     async def _run_with_context_agent(
         self,
         context_id: str,
-        content_blocks: list[ContentBlock],
+        prompt: _AgentPrompt,
         invocation_state: dict[str, Any],
         updater: TaskUpdater,
         stream_state: _StreamState | None,
@@ -202,12 +245,12 @@ class StrandsA2AExecutor(AgentExecutor):
         """Factory mode: run against this context's dedicated agent, serialized only per context."""
         agent, lock = await self._acquire_context_agent(context_id)
         async with lock:
-            await self._stream_agent(agent, content_blocks, invocation_state, updater, stream_state)
+            await self._stream_agent(agent, prompt, invocation_state, updater, stream_state)
 
     async def _run_with_shared_agent(
         self,
         context_id: str,
-        content_blocks: list[ContentBlock],
+        prompt: _AgentPrompt,
         invocation_state: dict[str, Any],
         updater: TaskUpdater,
         stream_state: _StreamState | None,
@@ -216,7 +259,7 @@ class StrandsA2AExecutor(AgentExecutor):
         async with self._contexts_lock:
             self._restore_state(self.agent, self._snapshots.get(context_id, self._template_snapshot))  # type: ignore[arg-type]
             try:
-                await self._stream_agent(self.agent, content_blocks, invocation_state, updater, stream_state)  # type: ignore[arg-type]
+                await self._stream_agent(self.agent, prompt, invocation_state, updater, stream_state)  # type: ignore[arg-type]
             finally:
                 # Persist updated history (even on error), evict, then reset the agent for the next caller.
                 self._snapshots[context_id] = self._capture_state(self.agent)  # type: ignore[arg-type]
@@ -227,15 +270,32 @@ class StrandsA2AExecutor(AgentExecutor):
     async def _stream_agent(
         self,
         agent: SAAgent,
-        content_blocks: list[ContentBlock],
+        prompt: _AgentPrompt,
         invocation_state: dict[str, Any],
         updater: TaskUpdater,
         stream_state: _StreamState | None,
     ) -> None:
-        """Stream one agent invocation and translate its events to A2A updates."""
+        """Stream one agent invocation and translate its events to A2A updates.
+
+        Raises:
+            ServerError: If the input does not match the agent's interrupt state — interrupt
+                responses that name no parked interrupt, or fresh content for a parked task. Both
+                fail before the agent runs, so a parked interrupt survives a rejected resume.
+        """
+        # Binding is checked here rather than at extraction: the agent, and with it the interrupt
+        # state this request must match, is only resolved once the context's snapshot is restored.
+        if _is_interrupt_resume(prompt):
+            self._validate_interrupt_resume(agent, cast(list[InterruptResponseContent], prompt))
+        elif agent._interrupt_state.activated:
+            raise ServerError(
+                error=InvalidParamsError(
+                    message="Task is awaiting an interrupt response and cannot accept a new message"
+                )
+            ) from None
+
         try:
             result: SAAgentResult | None = None
-            async for event in agent.stream_async(content_blocks, invocation_state=invocation_state):
+            async for event in agent.stream_async(prompt, invocation_state=invocation_state):
                 if "result" in event:
                     result = event["result"]
                 else:
@@ -322,17 +382,21 @@ class StrandsA2AExecutor(AgentExecutor):
             updater: The task updater for managing task state and sending updates.
 
         Raises:
-            ServerError: If input conversion fails (missing or empty content).
+            ServerError: If input conversion fails (missing or empty content), or if the message
+                carries malformed interrupt responses.
         """
-        # Convert A2A message parts to Strands ContentBlocks
-        if context.message and hasattr(context.message, "parts"):
-            content_blocks = self._convert_a2a_parts_to_content_blocks(context.message.parts)
-            if not content_blocks:
+        if not (context.message and hasattr(context.message, "parts")):
+            raise ServerError(error=InternalError(message="Request message is missing or has no parts")) from None
+
+        # Interrupt responses resume a parked task, so they are recognized before the generic
+        # conversion below would flatten them into text.
+        prompt: _AgentPrompt | None = self._extract_interrupt_responses(context.message.parts)
+        if prompt is None:
+            prompt = self._convert_a2a_parts_to_content_blocks(context.message.parts)
+            if not prompt:
                 raise ServerError(
                     error=InternalError(message="No valid content found in request message parts")
                 ) from None
-        else:
-            raise ServerError(error=InternalError(message="Request message is missing or has no parts")) from None
 
         if not self.enable_a2a_compliant_streaming:
             warnings.warn(
@@ -356,9 +420,9 @@ class StrandsA2AExecutor(AgentExecutor):
             raise ServerError(error=InternalError(message="Request is missing a context_id")) from None
 
         if self._agent_factory is not None:
-            await self._run_with_context_agent(context_id, content_blocks, invocation_state, updater, stream_state)
+            await self._run_with_context_agent(context_id, prompt, invocation_state, updater, stream_state)
         else:
-            await self._run_with_shared_agent(context_id, content_blocks, invocation_state, updater, stream_state)
+            await self._run_with_shared_agent(context_id, prompt, invocation_state, updater, stream_state)
 
     async def _handle_interrupt_result(self, result: SAAgentResult, updater: TaskUpdater) -> None:
         """Handle an agent result that contains interrupts.
@@ -367,17 +431,25 @@ class StrandsA2AExecutor(AgentExecutor):
         the A2A `input_required` state. The interrupt details are communicated to
         the client via the status message.
 
+        The details are carried twice: a TextPart describing what is needed, and a DataPart holding
+        each interrupt's id. Only the id lets a client address its response back to the interrupt
+        that raised it, and an id is generated server-side so it cannot be inferred from the prose.
+
         Args:
             result: The agent result containing interrupts.
             updater: The task updater for managing task state.
         """
         # Build a descriptive message about what input is needed
         interrupt_descriptions = []
+        pending_interrupts: list[dict[str, Any]] = []
         for interrupt in result.interrupts or []:
             desc = f"- {interrupt.name}"
             if interrupt.reason:
                 desc += f": {interrupt.reason}"
             interrupt_descriptions.append(desc)
+            pending_interrupts.append(
+                {"interruptId": interrupt.id, "name": interrupt.name, "reason": _jsonable(interrupt.reason)}
+            )
 
         if interrupt_descriptions:
             input_message = "Agent requires input:\n" + "\n".join(interrupt_descriptions)
@@ -386,7 +458,12 @@ class StrandsA2AExecutor(AgentExecutor):
             # Still transition to input_required — the agent signaled it needs input.
             input_message = "Agent requires additional input to continue"
 
-        await updater.requires_input(message=updater.new_agent_message(parts=[Part(root=TextPart(text=input_message))]))
+        # The TextPart stays first so clients that only read prose are unaffected.
+        parts = [Part(root=TextPart(text=input_message))]
+        if pending_interrupts:
+            parts.append(Part(root=DataPart(data={INTERRUPTS_KEY: pending_interrupts})))
+
+        await updater.requires_input(message=updater.new_agent_message(parts=parts))
 
     async def _handle_streaming_event(
         self, event: dict[str, Any], updater: TaskUpdater, stream_state: _StreamState | None
@@ -582,6 +659,117 @@ class StrandsA2AExecutor(AgentExecutor):
         if "." in file_name:
             return file_name.rsplit(".", 1)[0]
         return file_name
+
+    def _extract_interrupt_responses(self, parts: list[Part]) -> list[InterruptResponseContent] | None:
+        """Extract Strands interrupt responses from inbound A2A message parts.
+
+        A client resumes a task parked in ``input_required`` by sending a DataPart shaped like the
+        Strands ``InterruptResponseContent`` type::
+
+            {"kind": "data", "data": {"interruptResponse": {"interruptId": "<id>", "response": <any>}}}
+
+        Recognition is deliberately narrow: only the explicit shape above is treated as a resume, so
+        an ordinary DataPart still reaches the generic content-block path unchanged.
+
+        Args:
+            parts: List of A2A Part objects from the inbound message.
+
+        Returns:
+            The interrupt responses carried by ``parts``, or None when none are present and the
+            caller should fall back to generic content-block conversion.
+
+        Raises:
+            ServerError: If an interrupt response is malformed, repeats an interrupt id, or is
+                accompanied by unrelated content in the same message.
+        """
+        responses: list[InterruptResponseContent] = []
+        seen_ids: set[str] = set()
+        unrelated_parts = 0
+
+        for part in parts:
+            part_root = part.root
+            data = part_root.data if isinstance(part_root, DataPart) else None
+            if not isinstance(data, dict) or INTERRUPT_RESPONSE_KEY not in data:
+                unrelated_parts += 1
+                continue
+
+            response = data[INTERRUPT_RESPONSE_KEY]
+            if not isinstance(response, dict):
+                raise ServerError(
+                    error=InvalidParamsError(
+                        message=f"'{INTERRUPT_RESPONSE_KEY}' must be an object with 'interruptId' and 'response'"
+                    )
+                ) from None
+
+            interrupt_id = response.get("interruptId")
+            if not isinstance(interrupt_id, str) or not interrupt_id:
+                raise ServerError(
+                    error=InvalidParamsError(message="Interrupt response is missing a non-empty 'interruptId'")
+                ) from None
+
+            # A null response is a legitimate answer, so presence of the key is what matters.
+            if "response" not in response:
+                raise ServerError(
+                    error=InvalidParamsError(
+                        message=f"Interrupt response for '{interrupt_id}' is missing a 'response' field"
+                    )
+                ) from None
+
+            # Two answers for one interrupt are ambiguous; reject rather than silently choosing one.
+            if interrupt_id in seen_ids:
+                raise ServerError(
+                    error=InvalidParamsError(message=f"Duplicate interrupt response for '{interrupt_id}'")
+                ) from None
+
+            seen_ids.add(interrupt_id)
+            responses.append(
+                InterruptResponseContent(
+                    interruptResponse=InterruptResponse(interruptId=interrupt_id, response=response["response"])
+                )
+            )
+
+        if not responses:
+            return None
+
+        # The agent resumes from interrupt responses alone; delivering both would mean dropping the
+        # conversational content, which is exactly the silent behavior the resume path must avoid.
+        if unrelated_parts:
+            raise ServerError(
+                error=InvalidParamsError(
+                    message="A message carrying interrupt responses must not contain other content parts"
+                )
+            ) from None
+
+        logger.debug("interrupt_ids=<%s> | extracted interrupt responses from request", sorted(seen_ids))
+        return responses
+
+    def _validate_interrupt_resume(self, agent: SAAgent, responses: list[InterruptResponseContent]) -> None:
+        """Verify interrupt responses bind to interrupts actually parked on this context's agent.
+
+        Args:
+            agent: The agent serving this context, with its interrupt state already restored.
+            responses: Interrupt responses extracted from the inbound message.
+
+        Raises:
+            ServerError: If the agent holds no parked interrupts, or a response names an interrupt
+                the agent is not waiting on.
+        """
+        interrupt_state = agent._interrupt_state
+
+        if not interrupt_state.activated:
+            raise ServerError(
+                error=InvalidParamsError(message="Received interrupt responses but no interrupt is pending")
+            ) from None
+
+        unknown_ids = sorted(
+            content["interruptResponse"]["interruptId"]
+            for content in responses
+            if content["interruptResponse"]["interruptId"] not in interrupt_state.interrupts
+        )
+        if unknown_ids:
+            raise ServerError(
+                error=InvalidParamsError(message=f"No pending interrupt matches id(s): {', '.join(unknown_ids)}")
+            ) from None
 
     def _convert_a2a_parts_to_content_blocks(self, parts: list[Part]) -> list[ContentBlock]:
         """Convert A2A message parts to Strands ContentBlocks.

--- a/strands-py/src/strands/multiagent/a2a/executor.py
+++ b/strands-py/src/strands/multiagent/a2a/executor.py
@@ -679,8 +679,8 @@ class StrandsA2AExecutor(AgentExecutor):
             caller should fall back to generic content-block conversion.
 
         Raises:
-            ServerError: If an interrupt response is malformed, repeats an interrupt id, or is
-                accompanied by unrelated content in the same message.
+            ServerError: If an interrupt response is malformed, carries a null response, repeats an
+                interrupt id, or is accompanied by unrelated content in the same message.
         """
         responses: list[InterruptResponseContent] = []
         seen_ids: set[str] = set()
@@ -707,11 +707,13 @@ class StrandsA2AExecutor(AgentExecutor):
                     error=InvalidParamsError(message="Interrupt response is missing a non-empty 'interruptId'")
                 ) from None
 
-            # A null response is a legitimate answer, so presence of the key is what matters.
-            if "response" not in response:
+            # `Interrupt.response` of None means "not yet answered", so a null answer would leave
+            # the interrupt unsatisfied and re-raise it — the client would see an identical
+            # input_required and no error. Falsy answers such as False are fine.
+            if response.get("response") is None:
                 raise ServerError(
                     error=InvalidParamsError(
-                        message=f"Interrupt response for '{interrupt_id}' is missing a 'response' field"
+                        message=f"Interrupt response for '{interrupt_id}' must provide a non-null 'response'"
                     )
                 ) from None
 

--- a/strands-py/tests/strands/multiagent/a2a/conftest.py
+++ b/strands-py/tests/strands/multiagent/a2a/conftest.py
@@ -8,6 +8,7 @@ from a2a.server.events import EventQueue
 
 from strands.agent.agent import Agent as SAAgent
 from strands.agent.agent_result import AgentResult as SAAgentResult
+from strands.interrupt import _InterruptState
 from strands.types._snapshot import Snapshot
 
 
@@ -38,6 +39,10 @@ def mock_strands_agent():
     agent._model_state = {}
     agent.take_snapshot = MagicMock(return_value=Snapshot(scope="agent", schema_version="1.0", data={}, app_data={}))
     agent.load_snapshot = MagicMock()
+
+    # A real Agent always carries interrupt state; the executor reads it to decide whether a
+    # request resumes a parked interrupt. Default is deactivated, matching a fresh agent.
+    agent._interrupt_state = _InterruptState()
 
     return agent
 

--- a/strands-py/tests/strands/multiagent/a2a/test_executor.py
+++ b/strands-py/tests/strands/multiagent/a2a/test_executor.py
@@ -5,7 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from a2a.types import DataPart, FilePart, InternalError, TextPart, UnsupportedOperationError
+from a2a.types import DataPart, FilePart, InternalError, InvalidParamsError, TextPart, UnsupportedOperationError
 from a2a.utils.errors import ServerError
 
 from strands.agent.agent_result import AgentResult as SAAgentResult
@@ -2389,10 +2389,24 @@ async def test_execute_multiple_interrupt_responses_all_delivered(
 
 
 @pytest.mark.asyncio
-async def test_execute_interrupt_response_with_null_response_is_valid(
-    mock_strands_agent, mock_request_context, mock_event_queue
-):
-    """A null response is a legitimate answer; only an absent 'response' key is malformed."""
+async def test_execute_null_interrupt_response_rejected(mock_strands_agent, mock_request_context, mock_event_queue):
+    """A null answer leaves the interrupt unsatisfied, so it is refused instead of silently re-firing."""
+    _park_interrupt(mock_strands_agent, "int-1")
+    mock_strands_agent.stream_async = MagicMock()
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(mock_request_context, [_interrupt_response_part("int-1", None)])
+
+    with pytest.raises(ServerError) as exc_info:
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    assert isinstance(exc_info.value.error, InvalidParamsError)
+    mock_strands_agent.stream_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_falsy_interrupt_response_is_valid(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Only null is refused: False answers an interrupt just as well as True."""
     _park_interrupt(mock_strands_agent, "int-1")
 
     mock_result = MagicMock(spec=SAAgentResult)
@@ -2406,11 +2420,11 @@ async def test_execute_interrupt_response_with_null_response_is_valid(
     mock_strands_agent.stream_async = MagicMock(side_effect=mock_stream)
     executor = StrandsA2AExecutor(mock_strands_agent)
 
-    _request_with_parts(mock_request_context, [_interrupt_response_part("int-1", None)])
+    _request_with_parts(mock_request_context, [_interrupt_response_part("int-1", False)])
     await executor.execute(mock_request_context, mock_event_queue)
 
     tru_input = mock_strands_agent.stream_async.call_args[0][0]
-    exp_input = [{"interruptResponse": {"interruptId": "int-1", "response": None}}]
+    exp_input = [{"interruptResponse": {"interruptId": "int-1", "response": False}}]
     assert tru_input == exp_input
 
 
@@ -2425,9 +2439,10 @@ async def test_execute_interrupt_response_for_unknown_id_fails_closed(
 
     _request_with_parts(mock_request_context, [_interrupt_response_part("int-other", {"approved": True})])
 
-    with pytest.raises(ServerError):
+    with pytest.raises(ServerError) as exc_info:
         await executor.execute(mock_request_context, mock_event_queue)
 
+    assert isinstance(exc_info.value.error, InvalidParamsError)
     mock_strands_agent.stream_async.assert_not_called()
 
 
@@ -2441,9 +2456,10 @@ async def test_execute_interrupt_response_when_not_parked_fails_closed(
 
     _request_with_parts(mock_request_context, [_interrupt_response_part("int-1", {"approved": True})])
 
-    with pytest.raises(ServerError):
+    with pytest.raises(ServerError) as exc_info:
         await executor.execute(mock_request_context, mock_event_queue)
 
+    assert isinstance(exc_info.value.error, InvalidParamsError)
     mock_strands_agent.stream_async.assert_not_called()
 
 
@@ -2458,9 +2474,10 @@ async def test_execute_rejected_resume_leaves_interrupt_parked(
 
     _request_with_parts(mock_request_context, [_interrupt_response_part("int-other", "yes")])
 
-    with pytest.raises(ServerError):
+    with pytest.raises(ServerError) as exc_info:
         await executor.execute(mock_request_context, mock_event_queue)
 
+    assert isinstance(exc_info.value.error, InvalidParamsError)
     assert state.activated
     assert "int-1" in state.interrupts
 
@@ -2479,9 +2496,10 @@ async def test_execute_duplicate_interrupt_responses_rejected(
         [_interrupt_response_part("int-1", {"approved": True}), _interrupt_response_part("int-1", {"approved": False})],
     )
 
-    with pytest.raises(ServerError):
+    with pytest.raises(ServerError) as exc_info:
         await executor.execute(mock_request_context, mock_event_queue)
 
+    assert isinstance(exc_info.value.error, InvalidParamsError)
     mock_strands_agent.stream_async.assert_not_called()
 
 
@@ -2506,9 +2524,10 @@ async def test_execute_malformed_interrupt_response_rejected(
 
     _request_with_parts(mock_request_context, [_data_part(malformed)])
 
-    with pytest.raises(ServerError):
+    with pytest.raises(ServerError) as exc_info:
         await executor.execute(mock_request_context, mock_event_queue)
 
+    assert isinstance(exc_info.value.error, InvalidParamsError)
     mock_strands_agent.stream_async.assert_not_called()
 
 
@@ -2526,9 +2545,10 @@ async def test_execute_interrupt_response_mixed_with_other_parts_rejected(
         [_interrupt_response_part("int-1", {"approved": True}), _text_part("and also do something else")],
     )
 
-    with pytest.raises(ServerError):
+    with pytest.raises(ServerError) as exc_info:
         await executor.execute(mock_request_context, mock_event_queue)
 
+    assert isinstance(exc_info.value.error, InvalidParamsError)
     mock_strands_agent.stream_async.assert_not_called()
 
 
@@ -2543,9 +2563,10 @@ async def test_execute_new_message_while_parked_fails_closed(
 
     _request_with_parts(mock_request_context, [_text_part("never mind, do something else")])
 
-    with pytest.raises(ServerError):
+    with pytest.raises(ServerError) as exc_info:
         await executor.execute(mock_request_context, mock_event_queue)
 
+    assert isinstance(exc_info.value.error, InvalidParamsError)
     mock_strands_agent.stream_async.assert_not_called()
 
 

--- a/strands-py/tests/strands/multiagent/a2a/test_executor.py
+++ b/strands-py/tests/strands/multiagent/a2a/test_executor.py
@@ -2268,3 +2268,443 @@ async def test_concurrent_compliant_streaming_uses_distinct_artifact_ids():
     # Each request used exactly one artifact id, and the two requests' ids are disjoint.
     assert len(ids_a) == 1 and len(ids_b) == 1
     assert ids_a.isdisjoint(ids_b)
+
+
+# ── Inbound interrupt responses ──────────────────────────────────────────────
+#
+# Regression coverage for https://github.com/strands-agents/harness-sdk/issues/2948: a client
+# resumes a task parked in `input_required` by sending a DataPart shaped like
+# InterruptResponseContent. These tests guarantee such a part reaches the agent as an interrupt
+# response rather than being flattened into a text block, and that a response the executor cannot
+# bind to a parked interrupt is rejected before the agent runs.
+
+
+def _interrupt_response_part(interrupt_id, response):
+    """Build an A2A DataPart carrying an interrupt response for the given id."""
+    data_part = MagicMock(spec=DataPart)
+    data_part.data = {"interruptResponse": {"interruptId": interrupt_id, "response": response}}
+    part = MagicMock()
+    part.root = data_part
+    return part
+
+
+def _data_part(data):
+    """Build an A2A DataPart carrying arbitrary structured data."""
+    data_part = MagicMock(spec=DataPart)
+    data_part.data = data
+    part = MagicMock()
+    part.root = data_part
+    return part
+
+
+def _text_part(text):
+    """Build an A2A TextPart."""
+    text_part = MagicMock(spec=TextPart)
+    text_part.text = text
+    part = MagicMock()
+    part.root = text_part
+    return part
+
+
+def _park_interrupt(agent, *interrupt_ids):
+    """Put the agent into an interrupt state holding the given parked interrupt ids."""
+    from strands.interrupt import Interrupt, _InterruptState
+
+    state = _InterruptState()
+    state.interrupts = {id_: Interrupt(id=id_, name=f"name-{id_}") for id_ in interrupt_ids}
+    state.activated = True
+    agent._interrupt_state = state
+    return state
+
+
+def _request_with_parts(mock_request_context, parts, task_id="task-resume"):
+    """Point a request context at a task carrying the given message parts."""
+    task = MagicMock()
+    task.id = task_id
+    task.context_id = f"ctx-{task_id}"
+    mock_request_context.current_task = task
+
+    message = MagicMock()
+    message.parts = parts
+    mock_request_context.message = message
+    return mock_request_context
+
+
+@pytest.mark.asyncio
+async def test_execute_interrupt_response_resumes_parked_interrupt(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """An interrupt-response DataPart reaches the agent as InterruptResponseContent, not text."""
+    _park_interrupt(mock_strands_agent, "int-1")
+
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.stop_reason = "end_turn"
+    mock_result.interrupts = None
+    mock_result.__str__ = MagicMock(return_value="Campaign created")
+
+    async def mock_stream(agent_input, **kwargs):
+        yield {"result": mock_result}
+
+    mock_strands_agent.stream_async = MagicMock(side_effect=mock_stream)
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(mock_request_context, [_interrupt_response_part("int-1", {"approved": True})])
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    tru_input = mock_strands_agent.stream_async.call_args[0][0]
+    exp_input = [{"interruptResponse": {"interruptId": "int-1", "response": {"approved": True}}}]
+    assert tru_input == exp_input
+
+
+@pytest.mark.asyncio
+async def test_execute_multiple_interrupt_responses_all_delivered(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """Distinct interrupt ids in one message are all forwarded to the agent."""
+    _park_interrupt(mock_strands_agent, "int-1", "int-2")
+
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.stop_reason = "end_turn"
+    mock_result.interrupts = None
+    mock_result.__str__ = MagicMock(return_value="done")
+
+    async def mock_stream(agent_input, **kwargs):
+        yield {"result": mock_result}
+
+    mock_strands_agent.stream_async = MagicMock(side_effect=mock_stream)
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(
+        mock_request_context,
+        [_interrupt_response_part("int-1", "yes"), _interrupt_response_part("int-2", "no")],
+    )
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    tru_input = mock_strands_agent.stream_async.call_args[0][0]
+    exp_input = [
+        {"interruptResponse": {"interruptId": "int-1", "response": "yes"}},
+        {"interruptResponse": {"interruptId": "int-2", "response": "no"}},
+    ]
+    assert tru_input == exp_input
+
+
+@pytest.mark.asyncio
+async def test_execute_interrupt_response_with_null_response_is_valid(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """A null response is a legitimate answer; only an absent 'response' key is malformed."""
+    _park_interrupt(mock_strands_agent, "int-1")
+
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.stop_reason = "end_turn"
+    mock_result.interrupts = None
+    mock_result.__str__ = MagicMock(return_value="done")
+
+    async def mock_stream(agent_input, **kwargs):
+        yield {"result": mock_result}
+
+    mock_strands_agent.stream_async = MagicMock(side_effect=mock_stream)
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(mock_request_context, [_interrupt_response_part("int-1", None)])
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    tru_input = mock_strands_agent.stream_async.call_args[0][0]
+    exp_input = [{"interruptResponse": {"interruptId": "int-1", "response": None}}]
+    assert tru_input == exp_input
+
+
+@pytest.mark.asyncio
+async def test_execute_interrupt_response_for_unknown_id_fails_closed(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """A response naming an interrupt the agent is not parked on never reaches the agent."""
+    _park_interrupt(mock_strands_agent, "int-1")
+    mock_strands_agent.stream_async = MagicMock()
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(mock_request_context, [_interrupt_response_part("int-other", {"approved": True})])
+
+    with pytest.raises(ServerError):
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    mock_strands_agent.stream_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_interrupt_response_when_not_parked_fails_closed(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """Interrupt responses sent to an agent holding no interrupt are rejected."""
+    mock_strands_agent.stream_async = MagicMock()
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(mock_request_context, [_interrupt_response_part("int-1", {"approved": True})])
+
+    with pytest.raises(ServerError):
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    mock_strands_agent.stream_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_rejected_resume_leaves_interrupt_parked(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """Rejecting a resume must not clear the interrupt the agent is still waiting on."""
+    state = _park_interrupt(mock_strands_agent, "int-1")
+    mock_strands_agent.stream_async = MagicMock()
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(mock_request_context, [_interrupt_response_part("int-other", "yes")])
+
+    with pytest.raises(ServerError):
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    assert state.activated
+    assert "int-1" in state.interrupts
+
+
+@pytest.mark.asyncio
+async def test_execute_duplicate_interrupt_responses_rejected(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """Two responses for one interrupt id are ambiguous and rejected rather than silently resolved."""
+    _park_interrupt(mock_strands_agent, "int-1")
+    mock_strands_agent.stream_async = MagicMock()
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(
+        mock_request_context,
+        [_interrupt_response_part("int-1", {"approved": True}), _interrupt_response_part("int-1", {"approved": False})],
+    )
+
+    with pytest.raises(ServerError):
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    mock_strands_agent.stream_async.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        {"interruptResponse": "not-an-object"},
+        {"interruptResponse": {"response": "yes"}},
+        {"interruptResponse": {"interruptId": "", "response": "yes"}},
+        {"interruptResponse": {"interruptId": 42, "response": "yes"}},
+        {"interruptResponse": {"interruptId": "int-1"}},
+    ],
+)
+@pytest.mark.asyncio
+async def test_execute_malformed_interrupt_response_rejected(
+    malformed, mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """Malformed interrupt responses fail before the agent is invoked."""
+    _park_interrupt(mock_strands_agent, "int-1")
+    mock_strands_agent.stream_async = MagicMock()
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(mock_request_context, [_data_part(malformed)])
+
+    with pytest.raises(ServerError):
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    mock_strands_agent.stream_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_interrupt_response_mixed_with_other_parts_rejected(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """Content alongside an interrupt response would be silently dropped, so the message is rejected."""
+    _park_interrupt(mock_strands_agent, "int-1")
+    mock_strands_agent.stream_async = MagicMock()
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(
+        mock_request_context,
+        [_interrupt_response_part("int-1", {"approved": True}), _text_part("and also do something else")],
+    )
+
+    with pytest.raises(ServerError):
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    mock_strands_agent.stream_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_new_message_while_parked_fails_closed(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """A parked task does not accept a fresh conversational turn in place of a resume."""
+    _park_interrupt(mock_strands_agent, "int-1")
+    mock_strands_agent.stream_async = MagicMock()
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(mock_request_context, [_text_part("never mind, do something else")])
+
+    with pytest.raises(ServerError):
+        await executor.execute(mock_request_context, mock_event_queue)
+
+    mock_strands_agent.stream_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_ordinary_data_part_still_converts_to_text(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """A DataPart without an interrupt response keeps the generic structured-data path."""
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.stop_reason = "end_turn"
+    mock_result.interrupts = None
+    mock_result.__str__ = MagicMock(return_value="ok")
+
+    async def mock_stream(agent_input, **kwargs):
+        yield {"result": mock_result}
+
+    mock_strands_agent.stream_async = MagicMock(side_effect=mock_stream)
+    executor = StrandsA2AExecutor(mock_strands_agent)
+
+    _request_with_parts(mock_request_context, [_data_part({"campaign": "spring", "budget": 100})])
+    await executor.execute(mock_request_context, mock_event_queue)
+
+    tru_input = mock_strands_agent.stream_async.call_args[0][0]
+    assert len(tru_input) == 1
+    assert tru_input[0]["text"].startswith("[Structured Data]")
+    assert "spring" in tru_input[0]["text"]
+
+
+# ── Outbound interrupt advertisement ─────────────────────────────────────────
+#
+# An interrupt id is generated server-side, so a client can only answer an interrupt if the id
+# reaches it. These tests guarantee the input_required status message carries the ids in a DataPart
+# while keeping the human-readable TextPart clients already rely on.
+
+
+def _input_required_message(mock_event_queue):
+    """The status message from the single input_required event on the queue."""
+    from a2a.types import TaskState, TaskStatusUpdateEvent
+
+    events = [call[0][0] for call in mock_event_queue.enqueue_event.call_args_list]
+    input_required = [
+        e for e in events if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.input_required
+    ]
+    assert len(input_required) == 1
+    return input_required[0].status.message
+
+
+async def _run_until_interrupt(executor, mock_strands_agent, mock_request_context, mock_event_queue, interrupts):
+    """Drive one execution whose result carries the given interrupts."""
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.stop_reason = "interrupt"
+    mock_result.interrupts = interrupts
+
+    async def mock_stream(agent_input, **kwargs):
+        yield {"result": mock_result}
+
+    mock_strands_agent.stream_async = MagicMock(side_effect=mock_stream)
+    _request_with_parts(mock_request_context, [_text_part("do the thing")], task_id="task-out")
+    await executor.execute(mock_request_context, mock_event_queue)
+
+
+@pytest.mark.asyncio
+async def test_interrupt_advertises_ids_in_data_part(mock_strands_agent, mock_request_context, mock_event_queue):
+    """The input_required message carries each interrupt's id so a client can answer it."""
+    from strands.interrupt import Interrupt
+
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_until_interrupt(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [Interrupt(id="v1:tool_call:tu-1:abc", name="approve_campaign", reason={"name": "spring"})],
+    )
+
+    data_parts = [p.root.data for p in _input_required_message(mock_event_queue).parts if isinstance(p.root, DataPart)]
+    tru_data = data_parts
+    exp_data = [
+        {
+            "interrupts": [
+                {"interruptId": "v1:tool_call:tu-1:abc", "name": "approve_campaign", "reason": {"name": "spring"}}
+            ]
+        }
+    ]
+    assert tru_data == exp_data
+
+
+@pytest.mark.asyncio
+async def test_interrupt_keeps_human_readable_text_part(mock_strands_agent, mock_request_context, mock_event_queue):
+    """The prose part clients already read stays first and unchanged."""
+    from strands.interrupt import Interrupt
+
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_until_interrupt(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [Interrupt(id="int-1", name="approval", reason="Need user approval")],
+    )
+
+    first_part = _input_required_message(mock_event_queue).parts[0].root
+    assert isinstance(first_part, TextPart)
+    assert "approval" in first_part.text
+    assert "Need user approval" in first_part.text
+
+
+@pytest.mark.asyncio
+async def test_interrupt_advertises_every_pending_id(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Every interrupt the agent parked is addressable, not just the first."""
+    from strands.interrupt import Interrupt
+
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_until_interrupt(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [Interrupt(id="int-1", name="first"), Interrupt(id="int-2", name="second")],
+    )
+
+    data_parts = [p.root.data for p in _input_required_message(mock_event_queue).parts if isinstance(p.root, DataPart)]
+    tru_ids = [entry["interruptId"] for entry in data_parts[0]["interrupts"]]
+    exp_ids = ["int-1", "int-2"]
+    assert tru_ids == exp_ids
+
+
+@pytest.mark.asyncio
+async def test_interrupt_reason_that_is_not_json_falls_back_to_text(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """A reason the transport cannot encode degrades to its string form rather than failing late."""
+    from strands.interrupt import Interrupt
+
+    class Unserializable:
+        def __str__(self):
+            return "<custom reason>"
+
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_until_interrupt(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [Interrupt(id="int-1", name="approval", reason=Unserializable())],
+    )
+
+    data_parts = [p.root.data for p in _input_required_message(mock_event_queue).parts if isinstance(p.root, DataPart)]
+    tru_reason = data_parts[0]["interrupts"][0]["reason"]
+    exp_reason = "<custom reason>"
+    assert tru_reason == exp_reason
+
+
+@pytest.mark.asyncio
+async def test_interrupt_without_details_sends_no_data_part(mock_strands_agent, mock_request_context, mock_event_queue):
+    """stop_reason='interrupt' with no interrupts still parks the task, with nothing to advertise."""
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_until_interrupt(executor, mock_strands_agent, mock_request_context, mock_event_queue, [])
+
+    parts = _input_required_message(mock_event_queue).parts
+    assert not [p for p in parts if isinstance(p.root, DataPart)]
+    assert isinstance(parts[0].root, TextPart)


### PR DESCRIPTION
## Description

`StrandsA2AExecutor` could raise interrupts but never complete them, so human-in-the-loop did not work over A2A at all. A tool calling `tool_context.interrupt()` parked its task permanently, for two reasons:

- **Inbound**: `_convert_a2a_parts_to_content_blocks()` serialized every DataPart to `[Structured Data]\n{...}` text. A client's interrupt response arrived as a plain conversational turn rather than the `list[InterruptResponseContent]` that `_InterruptState.resume()` requires, so the parked tool never resumed and the approval payload reached the model as ordinary text it could be persuaded by.
- **Outbound**: interrupt ids are generated server-side (`v1:tool_call:<toolUseId>:<uuid>`), but `_handle_interrupt_result()` sent only the interrupt *name* and *reason* as prose. A client had no way to learn the id it needed to answer with.

Both halves are needed for a usable round trip, which is why they are one change: fixing only the inbound path leaves a feature that no client can exercise and no reviewer can validate without reaching into server internals.

Resume is now treated as a continuation of the parked state rather than a new conversational turn. Once a task is in `input_required`, the next message for it must carry an interrupt response, and every rejection happens before the agent runs — so a refused resume leaves the interrupt parked and retryable instead of letting an unverified approval through as chat.

## Public API Changes

Two DataPart contracts on the A2A wire. Neither changes any Python signature.

**Outbound** — the `input_required` status message now carries the pending interrupts. The existing `TextPart` stays first, so clients that only read prose are unaffected:

```json
{
  "kind": "data",
  "data": {
    "interrupts": [
      {"interruptId": "v1:tool_call:tu-1:a71adb48-...", "name": "approve_campaign", "reason": {"name": "spring-launch"}}
    ]
  }
}
```

**Inbound** — a client resumes by echoing the id back. The payload mirrors the existing `InterruptResponseContent` type verbatim, so the wire contract and the SDK type cannot drift, and the same shape re-cases directly to TypeScript:

```json
{
  "kind": "data",
  "data": {"interruptResponse": {"interruptId": "v1:tool_call:tu-1:a71adb48-...", "response": {"approved": true}}}
}
```

A full round trip from the client's side:

```python
# 1. Ask for something that needs approval -> task parks in input_required
response = await client.send_message(message_with_text("create the spring-launch campaign"))

# 2. Read the interrupt id off the status message
interrupts = next(
    part.root.data["interrupts"]
    for part in response.status.message.parts
    if part.root.kind == "data" and "interrupts" in part.root.data
)

# 3. Answer it, on the same taskId
await client.send_message(
    message_with_parts(
        task_id=response.id,
        parts=[Part(root=DataPart(data={
            "interruptResponse": {"interruptId": interrupts[0]["interruptId"], "response": {"approved": True}}
        }))],
    )
)
```

### Rejected inputs

Recognition is narrow and binding fails closed. All of these raise `InvalidParamsError` before the agent is invoked:

| Input | Why |
| --- | --- |
| Interrupt id not parked on this context's agent | An approval must bind to the interrupt that requested it |
| Interrupt response with no interrupt pending | Nothing to resume |
| Two responses for the same interrupt id | Ambiguous; picking one silently would discard a decision |
| Missing/blank `interruptId`, missing `response`, non-object payload | Malformed |
| Interrupt response mixed with other content parts | The agent resumes from responses alone, so the other content would be silently dropped |
| A fresh conversational turn while a task is parked | A parked task is answered or cancelled, not talked past |

A DataPart without an `interruptResponse` key is untouched and still takes the generic structured-data path.

The "mixed with other content parts" rule is the strictest of these and deliberately so. `_InterruptState.resume()` rejects any prompt whose contents are not all interrupt responses, so accompanying parts cannot be delivered — only dropped — and dropping them silently is what this change exists to avoid. It does mean a client following the common convention of pairing a `DataPart` with a human-readable `TextPart` gets rejected. Starting strict keeps the option open, since accepting more inputs later is backward compatible while withdrawing acceptance is not. Easy to relax to "ignore an accompanying TextPart" if you would rather meet that convention now.

## Design notes for reviewers

**Why this inbound shape.** It is already the cross-SDK JSON form of the type. `InterruptResponseContent.toJSON()` in `strands-ts/src/types/interrupt.ts` emits exactly `{interruptResponse: {interruptId, response}}`, `fromJSON()` reads it back, and the type guard tests for the `interruptResponse` key — so this contract needs no mapping layer in either SDK, and TypeScript parity can adopt it as-is. The alternative considered was an explicit envelope (`{"type": "interrupt_response", "id": ...}`), closer to the ADK sample's `{"type": "form"}` discriminator, but that would have introduced a second name for a type both SDKs already serialize, and `interruptResponse` is a unique self-discriminating key. Happy to switch if you would rather have the discriminator.

Worth flagging that there is otherwise no precedent to borrow here: across `a2a-samples`, no implementation sends a machine-readable resume payload. The ADK and LangGraph agents both route resumption through the model, which reads a correlation id out of conversational text and passes it to a tool, and the reference CLI answers `input_required` with a plain `TextPart`. Strands cannot do that — `_InterruptState.resume()` binds to an exact interrupt id and runs *before* the model, so there is no model in the loop to extract an id from prose.

**TypeScript parity.** `strands-ts/src/a2a/executor.ts` has the same gap and is untouched here, since that is a separate sub-project and a separate PR. The docs mark the feature Python-only. Happy to open the parity issue, or take it as a follow-up PR once the wire contract is settled here.

**Why this outbound shape.** This part does have precedent. The ADK expense-reimbursement sample sends a server-minted correlation id in a `DataPart` on `input_required` and rejects unknown ids on the way back — the same pattern implemented here.

**Where binding is checked.** Shape and duplicate validation happen at extraction, but id binding happens in `_stream_agent`, because the agent — and with it the interrupt state the request must match — is only resolved after the context's snapshot is restored.

## Documentation PR

Included here, under `site/`: a new **Answering Interrupts** section in `user-guide/concepts/multi-agent/agent-to-agent.mdx`, covering both wire shapes, a client example, and the rejection rules. Marked Python-only per the existing `:::note[Python only]` convention. `npm run build` passes with no broken links.

## Related Issues

Closes #2948

## Type of Change

New feature

Bug fix in effect — it makes #2948's scenario work — but it adds public wire surface, so it wants a minor bump rather than a patch.

## Testing

`hatch run prepare` passes for this change: ruff, mypy, and the full suite are green.

One unrelated flake to note, so it isn't mistaken for this change: `tests/strands/tools/mcp/test_mcp_client.py::test_call_tool_async_caller_cancellation_timeout_preserves_cancelled_error` fails intermittently in the full py3.13 run and passes in isolation. It reproduces on an unmodified `main` (1 failure in 3 runs) and touches no code this PR changes. Happy to open a separate issue for it.

Beyond the unit tests, I drove the round trip end to end against a real `Agent` with a real interrupting tool, through the A2A surface only — the test client reads the interrupt id off the outbound message exactly as a real client would, with no access to executor internals:

```
1. states=['input-required']
2. advertised=[{'interruptId': 'v1:tool_call:tu-1:a71adb48-...', 'name': 'approve_campaign', 'reason': {'name': 'spring-launch'}}]
3. guessed id refused: No pending interrupt matches id(s): guessed-id
4. states=['completed']  final='Campaign is live.'
```

Verified in both isolation modes: `agent_factory`, and the deprecated shared-agent mode where the parked interrupt survives the snapshot swap via the `session` preset's `interrupt_state` field.


- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
