### PR TITLE
fix(context): legacy file storage accepts bare filenames and stems

### DIFF
--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -190,13 +190,11 @@ class FileStorage:
         if ".." in reference:
             raise KeyError(f"Reference not found: {reference}")
 
-        prefix = f"{str(self._artifact_dir).rstrip('/')}/"
-        if "/" in reference:
-            if not reference.startswith(prefix):
+        ref_path = Path(reference)
+        if len(ref_path.parts) > 1:
+            if ref_path.parent.resolve() != self._artifact_dir.resolve():
                 raise KeyError(f"Reference not found: {reference}")
-            candidate = reference[len(prefix):]
-            if "/" in candidate:
-                raise KeyError(f"Reference not found: {reference}")
+            candidate = ref_path.name
         else:
             candidate = reference
 
@@ -269,14 +267,11 @@ class FileStorage:
         """
         if ".." in reference:
             raise KeyError(f"Reference not found: {reference}")
-        prefix = f"{str(self._artifact_dir).rstrip('/')}/"
-        if "/" in reference:
-            if not reference.startswith(prefix):
+        ref_path = Path(reference)
+        if len(ref_path.parts) > 1:
+            if ref_path.parent.resolve() != self._artifact_dir.resolve():
                 raise KeyError(f"Reference not found: {reference}")
-            candidate = reference[len(prefix):]
-            if "/" in candidate:
-                raise KeyError(f"Reference not found: {reference}")
-            return candidate
+            return ref_path.name
         return reference
 
     async def retrieve(self, reference: str) -> tuple[bytes, str]:

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -251,6 +251,34 @@ class FileStorage:
         host_path.write_bytes(content)
         return str(host_path)
 
+    def _resolve_from_path(self, reference: str) -> str:
+        """Validate a reference as a path within the artifact directory.
+
+        Used as a fallback when ``_resolve_reference`` fails (metadata
+        missing or corrupt). Only accepts full paths or bare filenames —
+        stem matching requires metadata.
+
+        Args:
+            reference: A full path or bare filename.
+
+        Returns:
+            The validated filename (basename).
+
+        Raises:
+            KeyError: If the path is outside the artifact directory.
+        """
+        if ".." in reference:
+            raise KeyError(f"Reference not found: {reference}")
+        prefix = f"{str(self._artifact_dir).rstrip('/')}/"
+        if "/" in reference:
+            if not reference.startswith(prefix):
+                raise KeyError(f"Reference not found: {reference}")
+            candidate = reference[len(prefix):]
+            if "/" in candidate:
+                raise KeyError(f"Reference not found: {reference}")
+            return candidate
+        return reference
+
     async def retrieve(self, reference: str) -> tuple[bytes, str]:
         """Retrieve content from a stored file.
 
@@ -268,7 +296,10 @@ class FileStorage:
         """
         if self._sandbox is not None:
             await self._ensure_sandbox_metadata()
-            filename = self._resolve_reference(reference)
+            try:
+                filename = self._resolve_reference(reference)
+            except KeyError:
+                filename = self._resolve_from_path(reference)
             full_path = self._artifact_path(filename)
             try:
                 content = await self._sandbox.read_file(full_path)
@@ -279,12 +310,7 @@ class FileStorage:
         try:
             filename = self._resolve_reference(reference)
         except KeyError:
-            # Fallback: try as a literal path (metadata may be stale/corrupt).
-            file_path = Path(reference) if Path(reference).is_absolute() else (self._artifact_dir / reference)
-            file_path = file_path.resolve()
-            if not file_path.is_relative_to(self._artifact_dir.resolve()) or not file_path.is_file():
-                raise
-            filename = file_path.name
+            filename = self._resolve_from_path(reference)
 
         file_path = (self._artifact_dir / filename).resolve()
         if not file_path.is_relative_to(self._artifact_dir.resolve()) or not file_path.is_file():

--- a/strands-py/src/strands/vended_plugins/context_offloader/storage.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/storage.py
@@ -172,6 +172,43 @@ class FileStorage:
         """Join a filename onto the artifact dir, preserving its string form."""
         return f"{str(self._artifact_dir).rstrip('/')}/{filename}"
 
+    def _resolve_reference(self, reference: str) -> str:
+        """Normalize a reference to a known filename in ``_content_types``.
+
+        Accepts full paths, bare filenames (with extension), and filename
+        stems (without extension). Validates against path traversal.
+
+        Args:
+            reference: Full path, bare filename, or filename stem.
+
+        Returns:
+            The resolved filename (basename with extension).
+
+        Raises:
+            KeyError: If the reference cannot be resolved or fails validation.
+        """
+        if ".." in reference:
+            raise KeyError(f"Reference not found: {reference}")
+
+        prefix = f"{str(self._artifact_dir).rstrip('/')}/"
+        if "/" in reference:
+            if not reference.startswith(prefix):
+                raise KeyError(f"Reference not found: {reference}")
+            candidate = reference[len(prefix):]
+            if "/" in candidate:
+                raise KeyError(f"Reference not found: {reference}")
+        else:
+            candidate = reference
+
+        if candidate in self._content_types:
+            return candidate
+
+        matches = [key for key in self._content_types if Path(key).stem == candidate]
+        if len(matches) == 1:
+            return matches[0]
+
+        raise KeyError(f"Reference not found: {reference}")
+
     async def store(self, key: str, content: bytes, content_type: str = "text/plain") -> str:
         """Store content as a file and return the path as reference.
 
