### PR TITLE
feat(hitl-py): add classifier option for LLM-driven risk classification

### DIFF
--- a/strands-py/src/strands/vended_interventions/hitl/__init__.py
+++ b/strands-py/src/strands/vended_interventions/hitl/__init__.py
@@ -19,6 +19,7 @@ Example:
     ```
 """
 
+from .classifier import HumanInTheLoopClassifier, LLMClassifierConfig
 from .hitl import HumanInTheLoop
 
-__all__ = ["HumanInTheLoop"]
+__all__ = ["HumanInTheLoop", "HumanInTheLoopClassifier", "LLMClassifierConfig"]

--- a/strands-py/src/strands/vended_interventions/hitl/classifier.py
+++ b/strands-py/src/strands/vended_interventions/hitl/classifier.py
@@ -1,0 +1,142 @@
+"""Built-in LLM risk classifier for the HumanInTheLoop handler.
+
+Uses an inner agent with structured output to evaluate whether a tool call
+requires human approval based on risk criteria.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+from ...hooks.events import BeforeToolCallEvent
+from ...models import Model
+
+
+@dataclass
+class ClassifierResult:
+    """Result from a classifier evaluation."""
+
+    requires_human_in_the_loop: bool
+    reason: str | None = field(default=None)
+
+
+@runtime_checkable
+class HumanInTheLoopClassifier(Protocol):
+    """Callable (sync or async) that decides whether a tool call requires human approval."""
+
+    def __call__(self, event: BeforeToolCallEvent, **kwargs: Any) -> ClassifierResult | Awaitable[ClassifierResult]:
+        """Evaluate whether a tool call requires human approval.
+
+        Args:
+            event: The tool call event under evaluation.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            ClassifierResult indicating whether approval is required.
+        """
+        ...
+
+
+class LLMClassifierConfig:
+    """Configuration for the built-in LLM risk classifier.
+
+    Args:
+        system_prompt: Risk criteria prompt. Defaults to a general-purpose risk prompt.
+        model: Model for risk evaluation. Defaults to the parent agent's model.
+    """
+
+    def __init__(self, *, system_prompt: str | None = None, model: Model | None = None) -> None:
+        """Initialize classifier configuration.
+
+        Args:
+            system_prompt: Custom system prompt describing risk criteria.
+            model: Model to use for classification.
+        """
+        self.system_prompt = system_prompt
+        self.model = model
+
+
+_DEFAULT_SYSTEM_PROMPT = """You are a risk evaluator for an AI agent's tool calls. Your job is to decide whether \
+each tool call requires human approval before executing.
+
+## When to require approval
+
+Require approval when the tool call:
+- Is destructive or irreversible (deleting data, dropping tables, revoking access)
+- Modifies important state in production or shared environments
+- Accesses or transmits sensitive data (credentials, PII, financial records)
+- Communicates externally (sending emails, posting messages, making payments)
+- Has a large blast radius (affecting many records, users, or systems)
+
+## When approval is NOT needed
+
+Do not require approval when the tool call:
+- Is read-only AND does not access sensitive data (listing non-sensitive files, querying public data, searching)
+- Operates on local or temporary resources
+- Has easily reversible effects
+- Is scoped to a single non-critical resource
+
+Note: even read-only operations that access credentials, secrets, PII, or financial data still require approval.
+
+## Instructions
+
+Evaluate the tool name and its input arguments. Consider what could go wrong if this specific call executes \
+with these specific arguments. When uncertain, require approval.
+
+Keep your reason under 10 words — it is shown to a human in a CLI prompt."""
+
+
+class _RiskDecision(BaseModel):
+    """Structured output schema for the inner classification agent."""
+
+    requires_approval: bool = Field(description="Whether this tool call requires human approval before executing")
+    reason: str = Field(description="Brief reason (under 10 words) why approval is or is not required")
+
+
+def create_llm_risk_classifier(config: LLMClassifierConfig | None = None) -> HumanInTheLoopClassifier:
+    """Create the built-in LLM risk classifier.
+
+    Args:
+        config: Optional configuration for the classifier.
+
+    Returns:
+        A classifier function that uses an inner LLM agent to evaluate risk.
+    """
+    system_prompt = (config.system_prompt if config else None) or _DEFAULT_SYSTEM_PROMPT
+    configured_model = config.model if config else None
+
+    async def classifier(event: BeforeToolCallEvent, **kwargs: Any) -> ClassifierResult:
+        from ...agent import Agent
+
+        model = configured_model or event.agent.model
+        if not model:
+            raise ValueError(
+                "LLM risk classifier has no model — pass `model` in "
+                "`LLMClassifierConfig(model=...)`, or ensure the parent agent has a model."
+            )
+
+        inner = Agent(model=model, system_prompt=system_prompt, callback_handler=None)
+        tool_use = event.tool_use
+        prompt = (
+            f"Should this tool call require human approval?\n\n"
+            f"Tool: {tool_use['name']}\n"
+            f"Input: {json.dumps(tool_use['input'], indent=2)}"
+        )
+        result = await inner.invoke_async(prompt, structured_output_model=_RiskDecision)
+        decision = result.structured_output
+        if not isinstance(decision, _RiskDecision):
+            raise ValueError(
+                f"LLM risk classifier produced no structured output (stop_reason={result.stop_reason!r})"
+            )
+
+        return ClassifierResult(
+            requires_human_in_the_loop=decision.requires_approval,
+            reason=decision.reason,
+        )
+
+    return classifier

--- a/strands-py/src/strands/vended_interventions/hitl/classifier.py
+++ b/strands-py/src/strands/vended_interventions/hitl/classifier.py
@@ -42,6 +42,7 @@ class HumanInTheLoopClassifier(Protocol):
         ...
 
 
+@dataclass
 class LLMClassifierConfig:
     """Configuration for the built-in LLM risk classifier.
 
@@ -50,15 +51,8 @@ class LLMClassifierConfig:
         model: Model for risk evaluation. Defaults to the parent agent's model.
     """
 
-    def __init__(self, *, system_prompt: str | None = None, model: Model | None = None) -> None:
-        """Initialize classifier configuration.
-
-        Args:
-            system_prompt: Custom system prompt describing risk criteria.
-            model: Model to use for classification.
-        """
-        self.system_prompt = system_prompt
-        self.model = model
+    system_prompt: str | None = field(default=None)
+    model: Model | None = field(default=None)
 
 
 _DEFAULT_SYSTEM_PROMPT = """You are a risk evaluator for an AI agent's tool calls. Your job is to decide whether \
@@ -98,7 +92,7 @@ class _RiskDecision(BaseModel):
     reason: str = Field(description="Brief reason (under 10 words) why approval is or is not required")
 
 
-def create_llm_risk_classifier(config: LLMClassifierConfig | None = None) -> HumanInTheLoopClassifier:
+def _create_llm_risk_classifier(config: LLMClassifierConfig | None = None) -> HumanInTheLoopClassifier:
     """Create the built-in LLM risk classifier.
 
     Args:

--- a/strands-py/src/strands/vended_interventions/hitl/hitl.py
+++ b/strands-py/src/strands/vended_interventions/hitl/hitl.py
@@ -289,16 +289,16 @@ class HumanInTheLoop(InterventionHandler):
             self._classified_tool_use_ids.add(tool_use_id)
 
             try:
-                result = self._classifier(event)
-                if inspect.isawaitable(result):
-                    result = await result
-                if not isinstance(result, ClassifierResult):
+                raw_result: Any = self._classifier(event)
+                if inspect.isawaitable(raw_result):
+                    raw_result = await raw_result
+                if not isinstance(raw_result, ClassifierResult):
                     logger.warning(
                         "tool=<%s> | classifier returned malformed result, defaulting to approval required",
                         tool_name,
                     )
                     return ClassifierResult(requires_human_in_the_loop=True)
-                return result
+                return raw_result
             except Exception as error:
                 logger.warning(
                     "tool=<%s> | classifier failed, defaulting to approval required",

--- a/strands-py/src/strands/vended_interventions/hitl/hitl.py
+++ b/strands-py/src/strands/vended_interventions/hitl/hitl.py
@@ -14,7 +14,7 @@ from typing import Any, Literal, Protocol, runtime_checkable
 from ...hooks.events import BeforeToolCallEvent
 from ...interventions.actions import Confirm, Deny, InterventionAction, Proceed, default_evaluate
 from ...interventions.handler import InterventionHandler
-from .classifier import ClassifierResult, HumanInTheLoopClassifier, LLMClassifierConfig, create_llm_risk_classifier
+from .classifier import ClassifierResult, HumanInTheLoopClassifier, LLMClassifierConfig, _create_llm_risk_classifier
 
 logger = logging.getLogger(__name__)
 
@@ -292,7 +292,7 @@ class HumanInTheLoop(InterventionHandler):
                 result = self._classifier(event)
                 if inspect.isawaitable(result):
                     result = await result
-                if not isinstance(getattr(result, "requires_human_in_the_loop", None), bool):
+                if not isinstance(result, ClassifierResult):
                     logger.warning(
                         "tool=<%s> | classifier returned malformed result, defaulting to approval required",
                         tool_name,
@@ -349,7 +349,7 @@ class HumanInTheLoop(InterventionHandler):
         if classifier is None or classifier is False:
             return None
         if classifier is True:
-            return create_llm_risk_classifier()
+            return _create_llm_risk_classifier()
         if isinstance(classifier, LLMClassifierConfig):
-            return create_llm_risk_classifier(classifier)
+            return _create_llm_risk_classifier(classifier)
         return classifier

--- a/strands-py/src/strands/vended_interventions/hitl/hitl.py
+++ b/strands-py/src/strands/vended_interventions/hitl/hitl.py
@@ -6,6 +6,7 @@ Pauses agent execution before tool calls so a human can approve or deny them.
 import asyncio
 import inspect
 import json
+import logging
 import threading
 from collections.abc import Awaitable
 from typing import Any, Literal, Protocol, runtime_checkable
@@ -13,6 +14,9 @@ from typing import Any, Literal, Protocol, runtime_checkable
 from ...hooks.events import BeforeToolCallEvent
 from ...interventions.actions import Confirm, Deny, InterventionAction, Proceed, default_evaluate
 from ...interventions.handler import InterventionHandler
+from .classifier import ClassifierResult, HumanInTheLoopClassifier, LLMClassifierConfig, create_llm_risk_classifier
+
+logger = logging.getLogger(__name__)
 
 _TRUST_RESPONSES = {"t", "trust"}
 _TRUSTED_TOOLS_KEY = "hitl:trusted_tools"
@@ -98,6 +102,12 @@ class HumanInTheLoop(InterventionHandler):
         # read_file runs freely, everything else pauses for approval
         agent = Agent(interventions=[HumanInTheLoop(allowed_tools=["read_file"])])
 
+        # LLM-driven risk classification — only risky calls get escalated
+        agent = Agent(interventions=[HumanInTheLoop(
+            allowed_tools=["read_file", "list_dir"],
+            classifier=True,
+        )])
+
         # CLI mode - prompts in terminal inline
         agent = Agent(interventions=[HumanInTheLoop(ask="stdio")])
 
@@ -115,6 +125,7 @@ class HumanInTheLoop(InterventionHandler):
         self,
         *,
         allowed_tools: list[str] | None = None,
+        classifier: bool | LLMClassifierConfig | HumanInTheLoopClassifier | None = None,
         enable_trust: bool = False,
         evaluate_trust: EvaluateCallback | None = None,
         evaluate: EvaluateCallback | None = None,
@@ -129,10 +140,17 @@ class HumanInTheLoop(InterventionHandler):
                 approval). For example, ``["read_file", "list_dir"]`` lets only those
                 two run freely, while ``["*", "!delete_file"]`` lets everything run
                 freely except ``delete_file``.
+            classifier: Determines how approval decisions are made for tools not in
+                ``allowed_tools``. Omitted/None: all non-allowed tools require approval.
+                ``True``: uses the built-in LLM risk classifier with defaults.
+                ``LLMClassifierConfig``: built-in LLM classifier with custom settings.
+                Custom callable: your own classification logic.
             enable_trust: When True, trust responses approve the tool AND remember it
                 in ``agent.state`` for the rest of the session (won't ask again).
                 Works in both interrupt/resume and inline ``ask`` modes. Negated
-                tools (``!tool``) cannot be trusted. Defaults to False.
+                tools (``!tool``) cannot be trusted. With a ``classifier``, trusting
+                a tool disables argument-level risk classification for that tool name
+                for the rest of the session. Defaults to False.
             evaluate_trust: Custom trust response validator. Defaults to accepting
                 ``"t"``/``"trust"`` (case-insensitive). When this returns True, the
                 tool is approved AND trusted for the session. Only evaluated when
@@ -160,6 +178,12 @@ class HumanInTheLoop(InterventionHandler):
         if isinstance(allowed_tools, str):
             raise ValueError("allowed_tools must be a list of tool names, not a single string")
         self._allowed_tools = set(allowed_tools or [])
+        self._classifier = self._resolve_classifier(classifier)
+        if self._classifier and "*" in self._allowed_tools:
+            logger.warning(
+                "classifier has no effect when allowed_tools contains '*' — all tools are already allowed"
+            )
+        self._classified_tool_use_ids: set[str] = set()
         self._enable_trust = enable_trust
         self._evaluate_trust = evaluate_trust if evaluate_trust is not None else self._is_trust_response
         self._evaluate = evaluate if evaluate is not None else default_evaluate
@@ -185,10 +209,13 @@ class HumanInTheLoop(InterventionHandler):
             otherwise a Confirm action (pausing via interrupt when no ``ask`` is set).
         """
         tool_name = event.tool_use["name"]
-        if not self._requires_approval(event):
+        classifier_result = await self._requires_approval(event)
+        if not classifier_result.requires_human_in_the_loop:
             return Proceed()
 
-        prompt = f'Tool "{tool_name}" requires human approval. Input: {json.dumps(event.tool_use["input"])}'
+        reason = f" — {classifier_result.reason}" if classifier_result.reason else ""
+        input_str = json.dumps(event.tool_use["input"])
+        prompt = f'Approve "{tool_name}"{reason}?\n  Input: {input_str}'
 
         is_negated = f"!{tool_name}" in self._allowed_tools
 
@@ -226,7 +253,7 @@ class HumanInTheLoop(InterventionHandler):
 
         return Confirm(prompt=prompt, response=response, evaluate=self._evaluate)
 
-    def _requires_approval(self, event: BeforeToolCallEvent) -> bool:
+    async def _requires_approval(self, event: BeforeToolCallEvent) -> ClassifierResult:
         """Decide whether the tool call needs human approval.
 
         Precedence (first match wins):
@@ -235,25 +262,52 @@ class HumanInTheLoop(InterventionHandler):
         2. Trusted at runtime via trust response (stored in ``agent.state``) -> runs freely
         3. Wildcard (``*``) -> runs freely
         4. Explicitly listed -> runs freely
-        5. Default -> requires approval
+        5. Classifier (if provided) -> its decision
+        6. Default (no classifier) -> requires approval
 
         Args:
             event: The tool call event under evaluation.
 
         Returns:
-            True if the tool requires human approval.
+            ClassifierResult indicating whether approval is required.
         """
         tool_name = event.tool_use["name"]
         if f"!{tool_name}" in self._allowed_tools:
-            return True
+            return ClassifierResult(requires_human_in_the_loop=True)
         trusted = event.agent.state.get(_TRUSTED_TOOLS_KEY) or []
         if tool_name in trusted:
-            return False
+            return ClassifierResult(requires_human_in_the_loop=False)
         if "*" in self._allowed_tools:
-            return False
+            return ClassifierResult(requires_human_in_the_loop=False)
         if tool_name in self._allowed_tools:
-            return False
-        return True
+            return ClassifierResult(requires_human_in_the_loop=False)
+
+        if self._classifier:
+            tool_use_id = event.tool_use["toolUseId"]
+            if tool_use_id in self._classified_tool_use_ids:
+                return ClassifierResult(requires_human_in_the_loop=True)
+            self._classified_tool_use_ids.add(tool_use_id)
+
+            try:
+                result = self._classifier(event)
+                if inspect.isawaitable(result):
+                    result = await result
+                if not isinstance(getattr(result, "requires_human_in_the_loop", None), bool):
+                    logger.warning(
+                        "tool=<%s> | classifier returned malformed result, defaulting to approval required",
+                        tool_name,
+                    )
+                    return ClassifierResult(requires_human_in_the_loop=True)
+                return result
+            except Exception as error:
+                logger.warning(
+                    "tool=<%s> | classifier failed, defaulting to approval required",
+                    tool_name,
+                    exc_info=error,
+                )
+                return ClassifierResult(requires_human_in_the_loop=True)
+
+        return ClassifierResult(requires_human_in_the_loop=True)
 
     def _trust_tool(self, event: BeforeToolCallEvent, tool_name: str) -> None:
         """Remember a tool as trusted for the rest of the session.
@@ -279,3 +333,23 @@ class HumanInTheLoop(InterventionHandler):
         if isinstance(response, str):
             return response.lower().strip() in _TRUST_RESPONSES
         return False
+
+    @staticmethod
+    def _resolve_classifier(
+        classifier: bool | LLMClassifierConfig | HumanInTheLoopClassifier | None,
+    ) -> HumanInTheLoopClassifier | None:
+        """Resolve the classifier param into a callable or None.
+
+        Args:
+            classifier: The raw classifier param from the constructor.
+
+        Returns:
+            A classifier callable, or None if no classifier is configured.
+        """
+        if classifier is None or classifier is False:
+            return None
+        if classifier is True:
+            return create_llm_risk_classifier()
+        if isinstance(classifier, LLMClassifierConfig):
+            return create_llm_risk_classifier(classifier)
+        return classifier

--- a/strands-py/tests/strands/vended_interventions/test_hitl.py
+++ b/strands-py/tests/strands/vended_interventions/test_hitl.py
@@ -565,14 +565,14 @@ class TestStdioMode:
 
 
 class TestPublicExports:
-    """Only HumanInTheLoop is exported; the callback Protocols stay defined but unexported."""
+    """Public API exports: HumanInTheLoop, HumanInTheLoopClassifier, LLMClassifierConfig."""
 
-    def test_only_human_in_the_loop_is_exported(self):
+    def test_public_exports(self):
         import strands.vended_interventions as vended
         import strands.vended_interventions.hitl as hitl
 
         assert vended.__all__ == ["CedarAuthorization", "HumanInTheLoop"]
-        assert hitl.__all__ == ["HumanInTheLoop"]
+        assert hitl.__all__ == ["HumanInTheLoop", "HumanInTheLoopClassifier", "LLMClassifierConfig"]
         assert vended.HumanInTheLoop is hitl.HumanInTheLoop
         assert hitl.HumanInTheLoop.name == "strands:human-in-the-loop"
 
@@ -661,3 +661,442 @@ class TestCustomInterventionHandler:
         result = agent("Run tool")
         assert result.stop_reason == "end_turn"
         assert executed == [True]
+
+
+class TestClassifierMode:
+    """Tests for the classifier option that enables LLM-driven risk classification."""
+
+    def test_classifier_true_interrupts_when_risky(self):
+        from unittest.mock import MagicMock
+
+        from strands.vended_interventions.hitl.classifier import ClassifierResult
+
+        executed = []
+
+        @tool(name="delete_file")
+        def delete_file() -> str:
+            executed.append(True)
+            return "deleted"
+
+        agent_model = MockedModelProvider(
+            [tool_use_message("delete_file", tool_input={"path": "/data"}), text_message("Done")]
+        )
+
+        mock_classifier = MagicMock(
+            return_value=ClassifierResult(requires_human_in_the_loop=True, reason="destructive operation")
+        )
+
+        agent = Agent(
+            model=agent_model,
+            tools=[delete_file],
+            interventions=[HumanInTheLoop(classifier=mock_classifier)],
+        )
+
+        result = agent("Delete the file")
+
+        assert result.stop_reason == "interrupt"
+        assert executed == []
+        assert "destructive operation" in result.interrupts[0].reason
+
+    def test_classifier_allows_tool_when_not_risky(self):
+        from unittest.mock import MagicMock
+
+        from strands.vended_interventions.hitl.classifier import ClassifierResult
+
+        executed = []
+
+        @tool(name="read_file")
+        def read_file() -> str:
+            executed.append(True)
+            return "content"
+
+        agent_model = MockedModelProvider(
+            [tool_use_message("read_file", tool_input={"path": "/tmp/x"}), text_message("Done")]
+        )
+
+        mock_classifier = MagicMock(
+            return_value=ClassifierResult(requires_human_in_the_loop=False, reason="read-only operation")
+        )
+
+        agent = Agent(
+            model=agent_model,
+            tools=[read_file],
+            interventions=[HumanInTheLoop(classifier=mock_classifier)],
+        )
+
+        result = agent("Read the file")
+
+        assert result.stop_reason == "end_turn"
+        assert executed == [True]
+
+    def test_allowed_tools_bypasses_classifier(self):
+        from unittest.mock import MagicMock
+
+        from strands.vended_interventions.hitl.classifier import ClassifierResult
+
+        executed = []
+
+        @tool(name="read_file")
+        def read_file() -> str:
+            executed.append(True)
+            return "content"
+
+        agent_model = MockedModelProvider([tool_use_message("read_file"), text_message("Done")])
+
+        mock_classifier = MagicMock(
+            return_value=ClassifierResult(requires_human_in_the_loop=True, reason="should not be called")
+        )
+
+        agent = Agent(
+            model=agent_model,
+            tools=[read_file],
+            interventions=[HumanInTheLoop(allowed_tools=["read_file"], classifier=mock_classifier)],
+        )
+
+        result = agent("Read")
+
+        assert result.stop_reason == "end_turn"
+        assert executed == [True]
+        mock_classifier.assert_not_called()
+
+    def test_custom_classifier_function(self):
+        from strands.vended_interventions.hitl.classifier import ClassifierResult
+
+        executed = []
+
+        @tool(name="deploy")
+        def deploy() -> str:
+            executed.append(True)
+            return "deployed"
+
+        agent_model = MockedModelProvider(
+            [tool_use_message("deploy", tool_input={"env": "prod"}), text_message("Done")]
+        )
+
+        def my_classifier(event, **kwargs):
+            return ClassifierResult(
+                requires_human_in_the_loop=event.tool_use["name"] == "deploy",
+                reason="deployment requires approval",
+            )
+
+        agent = Agent(
+            model=agent_model,
+            tools=[deploy],
+            interventions=[HumanInTheLoop(classifier=my_classifier)],
+        )
+
+        result = agent("Deploy")
+
+        assert result.stop_reason == "interrupt"
+        assert executed == []
+
+    def test_classifier_reason_appears_in_prompt(self):
+        from unittest.mock import MagicMock
+
+        from strands.vended_interventions.hitl.classifier import ClassifierResult
+
+        prompts = []
+
+        @tool(name="send_email")
+        def send_email() -> str:
+            return "sent"
+
+        agent_model = MockedModelProvider(
+            [tool_use_message("send_email", tool_input={"to": "all@co.com"}), text_message("Done")]
+        )
+
+        mock_classifier = MagicMock(
+            return_value=ClassifierResult(requires_human_in_the_loop=True, reason="external communication")
+        )
+
+        def capture_ask(prompt, **kwargs):
+            prompts.append(prompt)
+            return "no"
+
+        agent = Agent(
+            model=agent_model,
+            tools=[send_email],
+            interventions=[HumanInTheLoop(classifier=mock_classifier, ask=capture_ask)],
+        )
+
+        agent("Send email")
+
+        assert "external communication" in prompts[0]
+        assert "send_email" in prompts[0]
+
+    def test_classifier_config_resolves_to_built_in(self):
+        from unittest.mock import MagicMock, patch
+
+        from strands.vended_interventions.hitl.classifier import ClassifierResult, LLMClassifierConfig
+
+        mock_fn = MagicMock(return_value=ClassifierResult(requires_human_in_the_loop=False))
+
+        with patch(
+            "strands.vended_interventions.hitl.hitl.create_llm_risk_classifier", return_value=mock_fn
+        ) as mock_create:
+            config = LLMClassifierConfig(system_prompt="custom prompt")
+            HumanInTheLoop(classifier=config)
+
+            mock_create.assert_called_once_with(config)
+
+    def test_async_custom_classifier(self):
+        from strands.vended_interventions.hitl.classifier import ClassifierResult
+
+        executed = []
+
+        @tool(name="deploy")
+        def deploy() -> str:
+            executed.append(True)
+            return "deployed"
+
+        agent_model = MockedModelProvider(
+            [tool_use_message("deploy", tool_input={"env": "prod"}), text_message("Done")]
+        )
+
+        async def my_classifier(event, **kwargs):
+            return ClassifierResult(
+                requires_human_in_the_loop=True,
+                reason="async classifier says no",
+            )
+
+        agent = Agent(
+            model=agent_model,
+            tools=[deploy],
+            interventions=[HumanInTheLoop(classifier=my_classifier)],
+        )
+
+        result = agent("Deploy")
+
+        assert result.stop_reason == "interrupt"
+        assert executed == []
+
+    def test_classifier_error_fails_closed(self):
+        executed = []
+
+        @tool(name="my_tool")
+        def my_tool() -> str:
+            executed.append(True)
+            return "ran"
+
+        def broken_classifier(event, **kwargs):
+            raise RuntimeError("model down")
+
+        agent_model = MockedModelProvider([tool_use_message("my_tool"), text_message("Done")])
+        agent = Agent(
+            model=agent_model,
+            tools=[my_tool],
+            interventions=[HumanInTheLoop(classifier=broken_classifier)],
+        )
+
+        result = agent("Go")
+
+        assert result.stop_reason == "interrupt"
+        assert executed == []
+
+    def test_malformed_classifier_result_fails_closed(self):
+        from types import SimpleNamespace
+
+        executed = []
+
+        @tool(name="my_tool")
+        def my_tool() -> str:
+            executed.append(True)
+            return "ran"
+
+        def bad_classifier(event, **kwargs):
+            return SimpleNamespace(requires_human_in_the_loop=None)
+
+        agent_model = MockedModelProvider([tool_use_message("my_tool"), text_message("Done")])
+        agent = Agent(
+            model=agent_model,
+            tools=[my_tool],
+            interventions=[HumanInTheLoop(classifier=bad_classifier)],
+        )
+
+        result = agent("Go")
+
+        assert result.stop_reason == "interrupt"
+        assert executed == []
+
+    def test_classifier_not_called_on_resume(self):
+
+        from strands.vended_interventions.hitl.classifier import ClassifierResult
+
+        executed = []
+        call_count = []
+
+        @tool(name="my_tool")
+        def my_tool() -> str:
+            executed.append(True)
+            return "ran"
+
+        def counting_classifier(event, **kwargs):
+            call_count.append(1)
+            return ClassifierResult(requires_human_in_the_loop=True, reason="risky")
+
+        agent_model = MockedModelProvider([tool_use_message("my_tool"), text_message("Done")])
+        agent = Agent(
+            model=agent_model,
+            tools=[my_tool],
+            interventions=[HumanInTheLoop(classifier=counting_classifier)],
+        )
+
+        result = agent("Go")
+        assert result.stop_reason == "interrupt"
+        assert len(call_count) == 1
+
+        interrupt_id = result.interrupts[0].id
+        result = agent([{"interruptResponse": {"interruptId": interrupt_id, "response": "y"}}])
+        assert result.stop_reason == "end_turn"
+        assert executed == [True]
+        # Classifier was only called once (not again on resume)
+        assert len(call_count) == 1
+
+    def test_wildcard_with_classifier_warns(self, caplog):
+        import logging
+
+        from strands.vended_interventions.hitl.classifier import ClassifierResult
+
+        def my_classifier(event, **kwargs):
+            return ClassifierResult(requires_human_in_the_loop=True)
+
+        with caplog.at_level(logging.WARNING):
+            HumanInTheLoop(allowed_tools=["*"], classifier=my_classifier)
+
+        assert "classifier has no effect" in caplog.text
+
+
+class TestBuiltInClassifier:
+    """Tests for the actual create_llm_risk_classifier function body."""
+
+    @pytest.mark.asyncio
+    async def test_creates_inner_agent_and_returns_decision(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from strands.vended_interventions.hitl.classifier import (
+            ClassifierResult,
+            _RiskDecision,
+            create_llm_risk_classifier,
+        )
+
+        classifier = create_llm_risk_classifier()
+
+        mock_result = MagicMock()
+        mock_result.structured_output = _RiskDecision(requires_approval=True, reason="destructive")
+
+        event = MagicMock()
+        event.tool_use = {"name": "delete_file", "input": {"path": "/data"}}
+        event.agent.model = MagicMock()
+
+        with patch("strands.agent.Agent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.invoke_async = AsyncMock(return_value=mock_result)
+            mock_agent_cls.return_value = mock_agent
+
+            result = await classifier(event)
+
+        assert isinstance(result, ClassifierResult)
+        assert result.requires_human_in_the_loop is True
+        assert result.reason == "destructive"
+        mock_agent_cls.assert_called_once()
+        mock_agent.invoke_async.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_model_available(self):
+        from unittest.mock import MagicMock
+
+        from strands.vended_interventions.hitl.classifier import create_llm_risk_classifier
+
+        classifier = create_llm_risk_classifier()
+
+        event = MagicMock()
+        event.tool_use = {"name": "tool", "input": {}}
+        event.agent.model = None
+
+        with pytest.raises(ValueError, match="no model"):
+            await classifier(event)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_structured_output_is_none(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from strands.vended_interventions.hitl.classifier import create_llm_risk_classifier
+
+        classifier = create_llm_risk_classifier()
+
+        mock_result = MagicMock()
+        mock_result.structured_output = None
+        mock_result.stop_reason = "end_turn"
+
+        event = MagicMock()
+        event.tool_use = {"name": "tool", "input": {}}
+        event.agent.model = MagicMock()
+
+        with patch("strands.agent.Agent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.invoke_async = AsyncMock(return_value=mock_result)
+            mock_agent_cls.return_value = mock_agent
+
+            with pytest.raises(ValueError, match="no structured output"):
+                await classifier(event)
+
+    @pytest.mark.asyncio
+    async def test_uses_configured_model_over_agent_model(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from strands.vended_interventions.hitl.classifier import (
+            LLMClassifierConfig,
+            _RiskDecision,
+            create_llm_risk_classifier,
+        )
+
+        configured_model = MagicMock(name="configured_model")
+        agent_model = MagicMock(name="agent_model")
+        classifier = create_llm_risk_classifier(LLMClassifierConfig(model=configured_model))
+
+        mock_result = MagicMock()
+        mock_result.structured_output = _RiskDecision(requires_approval=False, reason="safe")
+
+        event = MagicMock()
+        event.tool_use = {"name": "read", "input": {}}
+        event.agent.model = agent_model
+
+        with patch("strands.agent.Agent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.invoke_async = AsyncMock(return_value=mock_result)
+            mock_agent_cls.return_value = mock_agent
+
+            await classifier(event)
+
+        call_kwargs = mock_agent_cls.call_args[1]
+        assert call_kwargs["model"] is configured_model
+
+    @pytest.mark.asyncio
+    async def test_uses_custom_system_prompt(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from strands.vended_interventions.hitl.classifier import (
+            LLMClassifierConfig,
+            _RiskDecision,
+            create_llm_risk_classifier,
+        )
+
+        custom_prompt = "Only approve writes."
+        classifier = create_llm_risk_classifier(LLMClassifierConfig(system_prompt=custom_prompt))
+
+        mock_result = MagicMock()
+        mock_result.structured_output = _RiskDecision(requires_approval=False, reason="ok")
+
+        event = MagicMock()
+        event.tool_use = {"name": "read", "input": {}}
+        event.agent.model = MagicMock()
+
+        with patch("strands.agent.Agent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.invoke_async = AsyncMock(return_value=mock_result)
+            mock_agent_cls.return_value = mock_agent
+
+            await classifier(event)
+
+        call_kwargs = mock_agent_cls.call_args[1]
+        assert call_kwargs["system_prompt"] == custom_prompt

--- a/strands-py/tests/strands/vended_interventions/test_hitl.py
+++ b/strands-py/tests/strands/vended_interventions/test_hitl.py
@@ -832,7 +832,7 @@ class TestClassifierMode:
         mock_fn = MagicMock(return_value=ClassifierResult(requires_human_in_the_loop=False))
 
         with patch(
-            "strands.vended_interventions.hitl.hitl.create_llm_risk_classifier", return_value=mock_fn
+            "strands.vended_interventions.hitl.hitl._create_llm_risk_classifier", return_value=mock_fn
         ) as mock_create:
             config = LLMClassifierConfig(system_prompt="custom prompt")
             HumanInTheLoop(classifier=config)
@@ -967,7 +967,7 @@ class TestClassifierMode:
 
 
 class TestBuiltInClassifier:
-    """Tests for the actual create_llm_risk_classifier function body."""
+    """Tests for the _create_llm_risk_classifier function body."""
 
     @pytest.mark.asyncio
     async def test_creates_inner_agent_and_returns_decision(self):
@@ -975,11 +975,11 @@ class TestBuiltInClassifier:
 
         from strands.vended_interventions.hitl.classifier import (
             ClassifierResult,
+            _create_llm_risk_classifier,
             _RiskDecision,
-            create_llm_risk_classifier,
         )
 
-        classifier = create_llm_risk_classifier()
+        classifier = _create_llm_risk_classifier()
 
         mock_result = MagicMock()
         mock_result.structured_output = _RiskDecision(requires_approval=True, reason="destructive")
@@ -1005,9 +1005,9 @@ class TestBuiltInClassifier:
     async def test_raises_when_no_model_available(self):
         from unittest.mock import MagicMock
 
-        from strands.vended_interventions.hitl.classifier import create_llm_risk_classifier
+        from strands.vended_interventions.hitl.classifier import _create_llm_risk_classifier
 
-        classifier = create_llm_risk_classifier()
+        classifier = _create_llm_risk_classifier()
 
         event = MagicMock()
         event.tool_use = {"name": "tool", "input": {}}
@@ -1020,9 +1020,9 @@ class TestBuiltInClassifier:
     async def test_raises_when_structured_output_is_none(self):
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        from strands.vended_interventions.hitl.classifier import create_llm_risk_classifier
+        from strands.vended_interventions.hitl.classifier import _create_llm_risk_classifier
 
-        classifier = create_llm_risk_classifier()
+        classifier = _create_llm_risk_classifier()
 
         mock_result = MagicMock()
         mock_result.structured_output = None
@@ -1046,13 +1046,13 @@ class TestBuiltInClassifier:
 
         from strands.vended_interventions.hitl.classifier import (
             LLMClassifierConfig,
+            _create_llm_risk_classifier,
             _RiskDecision,
-            create_llm_risk_classifier,
         )
 
         configured_model = MagicMock(name="configured_model")
         agent_model = MagicMock(name="agent_model")
-        classifier = create_llm_risk_classifier(LLMClassifierConfig(model=configured_model))
+        classifier = _create_llm_risk_classifier(LLMClassifierConfig(model=configured_model))
 
         mock_result = MagicMock()
         mock_result.structured_output = _RiskDecision(requires_approval=False, reason="safe")
@@ -1077,12 +1077,12 @@ class TestBuiltInClassifier:
 
         from strands.vended_interventions.hitl.classifier import (
             LLMClassifierConfig,
+            _create_llm_risk_classifier,
             _RiskDecision,
-            create_llm_risk_classifier,
         )
 
         custom_prompt = "Only approve writes."
-        classifier = create_llm_risk_classifier(LLMClassifierConfig(system_prompt=custom_prompt))
+        classifier = _create_llm_risk_classifier(LLMClassifierConfig(system_prompt=custom_prompt))
 
         mock_result = MagicMock()
         mock_result.structured_output = _RiskDecision(requires_approval=False, reason="ok")


### PR DESCRIPTION
## Description

Adds a `classifier` option to `HumanInTheLoop` that uses an inner LLM agent to decide per-call whether a tool needs human approval. Supports three shapes: `True` (built-in defaults), `LLMClassifierConfig` (custom prompt/model), or a custom callable (sync or async).

### API

```python
from strands.vended_interventions.hitl import HumanInTheLoop, HumanInTheLoopClassifier, LLMClassifierConfig
```

#### New types

```python
@dataclass
class ClassifierResult:
    """Result from a classifier evaluation (not exported from barrel)."""
    requires_human_in_the_loop: bool
    reason: str | None = None

