### PR TITLE
refactor(vended-tools): mark make_bash with typing_extensions.deprecated

### DIFF
--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -21,27 +21,40 @@ Example Usage:
 """
 
 import warnings
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import deprecated
 
 from .file_editor import file_editor, make_file_editor
 from .http_request import http_request, make_http_request
 from .shell import make_shell, shell
 from .sleep import make_sleep, sleep
 
-_DEPRECATED_NAMES = {"bash": "shell", "make_bash": "make_shell"}
+if TYPE_CHECKING:
+    from ..tools.decorator import DecoratedFunctionTool
+
+_RENAME_RATIONALE = (
+    "The tool routes commands through the sandbox, which runs sh or the remote login shell "
+    "rather than bash specifically."
+)
+
+
+@deprecated(f"make_bash is deprecated and will be removed in v2.0.0. Use make_shell instead. {_RENAME_RATIONALE}")
+def make_bash(**kwargs: Any) -> "DecoratedFunctionTool":
+    """Deprecated alias for :func:`make_shell`."""
+    return make_shell(**kwargs)
 
 
 def __getattr__(name: str) -> Any:
-    if name in _DEPRECATED_NAMES:
-        replacement = _DEPRECATED_NAMES[name]
+    # ``bash`` is a tool instance rather than a function, so it cannot carry the
+    # @deprecated decorator that ``make_bash`` uses; resolve it here instead.
+    if name == "bash":
         warnings.warn(
-            f"{name} is deprecated and will be removed in v2.0.0. Use {replacement} instead. "
-            "The tool routes commands through the sandbox, which runs sh or the remote login "
-            "shell rather than bash specifically.",
+            f"bash is deprecated and will be removed in v2.0.0. Use shell instead. {_RENAME_RATIONALE}",
             DeprecationWarning,
             stacklevel=2,
         )
-        return {"shell": shell, "make_shell": make_shell}[replacement]
+        return shell
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/strands-py/tests/strands/vended_tools/test_shell.py
+++ b/strands-py/tests/strands/vended_tools/test_shell.py
@@ -115,11 +115,25 @@ class TestDeprecatedBashAliases:
         with pytest.deprecated_call(match="bash is deprecated"):
             assert vended_tools.bash is shell
 
-    def test_make_bash_alias_warns_and_returns_make_shell(self):
+    def test_make_bash_alias_warns_and_builds_a_shell_tool(self):
         import strands.vended_tools as vended_tools
 
         with pytest.deprecated_call(match="make_bash is deprecated"):
-            assert vended_tools.make_bash is make_shell
+            tool = vended_tools.make_bash()
+        assert tool.tool_name == "shell"
+
+    def test_make_bash_alias_forwards_arguments(self):
+        import strands.vended_tools as vended_tools
+
+        with pytest.deprecated_call(match="make_bash is deprecated"):
+            tool = vended_tools.make_bash(name="sandbox_shell", description="custom desc")
+        assert tool.tool_name == "sandbox_shell"
+        assert tool.tool_spec["description"] == "custom desc"
+
+    def test_make_bash_is_marked_deprecated_for_static_analysis(self):
+        import strands.vended_tools as vended_tools
+
+        assert "make_shell" in vended_tools.make_bash.__deprecated__
 
     def test_unknown_attribute_still_raises(self):
         import strands.vended_tools as vended_tools


### PR DESCRIPTION
## Description

Follow-up to #3574, which renamed the sandbox-routed `bash` tool to `shell` and left `bash` / `make_bash` as deprecated aliases resolved through a module `__getattr__`.

This applies the deprecation pattern that [`team/FEATURE_LIFECYCLE.md`](https://github.com/strands-agents/harness-sdk/blob/main/team/FEATURE_LIFECYCLE.md?plain=1#L157) actually prescribes: `make_bash` now carries `@typing_extensions.deprecated`, so type checkers and IDEs flag callers at authoring time rather than only warning once at runtime.

`bash` keeps the `__getattr__` path — it is a tool *instance*, not a function, so no decorator can wrap it. The rationale string is shared between both so the two messages cannot drift.

Behavior is unchanged for callers: both names still emit a single `DeprecationWarning` and resolve to the `shell` equivalents, and `make_bash(**kwargs)` forwards through to `make_shell` (including `name` and `description`).

### Note on why the decorator is not sufficient on its own

Worth recording, since it affects how this pattern applies to tools generally: `@deprecated` raises a `DeprecationWarning`, which Python's default filter only surfaces when it originates in `__main__`. When an agent invokes a tool the call site is SDK internals, so the warning is suppressed and the user sees nothing.

That does not matter for `make_bash`, which users call directly from their own code — the decorator is exactly right here. But it does mean the decorator alone cannot carry a deprecation for a *tool* that only ever runs via the framework. In strands-agents/tools#550 that gap is covered with a `logger.warning` alongside the decorator.

## Related Issues

Follows #3574.

## Documentation PR

No docs change needed — the deprecated names and their timeline are unchanged from #3574, only the mechanism that reports them.

## Type of Change

Other (please describe): applies the prescribed deprecation mechanism to an existing alias; no behavior change

## Testing

- `hatch test` → **4721 passed**
- `ruff check` / `ruff format --check` clean; `mypy src/strands/vended_tools` clean (checked specifically, since `@deprecated` participates in typing)
- Added tests covering argument forwarding through the alias and the presence of the `__deprecated__` marker
- Manually verified both aliases warn once and return the canonical objects, and that `make_shell`'s keyword-only signature is still enforced through the wrapper

Replaced the previous `make_bash is make_shell` identity assertion, which no longer holds now that `make_bash` is a wrapper rather than a direct alias.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

On new warnings: this changes how an existing `DeprecationWarning` is raised; it does not add a new one.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.