@@ -217,11 +254,11 @@ class FileStorage:
     async def retrieve(self, reference: str) -> tuple[bytes, str]:
         """Retrieve content from a stored file.
 
-        Accepts both full paths (as returned by ``store()``) and bare
-        filenames for backward compatibility.
+        Accepts full paths (as returned by ``store()``), bare filenames,
+        and filename stems (without extension) for backward compatibility.
 
         Args:
-            reference: The file path or filename returned by store().
+            reference: The file path, filename, or stem returned by store().
 
         Returns:
             A tuple of (content bytes, content type).
@@ -231,26 +268,27 @@ class FileStorage:
         """
         if self._sandbox is not None:
             await self._ensure_sandbox_metadata()
-            prefix = f"{str(self._artifact_dir).rstrip('/')}/"
-            if not reference.startswith(prefix) or ".." in reference:
-                raise KeyError(f"Reference not found: {reference}")
-            filename = reference.split("/")[-1]
+            filename = self._resolve_reference(reference)
+            full_path = self._artifact_path(filename)
             try:
-                content = await self._sandbox.read_file(reference)
-            except Exception as e:
-                raise KeyError(f"Reference not found: {reference}") from e
+                content = await self._sandbox.read_file(full_path)
+            except Exception as exc:
+                raise KeyError(f"Reference not found: {reference}") from exc
             return content, self._content_types.get(filename, "application/octet-stream")
 
-        resolved_dir = self._artifact_dir.resolve()
-        ref_path = Path(reference)
-        file_path = ref_path.resolve() if len(ref_path.parts) > 1 else (self._artifact_dir / reference).resolve()
-        if not file_path.is_relative_to(resolved_dir):
-            file_path = (self._artifact_dir / reference).resolve()
-        if not file_path.is_relative_to(resolved_dir):
+        try:
+            filename = self._resolve_reference(reference)
+        except KeyError:
+            # Fallback: try as a literal path (metadata may be stale/corrupt).
+            file_path = Path(reference) if Path(reference).is_absolute() else (self._artifact_dir / reference)
+            file_path = file_path.resolve()
+            if not file_path.is_relative_to(self._artifact_dir.resolve()) or not file_path.is_file():
+                raise
+            filename = file_path.name
+
+        file_path = (self._artifact_dir / filename).resolve()
+        if not file_path.is_relative_to(self._artifact_dir.resolve()) or not file_path.is_file():
             raise KeyError(f"Reference not found: {reference}")
-        if not file_path.is_file():
-            raise KeyError(f"Reference not found: {reference}")
-        filename = file_path.name
         content_type = self._content_types.get(filename, "application/octet-stream")
         return file_path.read_bytes(), content_type
 

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -566,6 +566,17 @@ class TestFileStorageWithSandbox:
         _, content_type = await FileStorage(artifact_dir=artifact_dir, sandbox=sandbox).retrieve(ref)
         assert content_type == "image/png"
 
