### PR TITLE
fix(mcp): pin mcp dependency below v2.0.0

### DIFF
--- a/strands-mcp/pyproject.toml
+++ b/strands-mcp/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "mcp>=1.1.3",
+    "mcp>=1.1.3,<2.0.0",
     "pydantic>=2.0.0",
 ]
 
@@ -64,7 +64,7 @@ packages = ["src/strands_mcp_server"]
 
 [tool.hatch.envs.hatch-static-analysis]
 dependencies = [
-    "mcp>=1.1.3",
+    "mcp>=1.1.3,<2.0.0",
     "pydantic>=2.0.0",
     "ruff>=0.4.4",
 ]


### PR DESCRIPTION
## Problem

`strands-mcp` declares an **unbounded** `mcp>=1.1.3`. `mcp` 2.0.0 is now on PyPI, so a fresh resolve picks it up — and **2.0.0 removed the `mcp.server.fastmcp` module** (superseded by `mcp.server.mcpserver`).

`src/strands_mcp_server/server.py:5` imports it at module scope:

```python
from mcp.server.fastmcp import FastMCP
```

So on `mcp` 2.0.0 the package is **completely unusable** — not a subtle behavioural regression, a hard `ModuleNotFoundError`:

```
$ python -c "import strands_mcp_server.server"
  File "src/strands_mcp_server/server.py", line 5, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

That means the `strands-agents-mcp-server` console script fails to start, and CI test collection aborts before running anything:

```
ERROR tests/test_server.py
!!!! Interrupted: 1 error during collection !!!!
1 error in 0.93s
```

## Fix

Cap the range at `<2.0.0` in the two places `mcp` is declared — runtime `[project.dependencies]` and the `hatch-static-analysis` env — so they stay in sync.

```diff
 dependencies = [
-    "mcp>=1.1.3",
+    "mcp>=1.1.3,<2.0.0",
     "pydantic>=2.0.0",
 ]
```

The lower bound is deliberately left at `1.1.3` to keep this change surgical. This also brings `strands-mcp` in line with the constraint `strands-py` already uses (`mcp>=1.23.0,<2.0.0`).

## Verification

Reproduced the break and confirmed the fix in clean venvs:

| | mcp resolved | `import strands_mcp_server.server` | `pytest tests/` |
|---|---|---|---|
| before (`mcp>=1.1.3`) | **2.0.0** | ❌ `ModuleNotFoundError` | ❌ collection error |
| after (`mcp>=1.1.3,<2.0.0`) | **1.29.0** | ✅ OK | ✅ **50 passed** |

Also verified `mcp.server.fastmcp` imports fine on 1.29.0 and is absent from 2.0.0's `mcp/server/` tree, and that the edited `pyproject.toml` still parses.

## Notes

- This is a **stopgap to unbreak installs/CI**, not a migration. Porting `server.py` from `FastMCP` to the v2 `mcp.server.mcpserver` API should be tracked as separate work.
- Dependabot is configured for `/strands-mcp` with `versioning-strategy: increase-if-necessary` and a 30-day `semver-major` cooldown, so with this cap in place a future `mcp` v2 bump surfaces as a reviewable PR instead of silently breaking a fresh install.

cc @mkmeral