### PR TITLE
docs: mark agentic context management mode as experimental

### DIFF
--- a/site/src/content/docs/user-guide/concepts/context-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/context-management.mdx
@@ -87,6 +87,11 @@ agent = Agent(
 
 ## Agentic context management
 
+:::caution[Experimental]
+Agentic context management is experimental and may change in future
+versions. Use with caution in production environments.
+:::
+
 Auto mode compresses on a fixed threshold the SDK controls. Agentic mode hands that control to the model. Pass <Syntax py='context_manager="agentic"' ts='contextManager: "agentic"' /> and the model manages its own working memory: it sees how full the context window is and chooses when to compress, what to compress, and what to protect.
 
 <Tabs>

--- a/strands-py/src/strands/_context_manager/modes/agentic/agentic_context.py
+++ b/strands-py/src/strands/_context_manager/modes/agentic/agentic_context.py
@@ -1,5 +1,8 @@
 """Agentic context management: model-driven compression via injected tools.
 
+.. warning:: Experimental
+    This module is experimental and may change in future versions.
+
 When an agent is created with ``context_manager="agentic"``, three tools are injected
 (``summarize_context``, ``truncate_context``, ``pin_context``) that let the model manage
 its own conversation history, plus a middleware that surfaces live token usage to the model

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -124,7 +124,12 @@ _DEFAULT_AGENT_NAME = "Strands Agents"
 _DEFAULT_AGENT_ID = "default"
 
 ContextManagerStrategy = Literal["auto", "agentic"]
-"""Supported values for the ``context_manager`` parameter."""
+"""Supported values for the ``context_manager`` parameter.
+
+- ``"auto"``: SummarizingConversationManager with proactive compression + ContextOffloader.
+- ``"agentic"``: (Experimental) Lets the model drive context management via injected tools.
+  This mode may change in future versions.
+"""
 
 _CONTEXT_MANAGER_MAX_RESULT_TOKENS = 1_500
 """Benchmark-validated token threshold for offloading tool results."""

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -225,7 +225,8 @@ export type AgentConfig = {
    * Context management strategy.
    *
    * - `"auto"`: SummarizingConversationManager with proactive compression + ContextOffloader.
-   * - `"agentic"`: Lets the model drive context management via injected tools.
+   * - `"agentic"`: (Experimental) Lets the model drive context management via injected tools.
+   *   This mode may change in future versions.
    *
    * If `conversationManager` is also provided, the user's conversation manager is used instead.
    * Defaults to undefined (SlidingWindowConversationManager, no offloader).

--- a/strands-ts/src/context-manager/modes/agentic/agentic-context.ts
+++ b/strands-ts/src/context-manager/modes/agentic/agentic-context.ts
@@ -1,3 +1,9 @@
+/**
+ * Agentic context management: model-driven compression via injected tools.
+ *
+ * @experimental This module is experimental and may change in future versions.
+ */
+
 import { z } from 'zod'
 import { Message, TextBlock } from '../../../types/messages.js'
 import { tool } from '../../../tools/tool-factory.js'


### PR DESCRIPTION


## Description
The agentic context management mode depends on research into whether models effectively use context management tools. Mark it as experimental in the documentation site, Python SDK docstrings, and TypeScript SDK TSDoc comments.

