### PR TITLE
feat: support Tool Choice for Gemini in Python

### DIFF
--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -298,7 +298,7 @@ class GeminiModel(Model):
             tool_choice: Selection strategy for tool invocation.
 
         Returns:
-            Gemini tool config, or None when no strategy is requested.
+            Gemini tool config, or None when no recognized strategy is requested.
         """
         if tool_choice is None:
             return None
@@ -338,7 +338,8 @@ class GeminiModel(Model):
             system_prompt: System prompt to provide context to the model.
             params: Additional model parameters (e.g., temperature).
             tool_choice: Selection strategy for tool invocation. Applied only alongside tool specs, since there
-                is nothing to choose from without them. Takes precedence over a tool config set in params.
+                is nothing to choose from without them. A forcing tool choice takes precedence over the function
+                calling config of a tool config set in params.
 
         Returns:
             Gemini request config.
@@ -347,8 +348,16 @@ class GeminiModel(Model):
 
         tool_config = self._format_tool_choice(tool_choice) if tool_specs else None
         if tool_config is not None:
-            # A per-request tool choice is more specific than the tool config in params, so it takes precedence.
-            config_params["tool_config"] = tool_config
+            existing = config_params.get("tool_config")
+            if existing is None:
+                config_params["tool_config"] = tool_config
+            elif tool_choice is not None and ("any" in tool_choice or "tool" in tool_choice):
+                # A per-request choice that forces a tool is more specific than the tool config in params, so it
+                # wins - but only over the field a ToolChoice can express. An "auto" choice imposes no constraint,
+                # so it never clobbers an explicit params config.
+                config_params["tool_config"] = genai.types.ToolConfig.model_validate(existing).model_copy(
+                    update={"function_calling_config": tool_config.function_calling_config}
+                )
 
         return genai.types.GenerateContentConfig(
             system_instruction=system_prompt,
@@ -575,7 +584,9 @@ class GeminiModel(Model):
             tool_specs: List of tool specifications to make available to the model.
             system_prompt: System prompt to provide context to the model.
             tool_choice: Selection strategy for tool invocation. Applied only when tool specs are provided,
-                and takes precedence over a tool config set through the params config.
+                since there is nothing to choose from without them. A forcing tool choice takes precedence over
+                the function calling config of a tool config set through the params config; an "auto" choice
+                leaves it in place.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:

--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -338,7 +338,7 @@ class GeminiModel(Model):
             system_prompt: System prompt to provide context to the model.
             params: Additional model parameters (e.g., temperature).
             tool_choice: Selection strategy for tool invocation. Applied only alongside tool specs, since there
-                is nothing to choose from without them.
+                is nothing to choose from without them. Takes precedence over a tool config set in params.
 
         Returns:
             Gemini request config.
@@ -347,8 +347,8 @@ class GeminiModel(Model):
 
         tool_config = self._format_tool_choice(tool_choice) if tool_specs else None
         if tool_config is not None:
-            # A tool config set directly through params is the more specific instruction, so it wins.
-            config_params.setdefault("tool_config", tool_config)
+            # A per-request tool choice is more specific than the tool config in params, so it takes precedence.
+            config_params["tool_config"] = tool_config
 
         return genai.types.GenerateContentConfig(
             system_instruction=system_prompt,
@@ -574,7 +574,8 @@ class GeminiModel(Model):
             messages: List of message objects to be processed by the model.
             tool_specs: List of tool specifications to make available to the model.
             system_prompt: System prompt to provide context to the model.
-            tool_choice: Selection strategy for tool invocation. Applied only when tool specs are provided.
+            tool_choice: Selection strategy for tool invocation. Applied only when tool specs are provided,
+                and takes precedence over a tool config set through the params config.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:

--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -19,7 +19,7 @@ from ..types.content import ContentBlock, ContentBlockStartToolUse, Messages, Sy
 from ..types.event_loop import Usage
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException, ProviderTokenCountError
 from ..types.streaming import StreamEvent
-from ..types.tools import ToolChoice, ToolSpec
+from ..types.tools import ToolChoice, ToolChoiceToolDict, ToolSpec
 from ._defaults import resolve_config_metadata
 from ._validation import _has_location_source, validate_config_keys
 from .model import BaseModelConfig, Model
@@ -288,11 +288,46 @@ class GeminiModel(Model):
             tools.extend(self.config["gemini_tools"])
         return tools
 
+    @staticmethod
+    def _format_tool_choice(tool_choice: ToolChoice | None) -> genai.types.ToolConfig | None:
+        """Format a tool choice into a Gemini tool config.
+
+        - Docs: https://googleapis.github.io/python-genai/genai.html#genai.types.ToolConfig
+
+        Args:
+            tool_choice: Selection strategy for tool invocation.
+
+        Returns:
+            Gemini tool config, or None when no strategy is requested.
+        """
+        if tool_choice is None:
+            return None
+
+        allowed_function_names: list[str] | None = None
+        if "auto" in tool_choice:
+            mode = genai.types.FunctionCallingConfigMode.AUTO
+        elif "any" in tool_choice:
+            mode = genai.types.FunctionCallingConfigMode.ANY
+        elif "tool" in tool_choice:
+            # Gemini has no single-tool mode, so a specific tool is ANY narrowed to that one function.
+            mode = genai.types.FunctionCallingConfigMode.ANY
+            allowed_function_names = [cast(ToolChoiceToolDict, tool_choice)["tool"]["name"]]
+        else:
+            return None
+
+        return genai.types.ToolConfig(
+            function_calling_config=genai.types.FunctionCallingConfig(
+                mode=mode,
+                allowed_function_names=allowed_function_names,
+            ),
+        )
+
     def _format_request_config(
         self,
         tool_specs: list[ToolSpec] | None,
         system_prompt: str | None,
         params: dict[str, Any] | None,
+        tool_choice: ToolChoice | None = None,
     ) -> genai.types.GenerateContentConfig:
         """Format Gemini request config.
 
