### PR TITLE
fix: preserve interrupt state across cancelled resumes and middleware re-reads

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it, vi } from 'vitest'
 import { Agent } from '../agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
-import { ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
-import { AfterToolCallEvent, BeforeToolCallEvent, BeforeToolsEvent, InterruptEvent } from '../../hooks/events.js'
+import { TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
+import {
+  AfterToolCallEvent,
+  BeforeToolCallEvent,
+  BeforeToolsEvent,
+  InterruptEvent,
+  MessageAddedEvent,
+} from '../../hooks/events.js'
 import { FunctionTool } from '../../tools/function-tool.js'
 import { InterruptResponseContent } from '../../types/interrupt.js'
 import type { InterruptState, PendingToolExecution } from '../../interrupt.js'
@@ -1072,6 +1078,99 @@ describe('Agent interrupt system', () => {
 
       expect(events).toHaveLength(1)
       expect(events[0]!.interrupt).toMatchObject({ name: 'approve', source: 'tool' })
+    })
+  })
+
+  describe('cancel during approved tool execution', () => {
+    it('runs an approved tool only once when the resume is cancelled while the tool is in flight', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'sendEmail', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+        .addTurn({ type: 'textBlock', text: 'Nothing else happened' })
+
+      let raised = false
+      const sideEffects: string[] = []
+      let releaseTool!: () => void
+      const toolReleased = new Promise<void>((resolve) => (releaseTool = resolve))
+      let toolStarted!: () => void
+      const toolInFlight = new Promise<void>((resolve) => (toolStarted = resolve))
+
+      const tool = createMockTool('sendEmail', (context) => {
+        if (!raised) {
+          raised = true
+          context.interrupt({ name: 'confirm', reason: 'Send the email?' })
+        }
+        // eslint-disable-next-line require-yield
+        return (async function* () {
+          sideEffects.push('email sent')
+          toolStarted()
+          await toolReleased
+          return new ToolResultBlock({
+            toolUseId: context.toolUse.toolUseId,
+            status: 'success',
+            content: [new TextBlock('sent')],
+          })
+        })()
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+      const interruptResult = await agent.invoke('Send the email')
+      const interruptId = interruptResult.interrupts![0]!.id
+
+      // Human approves, then presses "stop" while the tool is still running.
+      const inflight = agent.invoke([new InterruptResponseContent({ interruptId, response: 'yes' })])
+      await toolInFlight
+      agent.cancel()
+      releaseTool()
+      expect((await inflight).stopReason).toBe('cancelled')
+
+      // The tool ran and its result is in history, so nothing is left to resume.
+      expect(getPendingToolExecution(agent)).toBeUndefined()
+
+      const toolUseIds = agent.messages.flatMap((m) =>
+        m.content.filter((b): b is ToolUseBlock => b.type === 'toolUseBlock').map((b) => b.toolUseId)
+      )
+      expect(toolUseIds).toEqual(['tool-1'])
+
+      // A fresh prompt is accepted (the agent is not wedged as interrupted).
+      await agent.invoke('what happened?')
+      expect(sideEffects).toEqual(['email sent'])
+    })
+  })
+
+  describe('stream break at InterruptEvent', () => {
+    it('does not replay a stored tool cycle when the stream is broken at InterruptEvent', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'deleteFiles', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+        .addTurn({ type: 'textBlock', text: 'Second' })
+
+      let raised = false
+      let toolRuns = 0
+      const tool = createMockTool('deleteFiles', (context) => {
+        if (!raised) {
+          raised = true
+          context.interrupt({ name: 'confirm', reason: 'Delete?' })
+        }
+        toolRuns += 1
+        return 'deleted'
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      // HITL streaming consumer: stop consuming once the interrupt surfaces.
+      for await (const event of agent.stream('Delete old files')) {
+        if (event instanceof InterruptEvent) break
+      }
+
+      // Kill switch to prevent infinite replay if the bug regresses.
+      agent.addHook(MessageAddedEvent, () => {
+        if (agent.messages.length > 30) agent.cancel()
+      })
+
+      const result = await agent.invoke('anything new')
+      expect(toolRuns).toBe(1)
+      expect(result.stopReason).toBe('endTurn')
     })
   })
 })

--- a/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
@@ -636,6 +636,52 @@ describe('Agent interrupt system', () => {
       expect(result2).toMatchObject({ stopReason: 'interrupt' })
       expect(interruptCount).toBe(3)
     })
