### PR TITLE
docs(openai): document TypeScript custom clients

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -282,8 +282,10 @@ if __name__ == "__main__":
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Custom client capability is not yet supported in the TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/model-providers/openai_imports.ts:custom_client_imports"
+
+--8<-- "user-guide/concepts/model-providers/openai.ts:custom_client"
 ```
 </Tab>
 </Tabs>

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai.ts
@@ -5,6 +5,7 @@
 // @ts-nocheck
 // Imports are in openai_imports.ts
 
+import OpenAI from 'openai'
 import { Agent } from '@strands-agents/sdk'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 import { z } from 'zod'
@@ -41,6 +42,25 @@ async function customServer() {
   const agent = new Agent({ model })
   const response = await agent.invoke('Hello!')
   // --8<-- [end:custom_server]
+}
+
+// Custom client
+async function customClient() {
+  // --8<-- [start:custom_client]
+  const client = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY || '<KEY>',
+  })
+
+  const model = new OpenAIModel({
+    api: 'chat',
+    client,
+    modelId: 'gpt-5.4',
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2?')
+  console.log(response)
+  // --8<-- [end:custom_client]
 }
 
 // Configuration

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai_imports.ts
@@ -5,6 +5,12 @@ import { Agent } from '@strands-agents/sdk'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 // --8<-- [end:basic_usage_imports]
 
+// --8<-- [start:custom_client_imports]
+import OpenAI from 'openai'
+import { Agent } from '@strands-agents/sdk'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+// --8<-- [end:custom_client_imports]
+
 // --8<-- [start:structured_output_imports]
 import { Agent } from '@strands-agents/sdk'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'


### PR DESCRIPTION
## Description

The TypeScript SDK already accepts a preconfigured OpenAI client, but the OpenAI provider page incorrectly says this capability is unsupported. Document the existing `client` option with a working TypeScript example so the page matches the public API.

No public API changes.

## Related Issues

None.

## Documentation PR

This PR updates the documentation directly.

## Type of Change

Documentation update

## Testing

Built the documentation site and validated the TypeScript snippets.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.