### PR TITLE
docs(shell): clarify security boundary

### DIFF
--- a/site/src/content/docs/user-guide/shell/configuration.mdx
+++ b/site/src/content/docs/user-guide/shell/configuration.mdx
@@ -5,12 +5,11 @@ sidebar:
   label: "Configuration"
 ---
 
-A fresh shell starts without host files or credentials. It can reach public URLs, while
-the SSRF guard blocks private, loopback, link-local, and cloud metadata addresses. You
-grant additional access by declaring which directories the agent sees, which
-credentials get injected on which requests, and which internal URLs the shell may
-reach. This guide covers each option, plus resource limits and the TOML format that
-captures the whole policy in one file.
+A fresh shell starts without host files or credentials and uses the
+[default network policy](#network-access). You grant additional access by declaring
+which directories the agent sees, which credentials get injected on which requests,
+and which internal URLs the shell may reach. This guide covers each option, plus
+resource limits and the TOML format that captures the whole policy in one file.
 
 Every option is available both as a constructor argument and as a TOML key. Use the constructor when the policy is dynamic (per session, computed at runtime); use TOML when the policy is static and you want it under version control or shared with the [MCP server](mcp-server.md).
 

--- a/site/src/content/docs/user-guide/shell/configuration.mdx
+++ b/site/src/content/docs/user-guide/shell/configuration.mdx
@@ -5,7 +5,12 @@ sidebar:
   label: "Configuration"
 ---
 
-A fresh shell can reach nothing. You open it up by declaring three things: which directories the agent sees, which credentials get injected on which requests, and which URLs the agent may reach. This guide covers each, plus resource limits and the TOML format that captures the whole policy in one file.
+A fresh shell starts without host files or credentials. It can reach public URLs, while
+the SSRF guard blocks private, loopback, link-local, and cloud metadata addresses. You
+grant additional access by declaring which directories the agent sees, which
+credentials get injected on which requests, and which internal URLs the shell may
+reach. This guide covers each option, plus resource limits and the TOML format that
+captures the whole policy in one file.
 
 Every option is available both as a constructor argument and as a TOML key. Use the constructor when the policy is dynamic (per session, computed at runtime); use TOML when the policy is static and you want it under version control or shared with the [MCP server](mcp-server.md).
 

--- a/site/src/content/docs/user-guide/shell/index.mdx
+++ b/site/src/content/docs/user-guide/shell/index.mdx
@@ -12,7 +12,8 @@ Strands Shell is a Bourne-compatible shell that runs inside your own process. It
 `fork`, `exec`, or a raw syscall. Its mediation boundary covers commands run through
 its MCP, Python, and Node.js surfaces; it does not extend to other tools registered
 with an agent. You declare which host files, internal URLs, and credentials the shell
-can reach. Public URLs remain reachable by default. The source is on
+can reach. Network access follows the
+[default policy](configuration.md#network-access). The source is on
 [GitHub](https://github.com/strands-agents/shell).
 
 ## Why a virtual shell
@@ -61,15 +62,15 @@ Strands Shell is written in Rust and compiles from one source to native bindings
 
 ## What you control
 
-A fresh shell starts without host files or credentials. Public URLs remain reachable,
-while the SSRF guard blocks private, loopback, link-local, and cloud metadata
-addresses. You grant additional access explicitly through three mechanisms:
+A fresh shell starts without host files or credentials and uses the
+[default network policy](configuration.md#network-access). You grant additional access
+explicitly through three mechanisms:
 
 - **Binds** map a host directory into the shell's filesystem. A `copy` bind snapshots the directory at construction time, isolating the agent from your live files. A `direct` bind passes reads and writes through to the host in real time. Prefer `copy` for source code and reserve `direct` for output directories.
 
 - **Credentials** attach a secret to a URL prefix. When a command makes a request to a matching URL, the Kernel injects the credential at request time. The agent doesn't hold the secret, and the Kernel doesn't re-inject on a redirect, even back to the same host.
 
-- **Allowed URLs** widen the network policy. By default the SSRF guard blocks private ranges (RFC1918, link-local, loopback, and cloud metadata endpoints) while letting public URLs through. Add a prefix to the allowlist to permit a specific internal host.
+- **Allowed URLs** permit specific internal hosts that the default network policy blocks.
 
 The [Configuration](configuration.md) guide covers each of these in depth, including the TOML format that lets you declare the whole policy in a file.
 

--- a/site/src/content/docs/user-guide/shell/index.mdx
+++ b/site/src/content/docs/user-guide/shell/index.mdx
@@ -7,7 +7,13 @@ sidebar:
 
 Agents run shell commands in tight loops: install dependencies, run tests, grep for errors, iterate. Those loops need to be fast, and they need to be contained. An agent that can run `curl` can also read your cloud credentials, reach your internal network, and overwrite files you didn't intend to expose.
 
-Strands Shell is a Bourne-compatible shell that runs inside your own process. It ships `grep`, `sed`, `jq`, `curl`, `find`, and dozens of other commands without calling `fork`, `exec`, or a raw syscall. You declare what the agent can reach (files, URLs, credentials) up front, and everything else doesn't exist as far as the agent is concerned. The source is on [GitHub](https://github.com/strands-agents/shell).
+Strands Shell is a Bourne-compatible shell that runs inside your own process. It ships
+`grep`, `sed`, `jq`, `curl`, `find`, and dozens of other commands without calling
+`fork`, `exec`, or a raw syscall. Its mediation boundary covers commands run through
+its MCP, Python, and Node.js surfaces; it does not extend to other tools registered
+with an agent. You declare which host files, internal URLs, and credentials the shell
+can reach. Public URLs remain reachable by default. The source is on
+[GitHub](https://github.com/strands-agents/shell).
 
 ## Why a virtual shell
 
@@ -28,7 +34,9 @@ This is a different tradeoff, not a strictly better one. A container isolates at
 
 ## How it works
 
-Your code talks to the shell through one of three surfaces: an MCP server, the Python API, or the Node.js API. Every command, file read, and network request flows through the Kernel, which is the single mediation boundary.
+Your code talks to the shell through one of three surfaces: an MCP server, the Python
+API, or the Node.js API. Every command, file read, and network request initiated
+inside Strands Shell flows through the Kernel, which is the single mediation boundary.
 
 ```mermaid
 flowchart TB
@@ -53,7 +61,9 @@ Strands Shell is written in Rust and compiles from one source to native bindings
 
 ## What you control
 
-A fresh shell starts empty without access to files, network, or credentials. You grant access explicitly through three mechanisms:
+A fresh shell starts without host files or credentials. Public URLs remain reachable,
+while the SSRF guard blocks private, loopback, link-local, and cloud metadata
+addresses. You grant additional access explicitly through three mechanisms:
 
 - **Binds** map a host directory into the shell's filesystem. A `copy` bind snapshots the directory at construction time, isolating the agent from your live files. A `direct` bind passes reads and writes through to the host in real time. Prefer `copy` for source code and reserve `direct` for output directories.
 
@@ -65,7 +75,10 @@ The [Configuration](configuration.md) guide covers each of these in depth, inclu
 
 ## What Strands Shell is not
 
-Strands Shell is a mediation layer, not a hardened sandbox. The Kernel enforces what the agent *should* reach through deny-by-default policy, and it runs in the same process as your code. It doesn't protect against memory-safety exploits in the shell engine itself, timing side channels, or an attacker who already controls the host process.
+Strands Shell is a mediation layer, not a hardened sandbox. The Kernel enforces its
+least-privilege policy inside the shell, and it runs in the same process as your code.
+It doesn't protect against memory-safety exploits in the shell engine itself, timing
+side channels, or an attacker who already controls the host process.
 
 The distinction matters for your threat model:
 

--- a/site/src/content/docs/user-guide/shell/mcp-server.mdx
+++ b/site/src/content/docs/user-guide/shell/mcp-server.mdx
@@ -10,8 +10,8 @@ The built-in MCP server exposes a sandboxed shell over JSON-RPC on stdio, so any
 ## Start the server
 
 Run the server with the `--mcp` flag. With no config, it starts a bare in-memory
-sandbox without host files or credentials. Public URLs remain reachable, while the
-SSRF guard blocks private, loopback, link-local, and cloud metadata addresses.
+sandbox without host files or credentials and uses the
+[default network policy](configuration.md#network-access).
 
 ```bash
 uvx strands-shell --mcp

--- a/site/src/content/docs/user-guide/shell/mcp-server.mdx
+++ b/site/src/content/docs/user-guide/shell/mcp-server.mdx
@@ -9,7 +9,9 @@ The built-in MCP server exposes a sandboxed shell over JSON-RPC on stdio, so any
 
 ## Start the server
 
-Run the server with the `--mcp` flag. With no config, it starts a bare in-memory sandbox: no host files, no network, no credentials.
+Run the server with the `--mcp` flag. With no config, it starts a bare in-memory
+sandbox without host files or credentials. Public URLs remain reachable, while the
+SSRF guard blocks private, loopback, link-local, and cloud metadata addresses.
 
 ```bash
 uvx strands-shell --mcp

--- a/site/src/content/docs/user-guide/shell/quickstart.mdx
+++ b/site/src/content/docs/user-guide/shell/quickstart.mdx
@@ -31,11 +31,10 @@ Add this to your MCP client configuration:
 }
 ```
 
-This starts a bare in-memory sandbox without access to host files or credentials.
-Public URLs remain reachable, while the SSRF guard blocks private, loopback,
-link-local, and cloud metadata addresses. To grant additional access, write a
-[TOML config file](configuration.md#toml-configuration) and pass it before the
-`--mcp` flag:
+This starts a bare in-memory sandbox without access to host files or credentials and
+uses the [default network policy](configuration.md#network-access). To grant additional
+access, write a [TOML config file](configuration.md#toml-configuration) and pass it
+before the `--mcp` flag:
 
 ```json
 {
@@ -157,10 +156,9 @@ for (const entry of entries) {
 ## What you built
 
 You created a sandbox with exactly one host directory visible to it and ran a
-command without exposing your home directory or credentials. Public URLs remain
-reachable, while the SSRF guard blocks private, loopback, link-local, and cloud
-metadata addresses. You add capability by adding binds, credentials, and allowed
-URLs.
+command without exposing your home directory or credentials. Network access follows
+the [default policy](configuration.md#network-access). You add capability by adding
+binds, credentials, and allowed URLs.
 
 ## Next steps
 

--- a/site/src/content/docs/user-guide/shell/quickstart.mdx
+++ b/site/src/content/docs/user-guide/shell/quickstart.mdx
@@ -31,7 +31,11 @@ Add this to your MCP client configuration:
 }
 ```
 
-This starts a bare in-memory sandbox without access to files, network, or credentials. To grant access, write a [TOML config file](configuration.md#toml-configuration) and pass it before the `--mcp` flag:
+This starts a bare in-memory sandbox without access to host files or credentials.
+Public URLs remain reachable, while the SSRF guard blocks private, loopback,
+link-local, and cloud metadata addresses. To grant additional access, write a
+[TOML config file](configuration.md#toml-configuration) and pass it before the
+`--mcp` flag:
 
 ```json
 {
@@ -152,7 +156,11 @@ for (const entry of entries) {
 
 ## What you built
 
-You created a sandbox with exactly one directory visible to it and ran a command that couldn't reach anything else: not your home directory, not your credentials, not the network. That's the whole model. You add capability by adding binds, credentials, and allowed URLs, and the agent gets nothing you didn't grant.
+You created a sandbox with exactly one host directory visible to it and ran a
+command without exposing your home directory or credentials. Public URLs remain
+reachable, while the SSRF guard blocks private, loopback, link-local, and cloud
+metadata addresses. You add capability by adding binds, credentials, and allowed
+URLs.
 
 ## Next steps
 

--- a/site/src/content/docs/user-guide/shell/security.mdx
+++ b/site/src/content/docs/user-guide/shell/security.mdx
@@ -35,11 +35,11 @@ A custom Kernel (for embedding the shell in another runtime) carries its own sec
 
 ## Least privilege by default
 
-Out of the box, a shell has no host files or credentials. It can reach public URLs,
-while the SSRF guard blocks private, loopback, link-local, and cloud metadata
-addresses. The TOML config defaults bind mode to `copy` (the safe choice), but the
-Python and Node.js constructors default to `direct`; always pass `mode` explicitly in
-code. The practices that follow from the principle of least privilege are:
+Out of the box, a shell has no host files or credentials and uses the
+[default network policy](configuration.md#network-access). The TOML config defaults
+bind mode to `copy` (the safe choice), but the Python and Node.js constructors default
+to `direct`; always pass `mode` explicitly in code. The practices that follow from the
+principle of least privilege are:
 
 - **Prefer `copy` over `direct` binds for source code.** A `copy` bind snapshots files into the VFS, isolating the agent from your live filesystem. Reserve `direct` for output directories where the agent must persist results.
 - **Scope binds narrowly.** Bind `/my/project/src`, not `/my/project` or `/`. The agent doesn't need your `.git`, your `.env`, or your `node_modules`.

--- a/site/src/content/docs/user-guide/shell/security.mdx
+++ b/site/src/content/docs/user-guide/shell/security.mdx
@@ -5,13 +5,24 @@ sidebar:
   label: "Security Model"
 ---
 
-Strands Shell exists to answer one question: what should this agent be allowed to touch? The answer is enforced by the Kernel, a single mediation boundary that every filesystem, network, and credential operation flows through. This page explains where that boundary sits, what it guarantees, and the threat models it does and doesn't cover.
+Strands Shell exists to answer one question: what should this shell be allowed to touch?
+The Kernel enforces the answer as the mediation boundary for filesystem, network, and
+credential operations initiated inside Strands Shell. This boundary does not extend to
+other tools registered with an agent, including community tools. Those tools retain
+their own security properties. This page explains where the Shell boundary sits, what
+it guarantees, and the threat models it does and doesn't cover.
 
-The framing that matters most: **Strands Shell is a mediation layer, not a hardened sandbox.** It enforces what an agent *should* reach through deny-by-default policy. It runs in the same process as your code, not in a VM. Getting this distinction right is the difference between an appropriate deployment and a false sense of safety.
+The framing that matters most: **Strands Shell is a mediation layer, not a hardened
+sandbox.** It enforces what an agent *should* reach through a least-privilege policy.
+It runs in the same process as your code, not in a VM. Getting this distinction right
+is the difference between an appropriate deployment and a false sense of safety.
 
 ## The Kernel boundary
 
-All effects flow through the Kernel. There's no path around it: the shell makes no `fork`, no `exec`, and no raw syscalls, because the engine runs entirely in userspace. A command that wants to read a file, reach a URL, or use a credential asks the Kernel, and the Kernel applies policy.
+All effects initiated inside Strands Shell flow through the Kernel. There's no path
+around it: the shell makes no `fork`, no `exec`, and no raw syscalls, because the
+engine runs entirely in userspace. A command that wants to read a file, reach a URL,
+or use a credential asks the Kernel, and the Kernel applies policy.
 
 The default Kernel is backed by an in-memory virtual filesystem and enforces four guarantees:
 
@@ -22,9 +33,13 @@ The default Kernel is backed by an in-memory virtual filesystem and enforces fou
 
 A custom Kernel (for embedding the shell in another runtime) carries its own security properties. The guarantees above describe the bundled implementation.
 
-## Deny by default
+## Least privilege by default
 
-Out of the box a shell is empty: no files, no network, no credentials. You add capability explicitly. The TOML config defaults bind mode to `copy` (the safe choice), but the Python and Node.js constructors default to `direct`; always pass `mode` explicitly in code. The principle is least privilege, and the practices that follow from it:
+Out of the box, a shell has no host files or credentials. It can reach public URLs,
+while the SSRF guard blocks private, loopback, link-local, and cloud metadata
+addresses. The TOML config defaults bind mode to `copy` (the safe choice), but the
+Python and Node.js constructors default to `direct`; always pass `mode` explicitly in
+code. The practices that follow from the principle of least privilege are:
 
 - **Prefer `copy` over `direct` binds for source code.** A `copy` bind snapshots files into the VFS, isolating the agent from your live filesystem. Reserve `direct` for output directories where the agent must persist results.
 - **Scope binds narrowly.** Bind `/my/project/src`, not `/my/project` or `/`. The agent doesn't need your `.git`, your `.env`, or your `node_modules`.
@@ -57,10 +72,15 @@ Match the tool to the threat model:
 - **"My agent shouldn't touch anything I haven't allowed."** The Kernel handles this directly. This covers the common cases: a coding agent on a repository, a research agent with a scoped API key, a CI assistant. No container required.
 - **"An untrusted tenant is running arbitrary adversarial code."** Add OS-level isolation. Run each shell instance inside a container or microVM, and let the Kernel handle in-process mediation on top. Construction is cheap, so one shell per session is the intended pattern.
 
-The two layers compose. The Kernel gives you fine-grained, fast, deny-by-default mediation; the container gives you a hard kernel boundary. For adversarial workloads, use both.
+The two layers compose. The Kernel gives you fine-grained, fast mediation; the
+container gives you a hard kernel boundary. For adversarial workloads, use both.
 
 ## Reporting a security issue
 
-A bypass of filesystem mediation, the SSRF guard, or credential injection is a security issue, not a normal bug. Reaching a path outside a bound mount, defeating the metadata-service block, exfiltrating an injected credential, or causing one MCP session to read another session's state all qualify.
+A bypass of filesystem mediation, the SSRF guard, or credential injection within the
+bundled Strands Shell Kernel is a security issue, not a normal bug. Reaching a path
+outside a bound mount, defeating the Shell metadata-service block, exfiltrating an
+injected credential, or causing one Shell MCP session to read another session's state
+all qualify.
 
 Don't open a public GitHub issue. Report through the [AWS Vulnerability Disclosure Program on HackerOne](https://hackerone.com/aws_vdp) or by email to `aws-security@amazon.com`. The repository's [SECURITY.md](https://github.com/strands-agents/shell/blob/main/SECURITY.md) has the full policy and the complete in-scope and out-of-scope lists.


### PR DESCRIPTION
## Description

Strands Shell documentation currently implies that a fresh runtime has no network access and can be read as extending Kernel guarantees to unrelated agent tools. Clarify that public egress is available by default and scope filesystem, SSRF, and credential guarantees to operations mediated by Strands Shell.

## Related Issues

None.

## Documentation PR

Included in this PR.

## Type of Change

Documentation update

## Testing

- `npm run build`
- `npm test`
- [ ] I ran `hatch run prepare` (the current root configuration does not define this command)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.