### PR TITLE
fix(ci): exclude bootstrap tools from MCP audit

### DIFF
--- a/.github/workflows/mcp-security-audit.yml
+++ b/.github/workflows/mcp-security-audit.yml
@@ -44,7 +44,10 @@ jobs:
           # Resolve the package's full dependency closure into a temporary
           # venv, then audit it. Auditing the project metadata directly skips
           # transitive deps; this mirrors what an end user actually installs.
-          python -m venv /tmp/audit-env
-          /tmp/audit-env/bin/pip install --upgrade pip
-          /tmp/audit-env/bin/pip install .
+          # Create the target without pip/setuptools bootstrap tooling, then
+          # use the runner's pip to install into it. This keeps the audit
+          # focused on declared runtime dependencies; if the project ever
+          # declares setuptools, pip will install it and it will be audited.
+          python -m venv --without-pip /tmp/audit-env
+          python -m pip --python /tmp/audit-env install .
           pip-audit --path /tmp/audit-env/lib/python*/site-packages


### PR DESCRIPTION
## Description

The MCP security audit currently scans `pip` and `setuptools` bootstrapped by the runner's Python 3.10 environment. This can report vulnerabilities unrelated to the MCP server's runtime dependency closure, creating noisy release annotations. The audit target now contains only the package and its declared runtime dependencies; a future declared dependency on `setuptools` would still be audited.

No public API changes.

## Related Issues

None.

## Documentation PR

Not required.

## Type of Change

Bug fix

## Testing

Validated that the MCP package and its dependency closure install into the no-pip target environment while `setuptools` remains absent.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.