@@ -302,14 +337,23 @@ class GeminiModel(Model):
             tool_specs: List of tool specifications to make available to the model.
             system_prompt: System prompt to provide context to the model.
             params: Additional model parameters (e.g., temperature).
+            tool_choice: Selection strategy for tool invocation. Applied only alongside tool specs, since there
+                is nothing to choose from without them.
 
         Returns:
             Gemini request config.
         """
+        config_params = dict(params or {})
+
+        tool_config = self._format_tool_choice(tool_choice) if tool_specs else None
+        if tool_config is not None:
+            # A tool config set directly through params is the more specific instruction, so it wins.
+            config_params.setdefault("tool_config", tool_config)
+
         return genai.types.GenerateContentConfig(
             system_instruction=system_prompt,
             tools=self._format_request_tools(tool_specs),
-            **(params or {}),
+            **config_params,
         )
 
     def _format_request(
@@ -318,6 +362,7 @@ class GeminiModel(Model):
         tool_specs: list[ToolSpec] | None,
         system_prompt: str | None,
         params: dict[str, Any] | None,
+        tool_choice: ToolChoice | None = None,
     ) -> dict[str, Any]:
         """Format a Gemini streaming request.
 
@@ -328,12 +373,13 @@ class GeminiModel(Model):
             tool_specs: List of tool specifications to make available to the model.
             system_prompt: System prompt to provide context to the model.
             params: Additional model parameters (e.g., temperature).
+            tool_choice: Selection strategy for tool invocation.
 
         Returns:
             A Gemini streaming request.
         """
         return {
-            "config": self._format_request_config(tool_specs, system_prompt, params).to_json_dict(),
+            "config": self._format_request_config(tool_specs, system_prompt, params, tool_choice).to_json_dict(),
             "contents": [content.to_json_dict() for content in self._format_request_content(messages)],
             "model": self.config["model_id"],
         }
@@ -518,6 +564,7 @@ class GeminiModel(Model):
         messages: Messages,
         tool_specs: list[ToolSpec] | None = None,
         system_prompt: str | None = None,
+        *,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:
@@ -527,8 +574,7 @@ class GeminiModel(Model):
             messages: List of message objects to be processed by the model.
             tool_specs: List of tool specifications to make available to the model.
             system_prompt: System prompt to provide context to the model.
-            tool_choice: Selection strategy for tool invocation.
-                Note: Currently unused.
+            tool_choice: Selection strategy for tool invocation. Applied only when tool specs are provided.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:
@@ -537,7 +583,9 @@ class GeminiModel(Model):
         Raises:
             ModelThrottledException: If the request is throttled by Gemini.
         """
