### PR TITLE
docs: replace deprecated strands_tools examples outside concepts/

### DIFF
--- a/site/docs/examples/evals-sdk/deterministic_evaluators.py
+++ b/site/docs/examples/evals-sdk/deterministic_evaluators.py
@@ -3,9 +3,13 @@
 Fast, code-based evaluation without LLM judges.
 """
 
+
+import ast
+import operator
+
 import asyncio
 
-from strands import Agent
+from strands import Agent, tool
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import Contains, Equals, StartsWith, ToolCalled
 
@@ -36,8 +40,27 @@ experiment = Experiment(
 # --- Trajectory evaluator ---
 
 from strands_evals.extractors import tools_use_extractor
-from strands_tools import calculator
 
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def get_response_with_tools(case: Case) -> dict:
     agent = Agent(tools=[calculator], callback_handler=None)

--- a/site/docs/examples/evals-sdk/evaluate_async.py
+++ b/site/docs/examples/evals-sdk/evaluate_async.py
@@ -1,12 +1,36 @@
+
+import ast
+import operator
+
 import asyncio
 
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
 
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolSelectionAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
 memory_exporter = telemetry.in_memory_exporter

--- a/site/docs/examples/evals-sdk/tool_parameter_accuracy_evaluator.py
+++ b/site/docs/examples/evals-sdk/tool_parameter_accuracy_evaluator.py
@@ -1,12 +1,36 @@
+
+import ast
+import operator
+
 import asyncio
 
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
 
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolParameterAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Setup telemetry
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()

--- a/site/docs/examples/evals-sdk/tool_selection_accuracy_evaluator.py
+++ b/site/docs/examples/evals-sdk/tool_selection_accuracy_evaluator.py
@@ -1,12 +1,36 @@
+
+import ast
+import operator
+
 import asyncio
 
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
 
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolSelectionAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Setup telemetry
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()

--- a/site/docs/examples/python/multi_agent_example/math_assistant.py
+++ b/site/docs/examples/python/multi_agent_example/math_assistant.py
@@ -1,6 +1,30 @@
+
+import ast
+import operator
+
 from strands import Agent, tool
-from strands_tools import calculator
 import json
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 MATH_ASSISTANT_SYSTEM_PROMPT = """
 You are math wizard, a specialized mathematics education assistant. Your capabilities include:

--- a/site/src/content/docs/integrations/model-providers/cohere.mdx
+++ b/site/src/content/docs/integrations/model-providers/cohere.mdx
@@ -24,9 +24,33 @@ pip install 'strands-agents[openai]' strands-agents-tools
 After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Cohere models as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/integrations/model-providers/crusoe.mdx
+++ b/site/src/content/docs/integrations/model-providers/crusoe.mdx
@@ -22,9 +22,33 @@ pip install 'strands-agents[openai]' strands-agents-tools
 After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Crusoe models as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/integrations/model-providers/fireworksai.mdx
+++ b/site/src/content/docs/integrations/model-providers/fireworksai.mdx
@@ -26,9 +26,33 @@ pip install 'strands-agents[openai]' strands-agents-tools
 After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Fireworks AI models as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/integrations/model-providers/mlx.mdx
+++ b/site/src/content/docs/integrations/model-providers/mlx.mdx
@@ -35,9 +35,33 @@ pip install strands-mlx strands-agents-tools
 ### Basic Agent
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_mlx import MLXModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = MLXModel(model_id="mlx-community/Qwen3-1.7B-4bit")
 agent = Agent(model=model, tools=[calculator])

--- a/site/src/content/docs/integrations/model-providers/nebius-token-factory.mdx
+++ b/site/src/content/docs/integrations/model-providers/nebius-token-factory.mdx
@@ -24,9 +24,33 @@ pip install 'strands-agents[openai]' strands-agents-tools
 After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Nebius Token Factory models as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/integrations/model-providers/nvidia-nim.mdx