+    @pytest.mark.asyncio
+    async def test_missing_metadata_fallback(self, tmp_path):
+        sandbox = TestSandbox(str(tmp_path))
+        artifact_dir = str(tmp_path / "artifacts")
+        storage = FileStorage(artifact_dir=artifact_dir, sandbox=sandbox)
+        ref = await storage.store("key_1", b"content", "image/png")
+
+        storage._content_types.clear()
+        _, content_type = await storage.retrieve(ref)
+        assert content_type == "application/octet-stream"
+
     def test_for_sandbox_keeps_explicit_sandbox(self, tmp_path):
         # An instance constructed with a sandbox is returned unchanged by for_sandbox.
         sandbox = TestSandbox(str(tmp_path))

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_storage.py
@@ -325,6 +325,15 @@ class TestFileStorage:
         assert content_type == "text/plain"
 
     @pytest.mark.asyncio
+    async def test_retrieve_accepts_stem_without_extension(self, tmp_path):
+        storage = FileStorage(artifact_dir=str(tmp_path))
+        ref = await storage.store("key_1", b"hello world", "text/plain")
+        stem = Path(ref).stem
+        content, content_type = await storage.retrieve(stem)
+        assert content == b"hello world"
+        assert content_type == "text/plain"
+
+    @pytest.mark.asyncio
     async def test_metadata_survives_across_instances(self, tmp_path):
         artifact_dir = str(tmp_path / "artifacts")
         storage1 = FileStorage(artifact_dir=artifact_dir)
@@ -514,6 +523,23 @@ class TestFileStorageWithSandbox:
     async def test_reference_under_artifact_dir(self, storage, tmp_path):
         ref = await storage.store("key_1", b"data")
         assert ref.startswith(f"{tmp_path / 'artifacts'}/")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_accepts_bare_filename(self, storage):
+        ref = await storage.store("key_1", b"hello sandbox", "text/plain")
+        filename = ref.split("/")[-1]
+        content, content_type = await storage.retrieve(filename)
+        assert content == b"hello sandbox"
+        assert content_type == "text/plain"
+
+    @pytest.mark.asyncio
+    async def test_retrieve_accepts_stem_without_extension(self, storage):
+        ref = await storage.store("key_1", b"hello sandbox", "text/plain")
+        filename = ref.split("/")[-1]
+        stem = filename.rsplit(".", 1)[0]
+        content, content_type = await storage.retrieve(stem)
+        assert content == b"hello sandbox"
+        assert content_type == "text/plain"
 
     @pytest.mark.asyncio
     async def test_retrieve_rejects_path_outside_artifact_dir(self, storage):


### PR DESCRIPTION
## Summary

Fixes #3494.

`FileStorage.retrieve()` documents that it "accepts both full paths (as returned by `store()`) and bare filenames for backward compatibility," but:

1. The **sandbox branch** required the full artifact-dir prefix, so bare filenames always raised `KeyError` — and since `Agent.sandbox` is never `None`, all agent-bound storage hit this path.
2. **Neither branch** resolved filename stems (without extension), which models commonly send.

## Changes

- **`_resolve_reference()`** — new helper that normalizes full paths, bare filenames, and extension-less stems against the `_content_types` registry. Uses `Path.resolve()` for cross-platform path comparison (Windows backslash paths).
- **`_resolve_from_path()`** — fallback helper for when metadata is missing/corrupt. Validates a reference as a path within the artifact directory without requiring `_content_types`. Both sandbox and host branches use it symmetrically.
- **Refactored `retrieve()`** — both branches try `_resolve_reference` first, then fall back to `_resolve_from_path` for resilience when the metadata sidecar is unavailable.
- **Tests** — new tests cover bare-filename and stem retrieval in both `TestFileStorage` and `TestFileStorageWithSandbox`, plus a sandbox metadata-missing fallback test.

## Scope

This fix is isolated to the legacy `FileStorage` class in `vended_plugins/context_offloader/`. The unified `strands.storage.LocalFileStorage` uses exact key matching and is not affected.

## Test plan

- [x] All 63 storage tests pass (Linux + macOS)
- [x] New tests cover bare filename retrieval through sandbox
- [x] New tests cover stem-without-extension retrieval in both branches
- [x] New test covers sandbox metadata-missing fallback
- [x] Path traversal rejection tests continue to pass
- [x] `test_missing_metadata_fallback` (corrupt metadata) still passes via host fallback
- [x] Cross-platform: uses `Path.resolve()` instead of string-based `/` checks for Windows compatibility
- [x] Linter passes (`hatch fmt --linter`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).