class LLMClassifierConfig:
    """Configuration for the built-in LLM classifier."""
    system_prompt: str | None = None  # Risk criteria prompt
    model: Model | None = None        # Defaults to the parent agent's model

class HumanInTheLoopClassifier(Protocol):
    """Custom classifier callable (sync or async)."""
    def __call__(self, event: BeforeToolCallEvent, **kwargs: Any) -> ClassifierResult | Awaitable[ClassifierResult]: ...
```

#### New option on `HumanInTheLoop`

```python
HumanInTheLoop(
    classifier=None,  # bool | LLMClassifierConfig | HumanInTheLoopClassifier
)
```

#### Precedence (first match wins)

1. Negated `!tool` → always requires approval
2. Trusted at runtime → runs freely
3. Wildcard `*` → runs freely
4. Explicitly in `allowed_tools` → runs freely
5. Classifier (if provided) → its decision
6. Default (no classifier) → requires approval

### Examples

```python
# Built-in LLM classifier with defaults
HumanInTheLoop(classifier=True)

# Built-in with custom prompt/model
HumanInTheLoop(classifier=LLMClassifierConfig(
    system_prompt="...",
    model=cheap_model,
))

# Custom sync classifier
from strands.vended_interventions.hitl.classifier import ClassifierResult

def my_classifier(event, **kwargs):
    return ClassifierResult(
        requires_human_in_the_loop=event.tool_use["name"].startswith("delete"),
        reason="destructive operation",
    )

HumanInTheLoop(classifier=my_classifier)

# Custom async classifier
async def my_async_classifier(event, **kwargs):
    result = await check_risk(event)
    return ClassifierResult(requires_human_in_the_loop=result.risky)

HumanInTheLoop(classifier=my_async_classifier)

# Composes with all existing features
HumanInTheLoop(
    allowed_tools=["read_file", "list_dir"],
    classifier=True,
    ask="stdio",
    enable_trust=True,
)
```

### Failure semantics

The classifier fails closed — if the classifier throws or returns a malformed result, the tool call requires approval (no reason exposed to the model).

### Module exports

```python
# strands-py/src/strands/vended_interventions/hitl/__init__.py
__all__ = ["HumanInTheLoop", "HumanInTheLoopClassifier", "LLMClassifierConfig"]
```

`ClassifierResult` is intentionally not exported from the barrel — it's available via direct import for custom classifier authors.

## Related Issues

N/A

## Type of Change

New feature

## Testing

- 46 tests pass (`hatch test -- tests/strands/vended_interventions/test_hitl.py`)
- Lint and format clean via `hatch fmt`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.