-        request = self._format_request(messages, tool_specs, system_prompt, self.config.get("params"))
+        request = self._format_request(
+            messages, tool_specs, system_prompt, self.config.get("params"), tool_choice=tool_choice
+        )
 
         client = self._get_client().aio
 

--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -337,9 +337,7 @@ class GeminiModel(Model):
             tool_specs: List of tool specifications to make available to the model.
             system_prompt: System prompt to provide context to the model.
             params: Additional model parameters (e.g., temperature).
-            tool_choice: Selection strategy for tool invocation. Applied only alongside tool specs, since there
-                is nothing to choose from without them. A forcing tool choice takes precedence over the function
-                calling config of a tool config set in params.
+            tool_choice: Selection strategy for tool invocation.
 
         Returns:
             Gemini request config.
@@ -348,16 +346,10 @@ class GeminiModel(Model):
 
         tool_config = self._format_tool_choice(tool_choice) if tool_specs else None
         if tool_config is not None:
-            existing = config_params.get("tool_config")
-            if existing is None:
-                config_params["tool_config"] = tool_config
-            elif tool_choice is not None and ("any" in tool_choice or "tool" in tool_choice):
-                # A per-request choice that forces a tool is more specific than the tool config in params, so it
-                # wins - but only over the field a ToolChoice can express. An "auto" choice imposes no constraint,
-                # so it never clobbers an explicit params config.
-                config_params["tool_config"] = genai.types.ToolConfig.model_validate(existing).model_copy(
-                    update={"function_calling_config": tool_config.function_calling_config}
-                )
+            # A tool config set in params wins, matching the other providers and the TypeScript SDK. A tool
+            # config expresses more than a ToolChoice can, so the explicit one is left whole rather than
+            # merged with, or replaced by, the narrower per-request choice.
+            config_params.setdefault("tool_config", tool_config)
 
         return genai.types.GenerateContentConfig(
             system_instruction=system_prompt,
@@ -584,9 +576,8 @@ class GeminiModel(Model):
             tool_specs: List of tool specifications to make available to the model.
             system_prompt: System prompt to provide context to the model.
             tool_choice: Selection strategy for tool invocation. Applied only when tool specs are provided,
-                since there is nothing to choose from without them. A forcing tool choice takes precedence over
-                the function calling config of a tool config set through the params config; an "auto" choice
-                leaves it in place.
+                since there is nothing to choose from without them, and only when params sets no tool config of
+                its own - an explicit tool config takes precedence.
             **kwargs: Additional keyword arguments for future extensibility.
 
         Yields:

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -1115,61 +1115,23 @@ def tool_config_param_model(gemini_client, model_id):
             mode=genai.types.FunctionCallingConfigMode.NONE,
             allowed_function_names=["safe_tool"],
         ),
-        # A field no ToolChoice can express, so a tool choice must leave it in place.
+        # A full tool config, so the assertions below pin that a tool choice leaves all of it in place.
         retrieval_config=genai.types.RetrievalConfig(language_code="en-GB"),
     )
     return GeminiModel(model_id=model_id, params={"tool_config": tool_config})
 
 
 @pytest.mark.parametrize(
-    ("tool_choice", "exp_function_calling_config"),
-    [
-        # No choice and an "auto" choice both leave the params tool config exactly as configured.
-        (None, {"mode": "NONE", "allowed_function_names": ["safe_tool"]}),
-        ({"auto": {}}, {"mode": "NONE", "allowed_function_names": ["safe_tool"]}),
-        # A forcing choice replaces the whole function calling config, allowlist included - the forced tool
-        # need not appear in a user's allowlist - while the fields it cannot express survive.
-        ({"any": {}}, {"mode": "ANY"}),
-        ({"tool": {"name": "name"}}, {"mode": "ANY", "allowed_function_names": ["name"]}),
-    ],
+    "tool_choice",
+    [None, {"auto": {}}, {"any": {}}, {"tool": {"name": "name"}}],
+    ids=["no-choice", "auto", "any", "tool"],
 )
 @pytest.mark.asyncio
