### PR TITLE
docs(changelog): sync strands-agents/harness-sdk typescript/v1.11.2

### DIFF
--- a/site/src/content/changelog/harness/typescript-v1.11.2.md
+++ b/site/src/content/changelog/harness/typescript-v1.11.2.md
@@ -1,0 +1,15 @@
+---
+sdk: harness
+language: typescript
+version: "1.11.2"
+tag: typescript/v1.11.2
+date: 2026-07-27
+releaseUrl: https://github.com/strands-agents/harness-sdk/releases/tag/typescript/v1.11.2
+packageUrl: https://www.npmjs.com/package/@strands-agents/sdk/v/1.11.2
+entries:
+  - { type: feat, breaking: false, scope: ts, areas: [multiagent, agent], title: "add agent-as-tool delegation", pr: 3265, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3265", commit: "a2761fd", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/a2761fd", author: liramon2 }
+  - { type: fix, breaking: false, scope: mcp, areas: [mcp], title: "deduplicate inverted-index postings", pr: 3417, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3417", commit: "0e517d6", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/0e517d6", author: March-77 }
+  - { type: docs, breaking: false, scope: mcp, areas: [mcp], title: "correct search tool contracts", pr: 3456, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3456", commit: "50b583f", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/50b583f", author: March-77 }
+  - { type: feat, breaking: false, scope: null, areas: [context], title: "add context manager class design doc", pr: 3307, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3307", commit: "cb3bffb", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/cb3bffb", author: lizradway }
+  - { type: chore, breaking: false, scope: null, areas: [persistence], title: "update context offloader comments to deprecate legacy storage", pr: 3476, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3476", commit: "58a501c", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/58a501c", author: lizradway }
+---


### PR DESCRIPTION
Automated changelog sync.
Add a curated `highlights:` block to any release file before merging if desired.