### PR TITLE
fix(context-offloader): refresh eviction cycle on retrieve for unified Storage backends

### DIFF
--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -323,6 +323,10 @@ class ContextOffloader(Plugin):
         Constraints:
           - pattern/line_range/context_lines only work on text content. For binary content, omit them.
           - Line numbers in results are 1-indexed and can be used in follow-up line_range calls.
+          - Retrieving a reference refreshes its eviction timer for unified Storage
+            backends, so actively-retrieved content survives ``evict_after_cycles``
+            beyond its store time — matching ``InMemoryStorage.retrieve``'s
+            last-access refresh behavior.
 
         Examples:
           {"reference": "ref_1", "pattern": "error"} -> lines containing "error" with 5 lines context
@@ -344,6 +348,10 @@ class ContextOffloader(Plugin):
             content_bytes, content_type = await _retrieve_content(storage, reference)
         except KeyError:
             return f"Error: reference not found: {reference}"
+
+        # Refresh the eviction cycle so actively-retrieved content survives
+        # eviction for unified Storage backends, matching InMemoryStorage.retrieve.
+        self._refresh_eviction_cycle(tool_context.agent, reference)
 
         if pattern is None and line_range is None and context_lines is None:
             return self._decode_full_content(content_bytes, content_type, reference)
@@ -539,6 +547,26 @@ class ContextOffloader(Plugin):
                 agent_cycles = {}
                 self._stored_cycles[agent] = agent_cycles
             agent_cycles[ref] = cycle
+
+    def _refresh_eviction_cycle(self, agent: Agent, reference: str) -> None:
+        """Refresh the eviction cycle for a retrieved reference.
+
+        Unified ``Storage`` backends are evicted by the plugin based on the cycle
+        recorded at *store* time (see ``_on_before_model_call``). Without a refresh
+        on retrieve, an entry is evicted ``evict_after_cycles`` after it was stored
+        regardless of active retrieval — so an agent that retrieves a reference at
+        cycle 15 can still hit "reference not found" at cycle 21 because the store
+        happened at cycle 0. ``InMemoryStorage.retrieve`` already refreshes its own
+        last-accessed cycle (storage.py:372); this mirrors that behavior for the
+        unified-Storage path so cross-backend behavior matches the documented
+        contract. A no-op for ``InMemoryStorage`` (``_track_stored_cycle`` is guarded
+        by ``not _is_offloader_storage``), which self-refreshes on retrieve.
+        """
+        cycle = agent.event_loop_metrics.cycle_count
+        self._track_stored_cycle(agent, reference, cycle)
+        logger.debug(
+            "reference=<%s>, cycle=<%d> | retrieve refreshed eviction cycle", reference, cycle
+        )
 
     def _slice_preview(self, text: str) -> str:
         """Slice text to approximately preview_tokens using character-based estimation.

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -985,6 +985,50 @@ class TestUnifiedStorage:
         assert len(await unified_storage.list("")) == 0
 
     @pytest.mark.asyncio
+    async def test_retrieve_refreshes_eviction_cycle_unified(self, unified_storage, unified_mock_agent):
+        """Retrieving offloaded content refreshes its stored cycle for unified Storage
+        backends so actively-retrieved entries survive eviction, mirroring
+        InMemoryStorage.retrieve's last-access refresh."""
+        plugin = ContextOffloader(
+            storage=unified_storage,
+            max_result_tokens=25,
+            preview_tokens=10,
+            include_retrieval_tool=True,
+            evict_after_cycles=3,
+        )
+
+        # Offload at cycle 1 (stored_cycle == 1)
+        unified_mock_agent.event_loop_metrics.cycle_count = 1
+        event = _make_event(unified_mock_agent, "hello world " * 50)
+        await plugin._handle_tool_result(event)
+
+        # Extract the reference from the offloaded placeholder
+        result_text = event.result["content"][0]["text"]
+        ref_line = [line for line in result_text.split("\n") if "tool_123_0" in line][0]
+        ref = ref_line.strip().split(" ")[0]
+
+        # Cycle 3: retrieve -> must refresh stored_cycle to 3
+        unified_mock_agent.event_loop_metrics.cycle_count = 3
+        tool_context = MagicMock(spec=ToolContext)
+        tool_context.agent = unified_mock_agent
+        content = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
+        assert "hello world" in content
+
+        # Cycle 5: without the refresh, stored_cycle=1 < threshold (5-3=2) -> evicted.
+        # With the refresh, stored_cycle=3 >= 2 -> survives.
+        bmc_event = BeforeModelCallEvent(agent=unified_mock_agent, invocation_state={})
+        unified_mock_agent.event_loop_metrics.cycle_count = 5
+        await plugin._on_before_model_call(bmc_event)
+        assert len(await unified_storage.list("")) == 1, (
+            "actively-retrieved entry must survive eviction for unified Storage backends"
+        )
+        # And remains retrievable
+        content_again = await plugin.retrieve_offloaded_content(
+            reference=ref, tool_context=tool_context
+        )
+        assert "hello world" in content_again
+
+    @pytest.mark.asyncio
     async def test_eviction_scoped_per_agent(self, unified_storage):
         plugin = ContextOffloader(
             storage=unified_storage,


### PR DESCRIPTION
## Description

`ContextOffloader` evicted unified-Storage entries `evict_after_cycles` after they were *stored*, regardless of active retrieval — while `InMemoryStorage.retrieve` refreshes its last-accessed cycle (`storage.py:372`) so actively-retrieved content survives eviction. An agent using `LocalFileStorage` or `S3Storage` could retrieve a reference at cycle 15 and still hit "reference not found" at cycle 21 because the store happened at cycle 0. Same plugin, same config, different data-loss behavior depending on the storage class — contradicting `InMemoryStorage.retrieve`'s docstring ("Refreshes the last-accessed turn so the entry stays alive longer", `storage.py:355-356`).

This change refreshes the stored cycle on retrieve for unified-Storage backends via `_refresh_eviction_cycle`, mirroring `InMemoryStorage.retrieve`. It is a no-op for `InMemoryStorage` (which already self-refreshes on retrieve), so behavior is unchanged for in-memory users. The fix is the single-line cycle update the InMemory backend already performs; it does not scan `agent.messages` and does not change the eviction contract — eviction remains a best-effort memory-bounding feature, and a referenced entry can still be evicted after `evict_after_cycles` of inactivity.

## Related Issues

Refs: context-offloader (RFC 0009, `team/designs/0009-context-offloader/`). No tracked bug issue — the cross-backend eviction divergence was found while auditing the offloader's retrieve path.

## Documentation PR

No documentation changes needed. The `retrieve_offloaded_content` tool docstring now documents the eviction-refresh behavior, and the offloader is a Python-only vended plugin.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- Added `TestUnifiedStorage::test_retrieve_refreshes_eviction_cycle_unified`: offloads at cycle 1, retrieves at cycle 3, advances to cycle 5 (past store + `evict_after_cycles=3`), asserts the entry survives and is still retrievable. Red on `main` (`assert 0 == 1` — the entry is evicted because the cycle-3 retrieval did not refresh the stored cycle), green with this fix.
- `cd strands-py && python -m pytest tests/strands/vended_plugins/context_offloader/` → 164 passed, no new warnings.
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
