### PR TITLE
fix(python): count usage from hook-retried model calls

### DIFF
--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -596,6 +596,7 @@ async def _handle_model_execution(
 
             # Check if hooks want to retry the model call
             if after_model_call_event.retry:
+                agent.event_loop_metrics.update_usage(usage)
                 logger.debug(
                     "stop_reason=<%s>, retry_requested=<True> | hook requested model retry",
                     stop_reason,

--- a/strands-py/tests/strands/agent/test_agent_hooks.py
+++ b/strands-py/tests/strands/agent/test_agent_hooks.py
@@ -347,7 +347,11 @@ async def test_hook_retry_on_successful_call():
                 "role": "assistant",
                 "content": [{"text": "This is a much longer and more detailed response"}],
             },
-        ]
+        ],
+        usages=[
+            {"inputTokens": 1000, "outputTokens": 1000, "totalTokens": 2000},
+            {"inputTokens": 7, "outputTokens": 7, "totalTokens": 14},
+        ],
     )
 
     # Hook that retries if response is too short
@@ -380,6 +384,11 @@ async def test_hook_retry_on_successful_call():
 
     # Verify final result is the longer response
     assert result.message["content"][0]["text"] == "This is a much longer and more detailed response"
+
+    # https://github.com/strands-agents/harness-sdk/issues/3623: retried calls still incur billable usage.
+    tru_usage = agent.event_loop_metrics.accumulated_usage
+    exp_usage = {"inputTokens": 1007, "outputTokens": 1007, "totalTokens": 2014}
+    assert tru_usage == exp_usage
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

A successful model call discarded by `AfterModelCallEvent.retry` still incurs billable token usage, but the retry branch skipped metrics accumulation entirely. This keeps that usage in `EventLoopMetrics`, so cost reporting and invocation token limits reflect every completed model call rather than only the accepted response.

## Related Issues

Resolves #3623

## Documentation PR

No documentation change is needed; this restores accounting behavior for the existing retry hook.

## Type of Change

Bug fix

## Testing

- [ ] I ran `hatch run prepare`
- [x] `pytest tests/strands/agent/test_agent_hooks.py tests/strands/event_loop/test_event_loop.py -q` (94 passed)
- [x] Ruff format and lint on both changed files
- [x] Mypy on `src/strands/event_loop/event_loop.py`
- [x] Control experiment: the regression assertion fails with the source fix removed and passes when restored

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] No documentation changes are required
- [x] No new documentation example is required
- [x] My changes generate no new warnings
- [x] No dependent changes are required

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.