+
+    it('preserves the pending tool interrupt when a resume is cancelled before the tool runs', async () => {
+      // A tool interrupt stores pending execution and stays activated. If the resume is
+      // cancelled before the tool executes, that pending interrupt must survive so a later
+      // resume can still run the tool — the cancelled pass must not wipe the interrupt state.
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'confirmTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('confirmTool', (context) => {
+        if (!toolExecuted) {
+          // First execution attempt raises the interrupt; later attempts run for real.
+          context.interrupt({ name: 'confirm', reason: 'Approve?' })
+        }
+        toolExecuted = true
+        return 'executed'
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const interruptResult = await agent.invoke('Go')
+      expect(interruptResult.stopReason).toBe('interrupt')
+      expect(getPendingToolExecution(agent)).toBeDefined()
+
+      // Resume, but cancel before the tool runs (a BeforeToolsEvent hook cancels this pass).
+      const cancelHook = agent.addHook(BeforeToolsEvent, () => {
+        agent.cancel()
+      })
+      const cancelledResult = await agent.invoke([
+        new InterruptResponseContent({ interruptId: interruptResult.interrupts![0]!.id, response: 'yes' }),
+      ])
+      expect(cancelledResult.stopReason).toBe('cancelled')
+      expect(toolExecuted).toBe(false)
+
+      // The pending tool interrupt survives the cancelled pass and is still resumable.
+      expect(getPendingToolExecution(agent)).toBeDefined()
+
+      // A subsequent resume (without the cancel hook) runs the tool to completion.
+      cancelHook()
+      const finalResult = await agent.invoke([
+        new InterruptResponseContent({ interruptId: interruptResult.interrupts![0]!.id, response: 'yes' }),
+      ])
+      expect(finalResult.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
+    })
   })
 
   describe('event contract during interrupt', () => {

--- a/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
@@ -638,9 +638,6 @@ describe('Agent interrupt system', () => {
     })
 
     it('preserves the pending tool interrupt when a resume is cancelled before the tool runs', async () => {
-      // A tool interrupt stores pending execution and stays activated. If the resume is
-      // cancelled before the tool executes, that pending interrupt must survive so a later
-      // resume can still run the tool — the cancelled pass must not wipe the interrupt state.
       const model = new MockMessageModel()
         .addTurn({ type: 'toolUseBlock', name: 'confirmTool', toolUseId: 'tool-1', input: {} })
         .addTurn({ type: 'textBlock', text: 'Done' })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1168,11 +1168,15 @@ export class Agent implements LocalAgent, InvokableAgent {
     options: InvokeOptions,
     invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
+    // Snapshot interrupts before the pass: a tool cycle within this pass can call the event
+    // loop's deactivate() and clear the live map, but a gate that re-reads its approval after
+    // next() must still see the resumed response.
+    const interruptsSnapshot = { ...this._interruptState.interrupts }
     const context: AgentStreamContext = {
       agent: this,
       args,
       ...(options !== undefined && { options }),
-      interrupt: createMiddlewareInterrupt(this._interruptState, 'middleware:agentStream'),
+      interrupt: createMiddlewareInterrupt(this._interruptState, 'middleware:agentStream', interruptsSnapshot),
     }
 
     // async function* doesn't bind lexical `this`; capture for the terminal callback.
@@ -1187,6 +1191,18 @@ export class Agent implements LocalAgent, InvokableAgent {
           return { result }
         }
       )
+      // A resumed AgentStreamStage interrupt that completes without a tool cycle never reaches
+      // the tool loop's deactivate(), so clear the interrupt state here. Guard on the absence of
+      // a pending tool execution so this only clears agent-stream interrupts and never wipes a
+      // pending tool interrupt — some non-interrupt endings (e.g. a cancelled resume) keep the
+      // tool interrupt activated on purpose.
+      if (
+        this._interruptState.activated &&
+        result.stopReason !== 'interrupt' &&
+        !this._interruptState.pendingToolExecution
+      ) {
+        this._interruptState.deactivate()
+      }
       return result
     } catch (error) {
       if (error instanceof InterruptError) {
@@ -1497,10 +1513,12 @@ export class Agent implements LocalAgent, InvokableAgent {
           let completedToolResults: Map<string, ToolResultBlock> | undefined
 
           if (pendingExecution) {
-            // Resume from stored state - skip model call
+            // Resume from stored state - skip model call. The pending marker is NOT cleared
+            // here: if this resumed pass is cancelled before the tool runs, the marker must
+            // survive so a later resume can still execute the tool. It is cleared by the
+            // deactivate() below once the tools actually execute.
             assistantMessage = pendingExecution.assistantMessage
             completedToolResults = pendingExecution.completedToolResults
-            this._interruptState.clearPendingToolExecution()
           } else {
             const modelResult = yield* this._invokeModel(invocationState, structuredOutputChoice)
 
@@ -1618,9 +1636,10 @@ export class Agent implements LocalAgent, InvokableAgent {
           yield this._appendMessage(assistantMessage, invocationState)
           yield this._appendMessage(toolResultMessage, invocationState)
 
-          // Deactivate interrupt state after successful tool execution so the next
-          // cycle starts with a clean slate (new interrupts can be raised again).
-          if (this._interruptState.activated) {
+          // Deactivate interrupt state after tools actually execute so the next cycle starts
+          // clean. Skip when cancelled: the tools were cancel-skipped (not run), so a pending
+          // tool interrupt must survive for a later resume rather than being wiped here.
+          if (this._interruptState.activated && !this.isCancelled) {
             this._interruptState.deactivate()
           }
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -388,7 +388,7 @@ const DEFAULT_AGENT_NAME = 'Strands Agent'
 const DEFAULT_AGENT_ID = 'agent'
 
 /** Result returned by tool-execution generators, threading the AfterToolsEvent back to the main loop. */
-type ToolsExecutionResult = { message: Message; afterToolsEvent: AfterToolsEvent }
+type ToolsExecutionResult = { message: Message; afterToolsEvent: AfterToolsEvent; toolsSkipped: boolean }
 
 /**
  * Orchestrates the interaction between a model, a set of tools, and MCP clients.
@@ -1617,6 +1617,14 @@ export class Agent implements LocalAgent, InvokableAgent {
           }
           const toolResultMessage = toolsResult.message
 
+          // Tools were skipped (not executed) — preserve pending state so the next resume
+          // can run them.
+          if (this.isCancelled && toolsResult.toolsSkipped && this._interruptState.pendingToolExecution) {
+            this._meter.endCycle(cycleStartTime)
+            this._tracer.endAgentLoopSpan(cycleSpan)
+            continue
+          }
+
           /**
            * Deferred append: both messages are added AFTER tool execution completes.
            * This keeps agent.messages in a valid, reinvokable state at all times.
@@ -1626,10 +1634,9 @@ export class Agent implements LocalAgent, InvokableAgent {
           yield this._appendMessage(assistantMessage, invocationState)
           yield this._appendMessage(toolResultMessage, invocationState)
 
-          // Deactivate interrupt state after tools actually execute so the next cycle starts
-          // clean. Skip when cancelled: the tools were cancel-skipped (not run), so a pending
-          // tool interrupt must survive for a later resume rather than being wiped here.
-          if (this._interruptState.activated && !this.isCancelled) {
+          // Deactivate interrupt state after successful tool execution so the next
+          // cycle starts with a clean slate (new interrupts can be raised again).
+          if (this._interruptState.activated) {
             this._interruptState.deactivate()
           }
 
@@ -2220,6 +2227,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     const toolResultBlocks: ToolResultBlock[] = []
     let toolResultMessage: Message
     let afterToolsEvent: AfterToolsEvent
+    let toolsSkipped = false
 
     try {
       if (toolUseBlocks.length === 0) {
@@ -2236,6 +2244,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           : undefined
 
       if (cancelMessage) {
+        toolsSkipped = true
         toolResultBlocks.push(...this._cancelAllAsResults(toolUseBlocks, cancelMessage))
         for (const result of toolResultBlocks) {
           yield new ToolResultEvent({ agent: this, result, invocationState })
@@ -2263,7 +2272,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       yield afterToolsEvent
     }
 
-    return { message: toolResultMessage, afterToolsEvent }
+    return { message: toolResultMessage, afterToolsEvent, toolsSkipped }
   }
 
   /**

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1634,6 +1634,9 @@ export class Agent implements LocalAgent, InvokableAgent {
           yield this._appendMessage(assistantMessage, invocationState)
           yield this._appendMessage(toolResultMessage, invocationState)
 
+          // Both messages are in history, so any stored pending execution is now stale.
+          this._interruptState.clearPendingToolExecution()
+
           // Deactivate interrupt state after successful tool execution so the next
           // cycle starts with a clean slate (new interrupts can be raised again).
           if (this._interruptState.activated) {

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1168,9 +1168,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     options: InvokeOptions,
     invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
-    // Snapshot interrupts before the pass: a tool cycle within this pass can call the event
-    // loop's deactivate() and clear the live map, but a gate that re-reads its approval after
-    // next() must still see the resumed response.
+    // Snapshot so a gate that re-reads its response after next() still resolves even if a tool cycle called deactivate().
     const interruptsSnapshot = { ...this._interruptState.interrupts }
     const context: AgentStreamContext = {
       agent: this,
@@ -1191,11 +1189,6 @@ export class Agent implements LocalAgent, InvokableAgent {
           return { result }
         }
       )
-      // A resumed AgentStreamStage interrupt that completes without a tool cycle never reaches
-      // the tool loop's deactivate(), so clear the interrupt state here. Guard on the absence of
-      // a pending tool execution so this only clears agent-stream interrupts and never wipes a
-      // pending tool interrupt — some non-interrupt endings (e.g. a cancelled resume) keep the
-      // tool interrupt activated on purpose.
       if (
         this._interruptState.activated &&
         result.stopReason !== 'interrupt' &&
@@ -1513,10 +1506,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           let completedToolResults: Map<string, ToolResultBlock> | undefined
 
           if (pendingExecution) {
-            // Resume from stored state - skip model call. The pending marker is NOT cleared
-            // here: if this resumed pass is cancelled before the tool runs, the marker must
-            // survive so a later resume can still execute the tool. It is cleared by the
-            // deactivate() below once the tools actually execute.
+            // Resume from stored state - skip model call.
             assistantMessage = pendingExecution.assistantMessage
             completedToolResults = pendingExecution.completedToolResults
           } else {

--- a/strands-ts/src/middleware/README.md
+++ b/strands-ts/src/middleware/README.md
@@ -265,3 +265,6 @@ Each requirement below is verified by tests and should hold across language impl
 - Interrupt ID uses the `agentStream` namespace
 - The interrupt source is `'middleware'`
 - InterruptEvent is yielded on the stream
+- After resuming to a non-tool completion, the interrupt state is cleared so the next fresh invocation is accepted
+- Resuming does not clobber a pending tool interrupt: if a tool interrupt is outstanding and its resume is cancelled before the tool runs, that interrupt survives and stays resumable
+- The stop reports every still-unanswered interrupt, not only the one just raised (so a partially-answered set is fully visible to the caller)

--- a/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
+++ b/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
@@ -312,10 +312,6 @@ describe('Middleware interrupts', () => {
     })
 
     it('re-reads the resumed response after next() even when a tool ran in the pass', async () => {
-      // The gate resolves its interrupt before next() and re-reads it after next() drains. The
-      // inner pass runs a tool whose successful cycle deactivates interrupt state. The re-read
-      // must still return the resumed response (from a snapshot taken before the pass) rather
-      // than re-raising — otherwise the resume never converges (livelock).
       const model = new MockMessageModel()
         .addTurn({ type: 'toolUseBlock', name: 'calc', toolUseId: 'tool-1', input: {} })
         .addTurn({ type: 'textBlock', text: 'done' })

--- a/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
+++ b/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
@@ -280,6 +280,74 @@ describe('Middleware interrupts', () => {
       expect(finalResult.stopReason).toBe('endTurn')
     })
 
+    it('clears interrupt state after resuming to a non-tool completion so the agent is reusable', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'textBlock', text: 'Resumed' })
+        .addTurn({ type: 'textBlock', text: 'Fresh' })
+
+      let interrupted = false
+      const agent = new Agent({ model, printer: false })
+      agent.addMiddleware(AgentStreamStage, async function* (context, next) {
+        if (!interrupted) {
+          interrupted = true
+          context.interrupt({ name: 'gate' })
+        }
+        return yield* next(context)
+      })
+
+      const { result: interruptResult } = await collectGenerator(agent.stream('Test'))
+      expect(interruptResult.stopReason).toBe('interrupt')
+
+      // Resume to a plain end-of-turn (no tool cycle to clear interrupt state).
+      const { result: resumedResult } = await collectGenerator(
+        agent.stream([
+          new InterruptResponseContent({ interruptId: interruptResult.interrupts![0]!.id, response: 'go' }),
+        ])
+      )
+      expect(resumedResult.stopReason).toBe('endTurn')
+
+      // A subsequent fresh invocation must not be rejected as "still interrupted".
+      const freshResult = await agent.invoke('Fresh call')
+      expect(freshResult.stopReason).toBe('endTurn')
+    })
+
+    it('re-reads the resumed response after next() even when a tool ran in the pass', async () => {
+      // The gate resolves its interrupt before next() and re-reads it after next() drains. The
+      // inner pass runs a tool whose successful cycle deactivates interrupt state. The re-read
+      // must still return the resumed response (from a snapshot taken before the pass) rather
+      // than re-raising — otherwise the resume never converges (livelock).
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'calc', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'done' })
+      const tool = createMockTool('calc', () => 'ok')
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const reads: Array<[string, unknown]> = []
+      agent.addMiddleware(AgentStreamStage, async function* (context, next) {
+        const pre = context.interrupt<string>({ name: 'gate' })
+        reads.push(['pre', pre.response])
+        const result = yield* next(context)
+        const post = context.interrupt<string>({ name: 'gate' })
+        reads.push(['post', post.response])
+        return result
+      })
+
+      const { result: interruptResult } = await collectGenerator(agent.stream('go'))
+      expect(interruptResult.stopReason).toBe('interrupt')
+
+      const { result: finalResult } = await collectGenerator(
+        agent.stream([
+          new InterruptResponseContent({ interruptId: interruptResult.interrupts![0]!.id, response: 'go' }),
+        ])
+      )
+
+      expect(finalResult.stopReason).toBe('endTurn')
+      expect(reads).toEqual([
+        ['pre', 'go'],
+        ['post', 'go'],
+      ])
+    })
+
     it('interrupt ID uses agentStream namespace', async () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
       const agent = new Agent({ model, printer: false })

--- a/strands-ts/src/middleware/interrupt.ts
+++ b/strands-ts/src/middleware/interrupt.ts
@@ -14,10 +14,7 @@ import type { MiddlewareInterruptResult } from './stages.js'
  * @param interruptState - State used to resolve prior responses
  * @param idPrefix - Prefix used to construct the interrupt identifier
  * @param priorResponses - Optional snapshot of interrupts to resolve prior responses from,
- *   instead of the live `interruptState.interrupts`. The agent-stream stage passes a snapshot
- *   taken before the pass: its context outlives a tool cycle in the same pass, and that cycle's
- *   `deactivate()` clears the live interrupts — reading a snapshot keeps a gate's re-read after
- *   `next()` stable. The tool stage omits it and reads live state.
+ *   instead of the live `interruptState.interrupts`.
  * @returns Interrupt function for a middleware context
  *
  * @internal

--- a/strands-ts/src/middleware/interrupt.ts
+++ b/strands-ts/src/middleware/interrupt.ts
@@ -13,17 +13,23 @@ import type { MiddlewareInterruptResult } from './stages.js'
  *
  * @param interruptState - State used to resolve prior responses
  * @param idPrefix - Prefix used to construct the interrupt identifier
+ * @param priorResponses - Optional snapshot of interrupts to resolve prior responses from,
+ *   instead of the live `interruptState.interrupts`. The agent-stream stage passes a snapshot
+ *   taken before the pass: its context outlives a tool cycle in the same pass, and that cycle's
+ *   `deactivate()` clears the live interrupts — reading a snapshot keeps a gate's re-read after
+ *   `next()` stable. The tool stage omits it and reads live state.
  * @returns Interrupt function for a middleware context
  *
  * @internal
  */
 export function createMiddlewareInterrupt(
   interruptState: InterruptState,
-  idPrefix: string
+  idPrefix: string,
+  priorResponses?: Readonly<Record<string, Interrupt>>
 ): <T = JSONValue>(params: InterruptParams) => MiddlewareInterruptResult<T> {
   return <T = JSONValue>(params: InterruptParams): MiddlewareInterruptResult<T> => {
     const interruptId = `${idPrefix}:${params.name}`
-    const existing = interruptState.interrupts[interruptId]
+    const existing = (priorResponses ?? interruptState.interrupts)[interruptId]
     if (existing?.response !== undefined) {
       return { response: existing.response as T }
     }


### PR DESCRIPTION
## Description
The TS changes in https://github.com/strands-agents/harness-sdk/pull/3466 (and subsequently https://github.com/strands-agents/harness-sdk/pull/3594) were split off into this PR. It fixes the following issues regarding interrupt lifecycle handling:
- When the agent resumes from an interrupt and the resume pass is cancelled before the interrupted tool ran, the pending state is wiped unconditionally. This causes subsequent resume attempts to fail.
- When the user resumes from an `AgentStreamStage` middleware interrupt and the pass completes without triggering any tool cycle, the interrupt was never deactivated. This caused future invocations to be rejected.
- When a middleware gate resolves an interrupt response before `next()` and re-reads it after `next()` returns, the tool cycle in `next()` may have already deactivated the interrupt. The gate would throw a new interrupt instead of returning the response, causing a livelock.

## Documentation PR

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran the pre-commit checks

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
