### PR TITLE
docs(labs): update Strands Robots page to current Robot() API

### DIFF
--- a/site/src/content/docs/labs/robots.mdx
+++ b/site/src/content/docs/labs/robots.mdx
@@ -1,29 +1,86 @@
 ---
 title: Robots
-description: 'Control physical robots with natural language through Strands Agents: vision-language-action policy inference, camera capture, and control loops.'
+description: 'Control, simulate, and train physical robots with natural language through Strands Agents: one Robot() call returns a MuJoCo simulation or real hardware, with pluggable vision-language-action policies and a peer-to-peer mesh.'
 ---
 
-[Strands Robots](https://github.com/strands-labs/robots) is a Python library for controlling physical robots with natural language. It provides a policy abstraction layer for vision-language-action (VLA) models and a hardware abstraction layer for robot control, letting you tell a robot what to do without programming it.
+[Strands Robots](https://github.com/strands-labs/robots) gives a Strands Agent
+hands. One `Robot()` call returns a **MuJoCo simulation** (the default - no GPU,
+no hardware) or a **real robot** - same code, same natural-language control, both
+auto-joined to a peer-to-peer **mesh**.
 
-The library provides a set of Strands Agents tools that handle several components of the robotics stack - from camera capture and servo calibration to policy inference and real-time control loops. An agent equipped with these tools can interpret instructions like "pick up the red block" and translate them into coordinated motor actions.
+```python
+from strands import Agent
+from strands_robots import Robot
+
+robot = Robot("so100")              # MuJoCo sim by default; mode="real" for hardware
+Agent(tools=[robot])("pick up the red cube")
+```
+
+The full documentation - guides, the robot catalog, policy references, and the
+hardware setup walkthroughs - lives at
+[strands-labs.github.io/robots](https://strands-labs.github.io/robots/).
 
 ## Getting started
 
-### Installation
+Examples use [`uv`](https://docs.astral.sh/uv/); plain `pip` works too. The base
+install is light (numpy, opencv-headless, Pillow) - pull in only the extras you
+need.
 
 ```bash
-pip install strands-robots
+# Most users start here (simulation, no GPU, no hardware):
+uv pip install "strands-robots[sim-mujoco]"
+
+# Real hardware + local policies:
+uv pip install "strands-robots[sim-mujoco,lerobot]"
+
+# Everything (except the GPU-only extras):
+uv pip install "strands-robots[all]"
 ```
 
-### Basic usage
+| Extra | Use for |
+|-------|---------|
+| `sim-mujoco` | MuJoCo simulation (recommended starting point) |
+| `sim-newton` / `sim-isaac` / `sim-gs` | GPU-native, photoreal, and Gaussian-splatting rendering backends |
+| `lerobot` | Real hardware, local VLA inference, dataset recording |
+| `groot-service` / `cosmos3-service` | NVIDIA GR00T / Cosmos 3 inference clients |
+| `mesh` / `mesh-iot` | Peer-to-peer robot mesh (+ AWS IoT Core for fleets) |
+| `all` | Kitchen sink (except GPU-only `sim-isaac` / `sim-gs`) |
+
+See the [full extras matrix](https://strands-labs.github.io/robots/) for the
+complete list (`molmoact2`, `curobo`, `wbc`, `motionbricks`, `benchmark-libero`,
+and more).
+
+### Simulation (no GPU, no hardware)
+
+```python
+from strands import Agent
+from strands_robots import Robot
+
+robot = Robot("so100")  # MuJoCo simulation
+agent = Agent(tools=[robot])
+agent("Wave the arm using the mock policy for 200 steps, then render a top-down view")
+```
+
+`Robot("so100")` returns a `Simulation` instance - the full simulation
+AgentTool. Drive it in natural language through an `Agent`, call its methods
+directly (`robot.render(camera_name="topdown")`), or dispatch an action by
+calling it (`robot(action="render", camera_name="topdown")`).
+
+:::note[World already exists]
+`Robot("so100")` already creates the world **and** adds the robot for you. Do
+**not** call `create_world()` again on the returned instance - it errors with
+*"World already exists."*
+:::
+
+### Real hardware + GR00T
 
 ```python
 from strands import Agent
 from strands_robots import Robot, gr00t_inference
 
 robot = Robot(
-    tool_name="my_arm",
-    robot="so101_follower",
+    "so101",
+    mode="real",
     cameras={
         "front": {"type": "opencv", "index_or_path": "/dev/video0", "fps": 30},
         "wrist": {"type": "opencv", "index_or_path": "/dev/video2", "fps": 30},
@@ -34,33 +91,95 @@ robot = Robot(
 
 agent = Agent(tools=[robot, gr00t_inference])
 
-# Start the inference service
+# Start the GR00T inference service (Docker, Jetson/x86 GPU)
 agent.tool.gr00t_inference(
     action="start",
     checkpoint_path="/data/checkpoints/model",
-    port=5555,
+    port=8000,
     data_config="so100_dualcam",
 )
 
-# Control the robot with natural language
-agent("Use my_arm to pick up the red block using GR00T policy on port 5555")
+agent("Use so101 to pick up the red block with the GR00T policy on port 8000")
 ```
 
-The `Robot` class is a Strands `AgentTool` that the agent can invoke directly. When the agent decides to use the robot, it calls the tool with an instruction and policy port, and the tool handles the entire observation-inference-action loop internally.
+## One agent, the whole robotics loop
+
+Teleoperate a real arm to collect demos, fine-tune a policy on them, run it in
+sim **and** on hardware, hand work to a fleet peer, and expose it all on ROS 2 -
+one library, one mental model.
+
+```python
+from strands import Agent
+from strands_robots import Robot
+from strands_robots.tools import train_policy
+
+# 1. TELEOPERATE a real SO-101 with its leader arm and RECORD demos as a
+#    LeRobotDataset (one prompt drives cameras + teleop + recording).
+follower = Robot("so101", mode="real", port="/dev/ttyACM0",
+                 cameras={"front": {"type": "opencv", "index_or_path": "/dev/video0"}})
+follower.attach_teleop("so101_leader", port="/dev/ttyACM1", id="leader")
+Agent(tools=[follower])(
+    "start_recording(repo_id='me/pick', root='/tmp/pick', fps=30, "
+    "task='pick up the cube'); teleoperate for 60s; stop_recording"
+)
+
+# 2. POST-TUNE a policy on those demos (LoRA fine-tune; GPU box).
+train_policy(action="train", provider="lerobot_local",
+             dataset_root="/tmp/pick", base_model="lerobot/smolvla_base",
+             output_dir="/tmp/pick_ckpt", method="lora", steps=20000)
+
+# 3. RUN the tuned checkpoint - same policy on a MuJoCo twin AND the real arm.
+twin = Robot("so101")                                              # sim twin, no hardware
+twin.run_policy(robot_name="so101", policy_provider="lerobot_local",
+                policy_config={"pretrained_name_or_path": "/tmp/pick_ckpt"}, duration=10.0)
+follower.start_task("pick up the cube", policy_provider="lerobot_local",
+                    policy_port=None, duration=10.0)               # real arm, in-process
+
+# 4. COORDINATE a fleet - tell a mesh peer to assist, in natural language.
+follower.mesh.tell(follower.mesh.peers[0]["peer_id"], "hold the tray steady")
+
+# 5. EXPOSE the running sim on ROS 2 - rviz / nav2 / any ros2 node can subscribe.
+from strands_robots.simulation import Simulation
+sim = Simulation(ros2_bridge=True); sim.create_world(); sim.add_robot("so101")
+sim.step(100)   # publishes /so101/joint_states + camera image_raw on the ROS 2 graph
+```
+
+| Step | Capability | Surface |
+|------|------------|---------|
+| 1 | Teleop + dataset recording | `Robot(mode="real")`, `attach_teleop`, `start_recording` |
+| 2 | Policy post-tuning | `train_policy` (LeRobot / GR00T trainers) |
+| 3 | Sim + hardware policy rollout | `run_policy` (sim), `start_task` (hardware) |
+| 4 | Fleet coordination | `robot.mesh.tell` / `robot_mesh` tool |
+| 5 | ROS 2 interop | `Simulation(ros2_bridge=True)`, `use_ros` |
+
+Steps 1 and 3-real need hardware; step 2 needs a GPU. Everything runs in sim with
+no hardware (`Robot("so101")`), so you can exercise the whole loop today.
+
+## Why strands-robots
+
+- **Sim-first, safe by default.** `Robot("so100")` spins up a MuJoCo world. You
+  never accidentally drive real servos - `mode="real"` is an explicit opt-in.
+- **50+ robots, 8 categories.** Arms, humanoids, quadrupeds, hands, drones, and
+  bimanual rigs - resolved from a single registry with auto-download of assets.
+- **Any policy.** VLA models (NVIDIA GR00T, LeRobot ACT/Pi0/SmolVLA/Diffusion),
+  plus classical motion planners, MPC, and scripted controllers behind one ABC.
+- **Mesh networking built in.** Every robot is a Zenoh peer. `tell()` another
+  robot what to do; broadcast an E-STOP; bridge to AWS IoT Core for fleets.
+- **ROS 2 interop.** Observe + command any ROS 2 graph (`use_ros`), act as a
+  robot with no rclpy (`use_rtps`), or expose a running sim as a ROS node.
+- **One mental model.** Sim and hardware share the same policy interface, the
+  same mesh, and the same natural-language control surface.
 
 ## How it works
-
-The system chains together three layers: a Strands Agent that interprets natural language, a policy provider that maps camera observations and instructions to action chunks, and a hardware abstraction layer that sends those actions to physical actuators.
 
 ```mermaid
 graph LR
     A[Natural Language<br/>'Pick up the red block'] --> B[Strands Agent]
-    B --> C[Robot class]
-    C --> D[Policy Provider]
-    C --> E[Hardware Abstraction]
-    D --> F[Action Chunk]
-    F --> E
-    E --> G[Robot Hardware]
+    B --> C[Robot<br/>sim or real]
+    C --> D[Policy Provider<br/>GR00T / Cosmos 3 / LeRobot / planner / mock]
+    D --> E[Action Chunk]
+    E --> F[MuJoCo Sim<br/>or Hardware]
+    F -->|observation| C
 
     classDef input fill:#2ea44f,stroke:#1b7735,color:#fff
     classDef agent fill:#0969da,stroke:#044289,color:#fff
@@ -69,291 +188,173 @@ graph LR
 
     class A input
     class B,C agent
-    class D,F policy
-    class E,G hardware
+    class D,E policy
+    class F hardware
 ```
 
-Each control cycle, the Robot class captures observations (camera frames and joint states), sends them to the policy for inference, receives an action chunk, and executes those actions on the hardware.
+Each control cycle, the robot captures observations (camera frames and joint
+states), sends them to the policy for inference, receives an action chunk, and
+executes those actions in the sim or on hardware.
 
-### Architecture
+## The `Robot()` factory
 
-```mermaid
-flowchart TB
-    subgraph Agent["🤖 Strands Agent"]
-        NL[Natural Language Input]
-        Tools[Tool Registry]
-    end
-
-    subgraph RobotTool["🦾 Robot Class"]
-        direction TB
-        RT[Robot Class]
-        TM[Task Manager]
-        AS[Async Executor]
-    end
-
-    subgraph Policy["🧠 Policy Layer"]
-        direction TB
-        PA[Policy Abstraction]
-        GP[GR00T Policy]
-        MP[Mock Policy]
-        CP[Custom Policy]
-    end
-
-    subgraph Inference["⚡ Inference Service"]
-        direction TB
-        DC[Docker Container]
-        ZMQ[ZMQ Server :5555]
-        TRT[TensorRT Engine]
-    end
-
-    subgraph Hardware["🔧 Hardware Layer"]
-        direction TB
-        LR[LeRobot]
-        CAM[Cameras]
-        SERVO[Feetech Servos]
-    end
-
-    NL --> Tools
-    Tools --> RT
-    RT --> TM
-    TM --> AS
-    AS --> PA
-    PA --> GP
-    PA --> MP
-    PA --> CP
-    GP --> ZMQ
-    ZMQ --> TRT
-    TRT --> DC
-    AS --> LR
-    LR --> CAM
-    LR --> SERVO
-
-    classDef agentStyle fill:#0969da,stroke:#044289,color:#fff
-    classDef robotStyle fill:#2ea44f,stroke:#1b7735,color:#fff
-    classDef policyStyle fill:#8250df,stroke:#5a32a3,color:#fff
-    classDef infraStyle fill:#bf8700,stroke:#875e00,color:#fff
-    classDef hwStyle fill:#d73a49,stroke:#a72b3a,color:#fff
-
-    class NL,Tools agentStyle
-    class RT,TM,AS robotStyle
-    class PA,GP,MP,CP policyStyle
-    class DC,ZMQ,TRT infraStyle
-    class LR,CAM,SERVO hwStyle
-```
-
-### Control flow
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant Agent as Strands Agent
-    participant Robot as Robot Class
-    participant Policy as Policy Provider
-    participant HW as Hardware
-
-    User->>Agent: "Pick up the red block"
-    Agent->>Robot: execute(instruction, policy_port)
-    
-    loop Control Loop
-        Robot->>HW: get_observation()
-        HW-->>Robot: {cameras, joint_states}
-        Robot->>Policy: get_actions(obs, instruction)
-        Policy-->>Robot: action_chunk
-        
-        loop Action Horizon
-            Robot->>HW: send_action(action)
-            Note over Robot,HW: sleep
-        end
-    end
-    
-    Robot-->>Agent: Task completed
-    Agent-->>User: "Picked up red block"
-```
-
-## Core concepts
-
-### Robot class
-
-The `Robot` class wraps a robot and exposes it as a Strands agent tool with four actions:
-
-| Action | Behavior | Use case |
-|--------|----------|----------|
-| `execute` | Blocks until the task completes or times out | Single-step tasks |
-| `start` | Returns immediately, runs task in background | Long-running tasks |
-| `status` | Reports current task progress | Monitoring async tasks |
-| `stop` | Interrupts a running task | Emergency stop |
+`Robot()` is a factory, not a wrapper - you get the real backend instance back
+with all its methods.
 
 ```python
-# Blocking - agent waits for completion
-agent("Use my_arm to pick up the red block using GR00T policy on port 5555")
-
-# Async - agent can check status or do other work
-agent("Start my_arm waving using GR00T on port 5555, then check status")
-
-# Stop
-agent("Stop my_arm immediately")
+Robot("so100")                       # mode="sim"  (default, safe)
+Robot("so100", mode="real")          # explicit hardware opt-in
+Robot("so100", mode="auto")          # probe USB for servos, fall back to sim
+Robot("my_arm", urdf_path="arm.xml") # bring your own MJCF/URDF
 ```
 
-Constructor parameters:
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `name` | `str` | required | Robot name or alias |
+| `mode` | `str` | `"sim"` | `"sim"`, `"real"`, or `"auto"` (case-insensitive) |
+| `backend` | `str` | `"mujoco"` | Sim backend: `"mujoco"`, `"newton"`, or `"isaac"` |
+| `urdf_path` | `str` | `None` | Explicit MJCF/URDF path (skips registry lookup) |
+| `cameras` | `dict` | `None` | Camera config (**`mode="real"` only**) |
+| `data_config` | `str` | name | Observation/action schema name |
+| `mesh` | `bool` | `True` | Auto-join the Zenoh mesh |
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `tool_name` | `str` | Name the agent uses to reference this robot |
-| `robot` | `str`, `RobotConfig`, or `Robot` | Robot type string (e.g. `"so101_follower"`), a config object, or a pre-built robot instance |
-| `cameras` | `dict` | Camera configuration mapping names to settings |
-| `port` | `str` | Serial port for the robot (e.g. `"/dev/ttyACM0"`) |
-| `data_config` | `str` | Policy data configuration name |
-| `control_frequency` | `float` | Control loop frequency in Hz (default: 50) |
-| `action_horizon` | `int` | Number of actions to execute per inference step (default: 8) |
+Safety rules: defaults to sim; `cameras=` is rejected in sim mode (add sim
+cameras with the `add_camera` action); unknown names raise `ValueError` unless
+you pass `urdf_path=`; `STRANDS_ROBOT_MODE` overrides detection.
 
-### Policy abstraction
+## Supported robots
 
-Policies are the bridge between observations and actions. The library defines a `Policy` abstract class that any VLA model can implement:
+50+ robots across 8 categories, resolved from the registry. Assets (MJCF +
+meshes) auto-download from
+[robot_descriptions](https://github.com/robot-descriptions/robot_descriptions.py)
+/ [MuJoCo Menagerie](https://github.com/google-deepmind/mujoco_menagerie) on
+first use. List them at runtime with
+`from strands_robots import list_robots; list_robots()`.
+
+| Category | Count | Examples |
+|----------|-------|----------|
+| **Arm** | 22 | so100, so101, koch, panda, fr3, ur5e, xarm7, kinova_gen3, kuka_iiwa |
+| **Humanoid** | 18 | unitree_g1, unitree_h1, apollo, talos, reachy2, booster_t1, cassie |
+| **Mobile** | 13 | spot, go1, unitree_go2, anymal_c, stretch3, lekiwi, earthrover |
+| **Hand** | 8 | shadow_hand, allegro_hand, leap_hand, ability_hand, robotiq_2f85 |
+| **Bimanual** | 3 | aloha, bi_openarm, trossen_wxai |
+| **Aerial** | 2 | crazyflie, skydio_x2 |
+| **Expressive** | 1 | reachy_mini |
+| **Mobile manip** | 1 | google_robot |
+
+**Hardware-capable** (drivable with `mode="real"` via LeRobot): `so100`,
+`so101`, `koch`, `omx`, `hope_jr`, `aloha`, `bi_openarm`, `reachy2`,
+`unitree_g1`, `lekiwi`, `earthrover`. All are simulatable. See the
+[full robot catalog](https://strands-labs.github.io/robots/).
+
+## Tools reference
+
+Import any of these and pass to `Agent(tools=[...])`. Each is a Strands
+AgentTool returning `{"status", "content"}`.
+
+| Tool | Purpose |
+|------|---------|
+| `Robot(...)` | Universal robot - sim or hardware, natural-language + async control |
+| `run_policy` | Multi-episode policy rollout with per-episode eval + dataset recording |
+| `train_policy` | Post-tune (fine-tune) a policy on a recorded dataset |
+| `use_lerobot` | Universal LeRobot bridge - call any lerobot module/class/config directly |
+| `robot_mesh` | Coordinate robots over the Zenoh mesh (`tell`, `broadcast`, E-STOP) |
+| `use_ros` / `use_rtps` | Bridge to / join a ROS 2 graph (in-process rclpy, or pure DDS) |
+| `gr00t_inference` | Manage NVIDIA GR00T inference services (Docker lifecycle) |
+| `lerobot_camera` | OpenCV / RealSense camera discovery, capture, record |
+| `lerobot_calibrate` | List, view, back up, restore LeRobot calibrations |
+| `lerobot_teleoperate` | Record demonstrations, replay episodes |
+| `pose_tool` | Store, recall, and execute named robot poses |
+| `serial_tool` | Low-level Feetech servo / raw serial communication |
+| `download_assets` | Pre-fetch robot MJCF + meshes into the asset cache |
+
+## Policy providers
+
+All policies implement one ABC -
+`async get_actions(observation, instruction, **kwargs)`. The interface is
+deliberately agnostic about *how* actions are produced, so it fits both VLA
+models and classical controllers.
 
 ```python
-from strands_robots import Policy, create_policy
+from strands_robots import create_policy
 
-# GR00T policy (ships with the library)
-policy = create_policy(
-    provider="groot",
-    data_config="so100_dualcam",
-    host="localhost",
-    port=5555,
-)
-
-# Mock policy (for testing without hardware)
-policy = create_policy(provider="mock")
+create_policy("mock")                                    # sinusoidal test actions
+create_policy("groot", port=5555)                        # NVIDIA GR00T via ZMQ
+create_policy("cosmos3", embodiment="droid", port=8000)  # NVIDIA Cosmos 3 via WebSocket
+create_policy("lerobot/act_aloha_sim_transfer_cube")     # local HuggingFace inference
 ```
 
-The `create_policy` factory ships with `"groot"` and `"mock"` providers. You can integrate additional VLA models by subclassing `Policy` and implementing `get_actions()` and `set_robot_state_keys()`.
+| Provider | Backend | Notes |
+|----------|---------|-------|
+| `mock` | none | Sinusoidal trajectories; no images needed (~10x faster) |
+| `groot` | NVIDIA GR00T N1.5/N1.6/N1.7 | ZMQ service or local in-process |
+| `cosmos3` | NVIDIA Cosmos 3 | WebSocket to a Cosmos policy server |
+| `lerobot_local` | HuggingFace | Direct ACT / Pi0 / SmolVLA / Diffusion inference |
+| `lerobot_async` / `remote` | HuggingFace / any | Offload to a remote `PolicyServer` (gRPC or WebSocket) |
 
-### Inference management
+See the [policies reference](https://strands-labs.github.io/robots/) for the
+full provider list, plus motion-planning policies (`moveit2`, `curobo`),
+whole-body control (`wbc`), and `motionbricks`.
 
-The `gr00t_inference` tool manages policy inference services running in Docker containers.
+## Teleoperation
+
+Drive any real robot - or a simulation - from one or more LeRobot teleoperators.
+`Teleoperator()` mirrors the `Robot()` factory; `attach_teleop()` +
+`teleoperate()` run the control loop.
 
 ```python
-# Start with TensorRT acceleration
-agent.tool.gr00t_inference(
-    action="start",
-    checkpoint_path="/data/checkpoints/model",
-    port=5555,
-    data_config="so100_dualcam",
-    use_tensorrt=True,
-)
+from strands_robots import Robot
 
-# Check status
-agent.tool.gr00t_inference(action="status", port=5555)
-
-# Stop
-agent.tool.gr00t_inference(action="stop", port=5555)
+# Leader arm -> follower arm (both speak {motor}.pos -> zero config)
+follower = Robot("so101", mode="real", port="/dev/ttyACM0")
+follower.attach_teleop("so101_leader", port="/dev/ttyACM1", id="leader")
+follower.teleoperate()                       # Ctrl+C or stop_teleoperate()
 ```
 
-Available actions: `start`, `stop`, `status`, `list`, `restart`, and `find_containers`.
+17 teleoperators drive 14 robots. Zero-config when action keys match; otherwise
+pass `map_fn`. Full matrix + recipes:
+[Teleoperation docs](https://strands-labs.github.io/robots/hardware/teleoperation/).
 
-## Additional tools
+## Recording & streaming datasets
 
-Beyond the core robot and inference tools, the library includes several utilities that the agent can use for setup, calibration, and data collection.
-
-### Camera tool
-
-Camera management supporting OpenCV and RealSense cameras.
-
-```python
-from strands_robots import lerobot_camera
-
-agent = Agent(tools=[lerobot_camera])
-
-agent("Discover all connected cameras")
-agent("Capture images from front and wrist cameras")
-agent("Record 30 seconds of video from the front camera")
-```
-
-Actions: `discover`, `capture`, `capture_batch`, `record`, `preview`, `test`.
-
-### Teleoperation tool
-
-Record demonstrations for imitation learning using a leader-follower setup.
-
-```python
-from strands_robots import lerobot_teleoperate
-
-agent.tool.lerobot_teleoperate(
-    action="start",
-    robot_type="so101_follower",
-    robot_port="/dev/ttyACM0",
-    teleop_type="so101_leader",
-    teleop_port="/dev/ttyACM1",
-    dataset_repo_id="my_user/cube_picking",
-    dataset_single_task="Pick up the red cube",
-    dataset_num_episodes=50,
-)
-```
-
-Actions: `start`, `stop`, `list`, `replay`.
-
-### Pose tool
-
-Store, retrieve, and execute named robot poses for repeatable positioning.
-
-```python
-from strands_robots import pose_tool
-
-agent = Agent(tools=[robot, pose_tool])
-
-agent("Save the current position as 'home'")
-agent("Go to the home pose")
-agent("Move the gripper to 50%")
-```
-
-Actions: `store_pose`, `load_pose`, `list_poses`, `move_motor`, `incremental_move`, `reset_to_home`.
-
-### Serial tool
-
-Low-level serial communication for servos and custom protocols.
-
-Actions: `list_ports`, `feetech_position`, `feetech_ping`, `send`, `monitor`.
-
-## Complete example
+The physical-AI data loop, end to end: **record** a LeRobotDataset from sim or
+hardware, **stream** it straight back for eval/training (no full download), and
+optionally **dump** it to a mutable Hugging Face Storage Bucket. Needs the
+`lerobot` extra.
 
 ```python
 from strands import Agent
-from strands_robots import Robot, gr00t_inference, lerobot_camera, pose_tool
+from strands_robots import Robot
 
-robot = Robot(
-    tool_name="orange_arm",
-    robot="so101_follower",
-    cameras={
-        "wrist": {"type": "opencv", "index_or_path": "/dev/video0", "fps": 15},
-        "front": {"type": "opencv", "index_or_path": "/dev/video2", "fps": 15},
-    },
-    port="/dev/ttyACM0",
-    data_config="so100_dualcam",
+sim = Robot("so100", mesh=False)
+agent = Agent(tools=[sim])
+
+# COLLECT - one natural-language prompt drives scene + cameras + policy + record.
+agent(
+    "Create a world with the so100 robot, add a red cube and a front camera, "
+    "start recording (repo_id='local/demo', root='/tmp/demo', fps=30, "
+    "overwrite=True, task='pick up the red cube'), run the mock policy for "
+    "60 steps, then stop recording."
 )
 
-agent = Agent(tools=[robot, gr00t_inference, lerobot_camera, pose_tool])
-
-agent.tool.gr00t_inference(
-    action="start",
-    checkpoint_path="/data/checkpoints/gr00t-wave/checkpoint-300000",
-    port=5555,
-    data_config="so100_dualcam",
-)
-
-while True:
-    user_input = input("\n> ")
-    if user_input.lower() in ["exit", "quit"]:
-        break
-    agent(user_input)
-
-agent.tool.gr00t_inference(action="stop", port=5555)
+# STREAM - read it back lazily; camera frames decode on the fly from the MP4
+# shards, state/action from parquet. Nothing is re-materialized to disk.
+reader = sim.stream_dataset("local/demo", root="/tmp/demo", shuffle=False)
 ```
 
-This gives you an interactive loop where you can issue natural language commands to the robot, check camera feeds, save poses, and manage inference services - all through conversation with the agent.
+:::note[Verify episode integrity]
+A recording's ground truth is the parquet under `meta/episodes/`, not the count
+a model narrates while collecting. Confirm the dataset holds the episodes you
+intended with `sim.verify_dataset_episodes(expected=20)` (or
+`strands-robots verify-dataset /tmp/demo --expected 20` in CI). This catches the
+"mega-episode" corruption class and `meta/info.json` vs parquet drift.
+:::
 
 ## Links
 
+- [Documentation](https://strands-labs.github.io/robots/)
 - [GitHub repository](https://github.com/strands-labs/robots)
 - [PyPI package](https://pypi.org/project/strands-robots/)
+- [Robots Sim](robots-sim.md) - simulation-only benchmarking and iterative control
 - [NVIDIA Isaac GR00T](https://github.com/NVIDIA/Isaac-GR00T)
 - [LeRobot](https://github.com/huggingface/lerobot)
-- [Jetson Containers](https://github.com/dusty-nv/jetson-containers)


### PR DESCRIPTION
## Description

The `labs/robots` docs page was significantly out of date. It documented the **pre-factory API**:

- `Robot(tool_name="my_arm", robot="so101_follower", ...)` — the current API is the `Robot("so100")` factory that returns a sim by default (or real hardware with `mode="real"`).
- Only `groot` / `mock` policy providers and 4 robot actions.
- No mention of the sim-first default, the 50+ robot registry, mesh networking, ROS 2 interop, policy post-tuning, teleoperation, or dataset recording/streaming — all of which the library now ships.

This PR rewrites the page as a **shorter, current version** sourced from the project [README](https://github.com/strands-labs/robots), and links out to the docs website (<https://strands-labs.github.io/robots/>) for the full robot catalog, policy references, and hardware setup walkthroughs.

## What changed

- Updated all code samples to the `Robot()` factory API (sim-first, `mode="real"` opt-in).
- Added the end-to-end loop (teleop → train → sim+real rollout → fleet → ROS 2).
- Refreshed the policy provider table (groot, cosmos3, lerobot_local, lerobot_async/remote) and the tools reference (`run_policy`, `train_policy`, `use_lerobot`, `robot_mesh`, `use_ros`/`use_rtps`, …).
- Added supported-robots catalog summary (50+ robots, 8 categories), teleoperation, and dataset recording/streaming sections.
- Kept it concise and pointed to the docs site for the exhaustive lists.
- Uses Starlight `:::note` asides and the sibling-page `.md` link convention.

## Scope

- Single file: `site/src/content/docs/labs/robots.mdx`.
- Docs-only; no code changes.

🤖 Drafted with the help of a coding agent; reviewed by me.