-async def test_stream_request_tool_config_param_precedence(
-    gemini_client, tool_config_param_model, messages, tool_spec, model_id, tool_choice, exp_function_calling_config
+async def test_stream_request_tool_config_param_takes_precedence(
+    gemini_client, tool_config_param_model, messages, tool_spec, model_id, tool_choice
 ):
+    """An explicit tool config wins over any per-request choice, matching the other providers."""
     await anext(tool_config_param_model.stream(messages, tool_specs=[tool_spec], tool_choice=tool_choice))
-
-    exp_request = {
-        "config": {
-            "tools": [
-                {
-                    "function_declarations": [
-                        {
-                            "description": tool_spec["description"],
-                            "name": tool_spec["name"],
-                            "parameters_json_schema": tool_spec["inputSchema"]["json"],
-                        }
-                    ]
-                }
-            ],
-            "tool_config": {
-                "function_calling_config": exp_function_calling_config,
-                "retrieval_config": {"language_code": "en-GB"},
-            },
-        },
-        "contents": [{"parts": [{"text": "test"}], "role": "user"}],
-        "model": model_id,
-    }
-    gemini_client.aio.models.generate_content_stream.assert_called_with(**exp_request)
-
-
-@pytest.mark.asyncio
-async def test_stream_forcing_tool_choice_does_not_leak_into_the_next_request(
-    gemini_client, tool_config_param_model, messages, tool_spec, model_id
-):
-    """A forced choice applies to its own request only, leaving the params tool config for the next one."""
-    await anext(tool_config_param_model.stream(messages, tool_specs=[tool_spec], tool_choice={"any": {}}))
-    await anext(tool_config_param_model.stream(messages, tool_specs=[tool_spec]))
 
     exp_request = {
         "config": {
@@ -1188,6 +1150,67 @@ async def test_stream_forcing_tool_choice_does_not_leak_into_the_next_request(
                 "function_calling_config": {"mode": "NONE", "allowed_function_names": ["safe_tool"]},
                 "retrieval_config": {"language_code": "en-GB"},
             },
+        },
+        "contents": [{"parts": [{"text": "test"}], "role": "user"}],
+        "model": model_id,
+    }
+    gemini_client.aio.models.generate_content_stream.assert_called_with(**exp_request)
+
+
+@pytest.mark.asyncio
+async def test_stream_tool_config_param_set_to_none_still_takes_precedence(
+    gemini_client, messages, tool_spec, model_id
+):
+    """Params owns the key, so an explicit None keeps a tool choice out of the request.
+
+    Matches the sibling providers, which spread params last and therefore let an explicit None win.
+    """
+    model = GeminiModel(model_id=model_id, params={"tool_config": None})
+
+    await anext(model.stream(messages, tool_specs=[tool_spec], tool_choice={"any": {}}))
+
+    exp_request = {
+        "config": {
+            "tools": [
+                {
+                    "function_declarations": [
+                        {
+                            "description": tool_spec["description"],
+                            "name": tool_spec["name"],
+                            "parameters_json_schema": tool_spec["inputSchema"]["json"],
+                        }
+                    ]
+                }
+            ],
+        },
+        "contents": [{"parts": [{"text": "test"}], "role": "user"}],
+        "model": model_id,
+    }
+    gemini_client.aio.models.generate_content_stream.assert_called_with(**exp_request)
+
+
+@pytest.mark.asyncio
+async def test_stream_tool_choice_does_not_persist_into_the_next_request(gemini_client, messages, tool_spec, model_id):
+    """A tool choice configures its own request only, so it never lands in the model's own params."""
+    model = GeminiModel(model_id=model_id, params={"temperature": 0.5})
+
+    await anext(model.stream(messages, tool_specs=[tool_spec], tool_choice={"any": {}}))
+    await anext(model.stream(messages, tool_specs=[tool_spec]))
+
+    exp_request = {
+        "config": {
+            "temperature": 0.5,
+            "tools": [
+                {
+                    "function_declarations": [
+                        {
+                            "description": tool_spec["description"],
+                            "name": tool_spec["name"],
+                            "parameters_json_schema": tool_spec["inputSchema"]["json"],
+                        }
+                    ]
+                }
+            ],
         },
         "contents": [{"parts": [{"text": "test"}], "role": "user"}],
         "model": model_id,

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -1111,16 +1111,33 @@ def tool_config_param_model(gemini_client, model_id):
     _ = gemini_client
 
     tool_config = genai.types.ToolConfig(
-        function_calling_config=genai.types.FunctionCallingConfig(mode=genai.types.FunctionCallingConfigMode.NONE)
+        function_calling_config=genai.types.FunctionCallingConfig(
+            mode=genai.types.FunctionCallingConfigMode.NONE,
+            allowed_function_names=["safe_tool"],
+        ),
+        # A field no ToolChoice can express, so a tool choice must leave it in place.
+        retrieval_config=genai.types.RetrievalConfig(language_code="en-GB"),
     )
     return GeminiModel(model_id=model_id, params={"tool_config": tool_config})
 
 
+@pytest.mark.parametrize(
+    ("tool_choice", "exp_function_calling_config"),
+    [
+        # No choice and an "auto" choice both leave the params tool config exactly as configured.
+        (None, {"mode": "NONE", "allowed_function_names": ["safe_tool"]}),
+        ({"auto": {}}, {"mode": "NONE", "allowed_function_names": ["safe_tool"]}),
+        # A forcing choice replaces the whole function calling config, allowlist included - the forced tool
+        # need not appear in a user's allowlist - while the fields it cannot express survive.
+        ({"any": {}}, {"mode": "ANY"}),
+        ({"tool": {"name": "name"}}, {"mode": "ANY", "allowed_function_names": ["name"]}),
+    ],
+)
 @pytest.mark.asyncio
-async def test_stream_request_tool_choice_takes_precedence_over_tool_config_param(
-    gemini_client, tool_config_param_model, messages, tool_spec, model_id
+async def test_stream_request_tool_config_param_precedence(
+    gemini_client, tool_config_param_model, messages, tool_spec, model_id, tool_choice, exp_function_calling_config
 ):
-    await anext(tool_config_param_model.stream(messages, tool_specs=[tool_spec], tool_choice={"any": {}}))
+    await anext(tool_config_param_model.stream(messages, tool_specs=[tool_spec], tool_choice=tool_choice))
 
     exp_request = {
         "config": {
@@ -1135,7 +1152,10 @@ async def test_stream_request_tool_choice_takes_precedence_over_tool_config_para
                     ]
                 }
             ],
-            "tool_config": {"function_calling_config": {"mode": "ANY"}},
+            "tool_config": {
+                "function_calling_config": exp_function_calling_config,
+                "retrieval_config": {"language_code": "en-GB"},
+            },
         },
         "contents": [{"parts": [{"text": "test"}], "role": "user"}],
         "model": model_id,
@@ -1144,9 +1164,11 @@ async def test_stream_request_tool_choice_takes_precedence_over_tool_config_para
 
 
 @pytest.mark.asyncio
-async def test_stream_request_tool_config_param_without_tool_choice(
+async def test_stream_forcing_tool_choice_does_not_leak_into_the_next_request(
     gemini_client, tool_config_param_model, messages, tool_spec, model_id
 ):
+    """A forced choice applies to its own request only, leaving the params tool config for the next one."""
+    await anext(tool_config_param_model.stream(messages, tool_specs=[tool_spec], tool_choice={"any": {}}))
     await anext(tool_config_param_model.stream(messages, tool_specs=[tool_spec]))
 
     exp_request = {
@@ -1162,7 +1184,10 @@ async def test_stream_request_tool_config_param_without_tool_choice(
                     ]
                 }
             ],
-            "tool_config": {"function_calling_config": {"mode": "NONE"}},
+            "tool_config": {
+                "function_calling_config": {"mode": "NONE", "allowed_function_names": ["safe_tool"]},
+                "retrieval_config": {"language_code": "en-GB"},
+            },
         },
         "contents": [{"parts": [{"text": "test"}], "role": "user"}],
         "model": model_id,

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -1059,6 +1059,96 @@ async def test_stream_request_with_gemini_tools_and_function_tools(gemini_client
     gemini_client.aio.models.generate_content_stream.assert_called_with(**exp_request)
 
 
+@pytest.mark.parametrize(
+    ("tool_choice", "exp_function_calling_config"),
+    [
+        ({"auto": {}}, {"mode": "AUTO"}),
+        ({"any": {}}, {"mode": "ANY"}),
+        ({"tool": {"name": "name"}}, {"allowed_function_names": ["name"], "mode": "ANY"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_stream_request_with_tool_choice(
+    gemini_client, model, messages, tool_spec, model_id, tool_choice, exp_function_calling_config
+):
+    await anext(model.stream(messages, tool_specs=[tool_spec], tool_choice=tool_choice))
+
+    exp_request = {
+        "config": {
+            "tools": [
+                {
+                    "function_declarations": [
+                        {
+                            "description": tool_spec["description"],
+                            "name": tool_spec["name"],
+                            "parameters_json_schema": tool_spec["inputSchema"]["json"],
+                        }
+                    ]
+                }
+            ],
+            "tool_config": {"function_calling_config": exp_function_calling_config},
+        },
+        "contents": [{"parts": [{"text": "test"}], "role": "user"}],
+        "model": model_id,
+    }
+    gemini_client.aio.models.generate_content_stream.assert_called_with(**exp_request)
+
+
+@pytest.mark.asyncio
+async def test_stream_request_with_tool_choice_and_no_tool_specs(gemini_client, model, messages, model_id):
+    await anext(model.stream(messages, tool_choice={"any": {}}))
+
+    exp_request = {
+        "config": {},
+        "contents": [{"parts": [{"text": "test"}], "role": "user"}],
+        "model": model_id,
+    }
+    gemini_client.aio.models.generate_content_stream.assert_called_with(**exp_request)
+
+
+@pytest.mark.asyncio
+async def test_stream_request_with_tool_choice_and_tool_config_param(gemini_client, messages, tool_spec, model_id):
+    tool_config = genai.types.ToolConfig(
+        function_calling_config=genai.types.FunctionCallingConfig(mode=genai.types.FunctionCallingConfigMode.NONE)
+    )
+    model = GeminiModel(model_id=model_id, params={"tool_config": tool_config})
+
+    await anext(model.stream(messages, tool_specs=[tool_spec], tool_choice={"any": {}}))
+
+    exp_request = {
+        "config": {
+            "tools": [
+                {
+                    "function_declarations": [
+                        {
+                            "description": tool_spec["description"],
+                            "name": tool_spec["name"],
+                            "parameters_json_schema": tool_spec["inputSchema"]["json"],
+                        }
+                    ]
+                }
+            ],
+            "tool_config": {"function_calling_config": {"mode": "NONE"}},
+        },
+        "contents": [{"parts": [{"text": "test"}], "role": "user"}],
+        "model": model_id,
+    }
+    gemini_client.aio.models.generate_content_stream.assert_called_with(**exp_request)
+
+
+def test_format_tool_choice_unrecognized_strategy(model):
+    tru_tool_config = model._format_tool_choice({"unrecognized": {}})
+    exp_tool_config = None
+    assert tru_tool_config == exp_tool_config
+
+
+@pytest.mark.asyncio
+async def test_stream_tool_choice_no_warning(model, messages, tool_spec, captured_warnings):
+    await anext(model.stream(messages, tool_specs=[tool_spec], tool_choice={"auto": {}}))
+
+    assert len(captured_warnings) == 0
+
+
 @pytest.mark.asyncio
 async def test_stream_handles_non_json_error(gemini_client, model, messages, alist):
     error_message = "Invalid API key"

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -1106,14 +1106,48 @@ async def test_stream_request_with_tool_choice_and_no_tool_specs(gemini_client, 
     gemini_client.aio.models.generate_content_stream.assert_called_with(**exp_request)
 
 
-@pytest.mark.asyncio
-async def test_stream_request_with_tool_choice_and_tool_config_param(gemini_client, messages, tool_spec, model_id):
+@pytest.fixture
+def tool_config_param_model(gemini_client, model_id):
+    _ = gemini_client
+
     tool_config = genai.types.ToolConfig(
         function_calling_config=genai.types.FunctionCallingConfig(mode=genai.types.FunctionCallingConfigMode.NONE)
     )
-    model = GeminiModel(model_id=model_id, params={"tool_config": tool_config})
+    return GeminiModel(model_id=model_id, params={"tool_config": tool_config})
 
-    await anext(model.stream(messages, tool_specs=[tool_spec], tool_choice={"any": {}}))
+
+@pytest.mark.asyncio
+async def test_stream_request_tool_choice_takes_precedence_over_tool_config_param(
+    gemini_client, tool_config_param_model, messages, tool_spec, model_id
+):
+    await anext(tool_config_param_model.stream(messages, tool_specs=[tool_spec], tool_choice={"any": {}}))
+
+    exp_request = {
+        "config": {
+            "tools": [
+                {
+                    "function_declarations": [
+                        {
+                            "description": tool_spec["description"],
+                            "name": tool_spec["name"],
+                            "parameters_json_schema": tool_spec["inputSchema"]["json"],
+                        }
+                    ]
+                }
+            ],
+            "tool_config": {"function_calling_config": {"mode": "ANY"}},
+        },
+        "contents": [{"parts": [{"text": "test"}], "role": "user"}],
+        "model": model_id,
+    }
+    gemini_client.aio.models.generate_content_stream.assert_called_with(**exp_request)
+
+
+@pytest.mark.asyncio
+async def test_stream_request_tool_config_param_without_tool_choice(
+    gemini_client, tool_config_param_model, messages, tool_spec, model_id
+):
+    await anext(tool_config_param_model.stream(messages, tool_specs=[tool_spec]))
 
     exp_request = {
         "config": {

--- a/strands-py/tests_integ/models/test_model_gemini.py
+++ b/strands-py/tests_integ/models/test_model_gemini.py
@@ -239,12 +239,13 @@ async def test_model_stream_tool_choice_tool_forces_the_named_tool(model, tool_s
         model.stream(messages, tool_specs=tool_specs, tool_choice={"tool": {"name": "tool_time"}}),
     )
 
-    tru_tool_names = [
+    # ANY mode may emit more than one call, so only the narrowing to tool_time is guaranteed.
+    tru_tool_names = {
         event["contentBlockStart"]["start"]["toolUse"]["name"]
         for event in events
         if "contentBlockStart" in event and "toolUse" in event["contentBlockStart"]["start"]
-    ]
-    exp_tool_names = ["tool_time"]
+    }
+    exp_tool_names = {"tool_time"}
     assert tru_tool_names == exp_tool_names
 
 

--- a/strands-py/tests_integ/models/test_model_gemini.py
+++ b/strands-py/tests_integ/models/test_model_gemini.py
@@ -204,6 +204,50 @@ def test_agent_with_gemini_code_execution_tool(gemini_tool_model):
     assert "5117" in str(result_turn2)
 
 
+@pytest.fixture
+def tool_specs():
+    return [
+        {
+            "name": "tool_time",
+            "description": "Get the current time for a city",
+            "inputSchema": {"json": {"type": "object", "properties": {"city": {"type": "string"}}}},
+        },
+        {
+            "name": "tool_weather",
+            "description": "Get the current weather for a city",
+            "inputSchema": {"json": {"type": "object", "properties": {"city": {"type": "string"}}}},
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_model_stream_tool_choice_any_forces_a_tool_use(model, tool_specs, alist):
+    messages = [{"role": "user", "content": [{"text": "Hello there!"}]}]
+
+    events = await alist(model.stream(messages, tool_specs=tool_specs, tool_choice={"any": {}}))
+
+    tru_stop_reason = next(event["messageStop"]["stopReason"] for event in events if "messageStop" in event)
+    exp_stop_reason = "tool_use"
+    assert tru_stop_reason == exp_stop_reason
+
+
+@pytest.mark.asyncio
+async def test_model_stream_tool_choice_tool_forces_the_named_tool(model, tool_specs, alist):
+    messages = [{"role": "user", "content": [{"text": "What is the weather in New York?"}]}]
+
+    events = await alist(
+        model.stream(messages, tool_specs=tool_specs, tool_choice={"tool": {"name": "tool_time"}}),
+    )
+
+    tru_tool_names = [
+        event["contentBlockStart"]["start"]["toolUse"]["name"]
+        for event in events
+        if "contentBlockStart" in event and "toolUse" in event["contentBlockStart"]["start"]
+    ]
+    exp_tool_names = ["tool_time"]
+    assert tru_tool_names == exp_tool_names
+
+
 def test_agent_with_reasoning_content(model, assistant_agent):
     """Test that reasoning content is captured in message history."""
 


### PR DESCRIPTION
## Description

`GeminiModel.stream()` accepted a `tool_choice` and discarded it — the docstring read `Note: Currently unused.` and nothing downstream consumed it. The practical cost is the event loop's forced structured-output retry: it re-invokes with `tool_choice={"any": {}}` expecting an API-level guarantee of a tool call, and on Gemini that retry was forced in name only, leaving `StructuredOutputException` reachable where Anthropic and Bedrock guarantee a call. This ports the mapping that already exists in the TypeScript SDK (`strands-ts/src/models/google/model.ts`), closing a py↔ts parity gap.

| Strands `ToolChoice` | Gemini `FunctionCallingConfigMode` |
|---|---|
| `{"auto": {}}` | `AUTO` |
| `{"any": {}}` | `ANY` |
| `{"tool": {"name": "X"}}` | `ANY` + `allowed_function_names=["X"]` |

A `tool_choice` with no tool specs is a no-op, matching TS — there is nothing to choose from.

### Public API Changes

No new surface: `tool_choice` was already on `GeminiModel.stream()` and on the base `Model` protocol. Two behavioral notes for reviewers.

**An explicit `tool_config` in `params` takes precedence over a per-request `tool_choice.`** Two earlier commits on this branch tried the other direction, then a field-level merge; both were abandoned because a Gemini `ToolConfig` carries fields a Strands `ToolChoice` cannot express (`retrieval_config`, `stream_function_call_arguments`), so each merge rule left another user-set field behind. Letting the explicit config win passes it through whole and matches the other providers and the TypeScript SDK, which all spread `params` last.

```python
model = GeminiModel(model_id=..., params={"tool_config": my_tool_config})

model.stream(messages, tool_specs=specs, tool_choice={"any": {}})  # my_tool_config still wins, unchanged
```

**`tool_choice` is now keyword-only**, matching `Model.stream()` and every other provider. Gemini was the only one missing the `*`, so a positional fourth argument was already outside the declared interface, and was silently ignored:

```python
# Before: accepted positionally, then discarded
model.stream(messages, tool_specs, system_prompt, {"any": {}})

# After
model.stream(messages, tool_specs, system_prompt, tool_choice={"any": {}})
```


## Related Issues

Resolves #1129

## Documentation PR

N/A

## Type of Change

New feature

## Testing

Summary: 64/64 `test_gemini.py` pass (57 pre-existing + 7 new), 265 pass across the model/event-loop/structured-output suites, `ruff format --check` + `ruff check` + `mypy` clean, and the same suite passes against the declared `google-genai` floor (1.67.0) as well as 2.14.0.


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works — **this PR was written by an agent; a human reviewer needs to own this box before merge.**
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly — docstrings only; no `site/` page covers per-provider `tool_choice`
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings — asserted by `test_stream_tool_choice_no_warning`
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