+++ b/site/src/content/docs/integrations/model-providers/nvidia-nim.mdx
@@ -29,9 +29,33 @@ pip install strands-nvidia-nim strands-agents-tools
 ### Basic Agent
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_nvidia_nim import NvidiaNIM
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = NvidiaNIM(
     api_key="your-nvidia-nim-api-key",
@@ -53,10 +77,34 @@ export NVIDIA_NIM_API_KEY=your-nvidia-nim-api-key
 ```
 
 ```python
+
+import ast
+import operator
+
 import os
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
 from strands_nvidia_nim import NvidiaNIM
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = NvidiaNIM(
     api_key=os.getenv("NVIDIA_NIM_API_KEY"),

--- a/site/src/content/docs/integrations/model-providers/sglang.mdx
+++ b/site/src/content/docs/integrations/model-providers/sglang.mdx
@@ -47,11 +47,35 @@ python -m sglang.launch_server \
 ### 2. Basic Agent
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 from transformers import AutoTokenizer
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
 from strands_sglang import SGLangModel
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main():
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507")

--- a/site/src/content/docs/integrations/model-providers/vllm.mdx
+++ b/site/src/content/docs/integrations/model-providers/vllm.mdx
@@ -97,10 +97,35 @@ print(f"Response tokens: {len(recorder.token_ids or [])}")
 Strands SDK already handles unknown tools and malformed JSON gracefully. `VLLMToolValidationHooks` adds RL-friendly enhancements:
 
 ```python
+import ast
+import operator
+
 import os
-from strands import Agent
-from strands_tools.calculator import calculator
+
+from strands import Agent, tool
 from strands_vllm import VLLMModel, VLLMToolValidationHooks
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
+
 
 model = VLLMModel(
     base_url=os.getenv("VLLM_BASE_URL", "http://localhost:8000/v1"),
@@ -161,16 +186,35 @@ The following span attributes are set:
 For building RL-ready trajectories with loss masks:
 
 ```python
+import ast
+import operator
+
 import asyncio
 import os
+
 from strands import Agent, tool
-from strands_tools.calculator import calculator as _calculator_impl
 from strands_vllm import TokenManager, VLLMModel, VLLMTokenRecorder, VLLMToolValidationHooks
 
 @tool
-def calculator(expression: str) -> dict:
-    return _calculator_impl(expression=expression)
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 async def main():
     model = VLLMModel(
         base_url=os.getenv("VLLM_BASE_URL", "http://localhost:8000/v1"),

--- a/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
@@ -127,7 +127,7 @@ Prompting is a primary functionality of Strands that allows you to invoke tools 
 <Tab label="Python">
 
 ```python
-result = agent.tool.current_time(timezone="US/Pacific")
+result = agent.tool.my_tool(param="value")
 ```
 </Tab>
 <Tab label="TypeScript">

--- a/site/src/content/docs/user-guide/concepts/agents/state.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/state.mdx
@@ -89,8 +89,32 @@ Direct tool calls are (by default) recorded in the conversation history:
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 

--- a/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
@@ -280,9 +280,33 @@ Combine structured output with tool usage to format tool execution results:
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
 from pydantic import BaseModel, Field
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 class MathResult(BaseModel):
     operation: str = Field(description="the performed operation")

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -45,8 +45,32 @@ While both `Agent` and `BidiAgent` share the same core purpose of enabling AI-po
 The standard `Agent` follows a traditional request-response pattern:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
@@ -492,10 +492,35 @@ asyncio.run(main())
 ### Tool Execution During Conversation
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.models import BidiNovaSonicModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main():
     model = BidiNovaSonicModel()

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
@@ -38,15 +38,38 @@ pip install 'strands-agents[bidi-all]'
 After installing `strands-agents[bidi-gemini]`, you can import and initialize the Strands Agents' Gemini Live provider as follows:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BidiGeminiLiveModel
 from strands_tools import stop
 
-from strands_tools import calculator
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main() -> None:
     model = BidiGeminiLiveModel(

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
@@ -42,15 +42,38 @@ pip install 'strands-agents[bidi-all]'
 After installing `strands-agents[bidi]`, you can import and initialize the Strands Agents' Nova Sonic provider as follows:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BidiNovaSonicModel
 from strands_tools import stop
 
-from strands_tools import calculator
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main() -> None:
     model = BidiNovaSonicModel(

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
@@ -37,15 +37,38 @@ pip install 'strands-agents[bidi-all]'
 After installing `strands-agents[bidi-openai]`, you can import and initialize the Strands Agents' OpenAI Realtime provider as follows:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BidiOpenAIRealtimeModel
 from strands_tools import stop
 
-from strands_tools import calculator
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main() -> None:
     model = BidiOpenAIRealtimeModel(

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
@@ -246,11 +246,35 @@ Always call `agent.stop()` **after** exiting the `run()` or `receive()` loop, ne
 Just like standard Strands agents, bidirectional agents can use tools during conversations:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 from strands import tool
 from strands.experimental.bidi import BidiAgent, BidiAudioIO
 from strands.experimental.bidi.models import BidiNovaSonicModel
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Define a custom tool
 @tool
@@ -271,7 +295,7 @@ def get_weather(location: str) -> str:
 model = BidiNovaSonicModel()
 agent = BidiAgent(
     model=model,
-    tools=[calculator, current_time, get_weather],
+    tools=[calculator, get_weather],
     system_prompt="You are a helpful assistant with access to tools."
 )
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -597,9 +597,33 @@ Tool caching allows you to reuse a cached tool definition across multiple reques
 In Python, use the `cache_tools` parameter to enable tool caching independently:
 
 ```python
+
+import ast
+import operator
+
 from strands import Agent, tool
 from strands.models import BedrockModel
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Using tool caching with BedrockModel
 bedrock_model = BedrockModel(
@@ -610,7 +634,7 @@ bedrock_model = BedrockModel(
 # Create an agent with the model and tools
 agent = Agent(
     model=bedrock_model,
-    tools=[calculator, current_time]
+    tools=[calculator]
 )
 # First request will cache the tools
 response1 = agent("What time is it?")

--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -37,9 +37,33 @@ After installing dependencies, you can import and initialize the Strands Agents'
 <Tab label="Python">
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.anthropic import AnthropicModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = AnthropicModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -41,9 +41,33 @@ After installing dependencies, you can import and initialize the Strands Agents'
 <Tab label="Python">
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.gemini import GeminiModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = GeminiModel(
     client_args={
@@ -329,10 +353,34 @@ Users can pass their own custom Gemini client to the GeminiModel for Strands Age
 <Tab label="Python">
 
 ```python
+
+import ast
+import operator
+
 from google import genai
-from strands import Agent
+from strands import Agent, tool
 from strands.models.gemini import GeminiModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 client = genai.Client(api_key="<KEY>")
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
@@ -23,9 +23,33 @@ pip install 'strands-agents[litellm]' strands-agents-tools
 After installing `litellm`, you can import and initialize Strands Agents' LiteLLM provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.litellm import LiteLLMModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = LiteLLMModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
@@ -29,9 +29,33 @@ pip install 'strands-agents[llamaapi]' strands-agents-tools
 After installing `llamaapi`, you can import and initialize Strands Agents' Llama API provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.llamaapi import LlamaAPIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = LlamaAPIModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
@@ -23,9 +23,33 @@ pip install strands-agents strands-agents-tools
 After setting up a llama.cpp server, you can import and initialize the Strands Agents' llama.cpp provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.llamacpp import LlamaCppModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = LlamaCppModel(
     base_url="http://localhost:8080",

--- a/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
@@ -26,9 +26,33 @@ pip install 'strands-agents[mistral]' strands-agents-tools
 After installing `mistral`, you can import and initialize Strands Agents' Mistral API provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.mistral import MistralModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = MistralModel(
     api_key="<YOUR_MISTRAL_API_KEY>",

--- a/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -242,9 +242,33 @@ print(f"Rating: {book_analysis.rating}")
 [Ollama models that support tool use](https://ollama.com/search?c=tools) can use tools through Strands' tool system:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.ollama import OllamaModel
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create an Ollama model
 ollama_model = OllamaModel(
@@ -255,7 +279,7 @@ ollama_model = OllamaModel(
 # Create an agent with tools
 agent = Agent(
     model=ollama_model,
-    tools=[calculator, current_time]
+    tools=[calculator]
 )
 
 # Use the agent with tools

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -37,9 +37,33 @@ After installing dependencies, you can import and initialize the Strands Agents'
 <Tab label="Python">
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
@@ -26,9 +26,33 @@ pip install 'strands-agents[sagemaker]' strands-agents-tools
 After installing the SageMaker dependencies, you can import and initialize the Strands Agents' SageMaker provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.sagemaker import SageMakerAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = SageMakerAIModel(
     endpoint_config={

--- a/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
@@ -23,9 +23,33 @@ pip install 'strands-agents[writer]' strands-agents-tools
 After installing `writer`, you can import and initialize Strands Agents' Writer provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.writer import WriterModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = WriterModel(
     client_args={"api_key": "<WRITER_API_KEY>"},

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -292,10 +292,35 @@ Create a Strands agent and expose it as an A2A server:
 <Tab label="Python">
 
 ```python
+import ast
+import operator
+
 import logging
-from strands_tools.calculator import calculator
-from strands import Agent
+
+from strands import Agent, tool
 from strands.multiagent.a2a import A2AServer
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
+
 
 logging.basicConfig(level=logging.INFO)
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -61,26 +61,26 @@ The simplest way to use an agent as a tool is to pass it directly in the `tools`
 
 ```python
 from strands import Agent
-from strands_tools import retrieve, http_request
+from strands_tools import http_request
 
 # Create specialized agents
 research_agent = Agent(
     system_prompt="""You are a specialized research assistant. Focus only on providing
     factual, well-sourced information in response to research questions.
     Always cite your sources when possible.""",
-    tools=[retrieve, http_request],
+    tools=[http_request],
 )
 
 product_agent = Agent(
     system_prompt="""You are a specialized product recommendation assistant.
     Provide personalized product suggestions based on user preferences.""",
-    tools=[retrieve, http_request],
+    tools=[http_request],
 )
 
 travel_agent = Agent(
     system_prompt="""You are a specialized travel planning assistant.
     Create detailed travel itineraries based on user preferences.""",
-    tools=[retrieve, http_request],
+    tools=[http_request],
 )
 
 # Create the orchestrator — agents are automatically converted to tools
@@ -163,7 +163,7 @@ For more control over how the agent is invoked — such as custom pre/post-proce
 
 ```python
 from strands import Agent, tool
-from strands_tools import retrieve, http_request
+from strands_tools import http_request
 
 RESEARCH_ASSISTANT_PROMPT = """
 You are a specialized research assistant. Focus only on providing
@@ -185,7 +185,7 @@ def research_assistant(query: str) -> str:
     try:
         research_agent = Agent(
             system_prompt=RESEARCH_ASSISTANT_PROMPT,
-            tools=[retrieve, http_request]
+            tools=[http_request]
         )
 
         response = research_agent(query)
@@ -223,7 +223,7 @@ def product_recommendation_assistant(query: str) -> str:
         product_agent = Agent(
             system_prompt="""You are a specialized product recommendation assistant.
             Provide personalized product suggestions based on user preferences.""",
-            tools=[retrieve, http_request, dialog],
+            tools=[http_request, dialog],
         )
         # Implementation with response handling
         # ...
@@ -246,7 +246,7 @@ def trip_planning_assistant(query: str) -> str:
         travel_agent = Agent(
             system_prompt="""You are a specialized travel planning assistant.
             Create detailed travel itineraries based on user preferences.""",
-            tools=[retrieve, http_request],
+            tools=[http_request],
         )
         # Implementation with response handling
         # ...

--- a/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
@@ -25,9 +25,33 @@ Python uses the [`stream_async`](@api/python/strands.agent.agent#Agent.stream_as
 > **Note**: Python also supports synchronous event handling via [callback handlers](./callback-handlers.md).
 
 ```python
+
+import ast
+import operator
+
 import asyncio
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Initialize our agent without a callback handler
 agent = Agent(
@@ -63,11 +87,36 @@ Here's how to integrate streaming with web frameworks to create a streaming endp
 <Tab label="Python - FastAPI">
 
 ```python
+
+import ast
+import operator
+
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from strands import Agent
-from strands_tools import calculator, http_request
+from strands import Agent, tool
+from strands_tools import http_request
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 app = FastAPI()
 
@@ -119,8 +168,32 @@ This async stream processor illustrates the event loop lifecycle events and how 
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create agent with event loop tracker
 agent = Agent(

--- a/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
@@ -21,8 +21,32 @@ For a complete list of available events including text generation, tool usage, l
 The simplest way to use a callback handler is to pass a callback function to your agent:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def custom_callback_handler(**kwargs):
     # Process stream data
@@ -70,8 +94,32 @@ Custom callback handlers enable you to have fine-grained control over what is st
 Custom callback handlers can be useful to debug sequences of events in the agent loop:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def debugger_callback_handler(**kwargs):
     # Print the values in kwargs so that we can see everything
@@ -92,9 +140,33 @@ This handler prints all calls to the callback handler including full event detai
 This handler demonstrates how to buffer text and only show it when a complete message is generated. This pattern is useful for chat interfaces where you want to show polished, complete responses:
 
 ```python
+
+import ast
+import operator
+
 import json
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def message_buffer_handler(**kwargs):
     # When a new message is created from the assistant, print its content
@@ -117,8 +189,32 @@ This handler leverages the `message` event which is triggered when a complete me
 This callback handler illustrates the event loop lifecycle events and how they relate to each other. It's useful for understanding the flow of execution in the Strands agent:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def event_loop_tracker(**kwargs):
     # Track event loop lifecycle

--- a/site/src/content/docs/user-guide/concepts/streaming/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/index.mdx
@@ -270,8 +270,32 @@ This example demonstrates how to identify event emitted from an agent:
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def process_event(event):
     """Shared event processor for both async iterators and callback handlers"""
@@ -319,10 +343,34 @@ Utilizing both [agents as a tool](../multi-agent/agents-as-tools.md) and [tool s
 <Tab label="Python">
 
 ```python
+
+import ast
+import operator
+
 from typing import AsyncIterator
 from dataclasses import dataclass
 from strands import Agent, tool
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 @dataclass
 class SubAgentResult:

--- a/site/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -27,8 +27,34 @@ Tools are passed to agents during initialization or at runtime, making them avai
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator, file_read, shell
+
+import ast
+import operator
+
+from strands import Agent, tool
+from strands_tools import file_read
+from strands.vended_tools import shell
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Add tools to our agent
 agent = Agent(
@@ -416,8 +442,34 @@ Pre-built tools are available in both Python and TypeScript to help you get star
 For Python, Strands offers a [community-supported tools package](https://github.com/strands-agents/tools/blob/main) with pre-built tools for development:
 
 ```python
-from strands import Agent
-from strands_tools import calculator, file_read, shell
+
+import ast
+import operator
+
+from strands import Agent, tool
+from strands_tools import file_read
+from strands.vended_tools import shell
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator, file_read, shell])
 ```

--- a/site/src/content/docs/user-guide/evals-sdk/cli.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/cli.mdx
@@ -51,8 +51,32 @@ The two modes are mutually exclusive — argparse rejects mixing them.
 
 ```python
 # my_pkg/agents.py
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def build_agent():
     return Agent(tools=[calculator], callback_handler=None)

--- a/site/src/content/docs/user-guide/evals-sdk/detectors/diagnosis.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/detectors/diagnosis.mdx
@@ -217,13 +217,37 @@ If the trajectory is not a `Session` (e.g., it's a plain list of tool names), di
 This example shows the complete workflow: run evaluations with diagnosis, then analyze the results.
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
-from strands import Agent
+from strands import Agent, tool
 from strands_evals import Case, Experiment, DiagnosisConfig, eval_task, TracedHandler
 from strands_evals.detectors import ConfidenceLevel, DiagnosisTrigger
 from strands_evals.evaluators import OutputEvaluator, GoalSuccessRateEvaluator
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 @eval_task(TracedHandler())
 def math_agent():

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
@@ -60,14 +60,38 @@ When using `StrandsInMemorySessionMapper`, you **must** include session ID trace
 :::
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolParameterAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Setup telemetry
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
@@ -44,7 +44,32 @@ The decorator wraps your function so that `Experiment.run_evaluations` receives 
 Accept a `Case` parameter to customize agent behavior per test case:
 
 ```python
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 @eval_task()
 def my_task(case):

--- a/site/src/content/docs/user-guide/evals-sdk/quickstart.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/quickstart.mdx
@@ -170,16 +170,40 @@ The `@eval_task()` decorator eliminates boilerplate. Your function can return an
 Now let's evaluate how well agents use tools. Create `my_evaluation/trajectory_eval.py`:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import TrajectoryEvaluator
 from strands_evals.extractors import tools_use_extractor
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Define task function that captures tool usage
 def get_response_with_tools(case: Case) -> dict:
     agent = Agent(
-        tools=[calculator, current_time],
+        tools=[calculator],
         system_prompt="You are a helpful assistant. Use tools when appropriate.",
         callback_handler=None
     )
@@ -233,7 +257,7 @@ evaluator = TrajectoryEvaluator(
 )
 
 # Update evaluator with tool descriptions to prevent context overflow
-sample_agent = Agent(tools=[calculator, current_time])
+sample_agent = Agent(tools=[calculator])
 tool_descriptions = tools_use_extractor.extract_tools_description(sample_agent, is_short=True)
 evaluator.update_trajectory_description(tool_descriptions)
 
@@ -261,10 +285,34 @@ When using `StrandsInMemorySessionMapper`, you **must** include session ID trace
 The `TracedHandler` handles all of this automatically:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_evals import eval_task, TracedHandler, Case, Experiment
 from strands_evals.evaluators import HelpfulnessEvaluator
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 @eval_task(TracedHandler())
 def user_task_function():
@@ -301,12 +349,36 @@ If you need more control (e.g., custom session mapping or per-case agent configu
 <summary>Manual task function (without decorator)</summary>
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import HelpfulnessEvaluator
 from strands_evals.telemetry import StrandsEvalsTelemetry
 from strands_evals.mappers import StrandsInMemorySessionMapper
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
 

--- a/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
@@ -97,8 +97,32 @@ The Strands Agents SDK uses standard log levels:
 The Strands Agents SDK logs information in several key areas. Let's look at what kinds of logs you might see when using the following example agent with a calculator tool:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create an agent with the calculator tool
 agent = Agent(tools=[calculator])

--- a/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
@@ -21,8 +21,32 @@ The Strands Agents SDK automatically tracks key metrics during agent execution:
 All these metrics are accessible through the [`AgentResult`](@api/python/strands.agent.agent_result#AgentResult) object that's returned whenever you invoke an agent. They are available for local analysis. To export them to an observability backend, configure Strands telemetry as described in the [Traces](./traces.md) documentation:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create an agent with tools
 agent = Agent(tools=[calculator])
@@ -89,8 +113,32 @@ The `agent_invocations` property is a list of [`AgentInvocation`](@api/python/st
 This allows you to track metrics at both the individual invocation level and across all invocations:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 
@@ -305,8 +353,32 @@ In addition to aggregate metrics, the Strands Agents SDK automatically collects 
 Each trace represents a cycle in the agent loop, with child traces for model invocations and tool calls:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 result = agent("What is 15 * 8 + 42?")

--- a/site/src/content/docs/user-guide/quickstart/python.mdx
+++ b/site/src/content/docs/user-guide/quickstart/python.mdx
@@ -109,8 +109,32 @@ from . import agent
 And finally our `agent.py` file where the goodies are:
 
 ```python
+
+import ast
+import operator
+
 from strands import Agent, tool
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Define a custom tool as a Python function using the @tool decorator
 @tool
@@ -135,7 +159,7 @@ def letter_counter(word: str, letter: str) -> int:
 
 # Create an agent with tools from the community-driven strands-tools package
 # as well as our custom letter_counter tool
-agent = Agent(tools=[calculator, current_time, letter_counter])
+agent = Agent(tools=[calculator, letter_counter])
 
 # Ask the agent a question that uses the available tools
 message = """
@@ -358,7 +382,7 @@ Agents display their reasoning and responses in real-time to the console by defa
 
 ```python
 agent = Agent(
-    tools=[calculator, current_time, letter_counter],
+    tools=[calculator, letter_counter],
     callback_handler=None,
 )
 ```
@@ -470,9 +494,33 @@ Strands provides two main approaches to capture streaming events from an agent: 
 For asynchronous applications (like web servers or APIs), Strands provides an async iterator approach using [`stream_async()`](@api/python/strands.agent.agent#Agent.stream_async). This is particularly useful with async frameworks like FastAPI or Django Channels.
 
 ```python
+
+import ast
+import operator
+
 import asyncio
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Initialize our agent without a callback handler
 agent = Agent(


### PR DESCRIPTION
## Description

Part 2 of 2, companion to #3644. Same substitution applied to the remaining areas: model-providers integrations, evals-sdk, observability, quickstart, and the runnable examples under `site/docs/examples`.

`strands-agents/tools` is deprecating `calculator`, `current_time`, `memory`, and `retrieve` (strands-agents/tools#566). `calculator` becomes a small self-contained `@tool` that walks an arithmetic AST against an explicit operator allowlist, so the prompts keep working without the `strands_tools` dependency and without demonstrating eval-style execution of model-supplied input. `current_time`, `memory`, and `retrieve` are removed from the tool lists that used them.

Split from #3631 (closed) so each PR fits the `pr-size-labeler` gate honestly — see #3644 for the full rationale, including the `sympy.sympify` security regression that the automated review caught in the original.

**Note the `evals-sdk` pages** — a couple assert on `expected_trajectory=["current_time"]`. Those assertions are updated alongside the tool swap so the eval examples stay self-consistent.

## Type of Change

Documentation update

## Testing

- Every generated helper executes and rejects non-arithmetic input (`144 ** 0.5 -> 12.0`; `ValueError` on `__import__('os').getpid()`).
- Every touched Python block parses.
- `ruff check` reports the same error count before and after on the affected example files under `site/docs/examples` — those files aren't ruff-clean upstream, so I compared rather than assuming.
- No `tools=[...]` entry references an undefined name.

- [ ] I ran `hatch run prepare`

Not applicable — `site/` only. `npm install` in `site/` fails with an npm registry auth error (`E401`) locally; CI covers it.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Best landed after #3644 to keep the diffs from overlapping, though they touch disjoint directories.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.