### PR TITLE
fix(bedrock): name S3 locations as a cause of Converse validation errors

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -424,6 +424,11 @@ For a complete list of input types, please refer to the [API Reference](@api/pyt
 
 As an alternative to providing media content as bytes, Amazon Bedrock supports referencing documents, images, and videos stored in Amazon S3 directly. This is useful when working with large files or when your content is already stored in S3.
 
+:::caution[Amazon Nova Models Only]
+
+The Converse API accepts S3 location sources only for Amazon Nova models. Other model families, including the default Claude model, reject the request with a `ValidationException`. Pass the media as bytes for those models.
+:::
+
 :::note[IAM Permissions Required]
 
 To use S3 locations, the IAM role or user making the Bedrock API call must have `s3:GetObject` permission on the S3 bucket and objects being referenced.
@@ -436,7 +441,7 @@ To use S3 locations, the IAM role or user making the Bedrock API call must have 
 from strands import Agent
 from strands.models import BedrockModel
 
-agent = Agent(model=BedrockModel())
+agent = Agent(model=BedrockModel(model_id="us.amazon.nova-pro-v1:0"))
 
 response = agent(
     [

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -424,9 +424,9 @@ For a complete list of input types, please refer to the [API Reference](@api/pyt
 
 As an alternative to providing media content as bytes, Amazon Bedrock supports referencing documents, images, and videos stored in Amazon S3 directly. This is useful when working with large files or when your content is already stored in S3.
 
-:::caution[Amazon Nova Models Only]
+:::note[Amazon Nova Models Only]
 
-The Converse API accepts S3 location sources only for Amazon Nova models. Other model families, including the default Claude model, reject the request with a `ValidationException`. Pass the media as bytes for those models.
+The Converse API accepts S3 locations only for Amazon Nova models that support media, such as Nova Pro and Nova Lite. Other model families, including the default Claude Sonnet 4.6, reject the request with a `ValidationException`. Pass the media as bytes for those models, and check [supported models and model features](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html) for the current list.
 :::
 
 :::note[IAM Permissions Required]

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -202,7 +202,9 @@ async function multimodalSupport() {
 // S3 location support for multimodal content
 async function s3LocationSupport() {
   // --8<-- [start:s3_location]
-  const agent = new Agent({ model: new BedrockModel() })
+  const agent = new Agent({
+    model: new BedrockModel({ modelId: 'us.amazon.nova-pro-v1:0' }),
+  })
 
   const response = await agent.invoke([
     new DocumentBlock({

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -76,6 +76,34 @@ def _suppress_task_exception(task: "asyncio.Task[None]") -> None:
         task.exception()
 
 
+def _has_s3_location_source(messages: Messages) -> bool:
+    """Check whether any message sources media from an S3 location.
+
+    The Converse API accepts an ``s3Location`` media source only for some model families, and the
+    validation error it returns otherwise does not always name S3 as the cause.
+
+    Args:
+        messages: Messages sent to Bedrock.
+
+    Returns:
+        True if any content block, including one nested in a tool result, sources media from an S3
+        location.
+    """
+    for message in messages:
+        for content_block in message.get("content") or []:
+            blocks: list[Any] = [content_block]
+            if "toolResult" in content_block:
+                blocks.extend(content_block["toolResult"].get("content") or [])
+
+            for block in blocks:
+                for media_type in ("document", "image", "video"):
+                    location = block.get(media_type, {}).get("source", {}).get("location") or {}
+                    if location.get("type") == "s3":
+                        return True
+
+    return False
+
+
 T = TypeVar("T", bound=BaseModel)
 
 DEFAULT_READ_TIMEOUT = 120
@@ -1088,6 +1116,18 @@ class BedrockModel(Model):
                     e,
                     "└ For more information see "
                     "https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#on-demand-throughput-isnt-supported",
+                )
+
+            if e.response["Error"]["Code"] == "ValidationException" and _has_s3_location_source(messages):
+                add_exception_note(
+                    e,
+                    "└ This request sources media from an S3 location, which the Converse API accepts only for "
+                    "Amazon Nova models. If that is the cause, pass the media as bytes or use a Nova model.",
+                )
+                add_exception_note(
+                    e,
+                    "└ For more information see "
+                    "https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#s3-location-support",
                 )
 
             raise e

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -1124,7 +1124,7 @@ class BedrockModel(Model):
                     "https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#on-demand-throughput-isnt-supported",
                 )
 
-            # Nova models accept S3 locations, so an S3 source is not the cause of their errors.
+            # S3 locations are only rejected outside the Nova family, so the note cannot apply here.
             model_id = self.config.get("model_id") or ""
             if (
                 e.response["Error"]["Code"] == "ValidationException"

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -82,6 +82,9 @@ def _has_s3_location_source(messages: Messages) -> bool:
     The Converse API accepts an ``s3Location`` media source only for some model families, and the
     validation error it returns otherwise does not always name S3 as the cause.
 
+    This runs while handling a Bedrock error, so it tolerates malformed content rather than raising
+    and masking the error it is describing.
+
     Args:
         messages: Messages sent to Bedrock.
 
@@ -92,13 +95,16 @@ def _has_s3_location_source(messages: Messages) -> bool:
     for message in messages:
         for content_block in message.get("content") or []:
             blocks: list[Any] = [content_block]
-            if "toolResult" in content_block:
-                blocks.extend(content_block["toolResult"].get("content") or [])
+            tool_result = content_block.get("toolResult") if isinstance(content_block, dict) else None
+            if isinstance(tool_result, dict):
+                blocks.extend(tool_result.get("content") or [])
 
             for block in blocks:
                 for media_type in ("document", "image", "video"):
-                    location = block.get(media_type, {}).get("source", {}).get("location") or {}
-                    if location.get("type") == "s3":
+                    media = block.get(media_type) if isinstance(block, dict) else None
+                    source = media.get("source") if isinstance(media, dict) else None
+                    location = source.get("location") if isinstance(source, dict) else None
+                    if isinstance(location, dict) and location.get("type") == "s3":
                         return True
 
     return False
@@ -1118,7 +1124,13 @@ class BedrockModel(Model):
                     "https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#on-demand-throughput-isnt-supported",
                 )
 
-            if e.response["Error"]["Code"] == "ValidationException" and _has_s3_location_source(messages):
+            # Nova models accept S3 locations, so an S3 source is not the cause of their errors.
+            model_id = self.config.get("model_id") or ""
+            if (
+                e.response["Error"]["Code"] == "ValidationException"
+                and "amazon.nova" not in model_id.lower()
+                and _has_s3_location_source(messages)
+            ):
                 add_exception_note(
                     e,
                     "└ This request sources media from an S3 location, which the Converse API accepts only for "

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -22,6 +22,7 @@ from strands.models.bedrock import (
     DEFAULT_BEDROCK_REGION,
     DEFAULT_READ_TIMEOUT,
     _clear_skip_count_tokens_cache,
+    _has_s3_location_source,
 )
 from strands.types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from strands.types.tools import ToolSpec
@@ -1890,11 +1891,17 @@ async def test_add_note_on_validation_exception_s3_location(content, bedrock_cli
             id="non_s3_location",
         ),
         pytest.param([], id="empty_content"),
+        pytest.param([{"document": "report.pdf"}], id="malformed_document"),
+        pytest.param([{"text": "test", "toolResult": "malformed"}], id="malformed_tool_result"),
     ],
 )
 @pytest.mark.asyncio
 async def test_add_note_on_validation_exception_without_s3_location(content, bedrock_client, model, alist):
-    """A ValidationException unrelated to S3 is not annotated with the S3 note."""
+    """A ValidationException unrelated to S3 is not annotated with the S3 note.
+
+    Malformed content is included because the S3 check runs while handling a Bedrock error: raising
+    there would replace the error it is describing.
+    """
     error_response = {
         "Error": {
             "Code": "ValidationException",
@@ -1908,6 +1915,86 @@ async def test_add_note_on_validation_exception_without_s3_location(content, bed
         await alist(model.stream([{"role": "user", "content": content}]))
 
     assert err.value.__notes__ == ["└ Bedrock region: us-west-2", "└ Model id: m1"]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="This test requires Python 3.11 or higher (need add_note)")
+@pytest.mark.asyncio
+async def test_add_note_on_validation_exception_s3_location_skipped_for_nova(bedrock_client, alist):
+    """Amazon Nova models accept S3 locations, so their errors are not annotated with the S3 note."""
+    nova_model = BedrockModel(model_id="us.amazon.nova-pro-v1:0")
+    error_response = {
+        "Error": {
+            "Code": "ValidationException",
+            "Message": "An error occurred (ValidationException) when calling the ConverseStream operation: "
+            "Provided S3Location not found",
+        }
+    }
+    bedrock_client.converse_stream.side_effect = ClientError(error_response, "ConverseStream")
+    messages = [
+        {
+            "role": "user",
+            "content": [{"document": {"name": "report.pdf", "format": "pdf", "source": {"location": S3_LOCATION}}}],
+        }
+    ]
+
+    with pytest.raises(ClientError) as err:
+        await alist(nova_model.stream(messages))
+
+    assert err.value.__notes__ == ["└ Bedrock region: us-west-2", "└ Model id: us.amazon.nova-pro-v1:0"]
+
+
+@pytest.mark.parametrize(
+    ("messages", "exp_has_s3_location"),
+    [
+        pytest.param([{"role": "user", "content": [{"image": {"source": {"location": S3_LOCATION}}}]}], True, id="s3"),
+        pytest.param(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "toolResult": {
+                                "toolUseId": "t1",
+                                "content": [{"video": {"source": {"location": S3_LOCATION}}}],
+                            }
+                        }
+                    ],
+                }
+            ],
+            True,
+            id="s3_in_tool_result",
+        ),
+        pytest.param(
+            [{"role": "user", "content": [{"video": {"source": {"location": {"type": "other"}}}}]}],
+            False,
+            id="other_location",
+        ),
+        pytest.param([{"role": "user", "content": [{"document": {"source": {"bytes": b"pdf"}}}]}], False, id="bytes"),
+        pytest.param([{"role": "user", "content": [{"document": {"source": None}}]}], False, id="source_none"),
+        pytest.param([{"role": "user", "content": [{"document": {"source": "s3://b/k"}}]}], False, id="source_str"),
+        pytest.param(
+            [{"role": "user", "content": [{"document": {"source": {"location": "s3"}}}]}], False, id="location_str"
+        ),
+        pytest.param([{"role": "user", "content": [{"document": "r.pdf"}]}], False, id="media_str"),
+        pytest.param([{"role": "user", "content": ["malformed"]}], False, id="block_str"),
+        pytest.param([{"role": "user", "content": [{"toolResult": "malformed"}]}], False, id="tool_result_str"),
+        pytest.param(
+            [{"role": "user", "content": [{"toolResult": {"toolUseId": "t1", "content": None}}]}],
+            False,
+            id="tool_result_content_none",
+        ),
+        pytest.param(
+            [{"role": "user", "content": [{"toolResult": {"toolUseId": "t1", "content": ["malformed"]}}]}],
+            False,
+            id="tool_result_content_str",
+        ),
+        pytest.param([{"role": "user", "content": None}], False, id="content_none"),
+        pytest.param([], False, id="no_messages"),
+    ],
+)
+def test_has_s3_location_source(messages, exp_has_s3_location):
+    """Malformed content yields False rather than raising, since this runs while handling an error."""
+    assert _has_s3_location_source(messages) is exp_has_s3_location
 
 
 def test_format_request_sends_s3_location_for_any_model(model):

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -1816,6 +1816,120 @@ async def test_add_note_on_validation_exception_throughput(bedrock_client, model
     ]
 
 
+S3_LOCATION = {"type": "s3", "uri": "s3://my-bucket/report.pdf"}
+S3_LOCATION_NOTE = (
+    "└ This request sources media from an S3 location, which the Converse API accepts only for "
+    "Amazon Nova models. If that is the cause, pass the media as bytes or use a Nova model."
+)
+S3_LOCATION_LINK = (
+    "└ For more information see "
+    "https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#s3-location-support"
+)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="This test requires Python 3.11 or higher (need add_note)")
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(
+            [{"document": {"name": "report.pdf", "format": "pdf", "source": {"location": S3_LOCATION}}}],
+            id="document",
+        ),
+        pytest.param([{"image": {"format": "png", "source": {"location": S3_LOCATION}}}], id="image"),
+        pytest.param([{"video": {"format": "mp4", "source": {"location": S3_LOCATION}}}], id="video"),
+        pytest.param(
+            [
+                {
+                    "toolResult": {
+                        "toolUseId": "t1",
+                        "content": [
+                            {"document": {"name": "r.pdf", "format": "pdf", "source": {"location": S3_LOCATION}}}
+                        ],
+                    }
+                }
+            ],
+            id="tool_result",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_add_note_on_validation_exception_s3_location(content, bedrock_client, model, alist):
+    """A ValidationException on a request sourcing media from S3 names S3 as a possible cause.
+
+    Guards against the opaque `source.type: Field required` error models outside the Amazon Nova
+    family return for an s3Location media source (#1744).
+    """
+    error_response = {
+        "Error": {
+            "Code": "ValidationException",
+            "Message": "An error occurred (ValidationException) when calling the ConverseStream operation: "
+            "The model returned the following errors: messages.0.content.0.document.source.type: Field required",
+        }
+    }
+    bedrock_client.converse_stream.side_effect = ClientError(error_response, "ConverseStream")
+
+    with pytest.raises(ClientError) as err:
+        await alist(model.stream([{"role": "user", "content": content}]))
+
+    assert err.value.__notes__ == [
+        "└ Bedrock region: us-west-2",
+        "└ Model id: m1",
+        S3_LOCATION_NOTE,
+        S3_LOCATION_LINK,
+    ]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="This test requires Python 3.11 or higher (need add_note)")
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param([{"text": "test"}], id="text"),
+        pytest.param([{"document": {"name": "r.pdf", "format": "pdf", "source": {"bytes": b"pdf"}}}], id="bytes"),
+        pytest.param(
+            [{"document": {"name": "r.pdf", "format": "pdf", "source": {"location": {"type": "other"}}}}],
+            id="non_s3_location",
+        ),
+        pytest.param([], id="empty_content"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_add_note_on_validation_exception_without_s3_location(content, bedrock_client, model, alist):
+    """A ValidationException unrelated to S3 is not annotated with the S3 note."""
+    error_response = {
+        "Error": {
+            "Code": "ValidationException",
+            "Message": "An error occurred (ValidationException) when calling the ConverseStream operation: "
+            "The model returned the following errors: malformed input",
+        }
+    }
+    bedrock_client.converse_stream.side_effect = ClientError(error_response, "ConverseStream")
+
+    with pytest.raises(ClientError) as err:
+        await alist(model.stream([{"role": "user", "content": content}]))
+
+    assert err.value.__notes__ == ["└ Bedrock region: us-west-2", "└ Model id: m1"]
+
+
+def test_format_request_sends_s3_location_for_any_model(model):
+    """S3 locations are sent to Bedrock regardless of model id, letting the service decide.
+
+    Guards against gating on the model id: an inference profile or provisioned throughput ARN does
+    not name its model family, so the SDK cannot classify it without dropping content that works
+    today (#1744).
+    """
+    messages = [
+        {
+            "role": "user",
+            "content": [{"document": {"name": "report.pdf", "format": "pdf", "source": {"location": S3_LOCATION}}}],
+        }
+    ]
+
+    tru_source = model.format_request(messages)["messages"][0]["content"][0]["document"]["source"]
+    exp_source = {"s3Location": {"uri": "s3://my-bucket/report.pdf"}}
+
+    assert tru_source == exp_source
+
+
 @pytest.mark.parametrize(
     "overflow_message",
     [


### PR DESCRIPTION
## Description

Bedrock's Converse API accepts an `s3Location` media source only for Amazon Nova models. When any other family gets one the request fails, and the error rarely names S3 as the cause — Claude reports `messages.0.content.0.document.source.type: Field required`, which reads like a malformed content block. Since the SDK defaults to Claude, the documented S3-location example fails this way, and the reporter of #1744 had to get an AWS SA involved to find out why.

The request now carries a note explaining the likely cause:

```
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the
ConverseStream operation: messages.0.content.0.document.source.type: Field required
└ Bedrock region: us-west-2
└ Model id: global.anthropic.claude-sonnet-4-6
└ This request sources media from an S3 location, which the Converse API accepts only for
  Amazon Nova models. If that is the cause, pass the media as bytes or use a Nova model.
└ For more information see https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/#s3-location-support
```

This reuses the `add_exception_note` pattern already used in the same handler for invalid model identifiers and on-demand throughput, and is skipped for Nova models, whose errors can never have an S3 source as the cause.

**What is deliberately *not* done: gating the request on the model id.** Bedrock owns this capability matrix and changes it without an SDK release, and an inference-profile or provisioned-throughput ARN does not name its model family — so classifying the model in the SDK would silently drop media that works today for those users. Nothing about the outgoing request changes; only the error gets more informative. `#2076` took the other route (drop the content block for non-Nova model ids), which turned the documented example into a silent success answering about a document the model never received, so this supersedes it.

The docs half of #1744's ask is included: the S3 Location section now states the Nova-only constraint and both examples pin a Nova model instead of the default Claude, which could never have worked.

## Related Issues

Fixes #1744. Supersedes #2076 — the root-cause diagnosis there is `Zelys-DFKH`'s; only the mechanism differs.

## Documentation PR

Included here under `site/`.

## Type of Change

Bug fix

## Testing

- [ ] I ran `hatch run prepare`

`hatch` isn't available in my environment, so I ran the underlying checks directly from `strands-py/`:

| Check | Result |
|---|---|
| `python -m pytest tests/strands/models/test_bedrock.py -q` | 204 passed |
| `python -m pytest tests/strands/{models,event_loop,types,agent}` | 1307 passed (excluding modules whose optional deps are absent here — the same 11 collection errors occur on unmodified `main`) |
| `python -m ruff check` / `ruff format --check` (both changed files) | clean |
| `python -m mypy src/strands/models/bedrock.py` | clean |
| `prettier --check` on the changed docs snippet | clean at the `printWidth: 90` override |

Exercised beyond the gates: mocked the real Claude/Llama/Mistral/Cohere/Qwen rejection strings and confirmed the note appears via `Agent.__call__`, `structured_output`, and `streaming=False`; confirmed it does *not* appear for `AccessDeniedException`, for non-S3 location types, or for Nova models; confirmed `ModelThrottledException` and `ContextWindowOverflowException` still short-circuit ahead of it; and confirmed the Python 3.10 `add_exception_note` fallback renders the notes in the message.

<details>
<summary>Review loop (2 rounds of independent fresh-context review)</summary>

Round 1 (correctness + adversarial + docs-accuracy) found and I fixed:

1. **Blocker** — the detection helper raised `AttributeError` on a non-dict `document`/`toolResult` value that `format_request` tolerates and sends. Because it runs *inside* `except ClientError`, that replaced Bedrock's real error and changed the exception type, so `except ClientError` in caller code stopped catching. Reachable from a tool returning a malformed content block. Fixed with `isinstance` guards at each level, plus 14 direct helper test cases as the regression guard.
2. The note fired for Nova models on unrelated validation errors, telling a Nova user to "use a Nova model". Now skipped when the model id names Nova.
3. Docs: `:::caution` → `:::note` per the site's own severity rubric, and the claim narrowed — Nova Micro accepts no media at all, so "only Amazon Nova models" over-promised.

Round 2 (fresh reviewer, verified the fixes cold, mutation-tested each one and fuzzed ~25 malformed message shapes): APPROVE, no must-fix findings. Its one open flag was that the AWS supported-models URL redirects; it returns 200 for me and is already linked twice elsewhere in this repo, including line 375 of this same page, so I kept it.

</details>

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

Opened by `strandly-the-agent` at `notowen333`'s request on #2076. I'm an AI agent — this is solid work for a human to approve, not a merge recommendation. Two judgment calls are worth a maintainer's eye: choosing to annotate the error rather than gate the request (see above), and that this leaves the unsupported-media request going to Bedrock rather than failing fast locally, which is the one thing a model-id gate would have bought.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.